### PR TITLE
test(integrate): out_wfc_lcao > 0 in lcao basis

### DIFF
--- a/tests/integrate/212_NO_wfc_out/INPUT
+++ b/tests/integrate/212_NO_wfc_out/INPUT
@@ -1,0 +1,18 @@
+INPUT_PARAMETERS
+#Parameters	(System)
+suffix                  autotest
+ntype			1
+nbands			4
+stru_file		STRU
+kpoint_file		KPT
+pseudo_dir		../tools/PP_ORB/
+orbital_dir		../tools/PP_ORB/
+latname			sc
+#Parameters (PW)
+ecutwfc			25.0              # Rydberg
+#Parameters (electronic)
+basis_type		lcao 	
+scf_thr			1e-10
+
+calculation     	scf
+out_wfc_lcao		1

--- a/tests/integrate/212_NO_wfc_out/KPT
+++ b/tests/integrate/212_NO_wfc_out/KPT
@@ -1,0 +1,4 @@
+K_POINTS
+0
+Gamma
+2 1 1 0 0 0

--- a/tests/integrate/212_NO_wfc_out/STRU
+++ b/tests/integrate/212_NO_wfc_out/STRU
@@ -1,0 +1,19 @@
+#This is the atom file containing all the information
+#about the lattice structure.
+
+ATOMIC_SPECIES
+H 1.0008  H_ONCV_PBE-1.0.upf 
+ 
+NUMERICAL_ORBITAL
+H_gga_6au_60Ry_2s1p.orb
+
+LATTICE_CONSTANT
+10.0  			#Lattice constant
+
+ATOMIC_POSITIONS
+Cartesian   		#Cartesian(Unit is LATTICE_CONSTANT)
+H 			#Name of element	
+0.0			#Magnetic for this element.
+2			#Number of atoms
+0.00 0.00 -0.0661400 0 0 0	#x,y,z, move_x, move_y, move_z
+0.00 0.00  0.0661400 0 0 0	#x,y,z, move_x, move_y, move_z

--- a/tests/integrate/212_NO_wfc_out/jd
+++ b/tests/integrate/212_NO_wfc_out/jd
@@ -1,0 +1,1 @@
+test out_wfc_lcao > 0

--- a/tests/integrate/212_NO_wfc_out/result.ref
+++ b/tests/integrate/212_NO_wfc_out/result.ref
@@ -1,0 +1,5 @@
+etotref -31.72940050479744
+etotperatomref -15.8647002524
+LOWF_K_1.dat 42.058102
+LOWF_K_2.dat 43.760182
+totaltimeref 0.63360

--- a/tests/integrate/312_NO_GO_wfc_out/INPUT
+++ b/tests/integrate/312_NO_GO_wfc_out/INPUT
@@ -1,0 +1,19 @@
+INPUT_PARAMETERS
+#Parameters	(System)
+suffix                  autotest
+ntype			1
+nbands			4
+stru_file		STRU
+kpoint_file		KPT
+pseudo_dir		../tools/PP_ORB/
+orbital_dir		../tools/PP_ORB/
+latname			sc
+#Parameters (PW)
+ecutwfc			25.0              # Rydberg
+#Parameters (electronic)
+basis_type		lcao 	
+scf_thr			1e-10
+
+calculation     	scf
+gamma_only		1
+out_wfc_lcao		1

--- a/tests/integrate/312_NO_GO_wfc_out/KPT
+++ b/tests/integrate/312_NO_GO_wfc_out/KPT
@@ -1,0 +1,4 @@
+K_POINTS
+0
+Gamma
+1 1 1 0 0 0

--- a/tests/integrate/312_NO_GO_wfc_out/STRU
+++ b/tests/integrate/312_NO_GO_wfc_out/STRU
@@ -1,0 +1,19 @@
+#This is the atom file containing all the information
+#about the lattice structure.
+
+ATOMIC_SPECIES
+H 1.0008  H_ONCV_PBE-1.0.upf 
+ 
+NUMERICAL_ORBITAL
+H_gga_6au_60Ry_2s1p.orb
+
+LATTICE_CONSTANT
+10.0  			#Lattice constant
+
+ATOMIC_POSITIONS
+Cartesian   		#Cartesian(Unit is LATTICE_CONSTANT)
+H 			#Name of element	
+0.0			#Magnetic for this element.
+2			#Number of atoms
+0.00 0.00 -0.0661400 0 0 0	#x,y,z, move_x, move_y, move_z
+0.00 0.00  0.0661400 0 0 0	#x,y,z, move_x, move_y, move_z

--- a/tests/integrate/312_NO_GO_wfc_out/jd
+++ b/tests/integrate/312_NO_GO_wfc_out/jd
@@ -1,0 +1,1 @@
+test out_wfc_lcao > 0 for gamma only

--- a/tests/integrate/312_NO_GO_wfc_out/result.ref
+++ b/tests/integrate/312_NO_GO_wfc_out/result.ref
@@ -1,0 +1,4 @@
+etotref -31.74264435040485
+etotperatomref -15.8713221752
+LOWF_GAMMA_S1.dat 42.056808
+totaltimeref 0.61908

--- a/tests/integrate/Autotest.sh
+++ b/tests/integrate/Autotest.sh
@@ -9,8 +9,7 @@ threshold=0.0000001
 # check accuracy
 ca=8
 # regex of case name
-#case="^[^#].*_.*$"
-case="^[^#].*_wfc_out$"
+case="^[^#].*_.*$"
 # enable AddressSanitizer
 sanitize=false
 

--- a/tests/integrate/Autotest.sh
+++ b/tests/integrate/Autotest.sh
@@ -171,7 +171,7 @@ for dir in $testdir; do
 		then
 			../tools/catch_properties.sh result.out
 			if [ $? == 1 ]; then
-            			echo -e "\e[1;31m [  FAILED  ]  Fatal Error in catch_properties.sh \e[0m"
+				echo -e "\e[1;31m [  FAILED  ]  Fatal Error in catch_properties.sh \e[0m"
 				let failed++
 				failed_case_list+=$dir
 				break

--- a/tests/integrate/Autotest.sh
+++ b/tests/integrate/Autotest.sh
@@ -9,7 +9,8 @@ threshold=0.0000001
 # check accuracy
 ca=8
 # regex of case name
-case="^[^#].*_.*$"
+#case="^[^#].*_.*$"
+case="^[^#].*_wfc_out$"
 # enable AddressSanitizer
 sanitize=false
 
@@ -169,7 +170,14 @@ for dir in $testdir; do
 		if test -z $g
 		then
 			../tools/catch_properties.sh result.out
-			check_out result.out
+			if [ $? == 1 ]; then
+            			echo -e "\e[1;31m [  FAILED  ]  Fatal Error in catch_properties.sh \e[0m"
+				let failed++
+				failed_case_list+=$dir
+				break
+			else
+				check_out result.out
+			fi
 		else
 			../tools/catch_properties.sh result.ref
 		fi

--- a/tests/integrate/CASES
+++ b/tests/integrate/CASES
@@ -106,6 +106,7 @@
 211_NO_S2_elec_add
 211_NO_elec_minus
 211_NO_S2_elec_minus
+212_NO_wfc_out
 212_NO_wfc_ienvelope
 220_NO_KP_MD_FIRE
 220_NO_KP_MD_NVE
@@ -130,6 +131,7 @@
 308_NO_GO_CS_CR
 311_NO_GO_elec_minus
 311_NO_GO_S2_elec_minus
+312_NO_GO_wfc_out
 312_NO_GO_wfc_ienvelope
 320_NO_GO_MD_FIRE
 320_NO_GO_MD_NVE

--- a/tests/integrate/tools/catch_properties.sh
+++ b/tests/integrate/tools/catch_properties.sh
@@ -133,8 +133,8 @@ if ! test -z "$has_lowf"  && [ $has_lowf -eq 1 ]; then
 				sed -i "1,$ s/[F-Z]//g" OUT.autotest/$lowf
 				sed -i "1,$ s/)//g" OUT.autotest/$lowf
 				sed -i "1,$ s/(//g" OUT.autotest/$lowf
-        			total_lowf=`sum_file OUT.autotest/$lowf`
-        			echo "$lowf $total_lowf" >>$1
+				total_lowf=`sum_file OUT.autotest/$lowf`
+				echo "$lowf $total_lowf" >>$1
 			fi
 		done
 	fi

--- a/tests/integrate/tools/catch_properties.sh
+++ b/tests/integrate/tools/catch_properties.sh
@@ -111,7 +111,6 @@ if ! test -z "$has_hs"  && [  $has_hs -eq 1 ]; then
 fi
 # echo "$has_lowf" ## test out_wfc_lcao > 0
 if ! test -z "$has_lowf"  && [ $has_lowf -eq 1 ]; then
-	nfile=0
 	if ! test -z "$gamma_only"  && [ $gamma_only -eq 1 ]; then
 		lowfiles=`ls OUT.autotest/ | grep LOWF_GAMMA`
 	else
@@ -124,7 +123,7 @@ if ! test -z "$has_lowf"  && [ $has_lowf -eq 1 ]; then
 		for lowf in $lowfiles;
 		do
 			if ! test -f OUT.autotest/$lowf; then
-				echo "Non-regular LOWF found"
+				echo "Irregular LOWF file found"
 				exit 1
 			else
 				sed -i "1,$ s/[a-d]//g" OUT.autotest/$lowf

--- a/tests/integrate/tools/catch_properties.sh
+++ b/tests/integrate/tools/catch_properties.sh
@@ -35,6 +35,8 @@ has_hs=`grep -En '(^|[[:space:]])out_mat_hs($|[[:space:]])' INPUT | awk '{print 
 has_r=`grep -En '(^|[[:space:]])out_mat_r($|[[:space:]])' INPUT | awk '{print $2}'`
 deepks_out_labels=`grep deepks_out_labels INPUT | awk '{print $2}' | sed s/[[:space:]]//g`
 deepks_bandgap=`grep deepks_bandgap INPUT | awk '{print $2}' | sed s/[[:space:]]//g`
+has_lowf=`grep out_wfc_lcao INPUT | awk '{print $2}' | sed s/[[:space:]]//g`
+gamma_only=`grep gamma_only INPUT | awk '{print $2}' | sed s/[[:space:]]//g`
 #echo $running_path
 base=`grep -En '(^|[[:space:]])basis_type($|[[:space:]])' INPUT | awk '{print $2}' | sed s/[[:space:]]//g`
 if [ $base == "pw" ]; then word="plane_wave_line" 
@@ -106,6 +108,36 @@ if ! test -z "$has_hs"  && [  $has_hs -eq 1 ]; then
         echo "totalHmatrix $total_h" >>$1
 	total_s=`sum_file OUT.autotest/data-0-S`
 	echo "totalSmatrix $total_s" >>$1
+fi
+# echo "$has_lowf" ## test out_wfc_lcao > 0
+if ! test -z "$has_lowf"  && [ $has_lowf -eq 1 ]; then
+	nfile=0
+	if ! test -z "$gamma_only"  && [ $gamma_only -eq 1 ]; then
+		lowfiles=`ls OUT.autotest/ | grep LOWF_GAMMA`
+	else
+		lowfiles=`ls OUT.autotest/ | grep LOWF_K`
+	fi
+	if test -z "$lowfiles"; then
+		echo "Can't find LOWF files"
+		exit 1
+	else
+		for lowf in $lowfiles;
+		do
+			if ! test -f OUT.autotest/$lowf; then
+				echo "Non-regular LOWF found"
+				exit 1
+			else
+				sed -i "1,$ s/[a-d]//g" OUT.autotest/$lowf
+				sed -i "1,$ s/[f-z]//g" OUT.autotest/$lowf
+				sed -i "1,$ s/[A-D]//g" OUT.autotest/$lowf
+				sed -i "1,$ s/[F-Z]//g" OUT.autotest/$lowf
+				sed -i "1,$ s/)//g" OUT.autotest/$lowf
+				sed -i "1,$ s/(//g" OUT.autotest/$lowf
+        			total_lowf=`sum_file OUT.autotest/$lowf`
+        			echo "$lowf $total_lowf" >>$1
+			fi
+		done
+	fi
 fi
 
 if [ $calculation == "ienvelope" ]; then


### PR DESCRIPTION
Add two CI tests: 212_NO_wfc_out (multiple k case) and 312_NO_GO_wfc_out (gamma only case) to cover "out_wfc_lcao = true" calculations. The existence and goodness of LOW files are tested in abacus-develop/tests/integrate/tools/catch_properties.sh. If anything irregular happens, catch_properties.sh echo related information and exit with 1, which then can be catched in abacus-develop/tests/integrate/Autotest.sh.