### PR TITLE
Refactor: Change the compilation position of multi-device ops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,10 +151,7 @@ if(USE_CUDA OR USE_CUSOLVER_LCAO)
   set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
   enable_language(CUDA)
   target_link_libraries(${ABACUS_BIN_NAME}
-    -lcufft
-    -lcublas
     -lcudart
-    -lcusolver
     -lnvToolsExt
   )
   set_property(TARGET ${ABACUS_BIN_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,6 +423,7 @@ target_link_libraries(${ABACUS_BIN_NAME}
     psi
     esolver
     vdw
+    device
 )
 
 if(ENABLE_LCAO)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -34,6 +34,37 @@ add_library(
     input_conv.cpp
 )
 
+list(APPEND device_srcs
+    module_hamilt/src/nonlocal.cpp
+    module_hamilt/src/veff.cpp
+    module_hamilt/src/ekinetic.cpp
+    module_pw/src/pw_multi_device.cpp
+    module_hsolver/src/dngvd_op.cpp
+    module_hsolver/src/math_kernel.cpp
+    module_elecstate/src/elecstate_multi_device.cpp
+    module_psi/src/memory_psi.cpp
+    module_psi/src/device.cpp
+)
+
+if(USE_CUDA)
+  list(APPEND device_srcs
+      module_hamilt/src/cuda/nonlocal.cu
+      module_hamilt/src/cuda/veff.cu
+      module_hamilt/src/cuda/ekinetic.cu
+      module_pw/src/cuda/pw_multi_device.cu
+      module_hsolver/src/cuda/dngvd_op.cu
+      module_hsolver/src/cuda/math_kernel.cu
+      module_elecstate/src/cuda/elecstate_multi_device.cu
+      module_psi/src/cuda/memory.cu
+  )
+endif()
+
+add_library(device OBJECT ${device_srcs})
+
+if(USE_CUDA)
+  target_link_libraries(device cusolver cublas cufft)
+endif()
+
 if(ENABLE_COVERAGE)
   add_coverage(driver)
 endif()

--- a/source/module_deepks/test/CMakeLists.txt
+++ b/source/module_deepks/test/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(
     base cell symmetry md surchem xc_
     neighbor orb io relax gint lcao parallel pdiag pw driver esolver hsolver psi elecstate hamilt planewave
     pthread vdw
-    deepks
+    deepks device
     ${ABACUS_LINK_LIBRARIES}
 )
 if(USE_ELPA)

--- a/source/module_elecstate/CMakeLists.txt
+++ b/source/module_elecstate/CMakeLists.txt
@@ -9,14 +9,7 @@ list(APPEND objects
     potentials/pot_local.cpp
     potentials/potential_new.cpp
     potentials/write_pot.cpp
-    src/elecstate_multi_device.cpp
 )
-
-if (USE_CUDA) 
-  list(APPEND objects src/cuda/elecstate_multi_device.cu)
-elseif(USE_ROCM)
-  list(APPEND objects src/rocm/elecstate_multi_device.cu)
-endif()
 
 if(ENABLE_LCAO)
   list(APPEND objects

--- a/source/module_elecstate/test/CMakeLists.txt
+++ b/source/module_elecstate/test/CMakeLists.txt
@@ -6,7 +6,7 @@ remove_definitions(-D__DEEPKS)
 if(ENABLE_LCAO)
   AddTest(
     TARGET EState_updaterhok_pw
-    LIBS ${math_libs} planewave_serial base_serial psi
+    LIBS ${math_libs} planewave_serial base_serial psi device
     SOURCES updaterhok_pw_test.cpp
             ../elecstate_pw.cpp ../elecstate.cpp
             ../../src_pw/charge.cpp ../../src_parallel/parallel_reduce.cpp
@@ -104,12 +104,7 @@ list(APPEND planewave_serial_srcs
   ../../module_pw/pw_init.cpp
   ../../module_pw/pw_transform.cpp
   ../../module_pw/pw_transform_k.cpp
-  ../../module_pw/src/pw_multi_device.cpp
 )
-
-if (USE_CUDA)
-  list(APPEND planewave_serial_srcs ../../module_pw/src/cuda/pw_multi_device.cu)
-endif()
 
 add_library(
   planewave_serial
@@ -117,26 +112,13 @@ add_library(
   ${planewave_serial_srcs}
 )
 
-if (USE_CUDA)
 AddTest(
   TARGET Elecstate_UTs
-  LIBS ${math_libs} psi base
+  LIBS ${math_libs} psi base device
   SOURCES elecstate_multi_device_test.cpp
-          ../src/elecstate_multi_device.cpp
-          ../src/cuda/elecstate_multi_device.cu
-          ../../src_parallel/parallel_reduce.cpp 
+          ../../src_parallel/parallel_reduce.cpp
           ../../src_parallel/parallel_global.cpp 
 )
-else()
-AddTest(
-  TARGET Elecstate_UTs
-  LIBS ${math_libs} psi base
-  SOURCES elecstate_multi_device_test.cpp
-          ../src/elecstate_multi_device.cpp
-          ../../src_parallel/parallel_reduce.cpp 
-          ../../src_parallel/parallel_global.cpp 
-)
-endif()
 
 if(ENABLE_COVERAGE)
   add_coverage(base_serial)

--- a/source/module_hamilt/CMakeLists.txt
+++ b/source/module_hamilt/CMakeLists.txt
@@ -4,9 +4,6 @@ add_subdirectory(ks_lcao)
 list(APPEND objects
     operator.cpp
     hamilt_pw.cpp
-    src/ekinetic.cpp
-    src/nonlocal.cpp
-    src/veff.cpp
     ks_pw/ekinetic_pw.cpp
     ks_pw/veff_pw.cpp
     ks_pw/nonlocal_pw.cpp
@@ -28,12 +25,6 @@ if(ENABLE_LCAO)
         ks_lcao/deepks_lcao.cpp
         ks_lcao/op_exx_lcao.cpp
     )
-endif()
-
-if (USE_CUDA)
-    list(APPEND objects src/cuda/ekinetic.cu src/cuda/nonlocal.cu src/cuda/veff.cu)
-elseif(USE_ROCM)
-    list(APPEND objects src/rocm/ekinetic.cu src/cuda/nonlocal.cu src/rocm/veff.cu)
 endif()
 
 add_library(

--- a/source/module_hsolver/CMakeLists.txt
+++ b/source/module_hsolver/CMakeLists.txt
@@ -4,8 +4,6 @@ list(APPEND objects
     hsolver_pw.cpp
     hsolver_pw_sdft.cpp
     diago_iter_assist.cpp
-    src/math_kernel.cpp
-    src/dngvd_op.cpp
 )
 
 if(ENABLE_LCAO)
@@ -18,15 +16,6 @@ if(ENABLE_LCAO)
         diago_elpa.cpp
     )
   endif ()
-endif()
-
-if (USE_CUDA)
-  list(APPEND objects 
-      src/cuda/math_kernel.cu
-      src/cuda/dngvd_op.cu
-  )
-elseif(USE_ROCM)
-  list(APPEND objects src/rocm/math_kernel.cu)
 endif()
 
 add_library(

--- a/source/module_hsolver/test/CMakeLists.txt
+++ b/source/module_hsolver/test/CMakeLists.txt
@@ -50,9 +50,6 @@ AddTest(
           ../../src_parallel/parallel_global.cpp
           ../../src_parallel/parallel_common.cpp  ../../src_parallel/parallel_reduce.cpp
 )
-if (USE_CUDA)
-  target_link_libraries(Dngvd_UTs cusolver cublas)
-endif()
 
 install(FILES H-KPoints-Si2.dat DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 install(FILES H-GammaOnly-Si2.dat DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/source/module_hsolver/test/CMakeLists.txt
+++ b/source/module_hsolver/test/CMakeLists.txt
@@ -43,13 +43,16 @@ AddTest(
   SOURCES math_kernel_test.cpp ../../src_parallel/parallel_global.cpp 
           ../../src_parallel/parallel_common.cpp  ../../src_parallel/parallel_reduce.cpp
 )
-AddTest(
-  TARGET Dngvd_UTs
-  LIBS ${math_libs} base device
-  SOURCES math_dngvd_test.cpp
-          ../../src_parallel/parallel_global.cpp
-          ../../src_parallel/parallel_common.cpp  ../../src_parallel/parallel_reduce.cpp
-)
+
+if(USE_CUDA)
+  AddTest(
+    TARGET Dngvd_UTs
+    LIBS ${math_libs} base device
+    SOURCES math_dngvd_test.cpp
+            ../../src_parallel/parallel_global.cpp
+            ../../src_parallel/parallel_common.cpp  ../../src_parallel/parallel_reduce.cpp
+  )
+endif()
 
 install(FILES H-KPoints-Si2.dat DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 install(FILES H-GammaOnly-Si2.dat DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/source/module_hsolver/test/CMakeLists.txt
+++ b/source/module_hsolver/test/CMakeLists.txt
@@ -2,79 +2,56 @@ remove_definitions(-D__CUDA)
 remove_definitions(-D__ROCM)
 AddTest(
   TARGET HSolver_cg
-  LIBS ${math_libs} base psi
+  LIBS ${math_libs} base psi device
   SOURCES diago_cg_test.cpp ../diago_cg.cpp  ../diago_iter_assist.cpp  
           ../../src_parallel/parallel_reduce.cpp
           ../../src_parallel/parallel_global.cpp ../../module_pw/test/test_tool.cpp
           ../../module_hamilt/operator.cpp
           ../../module_hamilt/ks_pw/operator_pw.cpp
-          ../src/math_kernel.cpp
-          ../src/dngvd_op.cpp
 )
 AddTest(
   TARGET HSolver_dav
-  LIBS ${math_libs} base psi
+  LIBS ${math_libs} base psi device
   SOURCES diago_david_test.cpp ../diago_david.cpp  ../diago_iter_assist.cpp 
           ../../src_parallel/parallel_reduce.cpp ../../src_parallel/parallel_global.cpp  ../../src_parallel/parallel_common.cpp
           ../../module_pw/test/test_tool.cpp
           ../../module_hamilt/operator.cpp
           ../../module_hamilt/ks_pw/operator_pw.cpp
-          ../src/math_kernel.cpp
-          ../src/dngvd_op.cpp
 )
 
 if(ENABLE_LCAO)
   if(USE_ELPA)
   AddTest(
     TARGET HSolver_LCAO
-    LIBS ${math_libs} ELPA::ELPA base genelpa psi
+    LIBS ${math_libs} ELPA::ELPA base genelpa psi device
     SOURCES diago_lcao_test.cpp ../diago_elpa.cpp ../diago_blas.cpp ../../src_parallel/parallel_global.cpp 
             ../../src_parallel/parallel_common.cpp ../../src_parallel/parallel_reduce.cpp
   )
   else()
     AddTest(
       TARGET HSolver_LCAO
-      LIBS ${math_libs} base psi
+      LIBS ${math_libs} base psi device
       SOURCES diago_lcao_test.cpp ../diago_blas.cpp ../../src_parallel/parallel_global.cpp
       ../../src_parallel/parallel_common.cpp ../../src_parallel/parallel_reduce.cpp
     )
   endif()
 endif()
 
-if (USE_CUDA)
 AddTest(
   TARGET Hsolver_UTs
-  LIBS ${math_libs} base cublas
+  LIBS ${math_libs} base device
   SOURCES math_kernel_test.cpp ../../src_parallel/parallel_global.cpp 
           ../../src_parallel/parallel_common.cpp  ../../src_parallel/parallel_reduce.cpp
-          ../../module_psi/src/memory_psi.cpp
-          ../../module_hsolver/src/math_kernel.cpp
-          ../../module_psi/src/cuda/memory.cu
-          ../src/cuda/math_kernel.cu
 )
 AddTest(
   TARGET Dngvd_UTs
-  LIBS ${math_libs} base cublas cusolver
-  SOURCES math_dngvd_test.cpp 
-          ../../src_parallel/parallel_global.cpp 
+  LIBS ${math_libs} base device
+  SOURCES math_dngvd_test.cpp
+          ../../src_parallel/parallel_global.cpp
           ../../src_parallel/parallel_common.cpp  ../../src_parallel/parallel_reduce.cpp
-          ../../module_psi/src/memory_psi.cpp
-          ../../module_psi/src/cuda/memory.cu
-          ../../module_hsolver/src/math_kernel.cpp
-          ../src/cuda/math_kernel.cu
-          ../../module_hsolver/src/dngvd_op.cpp
-          ../src/cuda/dngvd_op.cu
-
 )
-else()
-AddTest(
-  TARGET Hsolver_UTs
-  LIBS ${math_libs} base
-  SOURCES math_kernel_test.cpp ../../src_parallel/parallel_global.cpp 
-          ../../src_parallel/parallel_common.cpp  ../../src_parallel/parallel_reduce.cpp
-          ../../module_psi/src/memory_psi.cpp
-          ../src/math_kernel.cpp
-)
+if (USE_CUDA)
+  target_link_libraries(Dngvd_UTs cusolver cublas)
 endif()
 
 install(FILES H-KPoints-Si2.dat DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/source/module_md/test/CMakeLists.txt
+++ b/source/module_md/test/CMakeLists.txt
@@ -27,6 +27,8 @@ list(APPEND depend_files
   ../../module_base/intarray.cpp
   ../../module_base/realarray.cpp
   ../../module_base/complexarray.cpp
+  ../../module_base/complexmatrix.cpp
+  ../../module_base/global_variable.cpp
   ../../module_neighbor/sltk_adjacent_set.cpp
   ../../module_neighbor/sltk_atom_arrange.cpp
   ../../module_neighbor/sltk_atom.cpp
@@ -36,25 +38,27 @@ list(APPEND depend_files
   ../../src_io/output.cpp
   ../../src_io/print_info.cpp
   ../../module_esolver/esolver_lj.cpp
+  ../../src_parallel/parallel_reduce.cpp
+  ../../src_parallel/parallel_global.cpp
 )
 
 AddTest(
   TARGET md_LJ_pot
-  LIBS ${math_libs} psi
+  LIBS ${math_libs} psi device
   SOURCES LJ_pot_test.cpp  
   ${depend_files}
 )
 
 AddTest(
   TARGET md_func
-  LIBS ${math_libs} psi
+  LIBS ${math_libs} psi device
   SOURCES MD_func_test.cpp  
   ${depend_files}
 )
 
 AddTest(
   TARGET md_fire
-  LIBS ${math_libs} psi
+  LIBS ${math_libs} psi device
   SOURCES FIRE_test.cpp
   ../mdrun.cpp
   ../FIRE.cpp
@@ -63,7 +67,7 @@ AddTest(
 
 AddTest(
   TARGET md_verlet
-  LIBS ${math_libs} psi
+  LIBS ${math_libs} psi device
   SOURCES verlet_test.cpp
   ../mdrun.cpp
   ../verlet.cpp
@@ -72,7 +76,7 @@ AddTest(
 
 AddTest(
   TARGET md_nvt_nhc
-  LIBS ${math_libs} psi
+  LIBS ${math_libs} psi device
   SOURCES NVT_NHC_test.cpp
   ../mdrun.cpp
   ../Nose_Hoover.cpp
@@ -81,7 +85,7 @@ AddTest(
 
 AddTest(
   TARGET md_msst
-  LIBS ${math_libs} psi
+  LIBS ${math_libs} psi device
   SOURCES MSST_test.cpp
   ../mdrun.cpp
   ../MSST.cpp
@@ -90,7 +94,7 @@ AddTest(
 
 AddTest(
   TARGET md_lgv
-  LIBS ${math_libs} psi
+  LIBS ${math_libs} psi device
   SOURCES Langevin_test.cpp
   ../mdrun.cpp
   ../Langevin.cpp

--- a/source/module_psi/CMakeLists.txt
+++ b/source/module_psi/CMakeLists.txt
@@ -1,19 +1,7 @@
-list(APPEND psi_srcs
-    psi.cpp
-    src/device.cpp
-    src/memory_psi.cpp
-)
-
-if (USE_CUDA) 
-    list(APPEND psi_srcs src/cuda/memory.cu)
-elseif(USE_ROCM)
-    list(APPEND psi_srcs src/rocm/memory.hip)
-endif()
-
 add_library(
     psi
     OBJECT
-    ${psi_srcs}
+    psi.cpp
 )
 
 if(ENABLE_COVERAGE)

--- a/source/module_pw/CMakeLists.txt
+++ b/source/module_pw/CMakeLists.txt
@@ -9,14 +9,7 @@ list(APPEND objects
     pw_init.cpp
     pw_transform.cpp
     pw_transform_k.cpp
-    src/pw_multi_device.cpp
 )
-
-if (USE_CUDA)
-  list(APPEND objects src/cuda/pw_multi_device.cu)
-elseif(USE_ROCM)
-  list(APPEND objects src/rocm/pw_multi_device.cu)
-endif()
 
 add_library(
     planewave

--- a/source/module_pw/test/CMakeLists.txt
+++ b/source/module_pw/test/CMakeLists.txt
@@ -1,10 +1,11 @@
 add_definitions(-D__NORMAL)
 AddTest(
   TARGET pw_test
-  LIBS ${math_libs} planewave psi
-  SOURCES ../../module_base/matrix.cpp ../../module_base/matrix3.cpp ../../module_base/tool_quit.cpp 
+  LIBS ${math_libs} planewave psi device
+  SOURCES ../../module_base/matrix.cpp ../../module_base/complexmatrix.cpp ../../module_base/matrix3.cpp ../../module_base/tool_quit.cpp
           ../../module_base/mymath3.cpp ../../module_base/timer.cpp ../../module_base/global_variable.cpp 
           ../../src_parallel/parallel_global.cpp
+          ../../src_parallel/parallel_global.cpp ../../src_parallel/parallel_reduce.cpp
           pw_test.cpp test1-1-1.cpp test1-1-2.cpp test1-2.cpp test1-3.cpp test1-4.cpp  test1-5.cpp
           test2-1-1.cpp test2-1-2.cpp test2-2.cpp test2-3.cpp 
           test3-1.cpp test3-2.cpp test3-3.cpp 
@@ -16,27 +17,15 @@ AddTest(
           test_tool.cpp
 )
 
-if (USE_CUDA)
-target_link_libraries(pw_test cufft)
 AddTest(
     TARGET PW_UTs
-    LIBS ${math_libs} psi
+    LIBS ${math_libs} psi device
     SOURCES
     ../../module_base/tool_quit.cpp ../../module_base/global_variable.cpp
-    ../src/pw_multi_device.cpp
-    ../src/cuda/pw_multi_device.cu
+    ../../src_parallel/parallel_global.cpp ../../src_parallel/parallel_reduce.cpp
+    ../../module_base/complexmatrix.cpp ../../module_base/matrix.cpp
     pw_multi_device_test.cpp
 )
-else()
-AddTest(
-    TARGET PW_UTs
-    LIBS ${math_libs} psi
-    SOURCES
-    ../../module_base/tool_quit.cpp ../../module_base/global_variable.cpp
-    ../src/pw_multi_device.cpp
-    pw_multi_device_test.cpp
-)
-endif()
 
 add_test(NAME pw_test_parallel
       COMMAND mpirun -np 2 ./pw_test; mpirun -np 3./pw_test


### PR DESCRIPTION
There are two reasons to change the compilation position of those multi-device code from each modules gather to the `souce/CMakeLists.txt`:

- This helps to reduce the compilation logic(eg. `if USE_CUDA or USE_ROCM...`) for modules and the related test units. The only thing developers need to do is adding the new device library.

- Another one is that the current compilation of multi-device ops depends on the separate compilation of `cmake-cuda`, which is not supported for some platforms, such as `DCU` and many other devices with different programming languages. Therefore, compiling them together is helpful for the following development.

