### PR TITLE
Fix TO_STRING not defined.

### DIFF
--- a/ABACUS.develop/source/src_global/mathzone.h
+++ b/ABACUS.develop/source/src_global/mathzone.h
@@ -4,6 +4,7 @@
 #include "realarray.h"
 #include "vector3.h"
 #include "matrix3.h"
+#include "global_function.h"
 #include <vector>
 #include <map>
 #include <cassert>


### PR DESCRIPTION
Fix build error:
```text
In file included from ./src_global/mathzone.cpp:2:
./src_global/mathzone.h: In static member function ‘static T Mathzone::Max3(const T&, const T&, const T&)’:
./src_global/mathzone.h:27:28: error: there are no arguments to ‘TO_STRING’ that depend on a template parameter, so a declaration of ‘TO_STRING’ must be available [-fpermissive]
   else throw runtime_error(TO_STRING(__FILE__)+" line "+TO_STRING(__LINE__));
                            ^~~~~~~~~
```