### PR TITLE
fix: fix bug in md when cal_stress=0

### DIFF
--- a/source/module_md/MD_func.cpp
+++ b/source/module_md/MD_func.cpp
@@ -238,7 +238,10 @@ void MD_func::force_virial(
     ModuleBase::matrix force_temp(unit_in.nat, 3); 
     p_esolver->cal_Force(force_temp);
 
-    p_esolver->cal_Stress(stress);
+    if(GlobalV::CAL_STRESS)
+    {
+        p_esolver->cal_Stress(stress);
+    }
 
     if(mdp.md_ensolver == "FP")
     {


### PR DESCRIPTION
fix the bug mentioned in [abacusmodeling#221](https://github.com/abacusmodeling/abacus-develop/issues/221)