### PR TITLE
Fix symmetry_rho constant definitions.

### DIFF
--- a/source/module_symmetry/symmetry_rho.cpp
+++ b/source/module_symmetry/symmetry_rho.cpp
@@ -11,7 +11,7 @@ Symmetry_rho::~Symmetry_rho()
 
 }
 
-void Symmetry_rho::begin(const int &spin_now, const Charge_Broyden &CHR, const PW_Basis &pw, const Parallel_Grid &Pgrid, const Symmetry &symm) const
+void Symmetry_rho::begin(const int &spin_now, const Charge_Broyden &CHR, const PW_Basis &pw, Parallel_Grid &Pgrid, Symmetry &symm) const
 {
 	assert(spin_now < 4);//added by zhengdy-soc
 
@@ -26,14 +26,14 @@ void Symmetry_rho::begin(const int &spin_now, const Charge_Broyden &CHR, const P
 	return;
 }
 
-void Symmetry_rho::psymm(double* rho_part, const PW_Basis &pw, const Parallel_Grid &Pgrid, const Symmetry &symm) const
+void Symmetry_rho::psymm(double* rho_part, const PW_Basis &pw, Parallel_Grid &Pgrid, Symmetry &symm) const
 {
 #ifdef __MPI
 	// (1) reduce all rho from the first pool.
 	double* rhotot = new double[pw.ncxyz];
 	ZEROS(rhotot, pw.ncxyz);
 	Pgrid.reduce_to_fullrho(rhotot, rho_part);
-	
+
 	// (2)
 	if(RANK_IN_POOL==0)
 	{
@@ -56,7 +56,7 @@ void Symmetry_rho::psymm(double* rho_part, const PW_Basis &pw, const Parallel_Gr
 		}
 		*/
 	}
-	
+
 	// (3)
 	const int ncxy = pw.ncx * pw.ncy;
 	double* zpiece = new double[ncxy];
@@ -78,7 +78,7 @@ void Symmetry_rho::psymm(double* rho_part, const PW_Basis &pw, const Parallel_Gr
 		}
 		Pgrid.zpiece_to_all(zpiece,iz, rho_part);
 	}
-						
+
 	delete[] rhotot;
 	delete[] zpiece;
 #endif

--- a/source/module_symmetry/symmetry_rho.h
+++ b/source/module_symmetry/symmetry_rho.h
@@ -11,13 +11,13 @@ class Symmetry_rho
 	public:
 	Symmetry_rho();
 	~Symmetry_rho();
-	
-	void begin(const int &spin_now, const Charge_Broyden &CHR, const PW_Basis &pw, const Parallel_Grid &Pgrid, const Symmetry &symm) const;
+
+	void begin(const int &spin_now, const Charge_Broyden &CHR, const PW_Basis &pw, Parallel_Grid &Pgrid, Symmetry &symm) const;
 
 	private:
 
-	void psymm(double *rho_part, const PW_Basis &pw, const Parallel_Grid &Pgrid, const Symmetry &symm) const;
-	
+	void psymm(double *rho_part, const PW_Basis &pw, Parallel_Grid &Pgrid, Symmetry &symm) const;
+
 };
 
 #endif


### PR DESCRIPTION
Parameters Pgrid and symm modified in Symmetry_rho::begin and Symmetry_rho::psymm, they may not be set as const.