### PR TITLE
Build(docker): move libtorch to a separated folder.

### DIFF
--- a/Dockerfile.gnu
+++ b/Dockerfile.gnu
@@ -13,9 +13,9 @@ RUN git clone https://github.com/llohse/libnpy.git && \
 
 RUN wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.1%2Bcpu.zip \
         --no-check-certificate --quiet -O libtorch.zip && \
-    unzip -q libtorch.zip && rm libtorch.zip && \
-    cd libtorch && cp -r . /usr/local && \
-    cd .. && rm -r libtorch
+    unzip -q libtorch.zip -d /opt  && rm libtorch.zip
+
+ENV CMAKE_PREFIX_PATH=/opt/libtorch/share/cmake
 
 RUN git clone https://github.com/deepmodeling/abacus-develop.git --depth 1 && \
     cd abacus-develop && \

--- a/Dockerfile.intel
+++ b/Dockerfile.intel
@@ -50,9 +50,9 @@ RUN source /opt/intel/oneapi/setvars.sh \
 
 RUN wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.1%2Bcpu.zip \
         --no-check-certificate --quiet -O libtorch.zip && \
-    unzip -q libtorch.zip && rm libtorch.zip && \
-    cd libtorch && cp -r . /usr/local && \
-    cd .. && rm -r libtorch
+    unzip -q libtorch.zip -d /opt  && rm libtorch.zip
+
+ENV CMAKE_PREFIX_PATH=/opt/libtorch/share/cmake
 
 RUN git clone https://github.com/deepmodeling/abacus-develop.git --depth 1 && \
     cd abacus-develop && \


### PR DESCRIPTION
runtime library [libgomp.so.1] in /usr/lib/gcc/x86_64-linux-gnu/11 may be hidden by files in /usr/local/lib. Moving libtorch install to another folder to avoid potential issues