### PR TITLE
Feature: enabling the orbital (band gap) training in DeePKS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,9 @@ if(ENABLE_DEEPKS)
   set(CMAKE_CXX_STANDARD 14)
   find_package(Torch REQUIRED)
   include_directories(${TORCH_INCLUDE_DIRS})
-  target_link_libraries(${ABACUS_BIN_NAME} ${TORCH_LIBRARIES})
+  target_link_libraries(${ABACUS_BIN_NAME} 
+    ${TORCH_LIBRARIES}
+    deepks)
   add_compile_options(${TORCH_CXX_FLAGS})
 
   find_path(libnpy_SOURCE_DIR
@@ -234,7 +236,6 @@ add_subdirectory(source)
 target_link_libraries(${ABACUS_BIN_NAME}
     base
     cell
-    deepks
     symmetry
     md
     symmetry

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ if(ENABLE_DEEPKS)
   include(FetchContent)
     FetchContent_Declare(
       libnpy
-      GIT_REPOSITORY https://github.com/llohse/libnpy.git
+      GIT_REPOSITORY https://github.com.cnpmjs.org/llohse/libnpy.git
     )
     FetchContent_MakeAvailable(libnpy)
   endif()
@@ -234,6 +234,7 @@ add_subdirectory(source)
 target_link_libraries(${ABACUS_BIN_NAME}
     base
     cell
+    deepks
     symmetry
     md
     symmetry

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -1023,6 +1023,10 @@ bool Input::Read(const std::string &fn)
         {
             read_value(ifs, model_file);
         }
+		else if (strcmp("deepks_bandgap", word) == 0) // QO added 2021-12-15
+        {
+            read_value(ifs, deepks_bandgap);
+		}
 		else if (strcmp("out_potential", word) == 0)
         {
             read_value(ifs, out_potential);
@@ -2088,6 +2092,7 @@ void Input::Bcast()
     Parallel_Common::bcast_int( lmax_descriptor ); // mohan modified 2021-01-03
     Parallel_Common::bcast_int( deepks_scf ); // caoyu add 2021-06-02
 	Parallel_Common::bcast_string( model_file ); //  caoyu add 2021-06-03
+	Parallel_Common::bcast_int( deepks_bandgap ); // QO add 2021-12-15
 
 	Parallel_Common::bcast_int(out_potential);
     Parallel_Common::bcast_int( out_wf );

--- a/source/input.h
+++ b/source/input.h
@@ -456,6 +456,7 @@ class Input
 	int lmax_descriptor; //lmax used in descriptor, mohan added 2021-01-03
 	int deepks_scf;	//(need libnpy and libtorch) if set 1, a trained model would be needed to cal V_delta and F_delta
 	string model_file;		//needed when deepks_scf=1
+	int deepks_bandgap; //for bandgap label. QO added 2021-12-15	
 
 //==========================================================
 // variables for test only

--- a/source/input_conv.cpp
+++ b/source/input_conv.cpp
@@ -639,6 +639,7 @@ void Input_Conv::Convert(void)
 	#ifdef __DEEPKS
 	GlobalV::out_descriptor = INPUT.out_descriptor; 
 	GlobalV::deepks_scf = INPUT.deepks_scf;
+	GlobalV::deepks_bandgap = INPUT.deepks_bandgap; //QO added for bandgap label 2021-12-15
 	#endif
 	
     return;

--- a/source/module_base/global_variable.cpp
+++ b/source/module_base/global_variable.cpp
@@ -183,6 +183,7 @@ bool FINAL_SCF = false; //LiuXh add 20180619
 
 bool out_descriptor = false; //caoyu add 2021-10-16 for DeePKS
 bool deepks_scf = false; //caoyu add 2021-10-16 for DeePKS
+bool deepks_bandgap = false; //for bandgap label. QO added 2021-12-15
 
 int vnl_method = 1; //set defauld vnl method as old, added by zhengdy 2021-10-11
 

--- a/source/module_base/global_variable.h
+++ b/source/module_base/global_variable.h
@@ -199,6 +199,7 @@ extern bool FINAL_SCF; //LiuXh add 20180619
 
 extern bool out_descriptor; //caoyu add 2021-10-16 for DeePKS
 extern bool deepks_scf; //caoyu add 2021-10-16 for DeePKS
+extern bool deepks_bandgap; //QO added 2021-12-15 for DeePKS bandgap label
 
 //method for dealing with non-local potential in Hamiltonian matrix, 0 for old, 1 for new
 extern int vnl_method;

--- a/source/module_deepks/CMakeLists.txt
+++ b/source/module_deepks/CMakeLists.txt
@@ -2,6 +2,7 @@ if(ENABLE_DEEPKS)
     list(APPEND objects
         LCAO_deepks.cpp
         LCAO_deepks_fdelta.cpp
+        LCAO_deepks_odelta.cpp
         LCAO_deepks_io.cpp
         LCAO_deepks_mpi.cpp
         LCAO_deepks_pdm.cpp

--- a/source/module_deepks/CMakeLists.txt
+++ b/source/module_deepks/CMakeLists.txt
@@ -10,7 +10,7 @@ if(ENABLE_DEEPKS)
         LCAO_deepks_torch.cpp
         LCAO_deepks_vdelta.cpp
         )
-
+        
     add_library(
         deepks
         OBJECT

--- a/source/module_deepks/LCAO_deepks.cpp
+++ b/source/module_deepks/LCAO_deepks.cpp
@@ -266,4 +266,40 @@ void LCAO_Deepks::allocate_V_deltaR(const int nnr)
     ModuleBase::GlobalFunc::ZEROS(H_V_deltaR, nnr);
 }
 
+void LCAO_Deepks::init_orbital_pdm_shell(void)
+{
+    
+    this->orbital_pdm_shell = new double** [1];
+
+    for (int hl=0; hl<1; hl++)
+    {
+        this->orbital_pdm_shell[hl] = new double* [this->inlmax];
+
+        for(int inl = 0; inl < this->inlmax; inl++)
+        {
+            this->orbital_pdm_shell[hl][inl] = new double [(2 * this->lmaxd + 1) * (2 * this->lmaxd + 1)];
+            ModuleBase::GlobalFunc::ZEROS(orbital_pdm_shell[hl][inl], (2 * this->lmaxd + 1) * (2 * this->lmaxd + 1));
+        }
+
+    }
+
+    return;
+}
+
+
+void LCAO_Deepks::del_orbital_pdm_shell(void)
+{
+    for (int hl=0; hl<1; hl++)
+    {
+        for (int inl = 0;inl < this->inlmax; inl++)
+        {
+            delete[] this->orbital_pdm_shell[hl][inl];
+        }
+        delete[] this->orbital_pdm_shell[hl];
+    }
+    delete[] this->orbital_pdm_shell;
+
+    return;
+}
+
 #endif

--- a/source/module_deepks/LCAO_deepks.h
+++ b/source/module_deepks/LCAO_deepks.h
@@ -112,9 +112,9 @@ private:
     //dD/dX, tensor form of gdmx
     std::vector<torch::Tensor> gdmr_vector;
 
-    //orbital_pdm_shell \langle \phi_\mu|\alpha\rangle\langle\alpha|\phi_\nu\rnalge
+    //orbital_pdm_shell:[1,Inl,nm*nm]; \langle \phi_\mu|\alpha\rangle\langle\alpha|\phi_\nu\rnalge
     double*** orbital_pdm_shell;
-    //orbital_precalc
+    //orbital_precalc:[1,NAt,NDscrpt]; gvdm*orbital_pdm_shell
     torch::Tensor orbital_precalc_tensor;
 
     ///size of descriptor(projector) basis set
@@ -329,8 +329,11 @@ public:
 
 public:
     
-    void cal_o_delta(const std::vector<ModuleBase::matrix>& dm_hl/**<[in] density matrix*/);
-    void cal_o_delta_k(const std::vector<ModuleBase::ComplexMatrix>& dm_hl/**<[in] density matrix*/);
+    void cal_o_delta(const std::vector<ModuleBase::matrix>& dm_hl/**<[in] modified density matrix that contains HOMO and LUMO only*/,
+        const Parallel_Orbitals &ParaO);
+    void cal_o_delta_k(const std::vector<ModuleBase::ComplexMatrix>& dm_hl/**<[in] modified density matrix that contains HOMO and LUMO only*/,
+        const Parallel_Orbitals &ParaO,
+        const int nks);
 
 //-------------------
 // LCAO_deepks_torch.cpp
@@ -352,7 +355,8 @@ public:
 //      this is the term V(D) that enters the expression H_V_delta = |alpha>V(D)<alpha|
 //      caculated using torch::autograd::grad
 //6. cal_orbital_precalc : orbital_precalc is usted for training with orbital label, 
-//                         which equals gvdm * orbital_shell_pairs 
+//                         which equals gvdm * orbital_pdm_shell, 
+//                         orbital_pdm_shells[1,Inl,nm*nm] = dm_hl * overlap * overlap
 
 public:
 
@@ -378,7 +382,12 @@ public:
     void cal_gedm(const int nat);
 
     //calculates orbital_precalc
-    void cal_orbital_precalc(const std::vector<ModuleBase::matrix>& dm_hl/**<[in] density matrix*/);
+    void cal_orbital_precalc(const std::vector<ModuleBase::matrix>& dm_hl/**<[in] density matrix*/,
+        const int nat,
+        const UnitCell_pseudo &ucell,
+        const LCAO_Orbitals &orb,
+        Grid_Driver &GridD,
+        const Parallel_Orbitals &ParaO);
 
 private:
     void cal_gvdm(const int nat);

--- a/source/module_deepks/LCAO_deepks_io.cpp
+++ b/source/module_deepks/LCAO_deepks_io.cpp
@@ -177,4 +177,38 @@ void LCAO_Deepks::save_npy_f(const ModuleBase::matrix &f, const std::string &f_f
     return;
 }
 
+void LCAO_Deepks::save_npy_o(const double &bandgap, const std::string &o_file)
+{
+    ModuleBase::TITLE("LCAO_Deepks", "save_npy_o");
+    //save o_base
+    const long unsigned oshape[] = { 1 };
+    vector<double> npy_o;
+    npy_o.push_back(bandgap);
+    npy::SaveArrayAsNumpy(o_file, false, 1, oshape, npy_o);
+    return;
+}
+
+void LCAO_Deepks::save_npy_orbital_precalc(void)
+{
+    ModuleBase::TITLE("LCAO_Deepks", "save_npy_orbital_precalc");
+    //save orbital_precalc.npy (when bandgap label is in use)
+    //unit: a.u.
+    const long unsigned gshape[] = {(long unsigned) 1, GlobalC::ucell.nat, this->des_per_atom};
+    vector<double> npy_orbital_precalc;
+    for (int hl = 0;hl < 1; ++hl)
+    {
+        
+        for (int iat = 0;iat < GlobalC::ucell.nat;++iat)
+        {
+            for(int p=0; p<this->des_per_atom; ++p)
+            {
+                npy_orbital_precalc.push_back(this->orbital_precalc_tensor.index({ hl, iat, p }).item().toDouble());
+            }
+        }
+        
+    }
+    npy::SaveArrayAsNumpy("orbital_precalc.npy", false, 3, gshape, npy_orbital_precalc);
+    return;
+}
+
 #endif

--- a/source/module_deepks/LCAO_deepks_odelta.cpp
+++ b/source/module_deepks/LCAO_deepks_odelta.cpp
@@ -1,0 +1,81 @@
+//QO 2022-1-7
+//This file contains subroutines for calculating O_delta, i.e., corrections of the bandgap,
+//which is defind as sum_mu,nu rho^{hl}_mu,nu <chi_mu|alpha>V(D)<alpha|chi_nu>
+//where rho^{hl}_mu,nu = C_{L\mu}C_{L\nu} - C_{H\mu}C_{H\nu}, L for LUMO, H for HOMO
+
+//There are two subroutines in this file:
+//1. cal_o_delta, which is used for gamma point calculation
+//2. cal_o_delta_k, which is used for multi-k calculation
+
+#ifdef __DEEPKS
+
+#include "LCAO_deepks.h"
+
+void LCAO_Deepks::cal_o_delta(const std::vector<ModuleBase::matrix> &dm_hl)
+{
+    ModuleBase::TITLE("LCAO_Deepks", "cal_o_delta");
+    this->o_delta = 0;
+    for (int i = 0; i < GlobalV::NLOCAL; ++i)
+    {
+        for (int j = 0; j < GlobalV::NLOCAL; ++j)
+        {
+            const int mu = GlobalC::ParaO.trace_loc_row[j];
+            const int nu = GlobalC::ParaO.trace_loc_col[i];
+            
+            if (mu >= 0 && nu >= 0)
+            {                
+                const int index=nu*GlobalC::ParaO.nrow+mu;
+                for (int is = 0; is < GlobalV::NSPIN; ++is)
+                {
+                    this->o_delta += dm_hl[is](nu, mu) * this->H_V_delta[index];
+                }
+            }
+        }
+    }
+    Parallel_Reduce::reduce_double_all(this->o_delta);
+    return;
+}
+
+
+//calculating the correction of (LUMO-HOMO) energies, i.e., band gap corrections
+//for multi_k calculations
+void LCAO_Deepks::cal_o_delta_k(const std::vector<ModuleBase::ComplexMatrix> &dm_hl)
+{
+    ModuleBase::TITLE("LCAO_Deepks", "cal_o_delta_k");
+    std::complex<double> o_delta_k=std::complex<double>(0.0,0.0);
+    for (int i = 0; i < GlobalV::NLOCAL; ++i)
+    {
+        for (int j = 0; j < GlobalV::NLOCAL; ++j)
+        {
+            const int mu = GlobalC::ParaO.trace_loc_row[j];
+            const int nu = GlobalC::ParaO.trace_loc_col[i];
+            
+            if (mu >= 0 && nu >= 0)
+            {                
+                int iic;
+                if(GlobalV::KS_SOLVER=="genelpa" || GlobalV::KS_SOLVER=="scalapack_gvx")  // save the matrix as column major format
+                {
+                    iic=mu+nu*GlobalC::ParaO.nrow;
+                }
+                else
+                {
+                    iic=mu*GlobalC::ParaO.ncol+nu;
+                }
+                for(int ik=0;ik<GlobalC::kv.nks;ik++)
+                {
+                    o_delta_k += dm_hl[ik](nu, mu) * this->H_V_delta_k[ik][iic];
+                }
+            }
+        }
+    }
+    Parallel_Reduce::reduce_complex_double_all(o_delta_k);
+    if(o_delta_k.imag()>1e-12)
+    {
+        GlobalV::ofs_running << "o_delta_k : " << o_delta_k << std::endl;
+        //ModuleBase::WARNING_QUIT("o_delta_k","energy should be real!");
+    }
+    this->o_delta = o_delta_k.real();
+    return;
+}
+
+#endif

--- a/source/module_deepks/LCAO_deepks_odelta.cpp
+++ b/source/module_deepks/LCAO_deepks_odelta.cpp
@@ -11,7 +11,7 @@
 
 #include "LCAO_deepks.h"
 
-void LCAO_Deepks::cal_o_delta(const std::vector<ModuleBase::matrix> &dm_hl)
+void LCAO_Deepks::cal_o_delta(const std::vector<ModuleBase::matrix> &dm_hl, const Parallel_Orbitals &ParaO)
 {
     ModuleBase::TITLE("LCAO_Deepks", "cal_o_delta");
     this->o_delta = 0;
@@ -19,12 +19,12 @@ void LCAO_Deepks::cal_o_delta(const std::vector<ModuleBase::matrix> &dm_hl)
     {
         for (int j = 0; j < GlobalV::NLOCAL; ++j)
         {
-            const int mu = GlobalC::ParaO.trace_loc_row[j];
-            const int nu = GlobalC::ParaO.trace_loc_col[i];
+            const int mu = ParaO.trace_loc_row[j];
+            const int nu = ParaO.trace_loc_col[i];
             
             if (mu >= 0 && nu >= 0)
             {                
-                const int index=nu*GlobalC::ParaO.nrow+mu;
+                const int index = nu*ParaO.nrow + mu;
                 for (int is = 0; is < GlobalV::NSPIN; ++is)
                 {
                     this->o_delta += dm_hl[is](nu, mu) * this->H_V_delta[index];
@@ -39,7 +39,9 @@ void LCAO_Deepks::cal_o_delta(const std::vector<ModuleBase::matrix> &dm_hl)
 
 //calculating the correction of (LUMO-HOMO) energies, i.e., band gap corrections
 //for multi_k calculations
-void LCAO_Deepks::cal_o_delta_k(const std::vector<ModuleBase::ComplexMatrix> &dm_hl)
+void LCAO_Deepks::cal_o_delta_k(const std::vector<ModuleBase::ComplexMatrix> &dm_hl,
+    const Parallel_Orbitals &ParaO,
+    const int nks)
 {
     ModuleBase::TITLE("LCAO_Deepks", "cal_o_delta_k");
     std::complex<double> o_delta_k=std::complex<double>(0.0,0.0);
@@ -47,21 +49,21 @@ void LCAO_Deepks::cal_o_delta_k(const std::vector<ModuleBase::ComplexMatrix> &dm
     {
         for (int j = 0; j < GlobalV::NLOCAL; ++j)
         {
-            const int mu = GlobalC::ParaO.trace_loc_row[j];
-            const int nu = GlobalC::ParaO.trace_loc_col[i];
+            const int mu = ParaO.trace_loc_row[j];
+            const int nu = ParaO.trace_loc_col[i];
             
             if (mu >= 0 && nu >= 0)
             {                
                 int iic;
                 if(GlobalV::KS_SOLVER=="genelpa" || GlobalV::KS_SOLVER=="scalapack_gvx")  // save the matrix as column major format
                 {
-                    iic=mu+nu*GlobalC::ParaO.nrow;
+                    iic = mu + nu*ParaO.nrow;
                 }
                 else
                 {
-                    iic=mu*GlobalC::ParaO.ncol+nu;
+                    iic = mu*ParaO.ncol + nu;
                 }
-                for(int ik=0;ik<GlobalC::kv.nks;ik++)
+                for(int ik=0; ik<nks; ik++)
                 {
                     o_delta_k += dm_hl[ik](nu, mu) * this->H_V_delta_k[ik][iic];
                 }

--- a/source/module_deepks/LCAO_deepks_torch.cpp
+++ b/source/module_deepks/LCAO_deepks_torch.cpp
@@ -232,47 +232,53 @@ void LCAO_Deepks::cal_gedm(const int nat)
     return;
 }
 
-void LCAO_Deepks::cal_orbital_precalc(const std::vector<ModuleBase::matrix> &dm_hl)
+// calculates orbital_precalc[1,NAt,NDscrpt] = gvdm * orbital_pdm_shells;
+// orbital_pdm_shells[1,Inl,nm*nm] = dm_hl * overlap * overlap;
+void LCAO_Deepks::cal_orbital_precalc(const std::vector<ModuleBase::matrix> &dm_hl,
+    const int nat,
+    const UnitCell_pseudo &ucell,
+    const LCAO_Orbitals &orb,
+    Grid_Driver &GridD,
+    const Parallel_Orbitals &ParaO)
 {
     ModuleBase::TITLE("LCAO_Deepks", "calc_orbital_precalc");
     
-    const int nat = GlobalC::ucell.nat;
     this->cal_gvdm(nat);
-    const double Rcut_Alpha = GlobalC::ORB.Alpha[0].getRcut();
+    const double Rcut_Alpha = orb.Alpha[0].getRcut();
     this->init_orbital_pdm_shell();
    
-    for (int T0 = 0; T0 < GlobalC::ucell.ntype; T0++)
+    for (int T0 = 0; T0 < ucell.ntype; T0++)
     {
-		Atom* atom0 = &GlobalC::ucell.atoms[T0]; 
+		Atom* atom0 = &ucell.atoms[T0]; 
         
         for (int I0 =0; I0< atom0->na; I0++)
         {
-            const int iat = GlobalC::ucell.itia2iat(T0,I0);
+            const int iat = ucell.itia2iat(T0,I0);
             const ModuleBase::Vector3<double> tau0 = atom0->tau[I0];
-            GlobalC::GridD.Find_atom(GlobalC::ucell, atom0->tau[I0] ,T0, I0);
+            GridD.Find_atom(GlobalC::ucell, atom0->tau[I0] ,T0, I0);
 
-            for (int ad1=0; ad1<GlobalC::GridD.getAdjacentNum()+1 ; ++ad1)
+            for (int ad1=0; ad1<GridD.getAdjacentNum()+1 ; ++ad1)
             {
-                const int T1 = GlobalC::GridD.getType(ad1);
-                const int I1 = GlobalC::GridD.getNatom(ad1);
-                const int start1 = GlobalC::ucell.itiaiw2iwt(T1, I1, 0);
-                const ModuleBase::Vector3<double> tau1 = GlobalC::GridD.getAdjacentTau(ad1);
-				const Atom* atom1 = &GlobalC::ucell.atoms[T1];
+                const int T1 = GridD.getType(ad1);
+                const int I1 = GridD.getNatom(ad1);
+                const int start1 = ucell.itiaiw2iwt(T1, I1, 0);
+                const ModuleBase::Vector3<double> tau1 = GridD.getAdjacentTau(ad1);
+				const Atom* atom1 = &ucell.atoms[T1];
 				const int nw1_tot = atom1->nw*GlobalV::NPOL;
-				const double Rcut_AO1 = GlobalC::ORB.Phi[T1].getRcut(); 
+				const double Rcut_AO1 = orb.Phi[T1].getRcut(); 
 
-				for (int ad2=0; ad2 < GlobalC::GridD.getAdjacentNum()+1 ; ad2++)
+				for (int ad2=0; ad2 < GridD.getAdjacentNum()+1 ; ad2++)
 				{
-					const int T2 = GlobalC::GridD.getType(ad2);
-					const int I2 = GlobalC::GridD.getNatom(ad2);
-					const int start2 = GlobalC::ucell.itiaiw2iwt(T2, I2, 0);
+					const int T2 = GridD.getType(ad2);
+					const int I2 = GridD.getNatom(ad2);
+					const int start2 = ucell.itiaiw2iwt(T2, I2, 0);
 					const ModuleBase::Vector3<double> tau2 = GlobalC::GridD.getAdjacentTau(ad2);
-					const Atom* atom2 = &GlobalC::ucell.atoms[T2];
+					const Atom* atom2 = &ucell.atoms[T2];
 					const int nw2_tot = atom2->nw*GlobalV::NPOL;
 					
-					const double Rcut_AO2 = GlobalC::ORB.Phi[T2].getRcut();
-                	const double dist1 = (tau1-tau0).norm() * GlobalC::ucell.lat0;
-                	const double dist2 = (tau2-tau0).norm() * GlobalC::ucell.lat0;
+					const double Rcut_AO2 = orb.Phi[T2].getRcut();
+                	const double dist1 = (tau1-tau0).norm() * ucell.lat0;
+                	const double dist2 = (tau2-tau0).norm() * ucell.lat0;
 
 					if (dist1 > Rcut_Alpha + Rcut_AO1 || dist2 > Rcut_Alpha + Rcut_AO2)
 					{
@@ -282,13 +288,13 @@ void LCAO_Deepks::cal_orbital_precalc(const std::vector<ModuleBase::matrix> &dm_
 					for (int iw1=0; iw1<nw1_tot; ++iw1)
 					{
 						const int iw1_all = start1 + iw1; // this is \mu
-						const int iw1_local = GlobalC::ParaO.trace_loc_row[iw1_all];
+						const int iw1_local = ParaO.trace_loc_row[iw1_all];
 						if(iw1_local < 0)continue;
 						const int iw1_0 = iw1/GlobalV::NPOL;
 						for (int iw2=0; iw2<nw2_tot; ++iw2)
 						{
 							const int iw2_all = start2 + iw2; // this is \nu
-							const int iw2_local = GlobalC::ParaO.trace_loc_col[iw2_all];
+							const int iw2_local = ParaO.trace_loc_col[iw2_all];
 							if(iw2_local < 0)continue;
 							const int iw2_0 = iw2/GlobalV::NPOL;
 
@@ -297,9 +303,9 @@ void LCAO_Deepks::cal_orbital_precalc(const std::vector<ModuleBase::matrix> &dm_
 
                             assert(nlm1.size()==nlm2.size());
                             int ib=0;
-                            for (int L0 = 0; L0 <= GlobalC::ORB.Alpha[0].getLmax();++L0)
+                            for (int L0 = 0; L0 <= orb.Alpha[0].getLmax();++L0)
                             {
-                                for (int N0 = 0;N0 < GlobalC::ORB.Alpha[0].getNchi(L0);++N0)
+                                for (int N0 = 0;N0 < orb.Alpha[0].getNchi(L0);++N0)
                                 {
                                     const int inl = this->inl_index[T0](I0, L0, N0);
                                     const int nm = 2*L0+1;
@@ -336,7 +342,7 @@ void LCAO_Deepks::cal_orbital_precalc(const std::vector<ModuleBase::matrix> &dm_
     // transfer orbital_pdm_shell to orbital_pdm_shell_vector
     
 
-    int nlmax = this->inlmax/GlobalC::ucell.nat;
+    int nlmax = this->inlmax/nat;
    
     std::vector<torch::Tensor> orbital_pdm_shell_vector;
     
@@ -346,7 +352,7 @@ void LCAO_Deepks::cal_orbital_precalc(const std::vector<ModuleBase::matrix> &dm_
         for(int hl=0; hl<1; ++hl)
         {
             std::vector<torch::Tensor> ammv;
-            for (int iat=0; iat<GlobalC::ucell.nat; ++iat)
+            for (int iat=0; iat<nat; ++iat)
             {
                 int inl = iat*nlmax+nl;
                 int nm = 2*this->inl_l[inl]+1;

--- a/source/src_lcao/ELEC_scf.cpp
+++ b/source/src_lcao/ELEC_scf.cpp
@@ -555,6 +555,16 @@ void ELEC_scf::scf(const int &istep)
 				{
 					GlobalV::ofs_running << " " << GlobalV::global_out_dir << " final etot is " << GlobalC::en.etot * ModuleBase::Ry_to_eV << " eV" << std::endl;
 				}
+			}
+			else
+			{
+				GlobalV::ofs_running << " !! convergence has not been achieved @_@" << std::endl;
+				if(GlobalV::OUT_LEVEL=="ie" || GlobalV::OUT_LEVEL=="m") //xiaohui add "m" option, 2015-09-16
+				std::cout << " !! CONVERGENCE HAS NOT BEEN ACHIEVED !!" << std::endl;
+			}
+
+			if(conv_elec || iter==GlobalV::NITER)
+			{
 #ifdef __DEEPKS
 				if (GlobalV::out_descriptor)	//caoyu add 2021-06-04
 				{
@@ -586,14 +596,19 @@ void ELEC_scf::scf(const int &istep)
         	    			dm_bandgap.cal_dm(wg_hl); 
 						
 			    			if(GlobalV::GAMMA_ONLY_LOCAL){
-            	    			GlobalC::ld.cal_o_delta(dm_bandgap.dm_gamma);
+            	    			GlobalC::ld.cal_o_delta(dm_bandgap.dm_gamma,GlobalC::ParaO);
                 			}
 					
                 			else{
-            	    			GlobalC::ld.cal_o_delta_k(dm_bandgap.dm_k);
+            	    			GlobalC::ld.cal_o_delta_k(dm_bandgap.dm_k,GlobalC::ParaO, GlobalC::kv.nks);
                 			}	
 							GlobalC::ld.save_npy_o(GlobalC::wf.ekb[0][nocc] - GlobalC::wf.ekb[0][nocc-1] - GlobalC::ld.o_delta, "o_base.npy");
-			    			GlobalC::ld.cal_orbital_precalc(dm_bandgap.dm_gamma);
+			    			GlobalC::ld.cal_orbital_precalc(dm_bandgap.dm_gamma,
+								GlobalC::ucell.nat,
+								GlobalC::ucell,
+            					GlobalC::ORB,
+            					GlobalC::GridD,
+            					GlobalC::ParaO);
 							if(GlobalV::MY_RANK==0)
 								GlobalC::ld.save_npy_orbital_precalc();
         				}
@@ -608,12 +623,7 @@ void ELEC_scf::scf(const int &istep)
 				}
 #endif
 			}
-			else
-			{
-				GlobalV::ofs_running << " !! convergence has not been achieved @_@" << std::endl;
-				if(GlobalV::OUT_LEVEL=="ie" || GlobalV::OUT_LEVEL=="m") //xiaohui add "m" option, 2015-09-16
-				std::cout << " !! CONVERGENCE HAS NOT BEEN ACHIEVED !!" << std::endl;
-			}
+
 
 //			ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running,"ELECTRONS CONVERGED!");
 			ModuleBase::timer::tick("ELEC_scf","scf");

--- a/source/src_pw/energy.cpp
+++ b/source/src_pw/energy.cpp
@@ -17,7 +17,7 @@
 #include "H_Hartree_pw.h"
 #include "H_XC_pw.h"
 #ifdef __DEEPKS
-#include "../src_lcao/../module_deepks/LCAO_deepks.h"
+#include "../module_deepks/LCAO_deepks.h"
 #endif
 
 


### PR DESCRIPTION
This PR aims at enabling the orbital (band gap) training in DeePKS. Corresponding codes have been added in module_deepks and src_lcao/ELEC_scf.cpp. In addition, minor modification has been applied in ELEC_scf.cpp so that the code can generate "e_tot.npy", etc. even if the convergence of the SCF cycle has not been achieved. 
Also, the problem in CMakeLists.txt (haven't link deepks) has been fixed. 