### PR TITLE
fixed bug of NSCF parallel and DOJO pseudopotential FORCE calculation

### DIFF
--- a/ABACUS.develop/source/src_pw/electrons.cpp
+++ b/ABACUS.develop/source/src_pw/electrons.cpp
@@ -16,6 +16,10 @@ double Electrons::avg_iter = 0;
 
 Electrons::Electrons()
 {
+    iter = 0;
+    test = 0;
+    unit = 0;
+    delta_total_energy = 0.0;
 }
 
 Electrons::~Electrons()


### PR DESCRIPTION
1， fixed bug of NSCF parallel bug caused by no default value of some variables.
2,   fixed bug of DOJO pseudopotential FORCE calculation caused by NLCC treating error.