### PR TITLE
Build: fix OepnMP link for intel compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,6 @@ target_link_libraries(${ABACUS_BIN_NAME} Threads::Threads)
 if(USE_OPENMP)
   find_package(OpenMP REQUIRED)
   target_link_libraries(${ABACUS_BIN_NAME} OpenMP::OpenMP_CXX)
-  add_compile_options(${OpenMP_CXX_FLAGS})
 endif()
 
 include(CheckLanguage)


### PR DESCRIPTION
Using OpenMP target will only link this feature to the targeted library.
However, `add_compile_options` will add OpenMP flags to all targets
afterwards, without linking libraries properly.

Fix #949 .