### PR TITLE
Doc: add UT link libs instruction.

### DIFF
--- a/doc/developers.md
+++ b/doc/developers.md
@@ -46,6 +46,9 @@ To add a unit test:
 AddTest(
   TARGET <module_name>_<test_name> # this is the executable file name of the test
   SOURCES <test_name>.cpp
+
+  # OPTIONAL: if this test requires external libraries, add them with "LIBS" statement.
+  LIBS math_libs # `math_libs` includes all math libraries in ABACUS.
 )
 ```
 


### PR DESCRIPTION
Add instructions on `LIBS` in `AddTest` function; `dylib` is not implemented yet.