### PR TITLE
Fix GTest found condition typo.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,7 +226,7 @@ IF (BUILD_TESTING)
   find_package(Threads)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   find_package(GTest HINTS /usr/local/lib/ ${GTEST_DIR})
-  if(NOT DEFINED ${GTest_FOUND})
+  if(NOT DEFINED GTest_FOUND)
     include(FetchContent)
     FetchContent_Declare(
       googletest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,7 +226,7 @@ IF (BUILD_TESTING)
   find_package(Threads)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   find_package(GTest HINTS /usr/local/lib/ ${GTEST_DIR})
-  if(NOT DEFINED GTest_FOUND)
+  if(NOT ${GTest_FOUND})
     include(FetchContent)
     FetchContent_Declare(
       googletest


### PR DESCRIPTION
When evaluating whether a variable is defined, one should use in the form of  `IF(DEFINED some_variable)` without the `{}` wrapper.