### PR TITLE
Find cereal, ELPA, FFTW3, ScaLAPACK in CMake.

### DIFF
--- a/ABACUS.develop/cmake/CMakeLists.txt
+++ b/ABACUS.develop/cmake/CMakeLists.txt
@@ -13,51 +13,35 @@ project(ABACUS
 set(ABACUS_BIN_NAME ${PROJECT_NAME}-${PROJECT_VERSION})
 
 set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
+add_compile_options(-O2 -g)
+
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/modules)
 
 get_filename_component(ABACUS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/.. ABSOLUTE)
 set(ABACUS_SOURCE_DIR ${ABACUS_DIR}/source)
+include_directories(${ABACUS_SOURCE_DIR})
 
-set(CEREAL_DIR /usr/local)
-include_directories(${CEREAL_DIR}/include)
-
-set(ELPA_DIR /usr/local)
-include_directories(${ELPA_DIR}/include)
-
-set(FFTW_DIR /usr/local)
-include_directories(${FFTW_DIR}/include)
-
-set(SCALAPACK_DIR /usr/local)
-include_directories(${SCALAPACK_DIR}/include)
-
-# OpenBlas is required by ScaLAPACK
-find_package(BLAS REQUIRED)
-
-# We only use the header-only part of Boost
+# We only use headers
 find_package(Boost REQUIRED)
-include_directories(${Boost_INCLUDE_DIRS})
+find_package(Cereal REQUIRED)
 
+# We only use libraries while headers are customed in project:
+# - "blas_connector.h"
+# - "lapack_connect.h"
+# - "my_elpa.h"
+# - "scalapack_connector.h"
+find_package(BLAS REQUIRED)
+find_package(ELPA REQUIRED)
+find_package(ScaLAPACK REQUIRED)
+
+# Both header and library are needed
+find_package(FFTW3 REQUIRED)
 find_package(MPI REQUIRED)
-include_directories(${MPI_CXX_INCLUDE_PATH})
-add_compile_options(${MPI_CXX_COMPILE_FLAGS})
+include_directories(${MPI_CXX_INCLUDE_PATH} ${FFTW3_INCLUDE_DIRS})
 
-# Look for pthread or equivalent
+# No header needed
 find_package(Threads REQUIRED)
 find_package(OpenMP REQUIRED)
-
-set(EXTERNAL_LIB_NAMES
-    -lgfortran
-    -lm
-    -lelpa
-    -lfftw3
-    ${SCALAPACK_DIR}/lib/libscalapack.a
-)
-
-set(EXTERNAL_LIB_DIRS
-    ${LAPACK_DIR}/lib
-    ${FFTW_DIR}/lib
-    ${ELPA_DIR}/lib
-)
 
 add_definitions(
     -D__EXX
@@ -453,12 +437,10 @@ add_library(abacusTools OBJECT ${CODE_TOOLS})
 add_library(abacusCodePdiag OBJECT ${CODE_PDIAG})
 add_library(abacusCodePdiagMr OBJECT ${CODE_PDIAG_MR})
 
-target_include_directories(abacusCommon PUBLIC ${ABACUS_SOURCE_DIR})
-target_include_directories(abacusFirstPrinciple PUBLIC ${ABACUS_SOURCE_DIR})
-target_include_directories(abacusParallel PUBLIC ${ABACUS_SOURCE_DIR})
-target_include_directories(abacusTools PUBLIC ${ABACUS_SOURCE_DIR})
-target_include_directories(abacusCodePdiag PUBLIC ${ABACUS_SOURCE_DIR})
-target_include_directories(abacusCodePdiagMr PUBLIC ${ABACUS_SOURCE_DIR})
+target_include_directories(abacusFirstPrinciple PUBLIC
+    ${Cereal_INCLUDE_DIRS}
+    ${Boost_INCLUDE_DIRS}
+)
 
 add_executable(${ABACUS_BIN_NAME}
     ${ABACUS_SOURCE_DIR}/main.cpp
@@ -470,13 +452,14 @@ add_executable(${ABACUS_BIN_NAME}
     $<TARGET_OBJECTS:abacusCodePdiagMr>
 )
 target_link_libraries(${ABACUS_BIN_NAME}
-    ${EXTERNAL_LIB_NAMES}
+    -lgfortran
+    -lm
+    ELPA::ELPA
+    FFTW3::FFTW3
+    ScaLAPACK::ScaLAPACK
+    BLAS::BLAS
     MPI::MPI_CXX
     OpenMP::OpenMP_CXX
-    BLAS::BLAS
     Threads::Threads
-)
-target_link_directories(${ABACUS_BIN_NAME}
-    PUBLIC ${EXTERNAL_LIB_DIRS}
 )
 

--- a/ABACUS.develop/cmake/README.md
+++ b/ABACUS.develop/cmake/README.md
@@ -9,14 +9,6 @@ mkdir build
 cd build
 
 cmake ../cmake
-
-# Or specifying installation paths of dependencies:
-# cmake ../cmake \
-#   -DCEREAL_DIR=${CEREAL_DIR} \
-#   -DELPA_DIR=${FFTW_DIR} \
-#   -DFFTW_DIR=${ELPA_DIR} \
-#   -DSCALAPACK_DIR=${SCALAPACK_DIR}
-
 make -j 16
 ```
 

--- a/ABACUS.develop/cmake/modules/FindCereal.cmake
+++ b/ABACUS.develop/cmake/modules/FindCereal.cmake
@@ -1,0 +1,22 @@
+###############################################################################
+# - Find cereal
+# Find the native cereal headers.
+#
+#  CEREAL_FOUND - True if cereal is found.
+#  CEREAL_INCLUDE_DIRS - Where to find cereal headers.
+#
+
+find_path(Cereal_INCLUDE_DIR cereal/cereal.hpp)
+
+# Handle the QUIET and REQUIRED arguments and
+# set Cereal_FOUND to TRUE if all variables are non-zero.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Cereal DEFAULT_MSG Cereal_INCLUDE_DIR)
+
+# Copy the results to the output variables and target.
+if(Cereal_FOUND)
+    set(Cereal_INCLUDE_DIRS ${Cereal_INCLUDE_DIR})
+endif()
+
+mark_as_advanced(Cereal_INCLUDE_DIR)
+

--- a/ABACUS.develop/cmake/modules/FindELPA.cmake
+++ b/ABACUS.develop/cmake/modules/FindELPA.cmake
@@ -1,0 +1,33 @@
+###############################################################################
+# - Find ELPA
+# Find the native ELPA headers and libraries.
+#
+#  ELPA_FOUND        - True if libelpa is found.
+#  ELPA_LIBRARIES    - List of libraries when using libyaml
+#  ELPA_INCLUDE_DIRS - Where to find ELPA headers.
+#
+
+find_path(ELPA_INCLUDE_DIR elpa/elpa.h)
+find_library(ELPA_LIBRARY NAMES elpa)
+
+# Handle the QUIET and REQUIRED arguments and
+# set ELPA_FOUND to TRUE if all variables are non-zero.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ELPA DEFAULT_MSG ELPA_LIBRARY ELPA_INCLUDE_DIR)
+
+# Copy the results to the output variables and target.
+if(ELPA_FOUND)
+    set(ELPA_LIBRARIES ${ELPA_LIBRARY})
+    set(ELPA_INCLUDE_DIRS ${ELPA_INCLUDE_DIR})
+
+    if(NOT TARGET ELPA::ELPA)
+        add_library(ELPA::ELPA UNKNOWN IMPORTED)
+        set_target_properties(ELPA::ELPA PROPERTIES
+           IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+           IMPORTED_LOCATION "${ELPA_LIBRARY}"
+           INTERFACE_INCLUDE_DIRECTORIES "${ELPA_INCLUDE_DIR}")
+    endif()
+endif()
+
+mark_as_advanced(ELPA_INCLUDE_DIR ELPA_LIBRARY)
+

--- a/ABACUS.develop/cmake/modules/FindFFTW3.cmake
+++ b/ABACUS.develop/cmake/modules/FindFFTW3.cmake
@@ -1,0 +1,32 @@
+# - Find FFTW3
+# Find the native double precision FFTW3 headers and libraries.
+#
+#  FFTW3_INCLUDE_DIRS  - Where to find FFTW3 headers.
+#  FFTW3_LIBRARIES     - List of libraries when using FFTW3.
+#  FFTW3_FOUND         - True if FFTW3 is found.
+#
+
+find_path(FFTW3_INCLUDE_DIR fftw3.h)
+find_library(FFTW3_LIBRARY NAMES fftw3)
+
+# Handle the QUIET and REQUIRED arguments and
+# set FFTW3_FOUND to TRUE if all variables are non-zero.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(FFTW3 DEFAULT_MSG FFTW3_LIBRARY FFTW3_INCLUDE_DIR)
+
+# Copy the results to the output variables and target.
+if(FFTW3_FOUND)
+    set(FFTW3_LIBRARIES ${FFTW3_LIBRARY})
+    set(FFTW3_INCLUDE_DIRS ${FFTW3_INCLUDE_DIR})
+
+    if(NOT TARGET FFTW3::FFTW3)
+        add_library(FFTW3::FFTW3 UNKNOWN IMPORTED)
+        set_target_properties(FFTW3::FFTW3 PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+            IMPORTED_LOCATION "${FFTW3_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${FFTW3_INCLUDE_DIRS}")
+    endif()
+endif()
+
+mark_as_advanced(FFTW3_INCLUDE_DIR FFTW3_LIBRARY)
+

--- a/ABACUS.develop/cmake/modules/FindScaLAPACK.cmake
+++ b/ABACUS.develop/cmake/modules/FindScaLAPACK.cmake
@@ -1,0 +1,28 @@
+# - Find ScaLAPACK
+# Find the native double precision ScaLAPACK headers and libraries.
+#
+#  ScaLAPACK_LIBRARIES     - List of libraries when using ScaLAPACK.
+#  ScaLAPACK_FOUND         - True if ScaLAPACK is found.
+#
+
+find_library(ScaLAPACK_LIBRARY NAMES scalapack)
+
+# Handle the QUIET and REQUIRED arguments and
+# set ScaLAPACK_FOUND to TRUE if all variables are non-zero.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ScaLAPACK DEFAULT_MSG ScaLAPACK_LIBRARY)
+
+# Copy the results to the output variables and target.
+if(ScaLAPACK_FOUND)
+    set(ScaLAPACK_LIBRARIES ${ScaLAPACK_LIBRARY})
+
+    if(NOT TARGET ScaLAPACK::ScaLAPACK)
+        add_library(ScaLAPACK::ScaLAPACK UNKNOWN IMPORTED)
+        set_target_properties(ScaLAPACK::ScaLAPACK PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+            IMPORTED_LOCATION "${ScaLAPACK_LIBRARY}")
+    endif()
+endif()
+
+mark_as_advanced(ScaLAPACK_LIBRARY)
+


### PR DESCRIPTION
In response to #50, this version automatically searchs dependencies from system default include/library paths.
Below is possible log when executing `cmake ../cmake`.
```text
-- The CXX compiler identification is GNU 8.3.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Boost: /usr/include (found version "1.67.0")
-- Found Cereal: /usr/local/include
-- Looking for sgemm_
-- Looking for sgemm_ - not found
-- Looking for C++ include pthread.h
-- Looking for C++ include pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
-- Looking for sgemm_
-- Looking for sgemm_ - found
-- Found BLAS: /usr/local/lib/libopenblas.so
-- Found ELPA: /usr/local/lib/libelpa.so
-- Found ScaLAPACK: /usr/local/lib/libscalapack.a
-- Found FFTW3: /usr/local/lib/libfftw3.a
-- Found MPI_CXX: /usr/lib/x86_64-linux-gnu/libmpichcxx.so (found version "3.1")
-- Found MPI: TRUE (found version "3.1")
-- Found OpenMP_CXX: -fopenmp (found version "4.5")
-- Found OpenMP: TRUE (found version "4.5")
-- Configuring done
-- Generating done
-- Build files have been written to: /root/abacus-develop/ABACUS.develop/build
```