### PR TITLE
Fix: Remove unnecessary device memory operations

### DIFF
--- a/source/module_pw/fft.cpp
+++ b/source/module_pw/fft.cpp
@@ -1,5 +1,7 @@
 #include "fft.h"
 
+#include "module_base/global_variable.h"
+
 #ifdef _OPENMP
 #include <omp.h>
 #endif
@@ -33,8 +35,16 @@ void FFT::clear()
 	if(auxr!=nullptr) {fftw_free(auxr); auxr = nullptr;}
 	r_rspace = nullptr;
 #if defined(__CUDA) || defined(__UT_USE_CUDA)
-    if(auxg_3d!=nullptr) {cudaFree(auxg_3d); auxg_3d = nullptr;}
-    if(auxr_3d!=nullptr) {cudaFree(auxr_3d); auxr_3d = nullptr;}
+    if (GlobalV::device_flag == "gpu") {
+        if (auxg_3d != nullptr) {
+            cudaFree(auxg_3d);
+            auxg_3d = nullptr;
+        }
+        if (auxr_3d != nullptr) {
+            cudaFree(auxr_3d);
+            auxr_3d = nullptr;
+        }
+    }
 #endif
 #ifdef __MIX_PRECISION
 	this->cleanfFFT();
@@ -78,10 +88,12 @@ void FFT:: initfft(int nx_in, int ny_in, int nz_in, int lixy_in, int rixy_in, in
         // auxr_3d = static_cast<std::complex<double> *>(
         //     fftw_malloc(sizeof(fftw_complex) * (this->nx * this->ny * this->nz)));
         #if defined(__CUDA) || defined(__UT_USE_CUDA)
-        cudaMalloc(reinterpret_cast<void**>(&auxg_3d),
-                   this->nx * this->ny * this->nz * sizeof(std::complex<double>));
-        cudaMalloc(reinterpret_cast<void**>(&auxr_3d),
-                   this->nx * this->ny * this->nz * sizeof(std::complex<double>));
+        if (GlobalV::device_flag == "gpu") {
+            cudaMalloc(reinterpret_cast<void **>(&auxg_3d),
+                       this->nx * this->ny * this->nz * sizeof(std::complex<double>));
+            cudaMalloc(reinterpret_cast<void **>(&auxr_3d),
+                       this->nx * this->ny * this->nz * sizeof(std::complex<double>));
+        }
         #endif
 #ifdef __MIX_PRECISION
 		auxfg  = (std::complex<float> *) fftw_malloc(sizeof(fftwf_complex) * maxgrids);
@@ -207,7 +219,9 @@ void FFT :: initplan()
     //    FFTW_BACKWARD, FFTW_MEASURE);
 
     #if defined(__CUDA) || defined(__UT_USE_CUDA)
-    cufftPlan3d(&fft_handle, this->nx, this->ny, this->nz, CUFFT_Z2Z);
+    if (GlobalV::device_flag == "gpu") {
+        cufftPlan3d(&fft_handle, this->nx, this->ny, this->nz, CUFFT_Z2Z);
+    }
     #endif
 
 	destroyp = false;

--- a/source/module_pw/fft.cpp
+++ b/source/module_pw/fft.cpp
@@ -354,7 +354,9 @@ void FFT:: cleanFFT()
     // fftw_destroy_plan(this->plan3dforward);
     // fftw_destroy_plan(this->plan3dbackward);
     #if defined(__CUDA) || defined(__UT_USE_CUDA)
-    cufftDestroy(fft_handle);
+    if (GlobalV::device_flag == "gpu") {
+        cufftDestroy(fft_handle);
+    }
     #endif
 	destroyp = true;
 	return;

--- a/source/module_pw/pw_basis_k.cpp
+++ b/source/module_pw/pw_basis_k.cpp
@@ -1,6 +1,7 @@
 #include "pw_basis_k.h"
 #include "../module_base/constants.h"
 #include "../module_base/timer.h"
+
 namespace ModulePW
 {
 
@@ -18,7 +19,9 @@ PW_Basis_K::~PW_Basis_K()
     delete[] gk2;
     delete[] ig2ixyz_k_;
 #if defined(__CUDA) || defined(__UT_USE_CUDA)
-    cudaFree(this->ig2ixyz_k);
+    if (GlobalV::device_flag == "gpu") {
+        cudaFree(this->ig2ixyz_k);
+    }
 #endif
 }
 

--- a/source/src_pw/VNL_in_pw.cpp
+++ b/source/src_pw/VNL_in_pw.cpp
@@ -18,8 +18,10 @@ pseudopot_cell_vnl::pseudopot_cell_vnl()
 pseudopot_cell_vnl::~pseudopot_cell_vnl()
 {
 #ifdef __CUDA
-	cudaFree(this->d_deeq);
-	cudaFree(this->d_deeq_nc);
+    if (GlobalV::device_flag == "gpu") {
+        cudaFree(this->d_deeq);
+        cudaFree(this->d_deeq_nc);
+    }
 #endif
 }
 
@@ -80,9 +82,12 @@ void pseudopot_cell_vnl::init(const int ntype, const bool allocate_vkb)
 		this->nhtoj.create(ntype, this->nhm);
 		this->deeq.create(GlobalV::NSPIN, GlobalC::ucell.nat, this->nhm, this->nhm);
 #ifdef __CUDA
-		cudaMalloc((void**)&d_deeq, GlobalV::NSPIN*GlobalC::ucell.nat*this->nhm*this->nhm*sizeof(double));
-		cudaMalloc((void**)&d_deeq_nc, GlobalV::NSPIN*GlobalC::ucell.nat*this->nhm*this->nhm*sizeof(std::complex<double>));
-#endif		
+        if (GlobalV::device_flag == "gpu") {
+            cudaMalloc((void **) &d_deeq, GlobalV::NSPIN * GlobalC::ucell.nat * this->nhm * this->nhm * sizeof(double));
+            cudaMalloc((void **) &d_deeq_nc,
+                       GlobalV::NSPIN * GlobalC::ucell.nat * this->nhm * this->nhm * sizeof(std::complex<double>));
+        }
+#endif
 		this->deeq_nc.create(GlobalV::NSPIN, GlobalC::ucell.nat, this->nhm, this->nhm);
 		this->dvan.create(ntype, this->nhm, this->nhm);
 		this->dvan_so.create(GlobalV::NSPIN, ntype, this->nhm, this->nhm);
@@ -724,14 +729,16 @@ void pseudopot_cell_vnl::cal_effective_D(void)
         }
     }
 #ifdef __CUDA
-    cudaMemcpy(this->d_deeq,
-               this->deeq.ptr,
-               GlobalV::NSPIN * GlobalC::ucell.nat * this->nhm * this->nhm * sizeof(double),
-               cudaMemcpyHostToDevice);
-	cudaMemcpy(this->d_deeq_nc,
-           this->deeq_nc.ptr,
-           GlobalV::NSPIN * GlobalC::ucell.nat * this->nhm * this->nhm * sizeof(std::complex<double>),
-           cudaMemcpyHostToDevice);
+    if (GlobalV::device_flag == "gpu") {
+        cudaMemcpy(this->d_deeq,
+                   this->deeq.ptr,
+                   GlobalV::NSPIN * GlobalC::ucell.nat * this->nhm * this->nhm * sizeof(double),
+                   cudaMemcpyHostToDevice);
+        cudaMemcpy(this->d_deeq_nc,
+                   this->deeq_nc.ptr,
+                   GlobalV::NSPIN * GlobalC::ucell.nat * this->nhm * this->nhm * sizeof(std::complex<double>),
+                   cudaMemcpyHostToDevice);
+    }
 #endif
     return;
 } 

--- a/source/src_pw/wavefunc.cpp
+++ b/source/src_pw/wavefunc.cpp
@@ -381,7 +381,9 @@ void wavefunc::wfcinit_k(psi::Psi<std::complex<double>>* psi_in)
 		this->irindex = new int [GlobalC::wfcpw->fftnxy];
 		GlobalC::wfcpw->getfftixy2is(this->irindex);
     #if defined(__CUDA) || defined(__UT_USE_CUDA)
-    GlobalC::wfcpw->get_ig2ixyz_k();
+    if (GlobalV::device_flag == "gpu") {
+        GlobalC::wfcpw->get_ig2ixyz_k();
+    }
     #endif
 	}
 	if(GlobalV::CALCULATION=="nscf")


### PR DESCRIPTION
When GlobalV::device_flag is not "gpu", no device memory operations need to be performed.