### PR TITLE
add cmake support for unittest of module base

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,11 +31,14 @@ endfunction(AddTest)
 
 get_target_property(ABACUS_LINK_LIBRARIES ${ABACUS_BIN_NAME} LINK_LIBRARIES)
 
+set(TEST_BASE_DIR ${CMAKE_SOURCE_DIR}/source/module_base)
+include_directories(${TEST_BASE_DIR})
+
 AddTest(
   TARGET base_matrix3
-  SOURCES ${ABACUS_TEST_DIR}/module_base/matrix3.cpp
+  SOURCES ${ABACUS_TEST_DIR}/module_base/test_matrix3.cpp
 )
 AddTest(
   TARGET base_blas_connector
-  SOURCES ${ABACUS_TEST_DIR}/module_base/blas_connector.cpp
+  SOURCES ${ABACUS_TEST_DIR}/module_base/test_blas_connector.cpp
 )

--- a/tests/module_base/CMakeLists.txt
+++ b/tests/module_base/CMakeLists.txt
@@ -1,0 +1,143 @@
+########################################
+# CMake build system
+# This file is part of ABACUS
+cmake_minimum_required(VERSION 3.18)
+########################################
+# project name
+project(module_base_test)
+# enable cmake test
+enable_testing()
+# link the libraries anyway
+set(CMAKE_LINK_WHAT_YOU_USE TRUE)
+# set extra modules
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/../../modules)
+
+# load the package needed by the current UT module
+find_package(MPI)
+find_package(OpenMP)
+find_package(Threads)
+find_package(MPI REQUIRED)
+find_package(ELPA REQUIRED)
+find_package(GTest REQUIRED)
+find_package(Cereal REQUIRED)
+
+# compile the base module
+set(libname "module_base")
+set(LIB_BASE_DIR ${CMAKE_SOURCE_DIR}/../../source/module_base)
+include_directories(${LIB_BASE_DIR})
+file(GLOB LIB_SRC 
+     ${LIB_BASE_DIR}/complexarray.cpp 
+     ${LIB_BASE_DIR}/global_variable.cpp
+     ${LIB_BASE_DIR}/math_polyint.cpp
+     ${LIB_BASE_DIR}/matrix.cpp 
+     ${LIB_BASE_DIR}/sph_bessel.cpp
+     ${LIB_BASE_DIR}/tool_title.cpp 
+     ${LIB_BASE_DIR}/complexmatrix.cpp
+     ${LIB_BASE_DIR}/intarray.cpp 
+     ${LIB_BASE_DIR}/math_sphbes.cpp 
+     ${LIB_BASE_DIR}/memory.cpp
+     ${LIB_BASE_DIR}/sph_bessel_recursive-d1.cpp
+     ${LIB_BASE_DIR}/ylm.cpp
+     ${LIB_BASE_DIR}/element_basis_index.cpp
+     ${LIB_BASE_DIR}/integral.cpp
+     ${LIB_BASE_DIR}/math_ylmreal.cpp
+     ${LIB_BASE_DIR}/sph_bessel_recursive-d2.cpp
+     ${LIB_BASE_DIR}/export.cpp
+     ${LIB_BASE_DIR}/inverse_matrix.cpp
+     ${LIB_BASE_DIR}/timer.cpp
+     ${LIB_BASE_DIR}/global_file.cpp
+     ${LIB_BASE_DIR}/main.cpp
+     ${LIB_BASE_DIR}/mathzone.cpp
+     ${LIB_BASE_DIR}/polint.cpp
+     ${LIB_BASE_DIR}/tool_check.cpp
+     ${LIB_BASE_DIR}/global_function.cpp
+     ${LIB_BASE_DIR}/math_integral.cpp
+     ${LIB_BASE_DIR}/matrix3.cpp
+     ${LIB_BASE_DIR}/realarray.cpp
+     ${LIB_BASE_DIR}/tool_quit.cpp
+)
+add_library(${libname} ${LIB_SRC})
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+
+# compile the test executable
+file(GLOB TEST_SRC 
+     test_blas_connector.cpp
+     test_matrix3.cpp
+)
+
+add_executable(runUnitTests ${TEST_SRC})
+
+
+target_link_libraries(
+    runUnitTests 
+    gtest 
+    gtest_main 
+    ${libname} 
+    pthread 
+    coverage_config
+)
+
+# link the third party library
+if(DEFINED MKL_DIR)
+    set(MKL_DIR_CACHE "${MKL_DIR}")
+endif()
+
+if(DEFINED MKL_DIR_CACHE)
+    find_package(IntelMKL REQUIRED)
+    add_definitions(-D__MKL -DMKL_ILP64)
+    target_link_libraries(
+        runUnitTests
+        -lifcore
+        MPI::MPI_CXX
+        IntelMKL::MKL
+        OpenMP::OpenMP_CXX
+    )
+else()
+    find_package(LAPACK REQUIRED)
+    find_package(ScaLAPACK REQUIRED)
+    target_link_libraries(
+        runUnitTests
+        FFTW3::FFTW3
+        MPI::MPI_CXX
+        ScaLAPACK::ScaLAPACK
+        LAPACK::LAPACK
+        OpenMP::OpenMP_CXX
+    )
+endif()
+
+add_test(runUnitTests runUnitTests)
+
+# coverage setting
+add_library(coverage_config INTERFACE)
+target_compile_options(coverage_config INTERFACE
+    -O0        # no optimization
+    -g         # generate debug info
+    --coverage # sets all required flags
+)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
+target_link_options(coverage_config INTERFACE --coverage)
+else()
+target_link_libraries(coverage_config INTERFACE --coverage)
+endif()
+
+# setting gtest environ
+if(NOT GTEST_LIBRARIES)
+  configure_file(../../cmake/googletest.cmake.in googletest-download/CMakeLists.txt)
+  execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+  if(result)
+    message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+  endif()
+  execute_process(COMMAND ${CMAKE_COMMAND} --build .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+  if(result)
+    message(FATAL_ERROR "Build step for googletest failed: ${result}")
+  endif()
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src ${CMAKE_CURRENT_BINARY_DIR}/googletest-build EXCLUDE_FROM_ALL)
+else ()
+  include_directories(${GTEST_INCLUDE_DIRS})
+endif ()

--- a/tests/module_base/test_blas_connector.cpp
+++ b/tests/module_base/test_blas_connector.cpp
@@ -1,4 +1,4 @@
-#include "module_base/blas_connector.h"
+#include "blas_connector.h"
 #include "gtest/gtest.h"
 
 #include <algorithm>

--- a/tests/module_base/test_matrix3.cpp
+++ b/tests/module_base/test_matrix3.cpp
@@ -1,4 +1,4 @@
-#include "module_base/matrix3.h"
+#include "matrix3.h"
 #include "gtest/gtest.h"
 #include <random>
 #include <vector>


### PR DESCRIPTION
The previous module_base UT compilation process would require the pre-compilation process of Abacus. This would increase the complexity of UT compilation. Herein, this PR decouple the compilation of UT and Abacus main program, so that we could focus on the UT itself while compiling the test system. The main changes of this PR are:

- add cmake support for module_base
- use `test_` prefix for UT source files
- compile module_base as a unique shared library during the UT process

**Note that the original ctest process remains unchanged.**

The following command shows the new implementation's testing process in my local workstation:
```
/root/abacus-develop/abacus-develop/tests/module_base

root module_base $ mkdir build

root module_base $ cd build

root build $ cmake -DCMAKE_CXX_COMPILER=icpc -DMPI_CXX_COMPILER=mpiicpc -DCMAKE_INSTALL_PREFIX=$abacus_root -DELPA_DIR=/root/sXX_COMPILER=icpc -DMPI_CXX_COMPILER=mpiicpc -DCMAKE_INSTALL_PREFIX=$abacus_root -DELP_PREFIX=$abacus_root -DEL-- The C compiler identification is GNU 7.5.0AL_INCLUDEDIR=/root/softwares/cereal/include -DMKL_DIR=/opt/intel/mkl ..
-- The CXX compiler identification is Intel 18.0.5.20180823
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /opt/intel/compilers_and_libraries_2018.5.274/linux/bin/intel64/icpc - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found MPI_C: /opt/intel/compilers_and_libraries_2018.5.274/linux/mpi/intel64/lib/release_mt/libmpi.so (found version "3.1") 
-- Found MPI_CXX: /opt/intel/compilers_and_libraries_2018.5.274/linux/mpi/intel64/lib/libmpicxx.so (found version "3.1") 
-- Found MPI: TRUE (found version "3.1")  
-- Found OpenMP_C: -fopenmp (found version "4.5") 
-- Found OpenMP_CXX: -qopenmp (found version "5.0") 
-- Found OpenMP: TRUE (found version "4.5")  
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Found ELPA: /root/softwares/elpa-2016.05.004/lib/libelpa.so  
-- Found GTest: /root/abacus-develop/abacus-root/lib/cmake/GTest/GTestConfig.cmake (found version "1.11.0")  
-- Found Cereal: /root/softwares/cereal/include  
-- Found IntelMKL: /opt/intel/mkl/lib/intel64/libmkl_intel_lp64.so  
-- Configuring done
-- Generating done
-- Build files have been written to: /root/abacus-develop/abacus-develop/tests/module_base/build

root build $ make -j12
[  3%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/complexarray.cpp.o
[  6%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/element_basis_index.cpp.o
[  9%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/complexmatrix.cpp.o
[ 12%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/export.cpp.o
[ 15%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/global_function.cpp.o
[ 21%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/global_variable.cpp.o
[ 21%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/global_file.cpp.o
[ 30%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/inverse_matrix.cpp.o
[ 30%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/integral.cpp.o
[ 30%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/main.cpp.o
[ 33%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/math_integral.cpp.o
[ 36%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/intarray.cpp.o
[ 39%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/math_polyint.cpp.o
[ 42%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/math_sphbes.cpp.o
[ 45%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/math_ylmreal.cpp.o
[ 48%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/mathzone.cpp.o
[ 51%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/matrix.cpp.o
[ 54%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/matrix3.cpp.o
[ 57%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/memory.cpp.o
[ 60%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/polint.cpp.o
[ 63%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/realarray.cpp.o
[ 66%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/sph_bessel.cpp.o
[ 69%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/sph_bessel_recursive-d1.cpp.o
[ 72%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/sph_bessel_recursive-d2.cpp.o
[ 75%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/timer.cpp.o
[ 78%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/tool_check.cpp.o
[ 81%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/tool_quit.cpp.o
[ 84%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/tool_title.cpp.o
[ 87%] Building CXX object CMakeFiles/module_base.dir/root/abacus-develop/abacus-develop/source/module_base/ylm.cpp.o
[ 90%] Linking CXX static library libmodule_base.a
[ 90%] Built target module_base
[ 93%] Building CXX object CMakeFiles/runUnitTests.dir/test_blas_connector.cpp.o
[ 96%] Building CXX object CMakeFiles/runUnitTests.dir/test_matrix3.cpp.o
icpc: command line warning #10006: ignoring unknown option '-fcoverage'
icpc: command line warning #10006: ignoring unknown option '-fcoverage'
[100%] Linking CXX executable runUnitTests
icpc: command line warning #10006: ignoring unknown option '-fcoverage'
Warning: Unused direct dependencies:
        /opt/intel/compilers_and_libraries_2018.5.274/linux/compiler/lib/intel64_lin/libifcore.so.5
        /opt/intel/compilers_and_libraries_2018.5.274/linux/mpi/intel64/lib/libmpicxx.so.12
        /lib/x86_64-linux-gnu/librt.so.1
        /opt/intel/mkl/lib/intel64/libmkl_intel_thread.so
        /opt/intel/mkl/lib/intel64/libmkl_core.so
        /opt/intel/mkl/lib/intel64/libmkl_scalapack_lp64.so
        /opt/intel/mkl/lib/intel64/libmkl_blacs_intelmpi_lp64.so
        /opt/intel/compilers_and_libraries_2018.5.274/linux/compiler/lib/intel64_lin/libiomp5.so
        /lib/x86_64-linux-gnu/libm.so.6
[100%] Built target runUnitTests

root build $ ./runUnitTests 
Running main() from /root/packages/googletest/googletest/src/gtest_main.cc
[==========] Running 6 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 4 tests from blas_connector
[ RUN      ] blas_connector.sscal_
[       OK ] blas_connector.sscal_ (1 ms)
[ RUN      ] blas_connector.dscal_
[       OK ] blas_connector.dscal_ (0 ms)
[ RUN      ] blas_connector.cscal_
[       OK ] blas_connector.cscal_ (0 ms)
[ RUN      ] blas_connector.zscal_
[       OK ] blas_connector.zscal_ (0 ms)
[----------] 4 tests from blas_connector (1 ms total)

[----------] 2 tests from matrix3_test
[ RUN      ] matrix3_test.op_equal
[       OK ] matrix3_test.op_equal (0 ms)
[ RUN      ] matrix3_test.op_inequal
[       OK ] matrix3_test.op_inequal (0 ms)
[----------] 2 tests from matrix3_test (0 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 6 tests.
root build $ 
```