### PR TITLE
CI: Unify image name.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // To develop inside a pre-configured container, see https://code.visualstudio.com/docs/remote/containers .
 // For format details, see https://aka.ms/devcontainer.json .
 {
-	"image":"ghcr.io/deepmodeling/abacus-development-kit:gnu",
+	"image":"ghcr.io/deepmodeling/abacus-gnu",
 	"extensions": [
 		"ms-vscode.cpptools-extension-pack",
 		"xaver.clang-format",

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -25,7 +25,7 @@ jobs:
           build_args: "-DENABLE_LCAO=OFF"
           name: "Build without LCAO"
     name: ${{ matrix.name }}
-    container: ghcr.io/deepmodeling/abacus-development-kit:${{ matrix.tag }}
+    container: ghcr.io/deepmodeling/abacus-${{ matrix.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -32,8 +32,8 @@ jobs:
     name: Do the job on the runner
     needs: start-runner # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
-    container: 
-      image: ghcr.io/deepmodeling/abacus-development-kit:cuda
+    container:
+      image: ghcr.io/deepmodeling/abacus-cuda
       options: --gpus all
     steps:
       - name: Checkout
@@ -42,7 +42,7 @@ jobs:
         run: |
           nvidia-smi
           cmake -B build -DUSE_CUSOLVER_LCAO=ON
-          cmake --build build -j4 
+          cmake --build build -j4
           cmake --install build
           cmake -B build -DBUILD_TESTING=ON
           cmake --build build -j4 --target hsolver_diago
@@ -51,7 +51,7 @@ jobs:
           export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda/lib64
           cd tests/integrate
           echo "ks_solver cusolver" >> ./270_NO_MD_2O/INPUT
-          ./Autotest.sh -r 270_NO_MD_2O 
+          ./Autotest.sh -r 270_NO_MD_2O
       - name: Test UT
         run: |
           cd source/src_pdiag/test/
@@ -63,10 +63,10 @@ jobs:
           cd examples/performance
           ls -d P1*lcao* > allcase
           sed -i '/ks_solver/d' P1*lcao*/INPUT
-          sed -i '$a ks_solver cusolver' P1*lcao*/INPUT 
+          sed -i '$a ks_solver cusolver' P1*lcao*/INPUT
           bash run.sh
           cat sumall.dat
-          
+
 
   stop-runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,8 +1,6 @@
 name: Container
 
 on:
-  schedule:
-    - cron: '0 18 * * *'
   push:
     branches:
       - develop
@@ -39,9 +37,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           tags: |
-            ghcr.io/deepmodeling/abacus-development-kit:${{ matrix.dockerfile }}
+            ghcr.io/deepmodeling/abacus-${{ matrix.dockerfile }}:latest
             registry.dp.tech/deepmodeling/abacus-${{ matrix.dockerfile }}:latest
           file: Dockerfile.${{ matrix.dockerfile }}
-          cache-from: type=registry,ref=ghcr.io/deepmodeling/abacus-development-kit:${{matrix.dockerfile}}
+          cache-from: type=registry,ref=ghcr.io/deepmodeling/abacus-${{ matrix.dockerfile }}:latest
           cache-to: type=inline
           push: true

--- a/.github/workflows/dynamic.yml
+++ b/.github/workflows/dynamic.yml
@@ -10,7 +10,7 @@ jobs:
     name: Dynamic analysis
     runs-on: self-hosted
     if: github.repository_owner == 'deepmodeling'
-    container: ghcr.io/deepmodeling/abacus-development-kit:gnu
+    container: ghcr.io/deepmodeling/abacus-gnu
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         tag: ["gnu", "intel"]
-    container: ghcr.io/deepmodeling/abacus-development-kit:${{ matrix.tag }}
+    container: ghcr.io/deepmodeling/abacus-${{ matrix.tag }}
     timeout-minutes: 2880
     steps:
       - name: Checkout

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   clang-tidy:
     runs-on: ubuntu-latest
-    container: ghcr.io/deepmodeling/abacus-development-kit:gnu
+    container: ghcr.io/deepmodeling/abacus-gnu
     steps:
       - name: Checkout Pull Request
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     name: Test
     runs-on: self-hosted
     if: github.repository_owner == 'deepmodeling'
-    container: ghcr.io/deepmodeling/abacus-development-kit:gnu
+    container: ghcr.io/deepmodeling/abacus-gnu
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,2 +1,2 @@
 # https://www.gitpod.io/docs/configure
-image: "ghcr.io/deepmodeling/abacus-development-kit:gnu"
+image: "ghcr.io/deepmodeling/abacus-gnu"

--- a/docs/quick_start/easy_install.md
+++ b/docs/quick_start/easy_install.md
@@ -85,7 +85,7 @@ You can change the number after `-j` on your need: set to the number of CPU core
 
 We've built a ready-for-use version of ABACUS with docker [here](https://github.com/deepmodeling/abacus-develop/pkgs/container/abacus). For a quick start: pull the image, prepare the data, run container. Instructions on using the image can be accessed in [Dockerfile](../../Dockerfile). A mirror is available by `docker pull registry.dp.tech/deepmodeling/abacus`.
 
-We also offer a pre-built docker image containing all the requirements for development. Please refer to our [Package Page](https://github.com/deepmodeling/abacus-develop/pkgs/container/abacus-development-kit).
+We also offer a pre-built docker image containing all the requirements for development. Please refer to our [Package Page](https://github.com/orgs/deepmodeling/packages?repo_name=abacus-develop).
 
 The project is ready for VS Code development container. Please refer to [Developing inside a Container](https://code.visualstudio.com/docs/remote/containers#_quick-start-try-a-development-container). Choose `Open a Remote Window -> Clone a Repository in Container Volume` in VS Code command palette, and put the [git address](https://github.com/deepmodeling/abacus-develop.git) of `ABACUS` when prompted.
 


### PR DESCRIPTION
Change github image name from "abacus-development-kit" to "abacus-*".

Reverting #1489.