### PR TITLE
Build: fix sanitizer test logic.

### DIFF
--- a/.github/workflows/dynamic.yml
+++ b/.github/workflows/dynamic.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron: '0 3 * * *'
   workflow_dispatch:
-    inputs:
-      name:
-        description: 'Number of Cores to Run ABACUS'
-        required: false
-        default: '2'
 
 jobs:
   test:
@@ -19,14 +14,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Build and Test
+      - name: Building
         run: |
           cmake -B build -DENABLE_ASAN=1 -DBUILD_TESTING=ON -DENABLE_DEEPKS=1
           cmake --build build -j16
           cmake --install build
+      - name: Testing
+        run: |
           cmake --build build --target test ARGS="-V"
       - name: Publish Report to Dashboard
         uses: crazy-max/ghaction-github-pages@v2
+        if: ${{ ! cancelled() }}
         with:
           target_branch: dashboard
           build_dir: html


### PR DESCRIPTION
Using sanitizer is most likely produce failure. In this case,
the result should also be published.