### PR TITLE
Build: Only trigger some GitHub CI running on main repo

### DIFF
--- a/.github/workflows/dynamic.yml
+++ b/.github/workflows/dynamic.yml
@@ -2,7 +2,7 @@ name: Dynamic Analysis
 
 on:
   schedule:
-    - cron: '0 20 * * *'
+    - cron: '0 3 * * *'
   workflow_dispatch:
     inputs:
       name:
@@ -14,6 +14,7 @@ jobs:
   test:
     name: Do the job on the runner
     runs-on: self-hosted
+    if: github.repository_owner == 'deepmodeling'
     container: ghcr.io/deepmodeling/abacus-development-kit:gnu
     steps:
       - name: Checkout

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -6,6 +6,7 @@ on:
 jobs:
   clang-tidy:
     runs-on: self-hosted
+    if: github.repository_owner == 'deepmodeling'
     container: ghcr.io/deepmodeling/abacus-development-kit:gnu
     steps:
       - name: Checkout Pull Request

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,12 @@ on:
     branches:
       - develop
       - tryEigen
-jobs:
 
+jobs:
   test:
     name: Do the job on the runner
     runs-on: self-hosted
+    if: github.repository_owner == 'deepmodeling'
     container: ghcr.io/deepmodeling/abacus-development-kit:gnu
     steps:
       - name: Checkout


### PR DESCRIPTION
Some GitHub CI tests are using self-hosted machine. For forks, they have no access to this machine, resulting in annoying failure reports.