### PR TITLE
Build: update testing strategy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Integration Test and Unit Test
 
 on:
-  pull_request_target:
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
Before, we are using `pull_request_target` to access AWS token
to start a self-hosted runner. Since we are not using it, changing to
`pull_request` should be more secure, for this trigger can not access
repositry token.