### PR TITLE
CI(cov): set a longer timeout

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,8 +23,9 @@ jobs:
           cmake --install build
       - name: Testing
         run: |
-          cmake --build build --target test ARGS="-V"
+          cmake --build build --target test ARGS="-V --timeout 7200"
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3
+        if: ${{ ! cancelled() }}
         with:
           gcov: true


### PR DESCRIPTION
Carrying out coverage test is much more slower since the building disabled compiler optimizations. Hence, a longer test timeout is set.