### PR TITLE
Fix: cmake: deepks works with mkl; OpenMP flag is properly linked

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ project(ABACUS
 option(ENABLE_DEEPKS "Enable DeePKS functionality" OFF)
 option(ENABLE_LIBXC "Enable LibXC functionality" OFF)
 option(USE_CUDA "Enable support to CUDA." OFF)
-
+option(USE_OPENMP " Enable OpenMP in abacus." OFF)
 option(ENABLE_ASAN "Enable AddressSanitizer" OFF)
 option(BUILD_TESTING "Build ABACUS unit tests" OFF)
 option(GENERATE_TEST_REPORTS "Enable test report generation" OFF)
@@ -43,11 +43,12 @@ add_compile_definitions(__MPI)
 find_package(Threads REQUIRED)
 target_link_libraries(${ABACUS_BIN_NAME} Threads::Threads)
 
-find_package(OpenMP REQUIRED)
-target_link_libraries(${ABACUS_BIN_NAME} OpenMP::OpenMP_CXX)
-add_compile_options(${OpenMP_CXX_FLAGS})
-add_compile_definitions(__OPENMP)
-
+if(USE_OPENMP)
+  find_package(OpenMP REQUIRED)
+  target_link_libraries(${ABACUS_BIN_NAME} OpenMP::OpenMP_CXX)
+  add_compile_options(${OpenMP_CXX_FLAGS})
+  add_compile_definitions(__OPENMP)
+endif()
 
 set(CMAKE_CXX_STANDARD 11)
 include(CheckLanguage)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ include_directories(${ABACUS_SOURCE_DIR})
 add_executable(${ABACUS_BIN_NAME} source/main.cpp)
 
 find_package(Cereal REQUIRED)
-include_directories(${Cereal_INCLUDE_DIRS})
+include_directories(${Cereal_INCLUDE_DIR})
 add_compile_definitions(USE_CEREAL_SERIALIZATION)
 
 find_package(ELPA REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ project(ABACUS
 option(ENABLE_DEEPKS "Enable DeePKS functionality" OFF)
 option(ENABLE_LIBXC "Enable LibXC functionality" OFF)
 option(USE_CUDA "Enable support to CUDA." OFF)
-option(USE_OPENMP " Enable OpenMP in abacus." OFF)
+option(USE_OPENMP " Enable OpenMP in abacus." ON)
 option(ENABLE_ASAN "Enable AddressSanitizer" OFF)
 option(BUILD_TESTING "Build ABACUS unit tests" OFF)
 option(GENERATE_TEST_REPORTS "Enable test report generation" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,18 +132,23 @@ endif()
 if(ENABLE_DEEPKS)
   set(CMAKE_CXX_STANDARD 14)
   find_package(Torch REQUIRED)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
-  include(FetchContent)
-  FetchContent_Declare(
-    libnpy
-    GIT_REPOSITORY https://github.com.cnpmjs.org/llohse/libnpy.git
-  )
-  FetchContent_MakeAvailable(libnpy)
-  include_directories(
-    ${libnpy_SOURCE_DIR}
-    ${TORCH_INCLUDE_DIRS}
-  )
+  include_directories(${TORCH_INCLUDE_DIRS})
   target_link_libraries(${ABACUS_BIN_NAME} ${TORCH_LIBRARIES})
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
+
+  find_path(libnpy_SOURCE_DIR
+    npy.hpp
+    HINTS ${libnpy_INCLUDE_DIR}
+  )
+  if(NOT libnpy_SOURCE_DIR)
+  include(FetchContent)
+    FetchContent_Declare(
+      libnpy
+      GIT_REPOSITORY https://github.com.cnpmjs.org/llohse/libnpy.git
+    )
+    FetchContent_MakeAvailable(libnpy)
+  endif()
+  include_directories(${libnpy_SOURCE_DIR})
   add_compile_definitions(__DEEPKS)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,28 @@ else()
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-write-strings" )
 endif()
 
+if(DEFINED ENV{MKLROOT} AND NOT DEFINED MKLROOT)
+    set(MKLROOT "$ENV{MKLROOT}")
+endif()
+if(MKLROOT)
+  find_package(IntelMKL REQUIRED)
+  add_definitions(-D__MKL -DMKL_ILP64)
+  include_directories(${MKL_INCLUDE_DIRS} ${MKL_INCLUDE_DIRS}/fftw)
+  target_link_libraries(${ABACUS_BIN_NAME}
+    -lifcore
+    IntelMKL::MKL
+  )
+else()
+  find_package(FFTW3 REQUIRED)
+  find_package(LAPACK REQUIRED)
+  find_package(ScaLAPACK REQUIRED)
+  include_directories(${FFTW3_INCLUDE_DIRS})
+  target_link_libraries(${ABACUS_BIN_NAME}
+    FFTW3::FFTW3
+    LAPACK::LAPACK
+    ScaLAPACK::ScaLAPACK
+  )
+endif()
 
 if(ENABLE_DEEPKS)
   set(CMAKE_CXX_STANDARD 14)
@@ -138,29 +160,6 @@ if(ENABLE_LIBXC)
   else()
     message(WARNING "Will not use Libxc.")
   endif()
-endif()
-
-if(DEFINED ENV{MKLROOT} AND NOT DEFINED MKLROOT)
-    set(MKLROOT "$ENV{MKLROOT}")
-endif()
-if(MKLROOT)
-  find_package(IntelMKL REQUIRED)
-  add_definitions(-D__MKL -DMKL_ILP64)
-  include_directories(${MKL_INCLUDE_DIRS} ${MKL_INCLUDE_DIRS}/fftw)
-  target_link_libraries(${ABACUS_BIN_NAME}
-    -lifcore
-    IntelMKL::MKL
-  )
-else()
-  find_package(FFTW3 REQUIRED)
-  find_package(LAPACK REQUIRED)
-  find_package(ScaLAPACK REQUIRED)
-  include_directories(${FFTW3_INCLUDE_DIRS})
-  target_link_libraries(${ABACUS_BIN_NAME}
-    FFTW3::FFTW3
-    LAPACK::LAPACK
-    ScaLAPACK::ScaLAPACK
-  )
 endif()
 
 add_compile_definitions(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,12 +29,25 @@ add_executable(${ABACUS_BIN_NAME} source/main.cpp)
 
 find_package(Cereal REQUIRED)
 include_directories(${Cereal_INCLUDE_DIRS})
+add_compile_definitions(USE_CEREAL_SERIALIZATION)
+
 find_package(ELPA REQUIRED)
 include_directories(${ELPA_INCLUDE_DIR})
+target_link_libraries(${ABACUS_BIN_NAME} ELPA::ELPA)
+
 find_package(MPI REQUIRED)
 include_directories(${MPI_CXX_INCLUDE_PATH})
+target_link_libraries(${ABACUS_BIN_NAME} MPI::MPI_CXX)
+add_compile_definitions(__MPI)
+
 find_package(Threads REQUIRED)
+target_link_libraries(${ABACUS_BIN_NAME} Threads::Threads)
+
 find_package(OpenMP REQUIRED)
+target_link_libraries(${ABACUS_BIN_NAME} OpenMP::OpenMP_CXX)
+add_compile_options(${OpenMP_CXX_FLAGS})
+add_compile_definitions(__OPENMP)
+
 
 set(CMAKE_CXX_STANDARD 11)
 include(CheckLanguage)
@@ -134,19 +147,26 @@ if(MKLROOT)
   find_package(IntelMKL REQUIRED)
   add_definitions(-D__MKL -DMKL_ILP64)
   include_directories(${MKL_INCLUDE_DIRS} ${MKL_INCLUDE_DIRS}/fftw)
+  target_link_libraries(${ABACUS_BIN_NAME}
+    -lifcore
+    IntelMKL::MKL
+  )
 else()
   find_package(FFTW3 REQUIRED)
   find_package(LAPACK REQUIRED)
   find_package(ScaLAPACK REQUIRED)
   include_directories(${FFTW3_INCLUDE_DIRS})
+  target_link_libraries(${ABACUS_BIN_NAME}
+    FFTW3::FFTW3
+    LAPACK::LAPACK
+    ScaLAPACK::ScaLAPACK
+  )
 endif()
 
 add_compile_definitions(
   __EXX
   __FFTW3
   __FP
-  __MPI
-  __OPENMP
   __SELINV
   __LCAO
   METIS
@@ -154,7 +174,6 @@ add_compile_definitions(
   EXX_H_COMM=2
   TEST_EXX_LCAO=0
   TEST_EXX_RADIAL=1
-  USE_CEREAL_SERIALIZATION
 )
 
 add_subdirectory(source)
@@ -177,27 +196,7 @@ target_link_libraries(${ABACUS_BIN_NAME}
     ri
     driver
     -lm
-    ELPA::ELPA
-    MPI::MPI_CXX
-    OpenMP::OpenMP_CXX
-    Threads::Threads
 )
-
-if(MKLROOT)
-  target_link_libraries(${ABACUS_BIN_NAME}
-    -lifcore
-    IntelMKL::MKL
-    OpenMP::OpenMP_CXX
-  )
-else()
-  target_link_libraries(${ABACUS_BIN_NAME}
-    FFTW3::FFTW3
-    ScaLAPACK::ScaLAPACK
-    LAPACK::LAPACK
-    OpenMP::OpenMP_CXX
-  )
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX)
 target_link_libraries(${ABACUS_BIN_NAME}
   -lgfortran

--- a/Dockerfile.gnu
+++ b/Dockerfile.gnu
@@ -12,7 +12,7 @@ RUN cd /tmp \
 
 RUN cd /tmp \
     && git clone https://github.com/xianyi/OpenBLAS.git --single-branch --depth=1 \
-    && cd OpenBLAS && make NO_AVX512=1 FC=gfortran -j8 && make PREFIX=/usr/local install \
+    && cd OpenBLAS && make USE_OPENMP=1 NO_AVX512=1 FC=gfortran -j8 && make PREFIX=/usr/local install \
     && cd /tmp && rm -rf OpenBLAS
 
 RUN cd /tmp \

--- a/modules/FindCereal.cmake
+++ b/modules/FindCereal.cmake
@@ -3,22 +3,27 @@
 # Find the native cereal headers.
 #
 #  CEREAL_FOUND - True if cereal is found.
-#  CEREAL_INCLUDE_DIRS - Where to find cereal headers.
+#  CEREAL_INCLUDE_DIR - Where to find cereal headers.
 #
 
 find_path(Cereal_INCLUDE_DIR
     cereal/cereal.hpp
-    HINTS ${CEREAL_INCLUDEDIR}
+    HINTS ${CEREAL_INCLUDE_DIR}
 )
 
+if(NOT Cereal_INCLUDE_DIR)
+    include(FetchContent)
+    FetchContent_Declare(
+        cereal
+        GIT_REPOSITORY https://github.com.cnpmjs.org/USCiLab/cereal.git
+        # URL https://github.com/USCiLab/cereal/archive/refs/tags/v1.3.0.tar.gz
+    )
+    set(Cereal_INCLUDE_DIR ${cereal_SOURCE_DIR})
+endif()
 # Handle the QUIET and REQUIRED arguments and
 # set Cereal_FOUND to TRUE if all variables are non-zero.
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Cereal DEFAULT_MSG Cereal_INCLUDE_DIR)
 
 # Copy the results to the output variables and target.
-if(Cereal_FOUND)
-    set(Cereal_INCLUDE_DIRS ${Cereal_INCLUDE_DIR})
-endif()
-
 mark_as_advanced(Cereal_INCLUDE_DIR)


### PR DESCRIPTION
In CMakeLists, `find torch` is placed before `find intel mkl` part, which finds mkl by another approach, messing up the latter one. Simply swapping these two parts works fine for me.