### PR TITLE
Fix: symmetry = -1 will lead to unnecessary symmetry operations

### DIFF
--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -58,7 +58,7 @@ namespace ModuleESolver
         ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running, "SETUP UNITCELL");
 
         // symmetry analysis should be performed every time the cell is changed
-        if (ModuleSymmetry::Symmetry::symm_flag)
+        if (ModuleSymmetry::Symmetry::symm_flag == 1)
         {
             GlobalC::symm.analy_sys(ucell, GlobalV::ofs_running);
             ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running, "SYMMETRY");

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -51,7 +51,7 @@ void ESolver_KS_LCAO::Init(Input& inp, UnitCell& ucell)
 
     if (GlobalV::CALCULATION == "get_S")
     {
-        if (ModuleSymmetry::Symmetry::symm_flag)
+        if (ModuleSymmetry::Symmetry::symm_flag == 1)
         {
             GlobalC::symm.analy_sys(ucell, GlobalV::ofs_running);
             ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running, "SYMMETRY");

--- a/source/module_esolver/esolver_of.cpp
+++ b/source/module_esolver/esolver_of.cpp
@@ -52,7 +52,7 @@ void ESolver_OF::Init(Input &inp, UnitCell &ucell)
     ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running, "SETUP UNITCELL");
 
     // symmetry analysis should be performed every time the cell is changed
-    if (ModuleSymmetry::Symmetry::symm_flag)
+    if (ModuleSymmetry::Symmetry::symm_flag == 1)
     {
         GlobalC::symm.analy_sys(ucell, GlobalV::ofs_running);
         ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running, "SYMMETRY");

--- a/source/module_hsolver/hsolver_pw_sdft.cpp
+++ b/source/module_hsolver/hsolver_pw_sdft.cpp
@@ -119,7 +119,7 @@ namespace hsolver
 		else
 		{
 #ifdef __MPI
-			if(ModuleSymmetry::Symmetry::symm_flag)	MPI_Barrier(MPI_COMM_WORLD);
+			if(ModuleSymmetry::Symmetry::symm_flag == 1)	MPI_Barrier(MPI_COMM_WORLD);
 #endif
 		}
 

--- a/source/module_relax/relax_new/relax.cpp
+++ b/source/module_relax/relax_new/relax.cpp
@@ -620,7 +620,7 @@ void Relax::init_after_vc()
     GlobalC::ucell.setup_cell_after_vc(GlobalV::ofs_running);
     ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running, "SETUP UNITCELL");
 
-    if(ModuleSymmetry::Symmetry::symm_flag)
+    if(ModuleSymmetry::Symmetry::symm_flag == 1)
     {
         GlobalC::symm.analy_sys(GlobalC::ucell, GlobalV::ofs_running);
         ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running, "SYMMETRY");

--- a/source/module_relax/relax_old/variable_cell.cpp
+++ b/source/module_relax/relax_old/variable_cell.cpp
@@ -12,7 +12,7 @@ void Variable_Cell::init_after_vc()
     GlobalC::ucell.setup_cell_after_vc(GlobalV::ofs_running);
     ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running, "SETUP UNITCELL");
 
-    if(ModuleSymmetry::Symmetry::symm_flag)
+    if(ModuleSymmetry::Symmetry::symm_flag == 1)
     {
         GlobalC::symm.analy_sys(GlobalC::ucell, GlobalV::ofs_running);
         ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running, "SYMMETRY");

--- a/source/src_lcao/FORCE_STRESS.cpp
+++ b/source/src_lcao/FORCE_STRESS.cpp
@@ -335,7 +335,7 @@ void Force_Stress_LCAO::getForceStress(
         }
 
 		// pengfei 2016-12-20
-		if(ModuleSymmetry::Symmetry::symm_flag)
+		if(ModuleSymmetry::Symmetry::symm_flag == 1)
 		{
 			this->forceSymmetry(fcs);
 		}
@@ -550,7 +550,7 @@ void Force_Stress_LCAO::getForceStress(
 #endif
 
 
-		if(ModuleSymmetry::Symmetry::symm_flag)
+		if(ModuleSymmetry::Symmetry::symm_flag == 1)
 		{
 			GlobalC::symm.stress_symmetry(scs, GlobalC::ucell);
 		}//end symmetry

--- a/source/src_pw/forces.cpp
+++ b/source/src_pw/forces.cpp
@@ -148,7 +148,7 @@ void Forces<FPTYPE, Device>::init(ModuleBase::matrix& force, const ModuleBase::m
         GlobalV::ofs_running << "Atomic forces are not shifted if gate_flag or efield_flag == true!" << std::endl;
     }
 
-    if (ModuleSymmetry::Symmetry::symm_flag)
+    if (ModuleSymmetry::Symmetry::symm_flag == 1)
     {
         double* pos;
         double d1, d2, d3;

--- a/source/src_pw/of_stress_pw.cpp
+++ b/source/src_pw/of_stress_pw.cpp
@@ -94,7 +94,7 @@ void OF_Stress_PW::cal_stress(ModuleBase::matrix& sigmatot, ModuleBase::matrix& 
         }
     }
     
-	if(ModuleSymmetry::Symmetry::symm_flag)                          
+	if(ModuleSymmetry::Symmetry::symm_flag == 1)                          
 	{
 		GlobalC::symm.stress_symmetry(sigmatot, GlobalC::ucell);
 	}

--- a/source/src_pw/sto_forces.cpp
+++ b/source/src_pw/sto_forces.cpp
@@ -95,7 +95,7 @@ void Sto_Forces::init(ModuleBase::matrix& force, const ModuleBase::matrix& wg, c
         GlobalV::ofs_running << "Atomic forces are not shifted if gate_flag or efield_flag == true!" << std::endl;
     }
 	
-	if(ModuleSymmetry::Symmetry::symm_flag)
+	if(ModuleSymmetry::Symmetry::symm_flag == 1)
 	{
 		double *pos;
 		double d1,d2,d3;

--- a/source/src_pw/sto_stress_pw.cpp
+++ b/source/src_pw/sto_stress_pw.cpp
@@ -56,7 +56,7 @@ void Sto_Stress_PW::cal_stress(ModuleBase::matrix& sigmatot, const ModuleBase::m
         }
     }
     
-	if(ModuleSymmetry::Symmetry::symm_flag)                          
+	if(ModuleSymmetry::Symmetry::symm_flag == 1)                          
 	{
 		GlobalC::symm.stress_symmetry(sigmatot,GlobalC::ucell);
 	}
@@ -174,7 +174,7 @@ void Sto_Stress_PW::sto_stress_kin(ModuleBase::matrix& sigma, const ModuleBase::
 		}
 	}
 	//do symmetry
-	if(ModuleSymmetry::Symmetry::symm_flag)                          
+	if(ModuleSymmetry::Symmetry::symm_flag == 1)                          
 	{
 		GlobalC::symm.stress_symmetry(sigma,GlobalC::ucell);
 	}
@@ -392,7 +392,7 @@ void Sto_Stress_PW::sto_stress_nl(ModuleBase::matrix& sigma, const ModuleBase::m
 		}
 	}
 	//do symmetry
-	if(ModuleSymmetry::Symmetry::symm_flag)                          
+	if(ModuleSymmetry::Symmetry::symm_flag == 1)                          
 	{
 		GlobalC::symm.stress_symmetry(sigma,GlobalC::ucell);
 	}

--- a/source/src_pw/stress_func_kin.cpp
+++ b/source/src_pw/stress_func_kin.cpp
@@ -125,7 +125,7 @@ void Stress_Func::stress_kin(ModuleBase::matrix& sigma, const ModuleBase::matrix
 		}
 	}
 	//do symmetry
-	if(ModuleSymmetry::Symmetry::symm_flag)
+	if(ModuleSymmetry::Symmetry::symm_flag == 1)
 	{
 		GlobalC::symm.stress_symmetry(sigma, GlobalC::ucell);
 	}//end symmetry

--- a/source/src_pw/stress_func_nl.cpp
+++ b/source/src_pw/stress_func_nl.cpp
@@ -248,7 +248,7 @@ void Stress_Func::stress_nl(ModuleBase::matrix& sigma, const ModuleBase::matrix&
 		}
 	}
 	//do symmetry
-	if(ModuleSymmetry::Symmetry::symm_flag)
+	if(ModuleSymmetry::Symmetry::symm_flag == 1)
 	{
 		GlobalC::symm.stress_symmetry(sigma, GlobalC::ucell);
 	}//end symmetry

--- a/source/src_pw/stress_pw.cpp
+++ b/source/src_pw/stress_pw.cpp
@@ -95,7 +95,7 @@ void Stress_PW::cal_stress(ModuleBase::matrix& sigmatot, const psi::Psi<complex<
         }
     }
     
-	if(ModuleSymmetry::Symmetry::symm_flag)                          
+	if(ModuleSymmetry::Symmetry::symm_flag == 1)                          
 	{
 		GlobalC::symm.stress_symmetry(sigmatot, GlobalC::ucell);
 	}


### PR DESCRIPTION
There will be wrong results for test cases in #1633 , caused by one k-point only but not gamma point, symmetry=-1 will lead to wrong force and stress.