### PR TITLE
Update CMakeLists for compatiability in testing flag.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ project(ABACUS
 
 option(ENABLE_DEEPKS "Enable DeePKS functionality" OFF)
 option(ENABLE_ASAN "Enable AddressSanitizer" OFF)
-option(BUILD_UNIT_TESTS "Build ABACUS unit tests" ON)
+option(BUILD_TESTING "Build ABACUS unit tests" ON)
 option(GENERATE_TEST_REPORTS "Enable test report generation" OFF)
 
 if(ENABLE_DEEPKS)
@@ -167,7 +167,8 @@ install(PROGRAMS ${ABACUS_BIN_PATH}
     #DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
+include(CTest)
 enable_testing()
-IF (BUILD_UNIT_TESTS)
+IF (BUILD_TESTING)
   add_subdirectory(tests)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,5 +39,3 @@ AddTest(
   TARGET base_blas_connector
   SOURCES ${ABACUS_TEST_DIR}/module_base/blas_connector.cpp
 )
-
-# gtest_discover_tests(base_matrix3)


### PR DESCRIPTION
Use BUILD_TESTING instead of BUILD_UNIT_TESTS as an commonly used expression.