### PR TITLE
Fix codes for GNU compiling

### DIFF
--- a/ABACUS.develop/source/src_global/serialization_cereal.h
+++ b/ABACUS.develop/source/src_global/serialization_cereal.h
@@ -2,7 +2,7 @@
 #define SERIALIZATION_CEREAL_H
 
 #include <cereal/archives/binary.hpp>
-
+#include <cereal/archives/json.hpp>
 #include <cereal/types/vector.hpp>
 #include <cereal/types/map.hpp>
 #include <cereal/types/set.hpp>

--- a/ABACUS.develop/source/src_lcao/gint_gamma_rho.cpp
+++ b/ABACUS.develop/source/src_lcao/gint_gamma_rho.cpp
@@ -3,7 +3,6 @@
 #include "../module_ORB/ORB_read.h"
 #include "../src_pw/global.h"
 #include "src_global/blas_connector.h"
-#include <mkl_service.h>
 
 #include "global_fp.h" // mohan add 2021-01-30
 #include "../src_global/ylm.h"
@@ -272,8 +271,8 @@ double Gint_Gamma::gamma_charge(void)					// Peize Lin update OpenMP 2020.09.28
 
 	if(max_size)
     {
-        const int mkl_threads = mkl_get_max_threads();
-		mkl_set_num_threads(std::max(1,mkl_threads/GridT.nbx));			// Peize Lin update 2021.01.20
+        const int omp_threads = omp_get_max_threads();
+		omp_set_num_threads(std::max(1,omp_threads/GridT.nbx));			// Peize Lin update 2021.01.20
 		
 #ifdef __OPENMP
 		#pragma omp parallel
@@ -384,7 +383,7 @@ double Gint_Gamma::gamma_charge(void)					// Peize Lin update OpenMP 2020.09.28
 			}
 		}
 			
-        mkl_set_num_threads(mkl_threads);
+        omp_set_num_threads(omp_threads);
     } // end of if(max_size)
         
 //ENDandRETURN:

--- a/ABACUS.develop/source/src_lcao/gint_gamma_vl.cpp
+++ b/ABACUS.develop/source/src_lcao/gint_gamma_vl.cpp
@@ -3,7 +3,6 @@
 #include "../module_ORB/ORB_read.h"
 #include "../src_pw/global.h"
 #include "src_global/blas_connector.h"
-#include <mkl_service.h>
 
 #include "global_fp.h" // mohan add 2021-01-30
 #include "../src_global/ylm.h"
@@ -422,8 +421,8 @@ void Gint_Gamma::gamma_vlocal(void)						// Peize Lin update OpenMP 2020.09.27
         ZEROS(GridVlocal[i], GridT.lgd);
     }
 
-    const int mkl_threads = mkl_get_max_threads();
-	mkl_set_num_threads(std::max(1,mkl_threads/GridT.nbx));		// Peize Lin update 2021.01.20
+    const int omp_threads = omp_get_max_threads();
+	omp_set_num_threads(std::max(1,omp_threads/GridT.nbx));		// Peize Lin update 2021.01.20
 
 #ifdef __OPENMP
 	#pragma omp parallel
@@ -580,7 +579,7 @@ void Gint_Gamma::gamma_vlocal(void)						// Peize Lin update OpenMP 2020.09.27
 		} // end of if(max_size>0 && lgd_now>0)
 	} // end of #pragma omp parallel
 
-    mkl_set_num_threads(mkl_threads);
+    omp_set_num_threads(omp_threads);
 
     OUT(ofs_running, "temp variables are deleted");
     timer::tick("Gint_Gamma","gamma_vlocal",'K');

--- a/ABACUS.develop/source/src_pw/MD_fire.cpp
+++ b/ABACUS.develop/source/src_pw/MD_fire.cpp
@@ -15,7 +15,7 @@ MD_fire::MD_fire()
 
 void MD_fire::check_FIRE(
     const int& numIon, 
-    const Vector3<double>const* force, 
+    const Vector3<double>* force,
     double& deltaT, 
     Vector3<double>* vel)
 {

--- a/ABACUS.develop/source/src_pw/MD_fire.h
+++ b/ABACUS.develop/source/src_pw/MD_fire.h
@@ -10,7 +10,7 @@ class MD_fire
         ~MD_fire(){};
         void check_FIRE(
             const int& numIon, 
-            const Vector3<double>const* force, 
+            const Vector3<double>* force,
             double& deltaT, 
             Vector3<double>* vel);
     private:

--- a/ABACUS.develop/source/src_pw/MD_func.cpp
+++ b/ABACUS.develop/source/src_pw/MD_func.cpp
@@ -99,7 +99,7 @@ void MD_func::mdRestartOut(const int& step, const int& recordFreq, const int& nu
 	return;
 }
 
-double MD_func::GetAtomKE(const int& numIon, const Vector3<double>const* vel, const double const* allmass){
+double MD_func::GetAtomKE(const int& numIon, const Vector3<double>* vel, const double * allmass){
 //---------------------------------------------------------------------------
 // DESCRIPTION:
 //   This function calculates the classical kinetic energy of a group of atoms.
@@ -121,7 +121,7 @@ void MD_func::InitVelocity(
 	const int& numIon, 
 	const double& temperature, 
 	const double& fundamentalTime, 
-	const double const* allmass,
+	const double* allmass,
 	Vector3<double>* vel)
 {
 	if(!MY_RANK){ //xiaohui add 2015-09-25
@@ -377,7 +377,7 @@ double MD_func::Conserved(const double KE, const double PE, const int number){
    	return Conserved;
 }
 
-double MD_func::MAXVALF(const int numIon, const Vector3<double>const* force){
+double MD_func::MAXVALF(const int numIon, const Vector3<double>* force){
 	//cout<<"enter in MAXVALF"<<endl;
 	double max=0;
 	for(int i=0;i<numIon;i++){

--- a/ABACUS.develop/source/src_pw/MD_func.h
+++ b/ABACUS.develop/source/src_pw/MD_func.h
@@ -11,12 +11,12 @@ class MD_func
     ~MD_func(){};
 	bool RestartMD(const int& numIon, Vector3<double>* vel, int& step_rst);
     void mdRestartOut(const int& step, const int& recordFreq, const int& numIon, Vector3<double>* vel);
-	double GetAtomKE(const int& numIon, const Vector3<double>const* vel, const double const* allmass);
+	double GetAtomKE(const int& numIon, const Vector3<double>* vel, const double* allmass);
 	void InitVelocity(
 		const int& numIon, 
 		const double& temperature, 
 		const double& fundamentalTime, 
-		const double const* allmass,
+		const double* allmass,
 		Vector3<double>* vel);
 //	void ReadNewTemp(int step);
 	string intTurnTostring(long int iter,string path);
@@ -30,7 +30,7 @@ class MD_func
 		const double& temperature,
 		Vector3<double>* vel,
 		const double* allmass);
-	double MAXVALF(const int numIon, const Vector3<double>const* force);
+	double MAXVALF(const int numIon, const Vector3<double>* force);
 	double Conserved(const double KE, const double PE, const int number);
 };
 #endif

--- a/ABACUS.develop/source/src_pw/sto_che.cpp
+++ b/ABACUS.develop/source/src_pw/sto_che.cpp
@@ -80,11 +80,11 @@ void Stochastic_Chebychev::calcoef(double fun(double))
     {
         if(i == 0)
         {
-            coef[i] = real(exp(-ui*i*PI/norder2) * pcoef[i]) / norder2 * 2 / 3;
+            coef[i] = real(exp(-ui*(i*PI/norder2)) * pcoef[i]) / norder2 * 2 / 3;
         }
         else
         {
-            coef[i] = real(exp(-ui*i*PI/norder2) * pcoef[i]) / norder2 * 4 / 3;
+            coef[i] = real(exp(-ui*(i*PI/norder2)) * pcoef[i]) / norder2 * 4 / 3;
         }
     }
 
@@ -294,7 +294,7 @@ bool Stochastic_Chebychev::checkconverge(
         }
         for(int i = 0; i < ndim; ++i)
         {
-            arraynp1[i]=2*arraynp1[i]-arrayn_1[i];
+            arraynp1[i]=2.*arraynp1[i]-arrayn_1[i];
         }
         complex<double>* tem = arrayn_1;
         arrayn_1 = arrayn;

--- a/ABACUS.develop/source/src_pw/sto_che.h
+++ b/ABACUS.develop/source/src_pw/sto_che.h
@@ -91,7 +91,7 @@ void Stochastic_Chebychev::recurs(
     fun(arrayn,arraynp1,m);
     for(int i = 0; i < ndim * m; ++i)
     {
-        arraynp1[i]=2*arraynp1[i]-arrayn_1[i];
+        arraynp1[i]=2.*arraynp1[i]-arrayn_1[i];
     }
 }
 #endif// Eelectrons_Chebychev

--- a/ABACUS.develop/source/src_pw/sto_hchi.cpp
+++ b/ABACUS.develop/source/src_pw/sto_hchi.cpp
@@ -172,7 +172,7 @@ void Stochastic_hchi::orthogonal_to_psi_real(complex<double> *wfin, complex<doub
 	//LapackConnector::scal(nrxx,1/double(nrxx),wfout,1);
 	for(int ir = 0; ir < nrxx ; ++ir)
 	{
-		wfout[ir] = rl_chi[ir] / nrxx;
+		wfout[ir] = rl_chi[ir] / static_cast<double>(nrxx);
 	}
 	
 
@@ -397,7 +397,7 @@ void Stochastic_hchi::hchi_real(complex<double>*chi_in, complex<double> *hchi, c
 	//LapackConnector::scal(nrxx,1/DeltaE,hchi,1);
 	for(int i = 0; i < nrxx; ++i)
 	{
-		hchi[i] += rl_chi[i] / nrxx;
+		hchi[i] += rl_chi[i] / static_cast<double>(nrxx);
 	}
 	for(int i = 0; i < nrxx; ++i)
 	{

--- a/ABACUS.develop/source/src_ri/abfs.cpp
+++ b/ABACUS.develop/source/src_ri/abfs.cpp
@@ -6,7 +6,6 @@
 #include "src_pw/global.h"
 #include "src_global/global_function.h"
 #include <omp.h>
-#include <mkl_service.h>
 
 #include <fstream>		// Peize Lin test
 #include <iomanip>		// Peize Lin test
@@ -35,8 +34,8 @@ map<size_t,map<size_t,map<Abfs::Vector3_Order<int>,shared_ptr<matrix>>>> Abfs::c
 	for(size_t it=0; it!=ucell.ntype; ++it)
 		Vs_same_atom[it] = DPcal_V( it,it,{0,0,0}, m_abfs_abfs, index_abfs, 0,true, rwlock_Vw,Vws );
 	
-	const int mkl_threads = mkl_get_max_threads();
-	mkl_set_num_threads(std::max(1UL,mkl_threads/atom_centres_vector.size()));
+	const int omp_threads = omp_get_max_threads();
+	omp_set_num_threads(std::max(1UL,omp_threads/atom_centres_vector.size()));
 	
 	map<size_t,map<size_t,map<Vector3_Order<int>,shared_ptr<matrix>>>> Cs;
 	#pragma omp parallel for
@@ -65,7 +64,7 @@ map<size_t,map<size_t,map<Abfs::Vector3_Order<int>,shared_ptr<matrix>>>> Abfs::c
 			}
 		}
 	}
-	mkl_set_num_threads(mkl_threads);
+	omp_set_num_threads(omp_threads);
 	Abfs::delete_threshold_ptrs( Cs, threshold );
 	Vs_same_atom.clear();
 	Abfs::delete_empty_ptrs( Vws );

--- a/ABACUS.develop/source/src_ri/exx_abfs-screen-schwarz.cpp
+++ b/ABACUS.develop/source/src_ri/exx_abfs-screen-schwarz.cpp
@@ -4,7 +4,6 @@
 #include <cassert>
 #include <limits>
 #include <thread>
-#include <mkl_service.h>
 
 #include "src_external/src_test/src_ri/exx_abfs-screen-test.h"
 #include "src_external/src_test/src_ri/exx_lcao-test.h"

--- a/ABACUS.develop/source/src_ri/exx_lcao.cpp
+++ b/ABACUS.develop/source/src_ri/exx_lcao.cpp
@@ -22,7 +22,6 @@
 #include "exx_abfs-parallel-distribute-order.h"
 
 #include <thread>
-#include <mkl_service.h>
 
 // Peize Lin test
 #include<stdexcept>	
@@ -1433,8 +1432,8 @@ ofs_mpi.close();
 
 vector<map<size_t,map<size_t,map<Abfs::Vector3_Order<int>,matrix>>>> Exx_Lcao::cal_Hexx() const
 {
-	const int mkl_threads = mkl_get_max_threads();
-	mkl_set_num_threads(std::max(1UL,mkl_threads/atom_pairs_core.size()));
+	const int omp_threads = omp_get_max_threads();
+	omp_set_num_threads(std::max(1UL,omp_threads/atom_pairs_core.size()));
 	
 	vector<map<size_t,map<size_t,map<Abfs::Vector3_Order<int>,matrix>>>> HexxR(NSPIN);
 	omp_lock_t Hexx_lock;
@@ -1771,7 +1770,7 @@ vector<map<size_t,map<size_t,map<Abfs::Vector3_Order<int>,matrix>>>> Exx_Lcao::c
 	} // end omp parallel
 
 	omp_destroy_lock(&Hexx_lock);
-	mkl_set_num_threads(mkl_threads);
+	omp_set_num_threads(omp_threads);
 	
 	return HexxR;
 }


### PR DESCRIPTION
This PR includes 4 parts edits:
1. added new cereal header file to fit latest version cereal (this is not related to GNU)
2. changed APIs like `mkl_xxx` to `omp_xxx` when using ScaLAPACK instead of IntelMKL
3. reduced redudant `const` in C++ varialbe definition which is not support by GCC
4. explicitly cast `int` type to `double` when operates with `complex` type