### PR TITLE
Fix #586 : modify threshold of weight of occupation from 1.0e-8 to 1.0e-14

### DIFF
--- a/source/module_base/constants.h
+++ b/source/module_base/constants.h
@@ -94,7 +94,7 @@ const double RYDBERG_SI =  HARTREE_SI/2.0; //J
 
 // zero up to a given accuracy
 //const double epsr  = 1.0e-6;
-//const double epsg  = 1.0e-10;
+const double threshold_wg  = 1.0e-14;
 }
 
 #endif 

--- a/source/src_pw/charge.cpp
+++ b/source/src_pw/charge.cpp
@@ -760,7 +760,7 @@ void Charge::sum_band_k(void)
 				///
 				///only occupied band should be calculated.
 				///
-				if(GlobalC::wf.wg(ik, ibnd)<1e-8) continue;
+				if(GlobalC::wf.wg(ik, ibnd)<ModuleBase::threshold_wg) continue;
 				GlobalC::en.eband += GlobalC::wf.ekb[ik][ibnd] * GlobalC::wf.wg(ik, ibnd);
 				ModuleBase::GlobalFunc::ZEROS( porter, GlobalC::pw.nrxx );
 				for (int ig = 0;ig < GlobalC::kv.ngk[ik] ; ig++)
@@ -818,7 +818,7 @@ void Charge::sum_band_k(void)
 			///
 			///only occupied band should be calculated.
 			///
-			if(GlobalC::wf.wg(ik, ibnd)<1e-8) continue;
+			if(GlobalC::wf.wg(ik, ibnd)<ModuleBase::threshold_wg) continue;
 			GlobalC::en.eband += GlobalC::wf.ekb[ik][ibnd] * GlobalC::wf.wg(ik, ibnd);
 			//std::cout << "\n ekb = " << GlobalC::wf.ekb[ik][ibnd] << " wg = " << GlobalC::wf.wg(ik, ibnd);
 

--- a/source/src_pw/forces.cpp
+++ b/source/src_pw/forces.cpp
@@ -732,7 +732,7 @@ void Forces::cal_force_nl(ModuleBase::matrix& forcenl)
                 ///
                 ///only occupied band should be calculated.
                 ///
-                if(GlobalC::wf.wg(ik, ib) < 1.0e-8) continue;
+                if(GlobalC::wf.wg(ik, ib) < ModuleBase::threshold_wg) continue;
                 for (int i=0; i<nkb; i++)
                 {
                     for (int ig=0; ig<GlobalC::wf.npw; ig++)
@@ -754,7 +754,7 @@ void Forces::cal_force_nl(ModuleBase::matrix& forcenl)
             ///
 			///only occupied band should be calculated.
 			///
-            if(GlobalC::wf.wg(ik, ib) < 1.0e-8) continue;
+            if(GlobalC::wf.wg(ik, ib) < ModuleBase::threshold_wg) continue;
 			double fac = GlobalC::wf.wg(ik, ib) * 2.0 * GlobalC::ucell.tpiba;
         	int iat = 0;
         	int sum = 0;

--- a/source/src_pw/stress_func_nl.cpp
+++ b/source/src_pw/stress_func_nl.cpp
@@ -56,7 +56,7 @@ void Stress_Func::stress_nl(ModuleBase::matrix& sigma)
 			///
 			///only occupied band should be calculated.
 			///
-			if(GlobalC::wf.wg(ik, ib) < 1.0e-8) continue;
+			if(GlobalC::wf.wg(ik, ib) < ModuleBase::threshold_wg) continue;
 			for (int i = 0; i < nkb; i++) 
 			{
                 for (int ig = 0; ig < GlobalC::wf.npw; ig++) {
@@ -140,7 +140,7 @@ void Stress_Func::stress_nl(ModuleBase::matrix& sigma)
 					///
 					///only occupied band should be calculated.
 					///
-					if(GlobalC::wf.wg(ik, ib) < 1.0e-8) continue;
+					if(GlobalC::wf.wg(ik, ib) < ModuleBase::threshold_wg) continue;
 					for (int i=0; i<nkb; i++)
 					{
 						for (int ig=0; ig<GlobalC::wf.npw; ig++) 
@@ -169,7 +169,7 @@ void Stress_Func::stress_nl(ModuleBase::matrix& sigma)
 					///
 					///only occupied band should be calculated.
 					///
-					if(GlobalC::wf.wg(ik, ib) < 1.0e-5) continue;
+					if(GlobalC::wf.wg(ik, ib) < ModuleBase::threshold_wg) continue;
 					double fac = GlobalC::wf.wg(ik, ib) * 1.0;
 					int iat = 0;
 					int sum = 0;


### PR DESCRIPTION
1.0e-8 as a occupation threshold sometimes too big to get wrong results.
1.0e-14 is strict enough for screen out non-zero occupied bands.