### PR TITLE
Add: code format config & doc

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,166 +1,38 @@
 ---
-Language:        Cpp
-# BasedOnStyle:  LLVM
-AccessModifierOffset: -2
+BasedOnStyle: Microsoft
+AccessModifierOffset: '-2'
 AlignAfterOpenBracket: Align
-AlignConsecutiveMacros: None
-AlignConsecutiveAssignments: None
-AlignConsecutiveBitFields: None
-AlignConsecutiveDeclarations: None
-AlignEscapedNewlines: Right
-AlignOperands:   Align
-AlignTrailingComments: true
-AllowAllArgumentsOnNextLine: true
-AllowAllConstructorInitializersOnNextLine: true
-AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortEnumsOnASingleLine: true
-AllowShortBlocksOnASingleLine: Never
-AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
-AllowShortLambdasOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: Never
-AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: MultiLine
-AttributeMacros:
-  - __capability
-BinPackArguments: true
-BinPackParameters: true
-BraceWrapping:
-  AfterCaseLabel:  false
-  AfterClass:      false
-  AfterControlStatement: Never
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
-  AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  AfterExternBlock: false
-  BeforeCatch:     false
-  BeforeElse:      false
-  BeforeLambdaBody: false
-  BeforeWhile:     false
-  IndentBraces:    false
-  SplitEmptyFunction: true
-  SplitEmptyRecord: true
-  SplitEmptyNamespace: true
-BreakBeforeBinaryOperators: None
-BreakBeforeConceptDeclarations: true
-BreakBeforeBraces: Attach
-BreakBeforeInheritanceComma: false
-BreakInheritanceList: BeforeColon
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
-BreakConstructorInitializers: BeforeColon
-BreakAfterJavaFieldAnnotations: false
-BreakStringLiterals: true
-ColumnLimit:     80
-CommentPragmas:  '^ IWYU pragma:'
-CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
-ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
-Cpp11BracedListStyle: true
-DeriveLineEnding: true
-DerivePointerAlignment: false
-DisableFormat:   false
-EmptyLineBeforeAccessModifier: LogicalBlock
-ExperimentalAutoDetectBinPacking: false
-FixNamespaceComments: true
-ForEachMacros:
-  - foreach
-  - Q_FOREACH
-  - BOOST_FOREACH
-StatementAttributeLikeMacros:
-  - Q_EMIT
-IncludeBlocks:   Preserve
-IncludeCategories:
-  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
-    Priority:        2
-    SortPriority:    0
-    CaseSensitive:   false
-  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
-    Priority:        3
-    SortPriority:    0
-    CaseSensitive:   false
-  - Regex:           '.*'
-    Priority:        1
-    SortPriority:    0
-    CaseSensitive:   false
-IncludeIsMainRegex: '(Test)?$'
-IncludeIsMainSourceRegex: ''
-IndentCaseLabels: false
-IndentCaseBlocks: false
-IndentGotoLabels: true
-IndentPPDirectives: None
-IndentExternBlock: AfterExternBlock
-IndentRequires:  false
-IndentWidth:     4
-IndentWrappedFunctionNames: false
-InsertTrailingCommas: None
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: true
-MacroBlockBegin: ''
-MacroBlockEnd:   ''
-MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
-ObjCBinPackProtocolList: Auto
-ObjCBlockIndentWidth: 2
-ObjCBreakBeforeNestedBlockParam: true
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: true
-PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 19
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 1000
-PenaltyBreakTemplateDeclaration: 10
-PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 60
-PenaltyIndentedWhitespace: 0
+AlignConsecutiveMacros: 'true'
+AlignEscapedNewlines: Left
+AlignOperands: 'true'
+AlignTrailingComments: 'false'
+AllowAllArgumentsOnNextLine: 'false'
+AllowAllParametersOfDeclarationOnNextLine: 'false'
+BinPackArguments: 'false'
+BinPackParameters: 'false'
+BreakBeforeBinaryOperators: All
+BreakBeforeTernaryOperators: 'true'
+Cpp11BracedListStyle: 'true'
+DerivePointerAlignment: 'true'
+FixNamespaceComments: 'true'
+IncludeBlocks: Regroup
+IndentWidth: '4'
+Language: Cpp
 PointerAlignment: Right
-ReflowComments:  true
-SortIncludes:    true
-SortJavaStaticImport: Before
-SortUsingDeclarations: true
-SpaceAfterCStyleCast: false
-SpaceAfterLogicalNot: false
-SpaceAfterTemplateKeyword: true
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeCaseColon: false
-SpaceBeforeCpp11BracedList: false
-SpaceBeforeCtorInitializerColon: true
-SpaceBeforeInheritanceColon: true
-SpaceBeforeParens: ControlStatements
-SpaceAroundPointerQualifiers: Default
-SpaceBeforeRangeBasedForLoopColon: true
-SpaceInEmptyBlock: false
-SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
-SpacesInConditionalStatement: false
-SpacesInContainerLiterals: true
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
-SpaceBeforeSquareBrackets: false
-BitFieldColonSpacing: Both
-Standard:        Latest
-StatementMacros:
-  - Q_UNUSED
-  - QT_REQUIRE_VERSION
-TabWidth:        8
-UseCRLF:         false
-UseTab:          Never
-WhitespaceSensitiveMacros:
-  - STRINGIZE
-  - PP_STRINGIZE
-  - BOOST_PP_STRINGIZE
-  - NS_SWIFT_NAME
-  - CF_SWIFT_NAME
-...
+ReflowComments: 'true'
+SortIncludes: 'true'
+SortUsingDeclarations: 'true'
+SpaceAfterCStyleCast: 'false'
+SpaceAfterLogicalNot: 'false'
+SpaceBeforeRangeBasedForLoopColon: 'false'
+SpaceInEmptyParentheses: 'false'
+SpacesInAngles: 'false'
+SpacesInCStyleCastParentheses: 'false'
+SpacesInContainerLiterals: 'false'
+SpacesInParentheses: 'false'
+SpacesInSquareBrackets: 'false'
+Standard: Cpp11
+TabWidth: '4'
+UseTab: ForContinuationAndIndentation
 
+...

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,9 @@
 // For format details, see https://aka.ms/devcontainer.json.
 {
 	"image":"ghcr.io/deepmodeling/abacus-development-kit:gnu",
-	"extensions": ["ms-vscode.cpptools-extension-pack"]
+	"extensions": [
+		"ms-vscode.cpptools-extension-pack",
+		"xaver.clang-format",
+		"cschlosser.doxdocgen"
+	]
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-indent_style = space
+indent_style = tab
 indent_size = 4
 charset = utf-8
 end_of_line = lf

--- a/doc/developers.md
+++ b/doc/developers.md
@@ -156,4 +156,4 @@ An practical example is class [LCAO_Descriptor](https://github.com/deepmodeling/
 ### Code formatting style
 
 We use `clang-format` as our code formatter. The `.clang-format` file in root directory describes the rules to conform.
-A Visual Studio Code extension [clang-format](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format) can help you format your codes on save.
+For Visual Studio Code developers, the [official extension of C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) provided by Microsoft can help you format your codes following the rules. Configure your VS Code settings as `"C_Cpp.clang_format_style": "file"` (you can look up this option by pasting it into the search box of VS Code settings page), and the clang-format will take into effect. You may also set `"editor.formatOnSave": true` to avoid formatting files everytime manually.

--- a/doc/developers.md
+++ b/doc/developers.md
@@ -8,7 +8,7 @@
     - [Upating documentation](#updating-documentation)
     - [Macros](#macros)
     - [Comment style for documentation](#comment-style-for-documentation)
-
+	- [Code Formatting style](#code-formatting-style)
     [back to main page](../README.md)
 
 ## Raising issues on GitHub
@@ -32,7 +32,7 @@ The ABACUS code is reconstructed to form several self-contained modules. A descr
 ### Macros
 
 ### Comment Style for Documentation
-ABACUS uses Doxygen to generate docs directly from `.h ` and `.cpp` code files. 
+ABACUS uses Doxygen to generate docs directly from `.h ` and `.cpp` code files.
 
 For comments that need to be shown in documents, these formats should be used -- **Javadoc style** (as follow) is recommended, though Qt style is also ok. See it in [official manual](https://www.doxygen.nl/manual/docblocks.html).
 
@@ -56,7 +56,7 @@ An practical example is class [LCAO_Descriptor](https://github.com/deepmodeling/
     /********************************************//**
     *  ... text
     ***********************************************/
-    
+
     /////////////////////////////////////////////////
     /// ... text ...
     /////////////////////////////////////////////////
@@ -83,7 +83,7 @@ An practical example is class [LCAO_Descriptor](https://github.com/deepmodeling/
 
 - Parameters
     usage: `[in],[out],[in,out] description`
-    eg. 
+    eg.
     ```
     void foo(int v/**< [in] docs for input parameter v.*/);
     ```
@@ -98,7 +98,7 @@ An practical example is class [LCAO_Descriptor](https://github.com/deepmodeling/
     *   - sub item 1
     *     - sub sub item 1
     *     - sub sub item 2
-    *     . 
+    *     .
     *     The dot above ends the sub sub item list.
     *
     *     More text for the first sub item
@@ -117,7 +117,7 @@ An practical example is class [LCAO_Descriptor](https://github.com/deepmodeling/
     ```
     eg.2
     ```
-    /*! 
+    /*!
     *  A list of events:
     *    - mouse events
     *         -# mouse move event
@@ -139,16 +139,21 @@ An practical example is class [LCAO_Descriptor](https://github.com/deepmodeling/
     - eg.
     ```
     \f{eqnarray*}{
-            g &=& \frac{Gm_2}{r^2} \\ 
+            g &=& \frac{Gm_2}{r^2} \\
             &=& \frac{(6.673 \times 10^{-11}\,\mbox{m}^3\,\mbox{kg}^{-1}\,
-                \mbox{s}^{-2})(5.9736 \times 10^{24}\,\mbox{kg})}{(6371.01\,\mbox{km})^2} \\ 
+                \mbox{s}^{-2})(5.9736 \times 10^{24}\,\mbox{kg})}{(6371.01\,\mbox{km})^2} \\
             &=& 9.82066032\,\mbox{m/s}^2
     \f}
     ```
 
 - Tips
-    - Only comments in .h file will be visible in generated  by Doxygen + Sphinx; 
-    - Private class members will not be documented; 
-    - Use [Markdown features](https://www.doxygen.nl/manual/markdown.html), such as using a empty new line for a new paragraph. 
+    - Only comments in .h file will be visible in generated  by Doxygen + Sphinx;
+    - Private class members will not be documented;
+    - Use [Markdown features](https://www.doxygen.nl/manual/markdown.html), such as using a empty new line for a new paragraph.
 ​
 [back to top](#for-developers)
+
+### Code formatting style
+
+We use `clang-format` as our code formatter. The `.clang-format` file in root directory describes the rules to conform.
+A Visual Studio Code extension [clang-format](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format) can help you format your codes on save.


### PR DESCRIPTION
Update `.clang-format` file for a better formatting syntax.
Add corresponding instructions in doc.