### PR TITLE
Fix `test.yml` compatiability with `cmake`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           cmake -B build -DBUILD_TESTING=ON
           cmake --build build -j16
           cmake --install build
-          ctest --test-dir build --verbose
+          cmake --build build --target test
   stop-runner:
     name: Stop self-hosted EC2 runner
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           cmake -B build -DBUILD_TESTING=ON
           cmake --build build -j16
           cmake --install build
-          cmake --build build --target test
+          cmake --build build --target test ARGS="-V"
   stop-runner:
     name: Stop self-hosted EC2 runner
     needs:


### PR DESCRIPTION
I've changed the installation method for `cmake` from using local installers to `apt`. The `--test-dir` option is only available for `cmake` version `3.20` and above, but `apt install cmake` only get us a `3.18` version.