### PR TITLE
Fix: stuck when the specified number of atoms is larger than that listed in coordinate block

### DIFF
--- a/source/module_cell/read_atoms.cpp
+++ b/source/module_cell/read_atoms.cpp
@@ -607,7 +607,7 @@ bool UnitCell_pseudo::read_atom_positions(std::ifstream &ifpos, std::ofstream &o
 										if( (int)tmpid[0] < 0 )
 										{
 											std::cout << "read_atom_positions, mismatch in atom number for atom type: " << atoms[it].label << std::endl;
-											exit(0); 
+											exit(1); 
 										}
 
 										bool input_vec_mag=false;

--- a/source/module_cell/read_atoms.cpp
+++ b/source/module_cell/read_atoms.cpp
@@ -603,6 +603,13 @@ bool UnitCell_pseudo::read_atom_positions(std::ifstream &ifpos, std::ofstream &o
 
                                         string tmpid;
                                         tmpid = ifpos.get();
+
+										if( (int)tmpid[0] < 0 )
+										{
+											std::cout << "read_atom_positions, mismatch in atom number for atom type: " << atoms[it].label << std::endl;
+											exit(0); 
+										}
+
 										bool input_vec_mag=false;
 										bool input_angle_mag=false;
                                         while ( (tmpid != "\n") && (ifpos.eof()==false) && (tmpid !="#") )

--- a/source/module_deepks/LCAO_deepks_io.cpp
+++ b/source/module_deepks/LCAO_deepks_io.cpp
@@ -112,7 +112,7 @@ void LCAO_Deepks::save_npy_gvepsl(const int nat)
     ModuleBase::TITLE("LCAO_Deepks", "save_npy_gvepsl");
     if(GlobalV::MY_RANK!=0) return;
     //save grad_vepsl.npy (when  stress label is in use)
-    //unit: /Bohr^3
+    //unit: none
     const long unsigned gshape[] = {(long unsigned) 6, nat, this->des_per_atom};
     vector<double> npy_gvepsl;
     for (int i = 0;i < 6;i++)

--- a/source/src_lcao/FORCE_STRESS.cpp
+++ b/source/src_lcao/FORCE_STRESS.cpp
@@ -473,7 +473,7 @@ void Force_Stress_LCAO::getForceStress(
 #ifdef __DEEPKS
 		if (GlobalV::deepks_out_labels) //not parallelized yet
         {
-			GlobalC::ld.save_npy_s(scs, "s_base.npy", GlobalC::ucell.omega); //Ry/Bohr^3, S_base; no scf case -- same as S_tot
+			GlobalC::ld.save_npy_s(scs, "s_base.npy", GlobalC::ucell.omega); //change to energy unit Ry when printing, S_base;
 			// wenfei add 2021/11/2
 			if (GlobalV::deepks_scf)
 			{
@@ -484,13 +484,13 @@ void Force_Stress_LCAO::getForceStress(
 						scs(i,j) += svnl_dalpha(i,j);
 					}
 				}
-				GlobalC::ld.save_npy_s(scs, "s_tot.npy", GlobalC::ucell.omega); //Ry/Bohr^3, S_tot
+				GlobalC::ld.save_npy_s(scs, "s_tot.npy", GlobalC::ucell.omega); //change to energy unit Ry when printing, S_tot, w/ model
 				GlobalC::ld.cal_gvepsl(GlobalC::ucell.nat);
-				GlobalC::ld.save_npy_gvepsl(GlobalC::ucell.nat);//  /Bohr^3, grad_vepsl
+				GlobalC::ld.save_npy_gvepsl(GlobalC::ucell.nat); //  unitless, grad_vepsl
 			}
 			else
 			{
-				GlobalC::ld.save_npy_s(scs, "s_tot.npy", GlobalC::ucell.omega); //Ry/Bohr^3, S_tot; no scf case -- same as S_base
+				GlobalC::ld.save_npy_s(scs, "s_tot.npy", GlobalC::ucell.omega); //change to energy unit Ry when printing, S_tot, w/o model;
 			}
 		}	
 #endif


### PR DESCRIPTION
This PR fixes the stuck problem when the specified number of atoms is LARGER than that listed in coordinate block. However, no warning information would be given if the specified number of atoms is LESS than that listed in coordinate block, which should be fixed in the future. 
Fix #1222 .