### PR TITLE
Fix #265

### DIFF
--- a/source/src_pw/stress_func_print.cpp
+++ b/source/src_pw/stress_func_print.cpp
@@ -79,7 +79,7 @@ void Stress_Func::printstress_total(const matrix& scs, bool ry)
 
  	if(GlobalV::TEST_STRESS) 
 	{
-		std::cout << std::setiosflags(ios::fixed) << std::setprecision(6);
+		std::cout << std::fixed << std::setprecision(6);
 		std::cout << std::setiosflags(ios::showpos);
 		std::cout << " ------------------- TOTAL      STRESS --------------------" << std::endl;
     	std::cout << " " << std::setw(8) << "STRESS" << std::endl;


### PR DESCRIPTION
Fix an incorrect ofstream use.
See [fmtflags](https://www.cplusplus.com/reference/ios/ios_base/fmtflags/).
Now will output as expected:
------------------- TOTAL      STRESS --------------------
 STRESS
 -3501.861528   -0.000000      -0.000000
 -0.000000      -3501.861528   -0.000000
 -0.000000      +0.000000      -3501.861528