### PR TITLE
CI: add coverage test

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,6 +23,7 @@ jobs:
           cmake --build build --target test ARGS="-V"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        if: ${{ always() }}
         with:
           gcov: true
           verbose: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install Requirements for Coverage Testing
+        run: |
+          apt install -y lcov
       - name: Building
         run: |
           cmake -B build -DBUILD_TESTING=ON -DENABLE_COVERAGE=ON

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,9 @@ name: Coverage Analysis
 
 on:
   workflow_dispatch:
-
+  push:
+    tags:
+      - 'v*'
 jobs:
   test-coverage:
     name: Generate Coverage Report

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,26 @@
+name: Coverage Analysis
+
+on: [push, pull_request]
+
+jobs:
+  test-coverage:
+    name: Generate Coverage Report
+    runs-on: self-hosted
+    if: github.repository_owner == 'deepmodeling'
+    container: ghcr.io/deepmodeling/abacus-development-kit:gnu
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Building
+        run: |
+          cmake -B build -DBUILD_TESTING=ON -DENABLE_COVERAGE=ON
+          cmake --build build -j`nproc`
+          cmake --install build
+      - name: Testing
+        run: |
+          cmake --build build --target test ARGS="-V"
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          gcov: true
+          verbose: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,11 +1,12 @@
 name: Coverage Analysis
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
 
 jobs:
   test-coverage:
     name: Generate Coverage Report
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     container: ghcr.io/deepmodeling/abacus-development-kit:gnu
     steps:
       - name: Checkout
@@ -21,9 +22,7 @@ jobs:
       - name: Testing
         run: |
           cmake --build build --target test ARGS="-V"
-      - name: Upload coverage to Codecov
+      - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3
-        if: ${{ always() }}
         with:
           gcov: true
-          verbose: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,8 +5,7 @@ on: [push, pull_request]
 jobs:
   test-coverage:
     name: Generate Coverage Report
-    runs-on: self-hosted
-    if: github.repository_owner == 'deepmodeling'
+    runs-on: ubuntu-latest
     container: ghcr.io/deepmodeling/abacus-development-kit:gnu
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR adds a GitHub workflow of executing coverage test on dispatch and new version tag creating.
We use Codecov to host and visualize the result.
A demo on my fork can be accessed [here](https://app.codecov.io/gh/caic99/abacus-develop)(Note: not actual coverage percentage).