### PR TITLE
Fix: torch lib is not compatiable with c++ standard.

### DIFF
--- a/.github/workflows/hosted_test.yml
+++ b/.github/workflows/hosted_test.yml
@@ -11,7 +11,7 @@ jobs:
           build_args: ""
           name: "Build with GNU compilers"
         - tag: gnu
-          build_args: "-DENABLE_LIBXC=1"
+          build_args: "-DENABLE_LIBXC=1 -DENABLE_DEEPKS=1"
           name: "Build with GNU compilers and extra components"
         - tag: intel
           build_args: ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ if(ENABLE_DEEPKS)
   find_package(Torch REQUIRED)
   include_directories(${TORCH_INCLUDE_DIRS})
   target_link_libraries(${ABACUS_BIN_NAME} ${TORCH_LIBRARIES})
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
+  add_compile_options(${TORCH_CXX_FLAGS})
 
   find_path(libnpy_SOURCE_DIR
     npy.hpp

--- a/Dockerfile.gnu
+++ b/Dockerfile.gnu
@@ -39,8 +39,8 @@ RUN cd /tmp \
     && cd /tmp && rm -rf fftw-3.3.9 && rm fftw-3.3.9.tar.gz
 
 RUN cd /tmp \
-    && wget https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.9.0%2Bcpu.zip --no-check-certificate --quiet \
-    && unzip libtorch-shared-with-deps-1.9.0+cpu.zip \
+    && wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.1%2Bcpu.zip --no-check-certificate --quiet \
+    && unzip libtorch-cxx11-abi-shared-with-deps-1.9.1+cpu.zip \
     && cp -r libtorch/include /usr/local \
     && cp -r libtorch/lib /usr/local \
     && cp -r libtorch/share /usr/local \


### PR DESCRIPTION
Two libtorch versions are provided at https://pytorch.org/get-started/locally/ ; now we will choose the proper one.
See https://developers.redhat.com/blog/2015/02/05/gcc5-and-the-c11-abi .