### PR TITLE
Style: not using 'tab' anymore - space only.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -33,6 +33,5 @@ SpacesInParentheses: 'false'
 SpacesInSquareBrackets: 'false'
 Standard: Cpp11
 TabWidth: '4'
-UseTab: ForContinuationAndIndentation
-
+UseTab: Never
 ...

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-indent_style = tab
+indent_style = space
 indent_size = 4
 charset = utf-8
 end_of_line = lf


### PR DESCRIPTION
Tab visualizes differently in various editors. Changing it to 4 spaces conforming the Visual Studio standard of clang-format.