### PR TITLE
CI: ensuring docker build to use the latest codes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 # To build this Dockerfile, run `docker build -t abacus - < Dockerfile`.
+# Build without cloning the repo by `docker build https://github.com/deepmodeling/abacus-develop.git#develop`,
+#   and optionally choose the Dockerfile in use by appending e.g. `-f Dockerfile.gnu`.
 # Alternatively, pull the image with `docker pull ghcr.io/deepmodeling/abacus:latest`.
 # Also available at `docker pull registry.dp.tech/deepmodeling/abacus:latest`.
 
@@ -13,6 +15,11 @@ RUN apt update && apt install -y --no-install-recommends \
 
 ENV GIT_SSL_NO_VERIFY=true TERM=xterm-256color \
     OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 OMPI_MCA_btl_vader_single_copy_mechanism=none
+
+# This will fetch the latest commit info, and store in docker building cache.
+# If there are newer commits, docker build will ignore the cache and build latest codes.
+ADD https://api.github.com/repos/deepmodeling/abacus-develop/git/refs/heads/develop /dev/null
+
 RUN git clone https://github.com/deepmodeling/abacus-develop.git --depth 1 && \
     cd abacus-develop && \
     cmake -B build && \

--- a/Dockerfile.gnu
+++ b/Dockerfile.gnu
@@ -17,6 +17,8 @@ RUN wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-wit
 
 ENV CMAKE_PREFIX_PATH=/opt/libtorch/share/cmake
 
+ADD https://api.github.com/repos/deepmodeling/abacus-develop/git/refs/heads/develop /dev/null
+
 RUN git clone https://github.com/deepmodeling/abacus-develop.git --depth 1 && \
     cd abacus-develop && \
     cmake -B build -DENABLE_DEEPKS=ON && \

--- a/Dockerfile.intel
+++ b/Dockerfile.intel
@@ -54,6 +54,8 @@ RUN wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-wit
 
 ENV CMAKE_PREFIX_PATH=/opt/libtorch/share/cmake
 
+ADD https://api.github.com/repos/deepmodeling/abacus-develop/git/refs/heads/develop /dev/null
+
 RUN git clone https://github.com/deepmodeling/abacus-develop.git --depth 1 && \
     cd abacus-develop && \
     cmake -B build -DENABLE_DEEPKS=ON && \


### PR DESCRIPTION
When using `RUN git clone` in Dockerfile, docker build is not able to tell whether the targeted branch has modifications; it will use build cache since the command is exactly the same. Thus, the latest codes are not actually built when using build cache. 
We use `ADD` to fetch the head commit hash into building cache. If the hash remains the same, the cache can be utilized; and if there are incoming changes, there will be a different hash value. In this way, the cache will not be used.