### PR TITLE
Build: fix static analysis workflow logic.

### DIFF
--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -5,8 +5,7 @@ on:
 
 jobs:
   clang-tidy:
-    runs-on: self-hosted
-    if: github.repository_owner == 'deepmodeling'
+    runs-on: ubuntu-latest
     container: ghcr.io/deepmodeling/abacus-development-kit:gnu
     steps:
       - name: Checkout Pull Request
@@ -19,20 +18,16 @@ jobs:
       - name: Generate Build Commands
         run: |
           cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=1
-      - name: Checkout Changed Files
-        id: files
-        uses: deepmodeling/get-changed-files@master
       - name: Run clang-tidy
         run: |
-          printf "%s\n" ${{ steps.files.outputs.added_modified }} | grep -E "^.*\.(cpp|h)$" > cppfiles.txt
-          clang-tidy -p=build --export-fixes=diagnostics.yaml `cat cppfiles.txt`
-      - name: Run clang-tidy-pr-comments action
-        uses: deepmodeling/abacus-code-reviewer@master
+          git diff -U0 HEAD^ | clang-tidy-diff -p1 -path build -export-fixes fixes.yml
+      - name: Pull request comments from clang-tidy reports
+        uses: platisd/clang-tidy-pr-comments@1.1.6
         with:
           # The GitHub token (or a personal access token)
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # The path to the clang-tidy fixes generated previously
-          clang_tidy_fixes: diagnostics.yaml
+          clang_tidy_fixes: fixes.yml
           # Optionally set to true if you want the Action to request
           # changes in case warnings are found
           request_changes: true


### PR DESCRIPTION
This PR updated code static analysis pipeline following [this GitHub action](https://github.com/marketplace/actions/pull-request-comments-from-clang-tidy-reports) .