### PR TITLE
bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ We also provide many examples in the directories examples/ and tests/
 
 # For developers
 
-We also provide some [information](doc/developer.md) for developers.
-- [Build and install ABACUS with CMake](doc/developer.md#build-and-install-abacus-with-cmake)
-- [Raising issues on GitHub](doc/developer.md#raising-issues-on-github)
-- [Modularization and module tests](doc/developer.md#modularization-and-module-tests)
-- [Contributing to ABACUS](doc/developer.md#contributing-to-abacus)
+We also provide some [information](doc/developers.md) for developers.
+- [Build and install ABACUS with CMake](doc/developers.md#build-and-install-abacus-with-cmake)
+- [Raising issues on GitHub](doc/developers.md#raising-issues-on-github)
+- [Modularization and module tests](doc/developers.md#modularization-and-module-tests)
+- [Contributing to ABACUS](doc/developers.md#contributing-to-abacus)
 
 [back to top](#readme-top)

--- a/source/src_io/wf_local.cpp
+++ b/source/src_io/wf_local.cpp
@@ -452,12 +452,18 @@ void WF_Local::distri_lowf_new(double **ctot, const int &is)
 //2.2 copy from ctot to work, then bcast work
 			info=CTOT2q(myid, naroc, nb, ParaO.dim0, ParaO.dim1, iprow, ipcol, work, ctot);
 			info=MPI_Bcast(work, maxnloc, MPI_DOUBLE, 0, ParaO.comm_2D);
-			ofs_running << "iprow, ipcow : " << iprow << ipcol << endl;
-			for (int i=0; i<maxnloc; ++i)
+			//ofs_running << "iprow, ipcow : " << iprow << ipcol << endl;
+			//for (int i=0; i<maxnloc; ++i)
+			//{
+				//ofs_running << *(work+i)<<" ";
+			//}
+			//ofs_running << endl;
+//2.3 copy from work to wfc_gamma
+			const int inc=1;
+			if(myid==src_rank)
 			{
-				ofs_running << *(work+i)<<" ";
+				LapackConnector::copy(ParaO.nloc, work, inc, LOC.wfc_dm_2d.wfc_gamma[is].c, inc);
 			}
-			ofs_running << endl;
 		}//loop ipcol
 	}//loop	iprow
 

--- a/source/src_io/wf_local.h
+++ b/source/src_io/wf_local.h
@@ -12,7 +12,7 @@ namespace WF_Local
 	void distri_lowf(double** ctot, double **c);
 	void distri_lowf_complex(complex<double>** ctot, complex<double> **cc);
 
-	void distri_lowf_new(double** ctot);
+	void distri_lowf_new(double** ctot, const int &is);
 
 	void distri_lowf_aug(double** ctot, double **c_aug);
 	void distri_lowf_aug_complex(complex<double>** ctot, complex<double> **c_aug);

--- a/source/src_io/wf_local.h
+++ b/source/src_io/wf_local.h
@@ -12,10 +12,12 @@ namespace WF_Local
 	void distri_lowf(double** ctot, double **c);
 	void distri_lowf_complex(complex<double>** ctot, complex<double> **cc);
 
+	void distri_lowf_new(double** ctot);
+
 	void distri_lowf_aug(double** ctot, double **c_aug);
 	void distri_lowf_aug_complex(complex<double>** ctot, complex<double> **c_aug);
 
-	int read_lowf(double **c);
+	int read_lowf(double **c, const int &is);
 
 	int read_lowf_complex(complex<double> **c, const int &ik);
 }

--- a/source/src_lcao/local_orbital_charge.h
+++ b/source/src_lcao/local_orbital_charge.h
@@ -23,6 +23,7 @@ class Local_Orbital_Charge
 	//-----------------
 	void allocate_gamma(const Grid_Technique &gt);
 
+	void gamma_file(const Grid_Technique &gt);
 
 
 	//-----------------


### PR DESCRIPTION
out_lowf:

previously the array ctot(nbands*nlocal) is set to 0 for every iteration of ipcol and iprow, so when multiple processors are used, all values in blocks are 0 except for the ones stored on the last (ipcol, iprow)
I moved the allocation, printing and deallocation of ctot to outside the double loop (ipcol, iprow)