### PR TITLE
Feature: Add multi-device support for function module_base::ylm_real

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -46,6 +46,7 @@ list(APPEND device_srcs
     module_psi/src/device.cpp
     src_pw/src/force_multi_device.cpp
     src_pw/src/stress_multi_device.cpp
+    module_base/src/math_multi_device.cpp
 )
 
 if(USE_CUDA)
@@ -60,6 +61,7 @@ if(USE_CUDA)
       module_psi/src/cuda/memory.cu
       src_pw/src/cuda/force_multi_device.cu
       src_pw/src/cuda/stress_multi_device.cu
+      module_base/src/cuda/math_multi_device.cu
   )
 endif()
 

--- a/source/module_base/include/math_multi_device.h
+++ b/source/module_base/include/math_multi_device.h
@@ -1,0 +1,44 @@
+#ifndef MODULE_BASE_MATH_MULTI_DEVICE_H
+#define MODULE_BASE_MATH_MULTI_DEVICE_H
+
+#include "module_psi/psi.h"
+#include <complex>
+
+namespace ModuleBase {
+
+template <typename FPTYPE, typename Device>
+struct cal_ylm_real_op {
+    void operator() (
+        const Device *ctx,
+        const int &ng,
+        const int &lmax,
+        const FPTYPE &SQRT2,
+        const FPTYPE &PI,
+        const FPTYPE &PI_HALF,
+        const FPTYPE &FOUR_PI,
+        const FPTYPE &SQRT_INVERSE_FOUR_PI,
+        const FPTYPE *g,
+        FPTYPE * p,
+        FPTYPE * ylm);
+};
+
+#if __CUDA || __UT_USE_CUDA || __ROCM || __UT_USE_ROCM
+template <typename FPTYPE>
+struct cal_ylm_real_op<FPTYPE, psi::DEVICE_GPU> {
+    void operator() (
+        const psi::DEVICE_GPU *ctx,
+        const int &ng,
+        const int &lmax,
+        const FPTYPE &SQRT2,
+        const FPTYPE &PI,
+        const FPTYPE &PI_HALF,
+        const FPTYPE &FOUR_PI,
+        const FPTYPE &SQRT_INVERSE_FOUR_PI,
+        const FPTYPE *g,
+        FPTYPE * p,
+        FPTYPE * ylm);
+};
+
+#endif // __CUDA || __UT_USE_CUDA || __ROCM || __UT_USE_ROCM
+}  // namespace src_pw
+#endif //MODULE_BASE_MATH_MULTI_DEVICE_H

--- a/source/module_base/math_ylmreal.h
+++ b/source/module_base/math_ylmreal.h
@@ -3,6 +3,7 @@
 
 #include "vector3.h"
 #include "matrix.h"
+#include "module_psi/psi.h"
 
 namespace ModuleBase
 {
@@ -29,6 +30,17 @@ class YlmReal
         const ModuleBase::Vector3<double> *g, 
         matrix &ylm 	
     );
+
+    /**
+	 * @brief spherical harmonic function (real form) an array
+	 *
+	 * @param lmax2 [in] lmax2 = (lmax + 1)^2 ; lmax = angular quantum number
+	 * @param ng [in] the number of vectors
+	 * @param g [in] an array of vectors
+	 * @param ylm [out] Ylm; column index represent vector, row index represent Y00, Y10, Y11, Y1-1, Y20,Y21,Y2-1,Y22.Y2-2,...;
+	 */
+	template <typename FPTYPE, typename Device>
+    static void Ylm_Real(Device * ctx, const int lmax2, const int ng, const FPTYPE *g, FPTYPE * ylm);
 
 	/**
 	 * @brief gradient of spherical harmonic function (real form) an array of vectors

--- a/source/module_base/src/cuda/math_multi_device.cu
+++ b/source/module_base/src/cuda/math_multi_device.cu
@@ -1,0 +1,154 @@
+#include "cuda_runtime.h"
+#include "module_base/include/math_multi_device.h"
+
+namespace ModuleBase {
+
+#define THREADS_PER_BLOCK 256
+
+template <typename FPTYPE>
+__device__ __inline__
+FPTYPE __fact(const int n) {
+    FPTYPE f = 1.0;
+    for (int i = n; i > 1; i--) {
+        f *= i;
+    }
+    return f;
+}
+
+__device__ __inline__
+int __semi_fact(const int n)
+{
+    int semif = 1;
+    for (int i = n; i > 2; i -= 2)
+    {
+        semif *= i;
+    }
+    return semif;
+}
+
+template <typename FPTYPE>
+__global__ void cal_ylm_real(
+    const int ng,
+    const int lmax,
+    const FPTYPE SQRT2,
+    const FPTYPE PI,
+    const FPTYPE PI_HALF,
+    const FPTYPE FOUR_PI,
+    const FPTYPE SQRT_INVERSE_FOUR_PI,
+    const FPTYPE *g,
+    FPTYPE * p,
+    FPTYPE * ylm)
+{
+    int ig = blockIdx.x * blockDim.x + threadIdx.x;
+    if (ig >= ng) {return;}
+
+    FPTYPE cost = 0.0, phi = 0.0;
+    //----------------------------------------------------------
+    // EXPLAIN : if lmax = 1,only use Y00 , output result.
+    //----------------------------------------------------------
+    if (lmax == 0) {
+        ylm[0 * ng + ig] = SQRT_INVERSE_FOUR_PI;
+        return;
+    }
+    //----------------------------------------------------------
+    // LOCAL VARIABLES :
+    // NAME : cost = cos(theta),theta and phi are polar angles
+    // NAME : phi
+    //----------------------------------------------------------
+    const FPTYPE gmod = sqrt(g[ig * 3 + 0] * g[ig * 3 + 0] + g[ig * 3 + 1] * g[ig * 3 + 1] + g[ig * 3 + 2] * g[ig * 3 + 2]);
+    cost = gmod < 1.0e-9 ? 0.0 : g[ig * 3 + 2] / gmod;
+    //  beware the arc tan, it is defined modulo pi
+    if (g[ig * 3 + 0] > 1.0e-9) {
+        phi = atan(g[ig * 3 + 1] / g[ig * 3 + 0]);
+    }
+    else if (g[ig * 3 + 0] < -1.e-9) {
+        phi = atan(g[ig * 3 + 1] / g[ig * 3 + 0]) + PI;
+    }
+    else {
+        phi = PI_HALF * ((g[ig * 3 + 1] >= 0.0) ? 1.0 : -1.0); //HLX: modified on 10/13/2006
+    } // end if
+    //==========================================================
+    // NAME : p(Legendre Polynomials) (0 <= m <= l)
+    //==========================================================
+    int lm = -1;
+    for (int l = 0; l <= lmax; l++) {
+        const FPTYPE c = sqrt((2 * l + 1) / FOUR_PI);
+        if (l == 0) {
+            p[0 * (lmax + 1) * ng + 0 * ng + ig] = 1.0;
+        }
+        else if (l == 1) {
+            p[0 * (lmax + 1) * ng + 1 * ng + ig] = cost;
+            FPTYPE var = (1.0 - cost * cost) > 0.0 ? (1.0 - cost * cost) : 0.0;
+            p[1 * (lmax + 1) * ng + 1 * ng + ig] = -sqrt(var);
+        }
+        else {
+            const int l1 = l - 1,
+                    l2 = l - 2,
+                    l3 = 2 * l - 1;
+            //  recursion on l for P(:,l,m)
+            for (int m = 0; m <= l2; m++) {  // do m = 0, l - 2//mohan modify 2007-10-13
+                p[m * (lmax + 1) * ng + l * ng + ig] =
+                        (cost * l3 * p[m * (lmax + 1) * ng + l1 * ng + ig] -
+                         (l1 + m) * p[m * (lmax + 1) * ng + l2 * ng + ig]) / (l - m);
+            } // end do
+            p[l1 * (lmax + 1) * ng + l * ng + ig] =
+                    cost * l3 * p[l1 * (lmax + 1) * ng + l1 * ng + ig];
+            FPTYPE x2 = (1.0 - cost * cost) > 0.0 ? (1.0 - cost * cost) : 0.0;
+            p[l * (lmax + 1) * ng + l * ng + ig] = __semi_fact(l3) * pow(x2, static_cast<double>(l) / 2.0);//mohan modify 2007-10-13
+            if (l % 2 == 1) {
+                p[l * (lmax + 1) * ng + l * ng + ig] *= -1;
+            }
+        } // end if
+
+        // Y_lm, m = 0
+        ++lm;
+        ylm[lm * ng + ig] = c * p[0 * (lmax + 1) * ng + l * ng + ig];
+
+        for (int m = 1; m <= l; m++) {
+            // Y_lm, m > 0
+            const FPTYPE same =
+                    c * sqrt(__fact<double>(l - m) /
+                             __fact<double>(l + m)) * SQRT2;
+
+            ++lm;
+            ylm[lm * ng + ig] = same * p[m * (lmax + 1) * ng + l * ng + ig] * cos(m * phi);
+
+            // Y_lm, m < 0
+            ++lm;
+            ylm[lm * ng + ig] = same * p[m * (lmax + 1) * ng + l * ng + ig] * sin(m * phi);
+        }
+    }// end do
+}
+
+template <typename FPTYPE>
+void cal_ylm_real_op<FPTYPE, psi::DEVICE_GPU>::operator() (
+    const psi::DEVICE_GPU *ctx,
+    const int &ng,
+    const int &lmax,
+    const FPTYPE &SQRT2,
+    const FPTYPE &PI,
+    const FPTYPE &PI_HALF,
+    const FPTYPE &FOUR_PI,
+    const FPTYPE &SQRT_INVERSE_FOUR_PI,
+    const FPTYPE *g,
+    FPTYPE * p,
+    FPTYPE * ylm)
+{
+    int block = (ng + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
+    cal_ylm_real<FPTYPE><<<block, THREADS_PER_BLOCK>>>(
+        ng,
+        lmax,
+        SQRT2,
+        PI,
+        PI_HALF,
+        FOUR_PI,
+        SQRT_INVERSE_FOUR_PI,
+        g,
+        p,
+        ylm);
+}
+
+template struct cal_ylm_real_op<double, psi::DEVICE_GPU>;
+
+}  // namespace src_pw
+

--- a/source/module_base/src/math_multi_device.cpp
+++ b/source/module_base/src/math_multi_device.cpp
@@ -1,0 +1,123 @@
+#include "module_base/include/math_multi_device.h"
+#include <iostream>
+
+namespace ModuleBase{
+
+template <typename FPTYPE>
+FPTYPE __fact(const int n) {
+    FPTYPE f = 1.0;
+    for (int i = n; i > 1; i--) {
+        f *= i;
+    }
+    return f;
+}
+
+int __semi_fact(const int n)
+{
+    int semif = 1;
+    for (int i = n; i > 2; i -= 2)
+    {
+        semif *= i;
+    }
+    return semif;
+}
+
+template <typename FPTYPE>
+struct cal_ylm_real_op<FPTYPE, psi::DEVICE_CPU> {
+    void operator()(
+            const psi::DEVICE_CPU *ctx,
+            const int &ng,
+            const int &lmax,
+            const FPTYPE &SQRT2,
+            const FPTYPE &PI,
+            const FPTYPE &PI_HALF,
+            const FPTYPE &FOUR_PI,
+            const FPTYPE &SQRT_INVERSE_FOUR_PI,
+            const FPTYPE *g,
+            FPTYPE * p,
+            FPTYPE * ylm)
+    {
+        FPTYPE cost = 0.0, phi = 0.0;
+        for (int ig = 0; ig < ng; ig++) {
+            //----------------------------------------------------------
+            // EXPLAIN : if lmax = 1,only use Y00 , output result.
+            //----------------------------------------------------------
+            if (lmax == 0) {
+                ylm[0 * ng + ig] = SQRT_INVERSE_FOUR_PI;
+                continue;
+            }
+            //----------------------------------------------------------
+            // LOCAL VARIABLES :
+            // NAME : cost = cos(theta),theta and phi are polar angles
+            // NAME : phi
+            //----------------------------------------------------------
+            const FPTYPE gmod = sqrt(g[ig * 3 + 0] * g[ig * 3 + 0] + g[ig * 3 + 1] * g[ig * 3 + 1] + g[ig * 3 + 2] * g[ig * 3 + 2]);
+            cost = gmod < 1.0e-9 ? 0.0 : g[ig * 3 + 2] / gmod;
+            //  beware the arc tan, it is defined modulo pi
+            if (g[ig * 3 + 0] > 1.0e-9) {
+                phi = atan(g[ig * 3 + 1] / g[ig * 3 + 0]);
+            }
+            else if (g[ig * 3 + 0] < -1.e-9) {
+                phi = atan(g[ig * 3 + 1] / g[ig * 3 + 0]) + PI;
+            }
+            else {
+                phi = PI_HALF * ((g[ig * 3 + 1] >= 0.0) ? 1.0 : -1.0); //HLX: modified on 10/13/2006
+            } // end if
+            //==========================================================
+            // NAME : p(Legendre Polynomials) (0 <= m <= l)
+            //==========================================================
+            int lm = -1;
+            for (int l = 0; l <= lmax; l++) {
+                const FPTYPE c = sqrt((2 * l + 1) / FOUR_PI);
+                if (l == 0) {
+                    p[0 * (lmax + 1) * ng + 0 * ng + ig] = 1.0;
+                }
+                else if (l == 1) {
+                    p[0 * (lmax + 1) * ng + 1 * ng + ig] = cost;
+                    p[1 * (lmax + 1) * ng + 1 * ng + ig] = -sqrt(std::max(0.0, 1.0 - cost * cost));
+                }
+                else {
+                    const int l1 = l - 1,
+                            l2 = l - 2,
+                            l3 = 2 * l - 1;
+                    //  recursion on l for P(:,l,m)
+                    for (int m = 0; m <= l2; m++) {  // do m = 0, l - 2//mohan modify 2007-10-13
+                        p[m * (lmax + 1) * ng + l * ng + ig] =
+                                (cost * l3 * p[m * (lmax + 1) * ng + l1 * ng + ig] -
+                                 (l1 + m) * p[m * (lmax + 1) * ng + l2 * ng + ig]) / (l - m);
+                    } // end do
+                    p[l1 * (lmax + 1) * ng + l * ng + ig] =
+                            cost * l3 * p[l1 * (lmax + 1) * ng + l1 * ng + ig];
+                    FPTYPE x2 = std::max(0.0, 1.0 - cost * cost);
+                    p[l * (lmax + 1) * ng + l * ng + ig] = __semi_fact(l3) * pow(x2, static_cast<double>(l) / 2.0);//mohan modify 2007-10-13
+                    if (l % 2 == 1) {
+                        p[l * (lmax + 1) * ng + l * ng + ig] *= -1;
+                    }
+                } // end if
+
+                // Y_lm, m = 0
+                ++lm;
+                ylm[lm * ng + ig] = c * p[0 * (lmax + 1) * ng + l * ng + ig];
+
+                for (int m = 1; m <= l; m++) {
+                    // Y_lm, m > 0
+                    const FPTYPE same =
+                            c * sqrt(__fact<double>(l - m) /
+                                     __fact<double>(l + m)) * SQRT2;
+
+                    ++lm;
+                    ylm[lm * ng + ig] = same * p[m * (lmax + 1) * ng + l * ng + ig] * cos(m * phi);
+
+                    // Y_lm, m < 0
+                    ++lm;
+                    ylm[lm * ng + ig] = same * p[m * (lmax + 1) * ng + l * ng + ig] * sin(m * phi);
+                }
+           }// end do
+        }
+    }
+};
+
+template struct cal_ylm_real_op<double, psi::DEVICE_CPU>;
+
+}  // namespace src_pw
+

--- a/source/module_base/test/CMakeLists.txt
+++ b/source/module_base/test/CMakeLists.txt
@@ -65,8 +65,15 @@ AddTest(
 )
 AddTest(
   TARGET base_ylmreal
-  LIBS ${math_libs}
-  SOURCES math_ylmreal_test.cpp ../math_ylmreal.cpp ../ylm.cpp ../realarray.cpp ../timer.cpp ../matrix.cpp ../vector3.h
+  LIBS ${math_libs} device
+  SOURCES math_ylmreal_test.cpp ../math_ylmreal.cpp ../complexmatrix.cpp ../global_variable.cpp ../ylm.cpp ../realarray.cpp ../timer.cpp ../matrix.cpp ../vector3.h
+          ../../src_parallel/parallel_reduce.cpp ../../src_parallel/parallel_kpoints.cpp ../../src_parallel/parallel_global.cpp ../../src_parallel/parallel_common.cpp
+)
+AddTest(
+  TARGET base_uts
+  LIBS ${math_libs} base device
+  SOURCES math_multi_device_test.cpp
+  ../../src_parallel/parallel_reduce.cpp ../../src_parallel/parallel_kpoints.cpp ../../src_parallel/parallel_global.cpp ../../src_parallel/parallel_common.cpp
 )
 AddTest(
   TARGET base_math_sphbes

--- a/source/module_base/test/math_multi_device_test.cpp
+++ b/source/module_base/test/math_multi_device_test.cpp
@@ -1,0 +1,97 @@
+#include <vector>
+#include <complex>
+#include <gtest/gtest.h>
+#include "module_psi/include/memory.h"
+#include "module_base/include/math_multi_device.h"
+
+class TestModuleBaseMathMultiDevice : public ::testing::Test
+{
+protected:
+    // xx = tf.random.uniform([100], minval=-4, maxval=4, dtype = tf.float64)
+
+    const psi::DEVICE_CPU * cpu_ctx = {};
+    const psi::DEVICE_GPU * gpu_ctx = {};
+
+    int ng = 59, lmax = 1;
+
+    double SQRT2 = 1.4142135623730951, PI = 3.1415926535897931, PI_HALF = 1.5707963267948966,
+           FOUR_PI = 12.566370614359172, SQRT_INVERSE_FOUR_PI = 0.28209479177387814;
+
+
+    std::vector<double> g = {2, -2, -2, 1, -1, -1, 0, 0, 0, -1, 1, 1, -2, 2, 2, 2, -2, 0, 1, -1, 1, 0, 0, 2, -1, 1, 3, 2, -2, 2, 1, -1, 3, -1, 1, -3, -2, 2, -2, 1, -1, -3, 0, 0, -2, -1, 1, -1, -2, 2, 0, 2, 0, -2, 1, 1, -1, 0, 2, 0, -1, 3, 1, 3, -1, -1, 2, 0, 0, 1, 1, 1, 0, 2, 2, 3, -1, 1, 2, 0, 2, 1, 1, 3, 1, 1, -3, 0, 2, -2, -1, 3, -1, 2, 2, -2, 1, 3, -1, 3, 1, -1, 2, 2, 0, 1, 3, 1, 3, 1, 1, 2, 2, 2, -1, -3, 1, -2, -2, 2, -2, -2, -2, -3, -1, -1, -1, -3, -1, -2, -2, 0, -3, -1, 1, 1, -3, -1, 0, -2, 0, -1, -1, 1, -2, 0, 2, 1, -3, 1, 0, -2, 2, -1, -1, 3, -1, -1, -3, -2, 0, -2, -3, 1, -1, 0, -2, -2, -1, -1, -1, -2, 0, 0, -3, 1, 1};
+    std::vector<double> expected_ylm = {0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, 0.282095, -0.282095, -0.282095, 0, 0.282095, 0.282095, 0, 0.282095, 0.488603, 0.441958, 0.282095, 0.441958, -0.441958, -0.282095, -0.441958, -0.488603, -0.282095, 0, -0.345494, -0.282095, 0, 0.147319, -0.147319, 0, 0.282095, 0.345494, 0.147319, 0.345494, 0.441958, -0.441958, -0.345494, -0.147319, -0.282095, -0.147319, -0.147319, 0, 0.147319, 0.147319, 0.282095, 0.147319, 0.282095, -0.282095, -0.147319, -0.147319, 0, 0.147319, -0.147319, 0, 0.282095, 0.345494, 0.147319, 0.345494, 0.441958, -0.441958, -0.345494, -0.147319, -0.345494, -0.282095, 0, 0.147319, -0.282095, -0.282095, -2.99183e-17, 0.282095, 0.282095, -0.345494, -0.282095, -0, 0.147319, -0.282095, -0.147319, 0.147319, 0.282095, -0.147319, -0, 0.282095, 0.345494, -0.345494, -0.282095, -2.99183e-17, 0.147319, -0.441958, -0.488603, -0.282095, -2.11554e-17, -0.441958, -0.345494, -0.147319, -0.147319, -2.11554e-17, 0.147319, -0.282095, -0.147319, -0.441958, -0.345494, -0.147319, -0.441958, -0.282095, 0.147319, 0.282095, 0.282095, 0.441958, 0.147319, 0.345494, 0.441958, -0.147319, -2.99183e-17, 0.282095, 0.345494, -0.147319, -2.11554e-17, 0.147319, 0.147319, 0.345494, 0.441958, -2.11554e-17, 0.282095, 0.488603, 0.441958, 0.282095, 0.282095, -0.488603, -0.282095, -0.282095, 0.345494, 0.282095, -0, -0.147319, 0.282095, 0.147319, -0.147319, -0.282095, 0.147319, -0, -0.282095, -0.345494, -0, -0.282095, -0.488603, -0.441958, 0.147319, -0, -0.282095, -0.345494, 0.147319, -0, -0.147319, -0.147319, -0.345494, -0.441958, -0.282095, -0.441958, -0.147319, -0.345494, -0.441958, -0.147319, -0.282095, 0.441958, 0.282095, 0.282095, 0.147319, 0.441958, 0.345494, 0.147319, 0.441958, 0.488603, 0.282095, -4.23108e-17, 0.441958, 0.345494, 0.147319, 0.147319, -4.23108e-17, -0.147319, 0.345494, 0.282095, -5.98366e-17, -0.147319};
+
+
+    using delmem_var_op = psi::memory::delete_memory_op<double, psi::DEVICE_GPU>;
+    using resmem_var_op = psi::memory::resize_memory_op<double, psi::DEVICE_GPU>;
+    using syncmem_var_h2d_op = psi::memory::synchronize_memory_op<double, psi::DEVICE_GPU, psi::DEVICE_CPU>;
+    using syncmem_var_d2h_op = psi::memory::synchronize_memory_op<double, psi::DEVICE_CPU, psi::DEVICE_GPU>;
+
+    void SetUp() override {
+    }
+    void TearDown() override {
+    }
+};
+
+TEST_F(TestModuleBaseMathMultiDevice, cal_ylm_real_op_cpu)
+{
+    std::vector<double> p((lmax + 1) * (lmax + 1) * ng, 0.0);
+    std::vector<double> ylm(expected_ylm.size(), 0.0);
+    ModuleBase::cal_ylm_real_op<double, psi::DEVICE_CPU>()(
+            cpu_ctx,
+            ng,
+            lmax,
+            SQRT2,
+            PI,
+            PI_HALF,
+            FOUR_PI,
+            SQRT_INVERSE_FOUR_PI,
+            g.data(),
+            p.data(),
+            ylm.data());
+
+    for (int ii = 0; ii < ylm.size(); ii++) {
+        EXPECT_LT(fabs(ylm[ii] - expected_ylm[ii]), 6e-5);
+    }
+}
+
+#if __CUDA || __UT_USE_CUDA || __ROCM || __UT_USE_ROCM
+TEST_F(TestModuleBaseMathMultiDevice, cal_ylm_real_op_gpu)
+{
+    std::vector<double> p((lmax + 1) * (lmax + 1) * ng, 0.0);
+    std::vector<double> ylm(expected_ylm.size(), 0.0);
+    double * d_ylm = nullptr, * d_g = nullptr, * d_p = nullptr;
+
+    resmem_var_op()(gpu_ctx, d_g, g.size());
+    resmem_var_op()(gpu_ctx, d_p, p.size());
+    resmem_var_op()(gpu_ctx, d_ylm, ylm.size());
+
+    syncmem_var_h2d_op()(gpu_ctx, cpu_ctx, d_g, g.data(), g.size());
+    syncmem_var_h2d_op()(gpu_ctx, cpu_ctx, d_p, p.data(), p.size());
+    syncmem_var_h2d_op()(gpu_ctx, cpu_ctx, d_ylm, ylm.data(), ylm.size());
+
+    ModuleBase::cal_ylm_real_op<double, psi::DEVICE_GPU>()(
+            gpu_ctx,
+            ng,
+            lmax,
+            SQRT2,
+            PI,
+            PI_HALF,
+            FOUR_PI,
+            SQRT_INVERSE_FOUR_PI,
+            d_g,
+            d_p,
+            d_ylm);
+
+    syncmem_var_d2h_op()(cpu_ctx, gpu_ctx, ylm.data(), d_ylm, ylm.size());
+
+    for (int ii = 0; ii < ylm.size(); ii++) {
+        EXPECT_LT(fabs(ylm[ii] - expected_ylm[ii]), 6e-5);
+    }
+
+    delmem_var_op()(gpu_ctx, d_g);
+    delmem_var_op()(gpu_ctx, d_p);
+    delmem_var_op()(gpu_ctx, d_ylm);
+}
+
+#endif // __CUDA || __UT_USE_CUDA || __ROCM || __UT_USE_ROCM

--- a/source/module_base/test/math_ylmreal_test.cpp
+++ b/source/module_base/test/math_ylmreal_test.cpp
@@ -4,6 +4,7 @@
 #include"../matrix.h"
 #include"gtest/gtest.h"
 #include<math.h>
+#include "module_psi/psi.h"
 
 #define doublethreshold 1e-12
 
@@ -289,6 +290,19 @@ TEST_F(YlmRealTest,YlmReal)
             EXPECT_NEAR(ylm(i,j),ref[i*ng+j],doublethreshold)  << "Ylm[" << i << "], example " << j << " not pass";
         }
     } 
+}
+
+TEST_F(YlmRealTest,YlmRealTemplate)
+{
+    psi::DEVICE_CPU * cpu_ctx = {};
+    ModuleBase::YlmReal::Ylm_Real(cpu_ctx, nylm, ng, reinterpret_cast<double*>(g), ylm.c);
+    for(int i=0;i<nylm;++i)
+    {
+        for(int j=0;j<ng;++j)
+        {
+            EXPECT_NEAR(ylm(i,j),ref[i*ng+j],doublethreshold)  << "Ylm[" << i << "], example " << j << " not pass";
+        }
+    }
 }
 
 

--- a/source/module_orbital/test/CMakeLists.txt
+++ b/source/module_orbital/test/CMakeLists.txt
@@ -40,8 +40,9 @@ list(APPEND depend_files
   )
 AddTest(
   TARGET orbital_equal_test
-  LIBS ${math_libs}
+  LIBS ${math_libs} device
   SOURCES 1_snap_equal_test.cpp ORB_unittest.cpp
+  ../../src_parallel/parallel_reduce.cpp ../../src_parallel/parallel_kpoints.cpp ../../src_parallel/parallel_global.cpp ../../src_parallel/parallel_common.cpp
   ${depend_files}
 )
 install(DIRECTORY GaAs DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/../../../tests)

--- a/source/module_psi/test/CMakeLists.txt
+++ b/source/module_psi/test/CMakeLists.txt
@@ -1,22 +1,7 @@
-if (USE_CUDA)
 AddTest(
   TARGET Module_Psi_UTs
-  LIBS ${math_libs} base
+  LIBS ${math_libs} base device
   SOURCES memory_test.cpp device_test.cpp
-          ../src/memory_psi.cpp
-          ../src/device.cpp
-          ../src/cuda/memory.cu
           ../../src_parallel/parallel_reduce.cpp 
           ../../src_parallel/parallel_global.cpp 
 )
-else()
-AddTest(
-  TARGET Module_Psi_UTs
-  LIBS ${math_libs} base
-  SOURCES memory_test.cpp device_test.cpp
-          ../src/memory_psi.cpp
-          ../src/device.cpp
-          ../../src_parallel/parallel_reduce.cpp 
-          ../../src_parallel/parallel_global.cpp 
-)
-endif()

--- a/source/module_symmetry/test/CMakeLists.txt
+++ b/source/module_symmetry/test/CMakeLists.txt
@@ -4,6 +4,6 @@ remove_definitions(-D__CUDA)
 remove_definitions(-D__ROCM)
 AddTest(
   TARGET symmetry_symmetry
-  LIBS base ${math_libs}
+  LIBS base ${math_libs} device
   SOURCES symmetry_test.cpp ../symmetry.cpp ../symmetry_basic.cpp ../symm_other.cpp ../../src_parallel/parallel_reduce.cpp ../../src_parallel/parallel_common.cpp ../../src_parallel/parallel_global.cpp
 )

--- a/source/src_pw/VNL_in_pw.cpp
+++ b/source/src_pw/VNL_in_pw.cpp
@@ -177,7 +177,7 @@ void pseudopot_cell_vnl::getvnl(const int &ik, ModuleBase::ComplexMatrix& vkb_in
 		gk[ig] = GlobalC::wf.get_1qvec_cartesian(ik, ig);
 	}
 
-	ModuleBase::YlmReal::Ylm_Real(x1, npw, gk, ylm);
+	ModuleBase::YlmReal::Ylm_Real(this->cpu_ctx, x1, npw, reinterpret_cast<double *>(gk), ylm.c);
 
 	int jkb = 0;
 	for(int it = 0;it < GlobalC::ucell.ntype;it++)

--- a/source/src_pw/VNL_in_pw.h
+++ b/source/src_pw/VNL_in_pw.h
@@ -14,6 +14,7 @@
 #include "../module_cell/unitcell.h"
 #include "src_pw/forces.h"
 #include "src_pw/stress_func.h"
+#include "module_psi/psi.h"
 
 //==========================================================
 // Calculate the non-local pseudopotential in reciprocal
@@ -114,6 +115,8 @@ public:
 	#endif
 private:
 	bool getvkb = false;
+    psi::DEVICE_CPU * cpu_ctx = {};
+    psi::DEVICE_GPU * gpu_ctx = {};
 };
 
 #endif // VNL_IN_PW

--- a/source/src_pw/test/CMakeLists.txt
+++ b/source/src_pw/test/CMakeLists.txt
@@ -5,7 +5,7 @@ remove_definitions(-D__ROCM)
 
 AddTest(
   TARGET klist_test
-  LIBS ${math_libs} base symmetry
+  LIBS ${math_libs} base symmetry device
   SOURCES klist_test.cpp ../klist.cpp ../../src_parallel/parallel_reduce.cpp ../../src_parallel/parallel_kpoints.cpp ../../src_parallel/parallel_global.cpp ../../src_parallel/parallel_common.cpp ../../src_io/output.cpp
 )
 


### PR DESCRIPTION
This implementation was the first step to solve the current bottleneck(in a GPU environment) function `pseudopot_cell_vnl::getvnl`. And the main changes are :

1.  Add a new device template for function `pseudopot_cell_vnl::getvnl`(overloaded);
2. Add  the related UTs.

Note: This PR has introduced a new code style which adds the templates for the member functions of class instead of the class itself. 