### PR TITLE
Build: add gcc version check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ include_directories(${ABACUS_SOURCE_DIR})
 add_executable(${ABACUS_BIN_NAME} source/main.cpp)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5)
+  message(FATAL_ERROR "GCC4 is not supported.")
+endif()
 add_compile_options(-Wno-write-strings)
 set(FETCHCONTENT_QUIET FALSE) # Notify user when cloning git repo
 


### PR DESCRIPTION
GCC 4 may cause compilation error due to lacked support to c++11.