### PR TITLE
fix: Add the support to the multiple line heading in pseudopotential.

### DIFF
--- a/source/module_cell/read_pp_upf201.cpp
+++ b/source/module_cell/read_pp_upf201.cpp
@@ -128,7 +128,8 @@ int Pseudopot_upf::read_pseudo_upf201(std::ifstream &ifs)
 
 	if (ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_R", true, false))
 	{
-		ModuleBase::GlobalFunc::READ_VALUE(ifs, word); // type size columns
+		ifs.ignore(150, '>');
+		// ModuleBase::GlobalFunc::READ_VALUE(ifs, word); // type size columns
 		this->read_pseudo_upf201_r(ifs);
 	}
 	else if (ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_R>"))
@@ -139,7 +140,8 @@ int Pseudopot_upf::read_pseudo_upf201(std::ifstream &ifs)
 
     if (ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_RAB", true, false))
 	{
-		ModuleBase::GlobalFunc::READ_VALUE(ifs, word); // type size columns
+		ifs.ignore(150, '>');
+		// ModuleBase::GlobalFunc::READ_VALUE(ifs, word); // type size columns
 		this->read_pseudo_upf201_rab(ifs);
 	}
 	else if (ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_RAB>"))
@@ -224,7 +226,8 @@ int Pseudopot_upf::read_pseudo_upf201(std::ifstream &ifs)
 
 	if (ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_DIJ", true, false))
 	{
-		ModuleBase::GlobalFunc::READ_VALUE(ifs, word);  // type size columns
+		ifs.ignore(150, '>');
+		// ModuleBase::GlobalFunc::READ_VALUE(ifs, word);  // type size columns
 		this->read_pseudo_upf201_dij(ifs);
 	}
 	else if ( ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_DIJ>"))
@@ -289,7 +292,8 @@ int Pseudopot_upf::read_pseudo_upf201(std::ifstream &ifs)
 	//--------------------------------------
 	if (ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_RHOATOM", true, false))
 	{
-		ModuleBase::GlobalFunc::READ_VALUE(ifs, word); // type size columns
+    	ifs.ignore(150, '>');
+		// ModuleBase::GlobalFunc::READ_VALUE(ifs, word); // type size columns
 		this->read_pseudo_upf201_rhoatom(ifs);
 	}
 	else if (ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_RHOATOM>"))
@@ -527,10 +531,10 @@ void Pseudopot_upf::read_pseudo_upf201_dij(std::ifstream &ifs)
 		for(int j=0;j<nbeta;j++)
 		{
 			ifs >> dion(i,j);
-			if ( i != j  && dion(i,j) != 0.0 )
-			{
-				ModuleBase::WARNING_QUIT("read_pseudo_upf201","Error: for i != j, Dij of Pseudopotential must be 0.0");
-			}
+			// if ( i != j  && dion(i,j) != 0.0 )
+			// {
+			// 	ModuleBase::WARNING_QUIT("read_pseudo_upf201","Error: for i != j, Dij of Pseudopotential must be 0.0");
+			// }
 		}
 	}
 }


### PR DESCRIPTION
1. Fix the bug that multiple line heading of blocks `<PP_R>`, `<PP_RAB>`, `<PP_DIJ>`, and `<PP_RHOATOM>` in `PROJECT-Eu.UPF-1.txt` cannot be recognized by `Pseudopot_upf::read_pseudo_upf201`, mentioned in [issue137](https://github.com/abacusmodeling/abacus-develop/issues/137).
2. Release the restriction that off-diagonal elements of `PP_DIJ` (`Pseudopot_upf::dion`) must be zero. However, ABACUS currently only uses diagonal elements for computation, so further updates are needed .