### PR TITLE
Build: won't download libxc on absent.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,23 +241,13 @@ if(DEFINED Libxc_DIR)
   set(ENABLE_LIBXC ON)
 endif()
 if(ENABLE_LIBXC)
-  find_package(Libxc 5.1.7 HINTS ${Libxc_DIR}/share/cmake/Libxc)
+  find_package(Libxc 5.1.7 REQUIRED HINTS ${Libxc_DIR}/share/cmake/Libxc)
   if(${Libxc_FOUND})
-    message(STATUS "Found Libxc: version "${Libxc_VERSION})
+    message(STATUS "Found Libxc: version " ${Libxc_VERSION})
     target_link_libraries(${ABACUS_BIN_NAME} Libxc::xc)
     include_directories(${Libxc_INCLUDE_DIRS})
-  else()
-    include(FetchContent)
-    FetchContent_Declare(
-      Libxc
-      GIT_REPOSITORY https://gitlab.com/libxc/libxc.git
-      GIT_TAG "5.2.3"
-      GIT_SHALLOW TRUE
-      GIT_PROGRESS TRUE
-    )
-    FetchContent_MakeAvailable(Libxc)
+    add_compile_definitions(USE_LIBXC)
   endif()
-  add_compile_definitions(USE_LIBXC)
 endif()
 
 add_compile_definitions(


### PR DESCRIPTION
Libxc generates header files ad hoc, which might cause compilation errors.
Reverting #1173.