### PR TITLE
Fix warnings raised by icpc.

### DIFF
--- a/source/input.cpp
+++ b/source/input.cpp
@@ -2365,13 +2365,12 @@ void Input::Bcast()
 void Input::Check(void)
 {
     TITLE("Input","Check");
-/*
-	// Move checks on single value to read_value part, respectively.
+
 	if(nbands < 0) WARNING_QUIT("Input","NBANDS must > 0");
 //	if(nbands_istate < 0) WARNING_QUIT("Input","NBANDS_ISTATE must > 0");
 	if(nb2d < 0) WARNING_QUIT("Input","nb2d must > 0");
-	if(ntype < 0) WARNING_QUIT("Input","ntype must > 0");
- */
+	if(ntype <= 0) WARNING_QUIT("Input","ntype must > 0");
+
 	//std::cout << "diago_proc=" << diago_proc << std::endl;
 	//std::cout << " NPROC=" << GlobalV::NPROC << std::endl;
 	if(diago_proc<=0)

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -14,14 +14,14 @@
 
 Input INPUT;
 
-Input::Input() 
+Input::Input()
 {
 	angle1 = new double[1];
 	angle2 = new double[1];
-// all values set in Default	
+// all values set in Default
 }
 
-Input::~Input() 
+Input::~Input()
 {
 	delete[] angle1;
 	delete[] angle2;
@@ -33,7 +33,7 @@ void Input::Init(const std::string &fn)
     this->Default();
 
     bool success = this->Read(fn);
-	this->Default_2();			   
+	this->Default_2();
 
 //xiaohui add 2015-09-16
 #ifdef __MPI
@@ -73,7 +73,7 @@ void Input::Init(const std::string &fn)
 	GlobalV::ofs_running << "                                                                                     " << std::endl;
 
 	GlobalV::ofs_running << std::setiosflags(ios::right);
-                                                                                                                             
+
 
 #ifdef __MPI
 	//GlobalV::ofs_running << "    Version: Parallel, under ALPHA test" << std::endl;
@@ -161,7 +161,7 @@ void Input::Default(void)
     //local_basis=0; xiaohui modify 2013-09-01
     //linear_scaling=false; xiaohui modify 2013-09-01
 	basis_type = "pw"; //xiaohui add 2013-09-01
-	ks_solver = "default"; //xiaohui add 2013-09-01 
+	ks_solver = "default"; //xiaohui add 2013-09-01
     search_radius=-1.0; // unit: a.u. -1.0 has no meaning.
     search_pbc=true;
     symmetry=false;
@@ -273,14 +273,14 @@ void Input::Default(void)
 	dos_scale = 0.01;
     b_coef = 0.07;
 //----------------------------------------------------------
-// LCAO 
+// LCAO
 //----------------------------------------------------------
 	lcao_ecut = 0; // (Ry)
 	lcao_dk = 0.01;
 	lcao_dr = 0.01;
 	lcao_rmax = 30; // (a.u.)
 //----------------------------------------------------------
-// Selinv 
+// Selinv
 //----------------------------------------------------------
 	selinv_npole = 40;
 	selinv_temp = 2000;
@@ -290,11 +290,11 @@ void Input::Default(void)
 	selinv_threshold = 1.0e-3;
 	selinv_niter = 50;
 //----------------------------------------------------------
-// Molecular Dynamics 
+// Molecular Dynamics
 //----------------------------------------------------------
 /*
 	md_dt=20.0; //unit is 1 a.u., which is 4.8378*10e-17 s
-	md_restart=0; 
+	md_restart=0;
 	md_tolv=100.0;
 	md_thermostat="not_controlled"; //"rescaling","rescale-v","rescale-t","reduce-t"...
 	md_temp0=300; //kelvin
@@ -379,22 +379,22 @@ void Input::Default(void)
 	shift = 0.0;
 	metalcalc = false;
 	eps_degauss = 0.01;
-		
+
 	//epsilon0_choice = 0;
 
 //----------------------------------------------------------
 // exx										//Peize Lin add 2018-06-20
-//----------------------------------------------------------		
+//----------------------------------------------------------
 	exx_hybrid_type = "no";
 
 	exx_hybrid_alpha = 0.25;
 	exx_hse_omega = 0.11;
-		
+
 	exx_separate_loop = true;
 	exx_hybrid_step = 100;
-		
+
 	exx_lambda = 0.3;
-		
+
 	exx_pca_threshold = 0;
 	exx_c_threshold = 0;
 	exx_v_threshold = 0;
@@ -403,9 +403,9 @@ void Input::Default(void)
 	exx_cauchy_threshold = 0;
 	exx_ccp_threshold = 1E-8;
 	exx_ccp_rmesh_times = 10;
-		
+
 	exx_distribute_type = "htime";
-		
+
 	exx_opt_orb_lmax = 0;
 	exx_opt_orb_ecut = 0.0;
 	exx_opt_orb_tolerence = 0.0;
@@ -432,13 +432,13 @@ void Input::Default(void)
 	td_val_elec_03=1;
 	td_vext=0;
 	td_vext_dire=1;
-	
+
 	td_timescale = 0.5;
 	td_vexttype = 1;
 	td_vextout = 0;
 	td_dipoleout =0;
 
-	
+
 //----------------------------------------------------------			//Fuxiang He add 2016-10-26
 // constrained DFT
 //----------------------------------------------------------
@@ -471,7 +471,7 @@ void Input::Default(void)
 //==========================================================
     dft_plus_u = false;                    // 1:DFT+U correction; 0：standard DFT calcullation
 	yukawa_potential = false;
-	double_counting = 1; 
+	double_counting = 1;
 	omc = false;
 	dftu_type = 2;
 
@@ -486,7 +486,7 @@ bool Input::Read(const std::string &fn)
 
     std::ifstream ifs(fn.c_str(), ios::in);	// "in_datas/input_parameters"
 
-    if (!ifs) 
+    if (!ifs)
 	{
 		std::cout << " Can't find the INPUT file." << std::endl;
 		return false;
@@ -558,11 +558,11 @@ bool Input::Read(const std::string &fn)
         {
             read_value(ifs, latname);
         }
-		else if (strcmp("pseudo_rcut", word) == 0)// 
+		else if (strcmp("pseudo_rcut", word) == 0)//
         {
             read_value(ifs, pseudo_rcut);
         }
-		else if (strcmp("renormwithmesh", word) == 0)// 
+		else if (strcmp("renormwithmesh", word) == 0)//
 		{
             read_value(ifs, renormwithmesh);
         }
@@ -1055,7 +1055,7 @@ bool Input::Read(const std::string &fn)
         {
             read_value(ifs, out_band);
         }
-        
+
         else if (strcmp("out_hs", word) == 0)
         {
             read_value(ifs, out_hs);
@@ -1327,7 +1327,7 @@ bool Input::Read(const std::string &fn)
 	    else if (strcmp("vdwd2_d", word) == 0)
 	    {
 	        read_value(ifs, vdwD2_d);
-	    }		
+	    }
 	    else if (strcmp("vdwd2_c6_file", word) == 0)
 	    {
 	        read_value(ifs, vdwD2_C6_file);
@@ -1388,7 +1388,7 @@ bool Input::Read(const std::string &fn)
 		else if (strcmp("vdw_d", word) == 0)
         {
             read_value(ifs, vdw_d);
-        }	
+        }
         else if (strcmp("vdw_abc", word) == 0)
         {
             read_value(ifs, vdw_abc);
@@ -1400,7 +1400,7 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("vdw_radius_unit", word) == 0)
         {
             read_value(ifs, vdw_radius_unit);
-        }	
+        }
         else if (strcmp("vdw_cn_thr", word) == 0)
         {
             read_value(ifs, vdw_cn_thr);
@@ -1408,7 +1408,7 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("vdw_cn_thr_unit", word) == 0)
         {
             read_value(ifs, vdw_cn_thr_unit);
-        }		
+        }
         else if (strcmp("vdw_c6_file", word) == 0)
         {
             read_value(ifs, vdw_C6_file);
@@ -1436,7 +1436,7 @@ bool Input::Read(const std::string &fn)
         }
 //--------------------------------------------------------
 // restart           Peize Lin 2020-04-04
-//--------------------------------------------------------		
+//--------------------------------------------------------
         else if (strcmp("restart_save", word) == 0)
         {
             read_value(ifs, restart_save);
@@ -1507,7 +1507,7 @@ bool Input::Read(const std::string &fn)
 	    else if (strcmp("q_direction", word) == 0)
 	    {
 			ifs >> q_direct[0]; ifs >> q_direct[1]; read_value(ifs, q_direct[2]);
-	    }				
+	    }
 	    //else if (strcmp("start_q", word) == 0)
 	    //{
 	    //    read_value(ifs, start_q);
@@ -1568,7 +1568,7 @@ bool Input::Read(const std::string &fn)
         // {
              // for(int i=0; i<(ocp_n-1); i++)
              // {
-                 // ifs >> GlobalV::ocp_kb[i]; 
+                 // ifs >> GlobalV::ocp_kb[i];
              // }
 			// read_value(ifs, GlobalV::ocp_kb[ocp_n-1]);
         // }
@@ -1600,7 +1600,7 @@ bool Input::Read(const std::string &fn)
 	    else if (strcmp("metalcalc", word) == 0)
 	    {
 	        read_value(ifs, metalcalc);
-	    }	
+	    }
 	    else if (strcmp("eps_degauss", word) == 0)
 	    {
 	        read_value(ifs, eps_degauss);
@@ -1608,7 +1608,7 @@ bool Input::Read(const std::string &fn)
 	    //else if (strcmp("epsilon0_choice", word) == 0)
 	    //{
 	    //    read_value(ifs, epsilon0_choice);
-	    //}					
+	    //}
 //----------------------------------------------------------
 // exx
 // Peize Lin add 2018-06-20
@@ -1616,59 +1616,59 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("exx_hybrid_type", word) == 0)
         {
             read_value(ifs, exx_hybrid_type);
-        }		
+        }
         else if (strcmp("exx_hybrid_alpha", word) == 0)
         {
             read_value(ifs, exx_hybrid_alpha);
-        }		
+        }
         else if (strcmp("exx_hse_omega", word) == 0)
         {
             read_value(ifs, exx_hse_omega);
-        }		
+        }
         else if (strcmp("exx_separate_loop", word) == 0)
         {
             read_value(ifs, exx_separate_loop);
-        }		
+        }
         else if (strcmp("exx_hybrid_step", word) == 0)
         {
             read_value(ifs, exx_hybrid_step);
-        }		
+        }
         else if (strcmp("exx_lambda", word) == 0)
         {
             read_value(ifs, exx_lambda);
-        }		
+        }
         else if (strcmp("exx_pca_threshold", word) == 0)
         {
             read_value(ifs, exx_pca_threshold);
-        }		
+        }
         else if (strcmp("exx_c_threshold", word) == 0)
         {
             read_value(ifs, exx_c_threshold);
-        }			
+        }
         else if (strcmp("exx_v_threshold", word) == 0)
         {
             read_value(ifs, exx_v_threshold);
-        }			
+        }
         else if (strcmp("exx_dm_threshold", word) == 0)
         {
             read_value(ifs, exx_dm_threshold);
-        }		
+        }
         else if (strcmp("exx_schwarz_threshold", word) == 0)
         {
             read_value(ifs, exx_schwarz_threshold);
-        }		
+        }
         else if (strcmp("exx_cauchy_threshold", word) == 0)
         {
             read_value(ifs, exx_cauchy_threshold);
-        }		
+        }
         else if (strcmp("exx_ccp_threshold", word) == 0)
         {
             read_value(ifs, exx_ccp_threshold);
-        }		
+        }
         else if (strcmp("exx_ccp_rmesh_times", word) == 0)
         {
             read_value(ifs, exx_ccp_rmesh_times);
-        }		
+        }
         else if (strcmp("exx_distribute_type", word) == 0)
         {
             read_value(ifs, exx_distribute_type);
@@ -1728,7 +1728,7 @@ bool Input::Read(const std::string &fn)
         //else if (strcmp("epsilon0_choice", word) == 0)
         //{
         //    read_value(ifs, epsilon0_choice);
-        //}					
+        //}
 		else if (strcmp("cell_factor", word) == 0)
 		{
 			read_value(ifs, cell_factor);
@@ -1743,7 +1743,7 @@ bool Input::Read(const std::string &fn)
 		}
 //----------------------------------------------------------------------------------
 //         Xin Qu added on 2020-10-29 for DFT+U
-//----------------------------------------------------------------------------------		
+//----------------------------------------------------------------------------------
 		else if(strcmp("dft_plus_u",word)==0)
 		{
 			ifs >> dft_plus_u;
@@ -1792,7 +1792,7 @@ bool Input::Read(const std::string &fn)
         else if (ifs.fail() != 0)
         {
 			std::cout << " word = " << word << std::endl;
-			std::cout << " Fail to read parameters. " << std::endl; 
+			std::cout << " Fail to read parameters. " << std::endl;
             ifs.clear();
 			return false;
         }
@@ -1807,43 +1807,43 @@ bool Input::Read(const std::string &fn)
 //----------------------------------------------------------
     hubbard_u= new double [ntype];
 	for(int i=0; i<ntype; i++)
-	{						
-		hubbard_u[i] = 0.0;				
+	{
+		hubbard_u[i] = 0.0;
 	}
 
-	hund_j= new double [ntype];	
+	hund_j= new double [ntype];
 	for(int i=0; i<ntype; i++)
-	{						
-		hund_j[i] = 0.0;				
+	{
+		hund_j[i] = 0.0;
 	}
 
 	orbital_corr= new int [ntype];
 	for(int i=0; i<ntype; i++)
-	{						
-		orbital_corr[i] = -1;				
+	{
+		orbital_corr[i] = -1;
 	}
 
 	if(dft_plus_u)
 	{
 		ifs.clear();
     	ifs.seekg(0);  //move to the beginning of the file
-    	ifs.rdstate(); 
+    	ifs.rdstate();
     	while (ifs.good())
     	{
   			ifs >> word1;
   			strtolower(word1, word);     //convert uppercase std::string to lower case; word1 --> word
-	
+
 			if(strcmp("dftu_type",word)==0)
-			{	
-				ifs >> dftu_type;								
+			{
+				ifs >> dftu_type;
 			}
 			else if(strcmp("yukawa_potential", word)==0)
 			{
 				ifs >> yukawa_potential;
-			} 
+			}
 			else if (strcmp("yukawa_lambda",word)==0)
-			{							
-				ifs >> yukawa_lambda;			
+			{
+				ifs >> yukawa_lambda;
 			}
 			else if(strcmp("double_counting",word)==0)
 			{
@@ -1852,25 +1852,25 @@ bool Input::Read(const std::string &fn)
 			else if(strcmp("hubbard_u",word)==0)
 			{
 				for(int i=0; i<ntype; i++)
-				{		
-					ifs >> hubbard_u[i];				
-					hubbard_u[i] /= Ry_to_eV;				
+				{
+					ifs >> hubbard_u[i];
+					hubbard_u[i] /= Ry_to_eV;
 				}
-			} 
+			}
 			else if (strcmp("hund_j",word)==0)
 			{
 				for(int i=0;i<ntype;i++)
-				{			
+				{
 					ifs >> hund_j[i];
-					hund_j[i] /= Ry_to_eV;				
-				}		
+					hund_j[i] /= Ry_to_eV;
+				}
 			}
 			else if(strcmp("orbital_corr", word)==0)
 			{
 				for(int i=0;i<ntype;i++)
-				{			
-					ifs >> orbital_corr[i];								
-				}		
+				{
+					ifs >> orbital_corr[i];
+				}
 			}
 			else if(strcmp("omc",word)==0)
 			{
@@ -1884,11 +1884,11 @@ bool Input::Read(const std::string &fn)
 			if (ifs.eof() != 0)
   			{
 				break;
-  			}       
+  			}
 		}
-		
+
 		for(int i=0; i<ntype; i++)
-		{		
+		{
 
 			if(hubbard_u[i]<-1.0e-3)
 			{
@@ -1909,7 +1909,7 @@ bool Input::Read(const std::string &fn)
 			}
 		}
 
-		dft_plus_u = 0;		
+		dft_plus_u = 0;
 		for(int i=0; i<ntype; i++)
 		{
 			if(orbital_corr[i] != -1) dft_plus_u = 1;
@@ -1928,7 +1928,7 @@ bool Input::Read(const std::string &fn)
 		}
 
 	}
-	
+
 	if (basis_type == "pw")  // pengfei Li add 2015-1-31
 	{
 		gamma_only = 0;
@@ -2004,7 +2004,7 @@ void Input::Default_2(void)          //jiyy add 2019-08-04
 			vdw_radius="95";
 		}
 	}
-}		  
+}
 #ifdef __MPI
 void Input::Bcast()
 {
@@ -2144,7 +2144,7 @@ void Input::Bcast()
     Parallel_Common::bcast_int( lmax_descriptor ); // mohan modified 2021-01-03
     Parallel_Common::bcast_int( deepks_scf ); // caoyu add 2021-06-02
 	Parallel_Common::bcast_string( model_file ); //  caoyu add 2021-06-03
-	
+
 	Parallel_Common::bcast_int(out_potential);
     Parallel_Common::bcast_bool( out_wf );
 	Parallel_Common::bcast_int( out_dos );
@@ -2306,20 +2306,20 @@ void Input::Bcast()
 	Parallel_Common::bcast_double( eps_degauss );
 
 	// Peize Lin add 2018-06-20
-	Parallel_Common::bcast_string( exx_hybrid_type );		
-	Parallel_Common::bcast_double( exx_hybrid_alpha );		
-	Parallel_Common::bcast_double( exx_hse_omega );		
-	Parallel_Common::bcast_bool( exx_separate_loop );		
-	Parallel_Common::bcast_int( exx_hybrid_step );		
-	Parallel_Common::bcast_double( exx_lambda );		
-	Parallel_Common::bcast_double( exx_pca_threshold );		
-	Parallel_Common::bcast_double( exx_c_threshold );		
-	Parallel_Common::bcast_double( exx_v_threshold );		
-	Parallel_Common::bcast_double( exx_dm_threshold );		
-	Parallel_Common::bcast_double( exx_schwarz_threshold );		
-	Parallel_Common::bcast_double( exx_cauchy_threshold );		
-	Parallel_Common::bcast_double( exx_ccp_threshold );		
-	Parallel_Common::bcast_double( exx_ccp_rmesh_times );		
+	Parallel_Common::bcast_string( exx_hybrid_type );
+	Parallel_Common::bcast_double( exx_hybrid_alpha );
+	Parallel_Common::bcast_double( exx_hse_omega );
+	Parallel_Common::bcast_bool( exx_separate_loop );
+	Parallel_Common::bcast_int( exx_hybrid_step );
+	Parallel_Common::bcast_double( exx_lambda );
+	Parallel_Common::bcast_double( exx_pca_threshold );
+	Parallel_Common::bcast_double( exx_c_threshold );
+	Parallel_Common::bcast_double( exx_v_threshold );
+	Parallel_Common::bcast_double( exx_dm_threshold );
+	Parallel_Common::bcast_double( exx_schwarz_threshold );
+	Parallel_Common::bcast_double( exx_cauchy_threshold );
+	Parallel_Common::bcast_double( exx_ccp_threshold );
+	Parallel_Common::bcast_double( exx_ccp_rmesh_times );
 	Parallel_Common::bcast_string( exx_distribute_type );
 	Parallel_Common::bcast_int( exx_opt_orb_lmax );
 	Parallel_Common::bcast_double( exx_opt_orb_ecut );
@@ -2356,7 +2356,7 @@ void Input::Bcast()
 			Parallel_Common::bcast_double(angle2[i]);
 		}
 	}
-	
+
 		//Parallel_Common::bcast_int( epsilon0_choice );
     Parallel_Common::bcast_double( cell_factor); //LiuXh add 20180619
     Parallel_Common::bcast_int( new_dm ); // Shen Yu add 2019/5/9
@@ -2378,7 +2378,7 @@ void Input::Bcast()
 		hund_j = new double [this->ntype];
 		orbital_corr = new int [this->ntype];
 	}
-	
+
 	for(int i =0; i<this->ntype; i++)
 	{
 		Parallel_Common::bcast_double(hubbard_u[i]);
@@ -2416,7 +2416,7 @@ void Input::Check(void)
 	//if(basis_type=="pw" && ks_solver=="lapack") xiaohui modify 2013-09-04 //xiaohui add 2013-09-01
 	//{
 	//	WARNING_QUIT("Input","lapack can not be used in plane wave basis.");
-	//} xiaohui modify 2013-09-04	
+	//} xiaohui modify 2013-09-04
 
 	//xiaohui move 4 lines, 2015-09-30
 	//if(symmetry)
@@ -2477,7 +2477,7 @@ void Input::Check(void)
 /*
 		if(!noncolin)
         	force = 1;
-		else 
+		else
 		{
 			force = 0;//modified by zhengdy-soc, can't calculate force now!
 			std::cout<<"sorry, can't calculate force with soc now, would be implement in next version!"<<std::endl;
@@ -2506,10 +2506,10 @@ void Input::Check(void)
 
     else if (calculation == "nscf")
     {
-		GlobalV::CALCULATION == "nscf";
+		GlobalV::CALCULATION = "nscf";
         nstep = 1;
 		out_stru = 0;
-        
+
 		//if (local_basis == 0 && linear_scaling == 0) xiaohui modify 2013-09-01
 		if (basis_type == "pw") //xiaohui add 2013-09-01. Attention! maybe there is some problem
 		{
@@ -2537,7 +2537,7 @@ void Input::Check(void)
                 out_band = 0;
 		force=0;
 		start_wfc = "file";
-		start_pot = "atomic"; // useless, 
+		start_pot = "atomic"; // useless,
 		charge_extrap = "atomic"; //xiaohui modify 2015-02-01
 		out_charge = 1; // this leads to the calculation of state charge.
 		out_dm = 0;
@@ -2567,11 +2567,11 @@ void Input::Check(void)
 		if(basis_type == "pw") //xiaohui add 2013-09-01
 		{
 			WARNING_QUIT("Input::Check","calculate = istate is only availble for LCAO.");
-		}	
+		}
 	}
 	else if(calculation == "md") // mohan add 2011-11-04
 	{
-		GlobalV::CALCULATION = "md"; 
+		GlobalV::CALCULATION = "md";
 		symmetry = false;
 		force = 1;
         if(!out_md_control) out_level = "m";//zhengdy add 2019-04-07
@@ -2616,7 +2616,7 @@ void Input::Check(void)
     {
         WARNING_QUIT("Input","wrong 'start_pot',not 'atomic', 'file',please check");
     }
-	//xiaohui modify 2014-05-10, extra_pot value changes to 0~7	
+	//xiaohui modify 2014-05-10, extra_pot value changes to 0~7
 	//if (extra_pot <0 ||extra_pot > 7)
 	//{
 	//	WARNING_QUIT("Input","wrong 'extra_pot',neither 0~7.");
@@ -2675,7 +2675,7 @@ void Input::Check(void)
     {
         WARNING_QUIT("Input","nspin out of range!");
     }
-	
+
 
 	if(basis_type=="pw") //xiaohui add 2013-09-01
 	{
@@ -2694,11 +2694,11 @@ void Input::Check(void)
 		}
 		else if(ks_solver=="genelpa") //yshen add 2016-07-20
 		{
-			WARNING_QUIT("Input","genelpa can not be used with plane wave basis."); 
+			WARNING_QUIT("Input","genelpa can not be used with plane wave basis.");
 		}
 		else if(ks_solver=="scalapack_gvx") //Peize Lin add 2020.11.14
 		{
-			WARNING_QUIT("Input","scalapack_gvx can not be used with plane wave basis."); 
+			WARNING_QUIT("Input","scalapack_gvx can not be used with plane wave basis.");
 		}
 		else if(ks_solver=="hpseps")
 		{
@@ -2756,7 +2756,7 @@ void Input::Check(void)
 			else if (ks_solver == "lapack")
 			{
 #ifdef __MPI
-				WARNING_QUIT("Input","ks_solver=lapack is not an option for parallel version of ABACUS (try hpseps).");	
+				WARNING_QUIT("Input","ks_solver=lapack is not an option for parallel version of ABACUS (try hpseps).");
 #else
 				GlobalV::ofs_warning << " It's ok to use lapack." << std::endl;
 #endif
@@ -2859,18 +2859,18 @@ void Input::Check(void)
 	else if(bz>10)
 	{
 		WARNING_QUIT("Input","bz is too large!");
-	}	
+	}
 
 	if(basis_type=="lcao")
 	{
-		if(lcao_ecut == 0) 
+		if(lcao_ecut == 0)
 		{
-			lcao_ecut = ecutwfc; 
+			lcao_ecut = ecutwfc;
 			AUTO_SET("lcao_ecut",ecutwfc);
 		}
 	}
 
-	
+
 	// jiyy add 2019-08-04
 	if(vdw_method=="d2" || vdw_method=="d3_0" || vdw_method=="d3_bj")
 	{
@@ -2907,7 +2907,7 @@ void Input::Check(void)
 			WARNING_QUIT("Input","vdw_cn_thr_unit must be A or Bohr");
 		}
 	}
-	
+
 	if(spectral_type!="None" && spectral_type!="eels" && spectral_type!="absorption")
 	{
 		WARNING_QUIT("INPUT","spectral_type must be eels or absorption !");
@@ -2931,7 +2931,7 @@ void Input::Check(void)
 		if( q_direct[0] == 0 && q_direct[1] == 0 && q_direct[2] == 0)
 		{
 			WARNING_QUIT("INPUT","You must choose a direction!");
-		}		
+		}
 		//if( oband > nbands)
 		//{
 		//	WARNING_QUIT("INPUT","oband must <= nbands");
@@ -2939,13 +2939,13 @@ void Input::Check(void)
         //        if( oband == 1)
         //        {
         //            oband = nbands;
-        //        }		
+        //        }
 	}
 
-	if(exx_hybrid_type!="no" && 
-		exx_hybrid_type!="hf" && 
-		exx_hybrid_type!="pbe0" && 
-		exx_hybrid_type!="hse" && 
+	if(exx_hybrid_type!="no" &&
+		exx_hybrid_type!="hf" &&
+		exx_hybrid_type!="pbe0" &&
+		exx_hybrid_type!="hse" &&
 		exx_hybrid_type!="opt_orb")
 	{
 		WARNING_QUIT("INPUT","exx_hybrid_type must be no or hf or pbe0 or hse or opt_orb");
@@ -2965,9 +2965,9 @@ void Input::Check(void)
 		{
 			WARNING_QUIT("INPUT","must exx_ccp_rmesh_times >= 1");
 		}
-		if(exx_distribute_type!="htime" 
-			&& exx_distribute_type!="kmeans2" 
-			&& exx_distribute_type!="kmeans1" 
+		if(exx_distribute_type!="htime"
+			&& exx_distribute_type!="kmeans2"
+			&& exx_distribute_type!="kmeans1"
 			&& exx_distribute_type!="order")
 		{
 			WARNING_QUIT("INPUT","exx_distribute_type must be htime or kmeans2 or kmeans1");
@@ -2994,7 +2994,7 @@ void Input::Check(void)
 	{
 		WARNING("Input","To use pulay-kerker mixing method, please set mixing_type=pulay-kerker");
 	}
-	
+
 	if(berry_phase)
 	{
 		if(basis_type == "pw")
@@ -3011,13 +3011,13 @@ void Input::Check(void)
 		{
 			WARNING_QUIT("Input","calculate berry phase, please set basis_type = pw or lcao");
 		}
-		
+
 		if( !(gdir==1||gdir==2||gdir==3) )
 		{
 			WARNING_QUIT("Input","calculate berry phase, please set gdir = 1 or 2 or 3");
 		}
 	}
-	
+
 	if(towannier90)
 	{
 		if(basis_type == "pw" || basis_type == "lcao")
@@ -3029,7 +3029,7 @@ void Input::Check(void)
 		{
 			WARNING_QUIT("Input","to use towannier90, please set basis_type = pw or lcao");
 		}
-		
+
 		if(nspin == 2)
 		{
 			if( !(wannier_spin=="up"||wannier_spin=="down") )
@@ -3052,13 +3052,13 @@ void Input::Check(void)
 	{
 		GlobalV::global_readin_dir = read_file_dir + '/';
 	}
-	
+
     return;
 }
 
 void Input::close_log(void)const
 {
-	
+
     Global_File::close_all_log(GlobalV::MY_RANK, this->out_alllog);
 }
 
@@ -3089,4 +3089,3 @@ void Input::strtolower(char *sa, char *sb)
     }
     sb[len] = '\0';
 }
-

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -15,12 +15,6 @@
 
 Input INPUT;
 
-Input::Input()
-{
-	vector<double> angle1, angle2;
-	// all values set in Default
-}
-
 void Input::Init(const std::string &fn)
 {
 	timer::tick("Input","Init");

--- a/source/input.h
+++ b/source/input.h
@@ -4,6 +4,7 @@
 #include "module_base/vector3.h"
 #include <fstream>
 #include <string>
+#include <vector>
 #include "module_md/MD_parameters.h"
 
 using namespace std;
@@ -11,7 +12,7 @@ using namespace std;
 class Input
 {
 	public:
-    
+
 	Input();
     ~Input();
 
@@ -22,7 +23,7 @@ class Input
 	void close_log(void)const;
 
 //==========================================================
-// directories of files 
+// directories of files
 //==========================================================
 
     std::string suffix;			// suffix of out put dir
@@ -60,7 +61,7 @@ class Input
 	int gdir;               // berry phase calculation
 
 //==========================================================
-// Wannier functions 
+// Wannier functions
 //==========================================================
 	bool towannier90;       // add by jingan for wannier90
 	std::string NNKP;            // add by jingan for wannier90
@@ -69,7 +70,7 @@ class Input
 	bool mlwf_flag; 		// add by mohan
 
 //==========================================================
-// E field 
+// E field
 //==========================================================
     int efield;				// add electrical field
 	int edir;
@@ -78,7 +79,7 @@ class Input
 	double eamp;
 
 //==========================================================
-// Optical properties 
+// Optical properties
 //==========================================================
 	bool opt_epsilon2;		// true : calculate the dielectric functions
 	int  opt_nbands;		// number of bands for optical transition matrix
@@ -94,13 +95,13 @@ class Input
     double tot_magnetization;
 
 //==========================================================
-// LCAO parameters 
+// LCAO parameters
 //==========================================================
 	std::string basis_type; 			//xiaohui add 2013-09-01, for structural adjustment
 	std::string ks_solver; 			//xiaohui add 2013-09-01
 
 //==========================================================
-// Forces 
+// Forces
 //==========================================================
     int force;
     bool force_set;
@@ -108,7 +109,7 @@ class Input
 	double force_thr_ev2;	// invalid force threshold, mohan add 2011-04-17
 
 //==========================================================
-// Stress 
+// Stress
 //==========================================================
     double stress_thr;      // Pengfei Li 2017-11-01 //LiuXh update 20180515
     double press1;
@@ -121,7 +122,7 @@ class Input
 
     double cg_threshold;    // threshold when cg to bfgs, pengfei add 2011-08-15
 
-	double bfgs_w1;			// wolfe condition 1	
+	double bfgs_w1;			// wolfe condition 1
 	double bfgs_w2;			// wolfe condition 2
 
 	double trust_radius_max;	// trust radius max
@@ -139,10 +140,10 @@ class Input
 
     int ncx,ncy,ncz;		// three dimension of FFT charge/grid
     int nx,ny,nz;			// three dimension of FFT wavefunc
-	int bx,by,bz;			// big mesh ball. mohan add 2011-04-21 
+	int bx,by,bz;			// big mesh ball. mohan add 2011-04-21
 
 //==========================================================
-// technique 
+// technique
 //==========================================================
 	int diago_proc;			// the number of procs used to diag. mohan add 2012-01-13
     int diago_cg_maxiter;
@@ -231,7 +232,7 @@ class Input
 
 //==========================================================
 // two center integrals in LCAO
-// mohan add 2009-11-11 
+// mohan add 2009-11-11
 //==========================================================
 	double lcao_ecut;		// ecut of two center integral
 	double lcao_dk;			// delta k used in two center integral
@@ -242,7 +243,7 @@ class Input
 
 
 //==========================================================
-// selected inversion method 
+// selected inversion method
 //==========================================================
 	// selinv method parameter (cooperate with LinLin)
 	int selinv_npole;
@@ -254,7 +255,7 @@ class Input
 	int selinv_niter;
 
 //==========================================================
-// molecular dynamics 
+// molecular dynamics
 // added by Daye Zheng
 //==========================================================
 /*    int md_mdtype;                   //choose ensemble
@@ -282,11 +283,11 @@ class Input
 // vdw
 // Peize Lin add 2014-03-31, jiyy update 2019-08-01
 //==========================================================
-    std::string vdw_method;          //the method of vdw calculation                 
-    std::string vdw_s6;              //scale parameter 
-	std::string vdw_s8;              //scale parameter 
-	std::string vdw_a1;             //damping function parameter 
-	std::string vdw_a2;             //damping function parameter 
+    std::string vdw_method;          //the method of vdw calculation
+    std::string vdw_s6;              //scale parameter
+	std::string vdw_s8;              //scale parameter
+	std::string vdw_a1;             //damping function parameter
+	std::string vdw_a2;             //damping function parameter
 	double vdw_d;               //damping function parameter d
 	bool vdw_abc;               //third-order term?
     std::string vdw_radius;          //cutoff radius for std::pair interactions
@@ -303,7 +304,7 @@ class Input
 //==========================================================
 // Spectrum
 // pengfei Li add 2016-11-23
-//==========================================================    
+//==========================================================
 	//bool     epsilon;               // calculate epsilon or not
 	std::string   spectral_type;          // the type of the calculated spectrum
 	int      spectral_method;        // 0: tddft(linear response)
@@ -315,8 +316,8 @@ class Input
 	double  eta;                   // unit(Ry)
 	double  domega;                // unit(Ry)
 	int     nomega;
-	int     ecut_chi;                   // the dimension of G 
-	//int     oband;                 // the number of "occupied" bands  
+	int     ecut_chi;                   // the dimension of G
+	//int     oband;                 // the number of "occupied" bands
 	double  q_start[3];            // the position of the first q point in direct coordinate
 	double  q_direct[3];             // the q direction
 	//int     start_q;               // the serial number of the start qpoint
@@ -335,7 +336,7 @@ class Input
 	double   eps_degauss;            // degauss
 	//int	epsilon0_choice;             // 0: vasp's method  1: pwscf's method
 	bool     kmesh_interpolation;          // calculting <i,0|j,R>
-	double  qcar[100][3];          // the Cartesian position of q points(unit: 2*PI/lat0) 
+	double  qcar[100][3];          // the Cartesian position of q points(unit: 2*PI/lat0)
 	int ocp;
 	//int ocp_n;
 	std::string ocp_set;
@@ -348,24 +349,23 @@ class Input
 	double soc_lambda;
 
 	//	bool starting_spin_angle;
-	double *angle1;
-	double *angle2;
-		
+	vector<double> angle1, angle2;
+
 
 //==========================================================
 // exx
 // Peize Lin add 2018-06-20
-//==========================================================		
+//==========================================================
 	std::string exx_hybrid_type;		// "no", "hf", "pbe0", "hse"
 
 	double exx_hybrid_alpha;
 	double exx_hse_omega;
-	
+
 	bool exx_separate_loop;		// 0 or 1
 	int exx_hybrid_step;
-	
+
 	double exx_lambda;
-	
+
 	double exx_pca_threshold;
 	double exx_c_threshold;
 	double exx_v_threshold;
@@ -374,13 +374,13 @@ class Input
 	double exx_cauchy_threshold;
 	double exx_ccp_threshold;
 	double exx_ccp_rmesh_times;
-	
+
 	std::string exx_distribute_type;
-	
+
 	int exx_opt_orb_lmax;
 	double exx_opt_orb_ecut;
 	double exx_opt_orb_tolerence;
-	
+
 //==========================================================
 // tddft
 // Fuxiang He add 2016-10-26
@@ -400,7 +400,7 @@ class Input
 	int td_dipoleout;			// output the dipole or not
 
 
-	
+
 //==========================================================
 // restart
 // Peize Lin add 2020-04-04
@@ -410,12 +410,12 @@ class Input
 	//xiaohui add 2015-09-16
 	bool input_error;
     double cell_factor; //LiuXh add 20180619
-	
+
 //==========================================================
 // new DM algorithm test
 // add by Shen Yu @ 2019/5/9
 // newDM values:
-//  0: not use new DM algorithm; 
+//  0: not use new DM algorithm;
 //  1: use new DM algorithm and show no debug information
 //  2: use new DM algorithm and only show key debug information
 //  3: use new DM algorithm and show all detail debug information
@@ -425,10 +425,10 @@ class Input
 //==========================================================
 //    DFT+U       Xin Qu added on 2020-10-29
 //==========================================================
-    bool dft_plus_u;                //true:DFT+U correction; false：standard DFT calcullation(default)	
+    bool dft_plus_u;                //true:DFT+U correction; false：standard DFT calcullation(default)
 	int *orbital_corr;              // which correlated orbitals need corrected ; d:2 ,f:3, do not need correction:-1
     double *hubbard_u;              //Hubbard Coulomb interaction parameter U(ev)
-	double *hund_j;                 //Hund exchange parameter J(ev) 	
+	double *hund_j;                 //Hund exchange parameter J(ev)
 	bool omc;                       //whether turn on occupation matrix control method or not
 	bool yukawa_potential;          //default:false
 	double yukawa_lambda;            //default:0.0
@@ -439,7 +439,7 @@ class Input
 	int double_counting;            // 1:FLL(fully localized limit)(default); 2:AMF(around mean field)
 
 //==========================================================
-// DeepKS -- added by caoyu and mohan 
+// DeepKS -- added by caoyu and mohan
 //==========================================================
     int out_descriptor; // output descritpor for deepks. caoyu added 2020-11-24, mohan modified 2021-01-03
 	int lmax_descriptor; // lmax used in descriptor, mohan added 2021-01-03
@@ -450,7 +450,7 @@ class Input
 // variables for test only
 //==========================================================
 	bool test_just_neighbor;
-	
+
 	private:
 
 //==========================================================
@@ -467,7 +467,7 @@ class Input
 
     void Default(void);
 
-	void Default_2(void);    //jiyy add 2019-08-04											  
+	void Default_2(void);    //jiyy add 2019-08-04
 
     void Check(void);
 

--- a/source/input.h
+++ b/source/input.h
@@ -346,7 +346,7 @@ class Input
 	double soc_lambda;
 
 	//	bool starting_spin_angle;
-	vector<double> angle1, angle2;
+	vector<double> angle1={0}, angle2={0};
 
 
 //==========================================================

--- a/source/input.h
+++ b/source/input.h
@@ -13,9 +13,6 @@ class Input
 {
 	public:
 
-	Input();
-    ~Input();
-
     void Init(const std::string &fn);
 
     void Print(const std::string &fn)const;

--- a/source/input_conv.cpp
+++ b/source/input_conv.cpp
@@ -21,7 +21,7 @@
 #include "src_lcao/FORCE_STRESS.h"
 #include "src_lcao/local_orbital_charge.h"
 #include "src_lcao/ELEC_evolve.h"
-#endif 
+#endif
 
 void Input_Conv::Convert(void)
 {
@@ -36,7 +36,7 @@ void Input_Conv::Convert(void)
     if(INPUT.kpoint_file!= "") GlobalV::global_kpoint_card = INPUT.kpoint_file;
     if(INPUT.pseudo_dir != "") GlobalV::global_pseudo_dir = INPUT.pseudo_dir + "/";
     GlobalV::global_pseudo_type = INPUT.pseudo_type;
-	GlobalC::ucell.latName = INPUT.latname; 
+	GlobalC::ucell.latName = INPUT.latname;
 	GlobalC::ucell.ntype = INPUT.ntype;
 	GlobalC::ucell.lmaxmax = INPUT.lmaxmax;
 	GlobalC::ucell.set_vel = INPUT.set_vel;
@@ -46,7 +46,7 @@ void Input_Conv::Convert(void)
 	GlobalV::NPOOL = INPUT.npool;
 	GlobalV::CALCULATION = INPUT.calculation;
 
-	GlobalV::PSEUDORCUT = INPUT.pseudo_rcut; 
+	GlobalV::PSEUDORCUT = INPUT.pseudo_rcut;
     GlobalV::RENORMWITHMESH = INPUT.renormwithmesh;
 
 	// qianrui add 2021-2-5
@@ -65,8 +65,8 @@ void Input_Conv::Convert(void)
 	Efield::eamp = INPUT.eamp;
 
 	// optical
-	Optical::opt_epsilon2=INPUT.opt_epsilon2;	// mohan add 2010-03-24	
-	Optical::opt_nbands=INPUT.opt_nbands;		// number of bands for optical transition.	
+	Optical::opt_epsilon2=INPUT.opt_epsilon2;	// mohan add 2010-03-24
+	Optical::opt_nbands=INPUT.opt_nbands;		// number of bands for optical transition.
 
 	GlobalV::DFT_FUNCTIONAL = INPUT.dft_functional;
     GlobalV::NSPIN = INPUT.nspin;
@@ -198,14 +198,14 @@ void Input_Conv::Convert(void)
 	GlobalC::wf.mem_saver = INPUT.mem_saver; //mohan add 2010-09-07
 	GlobalC::en.printe    = INPUT.printe; // mohan add 2011-03-16
 
-    
+
 //----------------------------------------------------------
 // about spectrum, pengfei 2016-12-14
 //----------------------------------------------------------
 #ifdef __LCAO
-	if( (INPUT.spectral_type == "eels" && INPUT.eels_method == 0) 
-		|| (INPUT.spectral_type == "None" 
-		&& INPUT.eels_method == 0 
+	if( (INPUT.spectral_type == "eels" && INPUT.eels_method == 0)
+		|| (INPUT.spectral_type == "None"
+		&& INPUT.eels_method == 0
 		&& INPUT.kmesh_interpolation) )
 	{
 		if(INPUT.spectral_type == "eels")
@@ -222,15 +222,15 @@ void Input_Conv::Convert(void)
 		GlobalC::chi0_hilbert.eta = INPUT.eta;
 		GlobalC::chi0_hilbert.domega = INPUT.domega;
 		GlobalC::chi0_hilbert.nomega = INPUT.nomega;
-		GlobalC::chi0_hilbert.dim = INPUT.ecut_chi; 
+		GlobalC::chi0_hilbert.dim = INPUT.ecut_chi;
 		//GlobalC::chi0_hilbert.oband = INPUT.oband;
 
-		GlobalC::chi0_hilbert.q_start[0] = INPUT.q_start[0];  
-		GlobalC::chi0_hilbert.q_start[1] = INPUT.q_start[1]; 
+		GlobalC::chi0_hilbert.q_start[0] = INPUT.q_start[0];
+		GlobalC::chi0_hilbert.q_start[1] = INPUT.q_start[1];
 		GlobalC::chi0_hilbert.q_start[2] = INPUT.q_start[2];
 
-		GlobalC::chi0_hilbert.direct[0] = INPUT.q_direct[0]; 
-		GlobalC::chi0_hilbert.direct[1] = INPUT.q_direct[1]; 
+		GlobalC::chi0_hilbert.direct[0] = INPUT.q_direct[0];
+		GlobalC::chi0_hilbert.direct[1] = INPUT.q_direct[1];
 		GlobalC::chi0_hilbert.direct[2] = INPUT.q_direct[2];
 
 		//GlobalC::chi0_hilbert.start_q = INPUT.start_q;
@@ -244,16 +244,16 @@ void Input_Conv::Convert(void)
 		GlobalC::chi0_hilbert.kmesh_interpolation = INPUT.kmesh_interpolation;
 		for(int i=0; i<100; i++)
 		{
-			GlobalC::chi0_hilbert.qcar[i][0] = INPUT.qcar[i][0]; 
-			GlobalC::chi0_hilbert.qcar[i][1] = INPUT.qcar[i][1]; 
-			GlobalC::chi0_hilbert.qcar[i][2] = INPUT.qcar[i][2]; 
+			GlobalC::chi0_hilbert.qcar[i][0] = INPUT.qcar[i][0];
+			GlobalC::chi0_hilbert.qcar[i][1] = INPUT.qcar[i][1];
+			GlobalC::chi0_hilbert.qcar[i][2] = INPUT.qcar[i][2];
 		}
-		GlobalC::chi0_hilbert.lcao_box[0] = INPUT.lcao_box[0]; 
-		GlobalC::chi0_hilbert.lcao_box[1] = INPUT.lcao_box[1]; 
+		GlobalC::chi0_hilbert.lcao_box[0] = INPUT.lcao_box[0];
+		GlobalC::chi0_hilbert.lcao_box[1] = INPUT.lcao_box[1];
 		GlobalC::chi0_hilbert.lcao_box[2] = INPUT.lcao_box[2];
 	}
 #endif
-	
+
 	//if( INPUT.epsilon && (INPUT.epsilon_choice == 1))
 	if( INPUT.spectral_type == "eels" && INPUT.eels_method == 1)
 	{
@@ -265,18 +265,18 @@ void Input_Conv::Convert(void)
 		GlobalC::chi0_standard.nomega = INPUT.nomega;
 		GlobalC::chi0_standard.dim = INPUT.ecut_chi;
 		//GlobalC::chi0_standard.oband = INPUT.oband;
-		GlobalC::chi0_standard.q_start[0] = INPUT.q_start[0]; 
-	 	GlobalC::chi0_standard.q_start[1] = INPUT.q_start[1]; 
+		GlobalC::chi0_standard.q_start[0] = INPUT.q_start[0];
+	 	GlobalC::chi0_standard.q_start[1] = INPUT.q_start[1];
 		GlobalC::chi0_standard.q_start[2] = INPUT.q_start[2];
-		GlobalC::chi0_standard.direct[0] = INPUT.q_direct[0];  
-		GlobalC::chi0_standard.direct[1] = INPUT.q_direct[1]; 
+		GlobalC::chi0_standard.direct[0] = INPUT.q_direct[0];
+		GlobalC::chi0_standard.direct[1] = INPUT.q_direct[1];
 		GlobalC::chi0_standard.direct[2] = INPUT.q_direct[2];
 		//GlobalC::chi0_standard.start_q = INPUT.start_q;
 		//GlobalC::chi0_standard.interval_q = INPUT.interval_q;
 		GlobalC::chi0_standard.nq = INPUT.nq;
-		GlobalC::chi0_standard.out_epsilon = INPUT.out_epsilon;		
+		GlobalC::chi0_standard.out_epsilon = INPUT.out_epsilon;
 	}
-	
+
 	//if( INPUT.epsilon0 && (INPUT.epsilon0_choice == 1) )
 	if( INPUT.spectral_type == "absorption" && INPUT.absorption_method == 1)
 	{
@@ -290,7 +290,7 @@ void Input_Conv::Convert(void)
 		GlobalC::epsilon0_pwscf.metalcalc = INPUT.metalcalc;
 		GlobalC::epsilon0_pwscf.degauss = INPUT.eps_degauss;
 	}
-	
+
 	//if( INPUT.epsilon0 && (INPUT.epsilon0_choice == 0))
 	if( INPUT.spectral_type == "absorption" && INPUT.absorption_method == 0)
 	{
@@ -304,7 +304,7 @@ void Input_Conv::Convert(void)
 //--------------------------------------------
 // added by zhengdy-soc
 //--------------------------------------------
-	if(INPUT.noncolin||INPUT.lspinorb) 
+	if(INPUT.noncolin||INPUT.lspinorb)
 	{
 		GlobalV::NSPIN = 4;
 	}
@@ -331,10 +331,10 @@ void Input_Conv::Convert(void)
 		GlobalC::ucell.magnet.m_loc_ = new Vector3<double> [INPUT.ntype];
 		GlobalC::ucell.magnet.angle1_ = new double[INPUT.ntype];
 		GlobalC::ucell.magnet.angle2_ = new double[INPUT.ntype];
-		for(int i = 0;i<INPUT.ntype;i++)
+		for (int i = 0; i < INPUT.ntype; i++)
 		{
-			GlobalC::ucell.magnet.angle1_[i] = INPUT.angle1[i]/180*PI;
-			GlobalC::ucell.magnet.angle2_[i] = INPUT.angle2[i]/180*PI;
+			GlobalC::ucell.magnet.angle1_[i] = INPUT.angle1[i] / 180 * PI;
+			GlobalC::ucell.magnet.angle2_[i] = INPUT.angle2[i] / 180 * PI;
 		}
 #ifdef __MPI
 //			Parallel_Common::bcast_double(GlobalC::ucell.magnet.angle1_[i]);
@@ -350,7 +350,7 @@ void Input_Conv::Convert(void)
 		GlobalV::DOMAG_Z = false;
 		GlobalV::NPOL = 1;
 	}
-	
+
 //----------------------------------------------------------
 // Fuxiang He add 2016-10-26
 //----------------------------------------------------------
@@ -363,7 +363,7 @@ void Input_Conv::Convert(void)
 	ELEC_evolve::td_val_elec_02 = INPUT.td_val_elec_02;
 	ELEC_evolve::td_val_elec_03 = INPUT.td_val_elec_03;
 	ELEC_evolve::td_vext = INPUT.td_vext;
-	ELEC_evolve::td_vext_dire = INPUT.td_vext_dire;	
+	ELEC_evolve::td_vext_dire = INPUT.td_vext_dire;
 	ELEC_evolve::td_timescale = INPUT.td_timescale;
 	ELEC_evolve::td_vexttype = INPUT.td_vexttype;
 	ELEC_evolve::td_vextout = INPUT.td_vextout;
@@ -372,7 +372,7 @@ void Input_Conv::Convert(void)
 
 
 
-	// jiyy add 2020.10.11	
+	// jiyy add 2020.10.11
 	GlobalV::ocp = INPUT.ocp;
      //ocp_n = INPUT.ocp_n;
     GlobalV::ocp_set = INPUT.ocp_set;
@@ -388,7 +388,7 @@ void Input_Conv::Convert(void)
 		while(std::string::npos != pos2)
 		{
 			str.push_back(GlobalV::ocp_set.substr(pos1, pos2-pos1));
- 
+
 			pos1 = pos2 + c.size();
 			pos2 = GlobalV::ocp_set.find(c, pos1);
 		}
@@ -403,7 +403,7 @@ void Input_Conv::Convert(void)
 		const size_t nmatch=1;
 		for(int i=0; i<str.size(); ++i)
 		{
-			if(str[i] == "") 
+			if(str[i] == "")
 			{
 				continue;
 			}
@@ -435,12 +435,12 @@ void Input_Conv::Convert(void)
 			}
 		}
 	}
-		
+
     GlobalV::mulliken = INPUT.mulliken;//qifeng add 2019/9/10
 
 //----------------------------------------------------------
 // about restart, // Peize Lin add 2020-04-04
-//----------------------------------------------------------	
+//----------------------------------------------------------
 	if(INPUT.restart_save)
 	{
 		GlobalC::restart.folder = GlobalV::global_out_dir + "restart/";
@@ -473,7 +473,7 @@ void Input_Conv::Convert(void)
 
 //----------------------------------------------------------
 // about exx, Peize Lin add 2018-06-20
-//----------------------------------------------------------	
+//----------------------------------------------------------
 #ifdef __LCAO
 	if(INPUT.exx_hybrid_type=="no")
 	{
@@ -549,11 +549,11 @@ void Input_Conv::Convert(void)
 //----------------------------------------------------------
 // charge mixing(3/3)
 //----------------------------------------------------------
-    GlobalC::CHR.set_mixing(INPUT.mixing_mode, INPUT.mixing_beta, 
+    GlobalC::CHR.set_mixing(INPUT.mixing_mode, INPUT.mixing_beta,
 	INPUT.mixing_ndim, INPUT.mixing_gg0); //mohan modify 2014-09-27, add mixing_gg0
 
 //----------------------------------------------------------
-// iteration 
+// iteration
 //----------------------------------------------------------
     GlobalV::NITER = INPUT.niter;
     GlobalV::NSTEP = INPUT.nstep;
@@ -589,7 +589,7 @@ void Input_Conv::Convert(void)
 //	ORB.ecutwfc = INPUT.lcao_ecut;
 //	ORB.dk = INPUT.lcao_dk;
 //	ORB.dR = INPUT.lcao_dr;
-//	ORB.Rmax = INPUT.lcao_rmax; 
+//	ORB.Rmax = INPUT.lcao_rmax;
 
 	// mohan add 2021-02-16
 	berryphase::berry_phase_flag = INPUT.berry_phase;
@@ -607,4 +607,3 @@ void Input_Conv::Convert(void)
 	timer::tick("Input_Conv","Convert");
     return;
 }
-

--- a/source/module_base/math_sphbes.cpp
+++ b/source/module_base/math_sphbes.cpp
@@ -35,7 +35,7 @@ void Sphbes::BESSJY(double x, double xnu, double *rj, double *ry, double *rjp, d
     isign = 1;
     h = xnu * xi;
 
-    if (h < FPMIN) 
+    if (h < FPMIN)
 	{
 		h = FPMIN;
 	}
@@ -68,7 +68,7 @@ void Sphbes::BESSJY(double x, double xnu, double *rj, double *ry, double *rjp, d
         if (fabs(del - 1.0) < EPS) break;
     }
 
-    if (i > MAXIT) 
+    if (i > MAXIT)
 	{
 		std::cout << "x too large in bessjy; try asymptotic expansion" << std::endl;
 	}
@@ -91,7 +91,7 @@ void Sphbes::BESSJY(double x, double xnu, double *rj, double *ry, double *rjp, d
         rjl = rjtemp;
     }
 
-    if (rjl == 0.0) 
+    if (rjl == 0.0)
 	{
 		rjl = EPS;
 	}
@@ -270,7 +270,7 @@ double Sphbes::CHEBEV(double a, double b, double c[], int m, double x)
 	double y2 = 0.0;
     int j=0;
 
-    if ((x - a)*(x - b) > 0.0) 
+    if ((x - a)*(x - b) > 0.0)
 	{
 		std::cout << "x not in range in routine chebev" << std::endl;
 	}
@@ -309,7 +309,7 @@ double Sphbes::Spherical_Bessel_7(const int n, const double &x)
     // call BESSSJY
     BESSJY(x, order, &rj, &ry, &rjp, &ryp);
 
-    const int RTPIO2=1.2533141;
+    const double RTPIO2=1.2533141;
 
     const double factor = RTPIO2 / sqrt(x);
 
@@ -327,13 +327,13 @@ void Sphbes::Spherical_Bessel_Roots
 )
 {
     //TITLE("Sphbes","Spherical_Bessel_Roots");
-    if (num<=0) 
+    if (num<=0)
 	{
 		std::cout << "Spherical_Bessel_Roots, num<=0" << std::endl;
 		//WARNING_QUIT("Sphbes::Spherical_Bessel_Roots","num<=0");
 		exit(0);
 	}
-    if (rcut<=0.0) 
+    if (rcut<=0.0)
 	{
 		std::cout << "Spherical_Bessel_Roots, rcut<=0" << std::endl;
 		//WARNING_QUIT("Sphbes::Spherical_Bessel_Roots","rcut<=0.0");
@@ -597,7 +597,7 @@ void Sphbes::Spherical_Bessel
 
 
 void Sphbes::Spherical_Bessel
-(           
+(
 	const int &msh, //number of grid points
 	const double *r,//radial grid
 	const double &q,    //
@@ -610,7 +610,7 @@ void Sphbes::Spherical_Bessel
 
 	//calculate jlx first
 	Spherical_Bessel (msh, r, q, l, sj);
-	
+
 	for (int ir = 0; ir < msh; ir++)
 	{
 		sjp[ir] = 1.0;

--- a/source/module_base/matrix_wrapper.h
+++ b/source/module_base/matrix_wrapper.h
@@ -17,11 +17,11 @@
 class Matrix_Wrapper
 {
 public:
-	double *c;
 	int nr;
 	int nc;
+	double *c;
 	bool flag_delete_c;
-	
+
 	Matrix_Wrapper(): nr(0), nc(0), c(nullptr), flag_delete_c(false){}
 	Matrix_Wrapper( const matrix &m ): nr(m.nr), nc(m.nc), c(m.c), flag_delete_c(false){}
 	inline void create( const int nr_in, const int nc_in, const bool flag_zero );
@@ -62,8 +62,8 @@ inline Matrix_Wrapper::Matrix_Wrapper( Matrix_Wrapper &&m )
 	 c(m.c),
 	 flag_delete_c(m.flag_delete_c)
 {
-	m.nr = m.nc = 0; 
-	m.c = nullptr; 
+	m.nr = m.nc = 0;
+	m.c = nullptr;
 	m.flag_delete_c = false;
 }
 

--- a/source/module_base/sph_bessel.cpp
+++ b/source/module_base/sph_bessel.cpp
@@ -214,7 +214,7 @@ double Sph_Bessel::jlx7(const int &n, const double &x)
     }
 	order = n + 0.5;
 	BESSJY(x, order, &rj, &ry, &rjp, &ryp);
-	int RTPIO2=1.2533141;
+	double RTPIO2=1.2533141;
 	const double factor = RTPIO2 / sqrt(x);
 	return factor*rj;
 }
@@ -226,7 +226,7 @@ void Sph_Bessel::BESSJY(double x, double xnu, double *rj, double *ry, double *rj
 		   fact3,ff,gam,gam1,gam2,gammi,gampl,h,p,pimu,pimu2,q,r,rjl,
 		   rjl1,rjmu,rjp1,rjpl,rjtemp,ry1,rymu,rymup,rytemp,sum,sum1,
 		   temp,w,x2,xi,xi2,xmu,xmu2;
-	if (x <= 0.0 || xnu < 0.0) 
+	if (x <= 0.0 || xnu < 0.0)
 	{
 		std::cout << "Sph_Bessel::BESSJY, bad arguments in bessjy" << std::endl;
 		//WARNING_QUIT("Sph_Bessel::BESSJY","bad arguments in bessjy");
@@ -237,8 +237,8 @@ void Sph_Bessel::BESSJY(double x, double xnu, double *rj, double *ry, double *rj
 	xmu2=xmu*xmu;
 	xi=1.0/x;
 	xi2=2.0*xi;
-	w=xi2/pi; 
-	isign=1; 
+	w=xi2/pi;
+	isign=1;
 	h=xnu*xi;
 	if (h < fpmin) h=fpmin;
 	b=xi2*xnu;
@@ -256,13 +256,13 @@ void Sph_Bessel::BESSJY(double x, double xnu, double *rj, double *ry, double *rj
 		if (d < 0.0) isign = -isign;
 		if (fabs(del-1.0) < eps) break;
 	}
-	if (i > maxit) 
+	if (i > maxit)
 	{
 		std::cout << "Sph_Bessel::BESSJY, x too large in bessjy; try asymptotic expansion" << std::endl;
 		//WARNING_QUIT("Sph_Bessel::BESSJY","x too large in bessjy; try asymptotic expansion");
 		exit(0);
 	}
-	rjl=isign*fpmin; 
+	rjl=isign*fpmin;
 	rjpl=h*rjl;
 	rjl1=rjl;
 	rjp1=rjpl;
@@ -274,8 +274,8 @@ void Sph_Bessel::BESSJY(double x, double xnu, double *rj, double *ry, double *rj
 		rjl=rjtemp;
 	}
 	if (rjl == 0.0) rjl=eps;
-	f=rjpl/rjl; 
-	if (x < xmin) { 
+	f=rjpl/rjl;
+	if (x < xmin) {
 		x2=0.5*x;
 		pimu=pi*xmu;
 		fact = (fabs(pimu) < eps ? 1.0 : pimu/sin(pimu));
@@ -283,10 +283,10 @@ void Sph_Bessel::BESSJY(double x, double xnu, double *rj, double *ry, double *rj
 		e=xmu*d;
 		fact2 = (fabs(e) < eps ? 1.0 : sinh(e)/e);
 		this->BESCHB(xmu,&gam1,&gam2,&gampl,&gammi);
-		ff=2.0/pi*fact*(gam1*cosh(e)+gam2*fact2*d); 
+		ff=2.0/pi*fact*(gam1*cosh(e)+gam2*fact2*d);
 		e=exp(e);
-		p=e/(gampl*pi); 
-		q=1.0/(e*pi*gammi); 
+		p=e/(gampl*pi);
+		q=1.0/(e*pi*gammi);
 		pimu2=0.5*pimu;
 		fact3 = (fabs(pimu2) < eps ? 1.0 : sin(pimu2)/pimu2);
 		r=pi*pimu2*fact3*fact3;
@@ -305,7 +305,7 @@ void Sph_Bessel::BESSJY(double x, double xnu, double *rj, double *ry, double *rj
 			sum1 += del1;
 			if (fabs(del) < (1.0+fabs(sum))*eps) break;
 		}
-		if (i > maxit) 
+		if (i > maxit)
 		{
 			std::cout << "Sph_Bessel::BESSJY, bessy series failed to converge" << std::endl;
 			//WARNING_QUIT("Sph_Bessel::BESSJY","bessy series failed to converge");
@@ -314,7 +314,7 @@ void Sph_Bessel::BESSJY(double x, double xnu, double *rj, double *ry, double *rj
 		rymu = -sum;
 		ry1 = -sum1*xi2;
 		rymup=xmu*xi*rymu-ry1;
-		rjmu=w/(rymup-f*rymu); 
+		rjmu=w/(rymup-f*rymu);
 	} else {
 		a=0.25-xmu2;
 		p = -0.5*xi;
@@ -352,15 +352,15 @@ void Sph_Bessel::BESSJY(double x, double xnu, double *rj, double *ry, double *rj
 			p=temp;
 			if (fabs(dlr-1.0)+fabs(dli) < eps) break;
 		}
-		if (i > maxit) 
+		if (i > maxit)
 		{
 			std::cout << "Sph_Bessel::BESSJY, cf2 failed in bessjy" << std::endl;
 			//WARNING_QUIT("Sph_Bessel::BESSJY","cf2 failed in bessjy");
 			exit(0); // mohan add 2021-05-05
 		}
-		gam=(p-f)/q; 
+		gam=(p-f)/q;
 		rjmu=sqrt(w/((p-f)*gam+q));
-		
+
 		//rjmu=SIGN(rjmu,rjl);
 		if (rjl >=0 ) rjmu = fabs(rjmu);
 		else rjmu = -fabs(rjmu);
@@ -370,16 +370,16 @@ void Sph_Bessel::BESSJY(double x, double xnu, double *rj, double *ry, double *rj
 		ry1=xmu*xi*rymu-rymup;
 	}
 	fact=rjmu/rjl;
-	*rj=rjl1*fact; 		
+	*rj=rjl1*fact;
 	*rjp=rjp1*fact;
-	for (i=1;i<=nl;i++) { 
+	for (i=1;i<=nl;i++) {
 		rytemp=(xmu+i)*xi2*ry1-rymu;
 		rymu=ry1;
 		ry1=rytemp;
 	}
 	*ry=rymu;
 	*ryp=xnu*xi*rymu-ry1;
-}	
+}
 
 int Sph_Bessel::IMAX(int a, int b)
 {
@@ -399,8 +399,8 @@ void Sph_Bessel::BESCHB(double x, double *gam1, double *gam2, double *gampl, dou
                              1.2719271366546e-3, -4.9717367042e-6, -3.31261198e-8,
                              2.423096e-10, -1.702e-13, -1.49e-15
                          };
-    xx = 8.0 * x * x - 1.0; 
-	//Multiply x by 2 to make range be .1 to 1,and then 
+    xx = 8.0 * x * x - 1.0;
+	//Multiply x by 2 to make range be .1 to 1,and then
 	// apply transformation for evaluating even Chebyshev series.
     *gam1 = CHEBEV(-1.0, 1.0, c1, NUSE1, xx);
     *gam2 = CHEBEV(-1.0, 1.0, c2, NUSE2, xx);

--- a/source/src_lcao/ELEC_evolve.cpp
+++ b/source/src_lcao/ELEC_evolve.cpp
@@ -25,8 +25,8 @@ int ELEC_evolve::td_dipoleout;
 
 // this routine only serves for TDDFT using LCAO basis set
 void ELEC_evolve::evolve_psi(
-	const int &istep, 
-	LCAO_Hamilt &uhm, 
+	const int &istep,
+	LCAO_Hamilt &uhm,
 	std::complex<double> ***wfc)
 {
 	TITLE("ELEC_evolve","eveolve_psi");
@@ -35,15 +35,15 @@ void ELEC_evolve::evolve_psi(
 	int start_spin = -1;
 	uhm.GK.reset_spin(start_spin);
 	uhm.GK.allocate_pvpR();
-						
+
 	// pool parallization in future -- mohan note 2021-02-09
 	for(int ik=0; ik<GlobalC::kv.nks; ik++)
-	{	
+	{
 		//-----------------------------------------
 		//(1) prepare data for this k point.
 		// copy the local potential from array.
 		//-----------------------------------------
-		if(GlobalV::NSPIN==2) 
+		if(GlobalV::NSPIN==2)
 		{
 			GlobalV::CURRENT_SPIN = GlobalC::kv.isk[ik];
 		}
@@ -53,9 +53,9 @@ void ELEC_evolve::evolve_psi(
 		{
 			GlobalC::pot.vr_eff1[ir] = GlobalC::pot.vr_eff( GlobalV::CURRENT_SPIN, ir);
 		}
-		
+
 		//--------------------------------------------
-		//(2) check if we need to calculate 
+		//(2) check if we need to calculate
 		// pvpR = < phi0 | v(spin) | phiR> for a new spin.
 		//--------------------------------------------
 		if(GlobalV::CURRENT_SPIN == uhm.GK.get_spin() )
@@ -90,7 +90,7 @@ void ELEC_evolve::evolve_psi(
     	}
 
 		//--------------------------------------------
-		// (3) folding matrix, 
+		// (3) folding matrix,
 		// and diagonalize the H matrix (T+Vl+Vnl).
 		//--------------------------------------------
 
@@ -102,9 +102,9 @@ void ELEC_evolve::evolve_psi(
 		{
       std::vector<std::complex<double>> eff_pot(GlobalC::ParaO.nloc);
 			GlobalC::dftu.cal_eff_pot_mat_complex(ik, istep, &eff_pot[0]);
-      
+
 			for(int irc=0; irc<GlobalC::ParaO.nloc; irc++)
-				GlobalC::LM.Hloc2[irc] += eff_pot[irc];					
+				GlobalC::LM.Hloc2[irc] += eff_pot[irc];
 		}
 
 		// Peize Lin add at 2020.04.04
@@ -112,14 +112,14 @@ void ELEC_evolve::evolve_psi(
 		{
 			GlobalC::restart.load_disk("H", ik);
 			GlobalC::restart.info_load.load_H_finish = true;
-		}			
+		}
 		if(GlobalC::restart.info_save.save_H)
 		{
 			GlobalC::restart.save_disk("H", ik);
 		}
 
 		bool diago = true;
-		if (istep >= 1) 
+		if (istep >= 1)
 		{
 			diago = false;
 		}
@@ -139,7 +139,7 @@ void ELEC_evolve::evolve_psi(
 			timer::tick("Efficience","evolve_k");
 		}
 	} // end k
-			
+
 	// LiuXh modify 2019-07-15*/
 	if(!GlobalC::ParaO.out_hsR)
 	{
@@ -147,13 +147,13 @@ void ELEC_evolve::evolve_psi(
 	}
 
 	timer::tick("ELEC_evolve","evolve_psi");
-	return;	
+	return;
 }
 
 
 void ELEC_evolve::evolve_complex_matrix(
-	const int &ik, 
-	std::complex<double>** cc, 
+	const int &ik,
+	std::complex<double>** cc,
 	std::complex<double>** cc_init)const
 {
 	TITLE("Evolve_LCAO_Matrix","evolve_complex_matrix");
@@ -178,7 +178,7 @@ void ELEC_evolve::evolve_complex_matrix(
 
 	time_t time_end = time(NULL);
 	OUT_TIME("evolve(std::complex)", time_start, time_end);
-	
+
 	return;
 }
 
@@ -262,8 +262,8 @@ void ELEC_evolve::using_LAPACK_complex(const int &ik, std::complex<double>** c, 
 	{
 		std::complex<double> ccc[GlobalV::NLOCAL];
 		for(int j=0; j<GlobalV::NLOCAL; j++)
-		{	
-			ccc[j] = (0.0,0.0);
+		{
+			ccc[j] = std::complex<double>(0.0, 0.0);
 			for(int k=0; k<GlobalV::NLOCAL; k++)
 			{
 				 ccc[j] += U_operator(j,k)*c_init[i][k];
@@ -273,7 +273,7 @@ void ELEC_evolve::using_LAPACK_complex(const int &ik, std::complex<double>** c, 
 		{
 			c[i][j] = ccc[j];
 			GlobalC::LOWF.WFC_K[ik][i][j] = ccc[j];
-		}	
+		}
 	}
 
 //	delete[] work;
@@ -283,8 +283,8 @@ void ELEC_evolve::using_LAPACK_complex(const int &ik, std::complex<double>** c, 
 }
 
 void ELEC_evolve::using_LAPACK_complex_2(
-	const int &ik, 
-	std::complex<double>** c, 
+	const int &ik,
+	std::complex<double>** c,
 	std::complex<double>** c_init)const
 {
 
@@ -367,11 +367,11 @@ void ELEC_evolve::using_LAPACK_complex_2(
 	{
 		for(int j=0; j<GlobalV::NLOCAL; j++)
 		{
-			if(i==j) 
+			if(i==j)
 			{
 				Idmat(i,j) = std::complex<double>(1.0, 0.0);
 			}
-			else 
+			else
 			{
 				Idmat(i,j) = std::complex<double>(0.0, 0.0);
 			}
@@ -404,8 +404,8 @@ void ELEC_evolve::using_LAPACK_complex_2(
 	{
 		std::complex<double> ccc[GlobalV::NLOCAL];
 		for(int j=0; j<GlobalV::NLOCAL; j++)
-		{	
-			ccc[j] = (0.0,0.0);
+		{
+			ccc[j] = std::complex<double>(0.0, 0.0);
 			for(int k=0; k<GlobalV::NLOCAL; k++)
 			{
 				ccc[j] += U_operator(j,k)*c_init[i][k];
@@ -415,7 +415,7 @@ void ELEC_evolve::using_LAPACK_complex_2(
 		{
 			c[i][j] = ccc[j];
 			GlobalC::LOWF.WFC_K[ik][i][j] = ccc[j];
-		}	
+		}
 	}
 
 	delete[] work; // mohan add 2021-05-26

--- a/source/src_lcao/H_TDDFT_pw.cpp
+++ b/source/src_lcao/H_TDDFT_pw.cpp
@@ -3,7 +3,7 @@
 #include "ELEC_evolve.h"
 
 //==========================================================
-// this function aims to add external time-dependent potential 
+// this function aims to add external time-dependent potential
 // (eg: linear potential) used in tddft
 // fuxiang add in 2017-05
 //==========================================================
@@ -44,52 +44,52 @@ void Potential::set_vrs_tddft(const int istep)
 
                 if(ELEC_evolve::td_vext_dire == 1)
                 {
-                    if (k<GlobalC::pw.ncx*0.05) 
+                    if (k<GlobalC::pw.ncx*0.05)
 					{
 						this->vextold[ir] = (0.019447*k/GlobalC::pw.ncx-0.001069585)*GlobalC::ucell.lat0;
 					}
-                    else if (k>=GlobalC::pw.ncx*0.05 && k<GlobalC::pw.ncx*0.95) 
+                    else if (k>=GlobalC::pw.ncx*0.05 && k<GlobalC::pw.ncx*0.95)
 					{
 						this->vextold[ir] = -0.0019447*k/GlobalC::pw.ncx*GlobalC::ucell.lat0;
 					}
-                    else if (k>=GlobalC::pw.ncx*0.95) 
+                    else if (k>=GlobalC::pw.ncx*0.95)
 					{
 						this->vextold[ir] = (0.019447*(1.0*k/GlobalC::pw.ncx-1)-0.001069585)*GlobalC::ucell.lat0;
 					}
                 }
                 else if(ELEC_evolve::td_vext_dire == 2)
                 {
-                    if (j<GlobalC::pw.ncx*0.05) 
+                    if (j<GlobalC::pw.ncx*0.05)
 					{
 						this->vextold[ir] = (0.019447*j/GlobalC::pw.ncx-0.001069585)*GlobalC::ucell.lat0;
 					}
-                    else if (j>=GlobalC::pw.ncx*0.05 && j<GlobalC::pw.ncx*0.95)	
+                    else if (j>=GlobalC::pw.ncx*0.05 && j<GlobalC::pw.ncx*0.95)
 					{
 						this->vextold[ir] = -0.0019447*j/GlobalC::pw.ncx*GlobalC::ucell.lat0;
 					}
-                    else if (j>=GlobalC::pw.ncx*0.95) 
+                    else if (j>=GlobalC::pw.ncx*0.95)
 					{
 						this->vextold[ir] = (0.019447*(1.0*j/GlobalC::pw.ncx-1)-0.001069585)*GlobalC::ucell.lat0;
 					}
                 }
                 else if(ELEC_evolve::td_vext_dire == 3)
                 {
-                    if (i<GlobalC::pw.ncx*0.05) 
+                    if (i<GlobalC::pw.ncx*0.05)
 					{
 						this->vextold[ir] = (0.019447*i/GlobalC::pw.ncx-0.001069585)*GlobalC::ucell.lat0;
 					}
-                    else if (i>=GlobalC::pw.ncx*0.05 && i<GlobalC::pw.ncx*0.95) 
+                    else if (i>=GlobalC::pw.ncx*0.05 && i<GlobalC::pw.ncx*0.95)
 					{
 						this->vextold[ir] = -0.0019447*i/GlobalC::pw.ncx*GlobalC::ucell.lat0;
 					}
-                    else if (i>=GlobalC::pw.ncx*0.95) 
+                    else if (i>=GlobalC::pw.ncx*0.95)
 					{
 						this->vextold[ir] = (0.019447*(1.0*i/GlobalC::pw.ncx-1)-0.001069585)*GlobalC::ucell.lat0;
 					}
                 }
 
                 // Gauss
-				if (ELEC_evolve::td_vexttype = 1)
+				if (ELEC_evolve::td_vexttype == 1)
 				{
 					const double w = 22.13;    // eV
 					const double sigmasquare = 700;
@@ -100,7 +100,7 @@ void Potential::set_vrs_tddft(const int istep)
 				}
 
                 //HHG of H atom
-				if (ELEC_evolve::td_vexttype = 2)
+				if (ELEC_evolve::td_vexttype == 2)
 				{
 					const double w_h = 0.0588; //a.u.
 					const int stepcut1 = 1875;
@@ -123,20 +123,20 @@ void Potential::set_vrs_tddft(const int istep)
 
                 //HHG of H2
 				// Type 3 will be modified into more normolized type soon.
-				if (ELEC_evolve::td_vexttype = 3)
+				if (ELEC_evolve::td_vexttype == 3)
 				{
 					const double w_h2 = 0.0428;  //a.u.
 					const double w_h3 = 0.00107;  //a.u.
 					const double timenow = (istep)*ELEC_evolve::td_dr2*41.34;
 					// The parameters should be written in INPUT!
-					
+
 					//this->vext[ir] = this->vextold[ir]*2.74*cos(0.856*timenow)*sin(0.0214*timenow)*sin(0.0214*timenow);
 					//this->vext[ir] = this->vextold[ir]*2.74*cos(0.856*timenow)*sin(0.0214*timenow)*sin(0.0214*timenow)*0.01944;
 					this->vext[ir] = this->vextold[ir]*2.74*cos(w_h2*timenow)*sin(w_h3*timenow)*sin(w_h3*timenow);
 				}
-				
+
 					this->vr_eff(is,ir) = this->vltot[ir] + this->vr(is, ir) + this->vext[ir];
-				
+
                 //std::cout << "x: " << k <<"	" << "y: " << j <<"	"<< "z: "<< i <<"	"<< "ir: " << ir << std::endl;
                 //std::cout << "vext: " << this->vext[ir] << std::endl;
                 //std::cout << "vrs: " << vrs(is,ir) <<std::endl;

--- a/source/src_lcao/exx_lip.cpp
+++ b/source/src_lcao/exx_lip.cpp
@@ -24,7 +24,7 @@ Exx_Lip::Exx_Lip( const Exx_Global::Exx_Info &info_global )
 
 Exx_Lip::Exx_Info::Exx_Info( const Exx_Global::Exx_Info &info_global )
 	:hybrid_type(info_global.hybrid_type),
-	 hse_omega(info_global.hse_omega){} 
+	 hse_omega(info_global.hse_omega){}
 
 void Exx_Lip::cal_exx()
 {
@@ -39,7 +39,7 @@ void Exx_Lip::cal_exx()
 	{
 		std::cout<<name<<"\t"<<t<<std::endl;
 	};
-	
+
 timeval t;
 gettimeofday(&t, NULL);
 double t_phi_cal=0, t_qkg2_exp=0, t_b_cal=0, t_sum3_cal=0, t_b_sum=0, t_sum_all=0;
@@ -55,16 +55,16 @@ t_phi_cal += my_time(t);
 		judge_singularity(ik);
 		for( int iw_l=0; iw_l<GlobalV::NLOCAL; ++iw_l)
 			for( int iw_r=0; iw_r<GlobalV::NLOCAL; ++iw_r)
-				sum1[iw_l*GlobalV::NLOCAL+iw_r] = (0.0,0.0);
+				sum1[iw_l*GlobalV::NLOCAL+iw_r] = std::complex<double> (0.0,0.0);
 		if( Exx_Global::Hybrid_Type::HF==info.hybrid_type || Exx_Global::Hybrid_Type::PBE0==info.hybrid_type )
-		{			
+		{
 			sum2_factor = 0.0;
 			if(gzero_rank_in_pool==GlobalV::RANK_IN_POOL)
 				for( int iw_l=0; iw_l<GlobalV::NLOCAL; ++iw_l)
 					for( int iw_r=0; iw_r<GlobalV::NLOCAL; ++iw_r)
-						sum3[iw_l][iw_r] = (0.0,0.0);
+						sum3[iw_l][iw_r] = std::complex<double>(0.0, 0.0);
 		}
-		
+
 		for( int iq_tmp=iq_vecik; iq_tmp<iq_vecik+q_pack->kv_ptr->nks/GlobalV::NSPIN; ++iq_tmp)					// !!! k_point parallel incompleted. need to loop iq in other pool
 		{
 			int iq = (ik<(k_pack->kv_ptr->nks/GlobalV::NSPIN)) ? (iq_tmp%(q_pack->kv_ptr->nks/GlobalV::NSPIN)) : (iq_tmp%(q_pack->kv_ptr->nks/GlobalV::NSPIN)+(q_pack->kv_ptr->nks/GlobalV::NSPIN));
@@ -79,7 +79,7 @@ t_b_cal += my_time(t);
 						sum3_cal(iq,ib);
 t_sum3_cal += my_time(t);
 				b_sum(iq, ib);
-t_b_sum += my_time(t); 
+t_b_sum += my_time(t);
 			}
 		}
 		sum_all(ik);
@@ -123,16 +123,16 @@ void Exx_Lip::cal_exx()
 		judge_singularity(ik);
 		for( int iw_l=0; iw_l<GlobalV::NLOCAL; ++iw_l)
 			for( int iw_r=0; iw_r<GlobalV::NLOCAL; ++iw_r)
-				sum1[iw_l*GlobalV::NLOCAL+iw_r] = (0.0,0.0);
+				sum1[iw_l*GlobalV::NLOCAL+iw_r] = std::complex<double>(0.0,0.0);
 		if( Exx_Global::Hybrid_Type::HF==info.hybrid_type || Exx_Global::Hybrid_Type::PBE0==info.hybrid_type )
-		{			
+		{
 			sum2_factor = 0.0;
 			if(gzero_rank_in_pool==GlobalV::RANK_IN_POOL)
 				for( int iw_l=0; iw_l<GlobalV::NLOCAL; ++iw_l)
 					for( int iw_r=0; iw_r<GlobalV::NLOCAL; ++iw_r)
-						sum3[iw_l][iw_r] = (0.0,0.0);
+						sum3[iw_l][iw_r] = std::complex<double>(0.0,0.0);
 		}
-		
+
 		for( int iq_tmp=iq_vecik; iq_tmp<iq_vecik+q_pack->kv_ptr->nks/GlobalV::NSPIN; ++iq_tmp)					// !!! k_point parallel incompleted. need to loop iq in other pool
 		{
 			int iq = (ik<(k_pack->kv_ptr->nks/GlobalV::NSPIN)) ? (iq_tmp%(q_pack->kv_ptr->nks/GlobalV::NSPIN)) : (iq_tmp%(q_pack->kv_ptr->nks/GlobalV::NSPIN)+(q_pack->kv_ptr->nks/GlobalV::NSPIN));
@@ -550,7 +550,7 @@ void Exx_Lip::sum_all(int ik)
 void Exx_Lip::exx_energy_cal()
 {
 	TITLE("Exx_Lip","exx_energy_cal");
-	
+
 	double exx_energy_tmp = 0.0;
 
 	for( int ik=0; ik<k_pack->kv_ptr->nks; ++ik)
@@ -927,4 +927,3 @@ void Exx_Lip::read_q_pack()
 	return;
 }
 */
-

--- a/source/src_pdiag/pdiag_double.cpp
+++ b/source/src_pdiag/pdiag_double.cpp
@@ -718,7 +718,7 @@ void Pdiag_Double::diago_double_begin(
 				}
 			}//loop ipcol
 		}//loop iprow
-	
+
 		if(out_lowf && myid==0)
 		{
 			std::stringstream ss;
@@ -1150,7 +1150,8 @@ void Pdiag_Double::diago_complex_begin(
 			&M, &NZ, ekb, &orfac, wfc_2d.c, &one, &one, desc,
 			work.data(), &lwork, rwork.data(), &lrwork,
 			iwork.data(), &liwork, ifail.data(), iclustr.data(), gap.data(), &info);
-
+		if (info)
+			throw std::runtime_error("info=" + TO_STRING(info) + ". " + TO_STRING(__FILE__) + " line " + TO_STRING(__LINE__));
 		GlobalV::ofs_running<<"lwork="<<work[0]<<"\t"<<"liwork="<<iwork[0]<<std::endl;
 		lwork = work[0].real();
 		work.resize(lwork,0);
@@ -1162,7 +1163,8 @@ void Pdiag_Double::diago_complex_begin(
 			&GlobalV::NLOCAL, h_tmp.c, &one, &one, desc, s_tmp.c, &one, &one, desc,
 			NULL, NULL, &il, &iu, &abstol,
 			&M, &NZ, ekb, &orfac, wfc_2d.c, &one, &one, desc,
-			work.data(), &lwork, rwork.data(), &lrwork, iwork.data(), &liwork, ifail.data(), iclustr.data(), gap.data(), &info);
+			work.data(), &lwork, rwork.data(), &lrwork,
+			iwork.data(), &liwork, ifail.data(), iclustr.data(), gap.data(), &info);
 		GlobalV::ofs_running<<"M="<<M<<"\t"<<"NZ="<<NZ<<std::endl;
 
 		if(info)

--- a/source/src_pdiag/pdsyg2st.cpp
+++ b/source/src_pdiag/pdsyg2st.cpp
@@ -148,7 +148,7 @@ void pdsyg2st(char isuplo,MPI_Comm comm_2D,double *A,LocalMatrix loc_A,double *B
                 loc_B.col_pos=loc_B.col_pos+bm;
             }
             if (ki>=N_A-1) break;
-            if ((coord[0]==iarow))
+            if (coord[0]==iarow)
             {
                 transa='T';
                 transb='T';
@@ -165,8 +165,8 @@ void pdsyg2st(char isuplo,MPI_Comm comm_2D,double *A,LocalMatrix loc_A,double *B
 
                 //printf("(%d,%d), in pdsyg2st n=%d bm=%d, col_pos=%d, ki=%d\n",coord[0],coord[1],n,bm,loc_A.col_pos,ki);
                 //printf("(%d,%d), in pdsyg2st n=%d \n",coord[0],coord[1],n);
-				
-				
+
+
                 dtrsm_(&side,&uplo,&transa,&diag,&n,&m,&alpha,C_B,&ldc,&A[pos],&lda);
                 dtrsm_(&side,&uplo,&transb,&diag,&n,&m,&alpha,C_B,&ldc,&B[pos],&ldb);
 
@@ -268,7 +268,7 @@ void pdsyg2st(char isuplo,MPI_Comm comm_2D,double *A,LocalMatrix loc_A,double *B
                    &U_1[loc_A.row_pos*NB],&ldb,&beta,&A[pos],&ldc);
             dgemm_(&transa,&transb,&n,&m,&k,&alpha,&W_1[loc_A.col_pos],&lda,
                    &U1[loc_A.row_pos*NB],&ldb,&beta,&A[pos],&ldc);
-            if ((coord[0]==iarow))
+            if (coord[0]==iarow)
             {
                 lda=loc_A.col_num;
                 ldb=loc_A.col_num;
@@ -325,7 +325,7 @@ void pdsyg2st(char isuplo,MPI_Comm comm_2D,double *A,LocalMatrix loc_A,double *B
                 loc_B.row_pos=loc_B.row_pos+bm;
             }
             if (ki>=N_A-1) break;
-            if ((coord[1]==iacol))
+            if (coord[1]==iacol)
             {
                 transa='T';
                 transb='T';
@@ -440,7 +440,7 @@ void pdsyg2st(char isuplo,MPI_Comm comm_2D,double *A,LocalMatrix loc_A,double *B
                    &U_1[loc_A.row_pos*NB],&ldb,&beta,&A[pos],&ldc);
             dgemm_(&transa,&transb,&n,&m,&k,&alpha,&W_1[loc_A.col_pos],&lda,
                    &U1[loc_A.row_pos*NB],&ldb,&beta,&A[pos],&ldc);
-            if ((coord[1]==iacol))
+            if (coord[1]==iacol)
             {
                 lda=loc_A.col_num;
                 ldb=loc_A.col_num;
@@ -459,4 +459,3 @@ void pdsyg2st(char isuplo,MPI_Comm comm_2D,double *A,LocalMatrix loc_A,double *B
     MPI_Comm_free(&comm_col);
     MPI_Comm_free(&comm_row);
 }
-

--- a/source/src_pdiag/pzheg2st.cpp
+++ b/source/src_pdiag/pzheg2st.cpp
@@ -1,38 +1,38 @@
 #include "pzheg2st.h"
-#include "pzhtrsm.h" 
+#include "pzhtrsm.h"
 
 void pzheg2st(char isuplo,MPI_Comm comm_2D,std::complex<double> *A,LocalMatrix loc_A,std::complex<double> *B,
               LocalMatrix loc_B,int NB,int N_A)
 
 /*
  * PSEPS routine (version 1.0) --
- * Computer Network Information Center, CAS. 
+ * Computer Network Information Center, CAS.
  * December 15, 2005
- * 
+ *
  * Purpose
  * =======
- * pzheg2st transforms generalized  Hermitian eigenproblem into standard  
- * eigenproblem 
+ * pzheg2st transforms generalized  Hermitian eigenproblem into standard
+ * eigenproblem
  * computes Cholesky factorization of an N-by-N real
- * symmetric positive definite matrix B and  L-1AL-T ��U -TAU -1 with a 
- * 2D-block-cyclic in parallel. The routine introduces a new parallelization which 
+ * symmetric positive definite matrix B and  L-1AL-T ��U -TAU -1 with a
+ * 2D-block-cyclic in parallel. The routine introduces a new parallelization which
  * combines the Cholesky into the transformation from generalized to standard form.
  * Arguments
- * ========= 
- * NOTE: In the current code, matrix A employ 2D-blocked-cyclic mapping 
+ * =========
+ * NOTE: In the current code, matrix A employ 2D-blocked-cyclic mapping
  *       distribute.
  *
  *  isuplo  (global input) char
  *          = 'U' or 'u':  Upper triangles of sub( A ) and sub( B ) are stored;
  *          = 'L' or 'l':  Lower triangles of sub( A ) and sub( B ) are stored.
- *  comm_2D. (input) MPI_Comm 
+ *  comm_2D. (input) MPI_Comm
  *            2-D grid MPI communicator
  *  N_A  (global input) INTEGER
- *      The number of columns and rows to be operated on matrices A��N >= 0. 
+ *      The number of columns and rows to be operated on matrices A��N >= 0.
  *  NB  (input) INTEGER
  *       blocked size of 2D blocked cyclic matrix
  *  A       (local input/local output) double precision std::complex pointer,
- *          pointer into the local memory to an array of dimension 
+ *          pointer into the local memory to an array of dimension
  *          (loc_A.row_num, loc_A.col_num).
  *          On entry, this array contains the local pieces of the
  *          N-by-N Hermitian distributed matrix sub( A ). If UPLO = 'U',
@@ -41,7 +41,7 @@ void pzheg2st(char isuplo,MPI_Comm comm_2D,std::complex<double> *A,LocalMatrix l
  *          leading N-by-N lower triangular part of sub( A ) contains
  *          the lower triangular part of the matrix.
  *  B       (local input/local output) double precision std::complex pointer,
- *          pointer into the local memory to an array of dimension 
+ *          pointer into the local memory to an array of dimension
  *         (loc_B.row_num, loc_B.col_num).
  *          On entry, this array contains the local pieces of the
  *          N-by-N Hermitian distributed matrix sub( B). If UPLO = 'U',
@@ -50,8 +50,8 @@ void pzheg2st(char isuplo,MPI_Comm comm_2D,std::complex<double> *A,LocalMatrix l
  *          leading N-by-N lower triangular part of sub( A ) contains
  *          the lower triangular part of the matrix.
  *  loc_A and Loc_B:  (local input) struct Loc_A
- *          This struct avaible stores the information required to establish 
- *          the mapping between an object element and its corresponding 
+ *          This struct avaible stores the information required to establish
+ *          the mapping between an object element and its corresponding
  *          process and memory location.
  */
 {
@@ -134,7 +134,7 @@ void pzheg2st(char isuplo,MPI_Comm comm_2D,std::complex<double> *A,LocalMatrix l
                 for (j=0; j<NB; j++)
                 {
                     C_A1[i*NB+j]=C_B1[i*NB+j]=C_A[i*NB+j]=C_B[i*NB+j]=std::complex<double> (0.0,0.0);
-                   
+
                 }
             for (i=0; i<loc_A.row_num; i++)
                 for (j=0; j<NB; j++)
@@ -170,7 +170,7 @@ void pzheg2st(char isuplo,MPI_Comm comm_2D,std::complex<double> *A,LocalMatrix l
                 loc_B.col_pos=loc_B.col_pos+bm;
             }
             if (ki>=N_A-1) break;
-            if ((coord[0]==iarow))
+            if (coord[0]==iarow)
             {
                 transa='c';
                 transb='c';
@@ -183,11 +183,11 @@ void pzheg2st(char isuplo,MPI_Comm comm_2D,std::complex<double> *A,LocalMatrix l
                 ldb=loc_A.col_num;
                 ldc=NB;
                 pos=loc_A.row_pos*loc_A.col_num+loc_A.col_pos;
- 
+
                 alpha=std::complex<double> (1.0,0.0);
                 //printf("(%d,%d), in pdsyg2st n=%d bm=%d, col_pos=%d, ki=%d\n",coord[0],coord[1],n,bm,loc_A.col_pos,ki);
-                //printf("(%d,%d), in pdsyg2st n=%d \n",coord[0],coord[1],n);	
-				
+                //printf("(%d,%d), in pdsyg2st n=%d \n",coord[0],coord[1],n);
+
                 ztrsm_(&side,&uplo,&transa,&diag,&n,&m,&alpha,C_B,&ldc,&A[pos],&lda);
                 ztrsm_(&side,&uplo,&transb,&diag,&n,&m,&alpha,C_B,&ldc,&B[pos],&ldb);
 
@@ -209,7 +209,7 @@ void pzheg2st(char isuplo,MPI_Comm comm_2D,std::complex<double> *A,LocalMatrix l
             MPI_Bcast(W1,NB*loc_A.col_num,MPI_DOUBLE_COMPLEX,iarow,comm_col);
 
 			//std::cout << "\n Bcast done." << std::endl;
-			
+
             MPI_Bcast(W_1,NB*loc_A.col_num,MPI_DOUBLE_COMPLEX,iarow,comm_col);
 
 			//std::cout << "\n Bcast done." << std::endl;
@@ -302,7 +302,7 @@ void pzheg2st(char isuplo,MPI_Comm comm_2D,std::complex<double> *A,LocalMatrix l
                    &U_1[loc_A.row_pos*NB],&ldb,&beta,&A[pos],&ldc);
             zgemm_(&transa,&transb,&n,&m,&k,&alpha,&W_1[loc_A.col_pos],&lda,
                    &U1[loc_A.row_pos*NB],&ldb,&beta,&A[pos],&ldc);
-            if ((coord[0]==iarow))
+            if (coord[0]==iarow)
             {
                 lda=loc_A.col_num;
                 ldb=loc_A.col_num;
@@ -366,7 +366,7 @@ void pzheg2st(char isuplo,MPI_Comm comm_2D,std::complex<double> *A,LocalMatrix l
                 loc_B.row_pos=loc_B.row_pos+bm;
             }
             if (ki>=N_A-1) break;
-            if ((coord[1]==iacol))
+            if (coord[1]==iacol)
             {
                 transa='c';
                 transb='c';
@@ -485,7 +485,7 @@ void pzheg2st(char isuplo,MPI_Comm comm_2D,std::complex<double> *A,LocalMatrix l
                    &U_1[loc_A.row_pos*NB],&ldb,&beta,&A[pos],&ldc);
             zgemm_(&transa,&transb,&n,&m,&k,&alpha,&W_1[loc_A.col_pos],&lda,
                    &U1[loc_A.row_pos*NB],&ldb,&beta,&A[pos],&ldc);
-            if ((coord[1]==iacol))
+            if (coord[1]==iacol)
             {
                 lda=loc_A.col_num;
                 ldb=loc_A.col_num;

--- a/source/src_pw/diago_cg.cpp
+++ b/source/src_pw/diago_cg.cpp
@@ -80,9 +80,9 @@ void Diago_CG::diag
         {
             this->calculate_gradient( precondition, dim, hphi, sphi, g, pphi );
             this->orthogonal_gradient( dim,dmx, g, scg, lagrange, phi, m);
-            this->calculate_gamma_cg( iter, dim, precondition, g, scg, 
+            this->calculate_gamma_cg( iter, dim, precondition, g, scg,
 			g0, cg, gg_last, cg_norm, theta, phi_m);// scg used as sg
-            converged = this->update_psi( dim, cg_norm, theta, pphi, cg, scg, phi_m , 
+            converged = this->update_psi( dim, cg_norm, theta, pphi, cg, scg, phi_m ,
 			e[m], eps, hphi, sphi); // pphi is used as hcg
             if ( converged ) break;
         }//end iter
@@ -461,7 +461,7 @@ void Diago_CG::schmit_orth
 		std::cout << " m = " << m << std::endl;
 		for(int j=0; j<=m; ++j)
 		{
-			std::cout << "\n j = " << j << " lagrange norm = " << ( conj(lagrange[j]) * lagrange[j] ).real();
+			std::cout << "j = " << j << " lagrange norm = " << ( conj(lagrange[j]) * lagrange[j] ).real()<<std::endl;
 		}
         std::cout << " in diago_cg, psi norm = " << psi_norm << std::endl;
 		std::cout << " If you use GNU compiler, it may due to the zdotc is unavailable." << std::endl;

--- a/source/src_pw/hamilt_pw.cpp
+++ b/source/src_pw/hamilt_pw.cpp
@@ -25,9 +25,9 @@ Hamilt_PW::~Hamilt_PW()
 
 
 void Hamilt_PW::allocate(
-	const int &npwx, 
-	const int &npol, 
-	const int &nkb, 
+	const int &npwx,
+	const int &npol,
+	const int &nkb,
 	const int &nrxx)
 {
     TITLE("Hamilt_PW","allocate");
@@ -58,7 +58,7 @@ void Hamilt_PW::allocate(
 void Hamilt_PW::init_k(const int ik)
 {
     TITLE("Hamilt_PW","init_k");
-	
+
 	// mohan add 2010-09-30
 	// (1) Which spin to use.
 	if(GlobalV::NSPIN==2)
@@ -93,7 +93,7 @@ void Hamilt_PW::init_k(const int ik)
 
 	// (7) ik
 	GlobalV::CURRENT_K = ik;
-	
+
     return;
 }
 
@@ -130,7 +130,7 @@ void Hamilt_PW::diagH_subspace(
 		dmin= npw;
 		dmax = GlobalC::wf.npwx;
 	}
-	else 
+	else
 	{
 		dmin = GlobalC::wf.npwx*GlobalV::NPOL;
 		dmax = GlobalC::wf.npwx*GlobalV::NPOL;
@@ -178,7 +178,7 @@ void Hamilt_PW::diagH_subspace(
 		}
 		else if( 9==GlobalC::xcf.iexch_now && 12==GlobalC::xcf.igcx_now )			// HSE
 		{
-			add_Hexx(GlobalC::exx_global.info.hybrid_alpha);		
+			add_Hexx(GlobalC::exx_global.info.hybrid_alpha);
 		}
 	}
 #endif
@@ -207,7 +207,7 @@ void Hamilt_PW::diagH_subspace(
 		}
 	}
 #endif
-		
+
     //=======================
     //diagonize the H-matrix
     //=======================
@@ -267,11 +267,11 @@ void Hamilt_PW::diagH_subspace(
 	{
 		GlobalV::ofs_running << " Not do zgemm to get evc." << std::endl;
 	}
-	else if((GlobalV::BASIS_TYPE=="lcao" || GlobalV::BASIS_TYPE=="lcao_in_pw") 
+	else if((GlobalV::BASIS_TYPE=="lcao" || GlobalV::BASIS_TYPE=="lcao_in_pw")
 		&& ( GlobalV::CALCULATION == "scf" || GlobalV::CALCULATION == "md" || GlobalV::CALCULATION == "relax")) //pengfei 2014-10-13
 	{
 		// because psi and evc are different here,
-		// I think if psi and evc are the same, 
+		// I think if psi and evc are the same,
 		// there may be problems, mohan 2011-01-01
 		char transa = 'N';
 		char transb = 'T';
@@ -311,7 +311,7 @@ void Hamilt_PW::diagH_subspace(
 //	std::cout << "\n bands" << std::endl;
 //	for(int ib=0; ib<n_band; ib++)
 //	{
-//		std::cout << " ib=" << ib << " " << en[ib] * Ry_to_eV << std::endl; 
+//		std::cout << " ib=" << ib << " " << en[ib] * Ry_to_eV << std::endl;
 //	}
 
     //out.printcm_norm("hvec",hvec,1.0e-8);
@@ -366,7 +366,7 @@ void Hamilt_PW::h_psi(const std::complex<double> *psi_in, std::complex<double> *
 	std::complex<double> *tmhpsi;
 	const std::complex<double> *tmpsi_in;
  	if(GlobalV::T_IN_H)
-	{	
+	{
 		tmhpsi = hpsi;
 		tmpsi_in = psi_in;
 		for(int ib = 0 ; ib < m; ++ib)
@@ -508,7 +508,7 @@ void Hamilt_PW::h_psi(const std::complex<double> *psi_in, std::complex<double> *
 			{
 				const std::complex<double>* p = &GlobalC::ppcell.vkb(i,0);
 				const std::complex<double>* const p_end = p + GlobalC::wf.npw;
-				const std::complex<double>* psip = psi_in; 
+				const std::complex<double>* psip = psi_in;
 				for (;p<p_end;++p,++psip)
 				{
 					if(!GlobalV::NONCOLIN) becp[i] += psip[0]* conj( p[0] );
@@ -545,13 +545,13 @@ void Hamilt_PW::h_psi(const std::complex<double> *psi_in, std::complex<double> *
 				}
 
 				GlobalC::pw.FFT_wfc.FFT3D(GlobalC::UFFT.porter, 1);
-		
+
 				for (int ir = 0; ir < GlobalC::pw.nrxx; ir++)
-				{	
+				{
 					GlobalC::UFFT.porter[ir] = GlobalC::UFFT.porter[ir] * GlobalC::pot.vofk(GlobalV::CURRENT_SPIN,ir);
 				}
 				GlobalC::pw.FFT_wfc.FFT3D(GlobalC::UFFT.porter, -1);
-				
+
 				for (int ig = 0;ig < GlobalC::kv.ngk[GlobalV::CURRENT_K] ; ig++)
 				{
 					double fact = GlobalC::pw.get_GPlusK_cartesian_projection(GlobalV::CURRENT_K,ig,j) * GlobalC::ucell.tpiba;
@@ -599,12 +599,12 @@ void Hamilt_PW::add_nonlocal_pp(
 					{
 						for(int ib = 0; ib < m ; ++ib)
 						{
-							ps[(sum + ip2) * m + ib] += 
-							GlobalC::ppcell.deeq(GlobalV::CURRENT_SPIN, iat, ip, ip2) 
+							ps[(sum + ip2) * m + ib] +=
+							GlobalC::ppcell.deeq(GlobalV::CURRENT_SPIN, iat, ip, ip2)
 							* becp[ib * nkb + sum + ip];
 						}//end ib
 					}// end ih
-				}//end jh 
+				}//end jh
 				sum += nproj;
 				++iat;
 			} //end na
@@ -667,16 +667,16 @@ void Hamilt_PW::add_nonlocal_pp(
 	if(GlobalV::NPOL==1 && m==1)
 	{
 		int inc = 1;
-		zgemv_(&transa, 
-			&GlobalC::wf.npw, 
-			&GlobalC::ppcell.nkb, 
-			&ONE, 
-			GlobalC::ppcell.vkb.c, 
-			&GlobalC::wf.npwx, 
-			ps, 
-			&inc, 
-			&ONE, 
-			hpsi_in, 
+		zgemv_(&transa,
+			&GlobalC::wf.npw,
+			&GlobalC::ppcell.nkb,
+			&ONE,
+			GlobalC::ppcell.vkb.c,
+			&GlobalC::wf.npwx,
+			ps,
+			&inc,
+			&ONE,
+			hpsi_in,
 			&inc);
 	}
 	else
@@ -780,7 +780,7 @@ void Hamilt_PW::diag_zheev(const int &npw_in, ComplexMatrix &psi, const int &nba
 
         tmp /= tmp1 ;
 
-        tmpen[i] = tmp.real() ;
+		tmpen[i] = tmp.real() ;
 
         for (int j = 0; j <= i; j++)
         {
@@ -999,8 +999,8 @@ std::complex<double> Hamilt_PW::ddot(
 	const int incx = 1;
 	const int incy = 1;
 	// mohan add 2010-10-11
-	zdotc_(&result, &dim, psi_L, &incx, psi_R, &incy); 
-    
+	zdotc_(&result, &dim, psi_L, &incx, psi_R, &incy);
+
 	if(GlobalV::NPROC_IN_POOL>1)
 	{
 		Parallel_Reduce::reduce_complex_double_pool( result );
@@ -1017,7 +1017,7 @@ std::complex<double> Hamilt_PW::just_ddot(
 	std::complex<double> result = ZERO;
 
 	// mohan add 2010-10-11
-//	zdotc_(&result, &dim, psi_L, &incx, psi_R, &incy);  
+//	zdotc_(&result, &dim, psi_L, &incx, psi_R, &incy);
 
 	// mohan update 2011-09-21
 	static int warn_about_zdotc=true;
@@ -1029,7 +1029,7 @@ std::complex<double> Hamilt_PW::just_ddot(
 	}
 	for(int i=0; i<dim; ++i)
 	{
-		result += conj(psi_L[i])*psi_R[i];	
+		result += conj(psi_L[i])*psi_R[i];
 	}
 
     return result;
@@ -1057,4 +1057,3 @@ std::complex<double> Hamilt_PW::ddot(
 
     return result;
 }  // end of ddot
-

--- a/source/src_pw/occupy.cpp
+++ b/source/src_pw/occupy.cpp
@@ -7,7 +7,7 @@ Occupy::~Occupy(){}
 
 //===========================================================
 // Four smearing methods:
-// (1) do nothing 
+// (1) do nothing
 // (2) gaussian_broadening method (need 'degauss' value).
 // (3) tetrahedron method
 // (4) fixed_occupations
@@ -27,7 +27,7 @@ void Occupy::calculate_weights(void)
 	// for test
 //	std::cout << " gaussian_broadening = " << use_gaussian_broadening << std::endl;
 //	std::cout << " tetrahedron_method = " << use_tetrahedron_method << std::endl;
-//	std::cout << " fixed_occupations = " << fixed_occupations << std::endl; 
+//	std::cout << " fixed_occupations = " << fixed_occupations << std::endl;
 
 	if(GlobalV::KS_SOLVER=="selinv")
 	{
@@ -70,7 +70,7 @@ void Occupy::calculate_weights(void)
 			Occupy::gweights(GlobalC::kv.nks, GlobalC::kv.wk, GlobalV::NBANDS, GlobalC::ucell.magnet.get_neldw(), gaussian_parameter, gaussian_type,
 			                 GlobalC::wf.ekb, GlobalC::en.ef_dw, demet_dw, GlobalC::wf.wg, 1, GlobalC::kv.isk);
 			GlobalC::en.demet = demet_up + demet_dw;
-                        
+
 		}
 		else
 		{
@@ -99,11 +99,11 @@ void Occupy::calculate_weights(void)
 			}
 		}
     }
-	
-    if (GlobalV::TWO_EFERMI==2)
+
+    if (GlobalV::TWO_EFERMI)
     {
 		Parallel_Reduce::gather_max_double_all( GlobalC::en.ef_up );
-		Parallel_Reduce::gather_max_double_all( GlobalC::en.ef_dw );	
+		Parallel_Reduce::gather_max_double_all( GlobalC::en.ef_dw );
     }
     else
     {
@@ -122,7 +122,7 @@ void Occupy::calculate_weights(void)
 		Parallel_Reduce::gather_max_double_all( GlobalC::en.ef );
 		Parallel_Reduce::gather_max_double_all( etop );
 		Parallel_Reduce::gather_min_double_all( ebotom );
-		
+
 		//not parallel yet!
 //		OUT(GlobalV::ofs_running,"Top    Energy (eV)", etop * Ry_to_eV);
 //      OUT(GlobalV::ofs_running,"Fermi  Energy (eV)", GlobalC::en.ef * Ry_to_eV);
@@ -191,7 +191,7 @@ void Occupy::decision(const std::string &name,const std::string &smearing,const 
 
         else if (smearing == "marzari-vanderbilt" || smearing == "cold" || smearing == "mv")
         {
-            gaussian_type = -1; 
+            gaussian_type = -1;
         }
         else if (smearing == "fermi-dirac" || smearing == "fd")
         {
@@ -234,15 +234,15 @@ void Occupy::iweights
 	assert(is<2); //not include non-collinear yet!
 	double degspin;
 	bool conv = false;          // pengfei 2017-04-04
-	
+
 	degspin = (GlobalV::NSPIN == 2)? 1.0 : 2.0;
 	if(GlobalV::NSPIN == 4)degspin = 1.0;//added by zhengdy-soc
-	
+
 	assert( degspin > 0.0);
 	double ib_min = nelec/degspin;
-	
+
 	int ib_min1 = ( ib_min - int(ib_min) == 0) ? int(ib_min) : int(ib_min) + 1;
-	
+
 	for(int ik=0; ik<nks && !conv; ik++)
 	{
 		for(int ib=0; ib<nband && !conv; ib++)
@@ -260,17 +260,17 @@ void Occupy::iweights
 					}
 				}
 			}
-				
-			if( (GlobalV::NSPIN == 2 && count == ib_min1 * nks/2) 
-				|| (GlobalV::NSPIN == 1 && count == ib_min1 * nks) 
+
+			if( (GlobalV::NSPIN == 2 && count == ib_min1 * nks/2)
+				|| (GlobalV::NSPIN == 1 && count == ib_min1 * nks)
 				|| ((GlobalV::NSPIN == 4) && count == ib_min1 * nks))
 			{
 				conv = true;
 			}
 		}
 	}
-		
-	
+
+
 	for(int ik=0; ik<nks; ik++)
 	{
 		for(int ib=0; ib<nband; ib++)
@@ -373,7 +373,7 @@ void Occupy::efermig
     const int maxiter = 300;
     const double eps = 1.0e-10;
 
-	/*	
+	/*
 	for(int ik=0; ik<nks; ik++)
 	{
 		for(int i=0; i<nband; i++)
@@ -461,7 +461,7 @@ double Occupy::sumkg(
 	const int ngauss,
 	const double &e,
 	const int &is,
-	const int *isk	
+	const int *isk
 )
 {
 	//TITLE("Occupy","sumkg");
@@ -469,7 +469,7 @@ double Occupy::sumkg(
     for (int ik = 0;ik < nks; ik++)
 	{
 		if(is!=-1 && is!=isk[ik]) continue;
-	
+
 		double sum1 = 0.0;
 		for (int ib = 0;ib < GlobalV::NBANDS; ib++)
 		{
@@ -510,7 +510,7 @@ double Occupy::wgauss(const double &x,const int n)
     //============================
     double wga = 0.0;
     const double maxarg = 200.0;
-    
+
 	//===========================
     // Fermi-Dirac(fd) smearing
     //===========================
@@ -530,7 +530,7 @@ double Occupy::wgauss(const double &x,const int n)
         }
         return wga;
     }
-	
+
     //===================
     // Cold smearing(mv)
     //===================
@@ -541,7 +541,7 @@ double Occupy::wgauss(const double &x,const int n)
         wga = 0.50 * erf(xp) + 1.00 / sqrt( TWO_PI ) * std::exp(- arg) + 0.50;
         return wga;
     }
-    
+
 	//====================
     // Methfessel-Paxton       //pengfei 2014-10-13
     //====================
@@ -569,7 +569,7 @@ double Occupy::wgauss(const double &x,const int n)
         //std::cout << " wga = " <<wga<<std::endl;
         h0 = 2.00 * (-x) * h1 - 2.00 * static_cast<double>(ni) * h0 ;
         ++ni;
-        
+
         h1 = 2.00 * (-x) * h0 - 2.00 * static_cast<double>(ni) * h1 ;
     }
     return wga;
@@ -627,8 +627,8 @@ double Occupy::w1gauss(const double &x,const int n)
         w1 = 1.00 / sqrt(TWO_PI) * xp * std::exp(- arg);
         return w1;
     }
-    
-	
+
+
 	//====================
     // Methfessel-Paxton
     //====================
@@ -691,7 +691,7 @@ void Occupy::tweights(const int nks,const int nspin,const int nband,const double
 
     double e1, e2, e3, e4, c1, c2, c3, c4, dosef;
     int ik, ibnd, nt, nk, ns, i, kp1, kp2, kp3, kp4;
-	
+
 	double etetra[4];
     int itetra[4];
 

--- a/source/src_pw/threshold_elec.cpp
+++ b/source/src_pw/threshold_elec.cpp
@@ -1,10 +1,10 @@
 #include "global.h"
 #include "threshold_elec.h"
 
-Threshold_Elec::Threshold_Elec() 
-{ 
-	dr2 = 0.0; 
-	conv_elec = false; 
+Threshold_Elec::Threshold_Elec()
+{
+	dr2 = 0.0;
+	conv_elec = false;
 }
 
 void Threshold_Elec::set_ethr(void) const
@@ -21,7 +21,7 @@ void Threshold_Elec::set_ethr(void) const
     //===================
     if (GlobalV::CALCULATION=="nscf")
     {
-        if (abs(GlobalV::ETHR - 1.0e-2 < 1.0e-10))
+        if (abs(GlobalV::ETHR - 1.0e-2) < 1.0e-10)
         {
             GlobalV::ETHR = 0.1 * std::min(1.0e-2, GlobalV::DRHO2 / GlobalC::CHR.nelec);
         }
@@ -31,7 +31,7 @@ void Threshold_Elec::set_ethr(void) const
     //=================
     else if(GlobalV::CALCULATION=="scf" || GlobalV::CALCULATION=="md" || GlobalV::CALCULATION=="relax" || GlobalV::CALCULATION=="scf-sto")//qianrui 2021-2-20
     {
-        if (abs(GlobalV::ETHR - 1.0e-2 < 1.0e-10))
+        if (abs(GlobalV::ETHR - 1.0e-2) < 1.0e-10)
         {
             if (GlobalC::pot.start_pot == "file")
             {
@@ -70,7 +70,7 @@ void Threshold_Elec::update_ethr(const int &iter)
         }
 
 		//----------------------------
-		// GlobalV::ETHR changes in CG Method. 
+		// GlobalV::ETHR changes in CG Method.
 		// mohan update 2012-03-26
 		// mohan update 2012-02-08
 		//----------------------------
@@ -91,7 +91,7 @@ void Threshold_Elec::update_ethr(const int &iter)
 
 void Threshold_Elec::iter_end(std::ofstream &ofs)
 {
-	if(GlobalV::OUT_LEVEL != "m") 
+	if(GlobalV::OUT_LEVEL != "m")
 	{
 		print_eigenvalue(ofs);
 	}
@@ -119,7 +119,7 @@ void Threshold_Elec::print_eigenvalue(std::ofstream &ofs)
 	}
 
 
-	if(GlobalV::MY_RANK!=0) 
+	if(GlobalV::MY_RANK!=0)
 	{
 		return;
 	}
@@ -135,7 +135,7 @@ void Threshold_Elec::print_eigenvalue(std::ofstream &ofs)
             if (GlobalC::kv.isk[ik] == 0)ofs << "\n spin up :";
             if (GlobalC::kv.isk[ik] == 1)ofs << "\n spin down :";
         }
-        
+
         if (GlobalV::NSPIN==2)
         {
             if (GlobalC::kv.isk[ik] == 0)
@@ -157,11 +157,11 @@ void Threshold_Elec::print_eigenvalue(std::ofstream &ofs)
 
 			}
 		}       // Pengfei Li  added  14-9-9
-		else	
+		else
 		{
-			ofs << " " << ik+1 << "/" << GlobalC::kv.nks << " kpoint (Cartesian) = " 
-				<< GlobalC::kv.kvec_c[ik].x << " " << GlobalC::kv.kvec_c[ik].y << " " << GlobalC::kv.kvec_c[ik].z 
-				<< " (" << GlobalC::kv.ngk[ik] << " pws)" << std::endl; 
+			ofs << " " << ik+1 << "/" << GlobalC::kv.nks << " kpoint (Cartesian) = "
+				<< GlobalC::kv.kvec_c[ik].x << " " << GlobalC::kv.kvec_c[ik].y << " " << GlobalC::kv.kvec_c[ik].z
+				<< " (" << GlobalC::kv.ngk[ik] << " pws)" << std::endl;
 
 			ofs << std::setprecision(6);
 		}
@@ -183,7 +183,7 @@ void Threshold_Elec::print_eigenvalue(std::ofstream &ofs)
 			GlobalV::ofs_running << std::setiosflags(ios::showpoint);
 			for (int ib = 0; ib < GlobalV::NBANDS; ib++)
 			{
-				ofs << " [spin" << GlobalC::kv.isk[ik]+1 << "_state] " << std::setw(8) << ib+1 
+				ofs << " [spin" << GlobalC::kv.isk[ik]+1 << "_state] " << std::setw(8) << ib+1
 				<< std::setw(15) << GlobalC::wf.ekb[ik][ib] * Ry_to_eV << std::setw(15) << GlobalC::wf.wg(ik, ib) << std::endl;
 			}
 			ofs << std::endl;

--- a/source/src_ri/conv_coulomb_pot-inl.h
+++ b/source/src_ri/conv_coulomb_pot-inl.h
@@ -8,30 +8,30 @@
 
 inline double Conv_Coulomb_Pot::get_r_radial_outofrange( size_t ir ) const
 {
-	return orb.getRadial(conv_coulomb_pot.size()-1) 
-		+ orb.getRab(conv_coulomb_pot.size()-1) 
-		* ( ir - conv_coulomb_pot.size() + 1 ) ;	
+	return orb.getRadial(conv_coulomb_pot.size()-1)
+		+ orb.getRab(conv_coulomb_pot.size()-1)
+		* ( ir - conv_coulomb_pot.size() + 1 ) ;
 }
-	
+
 template< typename T >
-void Conv_Coulomb_Pot::cal_orbs_ccp( 
-	const T & orbs, 
-	T & orbs_ccp, 
-	size_t rmesh_times, 
+void Conv_Coulomb_Pot::cal_orbs_ccp(
+	const T & orbs,
+	T & orbs_ccp,
+	size_t rmesh_times,
 	size_t kmesh_times )
 {
 	orbs_ccp.resize(orbs.size());
-	for( int i=0; i!=orbs.size(); ++i )
+	for( size_t i=0; i!=orbs.size(); ++i )
 	{
 		cal_orbs_ccp( orbs[i], orbs_ccp[i], rmesh_times, kmesh_times );
 	}
 }
 
 template<>
-void Conv_Coulomb_Pot::cal_orbs_ccp<Numerical_Orbital_Lm>( 
-	const Numerical_Orbital_Lm & orbs, 
-	Numerical_Orbital_Lm & orbs_ccp, 
-	size_t rmesh_times, 
+void Conv_Coulomb_Pot::cal_orbs_ccp<Numerical_Orbital_Lm>(
+	const Numerical_Orbital_Lm & orbs,
+	Numerical_Orbital_Lm & orbs_ccp,
+	size_t rmesh_times,
 	size_t kmesh_times );
 
 #endif

--- a/source/src_ri/exx_abfs-construct_orbs.cpp
+++ b/source/src_ri/exx_abfs-construct_orbs.cpp
@@ -8,12 +8,12 @@
 #include "../src_external/src_test/src_ri/exx_abfs-construct_orbs-test.h"		// Peize Lin test
 #include "../src_lcao/global_fp.h"
 
-std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_Orbs::change_orbs( 
+std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_Orbs::change_orbs(
 	const LCAO_Orbitals &orbs_in,
 	const double kmesh_times )
 {
 	TITLE("Exx_Abfs::Construct_Orbs::change_orbs");
-	
+
 	std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> orbs;
 	orbs.resize( orbs_in.get_ntype() );
 	for (int T = 0;  T < orbs_in.get_ntype() ; T++)
@@ -47,7 +47,7 @@ std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_
 	return orbs;
 }
 
-std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_Orbs::change_orbs( 
+std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_Orbs::change_orbs(
 	const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &orbs_in,
 	const double kmesh_times )
 {
@@ -58,37 +58,37 @@ std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_
 // P = u/r * Y
 /*
 template<typename Orbs_Type>
-std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_Orbs::abfs_same_atom( 
+std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_Orbs::abfs_same_atom(
 	const Orbs_Type &orbs,
 	const double kmesh_times,
 	const double norm_threshold )
 {
-	const std::vector<std::vector<std::vector<std::vector<double>>>> 
+	const std::vector<std::vector<std::vector<std::vector<double>>>>
 		&&abfs_same_atom_psir = psir_mult_psir( orbs );
-	const std::vector<std::vector<std::vector<std::vector<double>>>> 
+	const std::vector<std::vector<std::vector<std::vector<double>>>>
 		&&abfs_same_atom_psir_orth = orth( abfs_same_atom_psir, orbs, norm_threshold );
-	const std::vector<std::vector<std::vector<std::vector<double>>>> 
+	const std::vector<std::vector<std::vector<std::vector<double>>>>
 		&&abfs_same_atom_psi_orth = div_r( abfs_same_atom_psir_orth, orbs.get_r_radial );
-	const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> 
+	const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>>
 		&&abfs_same_atom = orbital( abfs_same_atom_psi_orth, orbs, kmesh_times );
 	return abfs_same_atom;
 }
 */
 
 // P = f * Y
-std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_Orbs::abfs_same_atom( 
+std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_Orbs::abfs_same_atom(
 	const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &orbs,
 	const double kmesh_times_mot,
 	const double times_threshold )
 {
 	TITLE("Exx_Abfs::Construct_Orbs::abfs_same_atom");
-	
-	const std::vector<std::vector<std::vector<std::vector<double>>>> 
+
+	const std::vector<std::vector<std::vector<std::vector<double>>>>
 		abfs_same_atom_psi = psi_mult_psi( orbs );
-		
-	const std::vector<std::vector<std::vector<std::vector<double>>>> 
+
+	const std::vector<std::vector<std::vector<std::vector<double>>>>
 		abfs_same_atom_orth_psi = orth( abfs_same_atom_psi, orbs );
-	const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>>  
+	const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>>
 		abfs_same_atom = orbital( abfs_same_atom_orth_psi, orbs, 1 );
 
 	#if TEST_EXX_LCAO==1
@@ -97,8 +97,8 @@ std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_
 	#elif TEST_EXX_LCAO==-1
 		#error "TEST_EXX_LCAO"
 	#endif
-		
-	const std::vector<std::vector<std::vector<std::vector<double>>>> 
+
+	const std::vector<std::vector<std::vector<std::vector<double>>>>
 		abfs_same_atom_pca_psi = pca( abfs_same_atom, orbs, kmesh_times_mot, times_threshold );
 
 	#if TEST_EXX_LCAO==1
@@ -107,28 +107,28 @@ std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_
 		#error "TEST_EXX_LCAO"
 	#endif
 
-	const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>>  
+	const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>>
 		&&abfs_same_atom_pca = orbital( abfs_same_atom_pca_psi, orbs, 1 );
 	return abfs_same_atom_pca;
 }
 
-std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_Orbs::orth_orbs( 
+std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_Orbs::orth_orbs(
 	const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &orbs,
 	const double norm_threshold )
 {
 	TITLE("Exx_Abfs::Construct_Orbs::orth_orbs");
-	const std::vector<std::vector<std::vector<std::vector<double>>>> 
+	const std::vector<std::vector<std::vector<std::vector<double>>>>
 		orbs_psi = get_psi( orbs );
-	const std::vector<std::vector<std::vector<std::vector<double>>>> 
+	const std::vector<std::vector<std::vector<std::vector<double>>>>
 		orbs_psi_orth = orth( orbs_psi, orbs, norm_threshold );
-	const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> 
+	const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>>
 		orbs_new = orbital( orbs_psi_orth, orbs, 1 );
 	return orbs_new;
 }
 
 /*
 template<>
-std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_Orbs::psi_mult_psi( 
+std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_Orbs::psi_mult_psi(
 	const LCAO_Orbitals &orbs )
 {
 	std::vector<std::vector<std::vector<std::vector<double>>>> psi_mult_psi( orbs.get_ntype() );
@@ -144,7 +144,7 @@ std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_O
 					for( int N2=((L2==L1)?N1:0); N2!=orbs.Phi[T].getNchi(L2); ++N2 )
 					{
 						assert( orbs.Phi[T].PhiLN(L1,N1).getNr()==orbs.Phi[T].PhiLN(L2,N2).getNr() );
-						
+
 						std::vector<double> mult_psir( orbs.Phi[T].PhiLN(L1,N1).getNr() );
 						for( int ir=0; ir!=orbs.Phi[T].PhiLN(L1,N1).getNr(); ++ir)
 						{
@@ -163,7 +163,7 @@ std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_O
 }
 */
 
-std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_Orbs::psi_mult_psi( 
+std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_Orbs::psi_mult_psi(
 	const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &orbs )
 {
 	std::vector<std::vector<std::vector<std::vector<double>>>> psi_mult_psi( orbs.size() );
@@ -179,7 +179,7 @@ std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_O
 					for( int N2=((L2==L1)?N1:0); N2!=orbs[T][L2].size(); ++N2 )
 					{
 						assert( orbs[T][L1][N1].getNr()==orbs[T][L2][N2].getNr() );
-						
+
 						std::vector<double> mult_psir( orbs[T][L1][N1].getNr() );
 						for( int ir=0; ir!=orbs[T][L1][N1].getNr(); ++ir)
 						{
@@ -199,7 +199,7 @@ std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_O
 
 /*
 template<>
-std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_Orbs::psir_mult_psir( 
+std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_Orbs::psir_mult_psir(
 	const LCAO_Orbitals &orbs )
 {
 	std::vector<std::vector<std::vector<std::vector<double>>>> psir_mult_psir( orbs.get_ntype() );
@@ -215,7 +215,7 @@ std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_O
 					for( int N2=((L2==L1)?N1:0); N2!=orbs.Phi[T].getNchi(L2); ++N2 )
 					{
 						assert( orbs.Phi[T].PhiLN(L1,N1).getNr()==orbs.Phi[T].PhiLN(L2,N2).getNr() );
-						
+
 						std::vector<double> mult_psir( orbs.Phi[T].PhiLN(L1,N1).getNr() );
 						for( int ir=0; ir!=orbs.Phi[T].PhiLN(L1,N1).getNr(); ++ir)
 						{
@@ -250,7 +250,7 @@ std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_O
 					for( int N2=((L2==L1)?N1:0); N2!=orbs[T][L2].size(); ++N2 )
 					{
 						assert( orbs[T][L1][N1].getNr()==orbs[T][L2][N2].getNr() );
-						
+
 						std::vector<double> mult_psir( orbs[T][L1][N1].getNr() );
 						for( int ir=0; ir!=orbs[T][L1][N1].getNr(); ++ir)
 						{
@@ -264,7 +264,7 @@ std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_O
 				}
 			}
 		}
-	}	
+	}
 	return psir_mult_psir;
 }
 
@@ -277,12 +277,12 @@ std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_O
 std::ofstream ofs(GlobalC::exx_lcao.test_dir.process+"time_"+TO_STRING(GlobalV::MY_RANK),std::ofstream::app);
 	if(times_threshold>1)
 		return std::vector<std::vector<std::vector<std::vector<double>>>>(abfs.size());
-	
+
 	const std::vector<std::vector<std::pair<std::vector<double>,matrix>>> && eig = Exx_Abfs::PCA::cal_PCA( orbs, abfs, kmesh_times_mot );
-	
+
 	const std::vector<std::vector<std::vector<std::vector<double>>>> && psis = get_psi( abfs );
 	std::vector<std::vector<std::vector<std::vector<double>>>> psis_new( psis.size() );
-	
+
 	for( size_t T=0; T!=eig.size(); ++T )
 	{
 		double eig_value_max = 0;
@@ -293,15 +293,15 @@ ofs<<T<<"\t"<<L<<"\t"<<M<<"\t"<<eig[T][L].first[M]<<std::endl;
 				eig_value_max = std::max( eig_value_max, eig[T][L].first[M] );
 			}
 		const double eig_value_threshold = eig_value_max * times_threshold;
-		
+
 ofs<<"eig_value_max:\t"<<eig_value_max<<std::endl;
 ofs<<"eig_value_threshold:\t"<<eig_value_threshold<<std::endl;
-		
+
 		if(eig_value_max)
 		{
 			psis_new[T].resize( psis[T].size() );
 			for( size_t L=0; L!=eig[T].size(); ++L )
-			{			
+			{
 				const std::vector<double> &eig_value = eig[T][L].first;
 				const matrix &eig_vec = eig[T][L].second;
 				for( size_t M=0; M!=eig_value.size(); ++M )
@@ -335,7 +335,7 @@ ofs.close();
 }
 
 
-std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_Orbs::orth( 
+std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_Orbs::orth(
 	const std::vector<std::vector<std::vector<std::vector<double>>>> &psis,
 	const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &orbs,
 	const double norm_threshold )
@@ -344,8 +344,8 @@ std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_O
 	for( int T=0; T!=psis.size(); ++T )
 	{
 		const Numerical_Orbital_Lm &orb = orbs[T][0][0];
-		Gram_Schmidt_Orth<double,double> gso( 
-			orb.get_rab(), 
+		Gram_Schmidt_Orth<double,double> gso(
+			orb.get_rab(),
 			Gram_Schmidt_Orth<double,double>::Coordinate::Sphere );
 		psis_orth[T].resize( psis[T].size() );
 		for( int L=0; L!=psis[T].size(); ++L )
@@ -357,22 +357,22 @@ std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_O
 	return psis_orth;
 }
 
-std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_Orbs::div_r( 
+std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_Orbs::div_r(
 	const std::vector<std::vector<std::vector<std::vector<double>>>> &psirs,
 	const std::vector<double> &r_radial )
 {
 	std::vector<std::vector<std::vector<std::vector<double>>>> psis( psirs.size() );
-	for( int T=0; T!=psirs.size(); ++T )
+	for( auto T=0; T!=psirs.size(); ++T )
 	{
 		psis[T].resize( psirs[T].size() );
-		for( int L=0; L!=psirs[T].size(); ++L )
+		for( auto L=0; L!=psirs[T].size(); ++L )
 		{
 			psis[T][L].resize( psirs[T][L].size() );
-			for( int N=0; N!=psirs[T][L].size(); ++N )
+			for( auto N=0; N!=psirs[T][L].size(); ++N )
 			{
 				psis[T][L][N].resize( psirs[T][L][N].size() );
 				psis[T][L][N][0] = 0;
-				for( int ir=1; ir!=psirs[T][L][N].size(); ++ir )
+				for( auto ir=1; ir!=psirs[T][L][N].size(); ++ir )
 				{
 					psis[T][L][N][ir] = psirs[T][L][N][ir] / r_radial[ir];
 				}
@@ -415,7 +415,7 @@ std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_
 		{
 			orbs_new[T][L].resize( psis[T][L].size() );
 			for( int N=0; N!=psis[T][L].size(); ++N )
-			{				
+			{
 				orbs_new[T][L][N].set_orbital_info(
 					orb_info.getLabel(),
 					T,
@@ -434,7 +434,7 @@ std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_
 					true, GlobalV::FORCE);
 			}
 		}
-	}	
+	}
 	return orbs_new;
 }
 

--- a/tests/module_base/blas_connector.cpp
+++ b/tests/module_base/blas_connector.cpp
@@ -1,17 +1,17 @@
-#include "gtest/gtest.h"
 #include "module_base/blas_connector.h"
+#include "gtest/gtest.h"
 
-#include <array>
-#include <cstdlib>
 #include <algorithm>
+#include <array>
 #include <complex>
+#include <cstdlib>
 TEST(blas_connector, sscal_)
 {
 	typedef float T;
 	const int size = 8;
 	const T scale = 2;
 	const int incx = 1;
-	std::array<T,size> result, answer;
+	std::array<T, size> result, answer;
 	std::generate(result.begin(), result.end(), std::rand);
 	for (int i = 0; i < size; i++)
 		answer[i] = result[i] * scale;
@@ -26,7 +26,7 @@ TEST(blas_connector, dscal_)
 	const int size = 8;
 	const T scale = 2;
 	const int incx = 1;
-	std::array<T,size> result, answer;
+	std::array<T, size> result, answer;
 	std::generate(result.begin(), result.end(), std::rand);
 	for (int i = 0; i < size; i++)
 		answer[i] = result[i] * scale;
@@ -39,15 +39,17 @@ TEST(blas_connector, cscal_)
 {
 	typedef std::complex<float> T;
 	const int size = 8;
-	const T scale = {2,3};
+	const T scale = {2, 3};
 	const int incx = 1;
-	std::array<T,size> result, answer;
+	std::array<T, size> result, answer;
 	std::generate(result.begin(), result.end(), []()
-				  { return T{std::rand(), std::rand()}; });
+				  { return T{static_cast<float>(std::rand()),
+							 static_cast<float>(std::rand())}; });
 	for (int i = 0; i < size; i++)
 		answer[i] = result[i] * scale;
 	cscal_(&size, &scale, result.data(), &incx);
-	for (int i = 0; i < size; i++){
+	for (int i = 0; i < size; i++)
+	{
 		EXPECT_FLOAT_EQ(answer[i].real(), result[i].real());
 		EXPECT_FLOAT_EQ(answer[i].imag(), result[i].imag());
 	}
@@ -61,7 +63,8 @@ TEST(blas_connector, zscal_)
 	const int incx = 1;
 	std::array<T, size> result, answer;
 	std::generate(result.begin(), result.end(), []()
-				  { return T{std::rand(), std::rand()}; });
+				  { return T{static_cast<double>(std::rand()),
+							 static_cast<double>(std::rand())}; });
 	for (int i = 0; i < size; i++)
 		answer[i] = result[i] * scale;
 	zscal_(&size, &scale, result.data(), &incx);


### PR DESCRIPTION
Remaining issues:
- using directive refers to implicitly-defined namespace 'std' (i.e. `using namespace std`);
- MRRR related( register, char* conversion in `strcmp`, _etc._ ;
- source/run_lcao.cpp:137:10: warning: enumeration values 'No' and 'Generate_Matrix' not handled in switch [-Wswitch] `switch(GlobalC::exx_global.info.hybrid_type)`; (also in  source/src_lcao/ELEC_nscf.cpp:23:9)
- WIP: source/input.cpp:2335:23: warning: 'sizeof (this->angle1)' will return the size of the pointer, not the array itself [-Wsizeof-pointer-div] `if((sizeof(angle1) / sizeof(angle1[0]) != this->ntype)){`


