### PR TITLE
test(parallel): UT of methods in parallel_kpoints

### DIFF
--- a/source/src_parallel/test/CMakeLists.txt
+++ b/source/src_parallel/test/CMakeLists.txt
@@ -10,8 +10,15 @@ AddTest(
   SOURCES parallel_global_test.cpp ../../module_base/global_variable.cpp ../parallel_global.cpp
 )
 
+AddTest(
+  TARGET ParaKpoints
+  LIBS MPI::MPI_CXX
+  SOURCES parallel_kpoints_test.cpp ../../module_base/global_variable.cpp ../parallel_global.cpp ../parallel_common.cpp ../parallel_kpoints.cpp
+)
+
 install(FILES parallel_common_test.sh DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 install(FILES parallel_global_test.sh DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+install(FILES parallel_kpoints_test.sh DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 find_program(BASH bash)
 
@@ -21,5 +28,9 @@ add_test(NAME parallel_common_test
 )
 add_test(NAME parallel_global_test
       COMMAND ${BASH} parallel_global_test.sh
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+add_test(NAME parallel_kpoints_test
+      COMMAND ${BASH} parallel_kpoints_test.sh
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )

--- a/source/src_parallel/test/parallel_global_test.cpp
+++ b/source/src_parallel/test/parallel_global_test.cpp
@@ -21,25 +21,21 @@
 
 TEST(ParaGlobal,SplitGrid)
 {
-	// NPROC is set to 6 in parallel_global_test.sh
-	if(GlobalV::NPROC==6)
+	// NPROC is set to 4 in parallel_global_test.sh
+	if(GlobalV::NPROC==4)
 	{
 		Parallel_Global::split_grid_world(2);
-		EXPECT_EQ(GlobalV::GSIZE,3);
+		EXPECT_EQ(GlobalV::GSIZE,2);
 		if(GlobalV::MY_RANK==0) EXPECT_EQ(GlobalV::GRANK,0);
 		if(GlobalV::MY_RANK==1) EXPECT_EQ(GlobalV::GRANK,1);
-		if(GlobalV::MY_RANK==2) EXPECT_EQ(GlobalV::GRANK,2);
-		if(GlobalV::MY_RANK==3) EXPECT_EQ(GlobalV::GRANK,0);
-		if(GlobalV::MY_RANK==4) EXPECT_EQ(GlobalV::GRANK,1);
-		if(GlobalV::MY_RANK==5) EXPECT_EQ(GlobalV::GRANK,2);
-		Parallel_Global::split_grid_world(6);
+		if(GlobalV::MY_RANK==2) EXPECT_EQ(GlobalV::GRANK,0);
+		if(GlobalV::MY_RANK==3) EXPECT_EQ(GlobalV::GRANK,1);
+		Parallel_Global::split_grid_world(4);
 		EXPECT_EQ(GlobalV::GSIZE,1);
 		if(GlobalV::MY_RANK==0) EXPECT_EQ(GlobalV::GRANK,0);
 		if(GlobalV::MY_RANK==1) EXPECT_EQ(GlobalV::GRANK,0);
 		if(GlobalV::MY_RANK==2) EXPECT_EQ(GlobalV::GRANK,0);
 		if(GlobalV::MY_RANK==3) EXPECT_EQ(GlobalV::GRANK,0);
-		if(GlobalV::MY_RANK==4) EXPECT_EQ(GlobalV::GRANK,0);
-		if(GlobalV::MY_RANK==5) EXPECT_EQ(GlobalV::GRANK,0);
 	}
 	else
 	{
@@ -53,25 +49,21 @@ TEST(ParaGlobal,SplitGrid)
 
 TEST(ParaGlobal,SplitDiag)
 {
-	// NPROC is set to 6 in parallel_global_test.sh
-	if(GlobalV::NPROC==6)
+	// NPROC is set to 4 in parallel_global_test.sh
+	if(GlobalV::NPROC==4)
 	{
 		Parallel_Global::split_diag_world(2);
 		EXPECT_EQ(GlobalV::DSIZE,2);
 		if(GlobalV::MY_RANK==0) EXPECT_EQ(GlobalV::DRANK,0);
 		if(GlobalV::MY_RANK==1) EXPECT_EQ(GlobalV::DRANK,0);
-		if(GlobalV::MY_RANK==2) EXPECT_EQ(GlobalV::DRANK,0);
+		if(GlobalV::MY_RANK==2) EXPECT_EQ(GlobalV::DRANK,1);
 		if(GlobalV::MY_RANK==3) EXPECT_EQ(GlobalV::DRANK,1);
-		if(GlobalV::MY_RANK==4) EXPECT_EQ(GlobalV::DRANK,1);
-		if(GlobalV::MY_RANK==5) EXPECT_EQ(GlobalV::DRANK,1);
-		Parallel_Global::split_diag_world(6);
-		EXPECT_EQ(GlobalV::DSIZE,6);
+		Parallel_Global::split_diag_world(4);
+		EXPECT_EQ(GlobalV::DSIZE,4);
 		if(GlobalV::MY_RANK==0) EXPECT_EQ(GlobalV::DRANK,0);
 		if(GlobalV::MY_RANK==1) EXPECT_EQ(GlobalV::DRANK,1);
 		if(GlobalV::MY_RANK==2) EXPECT_EQ(GlobalV::DRANK,2);
 		if(GlobalV::MY_RANK==3) EXPECT_EQ(GlobalV::DRANK,3);
-		if(GlobalV::MY_RANK==4) EXPECT_EQ(GlobalV::DRANK,4);
-		if(GlobalV::MY_RANK==5) EXPECT_EQ(GlobalV::DRANK,5);
 	}
 	else
 	{

--- a/source/src_parallel/test/parallel_global_test.sh
+++ b/source/src_parallel/test/parallel_global_test.sh
@@ -3,7 +3,7 @@
 np=`cat /proc/cpuinfo | grep "cpu cores" | uniq| awk '{print $NF}'`
 echo "nprocs in this machine is $np"
 
-for i in 6;do
+for i in 4;do
     if [[ $i -gt $np ]];then
         continue
     fi

--- a/source/src_parallel/test/parallel_kpoints_test.cpp
+++ b/source/src_parallel/test/parallel_kpoints_test.cpp
@@ -1,0 +1,165 @@
+#ifdef __MPI
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "mpi.h"
+#include "module_base/global_variable.h"
+#include "src_parallel/parallel_kpoints.h"
+
+/************************************************
+ *  unit test of functions in parallel_kpoints.cpp
+ ***********************************************/
+
+/**
+ * The tested functions:
+ *   i. Parallel_Kpoints::init_pools() is the public interface 
+ *      to call the private function Parallel_Kpoints::divide_pools(),
+ *      which divide all processes into KPAR groups.
+ *   ii.Parallel_Kpoints::kinf() is the public interface
+ *      to call another three functions: get_nks_pool(), 
+ *      get_startk_pool(), get_whichpool(), which divide all kpoints
+ *      into KPAR groups.
+ * The default number of processes is set to 6 in parallel_kpoints_test.sh. 
+ * One may modify it to do more tests, or adapt this unittest to local 
+ * environment.
+ */
+
+class ParaPrepare
+{
+public:
+	ParaPrepare(int KPAR_in,int nkstot_in):
+		KPAR_(KPAR_in),nkstot_(nkstot_in){}
+	int KPAR_;
+	int nkstot_;
+	void test_init_pools(void);
+	void test_kinfo(const Parallel_Kpoints* Pkpts);
+};
+
+void ParaPrepare::test_kinfo(const Parallel_Kpoints* Pkpts)
+{
+	int nks_pool_[KPAR_]={0};
+	int startk_pool_[KPAR_]={0};
+	int whichpool_[nkstot_]={0};
+
+	int quotient = nkstot_/KPAR_;
+	int residue  = nkstot_%KPAR_;
+	// the previous "residue" pools have (quotient+1) kpoints
+	for(int i=0;i<KPAR_;i++)
+	{
+		nks_pool_[i] = quotient;
+		if(i<residue)
+		{
+		        nks_pool_[i]++;
+		}
+		// number of kpoints in each pool
+		EXPECT_EQ(Pkpts->nks_pool[i],nks_pool_[i]);
+		//
+		if(i>0)
+		{
+		  startk_pool_[i]=startk_pool_[i-1]+nks_pool_[i-1];
+		}
+		// the rank of the 1st process of each pool in MPI_COMM_WORLD
+		EXPECT_EQ(Pkpts->startk_pool[i],startk_pool_[i]);
+		//
+		for(int ik=0;ik<nks_pool_[i];ik++)
+		{
+			int k_now = ik + startk_pool_[i];
+			// the pool where this kpoint (k_now) resides
+			EXPECT_EQ(Pkpts->whichpool[k_now],i);
+		}
+	}
+}
+
+
+void ParaPrepare::test_init_pools()
+{
+	int* nproc_pool_= new int[KPAR_];
+	int quotient = GlobalV::NPROC/KPAR_;
+	int residue  = GlobalV::NPROC%KPAR_;
+	// the previous "residue" pools have (quotient+1) processes
+	for(int i=0;i<KPAR_;i++)
+	{
+		nproc_pool_[i] = quotient;
+		if(i<residue)
+		{
+			++nproc_pool_[i];
+		}
+	}
+	int color=-1;
+	int np_now=0;
+	for(int i=0;i<KPAR_;i++)
+	{
+		np_now += nproc_pool_[i];
+		if(GlobalV::MY_RANK < np_now)
+		{
+			color = i;
+			// GlobalV::MY_POOL is the pool where this process resides
+			EXPECT_EQ(GlobalV::MY_POOL,i);
+			break;
+		}
+	}
+	MPI_Comm test_comm;
+	int test_rank, test_size;
+	MPI_Comm_split(MPI_COMM_WORLD, color, GlobalV::MY_RANK, &test_comm);
+	MPI_Comm_rank(test_comm, &test_rank);
+	MPI_Comm_size(test_comm, &test_size);
+	// GlobalV::RANK_IN_POOL is the rank of this process in GlobalV::MY_POOL
+	EXPECT_EQ(GlobalV::RANK_IN_POOL,test_rank);
+	// GlobalV::NPROC_IN_POOL is the number of processes in GlobalV::MY_POOL where this process resides
+	EXPECT_EQ(GlobalV::NPROC_IN_POOL,test_size);
+        //printf("my_rank: %d \t test rank/size: %d/%d \t pool rank/size: %d/%d\n",
+	//       GlobalV::MY_RANK,test_rank,test_size,GlobalV::RANK_IN_POOL,GlobalV::NPROC_IN_POOL);
+	MPI_Comm_free(&test_comm);
+}
+
+class ParaKpoints : public ::testing::TestWithParam<ParaPrepare>
+{
+};
+	
+TEST_P(ParaKpoints,DividePools)
+{
+	ParaPrepare pp = GetParam();
+	Parallel_Kpoints* Pkpoints;
+	Pkpoints = new Parallel_Kpoints;
+	GlobalV::KPAR = pp.KPAR_;
+	if(pp.KPAR_>GlobalV::NPROC)
+	{
+		std::string output;
+		testing::internal::CaptureStdout();
+		EXPECT_EXIT(Pkpoints->init_pools(),testing::ExitedWithCode(0),"");
+		output = testing::internal::GetCapturedStdout();
+		EXPECT_THAT(output,testing::HasSubstr("Too many pools"));
+	}
+	else
+	{
+		Pkpoints->init_pools();
+		pp.test_init_pools();
+		Pkpoints->kinfo(pp.nkstot_);
+		pp.test_kinfo(Pkpoints);
+	}
+	delete Pkpoints;
+}
+
+INSTANTIATE_TEST_SUITE_P(TESTPK,ParaKpoints,::testing::Values(
+			// KPAR, nkstot
+			ParaPrepare(2,57),
+			ParaPrepare(3,67),
+			ParaPrepare(5,97),
+			ParaPrepare(97,97)
+			));
+
+int main(int argc, char **argv)
+{
+
+    MPI_Init(&argc, &argv);
+    testing::InitGoogleTest(&argc, argv);
+
+    MPI_Comm_size(MPI_COMM_WORLD,&GlobalV::NPROC);
+    MPI_Comm_rank(MPI_COMM_WORLD,&GlobalV::MY_RANK);
+
+    int result = RUN_ALL_TESTS();
+
+    MPI_Finalize();
+
+    return result;
+}
+#endif

--- a/source/src_parallel/test/parallel_kpoints_test.cpp
+++ b/source/src_parallel/test/parallel_kpoints_test.cpp
@@ -18,7 +18,7 @@
  *      to call another three functions: get_nks_pool(), 
  *      get_startk_pool(), get_whichpool(), which divide all kpoints
  *      into KPAR groups.
- * The default number of processes is set to 6 in parallel_kpoints_test.sh. 
+ * The default number of processes is set to 4 in parallel_kpoints_test.sh. 
  * One may modify it to do more tests, or adapt this unittest to local 
  * environment.
  */

--- a/source/src_parallel/test/parallel_kpoints_test.sh
+++ b/source/src_parallel/test/parallel_kpoints_test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+np=`cat /proc/cpuinfo | grep "cpu cores" | uniq| awk '{print $NF}'`
+echo "nprocs in this machine is $np"
+
+for i in 6;do
+    if [[ $i -gt $np ]];then
+        continue
+    fi
+    echo "TEST in parallel, nprocs=$i"
+    mpirun -np $i ./ParaKpoints
+    break    
+done

--- a/source/src_parallel/test/parallel_kpoints_test.sh
+++ b/source/src_parallel/test/parallel_kpoints_test.sh
@@ -3,7 +3,7 @@
 np=`cat /proc/cpuinfo | grep "cpu cores" | uniq| awk '{print $NF}'`
 echo "nprocs in this machine is $np"
 
-for i in 6;do
+for i in 4;do
     if [[ $i -gt $np ]];then
         continue
     fi


### PR DESCRIPTION
The tested functions:
 i. Parallel_Kpoints::init_pools() is the public interface to call the private function Parallel_Kpoints::divide_pools(),
      which divide all processes into KPAR groups.
 ii.Parallel_Kpoints::kinf() is the public interface to call another three functions: get_nks_pool(), get_startk_pool(), get_whichpool(),
     which divide all kpoints into KPAR groups.
 The default number of processes is set to 4 in parallel_kpoints_test.sh. One may modify it to do more tests, or adapt this unittest to local environment.
