### PR TITLE
Fix: add `.gitignore` items for generated files in `tests/deepks/*`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,10 @@ obj
 OUT.*
 log.txt
 result.out
+*.dat
 .DS_Store
 .cache
 .vscode
 html
-run.log
+*.log
+STRU_READIN_ADJUST.cif


### PR DESCRIPTION
For UT of `deepks`, the testing program generates files under `tests/deepks`. Adding these items into `.gitignore` to prevent misuse.