### PR TITLE
Save descriptor, e_base and f_base as .npy file

### DIFF
--- a/ABACUS.develop/examples/H2O-deepks-lcao/INPUT
+++ b/ABACUS.develop/examples/H2O-deepks-lcao/INPUT
@@ -24,6 +24,8 @@ mixing_type             pulay
 mixing_beta             0.4
 
 #Parameters (6.Deepks)
+force			1
+test_force			1
 out_descriptor          1
 lmax_descriptor			2
 newdm		1

--- a/ABACUS.develop/examples/H2O-deepks-lcao/INPUT
+++ b/ABACUS.develop/examples/H2O-deepks-lcao/INPUT
@@ -28,3 +28,4 @@ out_descriptor          1
 lmax_descriptor			2
 newdm		1
 deepks_scf	1
+model_file	model.ptg

--- a/ABACUS.develop/source/Makefile.system
+++ b/ABACUS.develop/source/Makefile.system
@@ -30,9 +30,13 @@ LIBXC_LIB         = -L${LIBXC_LIB_DIR} -lxc -Wl,-rpath=${LIBXC_LIB_DIR}
 
 CEREAL_INCLUDE_DIR = ${CEREAL_DIR}/include
 
+#============DeePKS================
 LIBTORCH_INCLUDE_DIR =  -isystem /home/cyFortneu/pkgs/libtorch/include -isystem /home/cyFortneu/pkgs/libtorch/include/torch/csrc/api/include
 LIBTORCH_LIB_DIR= /home/cyFortneu/pkgs/libtorch/lib
 LIBTORCH_LIB = -L${LIBTORCH_LIB_DIR} -ltorch -lc10 -Wl,-rpath,/home/cyFortneu/pkgs/libtorch/lib -Wl,--no-as-needed,"/home/cyFortneu/pkgs/libtorch/lib/libtorch_cpu.so" -Wl,--as-needed /home/cyFortneu/pkgs/libtorch/lib/libc10.so -lpthread -Wl,--no-as-needed,"/home/cyFortneu/pkgs/libtorch/lib/libtorch.so" -Wl,--as-needed 
+
+CNPY_INCLUDE_DIR = /home/cyFortneu/libnpy
+#============\DeePKS================
 
 #==========================
 # LIBS and INCLUDES
@@ -42,7 +46,7 @@ LIBTORCH_LIB = -L${LIBTORCH_LIB_DIR} -ltorch -lc10 -Wl,-rpath,/home/cyFortneu/pk
 LIBS = -lifcore -lm -lpthread ${LIBTORCH_LIB} ${LAPACK_LIB} ${FFTW_LIB} ${ELPA_LIB}
 #LIBS = -liomp5 -lpthread -lm -ldl ${BOOST_LIB} ${LAPACK_LIB} ${FFTW_LIB} ${LPA_LIB} ${LIBXC_LIB}
 
-INCLUDES = -I. -Icommands -I${BOOST_INCLUDE_DIR} -I${LAPACK_INCLUDE_DIR} -I${FFTW_INCLUDE_DIR} -I${LIBXC_INCLUDE_DIR} -I${CEREAL_INCLUDE_DIR} ${LIBTORCH_INCLUDE_DIR}
+INCLUDES = -I. -Icommands -I${BOOST_INCLUDE_DIR} -I${LAPACK_INCLUDE_DIR} -I${FFTW_INCLUDE_DIR} -I${LIBXC_INCLUDE_DIR} -I${CEREAL_INCLUDE_DIR} ${LIBTORCH_INCLUDE_DIR} -I${CNPY_INCLUDE_DIR}
 
 #==========================
 # OPTIMIZE OPTIONS

--- a/ABACUS.develop/source/input.cpp
+++ b/ABACUS.develop/source/input.cpp
@@ -1006,6 +1006,10 @@ bool Input::Read(const string &fn)
 		else if (strcmp("deepks_scf", word) == 0) // caoyu added 2021-06-02
         {
             read_value(ifs, deepks_scf);
+		}
+		else if (strcmp("model_file", word) == 0) // caoyu added 2021-06-03
+        {
+            read_value(ifs, model_file);
         }
 		else if (strcmp("out_potential", word) == 0)
         {
@@ -2075,8 +2079,10 @@ void Input::Bcast()
     Parallel_Common::bcast_int( out_dm );
     Parallel_Common::bcast_int( out_descriptor ); // caoyu added 2020-11-24, mohan modified 2021-01-03
     Parallel_Common::bcast_int( lmax_descriptor ); // mohan modified 2021-01-03
-
-    Parallel_Common::bcast_int( out_potential );
+    Parallel_Common::bcast_int( deepks_scf ); // caoyu add 2021-06-02
+	Parallel_Common::bcast_string( model_file ); //  caoyu add 2021-06-03
+	
+	Parallel_Common::bcast_int(out_potential);
     Parallel_Common::bcast_bool( out_wf );
 	Parallel_Common::bcast_int( out_dos );
         Parallel_Common::bcast_int( out_band );

--- a/ABACUS.develop/source/input.h
+++ b/ABACUS.develop/source/input.h
@@ -436,6 +436,7 @@ class Input
     int out_descriptor; // output descritpor for deepks. caoyu added 2020-11-24, mohan modified 2021-01-03
 	int lmax_descriptor; // lmax used in descriptor, mohan added 2021-01-03
 	int deepks_scf;	//if set 1, a trained model would be needed to cal V_delta and F_delta
+	string model_file;		//needed when deepks_scf=1
 
 	private:
 

--- a/ABACUS.develop/source/src_lcao/ELEC_scf.cpp
+++ b/ABACUS.develop/source/src_lcao/ELEC_scf.cpp
@@ -11,6 +11,7 @@
 #include "src_pw/occupy.h"
 //new
 #include "src_pw/H_Ewald_pw.h"
+#include "LCAO_descriptor.h"	//caoyu add 2021-06-04
 
 ELEC_scf::ELEC_scf(){}
 ELEC_scf::~ELEC_scf(){}
@@ -570,6 +571,10 @@ void ELEC_scf::scf(const int &istep)
 				if(OUT_LEVEL=="ie")
 				{
 					ofs_running << " " << global_out_dir << " final etot is " << en.etot * Ry_to_eV << " eV" << endl; 
+				}
+				if (INPUT.deepks_scf)	//caoyu add 2021-06-04
+				{
+					ld.save_npy_e(en.etot);//ebase = etot, no deepks E_delta including 
 				}
 			}
 			else

--- a/ABACUS.develop/source/src_lcao/FORCE_STRESS.cpp
+++ b/ABACUS.develop/source/src_lcao/FORCE_STRESS.cpp
@@ -188,7 +188,7 @@ void Force_Stress_LCAO::getForceStress(
 	//Force contribution from DFT+U
 	matrix force_dftu;
 	matrix stress_dftu;
-	if(INPUT.dft_plus_u)
+	if (INPUT.dft_plus_u)
 	{
 		if(isforce)
 		{

--- a/ABACUS.develop/source/src_lcao/FORCE_STRESS.cpp
+++ b/ABACUS.develop/source/src_lcao/FORCE_STRESS.cpp
@@ -259,12 +259,6 @@ void Force_Stress_LCAO::getForceStress(
 				{
 					fcs(iat, i) += force_dftu(iat, i);
 				}
-				//DeePKS force, caoyu add 2021-06-03
-				if(INPUT.deepks_scf)
-				{
-					fcs(iat, i) += ld.F_delta(iat, i);
-					ld.save_npy_f(ld.F_delta);
-				}
 				//sum total force for correction
 				sum += fcs(iat, i);
 			}
@@ -287,7 +281,13 @@ void Force_Stress_LCAO::getForceStress(
 		{
 			this->forceSymmetry(fcs);
 		}
-
+		
+		//DeePKS force, caoyu add 2021-06-03
+		if (INPUT.deepks_scf)
+		{
+			ld.save_npy_f(fcs);	//save fbase
+		}
+		
 		// print Rydberg force or not
 		bool ry = false;
 		if(istestf)

--- a/ABACUS.develop/source/src_lcao/FORCE_STRESS.cpp
+++ b/ABACUS.develop/source/src_lcao/FORCE_STRESS.cpp
@@ -263,6 +263,7 @@ void Force_Stress_LCAO::getForceStress(
 				if(INPUT.deepks_scf)
 				{
 					fcs(iat, i) += ld.F_delta(iat, i);
+					ld.save_npy_f(ld.F_delta);
 				}
 				//sum total force for correction
 				sum += fcs(iat, i);

--- a/ABACUS.develop/source/src_lcao/FORCE_STRESS.cpp
+++ b/ABACUS.develop/source/src_lcao/FORCE_STRESS.cpp
@@ -6,6 +6,7 @@
 #include "../src_pw/H_XC_pw.h"
 #include "src_pw/vdwd2.h"
 #include "src_pw/vdwd3.h"
+#include "LCAO_descriptor.h"	//caoyu add for deepks 2021-06-03
 
 double Force_Stress_LCAO::force_invalid_threshold_ev = 0.00;
 double Force_Stress_LCAO::output_acc = 1.0e-8;
@@ -258,6 +259,11 @@ void Force_Stress_LCAO::getForceStress(
 				{
 					fcs(iat, i) += force_dftu(iat, i);
 				}
+				//DeePKS force, caoyu add 2021-06-03
+				if(INPUT.deepks_scf)
+				{
+					fcs(iat, i) += ld.F_delta(iat, i);
+				}
 				//sum total force for correction
 				sum += fcs(iat, i);
 			}
@@ -325,6 +331,11 @@ void Force_Stress_LCAO::getForceStress(
 			if(vdwd2_para.flag_vdwd2||vdwd3_para.flag_vdwd3)
 			{
 				this->print_force("VDW        FORCE",force_vdw,1,ry);
+			}
+			//caoyu add 2021-06-03
+			if (INPUT.deepks_scf)
+			{
+				this->print_force("DeePKS 	FORCE", ld.F_delta, 1, ry);
 			}
 		}
 		

--- a/ABACUS.develop/source/src_lcao/LCAO_descriptor.cpp
+++ b/ABACUS.develop/source/src_lcao/LCAO_descriptor.cpp
@@ -8,8 +8,10 @@
 #include "global_fp.h"
 #include "../src_pw/global.h"
 #include "../src_io/winput.h"
+
 #include <torch/script.h>
 #include <torch/csrc/autograd/autograd.h>
+#include <npy.hpp>
 
 
 LCAO_Descriptor::LCAO_Descriptor(int lm, int inlm):lmaxd(lm), inlmax(inlm)
@@ -443,6 +445,16 @@ void LCAO_Descriptor::print_descriptor()
         }
     }
     ofs_running << "descriptors are printed" << endl;
+
+    //print descriptor in .npy format
+    vector<double>npy_des;
+    for (int i = 0;i < n_descriptor;++i)
+    {
+        npy_des.push_back(this->d[i]);
+    }
+    const long unsigned shape [] = {ucell.nat, des_per_atom};
+    npy::SaveArrayAsNumpy("dm_eig.npy", false, 2, shape, npy_des);
+
     return;
 }
 
@@ -792,7 +804,7 @@ void LCAO_Descriptor::print_F_delta()
                 << setw(15) << this->F_delta(iat, 2) << endl;
         }
     }
-    ofs << "F_delta(eV/Angstrom) from deepks model: " << endl;
+    ofs << "F_delta(eV/Angstrom) from deepks model: cd" << endl;
     ofs << setw(12) << "type" << setw(12) << "atom" << setw(15) << "dF_x" << setw(15) << "dF_y" << setw(15) << "dF_z" << endl;
     for (int it = 0;it < ucell.ntype;++it)
     {

--- a/ABACUS.develop/source/src_lcao/LCAO_descriptor.cpp
+++ b/ABACUS.develop/source/src_lcao/LCAO_descriptor.cpp
@@ -447,7 +447,7 @@ void LCAO_Descriptor::print_descriptor()
     ofs_running << "descriptors are printed" << endl;
 
     //print descriptor in .npy format
-    vector<double>npy_des;
+    vector<double> npy_des;
     for (int i = 0;i < n_descriptor;++i)
     {
         npy_des.push_back(this->d[i]);
@@ -585,11 +585,11 @@ void LCAO_Descriptor::del_gdmx()
     return;
 }
 
-void LCAO_Descriptor::cal_v_delta(const string& model_name)
+void LCAO_Descriptor::cal_v_delta(const string& model_file)
 {
     TITLE("LCAO_Descriptor", "cal_v_delta");
     //1.  (dE/dD)<alpha_m'|psi_nv>
-    this->load_model(model_name);
+    this->load_model(model_file);
     this->cal_gedm();
 
     //2. multiply and sum
@@ -702,10 +702,10 @@ void LCAO_Descriptor::cal_descriptor_tensor()
     return;
 }
 
-void LCAO_Descriptor::load_model(const string& model_name)
+void LCAO_Descriptor::load_model(const string& model_file)
 {
     try {
-        module = torch::jit::load(model_name);
+        module = torch::jit::load(model_file);
     }
     catch (const c10::Error& e) {
         std::cerr << "error loading the model" << std::endl;

--- a/ABACUS.develop/source/src_lcao/LCAO_descriptor.cpp
+++ b/ABACUS.develop/source/src_lcao/LCAO_descriptor.cpp
@@ -452,15 +452,6 @@ void LCAO_Descriptor::print_descriptor()
     }
     ofs_running << "descriptors are printed" << endl;
 
-    //print descriptor in .npy format
-    vector<double> npy_des;
-    for (int i = 0;i < n_descriptor;++i)
-    {
-        npy_des.push_back(this->d[i]);
-    }
-    const long unsigned shape [] = {ucell.nat, des_per_atom};
-    npy::SaveArrayAsNumpy("dm_eig.npy", false, 2, shape, npy_des);
-
     return;
 }
 
@@ -825,5 +816,45 @@ void LCAO_Descriptor::print_F_delta()
         }
     }
     ofs_running << "F_delta is printed" << endl;
+    return;
+}
+
+void LCAO_Descriptor::save_npy_d()
+{
+    //save descriptor in .npy format
+    vector<double> npy_des;
+    for (int i = 0;i < this->n_descriptor;++i)
+    {
+        npy_des.push_back(this->d[i]);
+    }
+    const long unsigned dshape[] = { ucell.nat, this->des_per_atom };
+    npy::SaveArrayAsNumpy("dm_eig.npy", false, 2, dshape, npy_des);
+    return;
+}
+
+void LCAO_Descriptor::save_npy_e(double& ebase)
+{   
+    //save e_base
+    const long unsigned eshape[] = { 1 };
+    vector<double> npy_ebase;
+    npy_ebase.push_back(ebase);
+    npy::SaveArrayAsNumpy("e_base.npy", false, 1, eshape, npy_ebase);
+    return;
+}
+
+void LCAO_Descriptor::save_npy_f(matrix& fbase)
+{
+    //save f_base
+    //caution: unit: Rydberg/Bohr
+    const long unsigned fshape[] = { ucell.nat, 3 };
+    vector<double> npy_fbase;
+    for (int iat = 0;iat < ucell.nat;++iat)
+    {
+        for (int i = 0;i < 3;i++)
+        {
+            npy_fbase.push_back(fbase(iat, i));
+        }
+    }
+    npy::SaveArrayAsNumpy("f_base.npy", false, 2, fshape, npy_fbase);
     return;
 }

--- a/ABACUS.develop/source/src_lcao/LCAO_descriptor.h
+++ b/ABACUS.develop/source/src_lcao/LCAO_descriptor.h
@@ -31,11 +31,11 @@ public:
 	void print_H_V_delta();
 	void print_F_delta();
 	
-	//deepks E_delta(Hartree)
+	//deepks E_delta(Ry)
 	double E_delta = 0.0;
 	//deepks V_delta, to be added to Hamiltonian matrix
 	double* H_V_delta;
-	//deepks F_delta, to be added to atom force
+	//deepks F_delta(Ry/Bohr), to be added to atom force
 	matrix	F_delta;
 
 private:
@@ -57,7 +57,7 @@ private:
     double *d;
 	vector<torch::Tensor> d_tensor;
 	
-	//gedm:dE/dD, [tot_Inl][2l+1][2l+1]
+	//gedm:dE/dD, [tot_Inl][2l+1][2l+1]	(E: Hartree)
 	std::vector<torch::Tensor> gedm_tensor;
 
 	//gdmx: dD/dX		\sum_{mu,nu} 4*c_mu*c_nu * <dpsi_mu/dx|alpha_m><alpha_m'|psi_nu>
@@ -65,7 +65,7 @@ private:
 	double*** gdmy;
 	double*** gdmz;
 
-	//dE/dD, autograd from loaded model
+	//dE/dD, autograd from loaded model(E: Ry)
 	double** gedm;	//[tot_Inl][2l+1][2l+1]	
 	
 

--- a/ABACUS.develop/source/src_lcao/LCAO_descriptor.h
+++ b/ABACUS.develop/source/src_lcao/LCAO_descriptor.h
@@ -24,7 +24,7 @@ public:
 	void print_descriptor(void);
 
 	
-	void cal_v_delta(const string& model_name);//<psi|V_delta|psi>
+	void cal_v_delta(const string& model_file);//<psi|V_delta|psi>
 	void cal_f_delta(matrix& dm);	//pytorch term remaining!
 	void print_H_V_delta();
 	void print_F_delta();
@@ -105,7 +105,7 @@ private:
 	const double& vz);
 
 	void init_gdmx();
-	void load_model(const string& model_name);
+	void load_model(const string& model_file);
 	void cal_gedm();	//need to load model in this step
 	void cal_gdmx(matrix& dm);	//dD/dX
 	void del_gdmx();

--- a/ABACUS.develop/source/src_lcao/LCAO_descriptor.h
+++ b/ABACUS.develop/source/src_lcao/LCAO_descriptor.h
@@ -30,7 +30,16 @@ public:
 	void cal_f_delta(matrix& dm);	//pytorch term remaining!
 	void print_H_V_delta();
 	void print_F_delta();
-	
+
+	/*These 3 func save the [dm_eig], [e_base], [f_base]
+	of current configuration as .npy file, when deepks_scf = 1.
+	After a full group of consfigurations are calculated,
+    we need a python script to 'load' and 'torch.cat' these .npy files,
+    and get l_e_delta and l_f_delta corresponding to the exact e,f data.*/
+	void save_npy_d();
+	void save_npy_e(double& ebase);	//Ry
+	void save_npy_f(matrix& fbase);//Ry
+
 	//deepks E_delta(Ry)
 	double E_delta = 0.0;
 	//deepks V_delta, to be added to Hamiltonian matrix

--- a/ABACUS.develop/source/src_lcao/LCAO_descriptor.h
+++ b/ABACUS.develop/source/src_lcao/LCAO_descriptor.h
@@ -4,15 +4,17 @@
 #include "../src_global/intarray.h"
 #include "../src_global/complexmatrix.h"
 #include <torch/script.h>
+#include "../src_pw/global.h"
 
 //caoyu add 2021-03-29
 class LCAO_Descriptor
 {
 public:
 
-    explicit LCAO_Descriptor(int lm, int inlm);
+    explicit LCAO_Descriptor();
     ~LCAO_Descriptor();
 
+	void init(int lm, int nm, int tot_inl);	// index of descriptor in all atoms
 	// cal S_alpha_mu: overlap between lcao basis Phi and descriptor basis Al
     void build_S_descriptor(const bool &calc_deri); 
 
@@ -67,14 +69,14 @@ private:
 	double** gedm;	//[tot_Inl][2l+1][2l+1]	
 	
 
-    int n_descriptor;
+	int n_descriptor;
 
 	// \sum_L{Nchi(L)*(2L+1)}
 	int des_per_atom;
 
-	const int lmaxd;
-
-	const int inlmax;
+	int lmaxd = 0;
+	int nmaxd = 0;
+	int inlmax = 0;
 
 	IntArray* alpha_index;
 	IntArray* inl_index;	//caoyu add 2021-05-07
@@ -115,6 +117,6 @@ private:
 	void cal_descriptor_tensor();
 	
 };
-
+extern LCAO_Descriptor ld;
 
 #endif

--- a/ABACUS.develop/source/src_lcao/LOOP_ions.cpp
+++ b/ABACUS.develop/source/src_lcao/LOOP_ions.cpp
@@ -145,8 +145,13 @@ void LOOP_ions::opt_ions(void)
                 ld.build_S_descriptor(1);   //for F_delta calculation
                 ld.cal_v_delta(INPUT.model_file);
                 ld.print_H_V_delta();
-                ld.cal_f_delta(LOC.wfc_dm_2d.dm_gamma[0]);
-                ld.print_F_delta();
+                ld.save_npy_d();
+                if (FORCE)
+                {
+                    ld.cal_f_delta(LOC.wfc_dm_2d.dm_gamma[0]);
+                    ld.print_F_delta();
+                }
+                    
             }
         }
 

--- a/ABACUS.develop/source/src_lcao/LOOP_ions.cpp
+++ b/ABACUS.develop/source/src_lcao/LOOP_ions.cpp
@@ -143,7 +143,7 @@ void LOOP_ions::opt_ions(void)
             if (INPUT.deepks_scf)
             {
                 ld.build_S_descriptor(1);   //for F_delta calculation
-                ld.cal_v_delta("cmodel.pt");
+                ld.cal_v_delta(INPUT.model_file);
                 ld.print_H_V_delta();
                 ld.cal_f_delta(LOC.wfc_dm_2d.dm_gamma[0]);
                 ld.print_F_delta();

--- a/ABACUS.develop/source/src_lcao/LOOP_ions.cpp
+++ b/ABACUS.develop/source/src_lcao/LOOP_ions.cpp
@@ -136,7 +136,7 @@ void LOOP_ions::opt_ions(void)
         //caoyu add 2021-03-31
         if (INPUT.out_descriptor)
         {
-            LCAO_Descriptor ld(ORB.get_lmax_d(), ucell.nat* ORB.Alpha[0].getTotal_nchi());
+            ld.init(ORB.get_lmax_d(), ORB.get_nchimax_d(), ucell.nat* ORB.Alpha[0].getTotal_nchi());
             ld.build_S_descriptor(0);  //derivation not needed yet
             ld.cal_projected_DM();
             ld.cal_descriptor();

--- a/ABACUS.develop/source/src_lcao/LOOP_ions.cpp
+++ b/ABACUS.develop/source/src_lcao/LOOP_ions.cpp
@@ -146,7 +146,6 @@ void LOOP_ions::opt_ions(void)
                 ld.cal_v_delta("cmodel.pt");
                 ld.print_H_V_delta();
                 ld.cal_f_delta(LOC.wfc_dm_2d.dm_gamma[0]);
-                cout << "cal f ok" << endl;
                 ld.print_F_delta();
             }
         }


### PR DESCRIPTION
Thanks tansongchen for finding this cnpy lib: https://github.com/llohse/libnpy. Include this in Makefile.
The added functions save .npy file [dm_eig.npy, e_base.npy, f_base.npy] for **a single configuration**. After running a whole group of configurations, a python script is needed to load and concatenate those .npy data and generate final data to be fed in NN. 

Sizes of file are like: 
(units: E -Rydberg; F- Rydberg/Bohr)
![image](https://user-images.githubusercontent.com/33978601/120795754-74b39c80-c56c-11eb-908c-c9b6e51d4bd2.png)
