### PR TITLE
fix : ABACUS outputs "Nan" when "nbspline" is set to 0 or 1.

### DIFF
--- a/source/module_base/math_bspline.cpp
+++ b/source/module_base/math_bspline.cpp
@@ -22,7 +22,9 @@ namespace ModuleBase
         this->Dx = Dxin;
         this->norder = norderin;
         assert(Dx > 0);
-        assert(norder >= 0);
+        //norder must be a positive even number.
+        assert(norder > 0);
+        assert(norder % 2 == 0); 
         bezier = new double [this->norder+1];
         for(int i = 0 ; i < norder+1 ; ++i)
         {

--- a/source/src_pw/pw_basis.cpp
+++ b/source/src_pw/pw_basis.cpp
@@ -760,11 +760,12 @@ void PW_Basis::setup_structure_factor(void)			// Peize Lin optimize and add Open
 //	outstr = GlobalV::global_out_dir + "strucFac.dat"; 
 //	std::ofstream ofs( outstr.c_str() ) ;
     bool usebspline;
-    if(nbspline >= 0)   usebspline = true;
+    if(nbspline > 0)   usebspline = true;
     else    usebspline = false;
     
     if(usebspline)
     {
+        nbspline = int((nbspline+1)/2)*2; // nbspline must be a positive even number.
         this->bspline_sf(nbspline);
     }
     else


### PR DESCRIPTION
Now parameter "nbspline" must be positive and even to use bspline to calculate structure factor.
When it is set to an odd number, we will add it by 1.
fix the issue #589
scope: math_bspline.cpp, pw_basis.cpp