### PR TITLE
Refactor: implement dm2d directly from `wfc_dm_2d.wfc_k` which have replaced `set_EDM_k`

### DIFF
--- a/source/src_lcao/FORCE_k.cpp
+++ b/source/src_lcao/FORCE_k.cpp
@@ -455,13 +455,40 @@ void Force_LCAO_k::cal_foverlap_k(
 	{
 		edm2d[is] = new double[GlobalC::LNNR.nnr];
 		ModuleBase::GlobalFunc::ZEROS(edm2d[is], GlobalC::LNNR.nnr);
-	}
-	bool with_energy = true;
+    }
+    
+    Record_adj RA;
+	RA.for_2d();
 
 	//--------------------------------------------	
 	// calculate the energy density matrix here.
-	//--------------------------------------------	
-	this->set_EDM_k(edm2d, with_energy);
+    //--------------------------------------------	
+    if (INPUT.new_dm > 0)
+    {
+        ModuleBase::timer::tick("Force_LCAO_k","cal_edm_2d");
+
+        ModuleBase::matrix wgEkb;
+        wgEkb.create(GlobalC::kv.nks, GlobalV::NBANDS);
+
+        for (int ik = 0; ik < GlobalC::kv.nks; ik++)
+        {
+            for(int ib=0; ib<GlobalV::NBANDS; ib++)
+            {
+                wgEkb(ik, ib) = GlobalC::wf.wg(ik, ib) * GlobalC::wf.ekb[ik][ib];
+            }
+        }
+        Wfc_Dm_2d wfc_edm_2d;
+        wfc_edm_2d.init();
+        wfc_edm_2d.wfc_k = GlobalC::LOC.wfc_dm_2d.wfc_k;
+        wfc_edm_2d.cal_dm(wgEkb);
+        wfc_edm_2d.cal_dm_R(edm2d, RA);
+        ModuleBase::timer::tick("Force_LCAO_k","cal_edm_2d");
+    }
+    else
+    {
+        bool with_energy = true;
+        this->set_EDM_k(edm2d, with_energy);
+    }
 
 	//--------------------------------------------
     //summation \sum_{i,j} E(i,j)*dS(i,j)
@@ -469,8 +496,7 @@ void Force_LCAO_k::cal_foverlap_k(
 	//--------------------------------------------
 	ModuleBase::Vector3<double> tau1, dtau, tau2;
 
-	Record_adj RA;
-	RA.for_2d();
+
 
 	int irr = 0;
 	int iat = 0;

--- a/source/src_lcao/FORCE_k.cpp
+++ b/source/src_lcao/FORCE_k.cpp
@@ -5,6 +5,7 @@
 #include <map>
 #include "../module_base/memory.h"
 #include "../module_base/timer.h"
+#include "wfc_dm_2d.h"  //caoyu add 2022-2-9
 
 #ifdef __DEEPKS
 #include "../module_deepks/LCAO_deepks.h"
@@ -54,21 +55,29 @@ void Force_LCAO_k::ftable_k (
 		dm2d[is] = new double[GlobalC::LNNR.nnr];
 		ModuleBase::GlobalFunc::ZEROS(dm2d[is], GlobalC::LNNR.nnr);
 	}
-	ModuleBase::Memory::record ("Force_LCAO_k", "dm2d", GlobalV::NSPIN*GlobalC::LNNR.nnr, "double");	
-	bool with_energy = false;
+    ModuleBase::Memory::record ("Force_LCAO_k", "dm2d", GlobalV::NSPIN*GlobalC::LNNR.nnr, "double");	
 
-	
-	this->set_EDM_k(dm2d, with_energy);
-	
-	this->cal_ftvnl_dphi_k(dm2d, isforce, isstress, ftvnl_dphi, stvnl_dphi);
+    if (INPUT.new_dm > 0)
+    {
+        Record_adj RA;
+        RA.for_2d();
+        GlobalC::LOC.wfc_dm_2d.cal_dm_R(dm2d, RA);
+    }
+    else
+    {
+        bool with_energy = false;
+        this->set_EDM_k(dm2d, with_energy);
+    }
+    
+    this->cal_ftvnl_dphi_k(dm2d, isforce, isstress, ftvnl_dphi, stvnl_dphi);
 
 
-	// ---------------------------------------
-	// doing on the real space grid.
-	// ---------------------------------------
-	this->cal_fvl_dphi_k(dm2d, isforce, isstress, fvl_dphi, svl_dphi);
+    // ---------------------------------------
+    // doing on the real space grid.
+    // ---------------------------------------
+    this->cal_fvl_dphi_k(dm2d, isforce, isstress, fvl_dphi, svl_dphi);
 
-	this->calFvnlDbeta(dm2d, isforce, isstress, fvnl_dbeta, svnl_dbeta, GlobalV::vnl_method);
+    this->calFvnlDbeta(dm2d, isforce, isstress, fvnl_dbeta, svnl_dbeta, GlobalV::vnl_method);
 
 #ifdef __DEEPKS
     if (GlobalV::deepks_scf)

--- a/source/src_lcao/FORCE_k.cpp
+++ b/source/src_lcao/FORCE_k.cpp
@@ -463,7 +463,7 @@ void Force_LCAO_k::cal_foverlap_k(
 	//--------------------------------------------	
 	// calculate the energy density matrix here.
     //--------------------------------------------	
-    if (INPUT.new_dm > 0)
+    if (INPUT.new_dm > 0 && INPUT.tddft==0)
     {
         ModuleBase::timer::tick("Force_LCAO_k","cal_edm_2d");
 

--- a/source/src_lcao/wfc_dm_2d.cpp
+++ b/source/src_lcao/wfc_dm_2d.cpp
@@ -7,12 +7,14 @@
 #include "wfc_dm_2d.h"
 #include "../module_base/blas_connector.h"
 #include "../module_base/scalapack_connector.h"
+#include "../module_base/timer.h"
 #include "global_fp.h"
 #include "../src_pw/global.h"
 
 #include "../src_external/src_test/test_function.h"
 #include "../src_external/src_test/src_global/complexmatrix-test.h"
 
+#include "./LCAO_nnr.h"
 void Wfc_Dm_2d::init()
 {
 	ModuleBase::TITLE("Wfc_Dm_2d", "init");
@@ -141,4 +143,66 @@ void Wfc_Dm_2d::cal_dm(const ModuleBase::matrix &wg)
 	#endif
 
 	return;
+}
+//ra.for_2d();
+//must cal cal_dm first
+void Wfc_Dm_2d::cal_dm_R(double** dm2d, Record_adj ra)
+{
+    ModuleBase::TITLE("Wfc_Dm_2d", "cal_dm_R");
+    assert(this->dm_k[0].nr > 0 && dm_k[0].nc > 0); //must call cal_dm first
+
+    for (int ik = 0;ik < GlobalC::kv.nks;++ik)
+    {
+        // allocate memory and pointer for each ispin
+        int ispin = 0;
+        if (GlobalV::NSPIN == 2)
+        {
+            ispin = GlobalC::kv.isk[ik];
+        }
+        for (int T1 = 0;T1 < GlobalC::ucell.ntype;++T1)
+        {
+            for (int I1 = 0;I1 < GlobalC::ucell.atoms[T1].na;++I1)
+            {
+                const int iat = GlobalC::ucell.itia2iat(T1, I1);
+                const int start1 = GlobalC::ucell.itiaiw2iwt(T1, I1, 0);
+                //irr: number of adjacent orbital pairs int this proc
+                const int irrstart = GlobalC::LNNR.nlocstart[iat];
+
+                int count = 0;
+                for (int cb = 0;cb < ra.na_each[iat];++cb)
+                {
+                    const int T2 = ra.info[iat][cb][3];
+                    const int I2 = ra.info[iat][cb][4];
+                    const int start2 = GlobalC::ucell.itiaiw2iwt(T2, I2, 0);
+                    //-----------------
+                    // exp[i * R * k]
+                    //-----------------
+                    const std::complex<double> phase =
+                        exp(ModuleBase::TWO_PI * ModuleBase::IMAG_UNIT * (
+                            GlobalC::kv.kvec_d[ik].x * ra.info[iat][cb][0] +
+                            GlobalC::kv.kvec_d[ik].y * ra.info[iat][cb][1] +
+                            GlobalC::kv.kvec_d[ik].z * ra.info[iat][cb][2]
+                            ));
+                    for (int iw1 = 0;iw1 < GlobalC::ucell.atoms[T1].nw;++iw1)
+                    {
+                        int iw1_all = start1 + iw1;
+                        int mu = GlobalC::ParaO.trace_loc_row[iw1_all];
+                        if (mu < 0)continue;
+                        for (int iw2 = 0;iw2 < GlobalC::ucell.atoms[T2].nw;++iw2)
+                        {
+                            int iw2_all = start2 + iw2;
+                            int nu = GlobalC::ParaO.trace_loc_col[iw2_all];
+                            if (nu < 0)continue;
+                            //Caution: output of pzgemm_ : col first in **each** proc itself !!
+                            dm2d[ispin][irrstart + count] += (this->dm_k[ik](nu, mu) * phase).real();
+                            ++count;
+                        }//iw2
+                    }//iw1
+                }//TI2(cb)
+                assert(count == GlobalC::LNNR.nlocdim[iat]);
+            }//I1
+        }//T1
+    }//ik
+    ModuleBase::timer::tick("Wfc_Dm_2d", "cal_dm_R");
+    return;
 }

--- a/source/src_lcao/wfc_dm_2d.h
+++ b/source/src_lcao/wfc_dm_2d.h
@@ -10,6 +10,8 @@
 #include "../module_base/complexmatrix.h"
 #include <vector>
 
+#include "./record_adj.h"   //caoyu add 2022-2-9
+
 class Wfc_Dm_2d
 {
 
@@ -25,8 +27,11 @@ class Wfc_Dm_2d
 	
 	void init(void);
 
-	// dm = wfc.T * wg * wfc.conj()
-	void cal_dm(const ModuleBase::matrix &wg);					// wg(ik,ib), cal all dm
+    // dm = wfc.T * wg * wfc.conj()
+    // in multi-k it is dm(k)
+	void cal_dm(const ModuleBase::matrix &wg);					// wg(ik,ib), cal all dm 
+    // dm(R) = wfc.T * wg * wfc.conj()*kphase, only used in multi-k 
+    void cal_dm_R(double** dm2d, Record_adj ra);					// wg(ik,ib), cal dm(R)
 };
 
 #endif


### PR DESCRIPTION
Now I still keep `set_EDM_k` and `WFC_K_aug` remained (but not called because of the default `new_dm=1`). 
Test have passed on 1/4/5 cores (`*_NO_KP_*` cases).
Multi-k-DeePKS tests are still needed. If passed, I will **delete** `set_EDM_k` and `WFC_K_aug`.