### PR TITLE
Autotest.sh ignore tiny numerical error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.PAT }}
           ec2-image-id: ami-07758124f42f794bf
-          ec2-instance-type: c5.4xlarge
+          ec2-instance-type: c5.xlarge
           subnet-id: subnet-f7edb991
           security-group-id: sg-fd5185e7
   test:

--- a/tests/integrate/Autotest.sh
+++ b/tests/integrate/Autotest.sh
@@ -9,7 +9,7 @@ threshold=0.0000001
 # check accuracy
 ca=8
 # regex of case name
-case="^[^#].*01_PW_.*$"
+case="^[^#].*_PW_.*$"
 # enable AddressSanitizer
 sanitize=false
 

--- a/tests/integrate/Autotest.sh
+++ b/tests/integrate/Autotest.sh
@@ -105,7 +105,7 @@ check_out(){
 				if [ $(echo "sqrt($deviation*$deviation) < $fatal_threshold"|bc) = 0 ]; then
 					let fatal++
 					echo -e "\e[1;31m [  FAILED  ] \e[0m"\
-						"An unacceptble deviation occurs."
+						"An unacceptable deviation occurs."
 				fi
 				break
 			else


### PR DESCRIPTION
In some certain cases, abacus failes to output result. This should be treated as failing to pass the test. 
However, in most common cases, the result error is slightly above threshold. This might be errors introduced by various of math libs. Currently we focus on a proper developing pipeline, and later deciding which result is canonical. 
Now, Autotest.sh will treat the former cases as 'fatal error', and exit with code 1. For the latter cases, the test script will raise a failed prompt, but will exit normally.