### PR TITLE
Build: Find Googletest by custom dir locally.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,7 +226,7 @@ IF (BUILD_TESTING)
   find_package(Threads)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   find_package(GTest HINTS /usr/local/lib/ ${GTEST_DIR})
-  if(NOT ${GTEST_FOUND})
+  if(NOT DEFINED ${GTest_FOUND})
     include(FetchContent)
     FetchContent_Declare(
       googletest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,7 +225,7 @@ IF (BUILD_TESTING)
   enable_testing()
   find_package(Threads)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  find_package(GTest HINTS /usr/local/lib/ PATHS ${GTEST_DIR})
+  find_package(GTest HINTS /usr/local/lib/ ${GTEST_DIR})
   if(NOT ${GTEST_FOUND})
     include(FetchContent)
     FetchContent_Declare(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,7 +225,7 @@ IF (BUILD_TESTING)
   enable_testing()
   find_package(Threads)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  find_package(GTest)
+  find_package(GTest HINTS /usr/local/lib/ PATHS ${GTEST_DIR})
   if(NOT ${GTEST_FOUND})
     include(FetchContent)
     FetchContent_Declare(

--- a/doc/developers.md
+++ b/doc/developers.md
@@ -11,9 +11,9 @@
   - [Code Formatting style](#code-formatting-style)
     [back to main page](../README.md)
 
-## Raising issues on GitHub
+## Creating issues on GitHub
 
-Raising issues on GitHub is a convernient way to notify the develper team about bugs and feature requests of the ABACUS code. We provide a few templates for issues.
+Creating issues on GitHub is a convernient way to notify the develper team about bugs and feature requests of the ABACUS code. We provide a few templates for issues.
 
 [back to top](#for-developers)
 
@@ -23,7 +23,7 @@ The ABACUS code is refactored to several self-contained modules. A description o
 
 ### Add a unit test
 
-If there are currently no unit tests provided for the module, do as follows. `module_base` provides a simple demonstration.
+We use GoogleTest as our test framework. Write your test under the corresponding module folder at `abacus-develop/tests`, then append the test to `tests/CMakeLists.txt`. If there are currently no unit tests provided for the module, do as follows. `module_base` provides a simple demonstration.
 
 - Add a folder named `test` under the module.
 - Append the content below to `CMakeLists.txt` of the module:
@@ -106,9 +106,6 @@ After your pull request is merged, you can safely delete your branch and pull th
     git pull --ff upstream develop
     ```
 
-### Providing unit tests
-
-We use GoogleTest as our test framework. Write your test under the corresponding module folder at `abacus-develop/tests`, then append the test to `tests/CMakeLists.txt`. To build tests for abacus, set `BUILD_TESTING=1` when configuring with CMake. Executables of test programs will be under `build/tests`.
 
 ### Updating documentation
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -124,7 +124,7 @@ If Libxc is not installed in standard path (i.e. installed with a custom prefix 
 cmake -B build -DLibxc_DIR=~/libxc
 ```
 
-To build tests for abacus, define `BUILD_TESTING` flag.
+To build tests for abacus, define `BUILD_TESTING` flag. You can also specify path to local installation of [Googletest](https://github.com/google/googletest) by setting `GTEST_DIR` flags. If not found in local, the configuration process will try to download it automatically.
 
 ```bash
 cmake -B build -DBUILD_TESTING=1
@@ -138,6 +138,8 @@ After configuring, start build and install by:
 cmake --build build -j9
 cmake --install build
 ```
+
+`-j9` specifies the number of jobs to run simultaneously. You can change the number on your need: set to the number of CPU cores to gain the best performance.
 
 [back to top](#download-and-install)
 


### PR DESCRIPTION
Now one can use `-DGTEST_DIR=<my_path_to_googletest>` to locate local `Googletest` installation.