### PR TITLE
GPU: removing std::vector from class diago_cg

### DIFF
--- a/source/module_hsolver/diago_cg.cpp
+++ b/source/module_hsolver/diago_cg.cpp
@@ -60,25 +60,25 @@ void DiagoCG<FPTYPE, Device>::diag_mock(hamilt::Hamilt *phm_in, psi::Psi<std::co
     //-------------------------------------------------------------------
     this->phi_m = new psi::Psi<std::complex<FPTYPE>, Device>(phi, 1, 1);
     // this->hphi.resize(this->dmx, ModuleBase::ZERO);
-    psi::memory::abacus_resize_memory(this->hphi, this->dmx, this->device);
+    psi::memory::abacus_resize_memory_zero(this->hphi, this->dmx, this->device);
     // this->sphi.resize(this->dmx, ModuleBase::ZERO);
-    psi::memory::abacus_resize_memory(this->sphi, this->dmx, this->device);
+    psi::memory::abacus_resize_memory_zero(this->sphi, this->dmx, this->device);
 
     this->cg = new psi::Psi<std::complex<FPTYPE>, Device>(phi, 1, 1);
     // this->scg.resize(this->dmx, ModuleBase::ZERO);
-    psi::memory::abacus_resize_memory(this->scg, this->dmx, this->device);
+    psi::memory::abacus_resize_memory_zero(this->scg, this->dmx, this->device);
     // this->pphi.resize(this->dmx, ModuleBase::ZERO);
-    psi::memory::abacus_resize_memory(this->pphi, this->dmx, this->device);
+    psi::memory::abacus_resize_memory_zero(this->pphi, this->dmx, this->device);
 
     //in band_by_band CG method, only the first band in phi_m would be calculated
     psi::Range cg_hpsi_range(0);
 
     // this->gradient.resize(this->dmx, ModuleBase::ZERO);
-    psi::memory::abacus_resize_memory(this->gradient, this->dmx, this->device);
+    psi::memory::abacus_resize_memory_zero(this->gradient, this->dmx, this->device);
     // this->g0.resize(this->dmx, ModuleBase::ZERO);
-    psi::memory::abacus_resize_memory(this->g0, this->dmx, this->device);
+    psi::memory::abacus_resize_memory_zero(this->g0, this->dmx, this->device);
     // this->lagrange.resize(this->n_band, ModuleBase::ZERO);
-    psi::memory::abacus_resize_memory(this->lagrange, this->n_band, this->device);
+    psi::memory::abacus_resize_memory_zero(this->lagrange, this->n_band, this->device);
 
     for (int m = 0; m < this->n_band; m++)
     {
@@ -213,25 +213,25 @@ void DiagoCG<double, psi::DEVICE_GPU>::diag_mock(hamilt::Hamilt *phm_in, psi::Ps
     //-------------------------------------------------------------------
     this->phi_m = new psi::Psi<std::complex<double>, psi::DEVICE_GPU>(phi, 1, 1);
     // this->hphi.resize(this->dmx, ModuleBase::ZERO);
-    psi::memory::abacus_resize_memory(this->hphi, this->dmx, this->device);
+    psi::memory::abacus_resize_memory_zero(this->hphi, this->dmx, this->device);
     // this->sphi.resize(this->dmx, ModuleBase::ZERO);
-    psi::memory::abacus_resize_memory(this->sphi, this->dmx, this->device);
+    psi::memory::abacus_resize_memory_zero(this->sphi, this->dmx, this->device);
 
     this->cg = new psi::Psi<std::complex<double>, psi::DEVICE_GPU>(phi, 1, 1);
     // this->scg.resize(this->dmx, ModuleBase::ZERO);
-    psi::memory::abacus_resize_memory(this->scg, this->dmx, this->device);
+    psi::memory::abacus_resize_memory_zero(this->scg, this->dmx, this->device);
     // this->pphi.resize(this->dmx, ModuleBase::ZERO);
-    psi::memory::abacus_resize_memory(this->pphi, this->dmx, this->device);
+    psi::memory::abacus_resize_memory_zero(this->pphi, this->dmx, this->device);
 
     //in band_by_band CG method, only the first band in phi_m would be calculated
     psi::Range cg_hpsi_range(0);
 
     // this->gradient.resize(this->dmx, ModuleBase::ZERO);
-    psi::memory::abacus_resize_memory(this->pphi, this->dmx, this->device);
+    psi::memory::abacus_resize_memory_zero(this->pphi, this->dmx, this->device);
     // this->g0.resize(this->dmx, ModuleBase::ZERO);
-    psi::memory::abacus_resize_memory(this->g0, this->dmx, this->device);
+    psi::memory::abacus_resize_memory_zero(this->g0, this->dmx, this->device);
     // this->lagrange.resize(this->n_band, ModuleBase::ZERO);
-    psi::memory::abacus_resize_memory(this->lagrange, this->n_band, this->device);
+    psi::memory::abacus_resize_memory_zero(this->lagrange, this->n_band, this->device);
 
     for (int m = 0; m < this->n_band; m++)
     {

--- a/source/module_hsolver/diago_cg.h
+++ b/source/module_hsolver/diago_cg.h
@@ -53,24 +53,24 @@ class DiagoCG : public DiagH
     psi::Psi<std::complex<FPTYPE>, Device>* phi_m = nullptr;
     // psi::Psi<std::complex<FPTYPE>, Device>* phi_m = nullptr;
     /// temp vector for S|psi> for one band, size dim
-    std::vector<std::complex<FPTYPE>> sphi;
+    std::complex<FPTYPE>* sphi = nullptr;
     /// temp vector for H|psi> for one band, size dim
-    std::vector<std::complex<FPTYPE>> hphi;
+    std::complex<FPTYPE>* hphi = nullptr;
 
     /// temp vector for , size dim
     psi::Psi<std::complex<FPTYPE>, Device>* cg = nullptr;
     // psi::Psi<std::complex<FPTYPE>, Device>* cg = nullptr;
     /// temp vector for , size dim
-    std::vector<std::complex<FPTYPE>> scg;
+    std::complex<FPTYPE>* scg = nullptr;
     /// temp vector for store psi in sorting with eigenvalues, size dim
-    std::vector<std::complex<FPTYPE>> pphi;
+    std::complex<FPTYPE>* pphi = nullptr;
 
     /// temp vector for , size dim
-    std::vector<std::complex<FPTYPE>> gradient;
+    std::complex<FPTYPE>* gradient = nullptr;
     /// temp vector for , size dim
-    std::vector<std::complex<FPTYPE>> g0;
+    std::complex<FPTYPE>* g0 = nullptr;
     /// temp vector for matrix eigenvector * vector S|psi> , size m_band
-    std::vector<std::complex<FPTYPE>> lagrange;
+    std::complex<FPTYPE>* lagrange = nullptr;
 
     /// device type of psi
     psi::AbacusDevice_t device = {};

--- a/source/module_psi/include/memory.h
+++ b/source/module_psi/include/memory.h
@@ -10,6 +10,9 @@ template<typename T>
 void abacus_resize_memory(T*&, const int, const AbacusDevice_t);
 
 template<typename T>
+void abacus_resize_memory_zero(T*&, const int, const AbacusDevice_t);
+
+template<typename T>
 void abacus_memset(T*, const int, const int, const AbacusDevice_t);
 
 template<typename T>

--- a/source/module_psi/src/memory.cpp
+++ b/source/module_psi/src/memory.cpp
@@ -22,6 +22,23 @@ void abacus_resize_memory(T * &arr, const int size, const AbacusDevice_t device)
       abacus_resize_memory_gpu_rocm(arr, size);
     #endif
   }
+}
+
+template<typename T>
+void abacus_resize_memory_zero(T * &arr, const int size, const AbacusDevice_t device) {
+  if (device == CpuDevice) {
+    if (arr != nullptr) {
+      free(arr);
+    }
+    arr = (T*) malloc(sizeof(T) * size);
+  }
+  else if (device == GpuDevice) {
+    #if __CUDA
+      abacus_resize_memory_gpu_cuda(arr, size);
+    #elif __ROCM
+      abacus_resize_memory_gpu_rocm(arr, size);
+    #endif
+  }
   abacus_memset(arr, 0, size, device);
 }
 
@@ -96,6 +113,9 @@ void abacus_delete_memory(
 
 template void abacus_resize_memory<double>(double*&, const int, const AbacusDevice_t);
 template void abacus_resize_memory<std::complex<double>>(std::complex<double>*&, const int, const AbacusDevice_t);
+
+template void abacus_resize_memory_zero<double>(double*&, const int, const AbacusDevice_t);
+template void abacus_resize_memory_zero<std::complex<double>>(std::complex<double>*&, const int, const AbacusDevice_t);
 
 template void abacus_memset<double>(double*, const int, const int, const AbacusDevice_t);
 template void abacus_memset<std::complex<double>>(std::complex<double>*, const int, const int, const AbacusDevice_t);

--- a/source/module_psi/src/memory.cpp
+++ b/source/module_psi/src/memory.cpp
@@ -22,6 +22,7 @@ void abacus_resize_memory(T * &arr, const int size, const AbacusDevice_t device)
       abacus_resize_memory_gpu_rocm(arr, size);
     #endif
   }
+  abacus_memset(arr, 0, size, device);
 }
 
 template<typename T>


### PR DESCRIPTION
Removing std::vector from class diago_cg.