### PR TITLE
Refactor: implement dm2d directly from `wfc_dm_2d.wfc_k` which can replace `set_EDM_k`

### DIFF
--- a/source/src_lcao/FORCE_gamma_edm.cpp
+++ b/source/src_lcao/FORCE_gamma_edm.cpp
@@ -671,10 +671,10 @@ void Force_LCAO_gamma::cal_foverlap(
             }
         }
 
-        Wfc_Dm_2d wfc_edm_2d;
-        wfc_edm_2d.init();
-        wfc_edm_2d.wfc_gamma=GlobalC::LOC.wfc_dm_2d.wfc_gamma;
-        wfc_edm_2d.cal_dm(wgEkb);
+        std::vector<ModuleBase::matrix> edm_gamma(GlobalV::NSPIN);
+        GlobalC::LOC.wfc_dm_2d.cal_dm(wgEkb,
+            GlobalC::LOC.wfc_dm_2d.wfc_gamma,
+            edm_gamma);
 
         ModuleBase::timer::tick("Force_LCAO_gamma","cal_edm_2d");
 
@@ -691,7 +691,7 @@ void Force_LCAO_gamma::cal_foverlap(
                     double sum = 0.0;
                     for(int is=0; is<GlobalV::NSPIN; ++is)
                     {
-                        sum += wfc_edm_2d.dm_gamma[is](nu, mu);
+                        sum += edm_gamma[is](nu, mu);
                     }
                     sum *= 2.0;
 

--- a/source/src_lcao/FORCE_k.cpp
+++ b/source/src_lcao/FORCE_k.cpp
@@ -5,7 +5,7 @@
 #include <map>
 #include "../module_base/memory.h"
 #include "../module_base/timer.h"
-#include "wfc_dm_2d.h"  //caoyu add 2022-2-9
+#include "wfc_dm_2d.h"
 
 #ifdef __DEEPKS
 #include "../module_deepks/LCAO_deepks.h"

--- a/source/src_lcao/FORCE_k.cpp
+++ b/source/src_lcao/FORCE_k.cpp
@@ -455,13 +455,40 @@ void Force_LCAO_k::cal_foverlap_k(
 	{
 		edm2d[is] = new double[GlobalC::LNNR.nnr];
 		ModuleBase::GlobalFunc::ZEROS(edm2d[is], GlobalC::LNNR.nnr);
-	}
-	bool with_energy = true;
+    }
+    
+    Record_adj RA;
+	RA.for_2d();
 
 	//--------------------------------------------	
 	// calculate the energy density matrix here.
-	//--------------------------------------------	
-	this->set_EDM_k(edm2d, with_energy);
+    //--------------------------------------------	
+    if (INPUT.new_dm > 0)
+    {
+        ModuleBase::timer::tick("Force_LCAO_k","cal_edm_2d");
+
+        ModuleBase::matrix wgEkb;
+        wgEkb.create(GlobalC::kv.nks, GlobalV::NBANDS);
+
+        for (int ik = 0; ik < GlobalC::kv.nks; ik++)
+        {
+            for(int ib=0; ib<GlobalV::NBANDS; ib++)
+            {
+                wgEkb(ik, ib) = GlobalC::wf.wg(ik, ib) * GlobalC::wf.ekb[ik][ib];
+            }
+        }
+        Wfc_Dm_2d wfc_edm_2d;
+        wfc_edm_2d.init();
+        wfc_edm_2d.wfc_k = GlobalC::LOC.wfc_dm_2d.wfc_k;
+        wfc_edm_2d.cal_dm(wgEkb);
+        wfc_edm_2d.cal_dm_R(edm2d, RA);
+        ModuleBase::timer::tick("Force_LCAO_k","cal_edm_2d");
+    }
+    else
+    {
+        bool with_energy = true;
+        this->set_EDM_k(edm2d, with_energy);
+    }
 
 	//--------------------------------------------
     //summation \sum_{i,j} E(i,j)*dS(i,j)
@@ -469,8 +496,7 @@ void Force_LCAO_k::cal_foverlap_k(
 	//--------------------------------------------
 	ModuleBase::Vector3<double> tau1, dtau, tau2;
 
-	Record_adj RA;
-	RA.for_2d();
+
 
 	int irr = 0;
 	int iat = 0;

--- a/source/src_lcao/FORCE_k.cpp
+++ b/source/src_lcao/FORCE_k.cpp
@@ -5,6 +5,7 @@
 #include <map>
 #include "../module_base/memory.h"
 #include "../module_base/timer.h"
+#include "wfc_dm_2d.h"  //caoyu add 2022-2-9
 
 #ifdef __DEEPKS
 #include "../module_deepks/LCAO_deepks.h"
@@ -54,21 +55,29 @@ void Force_LCAO_k::ftable_k (
 		dm2d[is] = new double[GlobalC::LNNR.nnr];
 		ModuleBase::GlobalFunc::ZEROS(dm2d[is], GlobalC::LNNR.nnr);
 	}
-	ModuleBase::Memory::record ("Force_LCAO_k", "dm2d", GlobalV::NSPIN*GlobalC::LNNR.nnr, "double");	
-	bool with_energy = false;
+    ModuleBase::Memory::record ("Force_LCAO_k", "dm2d", GlobalV::NSPIN*GlobalC::LNNR.nnr, "double");	
 
-	
-	this->set_EDM_k(dm2d, with_energy);
-	
-	this->cal_ftvnl_dphi_k(dm2d, isforce, isstress, ftvnl_dphi, stvnl_dphi);
+    if (INPUT.new_dm > 0)
+    {
+        Record_adj RA;
+        RA.for_2d();
+        GlobalC::LOC.wfc_dm_2d.cal_dm_R(dm2d, RA);
+    }
+    else
+    {
+        bool with_energy = false;
+        this->set_EDM_k(dm2d, with_energy);
+    }
+    
+    this->cal_ftvnl_dphi_k(dm2d, isforce, isstress, ftvnl_dphi, stvnl_dphi);
 
 
-	// ---------------------------------------
-	// doing on the real space grid.
-	// ---------------------------------------
-	this->cal_fvl_dphi_k(dm2d, isforce, isstress, fvl_dphi, svl_dphi);
+    // ---------------------------------------
+    // doing on the real space grid.
+    // ---------------------------------------
+    this->cal_fvl_dphi_k(dm2d, isforce, isstress, fvl_dphi, svl_dphi);
 
-	this->calFvnlDbeta(dm2d, isforce, isstress, fvnl_dbeta, svnl_dbeta, GlobalV::vnl_method);
+    this->calFvnlDbeta(dm2d, isforce, isstress, fvnl_dbeta, svnl_dbeta, GlobalV::vnl_method);
 
 #ifdef __DEEPKS
     if (GlobalV::deepks_scf)

--- a/source/src_lcao/FORCE_k.cpp
+++ b/source/src_lcao/FORCE_k.cpp
@@ -61,7 +61,9 @@ void Force_LCAO_k::ftable_k (
     {
         Record_adj RA;
         RA.for_2d();
-        GlobalC::LOC.wfc_dm_2d.cal_dm_R(RA, dm2d);
+        GlobalC::LOC.wfc_dm_2d.cal_dm_R(
+            GlobalC::LOC.wfc_dm_2d.dm_k,
+            RA, dm2d);
     }
     else
     {
@@ -477,12 +479,13 @@ void Force_LCAO_k::cal_foverlap_k(
                 wgEkb(ik, ib) = GlobalC::wf.wg(ik, ib) * GlobalC::wf.ekb[ik][ib];
             }
         }
-        Wfc_Dm_2d wfc_edm_2d;
-        wfc_edm_2d.init();
-        wfc_edm_2d.wfc_k = GlobalC::LOC.wfc_dm_2d.wfc_k;
-        wfc_edm_2d.cal_dm(wgEkb);
-        wfc_edm_2d.cal_dm_R(RA, edm2d);
-        ModuleBase::timer::tick("Force_LCAO_k","cal_edm_2d");
+        std::vector<ModuleBase::ComplexMatrix> edm_k(GlobalC::kv.nks);
+        GlobalC::LOC.wfc_dm_2d.cal_dm(wgEkb,
+            GlobalC::LOC.wfc_dm_2d.wfc_k,
+            edm_k);
+        GlobalC::LOC.wfc_dm_2d.cal_dm_R(edm_k,
+            RA, edm2d);
+        ModuleBase::timer::tick("Force_LCAO_k", "cal_edm_2d");
     }
     else
     {

--- a/source/src_lcao/FORCE_k.cpp
+++ b/source/src_lcao/FORCE_k.cpp
@@ -57,7 +57,7 @@ void Force_LCAO_k::ftable_k (
 	}
     ModuleBase::Memory::record ("Force_LCAO_k", "dm2d", GlobalV::NSPIN*GlobalC::LNNR.nnr, "double");	
 
-    if (INPUT.new_dm > 0)
+    if (INPUT.new_dm > 0 && INPUT.tddft == 0)
     {
         Record_adj RA;
         RA.for_2d();
@@ -463,7 +463,7 @@ void Force_LCAO_k::cal_foverlap_k(
 	//--------------------------------------------	
 	// calculate the energy density matrix here.
     //--------------------------------------------	
-    if (INPUT.new_dm > 0)
+    if (INPUT.new_dm > 0 && INPUT.tddft==0)
     {
         ModuleBase::timer::tick("Force_LCAO_k","cal_edm_2d");
 

--- a/source/src_lcao/FORCE_k.cpp
+++ b/source/src_lcao/FORCE_k.cpp
@@ -61,7 +61,7 @@ void Force_LCAO_k::ftable_k (
     {
         Record_adj RA;
         RA.for_2d();
-        GlobalC::LOC.wfc_dm_2d.cal_dm_R(dm2d, RA);
+        GlobalC::LOC.wfc_dm_2d.cal_dm_R(RA, dm2d);
     }
     else
     {
@@ -481,7 +481,7 @@ void Force_LCAO_k::cal_foverlap_k(
         wfc_edm_2d.init();
         wfc_edm_2d.wfc_k = GlobalC::LOC.wfc_dm_2d.wfc_k;
         wfc_edm_2d.cal_dm(wgEkb);
-        wfc_edm_2d.cal_dm_R(edm2d, RA);
+        wfc_edm_2d.cal_dm_R(RA, edm2d);
         ModuleBase::timer::tick("Force_LCAO_k","cal_edm_2d");
     }
     else

--- a/source/src_lcao/local_orbital_charge.cpp
+++ b/source/src_lcao/local_orbital_charge.cpp
@@ -124,7 +124,9 @@ void Local_Orbital_Charge::sum_bands(void)
             //density matrix has already been calculated.
             ModuleBase::timer::tick("LCAO_Charge","cal_dm_2d");
 
-            wfc_dm_2d.cal_dm(GlobalC::wf.wg);        // Peize Lin test 2019-01-16
+            wfc_dm_2d.cal_dm(GlobalC::wf.wg,
+                wfc_dm_2d.wfc_gamma,
+                wfc_dm_2d.dm_gamma);        // Peize Lin test 2019-01-16
 
             ModuleBase::timer::tick("LCAO_Charge","cal_dm_2d");
 
@@ -141,8 +143,10 @@ void Local_Orbital_Charge::sum_bands(void)
         this->cal_dk_k( GlobalC::GridT );
         if(GlobalV::KS_SOLVER=="genelpa" || GlobalV::KS_SOLVER=="scalapack_gvx")        // Peize Lin test 2019-05-15
 		{
-            wfc_dm_2d.cal_dm(GlobalC::wf.wg);
-		}
+            wfc_dm_2d.cal_dm(GlobalC::wf.wg,
+            wfc_dm_2d.wfc_k, 
+            wfc_dm_2d.dm_k);
+        }
     }
 
 

--- a/source/src_lcao/wfc_dm_2d.cpp
+++ b/source/src_lcao/wfc_dm_2d.cpp
@@ -146,7 +146,7 @@ void Wfc_Dm_2d::cal_dm(const ModuleBase::matrix &wg)
 }
 //ra.for_2d();
 //must cal cal_dm first
-void Wfc_Dm_2d::cal_dm_R(double** dm2d, Record_adj ra)
+void Wfc_Dm_2d::cal_dm_R(Record_adj &ra, double** dm2d)
 {
     ModuleBase::TITLE("Wfc_Dm_2d", "cal_dm_R");
     assert(this->dm_k[0].nr > 0 && dm_k[0].nc > 0); //must call cal_dm first

--- a/source/src_lcao/wfc_dm_2d.cpp
+++ b/source/src_lcao/wfc_dm_2d.cpp
@@ -7,12 +7,14 @@
 #include "wfc_dm_2d.h"
 #include "../module_base/blas_connector.h"
 #include "../module_base/scalapack_connector.h"
+#include "../module_base/timer.h"
 #include "global_fp.h"
 #include "../src_pw/global.h"
 
 #include "../src_external/src_test/test_function.h"
 #include "../src_external/src_test/src_global/complexmatrix-test.h"
 
+#include "./LCAO_nnr.h"
 void Wfc_Dm_2d::init()
 {
 	ModuleBase::TITLE("Wfc_Dm_2d", "init");
@@ -141,4 +143,66 @@ void Wfc_Dm_2d::cal_dm(const ModuleBase::matrix &wg)
 	#endif
 
 	return;
+}
+//ra.for_2d();
+//must cal cal_dm first
+void Wfc_Dm_2d::cal_dm_R(double** dm2d, Record_adj ra)
+{
+    ModuleBase::TITLE("Wfc_Dm_2d", "cal_dm_R");
+    assert(this->dm_k[0].nr > 0 && dm_k[0].nc > 0); //must call cal_dm first
+
+    for (int ik = 0;ik < GlobalC::kv.nks;++ik)
+    {
+        // allocate memory and pointer for each ispin
+        int ispin = 0;
+        if (GlobalV::NSPIN == 2)
+        {
+            ispin = GlobalC::kv.isk[ik];
+        }
+        for (int T1 = 0;T1 < GlobalC::ucell.ntype;++T1)
+        {
+            for (int I1 = 0;I1 < GlobalC::ucell.atoms[T1].na;++I1)
+            {
+                const int iat = GlobalC::ucell.itia2iat(T1, I1);
+                const int start1 = GlobalC::ucell.itiaiw2iwt(T1, I1, 0);
+                //irr: number of adjacent orbital pairs int this proc
+                const int irrstart = GlobalC::LNNR.nlocstart[iat];
+
+                int count = 0;
+                for (int cb = 0;cb < ra.na_each[iat];++cb)
+                {
+                    const int T2 = ra.info[iat][cb][3];
+                    const int I2 = ra.info[iat][cb][4];
+                    const int start2 = GlobalC::ucell.itiaiw2iwt(T2, I2, 0);
+                    //-----------------
+                    // exp[i * R * k]
+                    //-----------------
+                    const std::complex<double> phase =
+                        exp(ModuleBase::TWO_PI * ModuleBase::IMAG_UNIT * (
+                            GlobalC::kv.kvec_d[ik].x * ra.info[iat][cb][0] +
+                            GlobalC::kv.kvec_d[ik].y * ra.info[iat][cb][1] +
+                            GlobalC::kv.kvec_d[ik].z * ra.info[iat][cb][2]
+                            ));
+                    for (int iw1 = 0;iw1 < GlobalC::ucell.atoms[T1].nw;++iw1)
+                    {
+                        int iw1_all = start1 + iw1;
+                        int mu = GlobalC::ParaO.trace_loc_row[iw1_all];
+                        if (mu < 0)continue;
+                        for (int iw2 = 0;iw2 < GlobalC::ucell.atoms[T2].nw;++iw2)
+                        {
+                            int iw2_all = start2 + iw2;
+                            int nu = GlobalC::ParaO.trace_loc_col[iw2_all];
+                            if (nu < 0)continue;
+                            //Caution: output of pzgemm_ : col first in **each** proc itself !!
+                            dm2d[ispin][irrstart + count] += (this->dm_k[ik](nu, mu) * phase).real();
+                            ++count;
+                        }//iw2
+                    }//iw1
+                }//TI2(cb)
+                assert(count == GlobalC::LNNR.nlocdim[iat]);
+            }//I1
+        }//T1
+    }//ik
+    ModuleBase::timer::tick("Wfc_Dm_2d", "cal_dm_R");
+    return;
 }

--- a/source/src_lcao/wfc_dm_2d.h
+++ b/source/src_lcao/wfc_dm_2d.h
@@ -10,6 +10,8 @@
 #include "../module_base/complexmatrix.h"
 #include <vector>
 
+#include "./record_adj.h"   //caoyu add 2022-2-9
+
 class Wfc_Dm_2d
 {
 
@@ -25,8 +27,11 @@ class Wfc_Dm_2d
 	
 	void init(void);
 
-	// dm = wfc.T * wg * wfc.conj()
-	void cal_dm(const ModuleBase::matrix &wg);					// wg(ik,ib), cal all dm
+    // dm = wfc.T * wg * wfc.conj()
+    // in multi-k it is dm(k)
+	void cal_dm(const ModuleBase::matrix &wg);					// wg(ik,ib), cal all dm 
+    // dm(R) = wfc.T * wg * wfc.conj()*kphase, only used in multi-k 
+    void cal_dm_R(double** dm2d, Record_adj ra);					// wg(ik,ib), cal dm(R)
 };
 
 #endif

--- a/source/src_lcao/wfc_dm_2d.h
+++ b/source/src_lcao/wfc_dm_2d.h
@@ -31,7 +31,7 @@ class Wfc_Dm_2d
     // in multi-k it is dm(k)
 	void cal_dm(const ModuleBase::matrix &wg);					// wg(ik,ib), cal all dm 
     // dm(R) = wfc.T * wg * wfc.conj()*kphase, only used in multi-k 
-    void cal_dm_R(double** dm2d, Record_adj ra);					// wg(ik,ib), cal dm(R)
+    void cal_dm_R(Record_adj &ra, double** dm2d);					// wg(ik,ib), cal dm(R)
 };
 
 #endif

--- a/source/src_lcao/wfc_dm_2d.h
+++ b/source/src_lcao/wfc_dm_2d.h
@@ -15,23 +15,33 @@
 class Wfc_Dm_2d
 {
 
-	public:
+public:
 
-	// wfc stands for wave functions
-	std::vector<ModuleBase::matrix> wfc_gamma;			// wfc_gamma[is](ib,iw);
-	std::vector<ModuleBase::ComplexMatrix> wfc_k;		// wfc_k[ik](ib,iw);
+    // wfc stands for wave functions
+    std::vector<ModuleBase::matrix> wfc_gamma;			// wfc_gamma[is](ib,iw);
+    std::vector<ModuleBase::ComplexMatrix> wfc_k;		// wfc_k[ik](ib,iw);
 
-	// dm stands for density matrix
-	std::vector<ModuleBase::matrix> dm_gamma;			// dm_gamma[is](iw1,iw2);
-	std::vector<ModuleBase::ComplexMatrix> dm_k;		// dm_k[ik](iw1,iw2);
-	
-	void init(void);
+    // dm stands for density matrix
+    std::vector<ModuleBase::matrix> dm_gamma;			// dm_gamma[is](iw1,iw2);
+    std::vector<ModuleBase::ComplexMatrix> dm_k;		// dm_k[ik](iw1,iw2);
 
-    // dm = wfc.T * wg * wfc.conj()
-    // in multi-k it is dm(k)
-	void cal_dm(const ModuleBase::matrix &wg);					// wg(ik,ib), cal all dm 
+    void init(void);
+
+    // dm = wfc.T * wg * wfc.conj(); used in gamma_only
+    void cal_dm(const ModuleBase::matrix& wg,   // wg(ik,ib), cal all dm 
+        std::vector<ModuleBase::matrix>& wfc_gamma,
+        std::vector<ModuleBase::matrix>& dm_gamma);
+
+    // in multi-k,  it is dm(k)
+    void cal_dm(const ModuleBase::matrix& wg,    // wg(ik,ib), cal all dm 
+        std::vector<ModuleBase::ComplexMatrix>& wfc_k,
+        std::vector<ModuleBase::ComplexMatrix>& dm_k);
+
     // dm(R) = wfc.T * wg * wfc.conj()*kphase, only used in multi-k 
-    void cal_dm_R(Record_adj &ra, double** dm2d);					// wg(ik,ib), cal dm(R)
+    void cal_dm_R(
+        std::vector<ModuleBase::ComplexMatrix>& dm_k,
+        Record_adj& ra,
+        double** dm2d);     //output, dm2d[NSPIN][LNNR]
 };
 
 #endif

--- a/source/src_lcao/wfc_dm_2d.h
+++ b/source/src_lcao/wfc_dm_2d.h
@@ -10,7 +10,7 @@
 #include "../module_base/complexmatrix.h"
 #include <vector>
 
-#include "./record_adj.h"   //caoyu add 2022-2-9
+#include "./record_adj.h"
 
 class Wfc_Dm_2d
 {


### PR DESCRIPTION
Now I still keep `set_EDM_k` and `WFC_K_aug` remained (but not called because of the default `new_dm=1`, except for tddft case). 
Multi-k-DeePKS tests have passed.

As long as TDDFT branch debugged and merged, `set_EDM_k` and `WFC_K_aug` can be **deleted** .