### PR TITLE
Update ienvelope : `IState_Envelope::cal_env` can be used again

### DIFF
--- a/source/src_io/istate_envelope.h
+++ b/source/src_io/istate_envelope.h
@@ -1,5 +1,7 @@
 #ifndef ISTATE_ENVELOPE_H
 #define ISTATE_ENVELOPE_H
+#include "src_lcao/local_orbital_wfc.h"
+#include "src_lcao/gint_gamma.h"
 
 class IState_Envelope
 {
@@ -7,7 +9,7 @@ class IState_Envelope
 	IState_Envelope();
 	~IState_Envelope();
 
-	void begin();
+	void begin(Local_Orbital_wfc &lowf, Gint_Gamma &gg);
 
 	private:
 	bool *bands_picked;

--- a/source/src_io/wf_local.cpp
+++ b/source/src_io/wf_local.cpp
@@ -544,7 +544,6 @@ void WF_Local::distri_lowf_complex_new(std::complex<double>** ctot, const int& i
 			//}
 			//ofs_running << std::endl;
 //2.3 copy from work to wfc_k
-            std::cout << "2.2 ok" << std::endl;
             const int inc = 1;
 			if(myid==src_rank)
 			{

--- a/source/src_io/wf_local.h
+++ b/source/src_io/wf_local.h
@@ -21,10 +21,10 @@ namespace WF_Local
     void distri_lowf_complex_new(std::complex<double>** ctot, const int& ik,
         Local_Orbital_wfc &lowf);
 
-    int read_lowf(double** c, const int& is,
+    int read_lowf(double** ctot, const int& is,
         Local_Orbital_wfc &lowf);
 
-    int read_lowf_complex(std::complex<double>** c, const int& ik,
+    int read_lowf_complex(std::complex<double>** ctot, const int& ik,
         Local_Orbital_wfc &lowf);
 }
 

--- a/source/src_lcao/DM_k.cpp
+++ b/source/src_lcao/DM_k.cpp
@@ -49,57 +49,9 @@ void Local_Orbital_Charge::allocate_DM_k(void)
 
 	// Peize Lin test 2019-01-16 
     this->init_dm_2d();
-	if(GlobalC::wf.start_wfc=="file")
-	{
-		this->kpt_file(GlobalC::GridT, *this->LOWF);
-	}
 
     return;
 }
-
-void Local_Orbital_Charge::kpt_file(const Grid_Technique& gt,
-    Local_Orbital_wfc &lowf)
-{
-	ModuleBase::TITLE("Local_Orbital_Charge","kpt_file");
-
-	int error;
-	std::cout << " Read in wave functions files: " << GlobalC::kv.nkstot << std::endl;
-
-	std::complex<double> **ctot;
-
-	for(int ik=0; ik<GlobalC::kv.nkstot; ++ik)
-	{
-
-		lowf.wfc_k[ik].create(this->ParaV->ncol_bands, this->ParaV->nrow);
-		lowf.wfc_k[ik].zero_out();
-
-		GlobalV::ofs_running << " Read in wave functions " << ik + 1 << std::endl;
-		error = WF_Local::read_lowf_complex( ctot , ik, lowf);
-
-#ifdef __MPI
-		Parallel_Common::bcast_int(error);
-#endif
-		GlobalV::ofs_running << " Error=" << error << std::endl;
-		if(error==1)
-		{
-			ModuleBase::WARNING_QUIT("Local_Orbital_wfc","Can't find the wave function file: LOWF.dat");
-		}
-		else if(error==2)
-		{
-			ModuleBase::WARNING_QUIT("Local_Orbital_wfc","In wave function file, band number doesn't match");
-		}
-		else if(error==3)
-		{
-			ModuleBase::WARNING_QUIT("Local_Orbital_wfc","In wave function file, nlocal doesn't match");
-		}
-		else if(error==4)
-		{
-			ModuleBase::WARNING_QUIT("Local_Orbital_wfc","In k-dependent wave function file, k point is not correct");
-		}
-
-	}//loop ispin
-}
-
 
 #include "record_adj.h"
 inline void cal_DM_ATOM(

--- a/source/src_lcao/LOOP_elec.cpp
+++ b/source/src_lcao/LOOP_elec.cpp
@@ -258,7 +258,7 @@ void LOOP_elec::solver(const int& istep,
 	else if (GlobalV::CALCULATION=="ienvelope")
 	{
 		IState_Envelope IEP;
-		IEP.begin();
+		IEP.begin(lowf, this->UHM->GG);
 	}
 	else
 	{

--- a/source/src_lcao/local_orbital_charge.cpp
+++ b/source/src_lcao/local_orbital_charge.cpp
@@ -81,7 +81,9 @@ void Local_Orbital_Charge::allocate_dm_wfc(const Grid_Technique& gt,
     Local_Orbital_wfc &lowf)
 {
     ModuleBase::TITLE("Local_Orbital_Charge", "allocate_dm_wfc");
-	if(GlobalV::GAMMA_ONLY_LOCAL)
+
+    this->LOWF = &lowf;
+    if (GlobalV::GAMMA_ONLY_LOCAL)
 	{
 		// here we reset the density matrix dimension.
 		this->allocate_gamma(gt);
@@ -91,8 +93,6 @@ void Local_Orbital_Charge::allocate_dm_wfc(const Grid_Technique& gt,
 		lowf.allocate_k(gt, lowf);
 		this->allocate_DM_k();
 	}
-
-    this->LOWF = &lowf;
     
     return;
 }

--- a/source/src_lcao/local_orbital_charge.h
+++ b/source/src_lcao/local_orbital_charge.h
@@ -39,9 +39,6 @@ class Local_Orbital_Charge
 	// in DM_k.cpp
 	//-----------------
 	void allocate_DM_k(void);
-	
-    void kpt_file(const Grid_Technique& gt,
-        Local_Orbital_wfc &lowf);
 
 	// liaochen modify on 2010-3-23 
 	// change its state from private to public

--- a/source/src_lcao/local_orbital_wfc.cpp
+++ b/source/src_lcao/local_orbital_wfc.cpp
@@ -172,6 +172,35 @@ int  Local_Orbital_wfc::q2CTOT(
     return 0;
 }
 
+int  Local_Orbital_wfc::q2WFC(
+	int myid,
+	int naroc[2],
+	int nb,
+	int dim0,
+	int dim1,
+	int iprow,
+	int ipcol,
+	int loc_size,
+	double* work,
+	double** WFC)
+{
+    ModuleBase::TITLE(" Local_Orbital_wfc","q2WFC");
+    for (int j = 0; j < naroc[1]; ++j)
+    {
+        int igcol=globalIndex(j, nb, dim1, ipcol);
+        if(igcol>=GlobalV::NBANDS) continue;
+        for(int i=0; i<naroc[0]; ++i)
+        {
+            int igrow = globalIndex(i, nb, dim0, iprow);
+            int mu_local = GlobalC::GridT.trace_lo[igrow];
+            if (mu_local >= 0 )
+            {
+                WFC[igcol][mu_local]=work[j*naroc[0]+i];
+            }
+        }
+    }
+    return 0;
+}
 
 int  Local_Orbital_wfc::q2WFC_complex(
 	int naroc[2],

--- a/source/src_lcao/local_orbital_wfc.cpp
+++ b/source/src_lcao/local_orbital_wfc.cpp
@@ -101,28 +101,28 @@ void Local_Orbital_wfc::allocate_k(const Grid_Technique& gt,
 		for(int ik=0; ik<GlobalC::kv.nkstot; ++ik)
 		{
 			GlobalV::ofs_running << " Read in wave functions " << ik + 1 << std::endl;
-			error = WF_Local::read_lowf_complex( this->wfc_k_grid[ik], ik, lowf);
-		}
+            error = WF_Local::read_lowf_complex(this->wfc_k_grid[ik], ik, lowf);
 #ifdef __MPI
-		Parallel_Common::bcast_int(error);
+            Parallel_Common::bcast_int(error);
 #endif
-		GlobalV::ofs_running << " Error=" << error << std::endl;
-		if(error==1)
-		{
-			ModuleBase::WARNING_QUIT("Local_Orbital_wfc","Can't find the wave function file: LOWF.dat");
-		}
-		else if(error==2)
-		{
-			ModuleBase::WARNING_QUIT("Local_Orbital_wfc","In wave function file, band number doesn't match");
-		}
-		else if(error==3)
-		{
-			ModuleBase::WARNING_QUIT("Local_Orbital_wfc","In wave function file, nlocal doesn't match");
-		}
-		else if(error==4)
-		{
-			ModuleBase::WARNING_QUIT("Local_Orbital_wfc","In k-dependent wave function file, k point is not correct");
-		}
+            GlobalV::ofs_running << " Error=" << error << std::endl;
+            if(error==1)
+            {
+                ModuleBase::WARNING_QUIT("Local_Orbital_wfc","Can't find the wave function file: LOWF.dat");
+            }
+            else if(error==2)
+            {
+                ModuleBase::WARNING_QUIT("Local_Orbital_wfc","In wave function file, band number doesn't match");
+            }
+            else if(error==3)
+            {
+                ModuleBase::WARNING_QUIT("Local_Orbital_wfc","In wave function file, nlocal doesn't match");
+            }
+            else if(error==4)
+            {
+                ModuleBase::WARNING_QUIT("Local_Orbital_wfc","In k-dependent wave function file, k point is not correct");
+            }
+        }
 	}
 	else
 	{

--- a/source/src_lcao/local_orbital_wfc.h
+++ b/source/src_lcao/local_orbital_wfc.h
@@ -58,7 +58,7 @@ public:
     ///=========================================
     //name will be changed
     
-    ///for gamma_only, with output
+    ///for gamma_only, output total wfc
     int q2CTOT(
         int myid,
         int naroc[2],
@@ -70,8 +70,21 @@ public:
         int loc_size,
         double* work,
         double** CTOT);
-    
-    ///for multi-k, no output
+
+    //for gamma_only, 2d-to-grid without output
+    int  q2WFC(
+        int myid,
+        int naroc[2],
+        int nb,
+        int dim0,
+        int dim1,
+        int iprow,
+        int ipcol,
+        int loc_size,
+        double* work,
+        double** WFC);
+
+    ///for multi-k, 2d-to-grid without output
     int q2WFC_complex(
         int naroc[2],
         int nb,
@@ -82,7 +95,7 @@ public:
         std::complex<double>* work,
         std::complex<double>** WFC);
     
-    ///for multi-k, with output
+    ///for multi-k, 2d-to-grid with output
     int q2WFC_CTOT_complex(
         int myid,
         int naroc[2],


### PR DESCRIPTION
After removing `WFC_GAMMA`, `IState_Envelope::cal_env` can't work because it needs grid wavefunciton in gamma_only.
- fix some bugs in reading wavefunction I introduced during the refactor
- add 2d-to-grid convert before calling `cal_env` (now it can be used again)