### PR TITLE
Fix: google test repo branch name

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG "origin/main"
 )
 FetchContent_MakeAvailable(googletest)
 include_directories(${ABACUS_SOURCE_DIR})


### PR DESCRIPTION
Google test has changed its default branch name from "master" to "main", while the latter is not the default option of `git`.