### PR TITLE
GPU: Use template functors as the interface of multi device functions

### DIFF
--- a/source/module_hsolver/diago_cg.h
+++ b/source/module_hsolver/diago_cg.h
@@ -9,8 +9,9 @@
 #include "module_psi/include/device.h"
 #include "module_psi/include/memory.h"
 
-namespace hsolver
-{
+#include "module_hsolver/include/math_kernel.h"
+
+namespace hsolver {
 
 template<typename FPTYPE = double, typename Device = psi::DEVICE_CPU>
 class DiagoCG : public DiagH
@@ -88,6 +89,11 @@ class DiagoCG : public DiagH
 
     // used in diag() for template replace Hamilt with Hamilt_PW
     void diag_mock(hamilt::Hamilt *phm_in, psi::Psi<std::complex<FPTYPE>, Device> &phi, FPTYPE *eigenvalue_in);
+
+    using zdot_real_op = hsolver::zdot_real_op<FPTYPE, Device>;
+    using set_memory_op = psi::memory::set_memory_op<std::complex<FPTYPE>, Device>;
+    using delete_memory_op = psi::memory::delete_memory_op<std::complex<FPTYPE>, Device>;
+    using resize_memory_op = psi::memory::resize_memory_op<std::complex<FPTYPE>, Device>;
 };
 
 } // namespace hsolver

--- a/source/module_hsolver/include/math_kernel.h
+++ b/source/module_hsolver/include/math_kernel.h
@@ -1,3 +1,5 @@
+// TODO: This is a temperary location for these functions.
+// And will be moved to a global module(module base) later.
 #ifndef MODULE_HSOLVER_MATH_KERNEL_H
 #define MODULE_HSOLVER_MATH_KERNEL_H
 

--- a/source/module_hsolver/include/math_kernel.h
+++ b/source/module_hsolver/include/math_kernel.h
@@ -1,22 +1,34 @@
-#ifndef HSOLVER_MATH_KERNEL_H
-#define HSOLVER_MATH_KERNEL_H
+#ifndef MODULE_HSOLVER_MATH_KERNEL_H
+#define MODULE_HSOLVER_MATH_KERNEL_H
 
-#include <complex.h>
-#include "module_psi/psi.h"
 #include "module_base/blas_connector.h"
+#include "module_psi/psi.h"
 #include "src_parallel/parallel_reduce.h"
 
 namespace hsolver {
-template<typename FPTYPE>
-FPTYPE zdot_real(const int &dim, const std::complex<FPTYPE>* psi_L, const std::complex<FPTYPE>* psi_R, const psi::AbacusDevice_t device = psi::CpuDevice, const bool reduce = true);
 
-#if __CUDA || __UT_USE_CUDA
-template<typename FPTYPE>
-FPTYPE zdot_real_gpu_cuda(const int &dim, const std::complex<FPTYPE>* psi_L, const std::complex<FPTYPE>* psi_R, const psi::AbacusDevice_t device = psi::GpuDevice, const bool reduce = true);
-#elif __ROCM || __UT_USE_ROCM
-template<typename FPTYPE>
-FPTYPE zdot_real_gpu_rocm(const int &dim, const std::complex<FPTYPE>* psi_L, const std::complex<FPTYPE>* psi_R, const psi::AbacusDevice_t device = psi::GpuDevice, const bool reduce = true);
-#endif // 
-}
+template <typename FPTYPE, typename Device> 
+struct zdot_real_op {
+  FPTYPE operator() (
+      const Device* d, 
+      const int& dim, 
+      const std::complex<FPTYPE>* psi_L, 
+      const std::complex<FPTYPE>* psi_R, 
+      const bool reduce = true);
+};
 
-#endif 
+#if __CUDA || __UT_USE_CUDA || __ROCM || __UT_USE_ROCM
+// Partially specialize functor for psi::GpuDevice.
+template <typename FPTYPE> 
+struct zdot_real_op<FPTYPE, psi::DEVICE_GPU> {
+  FPTYPE operator()(
+      const psi::DEVICE_GPU* d, 
+      const int& dim, 
+      const std::complex<FPTYPE>* psi_L, 
+      const std::complex<FPTYPE>* psi_R, 
+      const bool reduce = true);
+};
+#endif // __CUDA || __UT_USE_CUDA || __ROCM || __UT_USE_ROCM
+} // namespace hsolver
+
+#endif // MODULE_HSOLVER_MATH_KERNEL_H

--- a/source/module_hsolver/src/cuda/math_kernel.cu
+++ b/source/module_hsolver/src/cuda/math_kernel.cu
@@ -1,31 +1,35 @@
 #include "module_hsolver/include/math_kernel.h"
 #include "module_psi/psi.h"
-#include <thrust/inner_product.h>
+
 #include <thrust/execution_policy.h>
+#include <thrust/inner_product.h>
 
 using namespace hsolver;
 
-// for this implementation, please check https://thrust.github.io/doc/group__transformed__reductions_ga321192d85c5f510e52300ae762c7e995.html
-// denghui modify 2022-10-03
-// Note that ddot_(2*dim,a,1,b,1) = REAL( zdotc_(dim,a,1,b,1) )
-template<typename FPTYPE>
-FPTYPE hsolver::zdot_real_gpu_cuda(
-    const int &dim, 
-    const std::complex<FPTYPE>* psi_L, 
-    const std::complex<FPTYPE>* psi_R, 
-    const psi::AbacusDevice_t device,
+// for this implementation, please check
+// https://thrust.github.io/doc/group__transformed__reductions_ga321192d85c5f510e52300ae762c7e995.html denghui modify
+// 2022-10-03 Note that ddot_(2*dim,a,1,b,1) = REAL( zdotc_(dim,a,1,b,1) ) GPU specialization of actual computation.
+template <typename FPTYPE>
+FPTYPE zdot_real_op<FPTYPE, psi::DEVICE_GPU>::operator()(
+    const psi::DEVICE_GPU* d,
+    const int& dim,
+    const std::complex<FPTYPE>* psi_L,
+    const std::complex<FPTYPE>* psi_R,
     const bool reduce)
 {
-    const FPTYPE* pL = reinterpret_cast<const FPTYPE*>(psi_L);
-    const FPTYPE* pR = reinterpret_cast<const FPTYPE*>(psi_R);
-    FPTYPE result = thrust::inner_product(thrust::device, pL, pL + dim * 2, pR, FPTYPE(0.0));
-    if (reduce) {
-        Parallel_Reduce::reduce_double_pool(result);
-    }
-    return result;
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+  // denghui modify 2022-10-07
+  // Note that  ddot_(2*dim,a,1,b,1) = REAL( zdotc_(dim,a,1,b,1) )
+  const FPTYPE* pL = reinterpret_cast<const FPTYPE*>(psi_L);
+  const FPTYPE* pR = reinterpret_cast<const FPTYPE*>(psi_R);
+  FPTYPE result = thrust::inner_product(thrust::device, pL, pL + dim * 2, pR, FPTYPE(0.0));
+  if (reduce) {
+      Parallel_Reduce::reduce_double_pool(result);
+  }
+  return result;
 }
 
 namespace hsolver {
-    template double zdot_real_gpu_cuda<double>(const int &dim, const std::complex<double>* psi_L, const std::complex<double>* psi_R, const psi::AbacusDevice_t device, const bool reduce);
+// Explicitly instantiate functors for the types of functor registered.
+template struct zdot_real_op<double, psi::DEVICE_GPU>;
 }
-

--- a/source/module_hsolver/src/math_kernel.cpp
+++ b/source/module_hsolver/src/math_kernel.cpp
@@ -7,7 +7,7 @@ using namespace hsolver;
 
 // CPU specialization of actual computation.
 template <typename FPTYPE> 
-struct zdot_real_op<FPTYPE, psi::DEVICE_CPU> {
+struct hsolver::zdot_real_op<FPTYPE, psi::DEVICE_CPU> {
   FPTYPE operator() (
       const psi::DEVICE_CPU* d,
       const int& dim,

--- a/source/module_hsolver/src/math_kernel.cpp
+++ b/source/module_hsolver/src/math_kernel.cpp
@@ -1,36 +1,34 @@
-#include <iomanip>
-#include <iostream>
 #include "module_hsolver/include/math_kernel.h"
 
+#include <iomanip>
+#include <iostream>
+
 using namespace hsolver;
-template<typename FPTYPE>
-FPTYPE hsolver::zdot_real(
-    const int &dim, 
-    const std::complex<FPTYPE>* psi_L, 
-    const std::complex<FPTYPE>* psi_R, 
-    const psi::AbacusDevice_t device,
-    const bool reduce)
-{
-    FPTYPE result = 0.0;
-    if (device == psi::CpuDevice) {
-      //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-      //qianrui modify 2021-3-14
-      //Note that  ddot_(2*dim,a,1,b,1) = REAL( zdotc_(dim,a,1,b,1) )
-      const FPTYPE* pL = reinterpret_cast<const FPTYPE*>(psi_L);
-      const FPTYPE* pR = reinterpret_cast<const FPTYPE*>(psi_R);
-      result = BlasConnector::dot(2 * dim, pL, 1, pR, 1);
-      if(reduce)  Parallel_Reduce::reduce_double_pool( result );
-    }
-    else if (device == psi::GpuDevice) {
-      #if __CUDA
-      result = zdot_real_gpu_cuda(dim, psi_L, psi_R, device, reduce);
-      #elif __ROCM
-      result = zdot_real_gpu_rocm(dim, psi_L, psi_R, device, reduce);
-      #endif 
+
+// CPU specialization of actual computation.
+template <typename FPTYPE> 
+struct zdot_real_op<FPTYPE, psi::DEVICE_CPU> {
+  FPTYPE operator() (
+      const psi::DEVICE_CPU* d,
+      const int& dim,
+      const std::complex<FPTYPE>* psi_L,
+      const std::complex<FPTYPE>* psi_R,
+      const bool reduce) 
+  {
+    //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+    // qianrui modify 2021-3-14
+    // Note that  ddot_(2*dim,a,1,b,1) = REAL( zdotc_(dim,a,1,b,1) )
+    const FPTYPE* pL = reinterpret_cast<const FPTYPE*>(psi_L);
+    const FPTYPE* pR = reinterpret_cast<const FPTYPE*>(psi_R);
+    FPTYPE result = BlasConnector::dot(2 * dim, pL, 1, pR, 1);
+    if (reduce) {
+      Parallel_Reduce::reduce_double_pool(result);
     }
     return result;
-}
+  }
+};
 
 namespace hsolver {
-    template double zdot_real<double>(const int &dim, const std::complex<double>* psi_L, const std::complex<double>* psi_R, const psi::AbacusDevice_t device, const bool reduce);
+// Explicitly instantiate functors for the types of functor registered.
+template struct zdot_real_op<double, psi::DEVICE_CPU>;
 }

--- a/source/module_psi/include/device.h
+++ b/source/module_psi/include/device.h
@@ -1,3 +1,5 @@
+// TODO: This is a temperary location for these functions.
+// And will be moved to a global module(module base) later.
 #ifndef MODULE_PSI_DEVICE_H_
 #define MODULE_PSI_DEVICE_H_
 

--- a/source/module_psi/include/memory.h
+++ b/source/module_psi/include/memory.h
@@ -1,3 +1,5 @@
+// TODO: This is a temperary location for these functions.
+// And will be moved to a global module(module base) later.
 #ifndef MODULE_PSI_MEMORY_H_
 #define MODULE_PSI_MEMORY_H_
 

--- a/source/module_psi/include/memory.h
+++ b/source/module_psi/include/memory.h
@@ -7,65 +7,77 @@
 namespace psi {
 namespace memory {
 
-template<typename T>
-void abacus_resize_memory(T*&, const int, const AbacusDevice_t);
+template <typename FPTYPE, typename Device> 
+struct resize_memory_op {
+  void operator()(const Device* dev, FPTYPE*& arr, const size_t size);
+};
 
-template<typename T>
-void abacus_resize_memory_zero(T*&, const int, const AbacusDevice_t);
+template <typename FPTYPE, typename Device> 
+struct set_memory_op {
+  void operator()(const Device* dev, FPTYPE* arr, const int var, const size_t size);
+};
 
-template<typename T>
-void abacus_memset(T*, const int, const int, const AbacusDevice_t);
+template <typename FPTYPE, typename Device_out, typename Device_in> 
+struct synchronize_memory_op {
+  void operator()(
+      const Device_out* dev_out, 
+      const Device_in* dev_in, 
+      FPTYPE* arr_out, 
+      const FPTYPE* arr_in, 
+      const size_t size);
+};
 
-template<typename T>
-void abacus_sync_memory(T*, const T*, const size_t,  const AbacusDevice_t, const AbacusDevice_t);
+template <typename FPTYPE, typename Device> 
+struct delete_memory_op {
+  void operator()(const Device* dev, FPTYPE* arr);
+};
 
-template<typename T>
-void abacus_delete_memory(T*, const AbacusDevice_t);
+#if __CUDA || __UT_USE_CUDA || __ROCM || __UT_USE_ROCM
+// Partially specialize operator for psi::GpuDevice.
+template <typename FPTYPE> 
+struct resize_memory_op<FPTYPE, psi::DEVICE_GPU> {
+  void operator()(const psi::DEVICE_GPU* dev, FPTYPE*& arr, const size_t size);
+};
 
-#if __CUDA || __UT_USE_CUDA
-template<typename T>
-void abacus_resize_memory_gpu_cuda(T*&, const int);
+template <typename FPTYPE> 
+struct set_memory_op<FPTYPE, psi::DEVICE_GPU> {
+  void operator()(const psi::DEVICE_GPU* dev, FPTYPE* arr, const int var, const size_t size);
+};
 
-template<typename T>
-void abacus_memset_gpu_cuda(T*, const int, const int);
-
-template <typename T>
-void abacus_memcpy_device_to_device_gpu_cuda(T* , const T*, const int);
-
-template <typename T>
-void abacus_memcpy_host_to_device_gpu_cuda(T* , const T*, const int);
-
-template <typename T>
-void abacus_memcpy_device_to_host_gpu_cuda(T* , const T*, const int);
-
-template<typename T>
-void abacus_delete_memory_gpu_cuda(T*);
+template <typename FPTYPE> 
+struct synchronize_memory_op<FPTYPE, psi::DEVICE_CPU, psi::DEVICE_GPU> {
+  void operator()(
+      const psi::DEVICE_CPU* dev_out, 
+      const psi::DEVICE_GPU* dev_in, 
+      FPTYPE* arr_out, 
+      const FPTYPE* arr_in, 
+      const size_t size);
+};
+template <typename FPTYPE> 
+struct synchronize_memory_op<FPTYPE, psi::DEVICE_GPU, psi::DEVICE_CPU> {
+  void operator()(
+      const psi::DEVICE_GPU* dev_out, 
+      const psi::DEVICE_CPU* dev_in, 
+      FPTYPE* arr_out, 
+      const FPTYPE* arr_in, 
+      const size_t size);
+};
+template <typename FPTYPE> 
+struct synchronize_memory_op<FPTYPE, psi::DEVICE_GPU, psi::DEVICE_GPU> {
+  void operator()(
+      const psi::DEVICE_GPU* dev_out, 
+      const psi::DEVICE_GPU* dev_in, 
+      FPTYPE* arr_out, 
+      const FPTYPE* arr_in, 
+      const size_t size);
+};
 
 template <typename FPTYPE>
-void abacus_malloc_device_memory_sync_gpu_cuda( FPTYPE*&, const std::vector<FPTYPE>&);
-
-#elif __ROCM || __UT_USE_ROCM
-template<typename T>
-void abacus_resize_memory_gpu_rocm(T*&, const int, const AbacusDevice_t);
-
-template<typename T>
-void abacus_memset_gpu_rocm(T*&, const int, const int, const AbacusDevice_t);
-
-template <typename T>
-void abacus_memcpy_device_to_device_gpu_rocm(T* , const T*, const int);
-
-template <typename T>
-void abacus_memcpy_host_to_device_gpu_rocm(T* , const T*, const int);
-
-template <typename T>
-void abacus_memcpy_device_to_host_gpu_rocm(T* , const T*, const int);
-
-template<typename T>
-void abacus_delete_memory_gpu_rocm(T*);
-
-template <typename FPTYPE>
-void malloc_device_memory_sync_gpu_rocm( FPTYPE*&, const std::vector<FPTYPE>&));
+struct delete_memory_op<FPTYPE, psi::DEVICE_GPU> {
+  void operator()(const psi::DEVICE_GPU* dev, FPTYPE* arr);
+};
 #endif
+// __CUDA || __UT_USE_CUDA || __ROCM || __UT_USE_ROCM 
 
 } // end of namespace memory
 } // end of namespace psi

--- a/source/module_psi/include/types.h
+++ b/source/module_psi/include/types.h
@@ -1,3 +1,5 @@
+// TODO: This is a temperary location for these functions.
+// And will be moved to a global module(module base) later.
 #ifndef MODULE_PSI_TYPES_H_
 #define MODULE_PSI_TYPES_H_
 

--- a/source/module_psi/psi.h
+++ b/source/module_psi/psi.h
@@ -4,6 +4,7 @@
 //#include "Basis.h"
 //#include "Cell.h"
 #include "module_psi/include/types.h"
+#include "module_psi/include/memory.h"
 
 namespace psi
 {
@@ -103,7 +104,7 @@ public:
     // return k_first
     const bool& get_k_first() const;
     // return device type of psi
-    const AbacusDevice_t& get_device() const;
+    const Device* get_device() const;
     // return psi_bias
     const int& get_psi_bias() const;
 
@@ -152,6 +153,11 @@ public:
     // method for parallelization 
     int parallel_type;
 //would be updated later */
+    
+    using set_memory_op = psi::memory::set_memory_op<T, Device>;
+    using delete_memory_op = psi::memory::delete_memory_op<T, Device>;
+    using resize_memory_op = psi::memory::resize_memory_op<T, Device>;
+    using synchronize_memory_op = psi::memory::synchronize_memory_op<T, Device, Device>;
 };
 
 //method for initial psi for each base, should be updated later

--- a/source/module_psi/src/memory.cpp
+++ b/source/module_psi/src/memory.cpp
@@ -7,124 +7,52 @@
 namespace psi{
 namespace memory{
 
-template<typename T>
-void abacus_resize_memory(T * &arr, const int size, const AbacusDevice_t device) {
-  if (device == CpuDevice) {
+template <typename FPTYPE> 
+struct resize_memory_op<FPTYPE, psi::DEVICE_CPU> {
+  void operator()(const psi::DEVICE_CPU* dev, FPTYPE*& arr, const size_t size) {
     if (arr != nullptr) {
       free(arr);
     }
-    arr = (T*) malloc(sizeof(T) * size);
+    arr = (FPTYPE*) malloc(sizeof(FPTYPE) * size);
   }
-  else if (device == GpuDevice) {
-    #if __CUDA
-      abacus_resize_memory_gpu_cuda(arr, size);
-    #elif __ROCM
-      abacus_resize_memory_gpu_rocm(arr, size);
-    #endif
-  }
-}
+};
 
-template<typename T>
-void abacus_resize_memory_zero(T * &arr, const int size, const AbacusDevice_t device) {
-  if (device == CpuDevice) {
-    if (arr != nullptr) {
-      free(arr);
-    }
-    arr = (T*) malloc(sizeof(T) * size);
+template <typename FPTYPE> 
+struct set_memory_op<FPTYPE, psi::DEVICE_CPU> {
+  void operator()(const psi::DEVICE_CPU* dev, FPTYPE* arr, const int var, const size_t size) {
+    memset(arr, var, sizeof(FPTYPE) * size);
   }
-  else if (device == GpuDevice) {
-    #if __CUDA
-      abacus_resize_memory_gpu_cuda(arr, size);
-    #elif __ROCM
-      abacus_resize_memory_gpu_rocm(arr, size);
-    #endif
-  }
-  abacus_memset(arr, 0, size, device);
-}
+};
 
-template<typename T>
-void abacus_memset(T* arr, const int val, const int size, const AbacusDevice_t device) {
-  if (device == CpuDevice) {
-    memset(arr, val, sizeof(T) * size);
+template <typename FPTYPE> 
+struct synchronize_memory_op<FPTYPE, psi::DEVICE_CPU, psi::DEVICE_CPU> {
+  void operator()(const psi::DEVICE_CPU* dev_out, 
+                  const psi::DEVICE_CPU* dev_in, 
+                  FPTYPE* arr_out, 
+                  const FPTYPE* arr_in, 
+                  const size_t size) {
+    memcpy(arr_out, arr_in, sizeof(FPTYPE) * size);
   }
-  else if (device == GpuDevice) {
-    #if __CUDA
-      abacus_memset_gpu_cuda(arr, val, size);
-    #elif __ROCM
-      abacus_memset_gpu_rocm(arr, val, size);
-    #endif
-  }
-}
+};
 
-template<typename T>
-void abacus_sync_memory(
-    T* arr1,
-    const T* arr2,
-    const size_t size, 
-    const AbacusDevice_t dev1,
-    const AbacusDevice_t dev2) 
-{
-  if (dev1 == dev2) {
-    if (dev1 == CpuDevice) {
-      memcpy(arr1, arr2, sizeof(T) * size);
-    }
-    else {
-      #if __CUDA
-      abacus_memcpy_device_to_device_gpu_cuda(arr1, arr2, size);
-      #elif __ROCM
-      abacus_memcpy_device_to_device_gpu_rocm(arr1, arr2, size);
-      #endif
-    }
-  }
-  else {
-    if (dev1 == CpuDevice) {
-      #if __CUDA
-      abacus_memcpy_device_to_host_gpu_cuda(arr1, arr2, size);
-      #elif __ROCM
-      abacus_memcpy_device_to_host_gpu_rocm(arr1, arr2, size);
-      #endif
-    }
-    else {
-      #if __CUDA
-      abacus_memcpy_host_to_device_gpu_cuda(arr1, arr2, size);
-      #elif __ROCM
-      abacus_memcpy_host_to_device_gpu_rocm(arr1, arr2, size);
-      #endif
-    }
-  }
-}
-
-template<typename T>
-void abacus_delete_memory(
-    T* arr,
-    const AbacusDevice_t device) 
-{
-  if (device == CpuDevice) {
+template <typename FPTYPE>
+struct delete_memory_op<FPTYPE, psi::DEVICE_CPU> {
+  void operator()(const psi::DEVICE_CPU* dev, FPTYPE* arr) {
     free(arr);
   }
-  else{
-    #if __CUDA
-      abacus_delete_memory_gpu_cuda(arr);
-    #elif __ROCM
-      abacus_delete_memory_gpu_rocm(arr);
-    #endif
-  }
-}
+};
 
-template void abacus_resize_memory<double>(double*&, const int, const AbacusDevice_t);
-template void abacus_resize_memory<std::complex<double>>(std::complex<double>*&, const int, const AbacusDevice_t);
+template struct resize_memory_op<double, psi::DEVICE_CPU>;
+template struct resize_memory_op<std::complex<double>, psi::DEVICE_CPU>;
 
-template void abacus_resize_memory_zero<double>(double*&, const int, const AbacusDevice_t);
-template void abacus_resize_memory_zero<std::complex<double>>(std::complex<double>*&, const int, const AbacusDevice_t);
+template struct set_memory_op<double, psi::DEVICE_CPU>;
+template struct set_memory_op<std::complex<double>, psi::DEVICE_CPU>;
 
-template void abacus_memset<double>(double*, const int, const int, const AbacusDevice_t);
-template void abacus_memset<std::complex<double>>(std::complex<double>*, const int, const int, const AbacusDevice_t);
+template struct synchronize_memory_op<double, psi::DEVICE_CPU, psi::DEVICE_CPU>;
+template struct synchronize_memory_op<std::complex<double>, psi::DEVICE_CPU, psi::DEVICE_CPU>;
 
-template void abacus_sync_memory<double>(double*, const double*, const size_t,  const AbacusDevice_t, const AbacusDevice_t);
-template void abacus_sync_memory<std::complex<double>>(std::complex<double>*, const std::complex<double>*, const size_t,  const AbacusDevice_t, const AbacusDevice_t);
-
-template void abacus_delete_memory<double>(double*, const AbacusDevice_t);
-template void abacus_delete_memory<std::complex<double>>(std::complex<double>*, const AbacusDevice_t);
+template struct delete_memory_op<double, psi::DEVICE_CPU>;
+template struct delete_memory_op<std::complex<double>, psi::DEVICE_CPU>;
 
 }
 }


### PR DESCRIPTION
This PR use template functors as the multi device function's interface, just like the [TensorFlow style](https://www.tensorflow.org/guide/create_op?hl=zh-cn). This helps to improve the readability of those methods. And the main changes are:

1. Use template functors as the multi device function's interface within `module_psi` and `module_hsolver`;
2. Change the related unit test style.

Note: The current position of those functors is conducive to isolating their influence on other modules, and they may be adjusted to module_base as the shared interfaces later.

TODO: Add UTs for all functors within `module_psi/include/memory.h`.