### PR TITLE
Fix: add OpenMP flag properly.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,8 @@ target_link_libraries(${ABACUS_BIN_NAME} Threads::Threads)
 if(USE_OPENMP)
   find_package(OpenMP REQUIRED)
   target_link_libraries(${ABACUS_BIN_NAME} OpenMP::OpenMP_CXX)
+  add_compile_options(${OpenMP_CXX_FLAGS})
+  add_link_options(${OpenMP_CXX_LIBRARIES})
 endif()
 
 include(CheckLanguage)


### PR DESCRIPTION
Now will treat OpenMP as a global feature, but not limited to main program.

Fixes #954
Related: #964