### PR TITLE
Fix: Keep the base definition of operator class in ks_pw consistent with ks_lcao

### DIFF
--- a/source/module_hamilt/ks_pw/ekinetic_pw.h
+++ b/source/module_hamilt/ks_pw/ekinetic_pw.h
@@ -10,9 +10,10 @@ namespace hamilt {
 #ifndef __EKINETICTEMPLATE
 #define __EKINETICTEMPLATE
 
-// template<class T> class Ekinetic : public T {};
-template<typename FPTYPE, typename Device = psi::DEVICE_CPU>
-class Ekinetic : public OperatorPW<FPTYPE, Device> {};
+template<class T> class Ekinetic : public T
+{};
+// template<typename FPTYPE, typename Device = psi::DEVICE_CPU>
+// class Ekinetic : public OperatorPW<FPTYPE, Device> {};
 
 #endif
 

--- a/source/module_hamilt/ks_pw/meta_pw.h
+++ b/source/module_hamilt/ks_pw/meta_pw.h
@@ -7,14 +7,15 @@
 
 namespace hamilt {
 
- #ifndef __METATEMPLATE
- #define __METATEMPLATE
+#ifndef __METATEMPLATE
+#define __METATEMPLATE
 
-// template<class T> class Meta : public T {};
-template<typename FPTYPE, typename Device = psi::DEVICE_CPU>
-class Meta : public OperatorPW<FPTYPE, Device> {};
+template<class T> class Meta : public T
+{};
+// template<typename FPTYPE, typename Device = psi::DEVICE_CPU>
+// class Meta : public OperatorPW<FPTYPE, Device> {};
 
- #endif
+#endif
 
 template<typename FPTYPE, typename Device>
 class Meta<OperatorPW<FPTYPE, Device>> : public OperatorPW<FPTYPE, Device>

--- a/source/module_hamilt/ks_pw/nonlocal_pw.h
+++ b/source/module_hamilt/ks_pw/nonlocal_pw.h
@@ -11,15 +11,15 @@
 
 namespace hamilt {
 
- #ifndef NONLOCALTEMPLATE_H
- #define NONLOCALTEMPLATE_H
+#ifndef NONLOCALTEMPLATE_H
+#define NONLOCALTEMPLATE_H
 
-// template<class T> class Nonlocal : public T {};
-template<typename FPTYPE, typename Device = psi::DEVICE_CPU>
-class Nonlocal : public OperatorPW<FPTYPE, Device> {};
+template<class T> class Nonlocal : public T
+{};
+// template<typename FPTYPE, typename Device = psi::DEVICE_CPU>
+// class Nonlocal : public OperatorPW<FPTYPE, Device> {};
 
-
- #endif
+#endif
 
 template<typename FPTYPE, typename Device>
 class Nonlocal<OperatorPW<FPTYPE, Device>> : public OperatorPW<FPTYPE, Device>

--- a/source/module_hamilt/ks_pw/veff_pw.h
+++ b/source/module_hamilt/ks_pw/veff_pw.h
@@ -7,14 +7,15 @@
 
 namespace hamilt {
 
- #ifndef __VEFFTEMPLATE
- #define __VEFFTEMPLATE
+#ifndef __VEFFTEMPLATE
+#define __VEFFTEMPLATE
 
-// template<class T> class Veff : public T {};
-template<typename FPTYPE, typename Device = psi::DEVICE_CPU>
-class Veff : public OperatorPW<FPTYPE, Device> {};
+template<class T> class Veff : public T
+{};
+// template<typename FPTYPE, typename Device = psi::DEVICE_CPU>
+// class Veff : public OperatorPW<FPTYPE, Device> {};
 
- #endif
+#endif
 
 template<typename FPTYPE, typename Device>
 class Veff<OperatorPW<FPTYPE, Device>> : public OperatorPW<FPTYPE, Device>


### PR DESCRIPTION
Keep the base definition of operator class in ks_pw consistent with that in ks_lcao.