### PR TITLE
refactor: overload init_pot for istep=0

### DIFF
--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -207,8 +207,8 @@ void ESolver_KS_LCAO::Init(Input& inp, UnitCell_pseudo& ucell)
         // Initialize the sum of all local potentials.
         // if ion_step==0, read in/initialize the potentials
         // this function belongs to ions LOOP
-        int ion_step = 0;
-        GlobalC::pot.init_pot(ion_step, GlobalC::sf.strucFac);
+        GlobalC::CHR.init_rho();
+        GlobalC::pot.init_pot(GlobalC::sf.strucFac);
         ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running, "INIT POTENTIAL");
     }
     if (this->phami != nullptr)

--- a/source/module_esolver/esolver_ks_lcao_elec.cpp
+++ b/source/module_esolver/esolver_ks_lcao_elec.cpp
@@ -246,7 +246,15 @@ namespace ModuleESolver
                 GlobalV::ofs_running << " Setup the Vl+Vh+Vxc according to new structure factor and new charge." << std::endl;
                 // calculate the new potential accordint to
                 // the new charge density.
-                GlobalC::pot.init_pot( istep-1, GlobalC::sf.strucFac );
+                if (istep==1)
+                {
+                    GlobalC::CHR.init_rho();
+                    GlobalC::pot.init_pot(GlobalC::sf.strucFac);
+                }
+                else
+                {
+                    GlobalC::pot.init_pot( istep-1, GlobalC::sf.strucFac );
+                }
             }
         }
 

--- a/source/module_esolver/esolver_ks_lcao_tddft.cpp
+++ b/source/module_esolver/esolver_ks_lcao_tddft.cpp
@@ -69,8 +69,8 @@ void ESolver_KS_LCAO_TDDFT::Init(Input& inp, UnitCell_pseudo& ucell)
     // Initialize the sum of all local potentials.
     // if ion_step==0, read in/initialize the potentials
     // this function belongs to ions LOOP
-    int ion_step = 0;
-    GlobalC::pot.init_pot(ion_step, GlobalC::sf.strucFac);
+    GlobalC::CHR.init_rho();
+    GlobalC::pot.init_pot(GlobalC::sf.strucFac);
     ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running, "INIT POTENTIAL");
 
     //------------------init Basis_lcao----------------------

--- a/source/module_esolver/esolver_ks_pw.cpp
+++ b/source/module_esolver/esolver_ks_pw.cpp
@@ -170,7 +170,15 @@ namespace ModuleESolver
                 GlobalV::ofs_running << " Setup the Vl+Vh+Vxc according to new structure factor and new charge." << std::endl;
                 // calculate the new potential accordint to
                 // the new charge density.
-                GlobalC::pot.init_pot( istep, GlobalC::sf.strucFac );
+                if (istep==1)
+                {
+                    GlobalC::CHR.init_rho();
+                    GlobalC::pot.init_pot(GlobalC::sf.strucFac);
+                }
+                else
+                {
+                    GlobalC::pot.init_pot( istep-1, GlobalC::sf.strucFac );
+                }
             }
         }
         if(GlobalC::ucell.cell_parameter_updated)

--- a/source/module_esolver/esolver_ks_pw.cpp
+++ b/source/module_esolver/esolver_ks_pw.cpp
@@ -102,7 +102,8 @@ namespace ModuleESolver
         //=========================================================
         // calculate the total local pseudopotential in real space
         //=========================================================
-        GlobalC::pot.init_pot(0, GlobalC::sf.strucFac); //atomic_rho, v_of_rho, set_vrs
+        GlobalC::CHR.init_rho();
+        GlobalC::pot.init_pot(GlobalC::sf.strucFac); //atomic_rho, v_of_rho, set_vrs
 
         GlobalC::pot.newd();
 

--- a/source/src_pw/potential.cpp
+++ b/source/src_pw/potential.cpp
@@ -145,8 +145,7 @@ void Potential::init_pot(const int &istep, // number of ionic steps
     GlobalC::CHR.set_rho_core(GlobalC::sf.strucFac);
 
     //--------------------------------------------------------------------
-    // (2) other effective potentials need charge density,
-    // choose charge density from ionic step 0.
+    // (2) other effective potentials need charge density.
     //--------------------------------------------------------------------
 
     // renormalize the charge density
@@ -237,14 +236,8 @@ void Potential::init_pot(ModuleBase::ComplexMatrix &sf)
 
     //--------------------------------------------------------------------
     // (2) other effective potentials need charge density,
-    // choose charge density from ionic step 0.
+    // choose charge density from ionic step 0 before call init_pot
     //--------------------------------------------------------------------
-    /*
-    if (istep == 0)
-    {
-        GlobalC::CHR.init_rho();
-    }
-    */
 
     // renormalize the charge density
     GlobalC::CHR.renormalize_rho();

--- a/source/src_pw/potential.h
+++ b/source/src_pw/potential.h
@@ -48,6 +48,8 @@ class Potential
                   ModuleBase::ComplexMatrix &sf // structure factors
     );
 
+    void init_pot(ModuleBase::ComplexMatrix &sf);
+
     ModuleBase::matrix v_of_rho(const double *const *const rho_in, const double *const rho_core_in);
 
     void set_vr_eff(void);


### PR DESCRIPTION
By overloading init_pot for istep=0, it is supposed to init_rho from wave function in the next step.