### PR TITLE
[reconstruction] Support installation in CMake.

### DIFF
--- a/ABACUS.develop/cmake/CMakeLists.txt
+++ b/ABACUS.develop/cmake/CMakeLists.txt
@@ -463,3 +463,8 @@ target_link_libraries(${ABACUS_BIN_NAME}
     Threads::Threads
 )
 
+install(PROGRAMS ${ABACUS_BIN_NAME}
+    TYPE BIN
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    RENAME ${PROJECT_NAME}
+)

--- a/ABACUS.develop/cmake/README.md
+++ b/ABACUS.develop/cmake/README.md
@@ -10,7 +10,9 @@ cd build
 
 cmake ../cmake
 make -j 16
+
+# By default, the binary will be copied to `/usr/local/bin/ABACUS`
+make install
 ```
 
 Then, the binary `ABACUS-${PROJECT_VERSION}` is generated in your working directory.
-


### PR DESCRIPTION
In response to #50, we allow to install ABACUS binary using CMake.
Possible log is shown as below:
```text
Install the project...
-- Install configuration: ""
-- Installing: /usr/local/bin/ABACUS
```