### PR TITLE
fix: change istep to mean total step in cell opt

### DIFF
--- a/source/module_relaxation/ions.h
+++ b/source/module_relaxation/ions.h
@@ -46,7 +46,7 @@ class Ions
 	bool if_do_relax();
 	bool if_do_cellrelax();
 	bool do_relax(const int& istep, int& jstep, const ModuleBase::matrix& ionic_force, const double& total_energy);
-	bool do_cellrelax(const int& istep, const ModuleBase::matrix& stress, const double& total_energy);
+	bool do_cellrelax(const int& istep, const int& stress_step, const ModuleBase::matrix& stress, const double& total_energy);
 	void reset_after_relax(const int& istep);
 	void reset_after_cellrelax(int& force_step, int& stress_step);
 

--- a/source/module_relaxation/ions_move_basic.cpp
+++ b/source/module_relaxation/ions_move_basic.cpp
@@ -118,7 +118,10 @@ void Ions_Move_Basic::move_atoms(double *move, double *pos)
 	//xiaohui modify 2015-03-15, cancel outputfile "STRU_NOW.xyz"
 	//GlobalC::ucell.print_cell_xyz("STRU_NOW.xyz");
 	//xiaohui add out_stru, 2015-09-30
-	if(out_stru==1) GlobalC::ucell.print_cell_cif("STRU_NOW.cif");
+	if(out_stru==1)
+	{
+		GlobalC::ucell.print_cell_cif("STRU_NOW.cif");
+	}
 	return;
 }
 

--- a/source/module_relaxation/lattice_change_basic.cpp
+++ b/source/module_relaxation/lattice_change_basic.cpp
@@ -8,6 +8,7 @@ bool Lattice_Change_Basic::converged = true;
 double Lattice_Change_Basic::largest_grad = 0.0;
 int Lattice_Change_Basic::update_iter = 0;
 int Lattice_Change_Basic::istep = 0;
+int Lattice_Change_Basic::stress_step = 0;
 
 double Lattice_Change_Basic::ediff = 0.0;
 double Lattice_Change_Basic::etot = 0.0;
@@ -262,7 +263,7 @@ void Lattice_Change_Basic::terminate(void)
     if (Lattice_Change_Basic::converged)
     {
         GlobalV::ofs_running << " end of lattice optimization" << std::endl;
-        ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "istep", Lattice_Change_Basic::istep);
+        ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "stress_step", Lattice_Change_Basic::stress_step);
         ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "update iteration", Lattice_Change_Basic::update_iter);
         /*
         GlobalV::ofs_running<<"Saving the approximate inverse hessian"<<std::endl;
@@ -288,7 +289,7 @@ void Lattice_Change_Basic::terminate(void)
 
 void Lattice_Change_Basic::setup_etot(const double &energy_in, const bool judgement)
 {
-    if (Lattice_Change_Basic::istep == 1)
+    if (Lattice_Change_Basic::stress_step == 1)
     {
         // p == previous
         Lattice_Change_Basic::etot_p = energy_in;

--- a/source/module_relaxation/lattice_change_basic.h
+++ b/source/module_relaxation/lattice_change_basic.h
@@ -11,6 +11,7 @@ namespace Lattice_Change_Basic
 	extern double largest_grad; // largest gradient among the forces,
 	extern int update_iter; // number of sucesfully updated iterations, 
 	extern int istep; // index of ionic steps, 
+	extern int stress_step; // index of stress step
 	extern double ediff; // energy difference compared to last step,
 	extern double etot; // total energy of this step,
 	extern double etot_p; // total energy of last step,

--- a/source/module_relaxation/lattice_change_cg.cpp
+++ b/source/module_relaxation/lattice_change_cg.cpp
@@ -93,7 +93,7 @@ void Lattice_Change_CG::start(const ModuleBase::matrix &stress_in, const double&
 	
 	CG_begin:
 	
-	if( Lattice_Change_Basic::istep == 1 )
+	if( Lattice_Change_Basic::stress_step == 1 )
 	{
 		steplength=Lattice_Change_Basic::lattice_change_ini;          // read in the init trust radius
 		//cout<<"Lattice_Change_Basic::lattice_change_ini = "<<Lattice_Change_Basic::lattice_change_ini<<endl;
@@ -281,7 +281,7 @@ void Lattice_Change_CG::start(const ModuleBase::matrix &stress_in, const double&
 void Lattice_Change_CG::setup_cg_grad(double *grad, const double *grad0, double *cg_grad, const double *cg_grad0, const int &ncggrad, int &flag)
 {
 	ModuleBase::TITLE("Lattice_Change_CG","setup_cg_grad");
-	assert(Lattice_Change_Basic::istep > 0);
+	assert(Lattice_Change_Basic::stress_step > 0);
 	double gamma;
 	double cg0_cg,cg0_cg0,cg0_g;
 	

--- a/source/module_relaxation/lattice_change_methods.cpp
+++ b/source/module_relaxation/lattice_change_methods.cpp
@@ -13,10 +13,11 @@ void Lattice_Change_Methods::allocate()
 	return;
 }
 
-void Lattice_Change_Methods::cal_lattice_change(const int &istep, const ModuleBase::matrix &stress, const double &etot)
+void Lattice_Change_Methods::cal_lattice_change(const int &istep, const int &stress_step, const ModuleBase::matrix &stress, const double &etot)
 {
 	ModuleBase::TITLE("Lattice_Change_Methods","lattice_change_init");
 	Lattice_Change_Basic::istep = istep;
+	Lattice_Change_Basic::stress_step = stress_step;
 	
 	lccg.start(stress,etot);
 	

--- a/source/module_relaxation/lattice_change_methods.h
+++ b/source/module_relaxation/lattice_change_methods.h
@@ -15,7 +15,7 @@ class Lattice_Change_Methods
 
 	void allocate(void);
 
-	void cal_lattice_change(const int &istep, const ModuleBase::matrix &stress, const double &etot);
+	void cal_lattice_change(const int &istep, const int &stress_step, const ModuleBase::matrix &stress, const double &etot);
 
 	bool get_converged(void)const {return Lattice_Change_Basic::converged;}
 

--- a/source/module_relaxation/relaxation.cpp
+++ b/source/module_relaxation/relaxation.cpp
@@ -39,7 +39,7 @@ bool Ions::relaxation(ModuleBase::matrix force, ModuleBase::matrix stress, const
 	{
 		//do cell relax calculation and generate next structure
 		bool converged = 0;
-		converged = this->do_cellrelax(stress_step, stress, GlobalC::en.etot);
+		converged = this->do_cellrelax(istep,stress_step, stress, GlobalC::en.etot);
 		if(!converged)
 		{
 			GlobalC::ucell.cell_parameter_updated = true;
@@ -100,10 +100,10 @@ bool Ions::do_relax(const int& istep, int& jstep, const ModuleBase::matrix& ioni
 	++jstep;
 	return IMM.get_converged();
 }
-bool Ions::do_cellrelax(const int& istep, const ModuleBase::matrix& stress, const double& total_energy)
+bool Ions::do_cellrelax(const int&istep, const int& stress_step, const ModuleBase::matrix& stress, const double& total_energy)
 {
 	ModuleBase::TITLE("Ions","do_cellrelax");
-	LCM.cal_lattice_change(istep, stress, total_energy);
+	LCM.cal_lattice_change(istep, stress_step, stress, total_energy);
     return LCM.get_converged();
 }
 void Ions::reset_after_relax(const int& istep)


### PR DESCRIPTION
Without this fix, the istep means stress_step in cell-relaxation, resulting in faulse update of STRU_ION?_D and STRU_NOW.cif files.