### PR TITLE
Add a device template for class psi

### DIFF
--- a/source/module_elecstate/test/CMakeLists.txt
+++ b/source/module_elecstate/test/CMakeLists.txt
@@ -11,6 +11,7 @@ AddTest(
           ../../src_pw/structure_factor.cpp ../../src_pw/pw_complement.cpp 
           ../../src_pw/klist.cpp ../../src_parallel/parallel_kpoints.cpp ../../src_pw/occupy.cpp  
           ../../module_elecstate/elecstate_pw.cpp ../../module_elecstate/elecstate.cpp
+          ../../module_psi/src/device.cpp
 )
 
 install(DIRECTORY support DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
@@ -33,6 +34,7 @@ AddTest(
             ../../src_pw/charge.cpp 
             ../../src_pdiag/pdiag_common.cpp
             ../../src_io/output.cpp ../../src_pw/soc.cpp
+            ../../module_psi/src/device.cpp
 )
 target_compile_definitions(EState_psiToRho_lcao PRIVATE __MPI)
 install(FILES elecstate_lcao_parallel_test.sh DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/source/module_hsolver/test/CMakeLists.txt
+++ b/source/module_hsolver/test/CMakeLists.txt
@@ -6,6 +6,7 @@ AddTest(
   SOURCES diago_cg_test.cpp ../diago_cg.cpp  ../diago_iter_assist.cpp  
           ../../module_psi/psi.cpp  ../../src_parallel/parallel_reduce.cpp
           ../../src_parallel/parallel_global.cpp ../../module_pw/test/test_tool.cpp
+          ../../module_psi/src/device.cpp
 )
 AddTest(
   TARGET HSolver_dav
@@ -13,12 +14,14 @@ AddTest(
   SOURCES diago_david_test.cpp ../diago_david.cpp  ../diago_iter_assist.cpp 
           ../../module_psi/psi.cpp  ../../src_parallel/parallel_reduce.cpp ../../src_parallel/parallel_global.cpp 
           ../../module_pw/test/test_tool.cpp
+          ../../module_psi/src/device.cpp
 )
 AddTest(
   TARGET HSolver_LCAO
   LIBS ${math_libs} ELPA::ELPA base
   SOURCES diago_lcao_test.cpp ../diago_elpa.cpp ../diago_blas.cpp ../../src_parallel/parallel_global.cpp 
           ../../src_parallel/parallel_common.cpp ../../src_parallel/parallel_reduce.cpp
+          ../../module_psi/src/device.cpp
 )
 
 install(FILES H-KPoints-Si2.dat DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/source/module_psi/CMakeLists.txt
+++ b/source/module_psi/CMakeLists.txt
@@ -2,4 +2,5 @@ add_library(
     psi
     OBJECT
     psi.cpp
+    src/device.cpp
 )

--- a/source/module_psi/include/device.h
+++ b/source/module_psi/include/device.h
@@ -1,13 +1,15 @@
-#ifndef ABACUS_DEVICE_H_
-#define ABACUS_DEVICE_H_
+#ifndef MODULE_PSI_DEVICE_H_
+#define MODULE_PSI_DEVICE_H_
 
 #include <iostream>
 #include "module_psi/include/types.h"
 
 namespace psi{
+namespace device {
 
-template<typename Device> std::string get_device_type (Device* dev);
+template<typename Device> AbacusDevice_t get_device_type (Device* dev);
 
-}
+} // end of namespace device
+} // end of namespace psi
 
-#endif  // ABACUS_DEVICE_H_
+#endif  // MODULE_PSI_DEVICE_H_

--- a/source/module_psi/include/device.h
+++ b/source/module_psi/include/device.h
@@ -1,0 +1,13 @@
+#ifndef ABACUS_DEVICE_H_
+#define ABACUS_DEVICE_H_
+
+#include <iostream>
+#include "module_psi/include/types.h"
+
+namespace psi{
+
+template<typename Device> std::string get_device_type (Device* dev);
+
+}
+
+#endif  // ABACUS_DEVICE_H_

--- a/source/module_psi/include/gpu_cuda.h
+++ b/source/module_psi/include/gpu_cuda.h
@@ -1,28 +1,13 @@
-#pragma once
+#ifndef MODULE_PSI_GPU_CUDA_H_
+#define MODULE_PSI_GPU_CUDA_H_
+
 #include <vector>
 #include <stdio.h>
 #include <assert.h>
 #include <cuda_runtime.h>
 
+namespace psi {
 namespace gpu_cuda {
-
-template <typename FPTYPE>
-void memcpy_device_to_host(
-    const FPTYPE * device, 
-    std::vector<FPTYPE> &host) 
-{
-  cudaMemcpy(&host[0], device, sizeof(FPTYPE) * host.size(), cudaMemcpyDeviceToHost);  
-}
-
-template <typename FPTYPE>
-void malloc_host_memory_sync(
-    FPTYPE * &host,
-    const FPTYPE * device,
-    const int size)
-{
-  host = (FPTYPE *)malloc(sizeof(FPTYPE) * size);
-  memcpy_device_to_host(device, host, size);
-}
 
 template <typename FPTYPE>
 void memcpy_host_to_device(
@@ -55,9 +40,7 @@ template <typename FPTYPE>
 void delete_device_memory(
     FPTYPE * &device) 
 {
-  if (device != NULL) {
-    cudaFree(device);
-  }
+  cudaFree(device);
 }
 
 template <typename FPTYPE>
@@ -118,4 +101,7 @@ void abacus_memcpy_host_to_device(
 }
 
 
-} // end of namespace deepmd
+} // end of namespace gpu_cuda
+} // end of namespace psi
+
+#endif  // MODULE_PSI_GPU_CUDA_H_

--- a/source/module_psi/include/gpu_cuda.h
+++ b/source/module_psi/include/gpu_cuda.h
@@ -1,0 +1,121 @@
+#pragma once
+#include <vector>
+#include <stdio.h>
+#include <assert.h>
+#include <cuda_runtime.h>
+
+namespace gpu_cuda {
+
+template <typename FPTYPE>
+void memcpy_device_to_host(
+    const FPTYPE * device, 
+    std::vector<FPTYPE> &host) 
+{
+  cudaMemcpy(&host[0], device, sizeof(FPTYPE) * host.size(), cudaMemcpyDeviceToHost);  
+}
+
+template <typename FPTYPE>
+void malloc_host_memory_sync(
+    FPTYPE * &host,
+    const FPTYPE * device,
+    const int size)
+{
+  host = (FPTYPE *)malloc(sizeof(FPTYPE) * size);
+  memcpy_device_to_host(device, host, size);
+}
+
+template <typename FPTYPE>
+void memcpy_host_to_device(
+    FPTYPE * device, 
+    const FPTYPE * host,
+    const int size) 
+{
+  cudaMemcpy(device, host, sizeof(FPTYPE) * size, cudaMemcpyHostToDevice);  
+}
+
+template <typename FPTYPE>
+void malloc_device_memory_sync(
+    FPTYPE * &device,
+    const FPTYPE * host,
+    const int size)
+{
+  cudaMalloc((void **)&device, sizeof(FPTYPE) * size);
+  memcpy_host_to_device(device, host, size);
+}
+
+template <typename FPTYPE>
+void malloc_device_memory(
+    FPTYPE * &device,
+    const int size)
+{
+  cudaMalloc((void **)&device, sizeof(FPTYPE) * size);
+}
+
+template <typename FPTYPE>
+void delete_device_memory(
+    FPTYPE * &device) 
+{
+  if (device != NULL) {
+    cudaFree(device);
+  }
+}
+
+template <typename FPTYPE>
+void memset_device_memory(
+    FPTYPE * device, 
+    const int var,
+    const int size) 
+{
+  cudaMemset(device, var, sizeof(FPTYPE) * size);  
+}
+
+template <typename FPTYPE>
+void abacus_resize_memory(
+    FPTYPE * arr, 
+    const int& size) 
+{
+  if (arr != nullptr) {
+    delete_device_memory(arr);
+  }
+  malloc_device_memory(arr, size);  
+}
+
+
+template <typename FPTYPE>
+void abacus_memset(
+    FPTYPE * arr, 
+    const int var,
+    const int& size) 
+{
+  memset_device_memory(arr, var, size);  
+}
+
+template <typename FPTYPE>
+void abacus_memcpy_device_to_device(
+    FPTYPE * arr1, 
+    const FPTYPE * arr2, 
+    const int size) 
+{
+  cudaMemcpy(arr1, arr2, sizeof(FPTYPE) * size, cudaMemcpyDeviceToDevice);  
+}
+
+template <typename FPTYPE>
+void abacus_memcpy_device_to_host(
+    FPTYPE * arr1, 
+    const FPTYPE * arr2, 
+    const int size) 
+{
+  cudaMemcpy(arr1, arr2, sizeof(FPTYPE) * size, cudaMemcpyDeviceToHost);  
+}
+
+template <typename FPTYPE>
+void abacus_memcpy_host_to_device(
+    FPTYPE * arr1, 
+    const FPTYPE * arr2, 
+    const int size) 
+{
+  cudaMemcpy(arr1, arr2, sizeof(FPTYPE) * size, cudaMemcpyHostToDevice);  
+}
+
+
+} // end of namespace deepmd

--- a/source/module_psi/include/memory.h
+++ b/source/module_psi/include/memory.h
@@ -1,0 +1,78 @@
+#ifndef ABACUS_MEMORY_H_
+#define ABACUS_MEMORY_H_
+
+#include <string.h>
+#include "module_psi/include/types.h"
+
+#if __CUDA
+#include <module_psi/include/gpu_cuda.h>
+#elif __ROCM
+#include <module_psi/include/gpu_cuda.h>
+#endif
+
+template<typename FPTYPE>
+void abacus_resize_memory(FPTYPE * &arr, const int& size, const std::string& device) {
+  if (device == "CPU") {
+    if (arr != nullptr) {
+      free(arr);
+    }
+    arr = (FPTYPE*) malloc(sizeof(FPTYPE) * size);
+  }
+  else if (device == "GPU") {
+    #if __CUDA
+      gpu_cuda::abacus_resize_memory(arr, size);
+    #elif __ROCM
+      gpu_rocm::abacus_resize_memory(arr, size);
+    #endif
+  }
+}
+
+template<typename FPTYPE>
+void abacus_memset(FPTYPE * &arr, const int & val, const int& size, const std::string& device) {
+  if (device == "CPU") {
+    memset(arr, val, sizeof(FPTYPE) * size);
+  }
+  else if (device == "GPU") {
+    #if __CUDA
+      gpu_cuda::abacus_memset(arr, val, size);
+    #elif __ROCM
+      gpu_rocm::abacus_memset(arr, val, size);
+    #endif
+  }
+}
+
+template<typename FPTYPE>
+void abacus_memory_sync(
+    FPTYPE * &arr1, 
+    const FPTYPE * &arr2, 
+    const int& size, 
+    const std::string& device1, 
+    const std::string& device2) 
+{
+  if (device1 == "CPU" and device2 == "CPU") {
+    memcpy(arr1, arr2, size);
+  }
+  if (device1 == "GPU" and device2 == "GPU") {
+    #if __CUDA
+      gpu_cuda::abacus_memcpy_device_to_device(arr1, arr2, size);
+    #elif __ROCM
+      gpu_rocm::abacus_memcpy_device_to_device(arr1, arr2, size);
+    #endif
+  }
+  else if (device1 == "CPU" and device2 == "GPU") {
+    #if __CUDA
+      gpu_cuda::abacus_memcpy_device_to_host(arr1, arr2, size);
+    #elif __ROCM
+      gpu_rocm::abacus_memcpy_device_to_host(arr1, arr2, size);
+    #endif
+  }
+  else if (device1 == "GPU" and device2 == "CPU") {
+    #if __CUDA
+      gpu_cuda::abacus_memcpy_host_to_device(arr1, arr2, size);
+    #elif __ROCM
+      gpu_rocm::abacus_memcpy_host_to_device(arr1, arr2, size);
+    #endif
+  }
+}
+
+#endif // ABACUS_MEMORY_H_

--- a/source/module_psi/include/memory.h
+++ b/source/module_psi/include/memory.h
@@ -14,7 +14,7 @@ namespace psi {
 namespace memory {
 
 template<typename FPTYPE>
-void abacus_reallocate_memory(FPTYPE * &arr, const int& size, const AbacusDevice_t& device) {
+void abacus_resize_memory(FPTYPE * &arr, const int& size, const AbacusDevice_t& device) {
   if (device == CpuDevice) {
     if (arr != nullptr) {
       free(arr);

--- a/source/module_psi/include/memory.h
+++ b/source/module_psi/include/memory.h
@@ -1,5 +1,5 @@
-#ifndef ABACUS_MEMORY_H_
-#define ABACUS_MEMORY_H_
+#ifndef MODULE_PSI_MEMORY_H_
+#define MODULE_PSI_MEMORY_H_
 
 #include <string.h>
 #include "module_psi/include/types.h"
@@ -10,15 +10,18 @@
 #include <module_psi/include/gpu_cuda.h>
 #endif
 
+namespace psi {
+namespace memory {
+
 template<typename FPTYPE>
-void abacus_resize_memory(FPTYPE * &arr, const int& size, const std::string& device) {
-  if (device == "CPU") {
+void abacus_reallocate_memory(FPTYPE * &arr, const int& size, const AbacusDevice_t& device) {
+  if (device == CpuDevice) {
     if (arr != nullptr) {
       free(arr);
     }
     arr = (FPTYPE*) malloc(sizeof(FPTYPE) * size);
   }
-  else if (device == "GPU") {
+  else if (device == GpuDevice) {
     #if __CUDA
       gpu_cuda::abacus_resize_memory(arr, size);
     #elif __ROCM
@@ -28,11 +31,11 @@ void abacus_resize_memory(FPTYPE * &arr, const int& size, const std::string& dev
 }
 
 template<typename FPTYPE>
-void abacus_memset(FPTYPE * &arr, const int & val, const int& size, const std::string& device) {
-  if (device == "CPU") {
+void abacus_memset(FPTYPE * &arr, const int & val, const int& size, const AbacusDevice_t& device) {
+  if (device == CpuDevice) {
     memset(arr, val, sizeof(FPTYPE) * size);
   }
-  else if (device == "GPU") {
+  else if (device == GpuDevice) {
     #if __CUDA
       gpu_cuda::abacus_memset(arr, val, size);
     #elif __ROCM
@@ -41,38 +44,7 @@ void abacus_memset(FPTYPE * &arr, const int & val, const int& size, const std::s
   }
 }
 
-template<typename FPTYPE>
-void abacus_memory_sync(
-    FPTYPE * &arr1, 
-    const FPTYPE * &arr2, 
-    const int& size, 
-    const std::string& device1, 
-    const std::string& device2) 
-{
-  if (device1 == "CPU" and device2 == "CPU") {
-    memcpy(arr1, arr2, size);
-  }
-  if (device1 == "GPU" and device2 == "GPU") {
-    #if __CUDA
-      gpu_cuda::abacus_memcpy_device_to_device(arr1, arr2, size);
-    #elif __ROCM
-      gpu_rocm::abacus_memcpy_device_to_device(arr1, arr2, size);
-    #endif
-  }
-  else if (device1 == "CPU" and device2 == "GPU") {
-    #if __CUDA
-      gpu_cuda::abacus_memcpy_device_to_host(arr1, arr2, size);
-    #elif __ROCM
-      gpu_rocm::abacus_memcpy_device_to_host(arr1, arr2, size);
-    #endif
-  }
-  else if (device1 == "GPU" and device2 == "CPU") {
-    #if __CUDA
-      gpu_cuda::abacus_memcpy_host_to_device(arr1, arr2, size);
-    #elif __ROCM
-      gpu_rocm::abacus_memcpy_host_to_device(arr1, arr2, size);
-    #endif
-  }
-}
+} // end of namespace memory
+} // end of namespace psi
 
-#endif // ABACUS_MEMORY_H_
+#endif // MODULE_PSI_MEMORY_H_

--- a/source/module_psi/include/types.h
+++ b/source/module_psi/include/types.h
@@ -1,20 +1,18 @@
-#ifndef ABACUS_TYPES_H_
-#define ABACUS_TYPES_H_
+#ifndef MODULE_PSI_TYPES_H_
+#define MODULE_PSI_TYPES_H_
 
 #include <map>
 #include <set>
 #include <string>
 
-namespace ABACUS {
+namespace psi {
+
 struct DEVICE_CPU;
 struct DEVICE_GPU;
 struct DEVICE_SYCL;
 
-extern DEVICE_CPU CpuDevice;
-extern DEVICE_GPU GpuDevice;
-extern DEVICE_SYCL SyclDevice;
-}  // end namespace Eigen
+enum AbacusDevice_t {UnKnown, CpuDevice, GpuDevice, SyclDevice};
 
+}  // end namespace psi
 
-
-#endif  // ABACUS_TYPES_H_
+#endif  // MODULE_PSI_TYPES_H_

--- a/source/module_psi/include/types.h
+++ b/source/module_psi/include/types.h
@@ -1,0 +1,20 @@
+#ifndef ABACUS_TYPES_H_
+#define ABACUS_TYPES_H_
+
+#include <map>
+#include <set>
+#include <string>
+
+namespace ABACUS {
+struct DEVICE_CPU;
+struct DEVICE_GPU;
+struct DEVICE_SYCL;
+
+extern DEVICE_CPU CpuDevice;
+extern DEVICE_GPU GpuDevice;
+extern DEVICE_SYCL SyclDevice;
+}  // end namespace Eigen
+
+
+
+#endif  // ABACUS_TYPES_H_

--- a/source/module_psi/psi.h
+++ b/source/module_psi/psi.h
@@ -3,7 +3,7 @@
 //#incude "Inputs.h"
 //#include "Basis.h"
 //#include "Cell.h"
-
+#include <string>
 #include <vector>
 #include <cassert>
 #include "module_base/global_variable.h"

--- a/source/module_psi/psi.h
+++ b/source/module_psi/psi.h
@@ -52,26 +52,26 @@ struct Range
 
 // there is the structure of electric wavefunction coefficient
 // the basic operations defined in the Operator Class
-template<typename T, typename Device = ABACUS::DEVICE_CPU>
+template<typename T, typename Device = DEVICE_CPU>
 class Psi
 {
 public:
     //Constructor 1: basic
     Psi(){
         this->npol = GlobalV::NPOL;
-        this->device = psi::get_device_type<Device>(ctx);
+        this->device = device::get_device_type<Device>(ctx);
     };
     //Constructor 2: specify ngk only, should call resize() later
     Psi(const int* ngk_in)
     {
         this->ngk = ngk_in;
         this->npol = GlobalV::NPOL;
-        this->device = psi::get_device_type<Device>(this->ctx);
+        this->device = device::get_device_type<Device>(this->ctx);
     }
     //Constructor 3: specify nk, nbands, nbasis, ngk, and do not need to call resize() later
     Psi(int nk_in, int nbd_in, int nbs_in, const int* ngk_in=nullptr)
     {
-        this->device = psi::get_device_type<Device>(this->ctx);
+        this->device = device::get_device_type<Device>(this->ctx);
         this->resize(nk_in, nbd_in, nbs_in);
         this->ngk = ngk_in;
         this->current_b = 0;
@@ -108,7 +108,7 @@ public:
     //in this case, fix_k can not be used
     Psi(T* psi_pointer, const Psi& psi_in, const int nk_in, int nband_in=0)
     {
-        this->device = psi::get_device_type<Device>(this->ctx);
+        this->device = device::get_device_type<Device>(this->ctx);
         assert(this->device == psi_in.device);
         assert(nk_in<=psi_in.get_nk());
         if(nband_in == 0)
@@ -133,7 +133,7 @@ public:
         const int nbasis_in)
     {
         assert(nks_in>0 && nbands_in>=0 && nbasis_in>0);
-        abacus_resize_memory(this->psi, nks_in * nbands_in * nbasis_in, this->device);
+        memory::abacus_reallocate_memory(this->psi, nks_in * nbands_in * nbasis_in, this->device);
         this->nk = nks_in;
         this->nbands = nbands_in;
         this->nbasis = nbasis_in;
@@ -275,7 +275,7 @@ public:
     void zero_out()
     {
         // this->psi.assign(this->psi.size(), T(0));
-        abacus_memset(this->psi, 0, this->size(), device);
+        memory::abacus_memset(this->psi, 0, this->size(), device);
     }
 
     // solve Range: return(pointer of begin, number of bands or k-points)
@@ -304,11 +304,10 @@ public:
     int npol = 1;
  
  private:   
-    std::vector<T> psi_insider;
-    T * psi = nullptr;
+    T * psi = nullptr; // avoid using C++ STL
 
-    std::string device = "";
-    Device * ctx = {};
+    AbacusDevice_t device = {}; // track the device type (CPU, GPU and SYCL are supported currented)
+    Device * ctx = {}; // an context identifier for obtaining the device variable
     // dimensions
     int nk=1; // number of k points
     int nbands=1; // number of bands

--- a/source/module_psi/psi.h
+++ b/source/module_psi/psi.h
@@ -7,6 +7,10 @@
 #include <vector>
 #include <cassert>
 #include "module_base/global_variable.h"
+#include "module_base/tool_quit.h"
+#include "module_psi/include/types.h"
+#include "module_psi/include/device.h"
+#include "module_psi/include/memory.h"
 
 #include <complex>
 
@@ -48,25 +52,28 @@ struct Range
 
 // there is the structure of electric wavefunction coefficient
 // the basic operations defined in the Operator Class
-template<typename T>
+template<typename T, typename Device = ABACUS::DEVICE_CPU>
 class Psi
 {
 public:
     //Constructor 1: basic
-    Psi(void){
+    Psi(){
         this->npol = GlobalV::NPOL;
+        this->device = psi::get_device_type<Device>(ctx);
     };
     //Constructor 2: specify ngk only, should call resize() later
     Psi(const int* ngk_in)
     {
         this->ngk = ngk_in;
         this->npol = GlobalV::NPOL;
+        this->device = psi::get_device_type<Device>(this->ctx);
     }
     //Constructor 3: specify nk, nbands, nbasis, ngk, and do not need to call resize() later
     Psi(int nk_in, int nbd_in, int nbs_in, const int* ngk_in=nullptr)
     {
-        this->ngk = ngk_in;
+        this->device = psi::get_device_type<Device>(this->ctx);
         this->resize(nk_in, nbd_in, nbs_in);
+        this->ngk = ngk_in;
         this->current_b = 0;
         this->current_k = 0;
         this->npol = GlobalV::NPOL;
@@ -79,6 +86,7 @@ public:
         {
             nband_in = psi_in.get_nbands();
         }
+        this->device = psi_in.device;
         this->resize(nk_in, nband_in, psi_in.get_nbasis());
         this->ngk = psi_in.ngk;
         this->npol = psi_in.npol;
@@ -88,13 +96,11 @@ public:
             // copy from Psi from psi_in(current_k, 0, 0), 
             // if size of k is 1, current_k in new Psi is psi_in.current_k 
             const T* tmp = psi_in.get_pointer();
-            if(nk_in==1) for(size_t index=0; index<this->size();++index)
-            {
-                psi[index] = tmp[index];
+            if(nk_in==1) {
                 //current_k for this Psi only keep the spin index same as the copied Psi
                 this->current_k = psi_in.get_current_k();
             } 
-            else for(size_t index=0; index<this->size();++index) psi[index] = tmp[index];
+            for(size_t index=0; index<this->size();++index) psi[index] = tmp[index];
         }
     }
 
@@ -102,6 +108,8 @@ public:
     //in this case, fix_k can not be used
     Psi(T* psi_pointer, const Psi& psi_in, const int nk_in, int nband_in=0)
     {
+        this->device = psi::get_device_type<Device>(this->ctx);
+        assert(this->device == psi_in.device);
         assert(nk_in<=psi_in.get_nk());
         if(nband_in == 0)
         {
@@ -125,15 +133,14 @@ public:
         const int nbasis_in)
     {
         assert(nks_in>0 && nbands_in>=0 && nbasis_in>0);
-        this->psi.resize(nks_in * nbands_in * nbasis_in);
+        abacus_resize_memory(this->psi, nks_in * nbands_in * nbasis_in, this->device);
         this->nk = nks_in;
         this->nbands = nbands_in;
         this->nbasis = nbasis_in;
         this->current_nbasis = nbasis_in;
-        this->psi_current = psi.data();
-        return;
+        this->psi_current = this->psi;
     }
-        
+
     // get the pointer for current k point or current band
     T* get_pointer(){return psi_current;}
     T* get_pointer(const int& ibands)
@@ -152,7 +159,8 @@ public:
     const int& get_nk() const {return nk;}
     const int& get_nbands() const {return nbands;}
     const int& get_nbasis() const {return nbasis;}
-    size_t size() const {return this->psi.size();}
+    // size_t size() const {return this->psi.size();}
+    size_t size() const {return this->nk * this->nbands * this->nbasis;}
 
     // choose k-point index , then Psi(iband, ibasis) can reach Psi(ik, iband, ibasis)
     void fix_k(const int ik) const
@@ -188,6 +196,9 @@ public:
         assert(ik>=0 && ik<this->nk);
 		assert(ibands>=0 && ibands<this->nbands);	
         assert(ibasis>=0 && ibasis<this->nbasis);
+        #if ((defined __CUDA) || (defined __ROCM))
+            ModuleBase::WARNING_QUIT("Psi operator ()", "GPU psi cannot fetch value by an overloaded operator ()!");
+        #endif 
 		return this->psi[(ik*this->nbands + ibands) * this->nbasis + ibasis];
 	}
 
@@ -196,6 +207,9 @@ public:
         assert(ik>=0 && ik<this->nk);
 		assert(ibands>=0 && ibands<this->nbands);	
         assert(ibasis>=0 && ibasis<this->nbasis);
+        #if ((defined __CUDA) || (defined __ROCM))
+            ModuleBase::WARNING_QUIT("Psi operator ()", "GPU psi cannot fetch value by an overloaded operator ()!");
+        #endif
 		return this->psi[(ik*this->nbands + ibands) * this->nbasis + ibasis];
 	}
 
@@ -205,6 +219,9 @@ public:
         assert(this->current_b==0);
 		assert(ibands>=0 && ibands<this->nbands);	
         assert(ibasis>=0 && ibasis<this->nbasis);
+        #if ((defined __CUDA) || (defined __ROCM))
+            ModuleBase::WARNING_QUIT("Psi operator ()", "GPU psi cannot fetch value by an overloaded operator ()!");
+        #endif
 		return this->psi_current[ibands * this->nbasis + ibasis];
 	}
 
@@ -213,6 +230,9 @@ public:
         assert(this->current_b==0);
 		assert(ibands>=0 && ibands<this->nbands);	
         assert(ibasis>=0 && ibasis<this->nbasis);
+        #if ((defined __CUDA) || (defined __ROCM))
+            ModuleBase::WARNING_QUIT("Psi operator ()", "GPU psi cannot fetch value by an overloaded operator ()!");
+        #endif
 		return this->psi_current[ibands * this->nbasis + ibasis];
 	}
 
@@ -220,12 +240,18 @@ public:
     T &operator()(const int ibasis)
 	{	
         assert(ibasis>=0 && ibasis<this->nbasis);
+        #if ((defined __CUDA) || (defined __ROCM))
+            ModuleBase::WARNING_QUIT("Psi operator ()", "GPU psi cannot fetch value by an overloaded operator ()!");
+        #endif
 		return this->psi_current[this->current_b * this->nbasis + ibasis];
 	}
 
 	const T &operator()(const int ibasis) const
 	{
         assert(ibasis>=0 && ibasis<this->nbasis);
+        #if ((defined __CUDA) || (defined __ROCM))
+            ModuleBase::WARNING_QUIT("Psi operator ()", "GPU psi cannot fetch value by an overloaded operator ()!");
+        #endif
 		return this->psi_current[this->current_b * this->nbasis + ibasis];
 	}
  
@@ -245,9 +271,11 @@ public:
     int get_current_nbas() const {return this->current_nbasis;}
     const int& get_ngk(const int ik_in) const {return this->ngk[ik_in];}
 
+    // mark
     void zero_out()
     {
-        this->psi.assign(this->psi.size(), T(0));
+        // this->psi.assign(this->psi.size(), T(0));
+        abacus_memset(this->psi, 0, this->size(), device);
     }
 
     // solve Range: return(pointer of begin, number of bands or k-points)
@@ -276,8 +304,11 @@ public:
     int npol = 1;
  
  private:   
-    std::vector<T> psi;
- 
+    std::vector<T> psi_insider;
+    T * psi = nullptr;
+
+    std::string device = "";
+    Device * ctx = {};
     // dimensions
     int nk=1; // number of k points
     int nbands=1; // number of bands

--- a/source/module_psi/psi.h
+++ b/source/module_psi/psi.h
@@ -133,7 +133,8 @@ public:
         const int nbasis_in)
     {
         assert(nks_in>0 && nbands_in>=0 && nbasis_in>0);
-        memory::abacus_reallocate_memory(this->psi, nks_in * nbands_in * nbasis_in, this->device);
+        // This function will delete the psi array first(if psi exist), then malloc a new memory for it.
+        memory::abacus_resize_memory(this->psi, nks_in * nbands_in * nbasis_in, this->device);
         this->nk = nks_in;
         this->nbands = nbands_in;
         this->nbasis = nbasis_in;

--- a/source/module_psi/src/device.cpp
+++ b/source/module_psi/src/device.cpp
@@ -5,16 +5,18 @@
 
 namespace psi{
 
+namespace device{
 
 // functions used in custom ops
-template<> std::string get_device_type <ABACUS::DEVICE_CPU> (ABACUS::DEVICE_CPU* dev) {
-    return "CPU";
+template<> AbacusDevice_t get_device_type <psi::DEVICE_CPU> (psi::DEVICE_CPU* dev) {
+    return CpuDevice;
 }
 
 #if ((defined __CUDA) || (defined __ROCM))
-template<> std::string get_device_type <ABACUS::DEVICE_GPU> (ABACUS::DEVICE_GPU* dev) {
-    return "GPU";
+template<> AbacusDevice_t get_device_type <psi::DEVICE_GPU> (psi::DEVICE_GPU* dev) {
+    return GpuDevice;
 }
 #endif
 
-}
+} // end of namespace device
+} // end of namespace psi

--- a/source/module_psi/src/device.cpp
+++ b/source/module_psi/src/device.cpp
@@ -1,0 +1,20 @@
+
+#include <iostream>
+#include "module_psi/include/types.h"
+#include "module_psi/include/device.h"
+
+namespace psi{
+
+
+// functions used in custom ops
+template<> std::string get_device_type <ABACUS::DEVICE_CPU> (ABACUS::DEVICE_CPU* dev) {
+    return "CPU";
+}
+
+#if ((defined __CUDA) || (defined __ROCM))
+template<> std::string get_device_type <ABACUS::DEVICE_GPU> (ABACUS::DEVICE_GPU* dev) {
+    return "GPU";
+}
+#endif
+
+}


### PR DESCRIPTION
We are trying to introduce a Device template in ABACUS' Psi class to define the GPU Psi class in the next step. The main changes are:

1. Add a Device template for class Psi. The current template types are CPU, GPU and SYCL(only CPU is supported actually now).
2. Add some folders, like include, src, and tests, for the implementations of functions and unittests running in module_psi.
3. Change the vector Psi into array Psi to avoid the usage of C++ STL.

And these modification will not have any effect on the code running of other modules.