### PR TITLE
GPU: add device template for class diag_cg

### DIFF
--- a/source/module_hamilt/CMakeLists.txt
+++ b/source/module_hamilt/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(ks_pw)
 add_library(
     hamilt
     OBJECT
+    operator.cpp
     hamilt_pw.cpp
     hamilt_lcao.cpp
     ks_pw/ekinetic_pw.cpp

--- a/source/module_hamilt/operator.cpp
+++ b/source/module_hamilt/operator.cpp
@@ -1,0 +1,107 @@
+#include "module_hamilt/operator.h"
+
+using namespace hamilt;
+
+
+template<typename FPTYPE, typename Device>
+Operator<FPTYPE, Device>::Operator(){}
+
+template<typename FPTYPE, typename Device>
+Operator<FPTYPE, Device>::~Operator() 
+{
+    if(this->hpsi != nullptr) delete this->hpsi;
+    Operator* last = this->next_op;
+    while(last != nullptr)
+    {
+        Operator* node_delete = last;
+        last = last->next_op;
+        node_delete->next_op = nullptr;
+        delete node_delete;
+    }
+}
+
+template<typename FPTYPE, typename Device>
+typename Operator<FPTYPE, Device>::hpsi_info Operator<FPTYPE, Device>::hPsi(hpsi_info&) const 
+{
+    ModuleBase::WARNING_QUIT("Operator::hPsi", "hPsi error!");
+    return hpsi_info(nullptr, 0, nullptr);
+}
+
+#if ((defined __CUDA) || (defined __ROCM))
+template<typename FPTYPE, typename Device>
+typename Operator<FPTYPE, Device>::hpsi_info_gpu Operator<FPTYPE, Device>::hPsi_gpu(hpsi_info_gpu&) const {
+    ModuleBase::WARNING_QUIT("Operator::hPsi_gpu", "GPU's implementation is not supported!");
+    return hpsi_info_gpu(nullptr, 0, nullptr);
+}
+#endif // ((defined __CUDA) || (defined __ROCM))
+
+template<typename FPTYPE, typename Device>
+void Operator<FPTYPE, Device>::init(const int ik_in) 
+{
+    this->ik = ik_in;
+    if(this->next_op != nullptr) {
+        this->next_op->init(ik_in);
+    }
+}
+
+template<typename FPTYPE, typename Device>
+void Operator<FPTYPE, Device>::add(Operator* next) 
+{
+    if(next==nullptr) return;
+    if(next->next_op != nullptr) this->add(next->next_op);
+    Operator* last = this;
+    while(last->next_op != nullptr)
+    {
+        if(next->cal_type==last->cal_type)
+        {
+            last->add(next);
+            return;
+        }
+        last = last->next_op;
+    }
+    last->next_op = next; 
+}
+
+template<typename FPTYPE, typename Device>
+FPTYPE* Operator<FPTYPE, Device>::get_hpsi(const hpsi_info& info) const
+{
+    const int nbands_range = (std::get<1>(info).range_2 - std::get<1>(info).range_1 + 1);
+    //in_place call of hPsi, hpsi inputs as new psi, 
+    //create a new hpsi and delete old hpsi later
+    FPTYPE* hpsi_pointer = std::get<2>(info);
+    const FPTYPE* psi_pointer = std::get<0>(info)->get_pointer();
+    if(this->hpsi != nullptr) 
+    {
+        delete this->hpsi;
+        this->hpsi = nullptr;
+    }
+    if(!hpsi_pointer)
+    {
+        ModuleBase::WARNING_QUIT("Operator::hPsi", "hpsi_pointer can not be nullptr");
+    }
+    else if(hpsi_pointer == psi_pointer)
+    {
+        this->in_place = true;
+        this->hpsi = new psi::Psi<FPTYPE>(std::get<0>(info)[0], 1, nbands_range);
+    }
+    else
+    {
+        this->in_place = false;
+        this->hpsi = new psi::Psi<FPTYPE>(hpsi_pointer, std::get<0>(info)[0], 1, nbands_range);
+    }
+    
+    hpsi_pointer = this->hpsi->get_pointer();
+    size_t total_hpsi_size = nbands_range * this->hpsi->get_nbasis();
+    ModuleBase::GlobalFunc::ZEROS(hpsi_pointer, total_hpsi_size);
+    return hpsi_pointer;
+}
+
+
+namespace hamilt {
+template class Operator<double, psi::DEVICE_CPU>;
+template class Operator<std::complex<double>, psi::DEVICE_CPU>;
+#if ((defined __CUDA) || (defined __ROCM))
+template class Operator<double, psi::DEVICE_GPU>;
+template class Operator<std::complex<double>, psi::DEVICE_GPU>;
+#endif
+}

--- a/source/module_hamilt/operator.h
+++ b/source/module_hamilt/operator.h
@@ -13,59 +13,28 @@ namespace hamilt
 // it is designed for "O|psi>" and "<psi|O|psi>"
 // Operator "O" might have several different types, which should be calculated one by one.
 // In basic class , function add() is designed for combine all operators together with a chain. 
-template<typename T>
+template<typename FPTYPE, typename Device = psi::DEVICE_CPU>
 class Operator
 {
     public:
-    Operator(){};
-    virtual ~Operator()
-    { 
-        if(this->hpsi != nullptr) delete this->hpsi;
-        Operator* last = this->next_op;
-        while(last != nullptr) 
-        {
-            Operator* node_delete = last;
-            last = last->next_op;
-            node_delete->next_op = nullptr;
-            delete node_delete;
-        } 
-    }
+    Operator();
+    virtual ~Operator();
 
     //this is the core function for Operator
     // do H|psi> from input |psi> , 
-    // output of hpsi would be first member of the returned tuple 
-    typedef std::tuple<const psi::Psi<T>*, const psi::Range, T*> hpsi_info;
-    virtual hpsi_info hPsi(hpsi_info& input)const 
-    {
-        ModuleBase::WARNING_QUIT("Operator::hPsi", "hPsi error!");
-        return hpsi_info(nullptr, 0, nullptr);
-    }
+    // output of hpsi would be first member of the returned tuple
+    typedef std::tuple<const psi::Psi<FPTYPE, Device>*, const psi::Range, FPTYPE*> hpsi_info;
+    virtual hpsi_info hPsi(hpsi_info& input) const; 
 
-    virtual void init(const int ik_in)
-    {
-        this->ik = ik_in;
-        if(this->next_op != nullptr)
-        {
-            this->next_op->init(ik_in);
-        }
-    }
+    #if ((defined __CUDA) || (defined __ROCM))
+    typedef std::tuple<const psi::Psi<FPTYPE, psi::DEVICE_GPU>*, const psi::Range, FPTYPE*> hpsi_info_gpu;
+    virtual hpsi_info_gpu hPsi_gpu(hpsi_info_gpu& input) const; 
+    #endif // ((defined __CUDA) || (defined __ROCM))
 
-    virtual void add(Operator* next)
-    {
-        if(next==nullptr) return;
-        if(next->next_op != nullptr) this->add(next->next_op);
-        Operator* last = this;
-        while(last->next_op != nullptr)
-        {
-            if(next->cal_type==last->cal_type)
-            {
-                last->add(next);
-                return;
-            }
-            last = last->next_op;
-        }
-        last->next_op = next; 
-    }
+    virtual void init(const int ik_in);
+
+    virtual void add(Operator* next);
+
 
     protected:
     int ik = 0;
@@ -77,7 +46,7 @@ class Operator
     Operator* next_op = nullptr;
 
     //if this Operator is first node in chain table, hpsi would not be empty
-    mutable psi::Psi<T>* hpsi = nullptr;
+    mutable psi::Psi<FPTYPE>* hpsi = nullptr;
 
     /*This function would analyze hpsi_info and choose how to arrange hpsi storage
     In hpsi_info, if the third parameter hpsi_pointer is set, which indicates memory of hpsi is arranged by developer;
@@ -86,38 +55,8 @@ class Operator
     1. hpsi_pointer != nullptr && psi_pointer == hpsi_pointer , psi would be replaced by hpsi, hpsi need a temporary memory
     2. hpsi_pointer != nullptr && psi_pointer != hpsi_pointer , this is the commonly case 
     */
-    T* get_hpsi(const hpsi_info& info)const
-    {
-        const int nbands_range = (std::get<1>(info).range_2 - std::get<1>(info).range_1 + 1);
-        //in_place call of hPsi, hpsi inputs as new psi, 
-        //create a new hpsi and delete old hpsi later
-        T* hpsi_pointer = std::get<2>(info);
-        const T* psi_pointer = std::get<0>(info)->get_pointer();
-        if(this->hpsi != nullptr) 
-        {
-            delete this->hpsi;
-            this->hpsi = nullptr;
-        }
-        if(!hpsi_pointer)
-        {
-            ModuleBase::WARNING_QUIT("Operator::hPsi", "hpsi_pointer can not be nullptr");
-        }
-        else if(hpsi_pointer == psi_pointer)
-        {
-            this->in_place = true;
-            this->hpsi = new psi::Psi<T>(std::get<0>(info)[0], 1, nbands_range);
-        }
-        else
-        {
-            this->in_place = false;
-            this->hpsi = new psi::Psi<T>(hpsi_pointer, std::get<0>(info)[0], 1, nbands_range);
-        }
-        
-        hpsi_pointer = this->hpsi->get_pointer();
-        size_t total_hpsi_size = nbands_range * this->hpsi->get_nbasis();
-        ModuleBase::GlobalFunc::ZEROS(hpsi_pointer, total_hpsi_size);
-        return hpsi_pointer;
-    }
+    FPTYPE* get_hpsi(const hpsi_info& info)const;
+
 };
 
 }//end namespace hamilt

--- a/source/module_hsolver/diago_cg.cpp
+++ b/source/module_hsolver/diago_cg.cpp
@@ -7,26 +7,173 @@
 #include "module_base/timer.h"
 #include "src_parallel/parallel_reduce.h"
 
-namespace hsolver
-{
+using namespace hsolver;
 
-typedef hamilt::Operator<std::complex<double>>::hpsi_info hp_info;
 
-DiagoCG::DiagoCG(const double *precondition_in)
+template<typename FPTYPE, typename Device>
+DiagoCG<FPTYPE, Device>::DiagoCG(const FPTYPE* precondition_in)
 {
     this->precondition = precondition_in;
     test_cg = 0;
     reorder = false;
-}
-DiagoCG::~DiagoCG()
-{
+    this->device = psi::device::get_device_type<Device>(this->ctx);
 }
 
-void DiagoCG::diag_mock(hamilt::Hamilt *phm_in, psi::Psi<std::complex<double>> &phi, double *eigenvalue_in)
+template<typename FPTYPE, typename Device>
+DiagoCG<FPTYPE, Device>::~DiagoCG() {}
+
+template<typename FPTYPE, typename Device>
+void DiagoCG<FPTYPE, Device>::diag_mock(hamilt::Hamilt *phm_in, psi::Psi<std::complex<FPTYPE>, Device> &phi, FPTYPE *eigenvalue_in)
 {
     ModuleBase::TITLE("DiagoCG", "diag_once");
     ModuleBase::timer::tick("DiagoCG", "diag_once");
+    
+    /// out : record for states of convergence
+    this->notconv = 0;
 
+    /// initialize variables
+    this->dim = phi.get_current_nbas();
+    this->dmx = phi.get_nbasis();
+    this->n_band = phi.get_nbands();
+    this->eigenvalue = eigenvalue_in;
+    ModuleBase::GlobalFunc::ZEROS(this->eigenvalue, this->n_band);
+
+    /// record for how many loops in cg convergence
+    FPTYPE avg = 0.0;
+
+    //-------------------------------------------------------------------
+    // "poor man" iterative diagonalization of a complex hermitian matrix
+    // through preconditioned conjugate gradient algorithm
+    // Band-by-band algorithm with minimal use of memory
+    // Calls hPhi and sPhi to calculate H|phi> and S|phi>
+    // Works for generalized eigenvalue problem (US pseudopotentials) as well
+    //-------------------------------------------------------------------
+    this->phi_m = new psi::Psi<std::complex<FPTYPE>, Device>(phi, 1, 1);
+    this->hphi.resize(this->dmx, ModuleBase::ZERO);
+    this->sphi.resize(this->dmx, ModuleBase::ZERO);
+
+    this->cg = new psi::Psi<std::complex<FPTYPE>, Device>(phi, 1, 1);
+    this->scg.resize(this->dmx, ModuleBase::ZERO);
+    this->pphi.resize(this->dmx, ModuleBase::ZERO);
+
+    //in band_by_band CG method, only the first band in phi_m would be calculated
+    psi::Range cg_hpsi_range(0);
+
+    this->gradient.resize(this->dmx, ModuleBase::ZERO);
+    this->g0.resize(this->dmx, ModuleBase::ZERO);
+    this->lagrange.resize(this->n_band, ModuleBase::ZERO);
+
+    for (int m = 0; m < this->n_band; m++)
+    {
+        if (test_cg > 2)
+            GlobalV::ofs_running << "Diagonal Band : " << m << std::endl;
+        //copy psi_in into internal psi, m=0 has been done in Constructor
+        if(m>0)
+        {
+            const std::complex<FPTYPE>* psi_m_in = &(phi(m, 0));
+            auto pphi_m = this->phi_m->get_pointer();
+            ModuleBase::GlobalFunc::COPYARRAY(psi_m_in, pphi_m, this->dim);
+        }
+        phm_in->sPsi(this->phi_m->get_pointer(), this->sphi.data(), (size_t)this->dim); // sphi = S|psi(m)>
+        this->schmit_orth(m, phi);
+        phm_in->sPsi(this->phi_m->get_pointer(), this->sphi.data(), (size_t)this->dim); // sphi = S|psi(m)>
+
+        //do hPsi, actually the result of hpsi stored in Operator,
+        //the necessary of copying operation should be checked later
+        using hpsi_info = typename hamilt::Operator<std::complex<FPTYPE>, Device>::hpsi_info;
+        hpsi_info cg_hpsi_in(this->phi_m, cg_hpsi_range, this->hphi.data());
+        phm_in->ops->hPsi(cg_hpsi_in);
+
+        this->eigenvalue[m] = ModuleBase::GlobalFunc::ddot_real(this->dim, this->phi_m->get_pointer(), this->hphi.data());
+
+        int iter = 0;
+        FPTYPE gg_last = 0.0;
+        FPTYPE cg_norm = 0.0;
+        FPTYPE theta = 0.0;
+        bool converged = false;
+        for (iter = 0; iter < DiagoIterAssist::PW_DIAG_NMAX; iter++)
+        {
+            this->calculate_gradient();
+            this->orthogonal_gradient(phm_in, phi, m);
+            this->calculate_gamma_cg(iter, gg_last, cg_norm, theta);
+            
+            hpsi_info cg_hpsi_in(this->cg, cg_hpsi_range, this->pphi.data());
+            phm_in->ops->hPsi(cg_hpsi_in);
+
+            phm_in->sPsi(this->cg->get_pointer(), this->scg.data(), (size_t)this->dim);
+            converged = this->update_psi(cg_norm, theta, this->eigenvalue[m]);
+
+            if (converged)
+                break;
+        } // end iter
+
+        std::complex<FPTYPE>* psi_temp = &(phi(m, 0));
+        ModuleBase::GlobalFunc::COPYARRAY(this->phi_m->get_pointer(), psi_temp, this->dim);
+
+        if (!converged)
+        {
+            ++this->notconv;
+        }
+        avg += static_cast<FPTYPE>(iter) + 1.00;
+
+        // reorder eigenvalues if they are not in the right order
+        // (this CAN and WILL happen in not-so-special cases)
+
+        if (m > 0 && reorder)
+        {
+            ModuleBase::GlobalFunc::NOTE("reorder bands!");
+            if (eigenvalue[m] - eigenvalue[m - 1] < -2.0 * DiagoIterAssist::PW_DIAG_THR)
+            {
+                // if the last calculated eigenvalue is not the largest...
+                int i = 0;
+                for (i = m - 2; i >= 0; i--)
+                {
+                    if (eigenvalue[m] - eigenvalue[i] > 2.0 * DiagoIterAssist::PW_DIAG_THR)
+                        break;
+                }
+                i++;
+
+                // last calculated eigenvalue should be in the i-th position: reorder
+                FPTYPE e0 = eigenvalue[m];
+                ModuleBase::GlobalFunc::COPYARRAY(psi_temp, pphi.data(), this->dim);
+
+                for (int j = m; j >= i + 1; j--)
+                {
+                    eigenvalue[j] = eigenvalue[j - 1];
+                    std::complex<FPTYPE>* phi_j = &phi(j, 0);
+                    std::complex<FPTYPE>* phi_j1 = &phi(j-1, 0);
+                    ModuleBase::GlobalFunc::COPYARRAY(phi_j1, phi_j, this->dim);
+                }
+
+                eigenvalue[i] = e0;
+                // dcopy(pphi, phi, i);
+                std::complex<FPTYPE>* phi_pointer = &phi(i, 0);
+                ModuleBase::GlobalFunc::COPYARRAY(pphi.data(), phi_pointer, this->dim);
+                // this procedure should be good if only a few inversions occur,
+                // extremely inefficient if eigenvectors are often in bad order
+                // (but this should not happen)
+            } // endif
+        } // end reorder
+
+    } // end m
+
+    avg /= this->n_band;
+    DiagoIterAssist::avg_iter += avg;
+
+    delete this->phi_m;
+    delete this->cg;
+
+    ModuleBase::timer::tick("DiagoCG", "diag_once");
+    return;
+} // end subroutine ccgdiagg
+
+#if ((defined __CUDA) || (defined __ROCM))
+template<>
+void DiagoCG<double, psi::DEVICE_GPU>::diag_mock(hamilt::Hamilt *phm_in, psi::Psi<std::complex<double>, psi::DEVICE_GPU> &phi, double *eigenvalue_in)
+{
+    ModuleBase::TITLE("DiagoCG", "diag_once");
+    ModuleBase::timer::tick("DiagoCG", "diag_once");
+    
     /// out : record for states of convergence
     this->notconv = 0;
 
@@ -47,11 +194,11 @@ void DiagoCG::diag_mock(hamilt::Hamilt *phm_in, psi::Psi<std::complex<double>> &
     // Calls hPhi and sPhi to calculate H|phi> and S|phi>
     // Works for generalized eigenvalue problem (US pseudopotentials) as well
     //-------------------------------------------------------------------
-    this->phi_m = new psi::Psi<std::complex<double>>(phi, 1, 1);
+    this->phi_m = new psi::Psi<std::complex<double>, psi::DEVICE_GPU>(phi, 1, 1);
     this->hphi.resize(this->dmx, ModuleBase::ZERO);
     this->sphi.resize(this->dmx, ModuleBase::ZERO);
 
-    this->cg = new psi::Psi<std::complex<double>>(phi, 1, 1);
+    this->cg = new psi::Psi<std::complex<double>, psi::DEVICE_GPU>(phi, 1, 1);
     this->scg.resize(this->dmx, ModuleBase::ZERO);
     this->pphi.resize(this->dmx, ModuleBase::ZERO);
 
@@ -79,8 +226,9 @@ void DiagoCG::diag_mock(hamilt::Hamilt *phm_in, psi::Psi<std::complex<double>> &
 
         //do hPsi, actually the result of hpsi stored in Operator,
         //the necessary of copying operation should be checked later
-        hp_info cg_hpsi_in(this->phi_m, cg_hpsi_range, this->hphi.data());
-        phm_in->ops->hPsi(cg_hpsi_in);
+        using hpsi_info = typename hamilt::Operator<std::complex<double>, psi::DEVICE_GPU>::hpsi_info;
+        hpsi_info cg_hpsi_in(this->phi_m, cg_hpsi_range, this->hphi.data());
+        phm_in->ops->hPsi_gpu(cg_hpsi_in);
 
         this->eigenvalue[m] = ModuleBase::GlobalFunc::ddot_real(this->dim, this->phi_m->get_pointer(), this->hphi.data());
 
@@ -95,8 +243,8 @@ void DiagoCG::diag_mock(hamilt::Hamilt *phm_in, psi::Psi<std::complex<double>> &
             this->orthogonal_gradient(phm_in, phi, m);
             this->calculate_gamma_cg(iter, gg_last, cg_norm, theta);
             
-            hp_info cg_hpsi_in(this->cg, cg_hpsi_range, this->pphi.data());
-            phm_in->ops->hPsi(cg_hpsi_in);
+            hpsi_info cg_hpsi_in(this->cg, cg_hpsi_range, this->pphi.data());
+            phm_in->ops->hPsi_gpu(cg_hpsi_in);
 
             phm_in->sPsi(this->cg->get_pointer(), this->scg.data(), (size_t)this->dim);
             converged = this->update_psi(cg_norm, theta, this->eigenvalue[m]);
@@ -164,8 +312,10 @@ void DiagoCG::diag_mock(hamilt::Hamilt *phm_in, psi::Psi<std::complex<double>> &
     ModuleBase::timer::tick("DiagoCG", "diag_once");
     return;
 } // end subroutine ccgdiagg
+#endif
 
-void DiagoCG::calculate_gradient()
+template<typename FPTYPE, typename Device>
+void DiagoCG<FPTYPE, Device>::calculate_gradient()
 {
     if (this->test_cg == 1)
         ModuleBase::TITLE("DiagoCG", "calculate_gradient");
@@ -181,10 +331,10 @@ void DiagoCG::calculate_gradient()
 
     // Update lambda !
     // (4) <psi|SPH|psi >
-    const double eh = ModuleBase::GlobalFunc::ddot_real(this->dim, this->sphi.data(), this->gradient.data());
+    const FPTYPE eh = ModuleBase::GlobalFunc::ddot_real(this->dim, this->sphi.data(), this->gradient.data());
     // (5) <psi|SPS|psi >
-    const double es = ModuleBase::GlobalFunc::ddot_real(this->dim, this->sphi.data(), this->pphi.data());
-    const double lambda = eh / es;
+    const FPTYPE es = ModuleBase::GlobalFunc::ddot_real(this->dim, this->sphi.data(), this->pphi.data());
+    const FPTYPE lambda = eh / es;
 
     // Update g!
     for (int i = 0; i < this->dim; i++)
@@ -200,7 +350,8 @@ void DiagoCG::calculate_gradient()
     return;
 }
 
-void DiagoCG::orthogonal_gradient(hamilt::Hamilt *phm_in, const psi::Psi<std::complex<double>> &eigenfunction, const int m)
+template<typename FPTYPE, typename Device>
+void DiagoCG<FPTYPE, Device>::orthogonal_gradient(hamilt::Hamilt *phm_in, const psi::Psi<std::complex<FPTYPE>> &eigenfunction, const int m)
 {
     if (test_cg == 1)
         ModuleBase::TITLE("DiagoCG", "orthogonal_gradient");
@@ -266,7 +417,7 @@ void DiagoCG::orthogonal_gradient(hamilt::Hamilt *phm_in, const psi::Psi<std::co
     {
         for (int j=0; j<dim; j++)
         {
-            const std::complex<double> oo = lagrange[i] * eigenfunction(i, j);
+            const std::complex<FPTYPE> oo = lagrange[i] * eigenfunction(i, j);
             g[j] -= oo;
             scg[j] -= oo;
         }
@@ -277,14 +428,15 @@ void DiagoCG::orthogonal_gradient(hamilt::Hamilt *phm_in, const psi::Psi<std::co
     return;
 }
 
-void DiagoCG::calculate_gamma_cg(const int iter, double &gg_last, const double &cg_norm, const double &theta)
+template<typename FPTYPE, typename Device>
+void DiagoCG<FPTYPE, Device>::calculate_gamma_cg(const int iter, FPTYPE &gg_last, const FPTYPE &cg_norm, const FPTYPE &theta)
 {
     if (test_cg == 1)
         ModuleBase::TITLE("DiagoCG", "calculate_gamma_cg");
     // ModuleBase::timer::tick("DiagoCG","gamma_cg");
     auto pcg = this->cg->get_pointer();
     auto pphi_m = this->phi_m->get_pointer();
-    double gg_inter;
+    FPTYPE gg_inter;
     if (iter > 0)
     {
         // (1) Update gg_inter!
@@ -306,7 +458,7 @@ void DiagoCG::calculate_gamma_cg(const int iter, double &gg_last, const double &
 
     // (3) Update gg_now!
     // gg_now = < g|P|scg > = < g|g0 >
-    const double gg_now = ModuleBase::GlobalFunc::ddot_real(this->dim, this->gradient.data(), this->g0.data());
+    const FPTYPE gg_now = ModuleBase::GlobalFunc::ddot_real(this->dim, this->gradient.data(), this->g0.data());
 
     if (iter == 0)
     {
@@ -320,7 +472,7 @@ void DiagoCG::calculate_gamma_cg(const int iter, double &gg_last, const double &
     {
         // (4) Update gamma !
         assert(gg_last != 0.0);
-        const double gamma = (gg_now - gg_inter) / gg_last;
+        const FPTYPE gamma = (gg_now - gg_inter) / gg_last;
 
         // (5) Update gg_last !
         gg_last = gg_now;
@@ -331,8 +483,8 @@ void DiagoCG::calculate_gamma_cg(const int iter, double &gg_last, const double &
             pcg[i] = gamma * pcg[i] + this->gradient[i];
         }
 
-        const double norma = gamma * cg_norm * sin(theta);
-        std::complex<double> znorma(norma * -1, 0.0);
+        const FPTYPE norma = gamma * cg_norm * sin(theta);
+        std::complex<FPTYPE> znorma(norma * -1, 0.0);
         const int one = 1;
         zaxpy_(&this->dim, &znorma, pphi_m, &one, pcg, &one);
         /*for (int i = 0; i < this->dim; i++)
@@ -344,7 +496,8 @@ void DiagoCG::calculate_gamma_cg(const int iter, double &gg_last, const double &
     return;
 }
 
-bool DiagoCG::update_psi(double &cg_norm, double &theta, double &eigenvalue)
+template<typename FPTYPE, typename Device>
+bool DiagoCG<FPTYPE, Device>::update_psi(FPTYPE &cg_norm, FPTYPE &theta, FPTYPE &eigenvalue)
 {
     if (test_cg == 1)
         ModuleBase::TITLE("DiagoCG", "update_psi");
@@ -354,20 +507,20 @@ bool DiagoCG::update_psi(double &cg_norm, double &theta, double &eigenvalue)
     if (cg_norm < 1.0e-10)
         return 1;
 
-    std::complex<double>* phi_m_pointer = this->phi_m->get_pointer();
+    std::complex<FPTYPE>* phi_m_pointer = this->phi_m->get_pointer();
 
-    const double a0
+    const FPTYPE a0
         = ModuleBase::GlobalFunc::ddot_real(this->dim, phi_m_pointer, this->pphi.data()) * 2.0 / cg_norm;
-    const double b0
+    const FPTYPE b0
         = ModuleBase::GlobalFunc::ddot_real(this->dim, this->cg->get_pointer(), this->pphi.data()) / (cg_norm * cg_norm);
 
-    const double e0 = eigenvalue;
+    const FPTYPE e0 = eigenvalue;
     theta = atan(a0 / (e0 - b0)) / 2.0;
 
-    const double new_e = (e0 - b0) * cos(2.0 * theta) + a0 * sin(2.0 * theta);
+    const FPTYPE new_e = (e0 - b0) * cos(2.0 * theta) + a0 * sin(2.0 * theta);
 
-    const double e1 = (e0 + b0 + new_e) / 2.0;
-    const double e2 = (e0 + b0 - new_e) / 2.0;
+    const FPTYPE e1 = (e0 + b0 + new_e) / 2.0;
+    const FPTYPE e2 = (e0 + b0 - new_e) / 2.0;
 
     if (e1 > e2)
     {
@@ -377,8 +530,8 @@ bool DiagoCG::update_psi(double &cg_norm, double &theta, double &eigenvalue)
     eigenvalue = min(e1, e2);
     //	OUT("eigenvalue",eigenvalue);
 
-    const double cost = cos(theta);
-    const double sint_norm = sin(theta) / cg_norm;
+    const FPTYPE cost = cos(theta);
+    const FPTYPE sint_norm = sin(theta) / cg_norm;
 
     //	std::cout << "\n cg_norm = " << this->ddot(dim, cg, cg);
     //	std::cout << "\n cg_norm_fac = "<< cg_norm * cg_norm;
@@ -409,9 +562,10 @@ bool DiagoCG::update_psi(double &cg_norm, double &theta, double &eigenvalue)
     }
 }
 
-void DiagoCG::schmit_orth(
+template<typename FPTYPE, typename Device>
+void DiagoCG<FPTYPE, Device>::schmit_orth(
                           const int &m, // end
-                          const psi::Psi<std::complex<double>> &psi)
+                          const psi::Psi<std::complex<FPTYPE>> &psi)
 {
     //	ModuleBase::TITLE("DiagoCG","schmit_orth");
     // ModuleBase::timer::tick("DiagoCG","schmit_orth");
@@ -423,7 +577,7 @@ void DiagoCG::schmit_orth(
     assert(m >= 0);
     assert(psi.get_nbands() >= m);
 
-    std::vector<std::complex<double>> lagrange_so(m + 1, ModuleBase::ZERO);
+    std::vector<std::complex<FPTYPE>> lagrange_so(m + 1, ModuleBase::ZERO);
 
     //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
     // qianrui replace 2021-3-15
@@ -454,7 +608,7 @@ void DiagoCG::schmit_orth(
     // be careful , here reduce m+1
     Parallel_Reduce::reduce_complex_double_pool(lagrange_so.data(), m + 1);
 
-    double psi_norm = lagrange_so[m].real();
+    FPTYPE psi_norm = lagrange_so[m].real();
 
     //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
     // qianrui replace 2021-3-15
@@ -507,11 +661,15 @@ void DiagoCG::schmit_orth(
     return;
 }
 
-void DiagoCG::diag(hamilt::Hamilt *phm_in, psi::Psi<std::complex<double>> &psi, double *eigenvalue_in)
+template<typename FPTYPE, typename Device>
+void DiagoCG<FPTYPE, Device>::diag(hamilt::Hamilt *phm_in, psi::Psi<std::complex<FPTYPE>, Device> &psi, FPTYPE *eigenvalue_in)
 {
     /// record the times of trying iterative diagonalization
     int ntry = 0;
     this->notconv = 0;
+    if (this->device != psi.get_device()) { 
+        ModuleBase::WARNING_QUIT("DiagoCG::diag()", "Device type of psi and diag_cg does not match!");
+    }
     do
     {
         if(DiagoIterAssist::need_subspace || ntry > 0)
@@ -536,4 +694,9 @@ void DiagoCG::diag(hamilt::Hamilt *phm_in, psi::Psi<std::complex<double>> &psi, 
     return;
 }
 
+namespace hsolver {
+template class DiagoCG<double, psi::DEVICE_CPU>;
+#if ((defined __CUDA) || (defined __ROCM))
+template class DiagoCG<double, psi::DEVICE_GPU>;
+#endif 
 } // namespace hsolver

--- a/source/module_hsolver/diago_cg.h
+++ b/source/module_hsolver/diago_cg.h
@@ -5,22 +5,27 @@
 #include "module_base/complexmatrix.h"
 #include "src_pw/structure_factor.h"
 
+#include "module_psi/include/types.h"
+#include "module_psi/include/device.h"
+#include "module_psi/include/memory.h"
+
 namespace hsolver
 {
 
+template<typename FPTYPE = double, typename Device = psi::DEVICE_CPU>
 class DiagoCG : public DiagH
 {
   public:
     // Constructor need:
     // 1. temporary mock of Hamiltonian "Hamilt_PW"
     // 2. precondition pointer should point to place of precondition array.
-    DiagoCG(const double *precondition_in);
+    DiagoCG(const FPTYPE *precondition_in);
     ~DiagoCG();
 
     // virtual void init(){};
-
+    // refactor hpsi_info
     // this is the override function diag() for CG method
-    void diag(hamilt::Hamilt *phm_in, psi::Psi<std::complex<double>> &psi, double *eigenvalue_in) override;
+    void diag(hamilt::Hamilt *phm_in, psi::Psi<std::complex<FPTYPE>, Device> &psi, FPTYPE *eigenvalue_in);
 
   private:
     /// static variables, used for passing control variables
@@ -39,44 +44,50 @@ class DiagoCG : public DiagH
     /// non-zero col size for inputted psi matrix
     int dim = 0;
     /// precondition for cg diag
-    const double *precondition = nullptr;
+    const FPTYPE *precondition = nullptr;
     /// eigenvalue results
-    double *eigenvalue = nullptr;
+    FPTYPE *eigenvalue = nullptr;
+
 
     /// temp vector for new psi for one band, size dim
-    psi::Psi<std::complex<double>>* phi_m = nullptr;
+    psi::Psi<std::complex<FPTYPE>, Device>* phi_m = nullptr;
+    // psi::Psi<std::complex<FPTYPE>, Device>* phi_m = nullptr;
     /// temp vector for S|psi> for one band, size dim
-    std::vector<std::complex<double>> sphi;
+    std::vector<std::complex<FPTYPE>> sphi;
     /// temp vector for H|psi> for one band, size dim
-    std::vector<std::complex<double>> hphi;
+    std::vector<std::complex<FPTYPE>> hphi;
 
     /// temp vector for , size dim
-    psi::Psi<std::complex<double>>* cg = nullptr;
+    psi::Psi<std::complex<FPTYPE>, Device>* cg = nullptr;
+    // psi::Psi<std::complex<FPTYPE>, Device>* cg = nullptr;
     /// temp vector for , size dim
-    std::vector<std::complex<double>> scg;
+    std::vector<std::complex<FPTYPE>> scg;
     /// temp vector for store psi in sorting with eigenvalues, size dim
-    std::vector<std::complex<double>> pphi;
+    std::vector<std::complex<FPTYPE>> pphi;
 
     /// temp vector for , size dim
-    std::vector<std::complex<double>> gradient;
+    std::vector<std::complex<FPTYPE>> gradient;
     /// temp vector for , size dim
-    std::vector<std::complex<double>> g0;
+    std::vector<std::complex<FPTYPE>> g0;
     /// temp vector for matrix eigenvector * vector S|psi> , size m_band
-    std::vector<std::complex<double>> lagrange;
+    std::vector<std::complex<FPTYPE>> lagrange;
 
+    /// device type of psi
+    psi::AbacusDevice_t device = {};
+    Device * ctx = {};
 
     void calculate_gradient();
 
-    void orthogonal_gradient(hamilt::Hamilt *phm_in, const psi::Psi<std::complex<double>> &eigenfunction, const int m);
+    void orthogonal_gradient(hamilt::Hamilt *phm_in, const psi::Psi<std::complex<FPTYPE>> &eigenfunction, const int m);
 
-    void calculate_gamma_cg(const int iter, double &gg_last, const double &cg0, const double &theta);
+    void calculate_gamma_cg(const int iter, FPTYPE &gg_last, const FPTYPE &cg0, const FPTYPE &theta);
 
-    bool update_psi(double &cg_norm, double &theta, double &eigenvalue);
+    bool update_psi(FPTYPE &cg_norm, FPTYPE &theta, FPTYPE &eigenvalue);
 
-    void schmit_orth(const int &m, const psi::Psi<std::complex<double>> &psi);
+    void schmit_orth(const int &m, const psi::Psi<std::complex<FPTYPE>> &psi);
 
     // used in diag() for template replace Hamilt with Hamilt_PW
-    void diag_mock(hamilt::Hamilt *phm_in, psi::Psi<std::complex<double>> &phi, double *eigenvalue_in);
+    void diag_mock(hamilt::Hamilt *phm_in, psi::Psi<std::complex<FPTYPE>, Device> &phi, FPTYPE *eigenvalue_in);
 };
 
 } // namespace hsolver

--- a/source/module_hsolver/diago_iter_assist.cpp
+++ b/source/module_hsolver/diago_iter_assist.cpp
@@ -164,6 +164,18 @@ void DiagoIterAssist::diagH_subspace(hamilt::Hamilt* pHamilt,
     return;
 }
 
+#if ((defined __CUDA) || (defined __ROCM))
+//----------------------------------------------------------------------
+// Hamiltonian diagonalization in the subspace spanned
+// by nstart states psi (atomic or random wavefunctions).
+// Produces on output n_band eigenvectors (n_band <= nstart) in evc.
+//----------------------------------------------------------------------
+void DiagoIterAssist::diagH_subspace(hamilt::Hamilt* pHamilt, const psi::Psi<std::complex<double>, psi::DEVICE_GPU> &psi, psi::Psi<std::complex<double>, psi::DEVICE_GPU> &evc, double *en, int n_band) {
+    ModuleBase::WARNING_QUIT("DiagoIterAssist::diagH_subspace","GPU's implementation is not supported currently!");
+}
+#endif
+
+
 void DiagoIterAssist::diagH_subspace_init(hamilt::Hamilt* pHamilt,
                                      const ModuleBase::ComplexMatrix &psi,
                                      psi::Psi<std::complex<double>> &evc,

--- a/source/module_hsolver/diago_iter_assist.h
+++ b/source/module_hsolver/diago_iter_assist.h
@@ -24,6 +24,13 @@ class DiagoIterAssist
                                psi::Psi<std::complex<double>> &evc,
                                double *en,
                                int n_band = 0);
+    #if ((defined __CUDA) || (defined __ROCM))
+    static void diagH_subspace(hamilt::Hamilt* pHamilt,
+                               const psi::Psi<std::complex<double>, psi::DEVICE_GPU> &psi,
+                               psi::Psi<std::complex<double>, psi::DEVICE_GPU> &evc,
+                               double *en,
+                               int n_band = 0);
+    #endif
     // for initializing wave function , this is a template function
     static void diagH_subspace_init(hamilt::Hamilt* pHamilt,
                                const ModuleBase::ComplexMatrix &psi,

--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -36,13 +36,13 @@ void HSolverPW::initDiagh()
             if(pdiagh->method != this->method)
             {
                 delete[] pdiagh;
-                pdiagh = new DiagoCG(precondition.data());
+                pdiagh = new DiagoCG<double>(precondition.data());
                 pdiagh->method = this->method;
             }
         }
         else
         {
-            pdiagh = new DiagoCG(precondition.data());
+            pdiagh = new DiagoCG<double>(precondition.data());
             pdiagh->method = this->method;
         }
     }
@@ -117,7 +117,7 @@ void HSolverPW::endDiagh()
     // it should be deleted before calculating charge
     if(this->method == "cg")
     {
-        delete (DiagoCG*)pdiagh;
+        delete (DiagoCG<double>*)pdiagh;
         pdiagh = nullptr;
     }
     if(this->method == "dav")

--- a/source/module_hsolver/test/CMakeLists.txt
+++ b/source/module_hsolver/test/CMakeLists.txt
@@ -6,6 +6,7 @@ AddTest(
   SOURCES diago_cg_test.cpp ../diago_cg.cpp  ../diago_iter_assist.cpp  
           ../../src_parallel/parallel_reduce.cpp
           ../../src_parallel/parallel_global.cpp ../../module_pw/test/test_tool.cpp
+          ../../module_hamilt/operator.cpp
 )
 AddTest(
   TARGET HSolver_dav
@@ -13,6 +14,7 @@ AddTest(
   SOURCES diago_david_test.cpp ../diago_david.cpp  ../diago_iter_assist.cpp 
           ../../src_parallel/parallel_reduce.cpp ../../src_parallel/parallel_global.cpp 
           ../../module_pw/test/test_tool.cpp
+          ../../module_hamilt/operator.cpp
 )
 AddTest(
   TARGET HSolver_LCAO

--- a/source/module_hsolver/test/diago_cg_test.cpp
+++ b/source/module_hsolver/test/diago_cg_test.cpp
@@ -125,7 +125,7 @@ class DiagoCGPrepare
 	    precondition_local = new double[DIAGOTEST::npw];
 	    for(int i=0;i<DIAGOTEST::npw;i++) precondition_local[i] = precondition[i];
 #endif
-        hsolver::DiagoCG cg(precondition_local);
+        hsolver::DiagoCG<double> cg(precondition_local);
         psi_local.fix_k(0);
         double start, end;
         start = MPI_Wtime();


### PR DESCRIPTION
This PR will support the GPU implementations of CG methods later. The main changes of this PR are:

1. Add  device template for class diag_cg;
2. Add device template for class operator;
3. In order to adapt to the GPU template, some additional function interfaces have been temporarily added, such as [hPsi_gpu()](https://github.com/denghuilu/abacus-develop/blob/3d30209b53be39368f83165586d1f7895b0916ea/source/module_hamilt/operator.h#L31).