### PR TITLE
bug report: in file module_base/math_sphbes.cpp, std namespace can't be removed

### DIFF
--- a/source/module_base/constants.h
+++ b/source/module_base/constants.h
@@ -1,7 +1,6 @@
 #ifndef CONSTANT_H
 #define CONSTANT_H
 #include <complex>
-using namespace std;
 
 //==========================================================
 // GLOBAL CONSTANTS 

--- a/source/module_base/integral.cpp
+++ b/source/module_base/integral.cpp
@@ -3,6 +3,7 @@
 #include "constants.h"
 #include <cassert>
 #include <cmath>
+
 namespace ModuleBase
 {
 

--- a/source/module_base/math_sphbes.cpp
+++ b/source/module_base/math_sphbes.cpp
@@ -1,7 +1,7 @@
 #include "math_sphbes.h"
 #include "timer.h"
 #include "constants.h"
-
+using namespace std;
 namespace ModuleBase
 {
 


### PR DESCRIPTION
bug report: in file module_base/math_sphbes.cpp, the 'using namespace std' line maybe is unnecessary but there are some errors occur when delete this line.
The bug shows: It can be compile normally if this line is removed, but Autotest will totally wrong with 5~10 eV errors occured.