### PR TITLE
TEST: Add test for blas_connector.h

### DIFF
--- a/tests/module_base/test_blas_connector.cpp
+++ b/tests/module_base/test_blas_connector.cpp
@@ -5,72 +5,367 @@
 #include <array>
 #include <complex>
 #include <cstdlib>
-TEST(blas_connector, sscal_)
-{
-	typedef float T;
-	const int size = 8;
-	const T scale = 2;
-	const int incx = 1;
-	std::array<T, size> result, answer;
-	std::generate(result.begin(), result.end(), std::rand);
-	for (int i = 0; i < size; i++)
-		answer[i] = result[i] * scale;
-	sscal_(&size, &scale, result.data(), &incx);
-	for (int i = 0; i < size; i++)
-		EXPECT_FLOAT_EQ(answer[i], result[i]);
+TEST(blas_connector, sscal_) {
+    typedef float T;
+    const int size = 8;
+    const T scale = 2;
+    const int incx = 1;
+    std::array<T, size> result, answer;
+    std::generate(result.begin(), result.end(),
+                  []() { return std::rand() / T(RAND_MAX); });
+    for (int i = 0; i < size; i++)
+        answer[i] = result[i] * scale;
+    sscal_(&size, &scale, result.data(), &incx);
+    for (int i = 0; i < size; i++)
+        EXPECT_FLOAT_EQ(answer[i], result[i]);
 }
 
-TEST(blas_connector, dscal_)
-{
-	typedef double T;
-	const int size = 8;
-	const T scale = 2;
-	const int incx = 1;
-	std::array<T, size> result, answer;
-	std::generate(result.begin(), result.end(), std::rand);
-	for (int i = 0; i < size; i++)
-		answer[i] = result[i] * scale;
-	dscal_(&size, &scale, result.data(), &incx);
-	for (int i = 0; i < size; i++)
-		EXPECT_FLOAT_EQ(answer[i], result[i]);
+TEST(blas_connector, dscal_) {
+    typedef double T;
+    const int size = 8;
+    const T scale = 2;
+    const int incx = 1;
+    std::array<T, size> result, answer;
+    std::generate(result.begin(), result.end(),
+                  []() { return std::rand() / T(RAND_MAX); });
+    for (int i = 0; i < size; i++)
+        answer[i] = result[i] * scale;
+    dscal_(&size, &scale, result.data(), &incx);
+    for (int i = 0; i < size; i++)
+        EXPECT_DOUBLE_EQ(answer[i], result[i]);
 }
 
-TEST(blas_connector, cscal_)
-{
-	typedef std::complex<float> T;
-	const int size = 8;
-	const T scale = {2, 3};
-	const int incx = 1;
-	std::array<T, size> result, answer;
-	std::generate(result.begin(), result.end(), []()
-				  { return T{static_cast<float>(std::rand()),
-							 static_cast<float>(std::rand())}; });
-	for (int i = 0; i < size; i++)
-		answer[i] = result[i] * scale;
-	cscal_(&size, &scale, result.data(), &incx);
-	for (int i = 0; i < size; i++)
-	{
-		EXPECT_FLOAT_EQ(answer[i].real(), result[i].real());
-		EXPECT_FLOAT_EQ(answer[i].imag(), result[i].imag());
-	}
+TEST(blas_connector, cscal_) {
+    typedef std::complex<float> T;
+    const int size = 8;
+    const T scale = {2, 3};
+    const int incx = 1;
+    std::array<T, size> result, answer;
+    std::generate(result.begin(), result.end(), []() {
+        return T{static_cast<float>(std::rand() / float(RAND_MAX)),
+                 static_cast<float>(std::rand() / float(RAND_MAX))};
+    });
+    for (int i = 0; i < size; i++)
+        answer[i] = result[i] * scale;
+    cscal_(&size, &scale, result.data(), &incx);
+    for (int i = 0; i < size; i++) {
+        EXPECT_FLOAT_EQ(answer[i].real(), result[i].real());
+        EXPECT_FLOAT_EQ(answer[i].imag(), result[i].imag());
+    }
 }
 
-TEST(blas_connector, zscal_)
-{
-	typedef std::complex<double> T;
-	const int size = 8;
-	const T scale = {2, 3};
-	const int incx = 1;
-	std::array<T, size> result, answer;
-	std::generate(result.begin(), result.end(), []()
-				  { return T{static_cast<double>(std::rand()),
-							 static_cast<double>(std::rand())}; });
-	for (int i = 0; i < size; i++)
-		answer[i] = result[i] * scale;
-	zscal_(&size, &scale, result.data(), &incx);
-	for (int i = 0; i < size; i++)
-	{
-		EXPECT_FLOAT_EQ(answer[i].real(), result[i].real());
-		EXPECT_FLOAT_EQ(answer[i].imag(), result[i].imag());
-	}
+TEST(blas_connector, zscal_) {
+    typedef std::complex<double> T;
+    const int size = 8;
+    const T scale = {2, 3};
+    const int incx = 1;
+    std::array<T, size> result, answer;
+    std::generate(result.begin(), result.end(), []() {
+        return T{static_cast<double>(std::rand() / double(RAND_MAX)),
+                 static_cast<double>(std::rand() / double(RAND_MAX))};
+    });
+    for (int i = 0; i < size; i++)
+        answer[i] = result[i] * scale;
+    zscal_(&size, &scale, result.data(), &incx);
+    for (int i = 0; i < size; i++) {
+        EXPECT_DOUBLE_EQ(answer[i].real(), result[i].real());
+        EXPECT_DOUBLE_EQ(answer[i].imag(), result[i].imag());
+    }
+}
+
+TEST(blas_connector, daxpy_) {
+    typedef double T;
+    const int size = 8;
+    const T scale = 2;
+    const int incx = 1;
+    const int incy = 1;
+    std::array<T, size> x_const, result, answer;
+    std::generate(x_const.begin(), x_const.end(),
+                  []() { return std::rand() / double(RAND_MAX); });
+    std::generate(result.begin(), result.end(),
+                  []() { return std::rand() / double(RAND_MAX); });
+    for (int i = 0; i < size; i++)
+        answer[i] = x_const[i] * scale + result[i];
+    daxpy_(&size, &scale, x_const.data(), &incx, result.data(), &incy);
+    for (int i = 0; i < size; i++)
+        EXPECT_DOUBLE_EQ(answer[i], result[i]);
+}
+
+TEST(blas_connector, zaxpy_) {
+    typedef std::complex<double> T;
+    const int size = 8;
+    const T scale = {2, 3};
+    const int incx = 1;
+    const int incy = 1;
+    std::array<T, size> x_const, result, answer;
+    std::generate(x_const.begin(), x_const.end(), []() {
+        return T{static_cast<double>(std::rand() / double(RAND_MAX)),
+                 static_cast<double>(std::rand() / double(RAND_MAX))};
+    });
+    std::generate(result.begin(), result.end(), []() {
+        return T{static_cast<double>(std::rand() / double(RAND_MAX)),
+                 static_cast<double>(std::rand() / double(RAND_MAX))};
+    });
+    for (int i = 0; i < size; i++)
+        answer[i] = x_const[i] * scale + result[i];
+    zaxpy_(&size, &scale, x_const.data(), &incx, result.data(), &incy);
+    for (int i = 0; i < size; i++) {
+        EXPECT_DOUBLE_EQ(answer[i].real(), result[i].real());
+        EXPECT_DOUBLE_EQ(answer[i].imag(), result[i].imag());
+    }
+}
+
+TEST(blas_connector, dcopy_) {
+    typedef double T;
+    long const size = 8;
+    int const incx = 1;
+    int const incy = 1;
+    std::array<T, size> x_const, result, answer;
+    std::generate(x_const.begin(), x_const.end(),
+                  []() { return std::rand() / double(RAND_MAX); });
+    for (int i = 0; i < size; i++)
+        answer[i] = x_const[i];
+    dcopy_(&size, x_const.data(), &incx, result.data(), &incy);
+    for (int i = 0; i < size; i++)
+        EXPECT_DOUBLE_EQ(answer[i], result[i]);
+}
+
+TEST(blas_connector, zcopy_) {
+    typedef std::complex<double> T;
+    long const size = 8;
+    int const incx = 1;
+    int const incy = 1;
+    std::array<T, size> x_const, result, answer;
+    std::generate(x_const.begin(), x_const.end(), []() {
+        return T{static_cast<double>(std::rand() / double(RAND_MAX)),
+                 static_cast<double>(std::rand() / double(RAND_MAX))};
+    });
+    for (int i = 0; i < size; i++)
+        answer[i] = x_const[i];
+    zcopy_(&size, x_const.data(), &incx, result.data(), &incy);
+    for (int i = 0; i < size; i++) {
+        EXPECT_DOUBLE_EQ(answer[i].real(), result[i].real());
+        EXPECT_DOUBLE_EQ(answer[i].imag(), result[i].imag());
+    }
+}
+
+TEST(blas_connector, dgemv_) {
+    typedef double T;
+    const char transa_m = 'N';
+    const char transa_n = 'T';
+    const int size_m = 3;
+    const int size_n = 4;
+    const T alpha_const = 2;
+    const T beta_const = 3;
+    const int lda = 5;
+    const int incx = 1;
+    const int incy = 1;
+    std::array<T, size_m> x_const_m, result_m, answer_m, c_dot_m{};
+    std::array<T, size_n> x_const_n, result_n, answer_n, c_dot_n{};
+    std::generate(x_const_n.begin(), x_const_n.end(),
+                  []() { return std::rand() / double(RAND_MAX); });
+    std::generate(result_n.begin(), result_n.end(),
+                  []() { return std::rand() / double(RAND_MAX); });
+    std::generate(x_const_m.begin(), x_const_m.end(),
+                  []() { return std::rand() / double(RAND_MAX); });
+    std::generate(result_m.begin(), result_m.end(),
+                  []() { return std::rand() / double(RAND_MAX); });
+    std::array<T, size_n * lda> a_const;
+    std::generate(a_const.begin(), a_const.end(),
+                  []() { return std::rand() / double(RAND_MAX); });
+    for (int i = 0; i < size_m; i++) {
+        for (int j = 0; j < size_n; j++) {
+            c_dot_m[i] += a_const[i + j * lda] * x_const_n[j];
+        }
+        answer_m[i] = alpha_const * c_dot_m[i] + beta_const * result_m[i];
+    }
+    dgemv_(&transa_m, &size_m, &size_n, &alpha_const, a_const.data(), &lda,
+           x_const_n.data(), &incx, &beta_const, result_m.data(), &incy);
+
+    for (int j = 0; j < size_n; j++) {
+        for (int i = 0; i < size_m; i++) {
+            c_dot_n[j] += a_const[i + j * lda] * x_const_m[i];
+        }
+        answer_n[j] = alpha_const * c_dot_n[j] + beta_const * result_n[j];
+    }
+    dgemv_(&transa_n, &size_m, &size_n, &alpha_const, a_const.data(), &lda,
+           x_const_m.data(), &incx, &beta_const, result_n.data(), &incy);
+
+    for (int i = 0; i < size_m; i++)
+        EXPECT_DOUBLE_EQ(answer_m[i], result_m[i]);
+    for (int j = 0; j < size_n; j++)
+        EXPECT_DOUBLE_EQ(answer_n[j], result_n[j]);
+}
+
+TEST(blas_connector, zgemv_) {
+    typedef std::complex<double> T;
+    const char transa_m = 'N';
+    const char transa_n = 'T';
+    const char transa_h = 'C';
+    const int size_m = 3;
+    const int size_n = 4;
+    const T alpha_const = {2, 3};
+    const T beta_const = {3, 4};
+    const int lda = 5;
+    const int incx = 1;
+    const int incy = 1;
+    std::array<T, size_m> x_const_m, x_const_c, result_m, answer_m, c_dot_m{};
+    std::array<T, size_n> x_const_n, result_n, result_c, answer_n, answer_c,
+        c_dot_n{}, c_dot_c{};
+    std::generate(x_const_n.begin(), x_const_n.end(), []() {
+        return T{static_cast<double>(std::rand() / double(RAND_MAX)),
+                 static_cast<double>(std::rand() / double(RAND_MAX))};
+    });
+    std::generate(result_n.begin(), result_n.end(), []() {
+        return T{static_cast<double>(std::rand() / double(RAND_MAX)),
+                 static_cast<double>(std::rand() / double(RAND_MAX))};
+    });
+    std::generate(x_const_m.begin(), x_const_m.end(), []() {
+        return T{static_cast<double>(std::rand() / double(RAND_MAX)),
+                 static_cast<double>(std::rand() / double(RAND_MAX))};
+    });
+    std::generate(result_m.begin(), result_m.end(), []() {
+        return T{static_cast<double>(std::rand() / double(RAND_MAX)),
+                 static_cast<double>(std::rand() / double(RAND_MAX))};
+    });
+    std::array<T, size_n * lda> a_const;
+    std::generate(a_const.begin(), a_const.end(), []() {
+        return T{static_cast<double>(std::rand() / double(RAND_MAX)),
+                 static_cast<double>(std::rand() / double(RAND_MAX))};
+    });
+    for (int i = 0; i < size_m; i++) {
+        for (int j = 0; j < size_n; j++) {
+            c_dot_m[i] += a_const[i + j * lda] * x_const_n[j];
+        }
+        answer_m[i] = alpha_const * c_dot_m[i] + beta_const * result_m[i];
+    }
+    zgemv_(&transa_m, &size_m, &size_n, &alpha_const, a_const.data(), &lda,
+           x_const_n.data(), &incx, &beta_const, result_m.data(), &incy);
+
+    for (int j = 0; j < size_n; j++) {
+        for (int i = 0; i < size_m; i++) {
+            c_dot_n[j] += a_const[i + j * lda] * x_const_m[i];
+        }
+        answer_n[j] = alpha_const * c_dot_n[j] + beta_const * result_n[j];
+    }
+    zgemv_(&transa_n, &size_m, &size_n, &alpha_const, a_const.data(), &lda,
+           x_const_m.data(), &incx, &beta_const, result_n.data(), &incy);
+
+    for (int j = 0; j < size_n; j++) {
+        for (int i = 0; i < size_m; i++) {
+            c_dot_c[j] += conj(a_const[i + j * lda]) * x_const_c[i];
+        }
+        answer_c[j] = alpha_const * c_dot_c[j] + beta_const * result_c[j];
+    }
+    zgemv_(&transa_h, &size_m, &size_n, &alpha_const, a_const.data(), &lda,
+           x_const_c.data(), &incx, &beta_const, result_c.data(), &incy);
+
+    for (int i = 0; i < size_m; i++) {
+        EXPECT_DOUBLE_EQ(answer_m[i].real(), result_m[i].real());
+        EXPECT_DOUBLE_EQ(answer_m[i].imag(), result_m[i].imag());
+    }
+    for (int j = 0; j < size_n; j++) {
+        EXPECT_DOUBLE_EQ(answer_n[j].real(), result_n[j].real());
+        EXPECT_DOUBLE_EQ(answer_n[j].imag(), result_n[j].imag());
+    }
+    for (int j = 0; j < size_n; j++) {
+        EXPECT_DOUBLE_EQ(answer_c[j].real(), result_c[j].real());
+        EXPECT_DOUBLE_EQ(answer_c[j].imag(), result_c[j].imag());
+    }
+}
+
+TEST(blas_connector, dgemm_) {
+    typedef double T;
+    const char transa_m = 'N';
+    const char transb_m = 'N';
+    const int size_m = 3;
+    const int size_n = 4;
+    const int size_k = 5;
+    const T alpha_const = 2;
+    const T beta_const = 3;
+    const int lda = 6;
+    const int ldb = 5;
+    const int ldc = 4;
+    std::array<T, size_k * lda> a_const;
+    std::array<T, size_n * ldb> b_const;
+    std::array<T, size_n * ldc> c_dot{}, answer, result;
+    std::generate(a_const.begin(), a_const.end(),
+                  []() { return std::rand() / double(RAND_MAX); });
+    std::generate(b_const.begin(), b_const.end(),
+                  []() { return std::rand() / double(RAND_MAX); });
+    std::generate(result.begin(), result.end(),
+                  []() { return std::rand() / double(RAND_MAX); });
+    for (int i = 0; i < size_m; i++) {
+        for (int j = 0; j < size_n; j++) {
+            for (int k = 0; k < size_k; k++) {
+                c_dot[i + j * ldc] +=
+                    a_const[i + k * lda] * b_const[k + j * ldb];
+            }
+            answer[i + j * ldc] = alpha_const * c_dot[i + j * ldc] +
+                                  beta_const * result[i + j * ldc];
+        }
+    }
+    dgemm_(&transa_m, &transb_m, &size_m, &size_n, &size_k, &alpha_const,
+           a_const.data(), &lda, b_const.data(), &ldb, &beta_const,
+           result.data(), &ldc);
+
+    for (int i = 0; i < size_m; i++)
+        for (int j = 0; j < size_n; j++) {
+            EXPECT_DOUBLE_EQ(answer[i + j * ldc], result[i + j * ldc]);
+        }
+}
+
+TEST(blas_connector, zgemm_) {
+    typedef std::complex<double> T;
+    const char transa_m = 'N';
+    const char transb_m = 'N';
+    const int size_m = 3;
+    const int size_n = 4;
+    const int size_k = 5;
+    const T alpha_const = {2, 3};
+    const T beta_const = {3, 4};
+    const int lda = 6;
+    const int ldb = 5;
+    const int ldc = 4;
+    std::array<T, size_k * lda> a_const;
+    std::array<T, size_n * ldb> b_const;
+    std::array<T, size_n * ldc> c_dot{}, answer, result;
+    std::generate(a_const.begin(), a_const.end(), []() {
+        return T{static_cast<double>(std::rand() / double(RAND_MAX)),
+                 static_cast<double>(std::rand() / double(RAND_MAX))};
+    });
+    std::generate(b_const.begin(), b_const.end(), []() {
+        return T{static_cast<double>(std::rand() / double(RAND_MAX)),
+                 static_cast<double>(std::rand() / double(RAND_MAX))};
+    });
+    std::generate(result.begin(), result.end(), []() {
+        return T{static_cast<double>(std::rand() / double(RAND_MAX)),
+                 static_cast<double>(std::rand() / double(RAND_MAX))};
+    });
+    for (int i = 0; i < size_m; i++) {
+        for (int j = 0; j < size_n; j++) {
+            for (int k = 0; k < size_k; k++) {
+                c_dot[i + j * ldc] +=
+                    a_const[i + k * lda] * b_const[k + j * ldb];
+            }
+            answer[i + j * ldc] = alpha_const * c_dot[i + j * ldc] +
+                                  beta_const * result[i + j * ldc];
+        }
+    }
+    zgemm_(&transa_m, &transb_m, &size_m, &size_n, &size_k, &alpha_const,
+           a_const.data(), &lda, b_const.data(), &ldb, &beta_const,
+           result.data(), &ldc);
+
+    for (int i = 0; i < size_m; i++)
+        for (int j = 0; j < size_n; j++) {
+            EXPECT_DOUBLE_EQ(answer[i + j * ldc].real(),
+                             result[i + j * ldc].real());
+            EXPECT_DOUBLE_EQ(answer[i + j * ldc].imag(),
+                             result[i + j * ldc].imag());
+        }
+}
+
+int main(int argc, char **argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
For Intel oneAPI, the following command shows the new implementation's testing process in my local workstation:
```
chentao@chentao:~/soft/abacus-develop/tests/module_base$ mkdir build
chentao@chentao:~/soft/abacus-develop/tests/module_base$ cd build/
chentao@chentao:~/soft/abacus-develop/tests/module_base/build$ cmake -DCMAKE_CXX_COMPILER=icpc -DMPI_CXX_COMPILER=mpiicpc  -DELPA_DIR=/home/chentao/soft/elpa -DCEREAL_INCLUDEDIR=/home/chentao/soft/cereal-1.3.0/include -DMKL_DIR=/opt/intel/oneapi/mkl/latest -DMKLROOT=/opt/intel/oneapi/mkl/latest ..
-- The C compiler identification is GNU 7.5.0
-- The CXX compiler identification is Intel 2021.3.0.20210609
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /opt/intel/oneapi/compiler/2021.3.0/linux/bin/intel64/icpc - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found MPI_C: /opt/intel/oneapi/mpi/2021.3.0/lib/release/libmpi.so (found version "3.1") 
-- Found MPI_CXX: /opt/intel/oneapi/mpi/2021.3.0/lib/libmpicxx.so (found version "3.1") 
-- Found MPI: TRUE (found version "3.1")  
-- Found OpenMP_C: -fopenmp (found version "4.5") 
-- Found OpenMP_CXX: -qopenmp (found version "5.0") 
-- Found OpenMP: TRUE (found version "4.5")  
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Found ELPA: /home/chentao/soft/elpa/lib/libelpa.so  
-- Found GTest: /usr/local/lib/cmake/GTest/GTestConfig.cmake (found version "1.11.0")  
-- Found Cereal: /home/chentao/soft/cereal-1.3.0/include  
-- Found IntelMKL: /opt/intel/oneapi/mkl/latest/lib/intel64/libmkl_intel_lp64.so  
-- Configuring done
-- Generating done
-- Build files have been written to: /home/chentao/soft/abacus-develop/tests/module_base/build
chentao@chentao:~/soft/abacus-develop/tests/module_base/build$ make
[  3%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/complexarray.cpp.o
[  6%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/complexmatrix.cpp.o
[  9%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/element_basis_index.cpp.o
[ 12%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/export.cpp.o
[ 15%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/global_file.cpp.o
[ 18%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/global_function.cpp.o
[ 21%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/global_variable.cpp.o
[ 24%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/intarray.cpp.o
[ 27%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/integral.cpp.o
[ 30%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/inverse_matrix.cpp.o
[ 33%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/main.cpp.o
[ 36%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/math_integral.cpp.o
[ 39%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/math_polyint.cpp.o
[ 42%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/math_sphbes.cpp.o
[ 45%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/math_ylmreal.cpp.o
[ 48%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/mathzone.cpp.o
[ 51%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/matrix.cpp.o
[ 54%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/matrix3.cpp.o
[ 57%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/memory.cpp.o
[ 60%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/polint.cpp.o
[ 63%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/realarray.cpp.o
[ 66%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/sph_bessel.cpp.o
[ 69%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/sph_bessel_recursive-d1.cpp.o
[ 72%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/sph_bessel_recursive-d2.cpp.o
[ 75%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/timer.cpp.o
[ 78%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/tool_check.cpp.o
[ 81%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/tool_quit.cpp.o
[ 84%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/tool_title.cpp.o
[ 87%] Building CXX object CMakeFiles/module_base.dir/home/chentao/soft/abacus-develop/source/module_base/ylm.cpp.o
[ 90%] Linking CXX static library libmodule_base.a
[ 90%] Built target module_base
[ 93%] Building CXX object CMakeFiles/runUnitTests.dir/test_blas_connector.cpp.o
icpc: command line warning #10148: option '--coverage' not supported
[ 96%] Building CXX object CMakeFiles/runUnitTests.dir/test_matrix3.cpp.o
icpc: command line warning #10148: option '--coverage' not supported
[100%] Linking CXX executable runUnitTests
icpc: command line warning #10148: option '--coverage' not supported
Warning: Unused direct dependencies:
        /opt/intel/oneapi/compiler/2021.3.0/linux/compiler/lib/intel64_lin/libifcore.so.5
        /opt/intel/oneapi/mpi/2021.3.0//lib/libmpicxx.so.12
        /opt/intel/oneapi/mpi/2021.3.0//lib/libmpifort.so.12
        /opt/intel/oneapi/mpi/2021.3.0//lib/release/libmpi.so.12
        /lib/x86_64-linux-gnu/librt.so.1
        /opt/intel/oneapi/mkl/2021.3.0/lib/intel64/libmkl_intel_thread.so.1
        /opt/intel/oneapi/mkl/2021.3.0/lib/intel64/libmkl_core.so.1
        /opt/intel/oneapi/mkl/2021.3.0/lib/intel64/libmkl_scalapack_lp64.so.1
        /opt/intel/oneapi/mkl/2021.3.0/lib/intel64/libmkl_blacs_intelmpi_lp64.so.1
        /lib/x86_64-linux-gnu/libm.so.6
[100%] Built target runUnitTests
chentao@chentao:~/soft/abacus-develop/tests/module_base/build$ ./runUnitTests 
[==========] Running 14 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 12 tests from blas_connector
[ RUN      ] blas_connector.sscal_
[       OK ] blas_connector.sscal_ (4 ms)
[ RUN      ] blas_connector.dscal_
[       OK ] blas_connector.dscal_ (0 ms)
[ RUN      ] blas_connector.cscal_
[       OK ] blas_connector.cscal_ (0 ms)
[ RUN      ] blas_connector.zscal_
[       OK ] blas_connector.zscal_ (0 ms)
[ RUN      ] blas_connector.daxpy_
[       OK ] blas_connector.daxpy_ (0 ms)
[ RUN      ] blas_connector.zaxpy_
[       OK ] blas_connector.zaxpy_ (0 ms)
[ RUN      ] blas_connector.dcopy_
[       OK ] blas_connector.dcopy_ (0 ms)
[ RUN      ] blas_connector.zcopy_
[       OK ] blas_connector.zcopy_ (0 ms)
[ RUN      ] blas_connector.dgemv_
[       OK ] blas_connector.dgemv_ (0 ms)
[ RUN      ] blas_connector.zgemv_
[       OK ] blas_connector.zgemv_ (0 ms)
[ RUN      ] blas_connector.dgemm_
[       OK ] blas_connector.dgemm_ (26 ms)
[ RUN      ] blas_connector.zgemm_
[       OK ] blas_connector.zgemm_ (0 ms)
[----------] 12 tests from blas_connector (31 ms total)

[----------] 2 tests from matrix3_test
[ RUN      ] matrix3_test.op_equal
[       OK ] matrix3_test.op_equal (0 ms)
[ RUN      ] matrix3_test.op_inequal
[       OK ] matrix3_test.op_inequal (0 ms)
[----------] 2 tests from matrix3_test (0 ms total)

[----------] Global test environment tear-down
[==========] 14 tests from 2 test suites ran. (31 ms total)
[  PASSED  ] 14 tests.
```
