### PR TITLE
Fix: remove invalid warning in `Pseudopot_upf::read_pseudo_upf201`.

### DIFF
--- a/source/module_base/global_function.cpp
+++ b/source/module_base/global_function.cpp
@@ -150,7 +150,7 @@ void TEST_LEVEL(const std::string &name)
     return;
 }
 
-bool SCAN_BEGIN(std::ifstream &ifs, const std::string &TargetName, const bool restart)
+bool SCAN_BEGIN(std::ifstream &ifs, const std::string &TargetName, const bool restart, const bool ifwarn)
 {
     std::string SearchName;
     bool find = false;
@@ -169,18 +169,18 @@ bool SCAN_BEGIN(std::ifstream &ifs, const std::string &TargetName, const bool re
             break;
         }
     }
-    if (!find)
+    if (!find && ifwarn)
     {
         GlobalV::ofs_warning << " In SCAN_BEGIN, can't find: " << TargetName << " block." << std::endl;
     }
     return find;
 }
 
-void SCAN_END(std::ifstream &ifs, const std::string &TargetName)
+void SCAN_END(std::ifstream &ifs, const std::string &TargetName, const bool ifwarn)
 {
     std::string SearchName;
     ifs >> SearchName;
-    if (SearchName != TargetName)
+    if (SearchName != TargetName && ifwarn)
     {
         GlobalV::ofs_warning << " In SCAN_END, can't find: " << TargetName << " block." << std::endl;
     }

--- a/source/module_base/global_function.h
+++ b/source/module_base/global_function.h
@@ -154,10 +154,12 @@ static void READ_VALUE(std::ifstream &ifs, T &v)
 }
 
 bool SCAN_BEGIN(std::ifstream &ifs, const std::string &TargetName, const bool restart=1, const bool ifwarn=true);
+// ifwarn: whether to call GlobalV::ofs_warning when the TargetName is not found, used to avoid invalid warning.
 // Mohan warning : the last term can't be written as const bool &restart,
 // I don't know why.
 
 void SCAN_END(std::ifstream &ifs, const std::string &TargetName, const bool ifwarn=true);
+// ifwarn: whether to call GlobalV::ofs_warning when the TargetName is not found, used to avoid invalid warning.
 
 template<class T>
 static inline void DCOPY( const T &a, T &b, const int &dim)

--- a/source/module_base/global_function.h
+++ b/source/module_base/global_function.h
@@ -153,11 +153,11 @@ static void READ_VALUE(std::ifstream &ifs, T &v)
     return;
 }
 
-bool SCAN_BEGIN(std::ifstream &ifs, const std::string &TargetName, const bool restart=1);
+bool SCAN_BEGIN(std::ifstream &ifs, const std::string &TargetName, const bool restart=1, const bool ifwarn=true);
 // Mohan warning : the last term can't be written as const bool &restart,
 // I don't know why.
 
-void SCAN_END(std::ifstream &ifs, const std::string &TargetName);
+void SCAN_END(std::ifstream &ifs, const std::string &TargetName, const bool ifwarn=true);
 
 template<class T>
 static inline void DCOPY( const T &a, T &b, const int &dim)

--- a/source/module_cell/read_pp_upf201.cpp
+++ b/source/module_cell/read_pp_upf201.cpp
@@ -126,7 +126,7 @@ int Pseudopot_upf::read_pseudo_upf201(std::ifstream &ifs)
 		ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_MESH>");
 	}
 
-	if (ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_R"))
+	if (ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_R", true, false))
 	{
 		ModuleBase::GlobalFunc::READ_VALUE(ifs, word); // type size columns
 		this->read_pseudo_upf201_r(ifs);
@@ -137,7 +137,7 @@ int Pseudopot_upf::read_pseudo_upf201(std::ifstream &ifs)
 	}
 	ModuleBase::GlobalFunc::SCAN_END(ifs, "</PP_R>");
 
-    if (ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_RAB"))
+    if (ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_RAB", true, false))
 	{
 		ModuleBase::GlobalFunc::READ_VALUE(ifs, word); // type size columns
 		this->read_pseudo_upf201_rab(ifs);
@@ -222,7 +222,7 @@ int Pseudopot_upf::read_pseudo_upf201(std::ifstream &ifs)
 		ifs >> word; //number of beta
 	}
 
-	if (ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_DIJ"))
+	if (ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_DIJ", true, false))
 	{
 		ModuleBase::GlobalFunc::READ_VALUE(ifs, word);  // type size columns
 		this->read_pseudo_upf201_dij(ifs);
@@ -287,7 +287,7 @@ int Pseudopot_upf::read_pseudo_upf201(std::ifstream &ifs)
 	//--------------------------------------
 	//-          PP_RHOATOM                - 
 	//--------------------------------------
-	if (ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_RHOATOM"))
+	if (ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_RHOATOM", true, false))
 	{
 		ModuleBase::GlobalFunc::READ_VALUE(ifs, word); // type size columns
 		this->read_pseudo_upf201_rhoatom(ifs);
@@ -301,7 +301,7 @@ int Pseudopot_upf::read_pseudo_upf201(std::ifstream &ifs)
 	//--------------------------------------
 	//-          PP_SPIN_ORB               - 
 	//--------------------------------------
-	ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_SPIN_ORB>");
+	ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_SPIN_ORB>", true, false);
 	//added by zhengdy-soc
 	delete[] this->jchi;
 	delete[] this->jjj;
@@ -378,13 +378,13 @@ int Pseudopot_upf::read_pseudo_upf201(std::ifstream &ifs)
 			break;
 		}
 	}
-	ModuleBase::GlobalFunc::SCAN_END(ifs, "</PP_SPIN_ORB>");
+	ModuleBase::GlobalFunc::SCAN_END(ifs, "</PP_SPIN_ORB>", false);
 	if (mesh%2 == 0)
 	{
 		mesh -= 1;
 	}
 	
-	ModuleBase::GlobalFunc::SCAN_END(ifs, "</UPF>");
+	ModuleBase::GlobalFunc::SCAN_END(ifs, "</UPF>", false);
 	delete []name;
 	delete []val;
 	


### PR DESCRIPTION
Add a parameter `ifwarn` to the `SCAN_BEGIN` and `SCAN_END` in `global_function.h` to switch the warning.
Fix a output bug in `Pseudopot_upf::read_pseudo_upf201`, which may out invalid warning. For example, if the key word in pseudopotential is `<PP_R>`, ABACUS will look for `<PP_R` first and output the warning that the `<PP_R` isn't found, next it will find `<PP_R>`, but `<PP_R` and `<PP_R>` are equivalent, so the warning is invalid.
As a result, I turn off the warning in the functions that look for `<PP_R`, `<PP_RAB`, `<PP_DIJ`, and `<PP_RHOATOM`.
Besides, many pseudopotentials do not have block `<PP_SPIN_ORB>`, the warning seems needless, so I turn off the warning when looking for `<PP_SPIN_ORB>` and `</PP_SPIN_ORB>`.
The warning of `</UPF>` is turned off for the same reason.
The problems of `<PP_SPIN_ORB>` and `</UPF>` are mentioned in [issue#128](https://github.com/abacusmodeling/abacus-develop/issues/128) in abacusmodeling/abacus-develop.