### PR TITLE
fix : ABACUS uses more FFT grids than QE proposed

### DIFF
--- a/source/src_pw/pw_complement.cpp
+++ b/source/src_pw/pw_complement.cpp
@@ -158,7 +158,6 @@ void PW_complement::get_FFT_dimension(
         // increase ibox[i] by 1 until it is totally factorizable by (2,3,5,7) 
         do
         {
-            ibox[i] += 1;
 			b = ibox[i];
 
 			// mohan add 2011-04-22            
@@ -196,8 +195,10 @@ void PW_complement::get_FFT_dimension(
 					done_factoring = true;
 				}
 			}//
+            ibox[i] += 1;
         }
         while (b != 1);
+        ibox[i] -= 1;
         //  b==1 means fftbox[i] is (2,3,5,7) factorizable 
     }
 

--- a/tests/integrate/104_PW_AF_magnetic/result.ref
+++ b/tests/integrate/104_PW_AF_magnetic/result.ref
@@ -1,3 +1,3 @@
-etotref -5866.1722658700873581
-etotperatomref -2933.0861329350
-totaltimeref 0.71
+etotref -5866.1747281854204630
+etotperatomref -2933.0873640927
+totaltimeref 1.37072

--- a/tests/integrate/104_PW_FM_magnetic/result.ref
+++ b/tests/integrate/104_PW_FM_magnetic/result.ref
@@ -1,3 +1,3 @@
-etotref -5866.1956614863693176
-etotperatomref -2933.0978307432
-totaltimeref 0.63
+etotref -5866.1972974975478792
+etotperatomref -2933.0986487488
+totaltimeref 1.55426

--- a/tests/integrate/104_PW_NC_magnetic/result.ref
+++ b/tests/integrate/104_PW_NC_magnetic/result.ref
@@ -1,3 +1,3 @@
-etotref -5866.1722689090174754
-etotperatomref -2933.0861344545
-totaltimeref 33.80
+etotref -5866.1747312893548951
+etotperatomref -2933.0873656447
+totaltimeref 4.63381

--- a/tests/integrate/105_PW_FD_smearing/result.ref
+++ b/tests/integrate/105_PW_FD_smearing/result.ref
@@ -1,3 +1,3 @@
-etotref -9154.9162428895924677
-etotperatomref -1830.9832485779
-totaltimeref 2.53
+etotref -9154.9242645437152532
+etotperatomref -1830.9848529087
+totaltimeref 5.19841

--- a/tests/integrate/105_PW_GA_smearing/result.ref
+++ b/tests/integrate/105_PW_GA_smearing/result.ref
@@ -1,3 +1,3 @@
-etotref -9154.8808225262437190
-etotperatomref -1830.9761645052
-totaltimeref 2.81
+etotref -9154.8888662199788087
+etotperatomref -1830.9777732440
+totaltimeref 5.20976

--- a/tests/integrate/150_PW_15_CR_VDW3/result.ref
+++ b/tests/integrate/150_PW_15_CR_VDW3/result.ref
@@ -1,5 +1,5 @@
-etotref -4009.5574819385051342
-etotperatomref -2004.7787409693
-totalforceref 0.822172
-totalstressref 5110.611149
-totaltimeref +3.28
+etotref -4009.5593316581530416
+etotperatomref -2004.7796658291
+totalforceref 0.853042
+totalstressref 5110.564941
+totaltimeref +4.07016

--- a/tests/integrate/803_PW_LT_bcc/result.ref
+++ b/tests/integrate/803_PW_LT_bcc/result.ref
@@ -1,5 +1,5 @@
-etotref -30.6143733848838551
-etotperatomref -15.3071866924
-totalforceref 7.577414
-totalstressref 84.029872
-totaltimeref +0.29
+etotref -30.6144125396525304
+etotperatomref -15.3072062698
+totalforceref 7.577368
+totalstressref 84.028843
+totaltimeref +0.37974


### PR DESCRIPTION
fix a bug that ABACUS uses more FFT grids than QE
some results:
104_PW_AF_magnetic, 104_PW_FM_magnetic, 104_PW_NC_magnetic:
before change: 16*16*16; after change: 15*15*15; QE: 15*15*15
105_PW_FD_smearing, 105_PW_GA_smearing:
before change: 16*24*100; after change: 15*24*100; QE: 15*24*100
150_PW_15_CR_VDW3:
before change: 27*27*90; after change: 25*25*90; QE: 25*25*90
803_PW_LT_bcc:
before change: 30*30*30; after change: 27*27*27; QE: 27*27*27
Thus,result.ref of these are changed.
scope : pw_complement.cpp