### PR TITLE
Build: pin OpenBLAS variant to OpenMP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 
 FROM ubuntu:22.04
 RUN apt update && apt install -y --no-install-recommends \
-    libopenblas-dev liblapack-dev libscalapack-mpi-dev libelpa-dev libfftw3-dev libcereal-dev libxc-dev \
+    libopenblas-openmp-dev liblapack-dev libscalapack-mpi-dev libelpa-dev libfftw3-dev libcereal-dev libxc-dev \
     g++ make cmake bc time sudo vim git
 # If you wish to use the LLVM compiler, replace 'g++' above with 'clang libomp-dev'.
 

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,7 +1,7 @@
 FROM nvidia/cuda:11.7.0-devel-ubuntu22.04
 
 RUN apt update && apt install -y --no-install-recommends \
-    libopenblas-dev liblapack-dev libscalapack-mpi-dev libelpa-dev libfftw3-dev libcereal-dev \
+    libopenblas-openmp-dev liblapack-dev libscalapack-mpi-dev libelpa-dev libfftw3-dev libcereal-dev \
     libxc-dev libgtest-dev libgmock-dev python3-numpy \
     bc cmake git g++ make bc time sudo unzip vim wget
 

--- a/Dockerfile.gnu
+++ b/Dockerfile.gnu
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 RUN apt update && apt install -y --no-install-recommends \
-    libopenblas-dev liblapack-dev libscalapack-mpi-dev libelpa-dev libfftw3-dev libcereal-dev \
+    libopenblas-openmp-dev liblapack-dev libscalapack-mpi-dev libelpa-dev libfftw3-dev libcereal-dev \
     libxc-dev libgtest-dev libgmock-dev python3-numpy \
     bc cmake git g++ make bc time sudo unzip vim wget
 

--- a/docs/quick_start/easy_install.md
+++ b/docs/quick_start/easy_install.md
@@ -21,7 +21,7 @@ ABACUS currently supports Linux. To compile ABACUS, please make sure that the fo
 These packages can be installed with popular package management system, such as `apt` and `yum`:
 
 ```bash
-sudo apt update && sudo apt install -y libopenblas-dev liblapack-dev libscalapack-mpi-dev libelpa-dev libfftw3-dev libcereal-dev libxc-dev g++ make cmake bc git
+sudo apt update && sudo apt install -y libopenblas-openmp-dev liblapack-dev libscalapack-mpi-dev libelpa-dev libfftw3-dev libcereal-dev libxc-dev g++ make cmake bc git
 ```
 
 > Installing ELPA by apt only matches requirements on Ubuntu 22.04. For earlier linux distributions, you should install elpa from source.


### PR DESCRIPTION
apt will install pthread variant for openblas.
This may cause incompatibility when using OpenMP in ABACUS.