### PR TITLE
Refactor :  remove GlobalC::LOC.wfc_dm_2d 

### DIFF
--- a/source/run_lcao.cpp
+++ b/source/run_lcao.cpp
@@ -21,9 +21,6 @@ void Run_lcao::lcao_line(void)
 {
     ModuleBase::TITLE("Run_lcao","lcao_line");
     ModuleBase::timer::tick("Run_lcao", "lcao_line");
-
-    std::vector<ModuleBase::matrix> wfc_gamma;
-    std::vector<ModuleBase::ComplexMatrix> wfc_k;
     
     // Setup the unitcell.
     // improvement: a) separating the first reading of the atom_card and subsequent
@@ -190,9 +187,7 @@ void Run_lcao::lcao_line(void)
 	{
         LOOP_cell lc;
         //keep wfc_gamma or wfc_k remaining
-        lc.opt_cell(wfc_gamma, wfc_k);
-
-        GlobalC::en.perform_dos(wfc_gamma, wfc_k);
+        lc.opt_cell();
 	}
 
 	ModuleBase::timer::tick("Run_lcao","lcao_line");

--- a/source/run_lcao.cpp
+++ b/source/run_lcao.cpp
@@ -20,8 +20,11 @@ Run_lcao::~Run_lcao(){}
 void Run_lcao::lcao_line(void)
 {
     ModuleBase::TITLE("Run_lcao","lcao_line");
-	ModuleBase::timer::tick("Run_lcao","lcao_line");
+    ModuleBase::timer::tick("Run_lcao", "lcao_line");
 
+    std::vector<ModuleBase::matrix> wfc_gamma;
+    std::vector<ModuleBase::ComplexMatrix> wfc_k;
+    
     // Setup the unitcell.
     // improvement: a) separating the first reading of the atom_card and subsequent
     // cell relaxation. b) put GlobalV::NLOCAL and GlobalV::NBANDS as input parameters
@@ -185,10 +188,11 @@ void Run_lcao::lcao_line(void)
 	}
 	else // cell relaxations
 	{
-		LOOP_cell lc;
-		lc.opt_cell();
+        LOOP_cell lc;
+        //keep wfc_gamma or wfc_k remaining
+        lc.opt_cell(wfc_gamma, wfc_k);
 
-		GlobalC::en.perform_dos();
+        GlobalC::en.perform_dos(wfc_gamma, wfc_k);
 	}
 
 	ModuleBase::timer::tick("Run_lcao","lcao_line");

--- a/source/src_io/berryphase.cpp
+++ b/source/src_io/berryphase.cpp
@@ -7,6 +7,12 @@ berryphase::berryphase()
 	GDIR = INPUT.gdir;
 }
 
+berryphase::berryphase(std::vector<ModuleBase::ComplexMatrix>* wfc_k_in) :
+    wfc_k(wfc_k_in)
+{
+	GDIR = INPUT.gdir;
+}
+
 berryphase::~berryphase()
 {
 	//GlobalV::ofs_running << "this is ~berryphase()" << std::endl;
@@ -318,7 +324,7 @@ double berryphase::stringPhase(int index_str, int nbands)
 			if(GlobalV::NSPIN!=4)
 			{
 				//std::complex<double> my_det = lcao_method.det_berryphase(ik_1,ik_2,dk,nbands);
-				zeta = zeta * lcao_method.det_berryphase(ik_1,ik_2,dk,nbands);
+				zeta = zeta * lcao_method.det_berryphase(ik_1,ik_2,dk,nbands, this->wfc_k);
 				// test by jingan
 				//GlobalV::ofs_running << "methon 1: det = " << my_det << std::endl;
 				// test by jingan

--- a/source/src_io/berryphase.h
+++ b/source/src_io/berryphase.h
@@ -10,7 +10,8 @@ class berryphase
 
 public:
 
-	berryphase();
+    berryphase();   //for pw-line
+    berryphase(std::vector<ModuleBase::ComplexMatrix>* wfc_k_in);   //for lcao-line
 	~berryphase();
 
 	// mohan add 2021-02-16
@@ -25,8 +26,10 @@ public:
 	int nppstr;
 	int direction;
 	int occ_nbands;
-	int GDIR;
-	
+    int GDIR;
+
+    std::vector<ModuleBase::ComplexMatrix>* wfc_k;
+
 	void get_occupation_bands();
 
 	void lcao_init();

--- a/source/src_io/energy_dos.cpp
+++ b/source/src_io/energy_dos.cpp
@@ -179,7 +179,7 @@ void energy::perform_dos( std::vector<ModuleBase::matrix> &wfc_gamma,
 #ifdef __LCAO
 	if(GlobalV::mulliken == 1)
 	{
-		Mulliken_Charge   MC;
+		Mulliken_Charge   MC(&wfc_gamma, &wfc_k);
 		MC.stdout_mulliken();			
 	}//qifeng add 2019/9/10
 #endif

--- a/source/src_io/energy_dos.cpp
+++ b/source/src_io/energy_dos.cpp
@@ -25,7 +25,8 @@
 #endif
 #include <sys/time.h>
 
-void energy::perform_dos(void)
+void energy::perform_dos( std::vector<ModuleBase::matrix> &wfc_gamma,
+    std::vector<ModuleBase::ComplexMatrix> &wfc_k)
 {
 	ModuleBase::TITLE("energy","perform_dos");
 
@@ -226,13 +227,14 @@ void energy::perform_dos(void)
 
 		int NUM=GlobalV::NLOCAL*npoints;
 		Wfc_Dm_2d D;
-		D.init();
-		if(GlobalV::GAMMA_ONLY_LOCAL)
+        D.init();
+        
+        if (GlobalV::GAMMA_ONLY_LOCAL)
 		{
 			for(int in=0;in<GlobalV::NSPIN;in++)
 			{
 
-				D.wfc_gamma[in]=GlobalC::LOC.wfc_dm_2d.wfc_gamma[in];
+				D.wfc_gamma[in]=wfc_gamma[in];
 			}
 
 		}
@@ -242,7 +244,7 @@ void energy::perform_dos(void)
 			for(int in=0;in<GlobalC::kv.nks;in++)
 			{
 
-				D.wfc_k[in] = GlobalC::LOC.wfc_dm_2d.wfc_k[in];
+				D.wfc_k[in] = wfc_k[in];
 			}
 		}
 

--- a/source/src_io/istate_charge.cpp
+++ b/source/src_io/istate_charge.cpp
@@ -6,7 +6,12 @@
 #include "../module_base/scalapack_connector.h"
 #include "../module_base/blas_connector.h"
 
-IState_Charge::IState_Charge(){}
+IState_Charge::IState_Charge(
+    std::vector<ModuleBase::matrix>* wfc_gamma_in,
+    std::vector<ModuleBase::matrix>* dm_gamma_in) :
+    wfc_gamma(wfc_gamma_in),
+    dm_gamma(dm_gamma_in)
+{}
 
 IState_Charge::~IState_Charge(){}
 
@@ -208,7 +213,7 @@ void IState_Charge::idmatrix(const int &ib)
 			}
 		
 			// wg_wfc(ib,iw) = wg[ib] * wfc(ib,iw);
-			ModuleBase::matrix wg_wfc(GlobalC::LOC.wfc_dm_2d->wfc_gamma[is]);
+			ModuleBase::matrix wg_wfc(this->wfc_gamma->at(is));
 	
 			for(int ir=0; ir!=wg_wfc.nr; ++ir)
 			{
@@ -219,16 +224,16 @@ void IState_Charge::idmatrix(const int &ib)
 			const double one_float=1.0, zero_float=0.0;
 			const int one_int=1;
 			const char N_char='N', T_char='T';
-			GlobalC::LOC.wfc_dm_2d->dm_gamma[is].create( wg_wfc.nr, wg_wfc.nc );
+			this->dm_gamma->at(is).create( wg_wfc.nr, wg_wfc.nc );
 
 			pdgemm_(
 				&N_char, &T_char,
 				&GlobalV::NLOCAL, &GlobalV::NLOCAL, &GlobalC::wf.wg.nc,
 				&one_float,
 				wg_wfc.c, &one_int, &one_int, GlobalC::ParaO.desc,
-				GlobalC::LOC.wfc_dm_2d->wfc_gamma[is].c, &one_int, &one_int, GlobalC::ParaO.desc,
+				wfc_gamma->at(is).c, &one_int, &one_int, GlobalC::ParaO.desc,
 				&zero_float,
-				GlobalC::LOC.wfc_dm_2d->dm_gamma[is].c, &one_int, &one_int, GlobalC::ParaO.desc);
+				dm_gamma->at(is).c, &one_int, &one_int, GlobalC::ParaO.desc);
 		}
 
 		std::cout << " finished calc dm_2d : " << std::endl;

--- a/source/src_io/istate_charge.cpp
+++ b/source/src_io/istate_charge.cpp
@@ -208,7 +208,7 @@ void IState_Charge::idmatrix(const int &ib)
 			}
 		
 			// wg_wfc(ib,iw) = wg[ib] * wfc(ib,iw);
-			ModuleBase::matrix wg_wfc(GlobalC::LOC.wfc_dm_2d.wfc_gamma[is]);
+			ModuleBase::matrix wg_wfc(GlobalC::LOC.wfc_dm_2d->wfc_gamma[is]);
 	
 			for(int ir=0; ir!=wg_wfc.nr; ++ir)
 			{
@@ -219,16 +219,16 @@ void IState_Charge::idmatrix(const int &ib)
 			const double one_float=1.0, zero_float=0.0;
 			const int one_int=1;
 			const char N_char='N', T_char='T';
-			GlobalC::LOC.wfc_dm_2d.dm_gamma[is].create( wg_wfc.nr, wg_wfc.nc );
+			GlobalC::LOC.wfc_dm_2d->dm_gamma[is].create( wg_wfc.nr, wg_wfc.nc );
 
 			pdgemm_(
 				&N_char, &T_char,
 				&GlobalV::NLOCAL, &GlobalV::NLOCAL, &GlobalC::wf.wg.nc,
 				&one_float,
 				wg_wfc.c, &one_int, &one_int, GlobalC::ParaO.desc,
-				GlobalC::LOC.wfc_dm_2d.wfc_gamma[is].c, &one_int, &one_int, GlobalC::ParaO.desc,
+				GlobalC::LOC.wfc_dm_2d->wfc_gamma[is].c, &one_int, &one_int, GlobalC::ParaO.desc,
 				&zero_float,
-				GlobalC::LOC.wfc_dm_2d.dm_gamma[is].c, &one_int, &one_int, GlobalC::ParaO.desc);
+				GlobalC::LOC.wfc_dm_2d->dm_gamma[is].c, &one_int, &one_int, GlobalC::ParaO.desc);
 		}
 
 		std::cout << " finished calc dm_2d : " << std::endl;

--- a/source/src_io/istate_charge.h
+++ b/source/src_io/istate_charge.h
@@ -1,22 +1,27 @@
 #ifndef ISTATE_CHARGE_H
 #define ISTATE_CHARGE_H
+#include<vector>
+#include<module_base/matrix.h>
+#include<module_base/complexmatrix.h>
 
 class IState_Charge
 {
-	public:
-
-	IState_Charge();
-	~IState_Charge();
+public:
+    IState_Charge(std::vector<ModuleBase::matrix> *wfc_gamma_in,
+        std::vector<ModuleBase::matrix> *dm_gamma_in);
+    ~IState_Charge();
 
 	void begin();
 
-	private:
+private:
 
 	int *bands_picked;
 
 #ifdef __MPI
 	void idmatrix(const int &ib);
 #endif
+    std::vector<ModuleBase::matrix> *wfc_gamma;
+    std::vector<ModuleBase::matrix> *dm_gamma;
 
 };
 #endif

--- a/source/src_io/mulliken_charge.cpp
+++ b/source/src_io/mulliken_charge.cpp
@@ -40,7 +40,7 @@ Mulliken_Charge::Mulliken_Charge()
 		for(int in=0;in<GlobalV::NSPIN;in++)
 		{
 
-			M.wfc_gamma[in]=GlobalC::LOC.wfc_dm_2d.wfc_gamma[in];
+			M.wfc_gamma[in]=GlobalC::LOC.wfc_dm_2d->wfc_gamma[in];
 		}
 
 	}
@@ -50,7 +50,7 @@ Mulliken_Charge::Mulliken_Charge()
 		for(int in=0;in<GlobalC::kv.nks;in++)
 		{
 
-			M.wfc_k[in] = GlobalC::LOC.wfc_dm_2d.wfc_k[in];
+			M.wfc_k[in] = GlobalC::LOC.wfc_dm_2d->wfc_k[in];
 		}
 	}
 

--- a/source/src_io/mulliken_charge.cpp
+++ b/source/src_io/mulliken_charge.cpp
@@ -32,26 +32,16 @@
 
 
 
-Mulliken_Charge::Mulliken_Charge()
+Mulliken_Charge::Mulliken_Charge(std::vector<ModuleBase::matrix> *wfc_gamma_in,
+    std::vector<ModuleBase::ComplexMatrix> *wfc_k_in)
 {
-	M.init();
 	if(GlobalV::GAMMA_ONLY_LOCAL)
 	{
-		for(int in=0;in<GlobalV::NSPIN;in++)
-		{
-
-			M.wfc_gamma[in]=GlobalC::LOC.wfc_dm_2d->wfc_gamma[in];
-		}
-
+        this->wfc_gamma = wfc_gamma_in;
 	}
 	else 
 	{
-
-		for(int in=0;in<GlobalC::kv.nks;in++)
-		{
-
-			M.wfc_k[in] = GlobalC::LOC.wfc_dm_2d->wfc_k[in];
-		}
+        this->wfc_k = wfc_k_in;
 	}
 
 	mug = new  std::complex<double>   [GlobalV::NLOCAL];
@@ -125,7 +115,7 @@ void Mulliken_Charge::cal_mulliken(void)
 			mud.resize(1);
 			mud[0].create(GlobalC::ParaO.ncol,GlobalC::ParaO.nrow);
 
-			ModuleBase::matrix Dwf = M.wfc_gamma[is];
+			ModuleBase::matrix Dwf = this->wfc_gamma->at(is);
 			for (int i=0; i<GlobalV::NBANDS; ++i)		  
 			{     
 				ModuleBase::GlobalFunc::ZEROS(mug, GlobalV::NLOCAL);
@@ -155,7 +145,7 @@ void Mulliken_Charge::cal_mulliken(void)
 						const int ir = GlobalC::ParaO.trace_loc_row[j];
 						const int ic = GlobalC::ParaO.trace_loc_col[i];
 
-						mug[j] = mud[0](ic,ir)*M.wfc_gamma[is](ic,ir);
+						mug[j] = mud[0](ic,ir)*this->wfc_gamma->at(is)(ic,ir);
 
 						const double x = mug[j].real();
 
@@ -232,7 +222,7 @@ void Mulliken_Charge::cal_mulliken(void)
 					GlobalC::LM.allocate_HS_k(GlobalC::ParaO.nloc);
 					GlobalC::LM.zeros_HSk('S');
 					GlobalC::LNNR.folding_fixedH(ik);
-					ModuleBase::ComplexMatrix Dwf = conj(M.wfc_k[ik]);
+					ModuleBase::ComplexMatrix Dwf = conj(this->wfc_k->at(ik));
 
 					for (int i=0; i<GlobalV::NBANDS; ++i)		  
 					{     
@@ -265,7 +255,7 @@ void Mulliken_Charge::cal_mulliken(void)
 								const int ir = GlobalC::ParaO.trace_loc_row[j];
 								const int ic = GlobalC::ParaO.trace_loc_col[i];
 
-								mug[j] = mud[0](ic,ir)*M.wfc_k[ik](ic,ir);
+								mug[j] = mud[0](ic,ir)*this->wfc_k->at(ik)(ic,ir);
 								const double x = mug[j].real();
 								MecMulP[is][j] +=x*GlobalC::wf.wg(ik,i);
 								// std::cout <<   wavog[j] << std::endl; 

--- a/source/src_io/mulliken_charge.h
+++ b/source/src_io/mulliken_charge.h
@@ -23,13 +23,15 @@ class Mulliken_Charge
 {
 	public:
 
-	Mulliken_Charge();
+	Mulliken_Charge(std::vector<ModuleBase::matrix> *wfc_gamma_in, 
+        std::vector<ModuleBase::ComplexMatrix> *wfc_k_in);
 	~Mulliken_Charge();
 
 	double**  DecMulP ;
 	double**  MecMulP ;
 	double***  ADecMulP ;
-	Wfc_Dm_2d M;
+    std::vector<ModuleBase::matrix> *wfc_gamma;
+    std::vector<ModuleBase::ComplexMatrix> *wfc_k;
 
 	std::complex<double> *mug;
 

--- a/source/src_io/unk_overlap_lcao.cpp
+++ b/source/src_io/unk_overlap_lcao.cpp
@@ -719,7 +719,9 @@ void unkOverlap_lcao::prepare_midmatrix_pblas(const int ik_L, const int ik_R, co
 	
 }
 
-std::complex<double> unkOverlap_lcao::det_berryphase(const int ik_L, const int ik_R, const ModuleBase::Vector3<double> dk, const int occ_bands)
+std::complex<double> unkOverlap_lcao::det_berryphase(const int ik_L, const int ik_R,
+    const ModuleBase::Vector3<double> dk, const int occ_bands,
+    std::vector<ModuleBase::ComplexMatrix>* wfc_k)
 {
 	const std::complex<double> minus = std::complex<double>(-1.0,0.0);
 	std::complex<double> det = std::complex<double>(1.0,0.0);
@@ -731,7 +733,6 @@ std::complex<double> unkOverlap_lcao::det_berryphase(const int ik_L, const int i
 	
 	this->prepare_midmatrix_pblas(ik_L,ik_R,dk,midmatrix);
 	
-	//GlobalC::LOC.wfc_dm_2d->wfc_k
 	char transa = 'C';
 	char transb = 'N';
 	int occBands = occ_bands;
@@ -740,14 +741,14 @@ std::complex<double> unkOverlap_lcao::det_berryphase(const int ik_L, const int i
 	int one = 1;
 #ifdef __MPI
 	pzgemm_(&transa,&transb,&occBands,&nlocal,&nlocal,&alpha,
-			GlobalC::LOC.wfc_dm_2d->wfc_k[ik_L].c,&one,&one,GlobalC::ParaO.desc,
+			wfc_k->at(ik_L).c,&one,&one,GlobalC::ParaO.desc,
 							  midmatrix,&one,&one,GlobalC::ParaO.desc,
 													   &beta,
 							   C_matrix,&one,&one,GlobalC::ParaO.desc);
 							   
 	pzgemm_(&transb,&transb,&occBands,&occBands,&nlocal,&alpha,
 								 C_matrix,&one,&one,GlobalC::ParaO.desc,
-			  GlobalC::LOC.wfc_dm_2d->wfc_k[ik_R].c,&one,&one,GlobalC::ParaO.desc,
+			wfc_k->at(ik_R).c,&one,&one,GlobalC::ParaO.desc,
 														 &beta,
 							   out_matrix,&one,&one,GlobalC::ParaO.desc);	
 

--- a/source/src_io/unk_overlap_lcao.cpp
+++ b/source/src_io/unk_overlap_lcao.cpp
@@ -731,7 +731,7 @@ std::complex<double> unkOverlap_lcao::det_berryphase(const int ik_L, const int i
 	
 	this->prepare_midmatrix_pblas(ik_L,ik_R,dk,midmatrix);
 	
-	//GlobalC::LOC.wfc_dm_2d.wfc_k
+	//GlobalC::LOC.wfc_dm_2d->wfc_k
 	char transa = 'C';
 	char transb = 'N';
 	int occBands = occ_bands;
@@ -740,14 +740,14 @@ std::complex<double> unkOverlap_lcao::det_berryphase(const int ik_L, const int i
 	int one = 1;
 #ifdef __MPI
 	pzgemm_(&transa,&transb,&occBands,&nlocal,&nlocal,&alpha,
-			GlobalC::LOC.wfc_dm_2d.wfc_k[ik_L].c,&one,&one,GlobalC::ParaO.desc,
+			GlobalC::LOC.wfc_dm_2d->wfc_k[ik_L].c,&one,&one,GlobalC::ParaO.desc,
 							  midmatrix,&one,&one,GlobalC::ParaO.desc,
 													   &beta,
 							   C_matrix,&one,&one,GlobalC::ParaO.desc);
 							   
 	pzgemm_(&transb,&transb,&occBands,&occBands,&nlocal,&alpha,
 								 C_matrix,&one,&one,GlobalC::ParaO.desc,
-			  GlobalC::LOC.wfc_dm_2d.wfc_k[ik_R].c,&one,&one,GlobalC::ParaO.desc,
+			  GlobalC::LOC.wfc_dm_2d->wfc_k[ik_R].c,&one,&one,GlobalC::ParaO.desc,
 														 &beta,
 							   out_matrix,&one,&one,GlobalC::ParaO.desc);	
 

--- a/source/src_io/unk_overlap_lcao.h
+++ b/source/src_io/unk_overlap_lcao.h
@@ -65,8 +65,10 @@ public:
 	void cal_orb_overlap();
 	void get_lcao_wfc_global_ik(std::complex<double> **ctot, std::complex<double> **cc);
 	void prepare_midmatrix_pblas(const int ik_L, const int ik_R, const ModuleBase::Vector3<double> dk, std::complex<double> *&midmatrix);
-	std::complex<double> det_berryphase(const int ik_L, const int ik_R, const ModuleBase::Vector3<double> dk, const int occ_bands);
-	
+    std::complex<double> det_berryphase(const int ik_L, const int ik_R,
+        const ModuleBase::Vector3<double> dk, const int occ_bands,
+        std::vector<ModuleBase::ComplexMatrix>* wfc_k);
+
 	void test();
 	
 	

--- a/source/src_io/wf_local.cpp
+++ b/source/src_io/wf_local.cpp
@@ -490,7 +490,7 @@ void WF_Local::distri_lowf_new(double **ctot, const int &is)
 			const int inc=1;
 			if(myid==src_rank)
 			{
-				BlasConnector::copy(GlobalC::ParaO.nloc, work, inc, GlobalC::LOC.wfc_dm_2d.wfc_gamma[is].c, inc);
+				BlasConnector::copy(GlobalC::ParaO.nloc, work, inc, GlobalC::LOC.wfc_dm_2d->wfc_gamma[is].c, inc);
 			}
 		}//loop ipcol
 	}//loop	iprow
@@ -562,7 +562,7 @@ void WF_Local::distri_lowf_complex_new(std::complex<double> **ctot, const int &i
 			const int inc=1;
 			if(myid==src_rank)
 			{
-				BlasConnector::copy(GlobalC::ParaO.nloc, work, inc, GlobalC::LOC.wfc_dm_2d.wfc_k[ik].c, inc);
+				BlasConnector::copy(GlobalC::ParaO.nloc, work, inc, GlobalC::LOC.wfc_dm_2d->wfc_k[ik].c, inc);
 			}
 		}//loop ipcol
 	}//loop	iprow

--- a/source/src_io/wf_local.cpp
+++ b/source/src_io/wf_local.cpp
@@ -63,7 +63,8 @@ inline int CTOT2q_c(
 }
 
 // be called in local_orbital_wfc::allocate_k
-int WF_Local::read_lowf_complex(std::complex<double> **c, const int &ik, const bool &newdm)
+int WF_Local::read_lowf_complex(std::complex<double>** c, const int& ik, 
+    std::vector<ModuleBase::ComplexMatrix> *wfc_k)
 {
     ModuleBase::TITLE("WF_Local","read_lowf_complex");
     ModuleBase::timer::tick("WF_Local","read_lowf_complex");
@@ -183,14 +184,7 @@ int WF_Local::read_lowf_complex(std::complex<double> **c, const int &ik, const b
     // so it's save.
 	
     //WF_Local::distri_lowf(ctot, GlobalC::SGO.totwfc[0]);
-    if(newdm==0)
-	{
-		WF_Local::distri_lowf_complex(ctot, c); 
-	}
-	else
-	{	
-		WF_Local::distri_lowf_complex_new(ctot, ik);
-	}
+	WF_Local::distri_lowf_complex_new(ctot, ik, wfc_k);
 	
 	// mohan add 2012-02-15,
 	// still have bugs, but can solve it later.
@@ -227,7 +221,8 @@ int WF_Local::read_lowf_complex(std::complex<double> **c, const int &ik, const b
 	return 0;
 }
 
-int WF_Local::read_lowf(double **c, const int &is)
+int WF_Local::read_lowf(double** c, const int& is,
+    std::vector<ModuleBase::matrix>* wfc_gamma)
 {
     ModuleBase::TITLE("WF_Local","read_lowf");
     ModuleBase::timer::tick("WF_Local","read_lowf");
@@ -330,7 +325,7 @@ int WF_Local::read_lowf(double **c, const int &is)
     // if GlobalV::DRANK!=0, ctot is not used,
     // so it's save.
 
-	WF_Local::distri_lowf_new(ctot, is);
+	WF_Local::distri_lowf_new(ctot, is, wfc_gamma);
 	
 	// mohan add 2012-02-15,
 	// still have bugs, but can solve it later.
@@ -430,7 +425,8 @@ void WF_Local::write_lowf_complex(const std::string &name, std::complex<double> 
     return;
 }
 
-void WF_Local::distri_lowf_new(double **ctot, const int &is)
+void WF_Local::distri_lowf_new(double** ctot, const int& is,
+    std::vector<ModuleBase::matrix> *wfc_gamma)
 {
     ModuleBase::TITLE("WF_Local","distri_lowf_new");
 #ifdef __MPI
@@ -490,7 +486,7 @@ void WF_Local::distri_lowf_new(double **ctot, const int &is)
 			const int inc=1;
 			if(myid==src_rank)
 			{
-				BlasConnector::copy(GlobalC::ParaO.nloc, work, inc, GlobalC::LOC.wfc_dm_2d->wfc_gamma[is].c, inc);
+				BlasConnector::copy(GlobalC::ParaO.nloc, work, inc, wfc_gamma->at(is).c, inc);
 			}
 		}//loop ipcol
 	}//loop	iprow
@@ -502,7 +498,8 @@ void WF_Local::distri_lowf_new(double **ctot, const int &is)
     return;
 }
 
-void WF_Local::distri_lowf_complex_new(std::complex<double> **ctot, const int &ik)
+void WF_Local::distri_lowf_complex_new(std::complex<double>** ctot, const int& ik,
+    std::vector<ModuleBase::ComplexMatrix> *wfc_k)
 {
     ModuleBase::TITLE("WF_Local","distri_lowf_complex_new");
 #ifdef __MPI
@@ -562,7 +559,7 @@ void WF_Local::distri_lowf_complex_new(std::complex<double> **ctot, const int &i
 			const int inc=1;
 			if(myid==src_rank)
 			{
-				BlasConnector::copy(GlobalC::ParaO.nloc, work, inc, GlobalC::LOC.wfc_dm_2d->wfc_k[ik].c, inc);
+				BlasConnector::copy(GlobalC::ParaO.nloc, work, inc, wfc_k->at(ik).c, inc);
 			}
 		}//loop ipcol
 	}//loop	iprow

--- a/source/src_io/wf_local.h
+++ b/source/src_io/wf_local.h
@@ -3,6 +3,8 @@
 
 #include "../module_base/global_function.h"
 #include "../module_base/global_variable.h"
+#include "module_base/matrix.h"
+#include "module_base/complexmatrix.h"
 
 // mohan add 2010-09-09
 namespace WF_Local
@@ -13,12 +15,16 @@ namespace WF_Local
 	void distri_lowf(double** ctot, double **c);
 	void distri_lowf_complex(std::complex<double>** ctot, std::complex<double> **cc);
 
-	void distri_lowf_new(double** ctot, const int &is);
-	void distri_lowf_complex_new(std::complex<double>** ctot, const int &ik);
+    void distri_lowf_new(double** ctot, const int& is,
+        std::vector<ModuleBase::matrix> *wfc_gamma);
+    void distri_lowf_complex_new(std::complex<double>** ctot, const int& ik,
+        std::vector<ModuleBase::ComplexMatrix> *wfc_k);
 
-	int read_lowf(double **c, const int &is);
+    int read_lowf(double** c, const int& is,
+        std::vector<ModuleBase::matrix> *wfc_gamma);
 
-	int read_lowf_complex(std::complex<double> **c, const int &ik, const bool &newdm);
+    int read_lowf_complex(std::complex<double>** c, const int& ik,
+        std::vector<ModuleBase::ComplexMatrix> *wfc_k);
 }
 
 #endif

--- a/source/src_lcao/DM_gamma.cpp
+++ b/source/src_lcao/DM_gamma.cpp
@@ -297,7 +297,7 @@ void Local_Orbital_Charge::gamma_file(const Grid_Technique& gt,
 		wfc_gamma[is].zero_out();
 
 		GlobalV::ofs_running << " Read in wave functions " << is << std::endl;
-		error = WF_Local::read_lowf( ctot , is);
+		error = WF_Local::read_lowf( ctot , is, &wfc_gamma);
 #ifdef __MPI
 		Parallel_Common::bcast_int(error);
 #endif

--- a/source/src_lcao/DM_gamma.cpp
+++ b/source/src_lcao/DM_gamma.cpp
@@ -270,17 +270,18 @@ void Local_Orbital_Charge::allocate_gamma(const Grid_Technique &gt)
 #endif
 
 	// Peize Lin test 2019-01-16
-    wfc_dm_2d.init();
+    wfc_dm_2d->init();
 
 	if(GlobalC::wf.start_wfc=="file")
 	{
-		this->gamma_file(gt);
+		this->gamma_file(gt, wfc_dm_2d->wfc_gamma);
 	}
 
     return;
 }
 
-void Local_Orbital_Charge::gamma_file(const Grid_Technique &gt)
+void Local_Orbital_Charge::gamma_file(const Grid_Technique& gt,
+    std::vector<ModuleBase::matrix> &wfc_gamma)
 {
 	ModuleBase::TITLE("Local_Orbital_Charge","gamma_file");
 
@@ -292,8 +293,8 @@ void Local_Orbital_Charge::gamma_file(const Grid_Technique &gt)
 	for(int is=0; is<GlobalV::NSPIN; ++is)
 	{
 
-		GlobalC::LOC.wfc_dm_2d.wfc_gamma[is].create(GlobalC::ParaO.ncol, GlobalC::ParaO.nrow);
-		GlobalC::LOC.wfc_dm_2d.wfc_gamma[is].zero_out();
+		wfc_gamma[is].create(GlobalC::ParaO.ncol, GlobalC::ParaO.nrow);
+		wfc_gamma[is].zero_out();
 
 		GlobalV::ofs_running << " Read in wave functions " << is << std::endl;
 		error = WF_Local::read_lowf( ctot , is);
@@ -348,11 +349,11 @@ void Local_Orbital_Charge::cal_dk_gamma_from_2D(void)
         // }
         GlobalV::ofs_running<<"2D block parameters:\n"<<"nblk: "<<GlobalC::ParaO.nb<<std::endl;
         GlobalV::ofs_running<<"DM in 2D format:\n_________________________________________\n";
-        for(int i=0; i<wfc_dm_2d.dm_gamma[is].nr; ++i)
+        for(int i=0; i<wfc_dm_2d->dm_gamma[is].nr; ++i)
         {
-            for(int j=0; j<wfc_dm_2d.dm_gamma[is].nc; ++j)
+            for(int j=0; j<wfc_dm_2d->dm_gamma[is].nc; ++j)
             {
-                GlobalV::ofs_running<<wfc_dm_2d.dm_gamma[is](i,j)<<" ";
+                GlobalV::ofs_running<<wfc_dm_2d->dm_gamma[is](i,j)<<" ";
             }
             GlobalV::ofs_running<<std::endl;
         }
@@ -366,7 +367,7 @@ void Local_Orbital_Charge::cal_dk_gamma_from_2D(void)
             const int icol=idx%GlobalV::NLOCAL;
             const int irow=(idx-icol)/GlobalV::NLOCAL;
             // sender_buffer[i]=wfc_dm_2d.dm_gamma[is](irow,icol);
-            sender_buffer[i]=wfc_dm_2d.dm_gamma[is](icol,irow); // sender_buffer is clomun major, 
+            sender_buffer[i]=wfc_dm_2d->dm_gamma[is](icol,irow); // sender_buffer is clomun major, 
                                                                 // so the row and column index should be switched
             if(sender_buffer[i]!=0) ++nNONZERO;
         }

--- a/source/src_lcao/DM_k.cpp
+++ b/source/src_lcao/DM_k.cpp
@@ -75,7 +75,7 @@ void Local_Orbital_Charge::kpt_file(const Grid_Technique& gt,
 		wfc_k[ik].zero_out();
 
 		GlobalV::ofs_running << " Read in wave functions " << ik + 1 << std::endl;
-		error = WF_Local::read_lowf_complex( ctot , ik , 1);
+		error = WF_Local::read_lowf_complex( ctot , ik, &wfc_k);
 
 #ifdef __MPI
 		Parallel_Common::bcast_int(error);

--- a/source/src_lcao/DM_k.cpp
+++ b/source/src_lcao/DM_k.cpp
@@ -49,16 +49,17 @@ void Local_Orbital_Charge::allocate_DM_k(void)
     }
 
 	// Peize Lin test 2019-01-16 
-    wfc_dm_2d.init();
+    wfc_dm_2d->init();
 	if(GlobalC::wf.start_wfc=="file")
 	{
-		this->kpt_file(GlobalC::GridT);
+		this->kpt_file(GlobalC::GridT, wfc_dm_2d->wfc_k);
 	}
 
     return;
 }
 
-void Local_Orbital_Charge::kpt_file(const Grid_Technique &gt)
+void Local_Orbital_Charge::kpt_file(const Grid_Technique& gt,
+    std::vector<ModuleBase::ComplexMatrix> &wfc_k)
 {
 	ModuleBase::TITLE("Local_Orbital_Charge","kpt_file");
 
@@ -70,8 +71,8 @@ void Local_Orbital_Charge::kpt_file(const Grid_Technique &gt)
 	for(int ik=0; ik<GlobalC::kv.nkstot; ++ik)
 	{
 
-		GlobalC::LOC.wfc_dm_2d.wfc_k[ik].create(GlobalC::ParaO.ncol, GlobalC::ParaO.nrow);
-		GlobalC::LOC.wfc_dm_2d.wfc_k[ik].zero_out();
+		wfc_k[ik].create(GlobalC::ParaO.ncol, GlobalC::ParaO.nrow);
+		wfc_k[ik].zero_out();
 
 		GlobalV::ofs_running << " Read in wave functions " << ik + 1 << std::endl;
 		error = WF_Local::read_lowf_complex( ctot , ik , 1);

--- a/source/src_lcao/ELEC_cbands_gamma.cpp
+++ b/source/src_lcao/ELEC_cbands_gamma.cpp
@@ -12,7 +12,9 @@ ELEC_cbands_gamma::ELEC_cbands_gamma(){};
 ELEC_cbands_gamma::~ELEC_cbands_gamma(){};
 
 
-void ELEC_cbands_gamma::cal_bands(const int &istep, LCAO_Hamilt &uhm)
+void ELEC_cbands_gamma::cal_bands(const int& istep, LCAO_Hamilt& uhm,
+    std::vector<ModuleBase::matrix>& wfc_gamma,
+    std::vector<ModuleBase::matrix>& dm_gamma)
 {
 	ModuleBase::TITLE("ELEC_cbands_gamma","cal_bands");
 	ModuleBase::timer::tick("ELEC_cband_gamma","cal_bands");
@@ -48,7 +50,7 @@ void ELEC_cbands_gamma::cal_bands(const int &istep, LCAO_Hamilt &uhm)
 		//--------------------------------------------
 
 		// Peize Lin add ik 2016-12-03
-		uhm.calculate_Hgamma(ik);
+		uhm.calculate_Hgamma(ik, dm_gamma);
 
     // Effective potential of DFT+U is added to total Hamiltonian here; Quxin adds on 20201029
 		if(INPUT.dft_plus_u) 
@@ -83,8 +85,8 @@ void ELEC_cbands_gamma::cal_bands(const int &istep, LCAO_Hamilt &uhm)
 		{
 			Diago_LCAO_Matrix DLM;
 			// the temperary array totwfc only have one spin direction.
-			//DLM.solve_double_matrix(ik, GlobalC::SGO.totwfc[0], GlobalC::LOC.wfc_dm_2d.wfc_gamma[ik]);
-			DLM.solve_double_matrix(ik, GlobalC::LOC.wfc_dm_2d.wfc_gamma[ik]); //LiuXh modify 2021-09-06, clear memory, totwfc not used now
+			//DLM.solve_double_matrix(ik, GlobalC::SGO.totwfc[0], wfc_gamma[ik]);
+			DLM.solve_double_matrix(ik, wfc_gamma[ik]); //LiuXh modify 2021-09-06, clear memory, totwfc not used now
 		}
 		else
 		{

--- a/source/src_lcao/ELEC_cbands_gamma.h
+++ b/source/src_lcao/ELEC_cbands_gamma.h
@@ -27,7 +27,9 @@ class ELEC_cbands_gamma
 
 	private:
 
-	static void cal_bands(const int &istep, LCAO_Hamilt &uhm);
+    static void cal_bands(const int& istep, LCAO_Hamilt& uhm,
+        std::vector<ModuleBase::matrix>& wfc_gamma,
+        std::vector<ModuleBase::matrix>& dm_gamma);
 
 
 };

--- a/source/src_lcao/ELEC_cbands_k.cpp
+++ b/source/src_lcao/ELEC_cbands_k.cpp
@@ -15,7 +15,9 @@ ELEC_cbands_k::ELEC_cbands_k(){};
 ELEC_cbands_k::~ELEC_cbands_k(){};
 
 
-void ELEC_cbands_k::cal_bands(const int &istep, LCAO_Hamilt &uhm)
+void ELEC_cbands_k::cal_bands(const int& istep, LCAO_Hamilt& uhm,
+    std::vector<ModuleBase::ComplexMatrix>& wfc_k,
+    std::vector<ModuleBase::ComplexMatrix>& dm_k)
 {
 	ModuleBase::TITLE("ELEC_cbands_k","cal_bands");
 	ModuleBase::timer::tick("ELEC_cbands_k","cal_bands");
@@ -27,7 +29,7 @@ void ELEC_cbands_k::cal_bands(const int &istep, LCAO_Hamilt &uhm)
 #ifdef __DEEPKS
 	if (GlobalV::deepks_scf)
     {
-		GlobalC::ld.cal_projected_DM_k(GlobalC::LOC.wfc_dm_2d.dm_k,
+		GlobalC::ld.cal_projected_DM_k(dm_k,
 			GlobalC::ucell,
             GlobalC::ORB,
             GlobalC::GridD,
@@ -140,7 +142,7 @@ void ELEC_cbands_k::cal_bands(const int &istep, LCAO_Hamilt &uhm)
 		// write the wave functions into GlobalC::LOWF.WFC_K[ik].
 		ModuleBase::timer::tick("Efficience","diago_k");
 		Diago_LCAO_Matrix DLM;
-		DLM.solve_complex_matrix(ik, GlobalC::LOWF.WFC_K[ik], GlobalC::LOC.wfc_dm_2d.wfc_k[ik]);
+		DLM.solve_complex_matrix(ik, GlobalC::LOWF.WFC_K[ik], wfc_k[ik]);
 		ModuleBase::timer::tick("Efficience","diago_k");
 
 		ModuleBase::timer::tick("Efficience","each_k");

--- a/source/src_lcao/ELEC_cbands_k.h
+++ b/source/src_lcao/ELEC_cbands_k.h
@@ -27,7 +27,9 @@ class ELEC_cbands_k
 
 	private:
 
-	static void cal_bands(const int &istep, LCAO_Hamilt &uhm);
+    static void cal_bands(const int& istep, LCAO_Hamilt& uhm,
+        std::vector<ModuleBase::ComplexMatrix>& wfc_k,
+        std::vector<ModuleBase::ComplexMatrix>& dm_k);
 
 
 };

--- a/source/src_lcao/ELEC_evolve.cpp
+++ b/source/src_lcao/ELEC_evolve.cpp
@@ -28,7 +28,8 @@ int ELEC_evolve::td_dipoleout;
 // this routine only serves for TDDFT using LCAO basis set
 void ELEC_evolve::evolve_psi(
 	const int &istep,
-	LCAO_Hamilt &uhm)
+    LCAO_Hamilt& uhm,
+    vector<ModuleBase::ComplexMatrix> &wfc_k)
 {
 	ModuleBase::TITLE("ELEC_evolve","eveolve_psi");
 	ModuleBase::timer::tick("ELEC_evolve","evolve_psi");
@@ -120,7 +121,7 @@ void ELEC_evolve::evolve_psi(
 		}		
 		ModuleBase::timer::tick("Efficience","evolve_k");
 		Evolve_LCAO_Matrix ELM;
-		ELM.evolve_complex_matrix(ik, GlobalC::LOWF.WFC_K[ik], GlobalC::LOC.wfc_dm_2d.wfc_k[ik]);
+		ELM.evolve_complex_matrix(ik, GlobalC::LOWF.WFC_K[ik], wfc_k[ik]);
 		ModuleBase::timer::tick("Efficience","evolve_k");
 	} // end k
 

--- a/source/src_lcao/ELEC_evolve.h
+++ b/source/src_lcao/ELEC_evolve.h
@@ -41,7 +41,8 @@ class ELEC_evolve
 
 	private:
 
-	static void evolve_psi(const int &istep, LCAO_Hamilt &uhm);
+    static void evolve_psi(const int& istep, LCAO_Hamilt& uhm,
+    vector<ModuleBase::ComplexMatrix> &wfc_k);
 
 };
 

--- a/source/src_lcao/ELEC_nscf.cpp
+++ b/source/src_lcao/ELEC_nscf.cpp
@@ -11,7 +11,11 @@
 ELEC_nscf::ELEC_nscf(){}
 ELEC_nscf::~ELEC_nscf(){}
 
-void ELEC_nscf::nscf(LCAO_Hamilt &uhm)
+void ELEC_nscf::nscf(LCAO_Hamilt& uhm,
+    std::vector<ModuleBase::matrix>& wfc_gamma,
+    std::vector<ModuleBase::matrix>& dm_gamma,
+    std::vector<ModuleBase::ComplexMatrix>& wfc_k,
+    std::vector<ModuleBase::ComplexMatrix>& dm_k)
 {
 	ModuleBase::TITLE("ELEC_nscf","nscf");
 
@@ -36,11 +40,11 @@ void ELEC_nscf::nscf(LCAO_Hamilt &uhm)
 	int istep=0; 
 	if(GlobalV::GAMMA_ONLY_LOCAL)
 	{
-		ELEC_cbands_gamma::cal_bands(istep, uhm);
+		ELEC_cbands_gamma::cal_bands(istep, uhm, wfc_gamma, dm_gamma);
 	}
 	else
 	{
-		ELEC_cbands_k::cal_bands(istep, uhm);
+		ELEC_cbands_k::cal_bands(istep, uhm, wfc_k, dm_k);
 	}
 
 	time_t time_finish=std::time(NULL);

--- a/source/src_lcao/ELEC_nscf.cpp
+++ b/source/src_lcao/ELEC_nscf.cpp
@@ -91,7 +91,7 @@ void ELEC_nscf::nscf(LCAO_Hamilt& uhm,
 	// add by jingan
 	if (berryphase::berry_phase_flag && ModuleSymmetry::Symmetry::symm_flag == 0)
     {
-    	berryphase bp;
+    	berryphase bp(&wfc_k);
 		bp.Macroscopic_polarization();
     }
 

--- a/source/src_lcao/ELEC_nscf.h
+++ b/source/src_lcao/ELEC_nscf.h
@@ -25,7 +25,11 @@ class ELEC_nscf
 
 	private:
 
-	static void nscf(LCAO_Hamilt &uhm); 
+    static void nscf(LCAO_Hamilt& uhm,
+        std::vector<ModuleBase::matrix>& wfc_gamma,
+        std::vector<ModuleBase::matrix>& dm_gamma,
+        std::vector<ModuleBase::ComplexMatrix>& wfc_k,
+        std::vector<ModuleBase::ComplexMatrix>& dm_k);
 
 
 };

--- a/source/src_lcao/ELEC_scf.cpp
+++ b/source/src_lcao/ELEC_scf.cpp
@@ -297,8 +297,21 @@ void ELEC_scf::scf(const int& istep,
 
 		 	GlobalC::dftu.cal_energy_correction(istep);
 			GlobalC::dftu.output();
+        }
+        
+#ifdef __DEEPKS
+        if(GlobalV::deepks_scf) 
+		{
+			if(GlobalV::GAMMA_ONLY_LOCAL)
+			{
+				GlobalC::ld.cal_e_delta_band(dm_gamma,GlobalC::ParaO);
+			}
+			else
+			{
+				GlobalC::ld.cal_e_delta_band_k(dm_k,GlobalC::ParaO,GlobalC::kv.nks);
+			}
 		}
-
+#endif
 		// (4) mohan add 2010-06-24
 		// using new charge density.
 		GlobalC::en.calculate_harris(2);

--- a/source/src_lcao/ELEC_scf.cpp
+++ b/source/src_lcao/ELEC_scf.cpp
@@ -185,7 +185,7 @@ void ELEC_scf::scf(const int& istep,
 			case 5:    case 6:   case 9:
 				if( !GlobalC::exx_global.info.separate_loop )
 				{
-					GlobalC::exx_lcao.cal_exx_elec();
+					GlobalC::exx_lcao.cal_exx_elec(dm_gamma, dm_k);
 				}
 				break;
 		}
@@ -282,7 +282,7 @@ void ELEC_scf::scf(const int& istep,
 			if(GlobalC::restart.info_load.load_H && GlobalC::restart.info_load.load_H_finish && !GlobalC::restart.info_load.restart_exx)
 			{
 				GlobalC::exx_global.info.set_xcfunc(GlobalC::xcf);
-				GlobalC::exx_lcao.cal_exx_elec();
+				GlobalC::exx_lcao.cal_exx_elec(dm_gamma, dm_k);
 				GlobalC::restart.info_load.restart_exx = true;
 			}
 		}

--- a/source/src_lcao/ELEC_scf.cpp
+++ b/source/src_lcao/ELEC_scf.cpp
@@ -23,7 +23,11 @@ ELEC_scf::~ELEC_scf(){}
 
 int ELEC_scf::iter=0;
 
-void ELEC_scf::scf(const int &istep)
+void ELEC_scf::scf(const int& istep,
+    std::vector<ModuleBase::matrix>& wfc_gamma,
+    std::vector<ModuleBase::matrix>& dm_gamma,
+    std::vector<ModuleBase::ComplexMatrix>& wfc_k,
+    std::vector<ModuleBase::ComplexMatrix>& dm_k)
 {
 	ModuleBase::TITLE("ELEC_scf","scf");
 	ModuleBase::timer::tick("ELEC_scf","scf");
@@ -195,17 +199,17 @@ void ELEC_scf::scf(const int &istep)
 		// mohan add 2021-02-09
 		if(GlobalV::GAMMA_ONLY_LOCAL)
 		{
-			ELEC_cbands_gamma::cal_bands(istep, GlobalC::UHM);
+			ELEC_cbands_gamma::cal_bands(istep, GlobalC::UHM, wfc_gamma, dm_gamma);
 		}
 		else
 		{
 			if(ELEC_evolve::tddft && istep >= 1 && iter > 1)
 			{
-				ELEC_evolve::evolve_psi(istep, GlobalC::UHM);
+				ELEC_evolve::evolve_psi(istep, GlobalC::UHM, wfc_k);
 			}
 			else
 			{
-				ELEC_cbands_k::cal_bands(istep, GlobalC::UHM);
+				ELEC_cbands_k::cal_bands(istep, GlobalC::UHM, wfc_k, dm_k);
 			}
 		}
 
@@ -288,8 +292,8 @@ void ELEC_scf::scf(const int &istep)
 		// the local occupation number matrix and energy correction
 		if(INPUT.dft_plus_u)
 		{
-			if(GlobalV::GAMMA_ONLY_LOCAL) GlobalC::dftu.cal_occup_m_gamma(iter);
-			else GlobalC::dftu.cal_occup_m_k(iter);
+			if(GlobalV::GAMMA_ONLY_LOCAL) GlobalC::dftu.cal_occup_m_gamma(iter, dm_gamma);
+			else GlobalC::dftu.cal_occup_m_k(iter, dm_k);
 
 		 	GlobalC::dftu.cal_energy_correction(istep);
 			GlobalC::dftu.output();

--- a/source/src_lcao/ELEC_scf.h
+++ b/source/src_lcao/ELEC_scf.h
@@ -3,6 +3,8 @@
 
 #include "../module_base/global_function.h"
 #include "../module_base/global_variable.h"
+#include "../module_base/matrix.h"
+#include "../module_base/complexmatrix.h"
 #include "../src_pw/threshold_elec.h"
 
 //-----------------------------------------------------------
@@ -26,7 +28,11 @@ class ELEC_scf: private Threshold_Elec
 
 	private:
 
-	void scf(const int &istep);
+    void scf(const int& istep,
+        std::vector<ModuleBase::matrix>& wfc_gamma,
+        std::vector<ModuleBase::matrix>& dm_gamma,
+        std::vector<ModuleBase::ComplexMatrix>& wfc_k,
+        std::vector<ModuleBase::ComplexMatrix>& dm_k);
 
 	static int iter;
 

--- a/source/src_lcao/FORCE_STRESS.cpp
+++ b/source/src_lcao/FORCE_STRESS.cpp
@@ -46,8 +46,9 @@ void Force_Stress_LCAO::getForceStress(
 	const bool isforce,
 	const bool isstress,
 	const bool istestf,
-	const bool istests,
-	ModuleBase::matrix &fcs,
+    const bool istests,
+    Wfc_Dm_2d &wfc_dm_2d,
+    ModuleBase::matrix& fcs,
 	ModuleBase::matrix &scs)
 {
     ModuleBase::TITLE("Force_Stress_LCAO","getForceStress");
@@ -135,6 +136,7 @@ void Force_Stress_LCAO::getForceStress(
 				GlobalV::GAMMA_ONLY_LOCAL,
 				isforce,
 				isstress,
+                wfc_dm_2d,
 				foverlap,
 				ftvnl_dphi,
 				fvnl_dbeta,
@@ -208,7 +210,7 @@ void Force_Stress_LCAO::getForceStress(
 	if (INPUT.dft_plus_u)
 	{
 		// Quxin add for DFT+U on 20201029
-		GlobalC::dftu.force_stress();
+		GlobalC::dftu.force_stress(wfc_dm_2d);
 		
         if (isforce) {
             force_dftu.create(nat, 3);
@@ -320,7 +322,7 @@ void Force_Stress_LCAO::getForceStress(
 
 				if(GlobalV::GAMMA_ONLY_LOCAL)
 				{
-    				GlobalC::ld.cal_gdmx(GlobalC::LOC.wfc_dm_2d.dm_gamma[0],
+    				GlobalC::ld.cal_gdmx(wfc_dm_2d.dm_gamma[0],
 						GlobalC::ucell,
 						GlobalC::ORB,
 						GlobalC::GridD,
@@ -328,7 +330,7 @@ void Force_Stress_LCAO::getForceStress(
 				}
 				else
 				{			
-					GlobalC::ld.cal_gdmx_k(GlobalC::LOC.wfc_dm_2d.dm_k,
+					GlobalC::ld.cal_gdmx_k(wfc_dm_2d.dm_k,
 						GlobalC::ucell,
 						GlobalC::ORB,
 						GlobalC::GridD,
@@ -722,8 +724,9 @@ void Force_Stress_LCAO::calForcePwPart(
 void Force_Stress_LCAO::calForceStressIntegralPart(
 	const bool isGammaOnly,
 	const bool isforce,
-	const bool isstress,
-	ModuleBase::matrix& foverlap,
+    const bool isstress,
+    Wfc_Dm_2d& wfc_dm_2d,
+    ModuleBase::matrix& foverlap,
 	ModuleBase::matrix& ftvnl_dphi,
 	ModuleBase::matrix& fvnl_dbeta,
 	ModuleBase::matrix& fvl_dphi,
@@ -742,6 +745,7 @@ void Force_Stress_LCAO::calForceStressIntegralPart(
     	flk.ftable_gamma(
 				isforce,
 				isstress,
+                wfc_dm_2d,
 				foverlap,
 				ftvnl_dphi,
 				fvnl_dbeta,
@@ -761,6 +765,7 @@ void Force_Stress_LCAO::calForceStressIntegralPart(
 		flk.ftable_k(
 				isforce,
 				isstress,
+                wfc_dm_2d,
 				foverlap,
 				ftvnl_dphi,
 				fvnl_dbeta,

--- a/source/src_lcao/FORCE_STRESS.h
+++ b/source/src_lcao/FORCE_STRESS.h
@@ -42,8 +42,9 @@ class Force_Stress_LCAO
 		const bool isforce, 
 		const bool isstress, 
 		const bool istestf, 
-		const bool istests, 
-		ModuleBase::matrix &fcs, 
+        const bool istests,
+        Wfc_Dm_2d &wfc_dm_2d,
+        ModuleBase::matrix& fcs,
 		ModuleBase::matrix &scs);
 
 	void forceSymmetry(ModuleBase::matrix &fcs);
@@ -57,8 +58,9 @@ class Force_Stress_LCAO
 	void calForceStressIntegralPart(
 		const bool isGammaOnly,
 		const bool isforce,
-		const bool isstress,
-		ModuleBase::matrix &foverlap,
+        const bool isstress,
+        Wfc_Dm_2d &wfc_dm_2d,
+        ModuleBase::matrix& foverlap,
 		ModuleBase::matrix &ftvnl_dphi,
 		ModuleBase::matrix &fvnl_dbeta,	
 		ModuleBase::matrix &fvl_dphi,

--- a/source/src_lcao/FORCE_gamma.cpp
+++ b/source/src_lcao/FORCE_gamma.cpp
@@ -16,8 +16,9 @@ Force_LCAO_gamma::~Force_LCAO_gamma ()
 // be called in force_lo.cpp
 void Force_LCAO_gamma::ftable_gamma (
 	const bool isforce,
-	const bool isstress,
-	ModuleBase::matrix& foverlap,
+    const bool isstress,
+    Wfc_Dm_2d& wfc_dm_2d,
+    ModuleBase::matrix& foverlap,
 	ModuleBase::matrix& ftvnl_dphi,
 	ModuleBase::matrix& fvnl_dbeta,	
 	ModuleBase::matrix& fvl_dphi,
@@ -39,24 +40,24 @@ void Force_LCAO_gamma::ftable_gamma (
     this->allocate_gamma();
 
     // calculate the 'energy density matrix' here.
-    this->cal_foverlap(isforce, isstress, foverlap, soverlap);
+    this->cal_foverlap(isforce, isstress, wfc_dm_2d, foverlap, soverlap);
 
-    this->cal_ftvnl_dphi(GlobalC::LOC.wfc_dm_2d.dm_gamma, isforce, isstress, ftvnl_dphi, stvnl_dphi);
-    this->calFvnlDbeta(GlobalC::LOC.wfc_dm_2d.dm_gamma, isforce, isstress, fvnl_dbeta, svnl_dbeta, GlobalV::vnl_method);
-    this->cal_fvl_dphi(GlobalC::LOC.wfc_dm_2d.dm_gamma, isforce, isstress, fvl_dphi, svl_dphi);
+    this->cal_ftvnl_dphi(wfc_dm_2d.dm_gamma, isforce, isstress, ftvnl_dphi, stvnl_dphi);
+    this->calFvnlDbeta(wfc_dm_2d.dm_gamma, isforce, isstress, fvnl_dbeta, svnl_dbeta, GlobalV::vnl_method);
+    this->cal_fvl_dphi(wfc_dm_2d.dm_gamma, isforce, isstress, fvl_dphi, svl_dphi);
     
     //caoyu add for DeePKS
 #ifdef __DEEPKS
     if (GlobalV::deepks_scf)
     {
-		GlobalC::ld.cal_projected_DM(GlobalC::LOC.wfc_dm_2d.dm_gamma[0],
+		GlobalC::ld.cal_projected_DM(wfc_dm_2d.dm_gamma[0],
             GlobalC::ucell,
             GlobalC::ORB,
             GlobalC::GridD,
             GlobalC::ParaO);
     	GlobalC::ld.cal_descriptor();
         GlobalC::ld.cal_gedm(GlobalC::ucell.nat);
-        GlobalC::ld.cal_f_delta_gamma(GlobalC::LOC.wfc_dm_2d.dm_gamma[0],
+        GlobalC::ld.cal_f_delta_gamma(wfc_dm_2d.dm_gamma[0],
             GlobalC::ucell,
             GlobalC::ORB,
             GlobalC::GridD,

--- a/source/src_lcao/FORCE_gamma.h
+++ b/source/src_lcao/FORCE_gamma.h
@@ -5,6 +5,7 @@
 #include "../module_base/global_variable.h"
 #include "../module_base/matrix.h"
 #include "LCAO_matrix.h" 
+#include "wfc_dm_2d.h"
 
 class Force_LCAO_gamma
 {
@@ -20,8 +21,9 @@ class Force_LCAO_gamma
 	//orthonormal force + contribution from T and VNL
 	void ftable_gamma (
 		const bool isforce,
-		const bool isstress,
-		ModuleBase::matrix& foverlap,
+        const bool isstress,
+        Wfc_Dm_2d &wfc_dm_2d,
+        ModuleBase::matrix& foverlap,
 		ModuleBase::matrix& ftvnl_dphi,
 		ModuleBase::matrix& fvnl_dbeta,	
 		ModuleBase::matrix& fvl_dphi,
@@ -53,8 +55,9 @@ class Force_LCAO_gamma
 
 	void cal_foverlap(
 		const bool isforce, 
-		const bool isstress, 
-		ModuleBase::matrix& foverlap, 
+        const bool isstress,
+        Wfc_Dm_2d &wfc_dm_2d,
+        ModuleBase::matrix& foverlap,
 		ModuleBase::matrix& soverlap);	
 
 	//-------------------------------------------------------------

--- a/source/src_lcao/FORCE_gamma_edm.cpp
+++ b/source/src_lcao/FORCE_gamma_edm.cpp
@@ -7,8 +7,9 @@
 // need energy density matrix here.
 void Force_LCAO_gamma::cal_foverlap(
 	const bool isforce, 
-	const bool isstress, 
-	ModuleBase::matrix& foverlap, 
+    const bool isstress,
+    Wfc_Dm_2d &wfc_dm_2d,
+    ModuleBase::matrix& foverlap,
 	ModuleBase::matrix& soverlap)
 {
     ModuleBase::TITLE("Force_LCAO_gamma","cal_foverlap");
@@ -28,8 +29,8 @@ void Force_LCAO_gamma::cal_foverlap(
     }
 
     std::vector<ModuleBase::matrix> edm_gamma(GlobalV::NSPIN);
-    GlobalC::LOC.wfc_dm_2d.cal_dm(wgEkb,
-        GlobalC::LOC.wfc_dm_2d.wfc_gamma,
+    wfc_dm_2d.cal_dm(wgEkb,
+        wfc_dm_2d.wfc_gamma,
         edm_gamma);
 
     ModuleBase::timer::tick("Force_LCAO_gamma","cal_edm_2d");

--- a/source/src_lcao/FORCE_k.cpp
+++ b/source/src_lcao/FORCE_k.cpp
@@ -24,6 +24,7 @@ Force_LCAO_k::~Force_LCAO_k ()
 void Force_LCAO_k::ftable_k (
 		const bool isforce,
 		const bool isstress,
+        Wfc_Dm_2d &wfc_dm_2d,
 		ModuleBase::matrix& foverlap,
 		ModuleBase::matrix& ftvnl_dphi,
 		ModuleBase::matrix& fvnl_dbeta,	
@@ -46,7 +47,7 @@ void Force_LCAO_k::ftable_k (
 
 	// calculate the energy density matrix
 	// and the force related to overlap matrix and energy density matrix.
-	this->cal_foverlap_k(isforce, isstress, foverlap, soverlap);
+	this->cal_foverlap_k(isforce, isstress, wfc_dm_2d, foverlap, soverlap);
 
 	// calculate the density matrix
 	double** dm2d = new double*[GlobalV::NSPIN];
@@ -59,8 +60,8 @@ void Force_LCAO_k::ftable_k (
 
     Record_adj RA;
     RA.for_2d();
-    GlobalC::LOC.wfc_dm_2d.cal_dm_R(
-        GlobalC::LOC.wfc_dm_2d.dm_k,
+    wfc_dm_2d.cal_dm_R(
+        wfc_dm_2d.dm_k,
         RA, dm2d);
     
     this->cal_ftvnl_dphi_k(dm2d, isforce, isstress, ftvnl_dphi, stvnl_dphi);
@@ -76,7 +77,7 @@ void Force_LCAO_k::ftable_k (
 #ifdef __DEEPKS
     if (GlobalV::deepks_scf)
     {
-		GlobalC::ld.cal_projected_DM_k(GlobalC::LOC.wfc_dm_2d.dm_k,
+		GlobalC::ld.cal_projected_DM_k(wfc_dm_2d.dm_k,
 			GlobalC::ucell,
             GlobalC::ORB,
             GlobalC::GridD,
@@ -85,7 +86,7 @@ void Force_LCAO_k::ftable_k (
     	GlobalC::ld.cal_descriptor();
 		GlobalC::ld.cal_gedm(GlobalC::ucell.nat);
 
-        GlobalC::ld.cal_f_delta_k(GlobalC::LOC.wfc_dm_2d.dm_k,
+        GlobalC::ld.cal_f_delta_k(wfc_dm_2d.dm_k,
 			GlobalC::ucell,
             GlobalC::ORB,
             GlobalC::GridD,
@@ -237,8 +238,9 @@ void Force_LCAO_k::finish_k(void)
 
 void Force_LCAO_k::cal_foverlap_k(
 	const bool isforce, 
-	const bool isstress, 
-	ModuleBase::matrix& foverlap, 
+    const bool isstress,
+    Wfc_Dm_2d &wfc_dm_2d,
+    ModuleBase::matrix& foverlap,
 	ModuleBase::matrix& soverlap)
 {
 	ModuleBase::TITLE("Force_LCAO_k","cal_foverlap_k");
@@ -273,10 +275,10 @@ void Force_LCAO_k::cal_foverlap_k(
         }
     }
     std::vector<ModuleBase::ComplexMatrix> edm_k(GlobalC::kv.nks);
-    GlobalC::LOC.wfc_dm_2d.cal_dm(wgEkb,
-        GlobalC::LOC.wfc_dm_2d.wfc_k,
+    wfc_dm_2d.cal_dm(wgEkb,
+        wfc_dm_2d.wfc_k,
         edm_k);
-    GlobalC::LOC.wfc_dm_2d.cal_dm_R(edm_k,
+    wfc_dm_2d.cal_dm_R(edm_k,
         RA, edm2d);
     ModuleBase::timer::tick("Force_LCAO_k", "cal_edm_2d");
 

--- a/source/src_lcao/FORCE_k.h
+++ b/source/src_lcao/FORCE_k.h
@@ -6,6 +6,7 @@
 #include "../module_base/matrix.h"
 #include "LCAO_matrix.h" 
 #include "FORCE_gamma.h"
+#include "wfc_dm_2d.h"
 
 class Force_LCAO_k : public Force_LCAO_gamma
 {
@@ -21,8 +22,9 @@ class Force_LCAO_k : public Force_LCAO_gamma
 	//orthonormal force + contribution from T and VNL
 	void ftable_k (
 		const bool isforce,
-		const bool isstress,
-		ModuleBase::matrix& foverlap,
+        const bool isstress,
+        Wfc_Dm_2d &wfc_dm_2d,
+        ModuleBase::matrix& foverlap,
 		ModuleBase::matrix& ftvnl_dphi,
 		ModuleBase::matrix& fvnl_dbeta,	
 		ModuleBase::matrix& fvl_dphi,
@@ -46,7 +48,7 @@ class Force_LCAO_k : public Force_LCAO_gamma
 	void cal_ftvnl_dphi_k(double** dm2d, const bool isforce, const bool isstress, ModuleBase::matrix& ftvnl_dphi, ModuleBase::matrix& stvnl_dphi);
 
 	// calculate the overlap force
-	void cal_foverlap_k(const bool isforce, const bool isstress, ModuleBase::matrix& foverlap, ModuleBase::matrix& soverlap);
+	void cal_foverlap_k(const bool isforce, const bool isstress, Wfc_Dm_2d &wfc_dm_2d, ModuleBase::matrix& foverlap, ModuleBase::matrix& soverlap);
 
 	// calculate the force due to < phi | Vlocal | dphi >
 	void cal_fvl_dphi_k(double** dm2d, const bool isforce, const bool isstress, ModuleBase::matrix& fvl_dphi, ModuleBase::matrix& svl_dphi);

--- a/source/src_lcao/LCAO_hamilt.cpp
+++ b/source/src_lcao/LCAO_hamilt.cpp
@@ -61,7 +61,7 @@ void LCAO_Hamilt::set_lcao_matrices(void)
     return;
 }
 
-void LCAO_Hamilt::calculate_Hgamma( const int &ik )				// Peize Lin add ik 2016-12-03
+void LCAO_Hamilt::calculate_Hgamma( const int &ik , vector<ModuleBase::matrix> dm_gamma)				// Peize Lin add ik 2016-12-03
 {
     ModuleBase::TITLE("LCAO_Hamilt","calculate_Hgamma");
     ModuleBase::timer::tick("LCAO_Hamilt","cal_Hgamma");
@@ -111,7 +111,7 @@ void LCAO_Hamilt::calculate_Hgamma( const int &ik )				// Peize Lin add ik 2016-
 
 	if (GlobalV::deepks_scf)
     {
-		GlobalC::ld.cal_projected_DM(GlobalC::LOC.wfc_dm_2d.dm_gamma[0],
+		GlobalC::ld.cal_projected_DM(dm_gamma[0],
             GlobalC::ucell,
             GlobalC::ORB,
             GlobalC::GridD,

--- a/source/src_lcao/LCAO_hamilt.h
+++ b/source/src_lcao/LCAO_hamilt.h
@@ -20,7 +20,7 @@ class LCAO_Hamilt
     void calculate_Hk( const int &ik);
     
     // used for Gamma only Hamiltonian matrix.
-    void calculate_Hgamma( const int &ik );						// Peize Lin add ik 2016-12-03
+    void calculate_Hgamma( const int &ik , vector<ModuleBase::matrix> dm_gamma);						// Peize Lin add ik 2016-12-03
 
     void calculate_STN_R(void); //LiuXh add 2019-07-15
 

--- a/source/src_lcao/LOOP_cell.cpp
+++ b/source/src_lcao/LOOP_cell.cpp
@@ -10,8 +10,7 @@
 LOOP_cell::LOOP_cell(){}
 LOOP_cell::~LOOP_cell(){}
 
-void LOOP_cell::opt_cell(std::vector<ModuleBase::matrix> &wfc_gamma,
-    std::vector<ModuleBase::ComplexMatrix> &wfc_k)
+void LOOP_cell::opt_cell()
 {
 	ModuleBase::TITLE("LOOP_cell","opt_cell");
 
@@ -68,9 +67,7 @@ void LOOP_cell::opt_cell(std::vector<ModuleBase::matrix> &wfc_gamma,
   if(INPUT.dft_plus_dmft) GlobalC::dmft.init(INPUT, GlobalC::ucell);
 
 	LOOP_ions ions;
-    ions.opt_ions(wfc_gamma, wfc_k);
-
-    
+    ions.opt_ions();
 
 	// mohan update 2021-02-10
     GlobalC::LOWF.orb_con.clear_after_ions(GlobalC::UOT, GlobalC::ORB, GlobalV::out_descriptor, GlobalC::ucell.infoNL.nproj);

--- a/source/src_lcao/LOOP_cell.cpp
+++ b/source/src_lcao/LOOP_cell.cpp
@@ -10,7 +10,8 @@
 LOOP_cell::LOOP_cell(){}
 LOOP_cell::~LOOP_cell(){}
 
-void LOOP_cell::opt_cell(void)
+void LOOP_cell::opt_cell(std::vector<ModuleBase::matrix> &wfc_gamma,
+    std::vector<ModuleBase::ComplexMatrix> &wfc_k)
 {
 	ModuleBase::TITLE("LOOP_cell","opt_cell");
 
@@ -67,7 +68,9 @@ void LOOP_cell::opt_cell(void)
   if(INPUT.dft_plus_dmft) GlobalC::dmft.init(INPUT, GlobalC::ucell);
 
 	LOOP_ions ions;
-	ions.opt_ions();
+    ions.opt_ions(wfc_gamma, wfc_k);
+
+    
 
 	// mohan update 2021-02-10
     GlobalC::LOWF.orb_con.clear_after_ions(GlobalC::UOT, GlobalC::ORB, GlobalV::out_descriptor, GlobalC::ucell.infoNL.nproj);

--- a/source/src_lcao/LOOP_cell.h
+++ b/source/src_lcao/LOOP_cell.h
@@ -11,8 +11,7 @@ class LOOP_cell
 	LOOP_cell();
 	~LOOP_cell();
 
-	void opt_cell(std::vector<ModuleBase::matrix> &wfc_gamma,
-    std::vector<ModuleBase::ComplexMatrix> &wfc_k);
+	void opt_cell();
 
 };
 

--- a/source/src_lcao/LOOP_cell.h
+++ b/source/src_lcao/LOOP_cell.h
@@ -1,14 +1,18 @@
 #ifndef LOOP_CELL_H
 #define LOOP_CELL_H
+#include<vector>
+#include "module_base/matrix.h"
+#include "module_base/complexmatrix.h"
 
-class LOOP_cell 
+class LOOP_cell
 {
 	public:
 
 	LOOP_cell();
 	~LOOP_cell();
 
-	void opt_cell(void);
+	void opt_cell(std::vector<ModuleBase::matrix> &wfc_gamma,
+    std::vector<ModuleBase::ComplexMatrix> &wfc_k);
 
 };
 

--- a/source/src_lcao/LOOP_elec.cpp
+++ b/source/src_lcao/LOOP_elec.cpp
@@ -216,7 +216,7 @@ void LOOP_elec::solver(const int& istep,
 				for( size_t hybrid_step=0; hybrid_step!=GlobalC::exx_global.info.hybrid_step; ++hybrid_step )
 				{
 					GlobalC::exx_global.info.set_xcfunc(GlobalC::xcf);
-					GlobalC::exx_lcao.cal_exx_elec();
+					GlobalC::exx_lcao.cal_exx_elec(wfc_dm_2d.dm_gamma, wfc_dm_2d.dm_k);
 					
 					ELEC_scf es;
 					es.scf(istep-1, wfc_dm_2d.wfc_gamma, wfc_dm_2d.dm_gamma, wfc_dm_2d.wfc_k, wfc_dm_2d.dm_k);

--- a/source/src_lcao/LOOP_elec.cpp
+++ b/source/src_lcao/LOOP_elec.cpp
@@ -26,7 +26,8 @@
 #include "../module_deepks/LCAO_deepks.h"
 #endif
 
-void LOOP_elec::solve_elec_stru(const int &istep)
+void LOOP_elec::solve_elec_stru(const int& istep,
+    Wfc_Dm_2d &wfc_dm_2d)
 {
     ModuleBase::TITLE("LOOP_elec","solve_elec_stru"); 
     ModuleBase::timer::tick("LOOP_elec","solve_elec_stru"); 
@@ -34,9 +35,9 @@ void LOOP_elec::solve_elec_stru(const int &istep)
 	// prepare HS matrices, prepare grid integral
 	this->set_matrix_grid();
 	// density matrix extrapolation and prepare S,T,VNL matrices 
-	this->before_solver(istep);
+	this->before_solver(istep, wfc_dm_2d);
 	// do self-interaction calculations / nscf/ tddft, etc. 
-	this->solver(istep);
+	this->solver(istep, wfc_dm_2d);
 
     ModuleBase::timer::tick("LOOP_elec","solve_elec_stru"); 
 	return;
@@ -94,7 +95,7 @@ void LOOP_elec::set_matrix_grid(void)
 }
 
 
-void LOOP_elec::before_solver(const int &istep)
+void LOOP_elec::before_solver(const int &istep, Wfc_Dm_2d &wfc_dm_2d)
 {
     ModuleBase::TITLE("LOOP_elec","before_solver"); 
     ModuleBase::timer::tick("LOOP_elec","before_solver"); 
@@ -105,7 +106,7 @@ void LOOP_elec::before_solver(const int &istep)
 	// the force.
 
 	// init density kernel and wave functions.
-	GlobalC::LOC.allocate_dm_wfc(GlobalC::GridT);
+	GlobalC::LOC.allocate_dm_wfc(GlobalC::GridT, wfc_dm_2d);
 
 	//======================================
 	// do the charge extrapolation before the density matrix is regenerated.
@@ -169,7 +170,8 @@ void LOOP_elec::before_solver(const int &istep)
 	return;
 }
 
-void LOOP_elec::solver(const int &istep)
+void LOOP_elec::solver(const int& istep,
+    Wfc_Dm_2d &wfc_dm_2d)
 {
     ModuleBase::TITLE("LOOP_elec","solver"); 
     ModuleBase::timer::tick("LOOP_elec","solver"); 
@@ -197,8 +199,9 @@ void LOOP_elec::solver(const int &istep)
 		if( Exx_Global::Hybrid_Type::No==GlobalC::exx_global.info.hybrid_type  )
 		{
 			ELEC_scf es;
-			es.scf(istep-1);
-		}
+            es.scf(istep - 1, wfc_dm_2d.wfc_gamma, wfc_dm_2d.dm_gamma,
+                wfc_dm_2d.wfc_k, wfc_dm_2d.dm_k);
+        }
 		else if( Exx_Global::Hybrid_Type::Generate_Matrix == GlobalC::exx_global.info.hybrid_type )
 		{
 			Exx_Opt_Orb exx_opt_orb;
@@ -207,7 +210,7 @@ void LOOP_elec::solver(const int &istep)
 		else    // Peize Lin add 2016-12-03
 		{
 			ELEC_scf es;
-			es.scf(istep-1);
+			es.scf(istep-1, wfc_dm_2d.wfc_gamma, wfc_dm_2d.dm_gamma, wfc_dm_2d.wfc_k, wfc_dm_2d.dm_k);
 			if( GlobalC::exx_global.info.separate_loop )
 			{
 				for( size_t hybrid_step=0; hybrid_step!=GlobalC::exx_global.info.hybrid_step; ++hybrid_step )
@@ -216,7 +219,7 @@ void LOOP_elec::solver(const int &istep)
 					GlobalC::exx_lcao.cal_exx_elec();
 					
 					ELEC_scf es;
-					es.scf(istep-1);
+					es.scf(istep-1, wfc_dm_2d.wfc_gamma, wfc_dm_2d.dm_gamma, wfc_dm_2d.wfc_k, wfc_dm_2d.dm_k);
 					if(ELEC_scf::iter==1)     // exx converge
 					{
 						break;
@@ -228,14 +231,15 @@ void LOOP_elec::solver(const int &istep)
 				GlobalC::exx_global.info.set_xcfunc(GlobalC::xcf);
 
 				ELEC_scf es;
-				es.scf(istep-1);
+				es.scf(istep-1, wfc_dm_2d.wfc_gamma, wfc_dm_2d.dm_gamma,
+                wfc_dm_2d.wfc_k, wfc_dm_2d.dm_k);
 				
 			}
 		}
 	}
 	else if (GlobalV::CALCULATION=="nscf")
 	{
-		ELEC_nscf::nscf(GlobalC::UHM);
+		ELEC_nscf::nscf(GlobalC::UHM, wfc_dm_2d.wfc_gamma, wfc_dm_2d.dm_gamma, wfc_dm_2d.wfc_k, wfc_dm_2d.dm_k);
 	}
 	else if (GlobalV::CALCULATION=="istate")
 	{

--- a/source/src_lcao/LOOP_elec.cpp
+++ b/source/src_lcao/LOOP_elec.cpp
@@ -243,7 +243,7 @@ void LOOP_elec::solver(const int& istep,
 	}
 	else if (GlobalV::CALCULATION=="istate")
 	{
-		IState_Charge ISC;
+		IState_Charge ISC(&wfc_dm_2d.wfc_gamma, &wfc_dm_2d.dm_gamma);
 		ISC.begin();
 	}
 	else if (GlobalV::CALCULATION=="ienvelope")

--- a/source/src_lcao/LOOP_elec.h
+++ b/source/src_lcao/LOOP_elec.h
@@ -3,6 +3,7 @@
 
 #include "../module_base/global_function.h"
 #include "../module_base/global_variable.h"
+#include "wfc_dm_2d.h"
 
 class LOOP_elec
 {
@@ -12,16 +13,18 @@ class LOOP_elec
 	~LOOP_elec(){};
 
 	// mohan add 2021-02-09
-	void solve_elec_stru(const int &istep);
+    void solve_elec_stru(const int& istep,
+        Wfc_Dm_2d& wfc_dm_2d);
 
 	private:
 
 	// set matrix and grid integral
 	void set_matrix_grid(void);
 
-	void before_solver(const int &istep);
+	void before_solver(const int &istep, Wfc_Dm_2d &wfc_dm_2d);
 
-	void solver(const int &istep); 
+    void solver(const int& istep,
+        Wfc_Dm_2d &wfc_dm_2d);
 
 };
 

--- a/source/src_lcao/LOOP_ions.cpp
+++ b/source/src_lcao/LOOP_ions.cpp
@@ -30,8 +30,7 @@ LOOP_ions::LOOP_ions()
 LOOP_ions::~LOOP_ions()
 {}
 
-void LOOP_ions::opt_ions(std::vector<ModuleBase::matrix> &wfc_gamma,
-    std::vector<ModuleBase::ComplexMatrix> &wfc_k)
+void LOOP_ions::opt_ions()
 {
     ModuleBase::TITLE("LOOP_ions","opt_ions");
     ModuleBase::timer::tick("LOOP_ions","opt_ions");
@@ -285,10 +284,8 @@ void LOOP_ions::opt_ions(std::vector<ModuleBase::matrix> &wfc_gamma,
 
     }
 
-    //copy wfc for dos
-    wfc_gamma = this->wfc_dm_2d.wfc_gamma;
-    wfc_k = this->wfc_dm_2d.wfc_k;
-    
+    GlobalC::en.perform_dos(this->wfc_dm_2d.wfc_gamma, this->wfc_dm_2d.wfc_k);
+
     ModuleBase::timer::tick("LOOP_ions", "opt_ions");
     return;
 }

--- a/source/src_lcao/LOOP_ions.h
+++ b/source/src_lcao/LOOP_ions.h
@@ -18,7 +18,8 @@ class LOOP_ions
 
 	LOOP_elec LOE;
 
-	void opt_ions(void);
+	void opt_ions(std::vector<ModuleBase::matrix> &wfc_gamma,
+        std::vector<ModuleBase::ComplexMatrix> &wfc_k); //output for dos
 	void output_HS_R(
         const std::string &SR_filename="data-SR-sparse_SPIN0.csr",
         const std::string &HR_filename_up="data-HR-sparse_SPIN0.csr",
@@ -32,7 +33,9 @@ class LOOP_ions
 
 	Ions_Move_Methods IMM;
 
-	Lattice_Change_Methods LCM;
+    Lattice_Change_Methods LCM;
+
+    Wfc_Dm_2d wfc_dm_2d;
 
 	
 	// PLEASE move 'force_stress()'  function to other places, such as FORCE_STRESS.cpp or

--- a/source/src_lcao/LOOP_ions.h
+++ b/source/src_lcao/LOOP_ions.h
@@ -18,8 +18,7 @@ class LOOP_ions
 
 	LOOP_elec LOE;
 
-	void opt_ions(std::vector<ModuleBase::matrix> &wfc_gamma,
-        std::vector<ModuleBase::ComplexMatrix> &wfc_k); //output for dos
+	void opt_ions(); //output for dos
 	void output_HS_R(
         const std::string &SR_filename="data-SR-sparse_SPIN0.csr",
         const std::string &HR_filename_up="data-HR-sparse_SPIN0.csr",

--- a/source/src_lcao/dftu.cpp
+++ b/source/src_lcao/dftu.cpp
@@ -277,7 +277,7 @@ void DFTU::init(
     return;
 }
 
-void DFTU::cal_occup_m_k(const int iter)
+void DFTU::cal_occup_m_k(const int iter,  std::vector<ModuleBase::ComplexMatrix> &dm_k)
 {
 	ModuleBase::TITLE("DFTU", "cal_occup_m_k");
 	ModuleBase::timer::tick("DFTU", "cal_occup_m_k");
@@ -333,7 +333,7 @@ void DFTU::cal_occup_m_k(const int iter)
 				&GlobalV::NLOCAL, &GlobalV::NLOCAL, &GlobalV::NLOCAL,
 				&alpha, 
 				&Sk[0], &one_int, &one_int, GlobalC::ParaO.desc, 
-				GlobalC::LOC.wfc_dm_2d.dm_k.at(ik).c, &one_int, &one_int, GlobalC::ParaO.desc,
+				dm_k.at(ik).c, &one_int, &one_int, GlobalC::ParaO.desc,
 				&beta, 
 				&srho[0], &one_int, &one_int, GlobalC::ParaO.desc);
 
@@ -489,7 +489,7 @@ void DFTU::cal_occup_m_k(const int iter)
 	return;
 }
 
-void DFTU::cal_occup_m_gamma(const int iter)
+void DFTU::cal_occup_m_gamma(const int iter,  std::vector<ModuleBase::matrix> &dm_gamma)
 {
 	ModuleBase::TITLE("DFTU", "cal_occup_m_gamma");	
 	ModuleBase::timer::tick("DFTU", "cal_occup_m_gamma");
@@ -531,7 +531,7 @@ void DFTU::cal_occup_m_gamma(const int iter)
 				&GlobalV::NLOCAL, &GlobalV::NLOCAL, &GlobalV::NLOCAL,
 				&alpha, 
 				GlobalC::LM.Sloc.data(), &one_int, &one_int, GlobalC::ParaO.desc, 
-				GlobalC::LOC.wfc_dm_2d.dm_gamma.at(is).c, &one_int, &one_int, GlobalC::ParaO.desc,
+				dm_gamma.at(is).c, &one_int, &one_int, GlobalC::ParaO.desc,
 				&beta,
 				&srho[0], &one_int, &one_int, GlobalC::ParaO.desc);
 

--- a/source/src_lcao/dftu.h
+++ b/source/src_lcao/dftu.h
@@ -37,8 +37,8 @@ public:
     static void folding_overlap_matrix(const int ik, std::complex<double>* Sk);
     
     //calculate the local occupation number matrix
-    void cal_occup_m_k(const int iter);
-    void cal_occup_m_gamma(const int iter);
+    void cal_occup_m_k(const int iter,  std::vector<ModuleBase::ComplexMatrix> &dm_k);
+    void cal_occup_m_gamma(const int iter,  std::vector<ModuleBase::matrix> &dm_gamma);
 
     void write_occup_m(const std::string &fn);
     void read_occup_m(const std::string &fn);

--- a/source/src_lcao/dftu_relax.cpp
+++ b/source/src_lcao/dftu_relax.cpp
@@ -49,7 +49,7 @@ DFTU_RELAX::DFTU_RELAX(){}
 
 DFTU_RELAX::~DFTU_RELAX(){}
 
-void DFTU_RELAX::force_stress()
+void DFTU_RELAX::force_stress(Wfc_Dm_2d &wfc_dm_2d)
 {
 	ModuleBase::TITLE("DFTU_RELAX", "force_stress");
 	ModuleBase::timer::tick("DFTU_RELAX", "force_stress");
@@ -94,7 +94,7 @@ void DFTU_RELAX::force_stress()
 			pdgemm_(&transT, &transN,
 					    &GlobalV::NLOCAL, &GlobalV::NLOCAL, &GlobalV::NLOCAL,
 					    &alpha, 
-					    GlobalC::LOC.wfc_dm_2d.dm_gamma[spin].c, &one_int, &one_int, GlobalC::ParaO.desc, 
+					    wfc_dm_2d.dm_gamma[spin].c, &one_int, &one_int, GlobalC::ParaO.desc, 
 					    VU, &one_int, &one_int, GlobalC::ParaO.desc,
 					    &beta,
 					    &rho_VU[0], &one_int, &one_int, GlobalC::ParaO.desc);
@@ -123,7 +123,7 @@ void DFTU_RELAX::force_stress()
 			pzgemm_(&transT, &transN,
 					    &GlobalV::NLOCAL, &GlobalV::NLOCAL, &GlobalV::NLOCAL,
 					    &alpha, 
-					    GlobalC::LOC.wfc_dm_2d.dm_k[ik].c, &one_int, &one_int, GlobalC::ParaO.desc, 
+					    wfc_dm_2d.dm_k[ik].c, &one_int, &one_int, GlobalC::ParaO.desc, 
 					    VU, &one_int, &one_int, GlobalC::ParaO.desc,
 					    &beta,
 					    &rho_VU[0], &one_int, &one_int, GlobalC::ParaO.desc);

--- a/source/src_lcao/dftu_relax.h
+++ b/source/src_lcao/dftu_relax.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include "dftu_yukawa.h"
 #include "../module_base/complexmatrix.h"
+#include "wfc_dm_2d.h"
 
 using namespace std;
 
@@ -24,7 +25,7 @@ public:
     DFTU_RELAX();
     ~DFTU_RELAX();
 
-    void force_stress();
+    void force_stress(Wfc_Dm_2d &wfc_dm_2d);
     void cal_force_k(const int ik, const std::complex<double>* rho_VU);
     void cal_stress_k(const int ik, const std::complex<double>* rho_VU);
     void cal_force_gamma(const double* rho_VU);

--- a/source/src_lcao/dmft.cpp
+++ b/source/src_lcao/dmft.cpp
@@ -92,7 +92,7 @@ namespace ModuleDMFT
     return;
   }
 
-  void DFT_DMFT_interface::out_to_dmft()
+  void DFT_DMFT_interface::out_to_dmft( std::vector<ModuleBase::ComplexMatrix> wfc_k)
   {
     ModuleBase::TITLE("DFT_DMFT_interface", "out_to_dmft");
     
@@ -102,7 +102,7 @@ namespace ModuleDMFT
 
     this->out_correlated_atom_info();
 
-    this->out_eigen_vector(GlobalC::LOC.wfc_dm_2d.wfc_k);
+    this->out_eigen_vector(wfc_k);
     
     this->out_bands(GlobalC::wf.ekb, GlobalC::en.ef, GlobalC::CHR.nelec);
 

--- a/source/src_lcao/dmft.h
+++ b/source/src_lcao/dmft.h
@@ -22,7 +22,7 @@ namespace ModuleDMFT
 
     public:
     void init(Input& in, UnitCell_pseudo &cell);
-    void out_to_dmft();
+    void out_to_dmft( std::vector<ModuleBase::ComplexMatrix> wfc_k);
     void out_kvector();
     void out_correlated_atom_info();
     void out_eigen_vector(const std::vector<ModuleBase::ComplexMatrix>& wfc);

--- a/source/src_lcao/local_orbital_charge.cpp
+++ b/source/src_lcao/local_orbital_charge.cpp
@@ -88,7 +88,7 @@ void Local_Orbital_Charge::allocate_dm_wfc(const Grid_Technique &gt, Wfc_Dm_2d &
 	}
 	else
 	{
-		GlobalC::LOWF.allocate_k(gt);
+		GlobalC::LOWF.allocate_k(gt, wfc_dm_2d.wfc_k);
 		this->allocate_DM_k();
 	}
 

--- a/source/src_lcao/local_orbital_charge.cpp
+++ b/source/src_lcao/local_orbital_charge.cpp
@@ -76,9 +76,10 @@ Local_Orbital_Charge::~Local_Orbital_Charge()
 
 
 
-void Local_Orbital_Charge::allocate_dm_wfc(const Grid_Technique &gt)
+void Local_Orbital_Charge::allocate_dm_wfc(const Grid_Technique &gt, Wfc_Dm_2d &wfc_dm_2d)
 {
-    ModuleBase::TITLE("Local_Orbital_Charge","allocate_dm_wfc");
+    ModuleBase::TITLE("Local_Orbital_Charge", "allocate_dm_wfc");
+    this->wfc_dm_2d = &wfc_dm_2d;
 
 	if(GlobalV::GAMMA_ONLY_LOCAL)
 	{
@@ -124,9 +125,9 @@ void Local_Orbital_Charge::sum_bands(void)
             //density matrix has already been calculated.
             ModuleBase::timer::tick("LCAO_Charge","cal_dm_2d");
 
-            wfc_dm_2d.cal_dm(GlobalC::wf.wg,
-                wfc_dm_2d.wfc_gamma,
-                wfc_dm_2d.dm_gamma);        // Peize Lin test 2019-01-16
+            wfc_dm_2d->cal_dm(GlobalC::wf.wg,
+                wfc_dm_2d->wfc_gamma,
+                wfc_dm_2d->dm_gamma);        // Peize Lin test 2019-01-16
 
             ModuleBase::timer::tick("LCAO_Charge","cal_dm_2d");
 
@@ -143,9 +144,9 @@ void Local_Orbital_Charge::sum_bands(void)
         this->cal_dk_k( GlobalC::GridT );
         if(GlobalV::KS_SOLVER=="genelpa" || GlobalV::KS_SOLVER=="scalapack_gvx")        // Peize Lin test 2019-05-15
 		{
-            wfc_dm_2d.cal_dm(GlobalC::wf.wg,
-            wfc_dm_2d.wfc_k, 
-            wfc_dm_2d.dm_k);
+            wfc_dm_2d->cal_dm(GlobalC::wf.wg,
+            wfc_dm_2d->wfc_k, 
+            wfc_dm_2d->dm_k);
         }
     }
 

--- a/source/src_lcao/local_orbital_charge.h
+++ b/source/src_lcao/local_orbital_charge.h
@@ -16,7 +16,7 @@ class Local_Orbital_Charge
 	~Local_Orbital_Charge();
 
 	// mohan added 2021-02-08
-	void allocate_dm_wfc(const Grid_Technique &gt);
+	void allocate_dm_wfc(const Grid_Technique &gt, Wfc_Dm_2d &wfc_dm_2d);
 	// sum bands to compute the electron charge density
 	void sum_bands(void);
 
@@ -25,8 +25,9 @@ class Local_Orbital_Charge
 	//-----------------
 	void allocate_gamma(const Grid_Technique &gt);
 
-	void gamma_file(const Grid_Technique &gt);
-	void cal_dk_gamma_from_2D_pub(void);
+    void gamma_file(const Grid_Technique& gt,
+        std::vector<ModuleBase::matrix> &wfc_gamma);
+    void cal_dk_gamma_from_2D_pub(void);
 
 
 	//-----------------
@@ -34,7 +35,8 @@ class Local_Orbital_Charge
 	//-----------------
 	void allocate_DM_k(void);
 	
-	void kpt_file(const Grid_Technique &gt);
+    void kpt_file(const Grid_Technique& gt,
+        std::vector<ModuleBase::ComplexMatrix> &wfc_k);
 
 	// liaochen modify on 2010-3-23 
 	// change its state from private to public
@@ -48,7 +50,8 @@ class Local_Orbital_Charge
 
 	void read_dm(const int &is, const std::string &fn);
 	
-	Wfc_Dm_2d wfc_dm_2d;		// Peize Lin test 2019-01-16
+    Wfc_Dm_2d* wfc_dm_2d;		// Peize Lin test 2019-01-16 
+    //trying to change it to pointer
 
 private:
 

--- a/source/src_lcao/local_orbital_wfc.cpp
+++ b/source/src_lcao/local_orbital_wfc.cpp
@@ -40,7 +40,8 @@ Local_Orbital_wfc::~Local_Orbital_wfc()
 
 }
 
-void Local_Orbital_wfc::allocate_k(const Grid_Technique &gt)
+void Local_Orbital_wfc::allocate_k(const Grid_Technique& gt,
+    std::vector<ModuleBase::ComplexMatrix>& wfc_k)
 {
 	ModuleBase::TITLE("Local_Orbital_wfc","allocate_k");
 	if(GlobalV::NLOCAL < GlobalV::NBANDS)
@@ -100,7 +101,7 @@ void Local_Orbital_wfc::allocate_k(const Grid_Technique &gt)
 		for(int ik=0; ik<GlobalC::kv.nkstot; ++ik)
 		{
 			GlobalV::ofs_running << " Read in wave functions " << ik + 1 << std::endl;
-			error = WF_Local::read_lowf_complex( this->WFC_K[ik], ik , 0);
+			error = WF_Local::read_lowf_complex( this->WFC_K[ik], ik, &wfc_k);
 		}
 #ifdef __MPI
 		Parallel_Common::bcast_int(error);

--- a/source/src_lcao/local_orbital_wfc.h
+++ b/source/src_lcao/local_orbital_wfc.h
@@ -21,8 +21,9 @@ class Local_Orbital_wfc
 	std::complex<double>* WFC_K_POOL; // [NK*GlobalV::NBANDS*GlobalV::NLOCAL]
 
 
-    void allocate_k(const Grid_Technique& gt);
-    
+    void allocate_k(const Grid_Technique& gt,
+        std::vector<ModuleBase::ComplexMatrix> &wfc_k);
+
     //=========================================
     // Init Cij, make it satisfy 2 conditions:
     // (1) Unit

--- a/source/src_lcao/run_md_lcao.cpp
+++ b/source/src_lcao/run_md_lcao.cpp
@@ -232,16 +232,18 @@ void Run_MD_LCAO::md_force_virial(
         GlobalC::en.evdw = vdwd3.get_energy();
     }
 
+    Wfc_Dm_2d wfc_dm_2d_md;
+    wfc_dm_2d_md.init();
     // solve electronic structures in terms of LCAO
-	// mohan add 2021-02-09
+    // mohan add 2021-02-09
     LOOP_elec LOE;
-	LOE.solve_elec_stru(istep+1);
+	LOE.solve_elec_stru(istep+1, wfc_dm_2d_md);
 
     //to call the force of each atom
 	ModuleBase::matrix fcs;//temp force matrix
 	Force_Stress_LCAO FSL;
 	FSL.allocate (); 
-	FSL.getForceStress(GlobalV::FORCE, GlobalV::STRESS, GlobalV::TEST_FORCE, GlobalV::TEST_STRESS, fcs, virial);
+	FSL.getForceStress(GlobalV::FORCE, GlobalV::STRESS, GlobalV::TEST_FORCE, GlobalV::TEST_STRESS, wfc_dm_2d_md, fcs, virial);
 
 	for(int ion=0; ion<numIon; ++ion)
     {

--- a/source/src_pw/energy.cpp
+++ b/source/src_pw/energy.cpp
@@ -69,21 +69,12 @@ void energy::calculate_harris(const int &flag)
 		}
 #endif
 #ifdef __DEEPKS
-        if(GlobalV::deepks_scf) 
-		{
-			this->etot_harris += GlobalC::ld.E_delta;  //caoyu add 2021-08-10
-			if(GlobalV::GAMMA_ONLY_LOCAL)
-			{
-				GlobalC::ld.cal_e_delta_band(GlobalC::LOC.wfc_dm_2d->dm_gamma,GlobalC::ParaO);
-			}
-			else
-			{
-				GlobalC::ld.cal_e_delta_band_k(GlobalC::LOC.wfc_dm_2d->dm_k,GlobalC::ParaO,GlobalC::kv.nks);
-			}
-			this->etot_harris -= GlobalC::ld.e_delta_band;
-		}
+        if (GlobalV::deepks_scf)
+        {
+            this->etot_harris += GlobalC::ld.E_delta - GlobalC::ld.e_delta_band;
+        }
 #endif
-	}
+    }
 	
 	return;
 }
@@ -126,16 +117,7 @@ void energy::calculate_etot(void)
 #ifdef __DEEPKS
 	if (GlobalV::deepks_scf)
 	{
-		this->etot += GlobalC::ld.E_delta;
-		if(GlobalV::GAMMA_ONLY_LOCAL)
-		{
-			GlobalC::ld.cal_e_delta_band(GlobalC::LOC.wfc_dm_2d->dm_gamma, GlobalC::ParaO);
-		}
-		else
-		{
-			GlobalC::ld.cal_e_delta_band_k(GlobalC::LOC.wfc_dm_2d->dm_k,GlobalC::ParaO,GlobalC::kv.nks);
-		}
-        this->etot -= GlobalC::ld.e_delta_band;
+		this->etot += GlobalC::ld.E_delta - GlobalC::ld.e_delta_band;
 	}
 #endif
 	return;

--- a/source/src_pw/energy.cpp
+++ b/source/src_pw/energy.cpp
@@ -74,11 +74,11 @@ void energy::calculate_harris(const int &flag)
 			this->etot_harris += GlobalC::ld.E_delta;  //caoyu add 2021-08-10
 			if(GlobalV::GAMMA_ONLY_LOCAL)
 			{
-				GlobalC::ld.cal_e_delta_band(GlobalC::LOC.wfc_dm_2d.dm_gamma,GlobalC::ParaO);
+				GlobalC::ld.cal_e_delta_band(GlobalC::LOC.wfc_dm_2d->dm_gamma,GlobalC::ParaO);
 			}
 			else
 			{
-				GlobalC::ld.cal_e_delta_band_k(GlobalC::LOC.wfc_dm_2d.dm_k,GlobalC::ParaO,GlobalC::kv.nks);
+				GlobalC::ld.cal_e_delta_band_k(GlobalC::LOC.wfc_dm_2d->dm_k,GlobalC::ParaO,GlobalC::kv.nks);
 			}
 			this->etot_harris -= GlobalC::ld.e_delta_band;
 		}
@@ -129,11 +129,11 @@ void energy::calculate_etot(void)
 		this->etot += GlobalC::ld.E_delta;
 		if(GlobalV::GAMMA_ONLY_LOCAL)
 		{
-			GlobalC::ld.cal_e_delta_band(GlobalC::LOC.wfc_dm_2d.dm_gamma, GlobalC::ParaO);
+			GlobalC::ld.cal_e_delta_band(GlobalC::LOC.wfc_dm_2d->dm_gamma, GlobalC::ParaO);
 		}
 		else
 		{
-			GlobalC::ld.cal_e_delta_band_k(GlobalC::LOC.wfc_dm_2d.dm_k,GlobalC::ParaO,GlobalC::kv.nks);
+			GlobalC::ld.cal_e_delta_band_k(GlobalC::LOC.wfc_dm_2d->dm_k,GlobalC::ParaO,GlobalC::kv.nks);
 		}
         this->etot -= GlobalC::ld.e_delta_band;
 	}

--- a/source/src_pw/energy.h
+++ b/source/src_pw/energy.h
@@ -26,7 +26,8 @@ class energy
     energy();
     ~energy();
 
-	void perform_dos(void);
+	void perform_dos(std::vector<ModuleBase::matrix> &wfc_gamma,
+    std::vector<ModuleBase::ComplexMatrix> &wfc_k);
 	void perform_dos_pw(void);
 
     double etot;    	   // the total energy of the solid

--- a/source/src_ri/exx_abfs-parallel-communicate-dm3.cpp
+++ b/source/src_ri/exx_abfs-parallel-communicate-dm3.cpp
@@ -95,12 +95,14 @@ Exx_Abfs::Parallel::Communicate::DM3::K_to_R(const std::vector<ModuleBase::Compl
 */
 
 #ifdef __MPI
-void Exx_Abfs::Parallel::Communicate::DM3::cal_DM(const double threshold_D)
+void Exx_Abfs::Parallel::Communicate::DM3::cal_DM(const double threshold_D,
+    std::vector<ModuleBase::matrix> &dm_gamma,
+    std::vector<ModuleBase::ComplexMatrix> &dm_k)
 {
 	ModuleBase::TITLE("Exx_Abfs::Parallel::Communicate::DM3::cal_DM");
 	std::vector<std::map<size_t,std::map<size_t,std::map<Abfs::Vector3_Order<int>,ModuleBase::matrix>>>> DR_a2D = GlobalV::GAMMA_ONLY_LOCAL
-		? K_to_R(GlobalC::LOC.wfc_dm_2d->dm_gamma, threshold_D)
-		: K_to_R(GlobalC::LOC.wfc_dm_2d->dm_k, threshold_D);
+		? K_to_R(dm_gamma, threshold_D)
+		: K_to_R(dm_k, threshold_D);
 	DMr = allreduce.a2D_to_exx(DR_a2D);
 
 	/*{

--- a/source/src_ri/exx_abfs-parallel-communicate-dm3.cpp
+++ b/source/src_ri/exx_abfs-parallel-communicate-dm3.cpp
@@ -99,8 +99,8 @@ void Exx_Abfs::Parallel::Communicate::DM3::cal_DM(const double threshold_D)
 {
 	ModuleBase::TITLE("Exx_Abfs::Parallel::Communicate::DM3::cal_DM");
 	std::vector<std::map<size_t,std::map<size_t,std::map<Abfs::Vector3_Order<int>,ModuleBase::matrix>>>> DR_a2D = GlobalV::GAMMA_ONLY_LOCAL
-		? K_to_R(GlobalC::LOC.wfc_dm_2d.dm_gamma, threshold_D)
-		: K_to_R(GlobalC::LOC.wfc_dm_2d.dm_k, threshold_D);
+		? K_to_R(GlobalC::LOC.wfc_dm_2d->dm_gamma, threshold_D)
+		: K_to_R(GlobalC::LOC.wfc_dm_2d->dm_k, threshold_D);
 	DMr = allreduce.a2D_to_exx(DR_a2D);
 
 	/*{

--- a/source/src_ri/exx_abfs-parallel-communicate-dm3.h
+++ b/source/src_ri/exx_abfs-parallel-communicate-dm3.h
@@ -18,7 +18,9 @@
 class Exx_Abfs::Parallel::Communicate::DM3
 {
 public:
-	void cal_DM(const double threshold_D);
+    void cal_DM(const double threshold_D,
+        std::vector<ModuleBase::matrix> &dm_gamma,
+        std::vector<ModuleBase::ComplexMatrix> &dm_k);
 
 	std::vector<std::map<size_t,std::map<size_t,std::map<Abfs::Vector3_Order<int>,ModuleBase::matrix>>>> DMr;
 

--- a/source/src_ri/exx_lcao.cpp
+++ b/source/src_ri/exx_lcao.cpp
@@ -915,7 +915,8 @@ ofs_mpi.close();
 	#endif
 }
 
-void Exx_Lcao::cal_exx_elec()
+void Exx_Lcao::cal_exx_elec(std::vector<ModuleBase::matrix> &dm_gamma,
+    std::vector<ModuleBase::ComplexMatrix> &dm_k)
 {
 	ModuleBase::TITLE("Exx_Lcao","cal_exx_elec");
 
@@ -947,7 +948,7 @@ gettimeofday( &t_start, NULL);
 ofs_mpi<<"TIME@ Exx_Lcao::cal_DM\t"<<time_during(t_start)<<std::endl;
 #elif EXX_DM==3
 gettimeofday( &t_start, NULL);
-	this->DM_para.cal_DM(info.dm_threshold);
+	this->DM_para.cal_DM(info.dm_threshold, dm_gamma, dm_k);
 ofs_mpi<<"TIME@ Exx_Lcao::cal_DM\t"<<time_during(t_start)<<std::endl;
 #endif
 
@@ -1117,14 +1118,15 @@ ofs_mpi.close();
 		}
 	};
 
-	auto print_wfc=[&]()		// Peize Lin test 2019-11-14
+	auto print_wfc=[&](std::vector<ModuleBase::matrix>& wfc_gamma,
+        std::vector<ModuleBase::ComplexMatrix>& wfc_k)		// Peize Lin test 2019-11-14
 	{
 		if(GlobalV::GAMMA_ONLY_LOCAL)
 		{
 			for(int is=0; is<GlobalV::NSPIN; ++is)
 			{		
 				std::ofstream ofs("wfc_"+ModuleBase::GlobalFunc::TO_STRING(istep)+"_"+ModuleBase::GlobalFunc::TO_STRING(is)+"_"+ModuleBase::GlobalFunc::TO_STRING(GlobalV::MY_RANK));
-				GlobalC::LOC.wfc_dm_2d->wfc_gamma[is].print(ofs, 1E-10)<<std::endl;
+				wfc_gamma[is].print(ofs, 1E-10)<<std::endl;
 			}
 		}
 		else
@@ -1132,7 +1134,7 @@ ofs_mpi.close();
 			for(int ik=0; ik<GlobalC::kv.nks; ++ik)
 			{
 				std::ofstream ofs("wfc_"+ModuleBase::GlobalFunc::TO_STRING(istep)+"_"+ModuleBase::GlobalFunc::TO_STRING(ik)+"_"+ModuleBase::GlobalFunc::TO_STRING(GlobalV::MY_RANK));
-				GlobalC::LOC.wfc_dm_2d->wfc_gamma[ik].print(ofs, 1E-10)<<std::endl;
+				wfc_gamma[ik].print(ofs, 1E-10)<<std::endl;
 			}
 		}
 	};

--- a/source/src_ri/exx_lcao.cpp
+++ b/source/src_ri/exx_lcao.cpp
@@ -1124,7 +1124,7 @@ ofs_mpi.close();
 			for(int is=0; is<GlobalV::NSPIN; ++is)
 			{		
 				std::ofstream ofs("wfc_"+ModuleBase::GlobalFunc::TO_STRING(istep)+"_"+ModuleBase::GlobalFunc::TO_STRING(is)+"_"+ModuleBase::GlobalFunc::TO_STRING(GlobalV::MY_RANK));
-				GlobalC::LOC.wfc_dm_2d.wfc_gamma[is].print(ofs, 1E-10)<<std::endl;
+				GlobalC::LOC.wfc_dm_2d->wfc_gamma[is].print(ofs, 1E-10)<<std::endl;
 			}
 		}
 		else
@@ -1132,7 +1132,7 @@ ofs_mpi.close();
 			for(int ik=0; ik<GlobalC::kv.nks; ++ik)
 			{
 				std::ofstream ofs("wfc_"+ModuleBase::GlobalFunc::TO_STRING(istep)+"_"+ModuleBase::GlobalFunc::TO_STRING(ik)+"_"+ModuleBase::GlobalFunc::TO_STRING(GlobalV::MY_RANK));
-				GlobalC::LOC.wfc_dm_2d.wfc_gamma[ik].print(ofs, 1E-10)<<std::endl;
+				GlobalC::LOC.wfc_dm_2d->wfc_gamma[ik].print(ofs, 1E-10)<<std::endl;
 			}
 		}
 	};

--- a/source/src_ri/exx_lcao.h
+++ b/source/src_ri/exx_lcao.h
@@ -37,7 +37,8 @@ public:
 public:
 	void init();
 	void cal_exx_ions();
-	void cal_exx_elec();
+	void cal_exx_elec(std::vector<ModuleBase::matrix> &dm_gamma,
+        std::vector<ModuleBase::ComplexMatrix> &dm_k);
 	void cal_exx_elec_nscf();
 	void add_Hexx(const size_t ik, const double alpha) const;
 private:


### PR DESCRIPTION
`Wfc_Dm_2d wfc_dm_2d` has been modified from global class into a member of `LOOP_ions`. 
Before totally remove the class `Wfc_Dm_2d`, merging this pr will prevent future collision with  @lyb9812 's modification caused by moving `cal_dm` function.