### PR TITLE
Test: rename CI step

### DIFF
--- a/.github/workflows/dynamic.yml
+++ b/.github/workflows/dynamic.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: Do the job on the runner
+    name: Dynamic analysis
     runs-on: self-hosted
     if: github.repository_owner == 'deepmodeling'
     container: ghcr.io/deepmodeling/abacus-development-kit:gnu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test:
-    name: Do the job on the runner
+    name: Test
     runs-on: self-hosted
     if: github.repository_owner == 'deepmodeling'
     container: ghcr.io/deepmodeling/abacus-development-kit:gnu
@@ -14,11 +14,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
-      - name: Build and Test
-        env:
-          GTEST_COLOR: 'yes'
+      - name: Build
         run: |
           cmake -B build -DBUILD_TESTING=ON -DENABLE_DEEPKS=ON
           cmake --build build -j8
           cmake --install build
+      - name: Test
+        env:
+          GTEST_COLOR: 'yes'
+        run: |
           cmake --build build --target test ARGS="-V"


### PR DESCRIPTION
Separate Build and Test to two steps for a more clear view in GitHub actions page.
Rename CI job name.