### PR TITLE
SCF: Finish cal dE and dF with libtorch

### DIFF
--- a/ABACUS.develop/examples/H2O-deepks-lcao/INPUT
+++ b/ABACUS.develop/examples/H2O-deepks-lcao/INPUT
@@ -23,8 +23,8 @@ sigma                   0.02
 mixing_type             pulay
 mixing_beta             0.4
 
-#Parameters (6.File)
-out_band                0
-out_descriptor          1 
+#Parameters (6.Deepks)
+out_descriptor          1
 lmax_descriptor			2
 newdm		1
+deepks_scf	1

--- a/ABACUS.develop/examples/H2O-deepks-lcao/jle.orb
+++ b/ABACUS.develop/examples/H2O-deepks-lcao/jle.orb
@@ -2,9 +2,9 @@
 Energy Cutoff(Ry)           50
 Radius Cutoff(a.u.)         6
 Lmax                        2
-Number of Sorbitals-->      3
-Number of Porbitals-->      2
-Number of Dorbitals-->      1
+Number of Sorbitals-->      13
+Number of Porbitals-->      13
+Number of Dorbitals-->      13
 ---------------------------------------------------------------------------
 SUMMARY END
 

--- a/ABACUS.develop/source/Makefile.system
+++ b/ABACUS.develop/source/Makefile.system
@@ -39,7 +39,7 @@ LIBTORCH_LIB = -L${LIBTORCH_LIB_DIR} -ltorch -lc10 -Wl,-rpath,/home/cyFortneu/pk
 #==========================
 # comment out by mohan 2021-02-06
 #LIBS = -lifcore -lm -lpthread ${LAPACK_LIB} ${FFTW_LIB} ${ELPA_LIB} ${LIBXC_LIB}
-LIBS = -lifcore -lm -lpthread ${LAPACK_LIB} ${FFTW_LIB} ${ELPA_LIB} ${LIBTORCH_LIB}
+LIBS = -lifcore -lm -lpthread ${LIBTORCH_LIB} ${LAPACK_LIB} ${FFTW_LIB} ${ELPA_LIB}
 #LIBS = -liomp5 -lpthread -lm -ldl ${BOOST_LIB} ${LAPACK_LIB} ${FFTW_LIB} ${LPA_LIB} ${LIBXC_LIB}
 
 INCLUDES = -I. -Icommands -I${BOOST_INCLUDE_DIR} -I${LAPACK_INCLUDE_DIR} -I${FFTW_INCLUDE_DIR} -I${LIBXC_INCLUDE_DIR} -I${CEREAL_INCLUDE_DIR} ${LIBTORCH_INCLUDE_DIR}

--- a/ABACUS.develop/source/input.cpp
+++ b/ABACUS.develop/source/input.cpp
@@ -1002,8 +1002,12 @@ bool Input::Read(const string &fn)
         else if (strcmp("lmax_descriptor", word) == 0)// mohan added 2021-01-03
         {
             read_value(ifs, lmax_descriptor);
+		}
+		else if (strcmp("deepks_scf", word) == 0) // caoyu added 2021-06-02
+        {
+            read_value(ifs, deepks_scf);
         }
-        else if (strcmp("out_potential", word) == 0)
+		else if (strcmp("out_potential", word) == 0)
         {
             read_value(ifs, out_potential);
         }

--- a/ABACUS.develop/source/input.h
+++ b/ABACUS.develop/source/input.h
@@ -435,6 +435,7 @@ class Input
 //==========================================================
     int out_descriptor; // output descritpor for deepks. caoyu added 2020-11-24, mohan modified 2021-01-03
 	int lmax_descriptor; // lmax used in descriptor, mohan added 2021-01-03
+	int deepks_scf;	//if set 1, a trained model would be needed to cal V_delta and F_delta
 
 	private:
 

--- a/ABACUS.develop/source/src_lcao/LCAO_descriptor.cpp
+++ b/ABACUS.develop/source/src_lcao/LCAO_descriptor.cpp
@@ -745,12 +745,22 @@ void LCAO_Descriptor::print_H_V_delta()
         ofs.open(ss.str().c_str());
     }
     ofs << "E_delta(Hartree) from deepks model: " << this->E_delta << endl;
-    ofs << "H_delta(gamma only)) from deepks model: " << endl;
+    ofs << "E_delta(eV) from deepks model: " << this->E_delta * Hartree_to_eV << endl;
+    ofs << "H_delta(Hartree)(gamma only)) from deepks model: " << endl;
     for (int i = 0;i < NLOCAL;++i)
     {
         for (int j = 0;j < NLOCAL;++j)
         {
             ofs<< setw(12)<< this->H_V_delta[i * NLOCAL + j] << " ";
+        }
+        ofs << endl;
+    }
+    ofs << "H_delta(eV)(gamma only)) from deepks model: " << endl;
+    for (int i = 0;i < NLOCAL;++i)
+    {
+        for (int j = 0;j < NLOCAL;++j)
+        {
+            ofs<< setw(12)<< this->H_V_delta[i * NLOCAL + j] *Hartree_to_eV<< " ";
         }
         ofs << endl;
     }
@@ -770,13 +780,29 @@ void LCAO_Descriptor::print_F_delta()
     {
         ofs.open(ss.str().c_str());
     }
+    ofs << "F_delta(Hatree/Angstrom) from deepks model: " << endl;
     ofs << setw(12) << "type" << setw(12) << "atom" << setw(15) << "dF_x" << setw(15) << "dF_y" << setw(15) << "dF_z" << endl;
     for (int it = 0;it < ucell.ntype;++it)
     {
         for (int ia = 0;ia < ucell.atoms[it].na;++ia)
         {
             int iat = ucell.itia2iat(it, ia);
-            ofs << setw(12) << ucell.atoms[it].label << setw(12) << ia << setw(15) << this->F_delta(iat, 0) << setw(15) << this->F_delta(iat, 1) << setw(15) << this->F_delta(iat, 2) << endl;
+            ofs << setw(12) << ucell.atoms[it].label << setw(12) << ia
+                << setw(15) << this->F_delta(iat, 0) << setw(15) << this->F_delta(iat, 1)
+                << setw(15) << this->F_delta(iat, 2) << endl;
+        }
+    }
+    ofs << "F_delta(eV/Angstrom) from deepks model: " << endl;
+    ofs << setw(12) << "type" << setw(12) << "atom" << setw(15) << "dF_x" << setw(15) << "dF_y" << setw(15) << "dF_z" << endl;
+    for (int it = 0;it < ucell.ntype;++it)
+    {
+        for (int ia = 0;ia < ucell.atoms[it].na;++ia)
+        {
+            int iat = ucell.itia2iat(it, ia);
+            ofs << setw(12) << ucell.atoms[it].label << setw(12)
+                << ia << setw(15) << this->F_delta(iat, 0) * Hartree_to_eV
+                << setw(15) << this->F_delta(iat, 1) * Hartree_to_eV
+                << setw(15) << this->F_delta(iat, 2) * Hartree_to_eV << endl;
         }
     }
     ofs_running << "F_delta is printed" << endl;

--- a/ABACUS.develop/source/src_lcao/LCAO_descriptor.cpp
+++ b/ABACUS.develop/source/src_lcao/LCAO_descriptor.cpp
@@ -1,4 +1,5 @@
 //caoyu add 2021-03-29
+
 #include "LCAO_descriptor.h"
 #include "LCAO_matrix.h"
 #include "../src_global/lapack_connector.h"
@@ -7,6 +8,9 @@
 #include "global_fp.h"
 #include "../src_pw/global.h"
 #include "../src_io/winput.h"
+#include <torch/script.h>
+#include <torch/csrc/autograd/autograd.h>
+
 
 LCAO_Descriptor::LCAO_Descriptor(int lm, int inlm):lmaxd(lm), inlmax(inlm)
 {
@@ -60,7 +64,6 @@ LCAO_Descriptor::~LCAO_Descriptor()
 void LCAO_Descriptor::build_S_descriptor(const bool &calc_deri)
 {
     TITLE("LCAO_Descriptor", "build_S_descriptor");
-
     // =======init==============
     // cal n(descriptor) per atom , related to Lmax, nchi(L) and m. (not total_nchi!)
 	this->des_per_atom=0; // mohan add 2021-04-21
@@ -290,6 +293,7 @@ void LCAO_Descriptor::cal_descriptor()
             }     //l
         }         //ia
     }             //it
+    this->cal_descriptor_tensor();  //use torch::symeig
     this->print_descriptor();
     return;
 }
@@ -589,9 +593,9 @@ void LCAO_Descriptor::cal_f_delta(matrix& dm2d)
                 {
                     for (int m2 = 0; m2 < nm;++m2)
                     {
-                        this->F_delta(iat, 1) += gedm[inl][m1 * nm + m2] * gdmx[iat][inl][m1 * nm + m2];
-                        this->F_delta(iat, 2) += gedm[inl][m1 * nm + m2] * gdmy[iat][inl][m1 * nm + m2];
-                        this->F_delta(iat, 3) += gedm[inl][m1 * nm + m2] * gdmz[iat][inl][m1 * nm + m2];
+                        this->F_delta(iat, 1) += this->gedm[inl][m1 * nm + m2] * gdmx[iat][inl][m1 * nm + m2];
+                        this->F_delta(iat, 2) += this->gedm[inl][m1 * nm + m2] * gdmy[iat][inl][m1 * nm + m2];
+                        this->F_delta(iat, 3) += this->gedm[inl][m1 * nm + m2] * gdmz[iat][inl][m1 * nm + m2];
                     }
                 }
                 
@@ -602,5 +606,67 @@ void LCAO_Descriptor::cal_f_delta(matrix& dm2d)
 
 
     this->del_gdmx();
+    return;
+}
+
+void LCAO_Descriptor::cal_descriptor_tensor()
+{
+    //init pdm_tensor and d_tensor
+    torch::Tensor tmp;
+    for (int inl = 0;inl < this->inlmax;++inl)
+    {
+        int nm = 2 * inl_l[inl] + 1;
+        tmp = torch::ones({ nm, nm }, torch::TensorOptions().dtype(torch::kFloat64));
+        for (int m1 = 0;m1 < nm;++m1)
+        {
+            for (int m2 = 0;m2 < nm;++m2)
+            {
+                tmp.index_put_({m1, m2}, this->pdm[inl][m1 * nm + m2]);
+            }
+        }
+        //torch::Tensor tmp = torch::from_blob(this->pdm[inl], { nm, nm }, torch::requires_grad());
+        tmp.requires_grad_(true);
+        this->pdm_tensor.push_back(tmp);
+        this->d_tensor.push_back(torch::ones({ nm }, torch::requires_grad(true)));
+    }
+
+    //cal d_tensor
+    for (int inl = 0;inl < inlmax;++inl)
+    {
+        torch::Tensor vd;
+        std::tuple<torch::Tensor, torch::Tensor> d_v(this->d_tensor[inl], vd);
+        d_v = torch::symeig(pdm_tensor[inl], /*eigenvalues=*/false, /*upper=*/true);
+        d_tensor[inl] = std::get<0>(d_v);
+    }
+    return;
+}
+
+void LCAO_Descriptor::cal_gedm()
+{
+    //load model
+    const char* model_name = "cmodel.pt";
+    try {
+        module = torch::jit::load(model_name);
+    }
+    catch (const c10::Error& e) {
+        std::cerr << "error loading the model" << std::endl;
+        return;
+    }
+    std::vector<torch::jit::IValue> inputs;
+    inputs.push_back(torch::cat(d_tensor, /*dim=*/0));
+    std::vector<torch::Tensor> ec;
+    ec.push_back(module.forward(inputs).toTensor());
+    std::vector<torch::Tensor> grad_shell;
+    for (int inl = 0;inl < inlmax;++inl)
+    {
+        int nm = 2 * inl_l[inl] + 1;
+        grad_shell.push_back(torch::ones({ nm, nm }));
+    }
+        this->gedm_tensor = torch::autograd::grad(ec, this->pdm_tensor, grad_shell);
+    //gedm size: [inl][3][nsph*nsph]
+
+    //gedm_Tensor to gedm
+    
+
     return;
 }

--- a/ABACUS.develop/source/src_lcao/LCAO_descriptor.h
+++ b/ABACUS.develop/source/src_lcao/LCAO_descriptor.h
@@ -23,6 +23,13 @@ public:
     void cal_descriptor(void);
 	void print_descriptor(void);
 
+	
+	void cal_v_delta(const string& model_name);//<psi|V_delta|psi>
+	void cal_f_delta(matrix& dm);	//pytorch term remaining!
+	void print_H_V_delta();
+	void print_F_delta();
+	
+
 	//deepks V_delta, to be added to Hamiltonian matrix
 	double* H_V_delta;
 	//deepks F_delta, to be added to atom force
@@ -97,15 +104,13 @@ private:
 	const double& vz);
 
 	void init_gdmx();
+	void load_model(const string& model_name);
 	void cal_gedm();	//need to load model in this step
-	void cal_gdmx(matrix& dm2d);	//dD/dX
+	void cal_gdmx(matrix& dm);	//dD/dX
 	void del_gdmx();
 	
 	void getdm(double* dm);
-
-	void cal_v_delta();	//pytorch term remaining!
-	void cal_f_delta(matrix& dm2d);	//pytorch term remaining!
-
+	
 	void cal_descriptor_tensor();
 	
 };

--- a/ABACUS.develop/source/src_lcao/LCAO_descriptor.h
+++ b/ABACUS.develop/source/src_lcao/LCAO_descriptor.h
@@ -29,7 +29,8 @@ public:
 	void print_H_V_delta();
 	void print_F_delta();
 	
-
+	//deepks E_delta(Hartree)
+	double E_delta = 0.0;
 	//deepks V_delta, to be added to Hamiltonian matrix
 	double* H_V_delta;
 	//deepks F_delta, to be added to atom force

--- a/ABACUS.develop/source/src_lcao/LCAO_descriptor.h
+++ b/ABACUS.develop/source/src_lcao/LCAO_descriptor.h
@@ -10,7 +10,7 @@ class LCAO_Descriptor
 {
 public:
 
-    LCAO_Descriptor(int lm, int inlm);
+    explicit LCAO_Descriptor(int lm, int inlm);
     ~LCAO_Descriptor();
 
 	// cal S_alpha_mu: overlap between lcao basis Phi and descriptor basis Al
@@ -29,7 +29,8 @@ public:
 	matrix	F_delta;
 
 private:
-
+	torch::jit::script::Module module;
+	
 	// overlap between lcao and descriptor basis
 	double** S_mu_alpha;	//[tot_Inl][NLOCAL][2l+1]	caoyu modified 2021-05-07
 
@@ -39,8 +40,16 @@ private:
 	double** DS_mu_alpha_z;
 	
 	// projected density matrix
-	double** pdm;	//[2l+1][2l+1]	caoyu modified 2021-05-07
+	double** pdm;	//[tot_Inl][2l+1][2l+1]	caoyu modified 2021-05-07
+	std::vector<torch::Tensor> pdm_tensor;
+
+	// descriptors
+    double *d;
+	vector<torch::Tensor> d_tensor;
 	
+	//gedm:dE/dD, [tot_Inl][2l+1][2l+1]
+	std::vector<torch::Tensor> gedm_tensor;
+
 	//gdmx: dD/dX		\sum_{mu,nu} 4*c_mu*c_nu * <dpsi_mu/dx|alpha_m><alpha_m'|psi_nu>
 	double*** gdmx;	//[natom][tot_Inl][2l+1][2l+1]	
 	double*** gdmy;
@@ -49,8 +58,6 @@ private:
 	//dE/dD, autograd from loaded model
 	double** gedm;	//[tot_Inl][2l+1][2l+1]	
 	
-	// descriptors
-    double *d;
 
     int n_descriptor;
 
@@ -90,6 +97,7 @@ private:
 	const double& vz);
 
 	void init_gdmx();
+	void cal_gedm();	//need to load model in this step
 	void cal_gdmx(matrix& dm2d);	//dD/dX
 	void del_gdmx();
 	
@@ -97,6 +105,8 @@ private:
 
 	void cal_v_delta();	//pytorch term remaining!
 	void cal_f_delta(matrix& dm2d);	//pytorch term remaining!
+
+	void cal_descriptor_tensor();
 	
 };
 

--- a/ABACUS.develop/source/src_lcao/LOOP_ions.cpp
+++ b/ABACUS.develop/source/src_lcao/LOOP_ions.cpp
@@ -140,6 +140,15 @@ void LOOP_ions::opt_ions(void)
             ld.build_S_descriptor(0);  //derivation not needed yet
             ld.cal_projected_DM();
             ld.cal_descriptor();
+            if (INPUT.deepks_scf)
+            {
+                ld.build_S_descriptor(1);   //for F_delta calculation
+                ld.cal_v_delta("cmodel.pt");
+                ld.print_H_V_delta();
+                ld.cal_f_delta(LOC.wfc_dm_2d.dm_gamma[0]);
+                cout << "cal f ok" << endl;
+                ld.print_F_delta();
+            }
         }
 
         time_t fstart = time(NULL);


### PR DESCRIPTION
1. link libtorch
2. cal descriptor with torch::Tensor, using torch::symeig
3. load a traced model, forward, and cal deriv by torch::autograd::grad  -- dE/dD
4. mulitply and sum -- <psi|V_delta|psi> and F_delta

results for 1 H2O:

![image](https://user-images.githubusercontent.com/33978601/120490157-c3d1c400-c3ea-11eb-9937-e461e577a912.png)
![image](https://user-images.githubusercontent.com/33978601/120490285-dc41de80-c3ea-11eb-948a-44c7f57bfb7b.png)
