### PR TITLE
Adjust the order of sticks on each core and fix a bug.

### DIFF
--- a/source/module_pw/pw_basis.h
+++ b/source/module_pw/pw_basis.h
@@ -123,8 +123,7 @@ private:
         int* st_bottom2D,                               // the z-coordinate of the bottom of stick on (x, y), stored in 2d x-y plane.
         int* st_i,                                      // x or x + nx (if x < 0) of stick.
         int* st_j,                                      // y or y + ny (if y < 0) of stick.
-        int* st_length,                                 // number of planewaves in stick, stored in 1d array with tot_nst elements.
-        int* st_bottom                                  // minimum z of stick, stored in 1d array with tot_nst elements.
+        int* st_length                                 // number of planewaves in stick, stored in 1d array with tot_nst elements.
     );
 // for distributeg_method1
     void divide_sticks(
@@ -133,20 +132,15 @@ private:
         int* st_j,          // y or y + ny (if y < 0) of stick.
         int* st_length,     // the stick on (x, y) consists of st_length[x*ny+y] planewaves.
         int* npw_per,       // number of planewaves on each core.
-        int* nst_per,       // number of sticks on each core.
-        int* is2ip         // ip of core containing is^th stick, map is to ip.         
+        int* nst_per       // number of sticks on each core.
     );
     void get_istot2ixy(
         int* st_i,          // x or x + nx (if x < 0) of stick.
-        int* st_j,          // y or y + ny (if y < 0) of stick.
-        int* is2ip          // ip of core containing is^th stick, map is to ip.
+        int* st_j          // y or y + ny (if y < 0) of stick.
     );
     void get_ig2isz_is2ixy(
-        int* st_i,          // x or x + nx (if x < 0) of stick.
-        int* st_j,          // y or y + ny (if y < 0) of stick.
         int* st_bottom,     // minimum z of stick, stored in 1d array with tot_nst elements.
-        int* st_length,     // the stick on (x, y) consists of st_length[x*ny+y] planewaves.
-        int* is2ip          // ip of core containing is^th stick, map is to ip.
+        int* st_length     // the stick on (x, y) consists of st_length[x*ny+y] planewaves.
     );
 // for distributeg_method2
     // void divide_sticks2(

--- a/source/module_pw/pw_distributeg_method1.cpp
+++ b/source/module_pw/pw_distributeg_method1.cpp
@@ -475,12 +475,21 @@ void PW_Basis::get_ig2isz_is2ixy(
     int* st_length2D     // the stick on (x, y) consists of st_length[x*ny+y] planewaves.
 )
 {
+    if (this->npw == 0)
+    {
+        this->ig2isz = new int[1]; // map ig to the z coordinate of this planewave.
+        this->ig2isz[0] = 0;
+        this->is2ixy = new int[1]; // map is (index of sticks) to ixy (ix + iy * nx).
+        this->is2ixy[0] = -1;
+        return;
+    }
+
     this->ig2isz = new int[this->npw]; // map ig to the z coordinate of this planewave.
     ModuleBase::GlobalFunc::ZEROS(this->ig2isz, this->npw);
     this->is2ixy = new int[this->nst]; // map is (index of sticks) to ixy (ix + iy * nx).
     for (int is = 0; is < this->nst; ++is) 
     {
-        is2ixy[is] = -1;
+        this->is2ixy[is] = -1;
     }
 
     int st_move = 0; // this is the st_move^th stick on current core.

--- a/source/module_pw/unittest/test1.cpp
+++ b/source/module_pw/unittest/test1.cpp
@@ -21,6 +21,7 @@ int main(int argc,char **argv)
     pwtest.initparameters(gamma_only, ecut, nproc, rank_in_pool, distribution_type);
     pwtest.distribute_r();
     pwtest.distribute_g();
+    MPI_Barrier(POOL_WORLD);
 
     int tot_npw = 0;
     int nxy = pwtest.nx * pwtest.ny;


### PR DESCRIPTION
< build > 
adjust the order of sticks on each core and simplify the procedure of distributeg_method1, now the sticks are sorted in the order of ixy increasing.
< fix >
fix a bug in get_ig2isz_is2ixy, when this->npw==0, ModuleBase::GlobalFunc::ZEROS will raise a error, so that I add a few code to deal with this case.
< range >
module_pw
