### PR TITLE
Fix bug of scalapack interface.

### DIFF
--- a/source/src_io/energy_dos.cpp
+++ b/source/src_io/energy_dos.cpp
@@ -368,7 +368,7 @@ void energy::perform_dos(Local_Orbital_wfc &lowf, LCAO_Hamilt &uhm)
 
 							const int NB= i+1;
 
-							const double one_float=1.0, zero_float=0.0;
+							const double one_float[2]={1.0, 0.0}, zero_float[2]={0.0, 0.0};
 							const int one_int=1;
 							//   const int two_int=2;
 							const char T_char='T';		// N_char='N',U_char='U'
@@ -377,10 +377,10 @@ void energy::perform_dos(Local_Orbital_wfc &lowf, LCAO_Hamilt &uhm)
 							pzgemv_(
 									&T_char,
 									&GlobalV::NLOCAL,&GlobalV::NLOCAL,
-									&one_float,
+									&one_float[0],
 									uhm.LM->Sloc2.data(), &one_int, &one_int, pv->desc,
 									Dwfc.c, &one_int, &NB, pv->desc, &one_int,
-									&zero_float,
+									&zero_float[0],
 									Mulk[0].c, &one_int, &NB, pv->desc,
 									&one_int);
 						#endif

--- a/source/src_io/mulliken_charge.cpp
+++ b/source/src_io/mulliken_charge.cpp
@@ -196,7 +196,7 @@ void Mulliken_Charge::cal_mulliken(LCAO_Hamilt &uhm)
 
 						const int NB= i+1;
 
-						const double one_float=1.0, zero_float=0.0;
+						const double one_float[2]={1.0, 0.0}, zero_float[2]={0.0, 0.0};
 						const int one_int=1;
 						//   const int two_int=2;
 
@@ -206,10 +206,10 @@ void Mulliken_Charge::cal_mulliken(LCAO_Hamilt &uhm)
 						pzgemv_(
 								&T_char,
 								&GlobalV::NLOCAL,&GlobalV::NLOCAL,
-								&one_float,
+								&one_float[0],
 								uhm.LM->Sloc2.data(), &one_int, &one_int, pv->desc,
 								Dwf.c, &one_int, &NB, pv->desc, &one_int,
-								&zero_float,
+								&zero_float[0],
 								mud[0].c, &one_int, &NB, pv->desc,
 								&one_int);
 					#endif

--- a/source/src_io/unk_overlap_lcao.cpp
+++ b/source/src_io/unk_overlap_lcao.cpp
@@ -738,19 +738,19 @@ std::complex<double> unkOverlap_lcao::det_berryphase(const int ik_L, const int i
 	char transb = 'N';
 	int occBands = occ_bands;
 	int nlocal = GlobalV::NLOCAL;
-	double alpha=1.0, beta=0.0;
+	double alpha[2]={1.0, 0.0}, beta[2]={0.0, 0.0};
 	int one = 1;
 #ifdef __MPI
-	pzgemm_(&transa,&transb,&occBands,&nlocal,&nlocal,&alpha,
+	pzgemm_(&transa,&transb,&occBands,&nlocal,&nlocal,&alpha[0],
 			lowf.wfc_k.at(ik_L).c,&one,&one,lowf.ParaV->desc,
 							  midmatrix,&one,&one,lowf.ParaV->desc,
-													   &beta,
+													   &beta[0],
 							   C_matrix,&one,&one,lowf.ParaV->desc);
 							   
-	pzgemm_(&transb,&transb,&occBands,&occBands,&nlocal,&alpha,
+	pzgemm_(&transb,&transb,&occBands,&occBands,&nlocal,&alpha[0],
 								 C_matrix,&one,&one,lowf.ParaV->desc,
 			lowf.wfc_k.at(ik_R).c,&one,&one,lowf.ParaV->desc,
-														 &beta,
+														 &beta[0],
 							   out_matrix,&one,&one,lowf.ParaV->desc);	
 
 	//int *ipiv = new int[ lowf.ParaV->nrow+lowf.ParaV->desc[4] ];

--- a/source/src_lcao/LCAO_evolve.cpp
+++ b/source/src_lcao/LCAO_evolve.cpp
@@ -416,8 +416,8 @@ int Evolve_LCAO_Matrix::using_ScaLAPACK_complex(const int &ik, ModuleBase::Compl
 	char transb = 'T'; //This place requires subsequent testing of different transb.
 	int descb = 0; 
 
-	double alpha_1 = 1.0;
-	double beta_1 = 0.0;
+	double alpha_1[2] = {1.0, 0.0};
+	double beta_1[2] = {0.0, 0.0};
 
 	//cout << "*Htmp2: " << *Htmp2 << endl;
 	//cout << "begin06:" << endl;
@@ -426,10 +426,10 @@ int Evolve_LCAO_Matrix::using_ScaLAPACK_complex(const int &ik, ModuleBase::Compl
 	pzgemm_(
 		&transa, &transb,
 		&GlobalV::NLOCAL, &GlobalV::NLOCAL, &GlobalV::NLOCAL,
-		&alpha_1,
+		&alpha_1[0],
 		Htmp2, &one_int, &one_int, this->LM->ParaV->desc,
 		Htmp1, &one_int, &one_int, this->LM->ParaV->desc, 
-		&beta_1,
+		&beta_1[0],
 		Htmp3, &one_int, &one_int, this->LM->ParaV->desc);
 
 	
@@ -439,10 +439,10 @@ int Evolve_LCAO_Matrix::using_ScaLAPACK_complex(const int &ik, ModuleBase::Compl
 	pzgemv_(
 		&transa,
 		&GlobalV::NLOCAL, &GlobalV::NLOCAL, 
-		&alpha_1,
+		&alpha_1[0],
 		Htmp3, &one_int, &one_int, this->LM->ParaV->desc,
 		wfc_2d.c, &one_int, &one_int, this->LM->ParaV->desc, &one_int, 
-		&beta_1,
+		&beta_1[0],
 		wfc_2d.c, &one_int, &one_int, this->LM->ParaV->desc, &one_int
         );
 

--- a/source/src_lcao/dm_2d.cpp
+++ b/source/src_lcao/dm_2d.cpp
@@ -135,7 +135,7 @@ void Local_Orbital_Charge::cal_dm(const ModuleBase::matrix& wg,    // wg(ik,ib),
             BlasConnector::scal( wg_wfc.nc, wg_local[ir], wg_wfc.c+ir*wg_wfc.nc, 1 );
         }
         // C++: dm(iw1,iw2) = wfc(ib,iw1).T * wg_wfc(ib,iw2)
-        const double one_float=1.0, zero_float=0.0;
+        const double one_float[2]={1.0, 0.0}, zero_float[2]={0.0, 0.0};
         const int one_int=1;
         const char N_char='N', T_char='T';
         dm_k[ik].create( this->ParaV->ncol, this->ParaV->nrow );
@@ -143,10 +143,10 @@ void Local_Orbital_Charge::cal_dm(const ModuleBase::matrix& wg,    // wg(ik,ib),
         pzgemm_(
             &N_char, &T_char,
             &GlobalV::NLOCAL, &GlobalV::NLOCAL, &wg.nc,
-            &one_float,
+            &one_float[0],
             wg_wfc.c, &one_int, &one_int, this->ParaV->desc_wfc,
             wfc_k[ik].c, &one_int, &one_int, this->ParaV->desc_wfc,
-            &zero_float,
+            &zero_float[0],
             dm_k[ik].c, &one_int, &one_int, this->ParaV->desc);
     #else
         const int lda=GlobalV::NLOCAL;


### PR DESCRIPTION
fix : pzgemv_ and pzgemm_ used double* for alpha and beta parameters but not complex<double>* , this would cause error in GNU compiler.