### PR TITLE
Refactor : Getting rid of GlobalC::UFFT

### DIFF
--- a/source/module_deepks/LCAO_deepks_fdelta.cpp
+++ b/source/module_deepks/LCAO_deepks_fdelta.cpp
@@ -10,6 +10,7 @@
 
 #include "LCAO_deepks.h"
 #include "../module_base/vector3.h"
+#include "../module_base/timer.h"
 
 //force for gamma only calculations
 //Pulay and HF terms are calculated together

--- a/source/module_deepks/LCAO_deepks_pdm.cpp
+++ b/source/module_deepks/LCAO_deepks_pdm.cpp
@@ -14,6 +14,7 @@
 
 #include "LCAO_deepks.h"
 #include "../module_base/vector3.h"
+#include "../module_base/timer.h"
 
 //this subroutine performs the calculation of projected density matrices
 //pdm_m,m'=\sum_{mu,nu} rho_{mu,nu} <chi_mu|alpha_m><alpha_m'|chi_nu>

--- a/source/module_deepks/LCAO_deepks_psialpha.cpp
+++ b/source/module_deepks/LCAO_deepks_psialpha.cpp
@@ -7,6 +7,7 @@
 
 #include "LCAO_deepks.h"
 #include "../module_base/vector3.h"
+#include "../module_base/timer.h"
 
 void LCAO_Deepks::build_psialpha(const bool& calc_deri,
     const UnitCell_pseudo &ucell,

--- a/source/module_deepks/LCAO_deepks_vdelta.cpp
+++ b/source/module_deepks/LCAO_deepks_vdelta.cpp
@@ -14,6 +14,7 @@
 #include "LCAO_deepks.h"
 #include "../module_base/vector3.h"
 #include "../src_parallel/parallel_reduce.h"
+#include "../module_base/timer.h"
 
 //this subroutine adds dV to the Kohn-Sham Hamiltonian
 //for gamma_only calculations

--- a/source/src_io/chi0_standard.cpp
+++ b/source/src_io/chi0_standard.cpp
@@ -13,6 +13,7 @@
 #include "../src_lcao/wavefunc_in_pw.h"
 #include "optical.h"
 #include "../src_pw/klist.h"
+#include "../src_pw/use_fft.h"
 #include <iostream>
 #include <cstring>
 #include <vector>
@@ -523,15 +524,17 @@ void Chi0_standard::Cal_Psi(int iq, std::complex<double> **psi_r)
 {
 	double phase_x, phase_xy, phase_xyz;
 	std::complex<double> exp_tmp;
+	//Rent a memory space for FFT operations
+	std::complex<double> *porter = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
 	for(int ib = 0; ib < GlobalV::NBANDS; ib++)
 	{
-		ModuleBase::GlobalFunc::ZEROS( GlobalC::UFFT.porter, (GlobalC::pw.nrxx) );
+		ModuleBase::GlobalFunc::ZEROS( porter, (GlobalC::pw.nrxx) );
 		for(int ig = 0; ig < GlobalC::kv.ngk[iq] ; ig++)
 		{
-			GlobalC::UFFT.porter[ GlobalC::pw.ig2fftw[GlobalC::wf.igk(iq,ig)] ] = GlobalC::wf.evc[iq](ib,ig);
+			porter[ GlobalC::pw.ig2fftw[GlobalC::wf.igk(iq,ig)] ] = GlobalC::wf.evc[iq](ib,ig);
 		}
 
-		GlobalC::pw.FFT_wfc.FFT3D(GlobalC::UFFT.porter,1);
+		GlobalC::pw.FFT_wfc.FFT3D(porter,1);
 		int ir=0;
 		for(int ix=0; ix<GlobalC::pw.ncx; ix++)
 		{
@@ -543,7 +546,7 @@ void Chi0_standard::Cal_Psi(int iq, std::complex<double> **psi_r)
 				{
 					phase_xyz = (phase_xy + GlobalC::kv.kvec_d[iq].z*iz/GlobalC::pw.ncz) *ModuleBase::TWO_PI;
 					exp_tmp = std::complex<double>( cos(phase_xyz), sin(phase_xyz) );
-					psi_r[ib][ir] = GlobalC::UFFT.porter[ir]*exp_tmp;
+					psi_r[ib][ir] = porter[ir]*exp_tmp;
 					ir++;
 				}
 
@@ -563,6 +566,8 @@ void Chi0_standard::Cal_b(int iq, int ik, int iqk)
 	double phase_x, phase_xy, phase_xyz;
 	ModuleBase::Vector3<double> q = GlobalC::kv.kvec_d[iq];
 	std::complex<double> exp_tmp;
+	//Rent a memory space for FFT operations
+	std::complex<double> *porter = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
 
 	Cal_Psi(ik, psi_r1);
 	Cal_Psi(iqk, psi_r2);
@@ -582,20 +587,20 @@ void Chi0_standard::Cal_b(int iq, int ik, int iqk)
 					{
 						phase_xyz = (phase_xy + q.z*iz/GlobalC::pw.ncz) *ModuleBase::TWO_PI;
 						exp_tmp = std::complex<double>(cos(-phase_xyz), sin(-phase_xyz));
-						GlobalC::UFFT.porter[ir] = conj(psi_r1[ib1][ir]) * psi_r2[ib2][ir] *exp_tmp;
+						porter[ir] = conj(psi_r1[ib1][ir]) * psi_r2[ib2][ir] *exp_tmp;
 						ir++;
 					}
 				}
 			}
 
-			GlobalC::pw.FFT_chg.FFT3D( GlobalC::UFFT.porter, -1);
+			GlobalC::pw.FFT_chg.FFT3D( porter, -1);
 			//for(int g0=0; g0<dim; g0++)
 			//{
-			//	b[g0][ib1][ib2] = GlobalC::UFFT.porter[ GlobalC::pw.ig2fftc[g0] ];
+			//	b[g0][ib1][ib2] = porter[ GlobalC::pw.ig2fftc[g0] ];
 			//}
 			for(int g0=0;g0<GlobalC::pw.ngmc; g0++)
 			{
-				b_core[g0] = GlobalC::UFFT.porter[ GlobalC::pw.ig2fftc[g0] ];
+				b_core[g0] = porter[ GlobalC::pw.ig2fftc[g0] ];
 			}
 
 #ifdef __MPI

--- a/source/src_io/epsilon0_vasp.cpp
+++ b/source/src_io/epsilon0_vasp.cpp
@@ -223,18 +223,20 @@ void Epsilon0_vasp:: Delete()
 
 void Epsilon0_vasp:: Cal_psi(int ik)      // pengfei Li 2018-11-13
 {
+	//Rent a memory space for FFT operations
+	std::complex<double> *porter = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
 	for(int ib=0; ib<GlobalV::NBANDS; ib++)
 	{
-		ModuleBase::GlobalFunc::ZEROS( GlobalC::UFFT.porter, (GlobalC::pw.nrxx) );
+		ModuleBase::GlobalFunc::ZEROS( porter, (GlobalC::pw.nrxx) );
 		for(int ig = 0; ig < GlobalC::kv.ngk[ik] ; ig++)
 		{
-			GlobalC::UFFT.porter[ GlobalC::pw.ig2fftw[GlobalC::wf.igk(ik,ig)] ] = GlobalC::wf.evc[ik](ib,ig);
+			porter[ GlobalC::pw.ig2fftw[GlobalC::wf.igk(ik,ig)] ] = GlobalC::wf.evc[ik](ib,ig);
 		}
-		GlobalC::pw.FFT_wfc.FFT3D(GlobalC::UFFT.porter,1);
+		GlobalC::pw.FFT_wfc.FFT3D(porter,1);
 
 		for(int ir=0; ir<GlobalC::pw.nrxx; ir++)
 		{
-			psi[ib][ir] = GlobalC::UFFT.porter[ir];
+			psi[ib][ir] = porter[ir];
 		}
 	}
 
@@ -243,41 +245,43 @@ void Epsilon0_vasp:: Cal_psi(int ik)      // pengfei Li 2018-11-13
 
 void Epsilon0_vasp:: Cal_psi_nabla(int ik)      // pengfei Li 2018-11-13
 {
+	//Rent a memory space for FFT operations
+	std::complex<double> *porter = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
 	for(int ib=0; ib<GlobalV::NBANDS; ib++)
 	{
-		ModuleBase::GlobalFunc::ZEROS( GlobalC::UFFT.porter, (GlobalC::pw.nrxx) );
+		ModuleBase::GlobalFunc::ZEROS( porter, (GlobalC::pw.nrxx) );
 		for(int ig = 0; ig < GlobalC::kv.ngk[ik] ; ig++)
 		{
-			GlobalC::UFFT.porter[ GlobalC::pw.ig2fftw[GlobalC::wf.igk(ik,ig)] ] = GlobalC::wf.evc[ik](ib,ig) * (GlobalC::pw.get_GPlusK_cartesian_projection(ik, ig, 0) * (ModuleBase::TWO_PI/GlobalC::ucell.lat0));
+			porter[ GlobalC::pw.ig2fftw[GlobalC::wf.igk(ik,ig)] ] = GlobalC::wf.evc[ik](ib,ig) * (GlobalC::pw.get_GPlusK_cartesian_projection(ik, ig, 0) * (ModuleBase::TWO_PI/GlobalC::ucell.lat0));
 		}
-		GlobalC::pw.FFT_wfc.FFT3D(GlobalC::UFFT.porter,1);
+		GlobalC::pw.FFT_wfc.FFT3D(porter,1);
 
 		for(int ir=0; ir<GlobalC::pw.nrxx; ir++)
 		{
-			psi_nabla[ib][ir][0] = GlobalC::UFFT.porter[ir];
+			psi_nabla[ib][ir][0] = porter[ir];
 		}
 		
-		ModuleBase::GlobalFunc::ZEROS( GlobalC::UFFT.porter, (GlobalC::pw.nrxx) );
+		ModuleBase::GlobalFunc::ZEROS( porter, (GlobalC::pw.nrxx) );
 		for(int ig = 0; ig < GlobalC::kv.ngk[ik] ; ig++)
 		{
-			GlobalC::UFFT.porter[GlobalC::pw.ig2fftw[GlobalC::wf.igk(ik, ig)]] = GlobalC::wf.evc[ik](ib, ig) * (GlobalC::pw.get_GPlusK_cartesian_projection(ik, ig, 1) * (ModuleBase::TWO_PI / GlobalC::ucell.lat0));
+			porter[GlobalC::pw.ig2fftw[GlobalC::wf.igk(ik, ig)]] = GlobalC::wf.evc[ik](ib, ig) * (GlobalC::pw.get_GPlusK_cartesian_projection(ik, ig, 1) * (ModuleBase::TWO_PI / GlobalC::ucell.lat0));
 		}
-		GlobalC::pw.FFT_wfc.FFT3D(GlobalC::UFFT.porter,1);
+		GlobalC::pw.FFT_wfc.FFT3D(porter,1);
 
 		for(int ir=0; ir<GlobalC::pw.nrxx; ir++)
 		{
-			psi_nabla[ib][ir][1] = GlobalC::UFFT.porter[ir];
+			psi_nabla[ib][ir][1] = porter[ir];
 		}
-		ModuleBase::GlobalFunc::ZEROS( GlobalC::UFFT.porter, (GlobalC::pw.nrxx) );
+		ModuleBase::GlobalFunc::ZEROS( porter, (GlobalC::pw.nrxx) );
 		for(int ig = 0; ig < GlobalC::kv.ngk[ik] ; ig++)
 		{
-			GlobalC::UFFT.porter[GlobalC::pw.ig2fftw[GlobalC::wf.igk(ik, ig)]] = GlobalC::wf.evc[ik](ib, ig) * (GlobalC::pw.get_GPlusK_cartesian_projection(ik, ig, 2) * (ModuleBase::TWO_PI / GlobalC::ucell.lat0));
+			porter[GlobalC::pw.ig2fftw[GlobalC::wf.igk(ik, ig)]] = GlobalC::wf.evc[ik](ib, ig) * (GlobalC::pw.get_GPlusK_cartesian_projection(ik, ig, 2) * (ModuleBase::TWO_PI / GlobalC::ucell.lat0));
 		}
-		GlobalC::pw.FFT_wfc.FFT3D(GlobalC::UFFT.porter,1);
+		GlobalC::pw.FFT_wfc.FFT3D(porter,1);
 
 		for(int ir=0; ir<GlobalC::pw.nrxx; ir++)
 		{
-			psi_nabla[ib][ir][2] = GlobalC::UFFT.porter[ir];
+			psi_nabla[ib][ir][2] = porter[ir];
 		}
 	}
 

--- a/source/src_io/to_wannier90.cpp
+++ b/source/src_io/to_wannier90.cpp
@@ -371,7 +371,7 @@ void toWannier90::writeUNK(const ModuleBase::ComplexMatrix *wfc_pw)
 		for(int ib = 0; ib < GlobalV::NBANDS; ib++)
 		{
 			if(!tag_cal_band[ib]) continue;
-			//std::complex<double> *porter = GlobalC::UFFT.porter;
+			//std::complex<double> *porter = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
 			//  u_k in real space
 			ModuleBase::GlobalFunc::ZEROS(porter, GlobalC::pw.nrxx);
 			for (int ig = 0; ig < GlobalC::kv.ngk[ik]; ig++)
@@ -1470,7 +1470,7 @@ void toWannier90::integral(const int meshr, const double *psir, const double *r,
 void toWannier90::ToRealSpace(const int &ik, const int &ib, const ModuleBase::ComplexMatrix *evc, std::complex<double> *psir, const ModuleBase::Vector3<double> G)
 {
 	// (1) set value
-	std::complex<double> *phase = GlobalC::UFFT.porter;
+	std::complex<double> *phase = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
     ModuleBase::GlobalFunc::ZEROS( psir, GlobalC::pw.nrxx );
 	ModuleBase::GlobalFunc::ZEROS( phase, GlobalC::pw.nrxx);
 
@@ -1506,7 +1506,7 @@ std::complex<double> toWannier90::unkdotb(const std::complex<double> *psir, cons
 {
 	std::complex<double> result(0.0,0.0);
 	int knumber = GlobalC::kv.ngk[ikb];
-	std::complex<double> *porter = GlobalC::UFFT.porter;
+	std::complex<double> *porter = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
 	ModuleBase::GlobalFunc::ZEROS( porter, GlobalC::pw.nrxx);
 	for (int ir = 0; ir < GlobalC::pw.nrxx; ir++)
 	{
@@ -1528,7 +1528,7 @@ std::complex<double> toWannier90::unkdotkb(const int &ik, const int &ikb, const 
 	// (1) set value
 	std::complex<double> result(0.0,0.0);
 	std::complex<double> *psir = new std::complex<double>[GlobalC::pw.nrxx];
-	std::complex<double> *phase = GlobalC::UFFT.porter;
+	std::complex<double> *phase = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
     ModuleBase::GlobalFunc::ZEROS( psir, GlobalC::pw.nrxx );
 	ModuleBase::GlobalFunc::ZEROS( phase, GlobalC::pw.nrxx);
 

--- a/source/src_io/unk_overlap_pw.cpp
+++ b/source/src_io/unk_overlap_pw.cpp
@@ -67,7 +67,7 @@ std::complex<double> unkOverlap_pw::unkdotp_G0(const int ik_L, const int ik_R, c
 {
 	// (1) set value
 	std::complex<double> result(0.0,0.0);
-	std::complex<double> *phase = GlobalC::UFFT.porter;
+	std::complex<double> *phase = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
 	std::complex<double> *psi_r = new std::complex<double>[GlobalC::pw.nrxx]; // 实空间的波函数
 
 	ModuleBase::GlobalFunc::ZEROS( phase, GlobalC::pw.nrxx);
@@ -182,7 +182,7 @@ std::complex<double> unkOverlap_pw::unkdotp_soc_G0(const int ik_L, const int ik_
 {
 	// (1) set value
 	std::complex<double> result(0.0,0.0);
-	std::complex<double> *phase = GlobalC::UFFT.porter;
+	std::complex<double> *phase = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
 	std::complex<double> *psi_up = new std::complex<double>[GlobalC::pw.nrxx];
 	std::complex<double> *psi_down = new std::complex<double>[GlobalC::pw.nrxx];
 	ModuleBase::GlobalFunc::ZEROS( phase, GlobalC::pw.nrxx);

--- a/source/src_io/write_pot.cpp
+++ b/source/src_io/write_pot.cpp
@@ -206,7 +206,7 @@ void Potential::write_elecstat_pot(const std::string &fn, const std::string &fn_
     v_elecstat = new double[GlobalC::pw.nrxx];
     ModuleBase::GlobalFunc::ZEROS(v_elecstat, GlobalC::pw.nrxx);
 
-    std::complex<double> *Porter = GlobalC::UFFT.porter;
+    std::complex<double> *Porter = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
     ModuleBase::GlobalFunc::ZEROS( Porter, GlobalC::pw.nrxx );
     
     int nspin0 = 1;

--- a/source/src_io/write_wfc_realspace.cpp
+++ b/source/src_io/write_wfc_realspace.cpp
@@ -75,13 +75,15 @@ namespace Write_Wfc_Realspace
 	std::vector<std::complex<double>> cal_wfc_r(const ModuleBase::ComplexMatrix &wfc_g, const int ik, const int ib)
 	{
 		ModuleBase::timer::tick("Write_Wfc_Realspace", "cal_wfc_r");
-		ModuleBase::GlobalFunc::ZEROS(GlobalC::UFFT.porter, GlobalC::pw.nrxx);
+		//Rent a memory space for FFT operations
+		std::complex<double> *porter = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
+		ModuleBase::GlobalFunc::ZEROS(porter, GlobalC::pw.nrxx);
 		std::vector<std::complex<double>> wfc_r(GlobalC::pw.nrxx);
 		for(int ig=0; ig<GlobalC::kv.ngk[ik]; ++ig)
-			GlobalC::UFFT.porter[ GlobalC::pw.ig2fftw[GlobalC::wf.igk(ik,ig)] ] = wfc_g(ib,ig);
-		GlobalC::pw.FFT_wfc.FFT3D(GlobalC::UFFT.porter,1);
+			porter[ GlobalC::pw.ig2fftw[GlobalC::wf.igk(ik,ig)] ] = wfc_g(ib,ig);
+		GlobalC::pw.FFT_wfc.FFT3D(porter,1);
 		for(int ir=0; ir<GlobalC::pw.nrxx; ++ir)
-			wfc_r[ir] = GlobalC::UFFT.porter[ir];
+			wfc_r[ir] = porter[ir];
 		ModuleBase::timer::tick("Write_Wfc_Realspace", "cal_wfc_r");
 		return wfc_r;
 	}

--- a/source/src_lcao/exx_lip.cpp
+++ b/source/src_lcao/exx_lip.cpp
@@ -329,12 +329,14 @@ void Exx_Lip::wf_wg_cal()
 
 void Exx_Lip::phi_cal(k_package *kq_pack, int ikq)
 {
+	//Rent a memory space for FFT operations
+	std::complex<double> *porter = UFFT_ptr->get_porter(0, GlobalC::pw.nrxx);
 	for( int iw=0; iw< GlobalV::NLOCAL; ++iw)
 	{
-		ModuleBase::GlobalFunc::ZEROS( UFFT_ptr->porter, pw_ptr->nrxx );
+		ModuleBase::GlobalFunc::ZEROS( porter, pw_ptr->nrxx );
 		for( int ig=0; ig<kq_pack->kv_ptr->ngk[ikq]; ++ig)
-			UFFT_ptr->porter[ pw_ptr->ig2fftw[kq_pack->wf_ptr->igk(ikq,ig)] ] = kq_pack->wf_ptr->wanf2[ikq](iw,ig);
-		pw_ptr->FFT_wfc.FFT3D(UFFT_ptr->porter,1);
+			porter[ pw_ptr->ig2fftw[kq_pack->wf_ptr->igk(ikq,ig)] ] = kq_pack->wf_ptr->wanf2[ikq](iw,ig);
+		pw_ptr->FFT_wfc.FFT3D(porter,1);
 		int ir(0);
 		for( int ix=0; ix<pw_ptr->ncx; ++ix)
 		{
@@ -346,7 +348,7 @@ void Exx_Lip::phi_cal(k_package *kq_pack, int ikq)
 				{
 					const double phase_xyz = phase_xy + kq_pack->kv_ptr->kvec_d[ikq].z * iz / pw_ptr->ncz;
 					const std::complex<double> exp_tmp = exp(phase_xyz*ModuleBase::TWO_PI*ModuleBase::IMAG_UNIT);
-					phi[iw][ir] = UFFT_ptr->porter[ir]*exp_tmp;
+					phi[iw][ir] = porter[ir]*exp_tmp;
 					++ir;
 				}
 			}
@@ -359,16 +361,18 @@ void Exx_Lip::psi_cal()
 	ModuleBase::TITLE("Exx_Lip","psi_cal");
 	if (GlobalC::pot.start_pot=="atomic")
 	{
+		//Rent a memory space for FFT operations
+		std::complex<double> *porter = UFFT_ptr->get_porter(0, GlobalC::pw.nrxx);
 		for( int iq = 0; iq < q_pack->kv_ptr->nks; ++iq)
 		{
 			for( int ib = 0; ib < GlobalV::NBANDS; ++ib)
 			{
-				ModuleBase::GlobalFunc::ZEROS( UFFT_ptr->porter, pw_ptr->nrxx );
+				ModuleBase::GlobalFunc::ZEROS( porter, pw_ptr->nrxx );
 				for( int ig = 0; ig < q_pack->kv_ptr->ngk[iq] ; ++ig)
 				{
-					UFFT_ptr->porter[ pw_ptr->ig2fftw[q_pack->wf_ptr->igk(iq,ig)] ] = q_pack->wf_ptr->evc[iq](ib,ig);
+					porter[ pw_ptr->ig2fftw[q_pack->wf_ptr->igk(iq,ig)] ] = q_pack->wf_ptr->evc[iq](ib,ig);
 				}
-				pw_ptr->FFT_wfc.FFT3D(UFFT_ptr->porter,1);
+				pw_ptr->FFT_wfc.FFT3D(porter,1);
 				int ir(0);
 				for( int ix=0; ix<pw_ptr->ncx; ++ix)
 				{
@@ -380,7 +384,7 @@ void Exx_Lip::psi_cal()
 						{
 							const double phase_xyz = phase_xy + q_pack->kv_ptr->kvec_d[iq].z * iz / pw_ptr->ncz;
 							const std::complex<double> exp_tmp = exp(phase_xyz*ModuleBase::TWO_PI*ModuleBase::IMAG_UNIT);
-							psi[iq][ib][ir] = UFFT_ptr->porter[ir]*exp_tmp;
+							psi[iq][ib][ir] = porter[ir]*exp_tmp;
 							++ir;
 						}
 					}
@@ -478,7 +482,7 @@ void Exx_Lip::b_cal( int ik, int iq, int ib)
 		}
 	}
 
-	std::complex<double> * const porter = UFFT_ptr->porter;
+	std::complex<double> * const porter = UFFT_ptr->get_porter(0, GlobalC::pw.nrxx);
 	const int * const ig2fftc = pw_ptr->ig2fftc;
 	for(size_t iw=0; iw< GlobalV::NLOCAL; ++iw)
 	{

--- a/source/src_pw/diago_cg.cu
+++ b/source/src_pw/diago_cg.cu
@@ -2,6 +2,7 @@
 #include "cuda_runtime.h"
 #include "global.h"
 #include "nvToolsExt.h"
+#include "../module_base/timer.h"
 using namespace CudaCheck;
 
 template<class T, class T2>

--- a/source/src_pw/hamilt.cu
+++ b/source/src_pw/hamilt.cu
@@ -4,6 +4,8 @@
 #include "diago_david.h"
 #include "diago_cg.cuh"
 #include "cufft.h"
+#include "../module_base/timer.h"
+
 using namespace CudaCheck;
 
 Hamilt::Hamilt() 

--- a/source/src_pw/hamilt_pw.cpp
+++ b/source/src_pw/hamilt_pw.cpp
@@ -407,52 +407,54 @@ void Hamilt_PW::h_psi(const std::complex<double> *psi_in, std::complex<double> *
 	{
 		tmhpsi = hpsi;
 		tmpsi_in = psi_in;
+		//Rent a memory space for FFT operations
+		std::complex<double> *porter = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
 		for(int ib = 0 ; ib < m; ++ib)
 		{
 			if(GlobalV::NSPIN!=4){
-				ModuleBase::GlobalFunc::ZEROS( GlobalC::UFFT.porter, GlobalC::pw.nrxx);
-				GlobalC::UFFT.RoundTrip( tmpsi_in, GlobalC::pot.vr_eff1, GR_index, GlobalC::UFFT.porter );
+				ModuleBase::GlobalFunc::ZEROS( porter, GlobalC::pw.nrxx);
+				GlobalC::UFFT.RoundTrip( tmpsi_in, GlobalC::pot.vr_eff1, GR_index, GlobalC::wf.npw, GlobalC::pw.nrxx, porter );
 				for (j = 0;j < GlobalC::wf.npw;j++)
 				{
-					tmhpsi[j] += GlobalC::UFFT.porter[ GR_index[j] ];
+					tmhpsi[j] += porter[ GR_index[j] ];
 				}
 			}
 			else
 			{
-				std::complex<double>* porter1 = new std::complex<double>[GlobalC::pw.nrxx];
-				ModuleBase::GlobalFunc::ZEROS( GlobalC::UFFT.porter, GlobalC::pw.nrxx);
+				//Rent a memory space for FFT operations
+				std::complex<double>* porter1 = Use_FFT::get_porter(GlobalC::pw.nrxx, GlobalC::pw.nrxx * GlobalV::NPOL);
+				ModuleBase::GlobalFunc::ZEROS( porter, GlobalC::pw.nrxx);
 				ModuleBase::GlobalFunc::ZEROS( porter1, GlobalC::pw.nrxx);
 				for (int ig=0; ig< GlobalC::wf.npw; ig++)
 				{
-					GlobalC::UFFT.porter[ GR_index[ig]  ] = tmpsi_in[ig];
+					porter[ GR_index[ig]  ] = tmpsi_in[ig];
 					porter1[ GR_index[ig]  ] = tmpsi_in[ig + GlobalC::wf.npwx];
 				}
 				// (2) fft to real space and doing things.
-				GlobalC::pw.FFT_wfc.FFT3D( GlobalC::UFFT.porter, 1);
+				GlobalC::pw.FFT_wfc.FFT3D( porter, 1);
 				GlobalC::pw.FFT_wfc.FFT3D( porter1, 1);
 				std::complex<double> sup,sdown;
 				for (int ir=0; ir< GlobalC::pw.nrxx; ir++)
 				{
-					sup = GlobalC::UFFT.porter[ir] * (GlobalC::pot.vr_eff(0,ir) + GlobalC::pot.vr_eff(3,ir)) +
-						porter1[ir] * (GlobalC::pot.vr_eff(1,ir) - std::complex<double>(0.0,1.0) * GlobalC::pot.vr_eff(2,ir));
+					sup = porter[ir] * (GlobalC::pot.vr_eff(0,ir) + GlobalC::pot.vr_eff(3,ir)) +
+					 	porter1[ir] * (GlobalC::pot.vr_eff(1,ir) - std::complex<double>(0.0,1.0) * GlobalC::pot.vr_eff(2,ir));
 					sdown = porter1[ir] * (GlobalC::pot.vr_eff(0,ir) - GlobalC::pot.vr_eff(3,ir)) +
-					GlobalC::UFFT.porter[ir] * (GlobalC::pot.vr_eff(1,ir) + std::complex<double>(0.0,1.0) * GlobalC::pot.vr_eff(2,ir));
-					GlobalC::UFFT.porter[ir] = sup;
+					porter[ir] * (GlobalC::pot.vr_eff(1,ir) + std::complex<double>(0.0,1.0) * GlobalC::pot.vr_eff(2,ir));
+					porter[ir] = sup;
 					porter1[ir] = sdown;
 				}
 				// (3) fft back to G space.
-				GlobalC::pw.FFT_wfc.FFT3D( GlobalC::UFFT.porter, -1);
+				GlobalC::pw.FFT_wfc.FFT3D( porter, -1);
 				GlobalC::pw.FFT_wfc.FFT3D( porter1, -1);
 
 				for (j = 0;j < GlobalC::wf.npw;j++)
 				{
-					tmhpsi[j] += GlobalC::UFFT.porter[ GR_index[j] ];
+					tmhpsi[j] += porter[ GR_index[j] ];
 				}
 				for (j = 0;j < GlobalC::wf.npw;j++ )
 				{
 					tmhpsi[j+GlobalC::wf.npwx] += porter1[ GR_index[j] ];
 				}
-				delete[] porter1;
 			}
 			tmhpsi += dmax;
 			tmpsi_in += dmax;
@@ -536,29 +538,31 @@ void Hamilt_PW::h_psi(const std::complex<double> *psi_in, std::complex<double> *
 	{
 		tmhpsi = hpsi;
 		tmpsi_in = psi_in;
+		//Rent a memory space for FFT operations
+		std::complex<double> *porter = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
 		for(int ib = 0; ib < m; ++ib)
 		{
 			for(int j=0; j<3; j++)
 			{
-				ModuleBase::GlobalFunc::ZEROS( GlobalC::UFFT.porter, GlobalC::pw.nrxx);
+				ModuleBase::GlobalFunc::ZEROS( porter, GlobalC::pw.nrxx);
 				for (int ig = 0;ig < GlobalC::kv.ngk[GlobalV::CURRENT_K] ; ig++)
 				{
 					double fact = GlobalC::pw.get_GPlusK_cartesian_projection(GlobalV::CURRENT_K,GlobalC::wf.igk(GlobalV::CURRENT_K,ig),j) * GlobalC::ucell.tpiba;
-					GlobalC::UFFT.porter[ GR_index[ig] ] = tmpsi_in[ig] * complex<double>(0.0,fact);
+					porter[ GR_index[ig] ] = tmpsi_in[ig] * complex<double>(0.0,fact);
 				}
 
-				GlobalC::pw.FFT_wfc.FFT3D(GlobalC::UFFT.porter, 1);
+				GlobalC::pw.FFT_wfc.FFT3D(porter, 1);
 
 				for (int ir = 0; ir < GlobalC::pw.nrxx; ir++)
 				{
-					GlobalC::UFFT.porter[ir] = GlobalC::UFFT.porter[ir] * GlobalC::pot.vofk(GlobalV::CURRENT_SPIN,ir);
+					porter[ir] = porter[ir] * GlobalC::pot.vofk(GlobalV::CURRENT_SPIN,ir);
 				}
-				GlobalC::pw.FFT_wfc.FFT3D(GlobalC::UFFT.porter, -1);
+				GlobalC::pw.FFT_wfc.FFT3D(porter, -1);
 
 				for (int ig = 0;ig < GlobalC::kv.ngk[GlobalV::CURRENT_K] ; ig++)
 				{
 					double fact = GlobalC::pw.get_GPlusK_cartesian_projection(GlobalV::CURRENT_K,GlobalC::wf.igk(GlobalV::CURRENT_K,ig),j) * GlobalC::ucell.tpiba;
-					tmhpsi[ig] = tmhpsi[ig] - complex<double>(0.0,fact) * GlobalC::UFFT.porter[ GR_index[ig] ];
+					tmhpsi[ig] = tmhpsi[ig] - complex<double>(0.0,fact) * porter[ GR_index[ig] ];
 				}
 			}//x,y,z directions
 		}

--- a/source/src_pw/hamilt_pw.cu
+++ b/source/src_pw/hamilt_pw.cu
@@ -5,6 +5,8 @@
 #include "../module_base/blas_connector.h"
 #include "../src_io/optical.h" // only get judgement to calculate optical matrix or not.
 #include "myfunc.h"
+#include "../module_base/timer.h"
+#include "../src_parallel/parallel_reduce.h"
 using namespace CudaCheck;
 
 __global__ void cast_d2f(float *dst, double *src, int size)

--- a/source/src_pw/hamilt_pw.cu
+++ b/source/src_pw/hamilt_pw.cu
@@ -821,7 +821,7 @@ void Hamilt_PW::h_psi_cuda(const float2 *psi_in, float2 *hpsi, float2 *vkb_c, co
             CHECK_CUDA(cudaMemset(f_porter, 0, GlobalC::pw.nrxx * sizeof(float2)));
 
 			//todo
-            GlobalC::UFFT.RoundTrip( tmpsi_in, f_vr_eff1, GR_index_d, f_porter );
+            GlobalC::UFFT.RoundTrip( tmpsi_in, f_vr_eff1, GR_index_d, GlobalC::wf.npw, GlobalC::pw.nrxx, f_porter );
 
             // for (j = 0;j < wf.npw;j++)
             // {
@@ -1005,7 +1005,7 @@ void Hamilt_PW::h_psi_cuda(const double2 *psi_in, double2 *hpsi, double2 *vkb_c,
         for(int ib = 0 ; ib < m; ++ib)
         {
             CHECK_CUDA(cudaMemset(GlobalC::UFFT.d_porter, 0, GlobalC::pw.nrxx * sizeof(double2)));
-            GlobalC::UFFT.RoundTrip( tmpsi_in, GlobalC::pot.d_vr_eff1, GR_index_d, GlobalC::UFFT.d_porter );
+            GlobalC::UFFT.RoundTrip( tmpsi_in, GlobalC::pot.d_vr_eff1, GR_index_d, GlobalC::wf.npw, GlobalC::pw.nrxx, GlobalC::UFFT.d_porter );
 
             int thread = 512;
             int block = (GlobalC::wf.npw + thread - 1) / thread;
@@ -1163,52 +1163,54 @@ void Hamilt_PW::h_psi(const std::complex<double> *psi_in, std::complex<double> *
 	{
 		tmhpsi = hpsi;
 		tmpsi_in = psi_in;
+		//Rent a memory space for FFT operations
+		std::complex<double> *porter = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
 		for(int ib = 0 ; ib < m; ++ib)
 		{
 			if(GlobalV::NSPIN!=4){
-				ModuleBase::GlobalFunc::ZEROS( GlobalC::UFFT.porter, GlobalC::pw.nrxx);
-				GlobalC::UFFT.RoundTrip( tmpsi_in, GlobalC::pot.vr_eff1, GR_index, GlobalC::UFFT.porter );
+				ModuleBase::GlobalFunc::ZEROS( porter, GlobalC::pw.nrxx);
+				GlobalC::UFFT.RoundTrip( tmpsi_in, GlobalC::pot.vr_eff1, GR_index, GlobalC::wf.npw, GlobalC::pw.nrxx, porter );
 				for (j = 0;j < GlobalC::wf.npw;j++)
 				{
-					tmhpsi[j] += GlobalC::UFFT.porter[ GR_index[j] ];
+					tmhpsi[j] += porter[ GR_index[j] ];
 				}
 			}
 			else
 			{
-				std::complex<double>* porter1 = new std::complex<double>[GlobalC::pw.nrxx];
-				ModuleBase::GlobalFunc::ZEROS( GlobalC::UFFT.porter, GlobalC::pw.nrxx);
+				//Rent a memory space for FFT operations
+				std::complex<double>* porter1 = Use_FFT::get_porter(GlobalC::pw.nrxx, GlobalC::pw.nrxx * GlobalV::NPOL);
+				ModuleBase::GlobalFunc::ZEROS( porter, GlobalC::pw.nrxx);
 				ModuleBase::GlobalFunc::ZEROS( porter1, GlobalC::pw.nrxx);
 				for (int ig=0; ig< GlobalC::wf.npw; ig++)
 				{
-					GlobalC::UFFT.porter[ GR_index[ig]  ] = tmpsi_in[ig];
+					porter[ GR_index[ig]  ] = tmpsi_in[ig];
 					porter1[ GR_index[ig]  ] = tmpsi_in[ig + GlobalC::wf.npwx];
 				}
 				// (2) fft to real space and doing things.
-				GlobalC::pw.FFT_wfc.FFT3D( GlobalC::UFFT.porter, 1);
+				GlobalC::pw.FFT_wfc.FFT3D( porter, 1);
 				GlobalC::pw.FFT_wfc.FFT3D( porter1, 1);
 				std::complex<double> sup,sdown;
 				for (int ir=0; ir< GlobalC::pw.nrxx; ir++)
 				{
-					sup = GlobalC::UFFT.porter[ir] * (GlobalC::pot.vr_eff(0,ir) + GlobalC::pot.vr_eff(3,ir)) +
+					sup = porter[ir] * (GlobalC::pot.vr_eff(0,ir) + GlobalC::pot.vr_eff(3,ir)) +
 						porter1[ir] * (GlobalC::pot.vr_eff(1,ir) - std::complex<double>(0.0,1.0) * GlobalC::pot.vr_eff(2,ir));
 					sdown = porter1[ir] * (GlobalC::pot.vr_eff(0,ir) - GlobalC::pot.vr_eff(3,ir)) +
-					GlobalC::UFFT.porter[ir] * (GlobalC::pot.vr_eff(1,ir) + std::complex<double>(0.0,1.0) * GlobalC::pot.vr_eff(2,ir));
-					GlobalC::UFFT.porter[ir] = sup;
+					porter[ir] * (GlobalC::pot.vr_eff(1,ir) + std::complex<double>(0.0,1.0) * GlobalC::pot.vr_eff(2,ir));
+					porter[ir] = sup;
 					porter1[ir] = sdown;
 				}
 				// (3) fft back to G space.
-				GlobalC::pw.FFT_wfc.FFT3D( GlobalC::UFFT.porter, -1);
+				GlobalC::pw.FFT_wfc.FFT3D( porter, -1);
 				GlobalC::pw.FFT_wfc.FFT3D( porter1, -1);
 
 				for (j = 0;j < GlobalC::wf.npw;j++)
 				{
-					tmhpsi[j] += GlobalC::UFFT.porter[ GR_index[j] ];
+					tmhpsi[j] += porter[ GR_index[j] ];
 				}
 				for (j = 0;j < GlobalC::wf.npw;j++ )
 				{
 					tmhpsi[j+GlobalC::wf.npwx] += porter1[ GR_index[j] ];
 				}
-				delete[] porter1;
 			}
 			tmhpsi += dmax;
 			tmpsi_in += dmax;
@@ -1292,29 +1294,31 @@ void Hamilt_PW::h_psi(const std::complex<double> *psi_in, std::complex<double> *
 	{
 		tmhpsi = hpsi;
 		tmpsi_in = psi_in;
+		//Rent a memory space for FFT operations
+		std::complex<double> *porter = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
 		for(int ib = 0; ib < m; ++ib)
 		{
 			for(int j=0; j<3; j++)
 			{
-				ModuleBase::GlobalFunc::ZEROS( GlobalC::UFFT.porter, GlobalC::pw.nrxx);
+				ModuleBase::GlobalFunc::ZEROS( porter, GlobalC::pw.nrxx);
 				for (int ig = 0;ig < GlobalC::kv.ngk[GlobalV::CURRENT_K] ; ig++)
 				{
 					double fact = GlobalC::pw.get_GPlusK_cartesian_projection(GlobalV::CURRENT_K,GlobalC::wf.igk(GlobalV::CURRENT_K,ig),j) * GlobalC::ucell.tpiba;
-					GlobalC::UFFT.porter[ GR_index[ig] ] = tmpsi_in[ig] * complex<double>(0.0,fact);
+					porter[ GR_index[ig] ] = tmpsi_in[ig] * complex<double>(0.0,fact);
 				}
 
-				GlobalC::pw.FFT_wfc.FFT3D(GlobalC::UFFT.porter, 1);
+				GlobalC::pw.FFT_wfc.FFT3D(porter, 1);
 
 				for (int ir = 0; ir < GlobalC::pw.nrxx; ir++)
 				{
-					GlobalC::UFFT.porter[ir] = GlobalC::UFFT.porter[ir] * GlobalC::pot.vofk(GlobalV::CURRENT_SPIN,ir);
+					porter[ir] = porter[ir] * GlobalC::pot.vofk(GlobalV::CURRENT_SPIN,ir);
 				}
-				GlobalC::pw.FFT_wfc.FFT3D(GlobalC::UFFT.porter, -1);
+				GlobalC::pw.FFT_wfc.FFT3D(porter, -1);
 
 				for (int ig = 0;ig < GlobalC::kv.ngk[GlobalV::CURRENT_K] ; ig++)
 				{
 					double fact = GlobalC::pw.get_GPlusK_cartesian_projection(GlobalV::CURRENT_K,GlobalC::wf.igk(GlobalV::CURRENT_K,ig),j) * GlobalC::ucell.tpiba;
-					tmhpsi[ig] = tmhpsi[ig] - complex<double>(0.0,fact) * GlobalC::UFFT.porter[ GR_index[ig] ];
+					tmhpsi[ig] = tmhpsi[ig] - complex<double>(0.0,fact) * porter[ GR_index[ig] ];
 				}
 			}//x,y,z directions
 		}

--- a/source/src_pw/potential_libxc.cpp
+++ b/source/src_pw/potential_libxc.cpp
@@ -10,8 +10,9 @@
 #include "global.h"
 #include "../module_base/global_function.h"
 #include "../module_base/global_variable.h"
+#include "module_base/timer.h"
+#include "src_parallel/parallel_reduce.h"
 #include "xc_gga_pw.h"
-#include "../module_base/global_function.h"
 #ifdef __LCAO
 #include "../src_lcao/global_fp.h"
 #endif

--- a/source/src_pw/potential_libxc_meta.cpp
+++ b/source/src_pw/potential_libxc_meta.cpp
@@ -10,10 +10,10 @@
 #include "global.h"
 #include "../module_base/global_function.h"
 #include "../module_base/global_variable.h"
+#include "module_base/timer.h"
+#include "src_parallel/parallel_reduce.h"
 #include "xc_gga_pw.h"
 #include "./xc_functional.h"
-
-#include "../module_base/global_function.h"
 #ifdef __LCAO
 #include "../src_lcao/global_fp.h"
 #endif

--- a/source/src_pw/sto_hchi.cpp
+++ b/source/src_pw/sto_hchi.cpp
@@ -468,13 +468,20 @@ void Stochastic_hchi:: hchi_reciprocal(std::complex<double> *chig, std::complex<
 	{
 		chibg = chig;
 		hchibg = hchig;
+		//Rent a memory space for FFT operations
+		std::complex<double> *porter = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
 		for(int ib = 0 ; ib < m ; ++ib)
 		{
-			ModuleBase::GlobalFunc::ZEROS( GlobalC::UFFT.porter, GlobalC::pw.nrxx);
-			GlobalC::UFFT.RoundTrip( chibg, GlobalC::pot.vr_eff1, GRA_index, GlobalC::UFFT.porter );
+			ModuleBase::GlobalFunc::ZEROS( porter, GlobalC::pw.nrxx);
+			GlobalC::UFFT.RoundTrip(chibg,
+									GlobalC::pot.vr_eff1,
+									GRA_index,
+									npw,
+									GlobalC::pw.nrxx,
+									porter);
 			for (int ig = 0; ig < npw; ++ig)
 			{
-				hchibg[ig] += GlobalC::UFFT.porter[ GRA_index[ig] ];
+				hchibg[ig] += porter[ GRA_index[ig] ];
 			}
 			chibg += npw;
 			hchibg += npw;

--- a/source/src_pw/sto_iter.cpp
+++ b/source/src_pw/sto_iter.cpp
@@ -390,7 +390,7 @@ void Stochastic_Iter::sum_stoband()
     ModuleBase::GlobalFunc::ZEROS(sto_rho, nrxx);
 
     std::complex<double> * pchi;
-    std::complex<double>* porter = GlobalC::UFFT.porter;
+    std::complex<double>* porter = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
     int* GRA_index = stohchi.GRA_index;
     double out2;
 
@@ -426,7 +426,7 @@ void Stochastic_Iter::sum_stoband()
                 {
                     porter[ GRA_index[ig] ] = tmpout[ig];
                 }
-                GlobalC::pw.FFT_wfc.FFT3D(GlobalC::UFFT.porter, 1);
+                GlobalC::pw.FFT_wfc.FFT3D(porter, 1);
                 for(int ir = 0 ; ir < nrxx ; ++ir)
                 {
                     GlobalC::CHR.rho[0][ir] += norm(porter[ir]);

--- a/source/src_pw/stress_func_har.cpp
+++ b/source/src_pw/stress_func_har.cpp
@@ -9,7 +9,7 @@ void Stress_Func::stress_har(ModuleBase::matrix& sigma, const bool is_pw)
 	ModuleBase::timer::tick("Stress_Func","stress_har");
 	double shart;
 
-	std::complex<double> *Porter = GlobalC::UFFT.porter;
+	std::complex<double> *Porter = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
 
 	//  Hartree potential VH(r) from n(r)
 	ModuleBase::GlobalFunc::ZEROS( Porter, GlobalC::pw.nrxx );

--- a/source/src_pw/stress_func_loc.cpp
+++ b/source/src_pw/stress_func_loc.cpp
@@ -15,7 +15,7 @@ void Stress_Func::stress_loc(ModuleBase::matrix& sigma, const bool is_pw)
 
     dvloc = new double[GlobalC::pw.ngmc];
 
-	std::complex<double> *Porter = GlobalC::UFFT.porter;
+	std::complex<double> *Porter = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
 
 	ModuleBase::GlobalFunc::ZEROS( Porter, GlobalC::pw.nrxx );
 	for(int is=0; is<GlobalV::NSPIN; is++)

--- a/source/src_pw/use_fft.h
+++ b/source/src_pw/use_fft.h
@@ -5,6 +5,7 @@
 #include "../module_base/global_variable.h"
 #include "../module_base/matrix.h"
 #include "../module_base/complexmatrix.h"
+#include <vector>
 
 #ifdef __CUDA
 #include "cufft.h"
@@ -23,7 +24,11 @@ class Use_FFT
 	Use_FFT();
 	~Use_FFT();
 
-	std::complex<double> *porter;
+/// This is a memory space for FFT operation
+private:
+	static std::vector<std::complex<double>> porter;
+public:
+	static std::complex<double>* get_porter(const int &begin, const int &end);
 
 	void allocate(void);
 
@@ -54,30 +59,36 @@ class Use_FFT
 	    const std::complex<double> *psi,
 		const double *vr,
 		const int *_index,
+		const int &max_g,
+    	const int &max_r,
 		std::complex<double> *psic);
 
 #ifdef __CUDA
 	double2 *d_porter;
 	cufftHandle fft_handle;
-	void RoundTrip(const float2 *psi, const float *vr, const int *fft_index, float2 *psic)
+	void RoundTrip(const float2 *psi, const float *vr, const int *fft_index, const int &max_g,
+    	const int &max_r, float2 *psic)
 	{
-		RoundTrip_kernel(psi, vr, fft_index, psic);
+		RoundTrip_kernel(psi, vr, fft_index, max_g, max_r, psic);
 	}
-	void RoundTrip(const double2 *psi, const double *vr, const int *fft_index, double2 *psic)
+	void RoundTrip(const double2 *psi, const double *vr, const int *fft_index, const int &max_g,
+    	const int &max_r, double2 *psic)
 	{
-		RoundTrip_kernel(psi, vr, fft_index, psic);
+		RoundTrip_kernel(psi, vr, fft_index, max_g, max_r, psic);
 	}
 #endif
 
 #ifdef __ROCM
 	hipfftHandle fft_handle;
-	void RoundTrip(const hipblasComplex *psi, const float *vr, const int *fft_index, hipblasComplex *psic)
+	void RoundTrip(const hipblasComplex *psi, const float *vr, const int *fft_index, const int &max_g,
+    	const int &max_r, hipblasComplex *psic)
 	{
-		RoundTrip_kernel(psi, vr, fft_index, psic);
+		RoundTrip_kernel(psi, vr, fft_index, max_g, max_r, psic);
 	}
-	void RoundTrip(const hipblasDoubleComplex *psi, const double *vr, const int *fft_index, hipblasDoubleComplex *psic)
+	void RoundTrip(const hipblasDoubleComplex *psi, const double *vr, const int *fft_index, const int &max_g,
+    	const int &max_r, hipblasDoubleComplex *psic)
 	{
-		RoundTrip_kernel(psi, vr, fft_index, psic);
+		RoundTrip_kernel(psi, vr, fft_index, max_g, max_r, psic);
 	}
 #endif
 

--- a/source/src_pw/use_fft_kernel.h
+++ b/source/src_pw/use_fft_kernel.h
@@ -6,8 +6,10 @@
 #include "cufft.h"
 #include "device_launch_parameters.h"
 
-void RoundTrip_kernel(const float2 *psi, const float *vr, const int *fft_index, float2 *psic);
-void RoundTrip_kernel(const double2 *psi, const double *vr, const int *fft_index, double2 *psic);
+void RoundTrip_kernel(const float2 *psi, const float *vr, const int *fft_index, const int &max_g,
+    	const int &max_r, float2 *psic);
+void RoundTrip_kernel(const double2 *psi, const double *vr, const int *fft_index, const int &max_g,
+    	const int &max_r, double2 *psic);
 
 #endif
 
@@ -16,8 +18,10 @@ void RoundTrip_kernel(const double2 *psi, const double *vr, const int *fft_index
 #include "hipblas.h"
 #include "hipfft.h"
 
-void RoundTrip_kernel(const hipblasComplex *psi, const float *vr, const int *fft_index, hipblasComplex *psic);
-void RoundTrip_kernel(const hipblasDoubleComplex *psi, const double *vr, const int *fft_index, hipblasDoubleComplex *psic);
+void RoundTrip_kernel(const hipblasComplex *psi, const float *vr, const int *fft_index, const int &max_g,
+    	const int &max_r, hipblasComplex *psic);
+void RoundTrip_kernel(const hipblasDoubleComplex *psi, const double *vr, const int *fft_index, const int &max_g,
+    	const int &max_r, hipblasDoubleComplex *psic);
 
 #endif
 

--- a/source/src_pw/xc_functional.h
+++ b/source/src_pw/xc_functional.h
@@ -11,6 +11,7 @@
 
 #include "../module_base/global_function.h"
 #include "../module_base/global_variable.h"
+#include "../module_base/vector3.h"
 class XC_Functional
 {
 	public:

--- a/source/src_pw/xc_gga_pw.cpp
+++ b/source/src_pw/xc_gga_pw.cpp
@@ -365,7 +365,7 @@ void GGA_PW::grad_wfc( const std::complex<double> *rhog, const int ik, std::comp
 	kplusg = new double[npw];
 	ModuleBase::GlobalFunc::ZEROS(kplusg, npw);
 
-	std::complex<double> *Porter = GlobalC::UFFT.porter;
+	std::complex<double> *Porter = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
 
 	for(int ipol=0; ipol<3; ipol++)
 	{
@@ -394,7 +394,7 @@ void GGA_PW::grad_rho( const std::complex<double> *rhog, ModuleBase::Vector3<dou
 	std::complex<double> *gdrtmpg = new std::complex<double>[GlobalC::pw.ngmc];
 	ModuleBase::GlobalFunc::ZEROS(gdrtmpg, GlobalC::pw.ngmc);
 
-	std::complex<double> *Porter = GlobalC::UFFT.porter;
+	std::complex<double> *Porter = Use_FFT::get_porter(0, GlobalC::pw.nrxx);
 
 	// the formula is : rho(r)^prime = \int iG * rho(G)e^{iGr} dG
 	for(int ig=0; ig<GlobalC::pw.ngmc; ig++)


### PR DESCRIPTION
This refactoring work contains code about CUDA and ROCM, I just make sure that compiling with CUDA is okay, please review it. @Asuna981002