### PR TITLE
fix : calculate dos_smearing without reading DOS first

### DIFF
--- a/source/src_io/dos.cpp
+++ b/source/src_io/dos.cpp
@@ -143,7 +143,8 @@ bool Dos::calculate_dos
 (
 	const int &is,
 	const std::vector<int> &isk,
-	const std::string &fa, //file address
+	const std::string &fa, //file address for DOS
+	const std::string &fa1, //file address for DOS_smearing
 	const double &de_ev, // delta energy in ev
 	const double &emax_ev,
 	const double &emin_ev,// minimal energy in ev.
@@ -157,10 +158,15 @@ bool Dos::calculate_dos
 {
 	ModuleBase::TITLE("Dos","calculae_dos");
 	std::ofstream ofs;
+	std::ofstream ofs1;
 	if(GlobalV::MY_RANK==0)
 	{
 		ofs.open(fa.c_str());//make the file clear!!
+		ofs1.open(fa1.c_str());//make the file clear!!
 	}
+	std::vector<double> dos;
+	std::vector<double> ene;
+	std::vector<double> dos2; //dos_smearing
 
 #ifdef __MPI
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -179,6 +185,8 @@ bool Dos::calculate_dos
 
 	// mohan fixed bug 2010-1-18
 	const int npoints = static_cast<int>(std::floor ( ( emax_ev - emin_ev ) / de_ev )) ;
+	dos.clear();
+	ene.clear();
 	if(npoints <= 0)
 	{
 		ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"npoints",npoints);
@@ -233,12 +241,53 @@ bool Dos::calculate_dos
 		if(GlobalV::MY_RANK==0)
 		{
 			ofs << e_new << " " << count << std::endl;
+			dos.push_back(count);
+			ene.push_back(e_new);
 		}
 
 	}
+
+	//now use Gaussian smearing to smooth the dos and write to DOS_is_smearing
+	if(GlobalV::MY_RANK==0)
+	{
+		dos2.resize(dos.size()-1);
+
+		//double b = INPUT.b_coef;
+		double b = sqrt(2.0)*GlobalC::en.bcoeff;
+		for(int i=0;i<dos.size()-1;i++)
+		{
+			double Gauss=0.0;
+
+			for(int j=0;j<dos.size()-1;j++)
+			{
+				double de = ene[j] - ene[i];
+				double de2 = de * de;
+				//----------------------------------------------------------
+				// EXPLAIN : if en
+				//----------------------------------------------------------
+				Gauss = exp(-de2/b/b)/sqrt(3.1415926)/b;
+				dos2[j] += dos[i]*Gauss;
+			}
+		}
+
+		//----------------------------------------------------------
+		// EXPLAIN : output DOS_smearing.dat
+		//----------------------------------------------------------
+		double sum2=0.0;
+		for(int i=0;i<dos.size()-1;i++)
+		{
+			sum2 += dos2[i];
+			ofs1 <<std::setw(20)<<ene[i]
+				<<std::setw(20)<<dos2[i]
+				<<std::setw(20)<<sum2<<"\n";
+		}
+	}
+
+
 	if(GlobalV::MY_RANK==0)
 	{
 		ofs.close();
+		ofs1.close();
 	}
 	ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"number of bands",nbands);
 	ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"sum up the states", sum);

--- a/source/src_io/dos.cpp
+++ b/source/src_io/dos.cpp
@@ -166,7 +166,7 @@ bool Dos::calculate_dos
 	}
 	std::vector<double> dos;
 	std::vector<double> ene;
-	std::vector<double> dos2; //dos_smearing
+	std::vector<double> dos_smearing; //dos_smearing
 
 #ifdef __MPI
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -250,7 +250,7 @@ bool Dos::calculate_dos
 	//now use Gaussian smearing to smooth the dos and write to DOS_is_smearing
 	if(GlobalV::MY_RANK==0)
 	{
-		dos2.resize(dos.size()-1);
+		dos_smearing.resize(dos.size()-1);
 
 		//double b = INPUT.b_coef;
 		double b = sqrt(2.0)*GlobalC::en.bcoeff;
@@ -266,7 +266,7 @@ bool Dos::calculate_dos
 				// EXPLAIN : if en
 				//----------------------------------------------------------
 				Gauss = exp(-de2/b/b)/sqrt(3.1415926)/b;
-				dos2[j] += dos[i]*Gauss;
+				dos_smearing[j] += dos[i]*Gauss;
 			}
 		}
 
@@ -276,9 +276,9 @@ bool Dos::calculate_dos
 		double sum2=0.0;
 		for(int i=0;i<dos.size()-1;i++)
 		{
-			sum2 += dos2[i];
+			sum2 += dos_smearing[i];
 			ofs1 <<std::setw(20)<<ene[i]
-				<<std::setw(20)<<dos2[i]
+				<<std::setw(20)<<dos_smearing[i]
 				<<std::setw(20)<<sum2<<"\n";
 		}
 	}

--- a/source/src_io/dos.h
+++ b/source/src_io/dos.h
@@ -9,7 +9,8 @@ namespace Dos
 	bool calculate_dos(
 		const int &is,
 		const std::vector<int> &isk,
-		const std::string &fn,// file address.
+		const std::string &fn,// file address for DOS.
+		const std::string &fn1,// file address for DOS_smearing.
 		const double &de_ev, // delta energy in ev.
 		const double &emax_ev,// maximal energy in ev.
 		const double &emin_ev,// minimal energy in ev.

--- a/source/src_io/energy_dos.cpp
+++ b/source/src_io/energy_dos.cpp
@@ -651,106 +651,18 @@ void energy::perform_dos(void)
 	 {
 		 std::stringstream ss;
 		 ss << GlobalV::global_out_dir << "DOS" << is+1;
+		 std::stringstream ss1;
+		 ss1 << GlobalV::global_out_dir << "DOS" << is+1 << "_smearing.dat";
 
 		 Dos::calculate_dos(
 				 is,
 				 GlobalC::kv.isk,
-				 ss.str(), 
+				 ss.str(),
+				 ss1.str(),
 				 this->dos_edelta_ev, 
 				 emax, 
 				 emin, 
 				 GlobalC::kv.nks, GlobalC::kv.nkstot, GlobalC::kv.wk, GlobalC::wf.wg, GlobalV::NBANDS, GlobalC::wf.ekb );
-		 std::ifstream in(ss.str().c_str());
-		 if(!in)
-		 {
-			 //      std::cout<<"\n Can't find file : "<< name << std::endl;
-			 //      return 0;
-		 }
-
-		 //----------------------------------------------------------
-		 // FOUND LOCAL VARIABLES :
-		 // NAME : number(number of DOS points)
-		 // NAME : nk(number of k point used)
-		 // NAME : energy(energy range,from emin_ev to emax_ev)
-		 // NAME : dos(old,count k points in the energy range)
-		 // NAME : dos2(new,count k points in the energy range)
-		 //----------------------------------------------------------
-		 int number=0;
-		 int nk=0;
-		 in >> number;
-		 in >> nk;
-		 double *energy = new double[number];
-		 double *dos = new double[number];
-		 double *dos2 = new double[number];
-		 for(int i=0 ;i<number; i++)
-		 {
-			 energy[i] = 0.0;
-			 dos[i] = 0.0;
-			 dos2[i] =0.0;
-		 }
-
-		 for(int i=0;i<number;i++)
-		 {
-			 in >> energy[i] >> dos[i];
-		 }
-		 if(!in.eof())
-		 {
-			 //std::cout<<"\n Read Over!"<<std::endl;
-		 }
-		 in.close();
-
-		 //----------------------------------------------------------
-		 // EXPLAIN : b is an empirical value.
-		 // please DIY b!!
-		 //----------------------------------------------------------
-
-		 //double b = INPUT.b_coef;
-		 double b = sqrt(2.0)*bcoeff;
-		 for(int i=0;i<number;i++)
-		 {
-			 double Gauss=0.0;
-
-			 for(int j=0;j<number;j++)
-			 {
-				 double de = energy[j] - energy[i];
-				 double de2 = de * de;
-				 //----------------------------------------------------------
-				 // EXPLAIN : if en
-				 //----------------------------------------------------------
-				 Gauss = exp(-de2/b/b)/sqrt(3.1415926)/b;
-				 dos2[j] += dos[i]*Gauss;
-			 }
-		 }
-
-		 //----------------------------------------------------------
-		 // EXPLAIN : output DOS2.txt
-		 //----------------------------------------------------------
-		 std::stringstream sss;
-		 sss << GlobalV::global_out_dir << "DOS" << is+1 << "_smearing" << ".dat" ;
-		 std::ofstream out(sss.str().c_str());
-		 double sum2=0.0;
-		 for(int i=0;i<number;i++)
-		 {
-			 sum2 += dos2[i];
-			 //            if(dos2[i]<1e-5)
-			 //            {
-			 //                    dos2[i] = 0.00;
-			 //            }
-			 out <<std::setw(20)<<energy[i]
-				 <<std::setw(20)<<dos2[i]
-				 <<std::setw(20)<<sum2<<"\n";
-		 }
-		 out.close();
-
-		 //----------------------------------------------------------
-		 // DELETE
-		 //----------------------------------------------------------
-		 delete[] dos;
-		 delete[] dos2;
-		 delete[] energy;
-
-		 //std::cout<<" broden spectrum over, success : ) "<<std::endl;
-
 	 }
 
 

--- a/source/src_io/energy_dos_pw.cpp
+++ b/source/src_io/energy_dos_pw.cpp
@@ -148,109 +148,19 @@ void energy::perform_dos_pw(void)
 //DOS_ispin contains not smoothed dos
 			 std::stringstream ss;
 			 ss << GlobalV::global_out_dir << "DOS" << is+1;
+			 std::stringstream ss1;
+			 ss1 << GlobalV::global_out_dir << "DOS" << is+1 << "_smearing.dat";
 
 			 Dos::calculate_dos(
 					 is,
 					 GlobalC::kv.isk,
-					 ss.str(), 
+					 ss.str(),
+					 ss1.str(), 
 					 this->dos_edelta_ev, 
 					 emax, 
 					 emin, 
 					 GlobalC::kv.nks, GlobalC::kv.nkstot, GlobalC::kv.wk, GlobalC::wf.wg, GlobalV::NBANDS, GlobalC::wf.ekb );
-			 std::ifstream in(ss.str().c_str());
-			 if(!in)
-			 {
-				       //std::cout<<"\n Can't find file : "<< name << std::endl;
-				       //return 0;
-			 }
-
-			 //----------------------------------------------------------
-			 // FOUND LOCAL VARIABLES :
-			 // NAME : number(number of DOS points)
-			 // NAME : nk(number of k point used)
-			 // NAME : energy(energy range,from emin_ev to emax_ev)
-			 // NAME : dos(old,count k points in the energy range)
-			 // NAME : dos2(new,count k points in the energy range)
-			 //----------------------------------------------------------
-			 int number=0;
-			 int nk=0;
-			 in >> number;
-			 in >> nk;
-			 double *energy = new double[number];
-			 double *dos = new double[number];
-			 double *dos2 = new double[number];
-			 for(int i=0 ;i<number; i++)
-			 {
-				 energy[i] = 0.0;
-				 dos[i] = 0.0;
-				 dos2[i] =0.0;
-			 }
-
-			 for(int i=0;i<number;i++)
-			 {
-				 in >> energy[i] >> dos[i];
-			 }
-			 if(!in.eof())
-			 {
-				 //std::cout<<"\n Read Over!"<<std::endl;
-			 }
-			 in.close();
-
-//now use Gaussian smearing to smooth the dos and write to DOS_is_smearing
-
-			 //----------------------------------------------------------
-			 // EXPLAIN : b is an empirical value.
-			 // please DIY b!!
-			 //----------------------------------------------------------
-
-			 //double b = INPUT.b_coef;
-			 double b = sqrt(2.0)*bcoeff;
-			 for(int i=0;i<number;i++)
-			 {
-				 double Gauss=0.0;
-	
-				 for(int j=0;j<number;j++)
-				 {
-					 double de = energy[j] - energy[i];
-					 double de2 = de * de;
-					 //----------------------------------------------------------
-					 // EXPLAIN : if en
-					 //----------------------------------------------------------
-					 Gauss = exp(-de2/b/b)/sqrt(3.1415926)/b;
-					 dos2[j] += dos[i]*Gauss;
-				 }
-			 }
-
-		 //----------------------------------------------------------
-		 // EXPLAIN : output DOS2.txt
-		 //----------------------------------------------------------
-		 std::stringstream sss;
-		 sss << GlobalV::global_out_dir << "DOS" << is+1 << "_smearing" << ".dat" ;
-		 std::ofstream out(sss.str().c_str());
-		 double sum2=0.0;
-		 for(int i=0;i<number;i++)
-		 {
-			 sum2 += dos2[i];
-			 //            if(dos2[i]<1e-5)
-			 //            {
-			 //                    dos2[i] = 0.00;
-			 //            }
-			 out <<std::setw(20)<<energy[i]
-				 <<std::setw(20)<<dos2[i]
-				 <<std::setw(20)<<sum2<<"\n";
-		 }
-		 out.close();
-
-		 //----------------------------------------------------------
-		 // DELETE
-		 //----------------------------------------------------------
-		 delete[] dos;
-		 delete[] dos2;
-		 delete[] energy;
-
-		 //std::cout<<" broden spectrum over, success : ) "<<std::endl;
-
-	 }
+	 	}
 
 	}//out_dos=1
 	if(this->out_band) //pengfei 2014-10-13

--- a/source/src_io/eximport.h
+++ b/source/src_io/eximport.h
@@ -109,25 +109,6 @@ public:
 		const int &nband
 	);
 
-//==========================================================
-// MEMBER FUNCTION : calculate_dos
-// DO : output DOS in nscf case.
-// RETURN : = TRUE (seccess)
-//  	    = FALSE (failure)
-//==========================================================
-	bool calculate_dos
-	(
- 		const std::string &fa, // file address.
-		const double de_ev, // delta energy in ev
-		const double emax_ev, // maximal energy in ev.
-		const double emin_ev, // minimal energy in ev.
-		const int nks, // number of k points included.
-		const int nbands, // number of nbands included.
-		const ModuleBase::matrix &et// store energy for each k point
-		                    // and each band
-	);
-
-
 #ifdef __MPI
 //==========================================================
 // MEMBER FUNCTION : out_charge_mpi


### PR DESCRIPTION
The reason behind this bug is that in calculating DOS_smearing, the program first takes the calculated DOS as input:
```cpp
			 for(int i=0;i<number;i++)
			 {
				 in >> energy[i] >> dos[i];
			 }
			 if(!in.eof())
			 {
				 //std::cout<<"\n Read Over!"<<std::endl;
			 }
			 in.close();
```
This might have something to do with the input buffer. Also, it is bad practice to use the output file of the program as input file.
The way to fix this is to save the array that stores DOS and use that in calculating DOS_smearing, instead of reading from DOS.