### PR TITLE
Build: use public docker registry address

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Login to Aliyun Registry
         uses: docker/login-action@v1
         with:
-          registry: ${{ secrets.DP_HARBOR_REGISTRY }}
+          registry: registry.dp.tech
           username: ${{ secrets.DP_HARBOR_USERNAME }}
           password: ${{ secrets.DP_HARBOR_PASSWORD }}
 
@@ -37,9 +37,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           tags: |
-            ghcr.io/${{ github.repository_owner }}/abacus-development-kit:${{ matrix.dockerfile }}
-            ${{ secrets.DP_HARBOR_REGISTRY }}/dplc/abacus-${{ matrix.dockerfile }}:latest
+            ghcr.io/deepmodeling/abacus-development-kit:${{ matrix.dockerfile }}
+            registry.dp.tech/deepmodeling/abacus-${{ matrix.dockerfile }}:latest
           file: Dockerfile.${{ matrix.dockerfile }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/abacus-development-kit:${{matrix.dockerfile}}
+          cache-from: type=registry,ref=ghcr.io/deepmodeling/abacus-development-kit:${{matrix.dockerfile}}
           cache-to: type=inline
           push: true

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -18,8 +18,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ghcr.io/${{ github.repository_owner }}/abacus
-            ${{ secrets.DP_HARBOR_REGISTRY }}/dplc/abacus
+            ghcr.io/deepmodeling/abacus
+            registry.dp.tech/deepmodeling/abacus
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
@@ -37,7 +37,7 @@ jobs:
       - name: Login to Aliyun Registry
         uses: docker/login-action@v1
         with:
-          registry: ${{ secrets.DP_HARBOR_REGISTRY }}
+          registry: registry.dp.tech
           username: ${{ secrets.DP_HARBOR_USERNAME }}
           password: ${{ secrets.DP_HARBOR_PASSWORD }}
 

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -20,6 +20,7 @@ jobs:
           cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=1
       - name: Run clang-tidy
         run: |
+          git config --global --add safe.directory /__w/abacus-develop/abacus-develop
           git diff -U0 HEAD^ | clang-tidy-diff -p1 -path build -export-fixes fixes.yml
       - name: Pull request comments from clang-tidy reports
         uses: platisd/clang-tidy-pr-comments@master

--- a/docs/install.md
+++ b/docs/install.md
@@ -15,7 +15,7 @@
 
 ### Container Deployment
 
-We've built a ready-for-use version of ABACUS with docker [here](https://github.com/deepmodeling/abacus-develop/pkgs/container/abacus). For a quick start: pull the image, prepare the data, run container. Instructions on using the image can be accessed in [Dockerfile](../Dockerfile).
+We've built a ready-for-use version of ABACUS with docker [here](https://github.com/deepmodeling/abacus-develop/pkgs/container/abacus). For a quick start: pull the image, prepare the data, run container. Instructions on using the image can be accessed in [Dockerfile](../Dockerfile). A mirror is available by `docker pull registry.dp.tech/deepmodeling/abacus`.
 
 We also offer a pre-built docker image containing all the requirements for development. Please refer to our [Package Page](https://github.com/deepmodeling/abacus-develop/pkgs/container/abacus-development-kit).
 


### PR DESCRIPTION
We are now using `registry.dp.tech/deepmodeling` as our image base address; this enables public using without login to the registry. A uniforming on image names and abilities between github registry and our aliyun registry will be discussed later.