### PR TITLE
Replace the APIs for more efficient solving eigenpairs in davidson and CG-subspace

### DIFF
--- a/source/module_base/lapack_connector.h
+++ b/source/module_base/lapack_connector.h
@@ -383,12 +383,10 @@ public:
     }
 
     static inline
-    void zheevx( const int itype, const char jobz, const char range, const char uplo,
-                 const int n, const std::complex<double>* a, const int lda, const std::complex<double>* b,
-                 const int ldb, const double vl, const double vu, const int il, const int iu,
+    void zheevx( const int itype, const char jobz, const char range, const char uplo, const int n, 
+                 const std::complex<double>* a, const int lda, const double vl, const double vu, const int il, const int iu,
                  const double abstol, const int m, double* w, std::complex<double>* z, const int ldz,
-                 std::complex<double>* work, const int lwork, double* rwork, int* iwork,
-                 int* ifail, int info, int nbase_x)
+                 std::complex<double>* work, const int lwork, double* rwork, int* iwork, int* ifail, int info, int nbase_x)
     {
         // Transpose the std::complex matrix to the fortran-form real-std::complex array.
         std::complex<double>* aux = LapackConnector::transpose(a, n, lda, nbase_x);
@@ -396,7 +394,8 @@ public:
 
         // call the fortran routine
         zheevx_(&jobz, &range, &uplo, &n, 
-                aux, &lda, &vl, &vu, &il, &iu, &abstol, &m, w, zux, &ldz, 
+                aux, &lda, &vl, &vu, &il, &iu, 
+                &abstol, &m, w, zux, &ldz, 
                 work, &lwork, rwork, iwork, ifail, &info);
 
         // Transpose the fortran-form real-std::complex array to the std::complex matrix

--- a/source/module_base/lapack_connector.h
+++ b/source/module_base/lapack_connector.h
@@ -22,18 +22,42 @@
 extern "C"
 {
     int ilaenv_(int* ispec,const char* name,const char* opts,
-    const int* n1,const int* n2,const int* n3,const int* n4);
+                const int* n1,const int* n2,const int* n3,const int* n4);
+
+
     // solve the generalized eigenproblem Ax=eBx, where A is Hermitian and complex couble
-    // zhegv_ returns all eigenvalues while zhegvx_ returns selected ones
+    // zhegv_ & zhegvd_ returns all eigenvalues while zhegvx_ returns selected ones
+
+    void zhegvd_(const int* itype, const char* jobz, const char* uplo, const int* n,
+                 std::complex<double>* a, const int* lda, std::complex<double>* b, const int* ldb, 
+                 double* w, std::complex<double>* work, int* lwork, double* rwork, int* lrwork,
+                 int* iwork, int* liwork, int* info);
+
     void zhegv_(const int* itype,const char* jobz,const char* uplo,const int* n,
                 std::complex<double>* a,const int* lda,std::complex<double>* b,const int* ldb,
                 double* w,std::complex<double>* work,int* lwork,double* rwork,int* info);
+
     void zhegvx_(const int* itype,const char* jobz,const char* range,const char* uplo,
                  const int* n,std::complex<double> *a,const int* lda,std::complex<double> *b,
                  const int* ldb,const double* vl,const double* vu,const int* il,
                  const int* iu,const double* abstol,const int* m,double* w,
                  std::complex<double> *z,const int *ldz,std::complex<double> *work,const int* lwork,
                  double* rwork,int* iwork,int* ifail,int* info);
+
+    // solve the eigenproblem Ax=ex, where A is Hermitian and complex couble
+    // zheev_ returns all eigenvalues while zheevx_ returns selected ones
+    void zheev_(const char* jobz,const char* uplo,const int* n,std::complex<double> *a,
+                const int* lda,double* w,std::complex<double >* work,const int* lwork,
+                double* rwork,int* info);
+
+    void zheevx_(const char* jobz,const char* range,const char* uplo,
+                 const int* n,std::complex<double> *a,const int* lda,
+                 const double* vl,const double* vu,const int* il,
+                 const int* iu,const double* abstol,const int* m,double* w,
+                 std::complex<double> *z,const int *ldz,std::complex<double> *work,const int* lwork,
+                 double* rwork,int* iwork,int* ifail,int* info);
+
+
 	// solve the generalized eigenproblem Ax=eBx, where A is Symmetric and real couble
     // dsygv_ returns all eigenvalues while dsygvx_ returns selected ones
 	void dsygv_(const int* itype, const char* jobz,const char* uplo, const int* n,
@@ -47,10 +71,8 @@ extern "C"
     // solve the eigenproblem Ax=ex, where A is Symmetric and real double
 	void dsyev_(const char* jobz,const char* uplo,const int* n,double *a,
                 const int* lda,double* w,double* work,const int* lwork, int* info);
-    // solve the eigenproblem Ax=ex, where A is Hermitian and complex couble
-    void zheev_(const char* jobz,const char* uplo,const int* n,std::complex<double> *a,
-                const int* lda,double* w,std::complex<double >* work,const int* lwork,
-                double* rwork,int* info);
+    
+
     // dsytrf_ computes the Bunch-Kaufman factorization of a double precision
     // symmetric matrix, while dsytri takes its output to perform martrix inversion
     void dsytrf_(const char* uplo, const int* n, double * a, const int* lda,
@@ -226,7 +248,34 @@ public:
         return nb;
     }
 
-    // wrap function of fortran lapack routine zhegv.
+    // wrap function of fortran lapack routine zhegvd.
+    static inline
+    void zhegvd(const int itype, const char jobz, const char uplo, const int n, 
+                ModuleBase::ComplexMatrix& a, const int lda, 
+                ModuleBase::ComplexMatrix& b, const int ldb, double* w, 
+                std::complex<double>* work, int lwork, double* rwork, int lrwork,
+                int* iwork, int liwork, int info)
+    {	
+        // Transpose the std::complex matrix to the fortran-form real-std::complex array.
+        std::complex<double>* aux = LapackConnector::transpose(a, n, lda);
+        std::complex<double>* bux = LapackConnector::transpose(b, n, ldb);
+
+        // call the fortran routine
+        zhegvd_(&itype, &jobz, &uplo, &n, 
+                aux, &lda, bux, &ldb, w,
+                work, &lwork, rwork, &lrwork,
+                iwork, &liwork, &info);
+        
+        // Transpose the fortran-form real-std::complex array to the std::complex matrix.
+        LapackConnector::transpose(aux, a, n, lda);
+        LapackConnector::transpose(bux, b, n, ldb);
+        
+        // free the memory.
+        delete[] aux;
+        delete[] bux;
+    }
+
+    // wrap function of fortran lapack routine zhegv ( ModuleBase::ComplexMatrix version ).
     static inline
     void zhegv(	const int itype,const char jobz,const char uplo,const int n,ModuleBase::ComplexMatrix& a,
                 const int lda,ModuleBase::ComplexMatrix& b,const int ldb,double* w,std::complex<double>* work,
@@ -244,20 +293,21 @@ public:
         delete[] aux;
         delete[] bux;
     }
-    // wrap function of fortran lapack routine zhegv.
+
+    // wrap function of fortran lapack routine zhegv ( pointer version ) .
     static inline
     void zhegv(	const int itype, const char jobz, const char uplo, const int n, std::complex<double>* a,
                 const int lda, const std::complex<double>* b, const int ldb, double* w, std::complex<double>* work,
                 int lwork, double* rwork, int info, int ld_real)
-    {	// Transpose the std::complex matrix to the fortran-form real-std::complex array.
+    {	
+        // Transpose the std::complex matrix to the fortran-form real-std::complex array.
         std::complex<double>* aux = LapackConnector::transpose(a, n, lda, ld_real);
         std::complex<double>* bux = LapackConnector::transpose(b, n, ldb, ld_real);
 
         // call the fortran routine
         zhegv_(&itype, &jobz, &uplo, &n, aux, &lda, bux, &ldb, w, work, &lwork, rwork, &info);
+        
         // Transpose the fortran-form real-std::complex array to the std::complex matrix.
-        // LapackConnector::transpose(aux, a, n, lda);
-        // LapackConnector::transpose(bux, b, n, ldb);
         for (int i = 0; i < n; ++i)
         {
             for (int j = 0; j < lda; ++j)
@@ -270,7 +320,7 @@ public:
         delete[] bux;
     }
 
-    // wrap function of fortran lapack routine zheev.
+    // wrap function of fortran lapack routine zhegvx ( ModuleBase::ComplexMatrix version ).
     static inline
     void zhegvx( const int itype, const char jobz, const char range, const char uplo,
                  const int n, const ModuleBase::ComplexMatrix& a, const int lda, const ModuleBase::ComplexMatrix& b,
@@ -298,7 +348,8 @@ public:
         delete[] zux;
 
     }
-    // wrap function of fortran lapack routine zheev.
+
+    // wrap function of fortran lapack routine zhegvx ( pointer version ).
     static inline
     void zhegvx( const int itype, const char jobz, const char range, const char uplo,
                  const int n, const std::complex<double>* a, const int lda, const std::complex<double>* b,
@@ -330,6 +381,39 @@ public:
         delete[] bux;
         delete[] zux;
     }
+
+    static inline
+    void zheevx( const int itype, const char jobz, const char range, const char uplo,
+                 const int n, const std::complex<double>* a, const int lda, const std::complex<double>* b,
+                 const int ldb, const double vl, const double vu, const int il, const int iu,
+                 const double abstol, const int m, double* w, std::complex<double>* z, const int ldz,
+                 std::complex<double>* work, const int lwork, double* rwork, int* iwork,
+                 int* ifail, int info, int nbase_x)
+    {
+        // Transpose the std::complex matrix to the fortran-form real-std::complex array.
+        std::complex<double>* aux = LapackConnector::transpose(a, n, lda, nbase_x);
+        std::complex<double>* zux = new std::complex<double>[n*iu];// mohan modify 2009-08-02
+
+        // call the fortran routine
+        zheevx_(&jobz, &range, &uplo, &n, 
+                aux, &lda, &vl, &vu, &il, &iu, &abstol, &m, w, zux, &ldz, 
+                work, &lwork, rwork, iwork, ifail, &info);
+
+        // Transpose the fortran-form real-std::complex array to the std::complex matrix
+        for (int i = 0; i < iu; ++i)
+        {
+            for (int j = 0; j < n; ++j)
+            {
+                z[j * nbase_x + i] = zux[i*n+j];
+            }
+        }
+
+        // free the memory.
+        delete[] aux;
+        delete[] zux;
+    }
+
+
 
 	// calculate the eigenvalues and eigenfunctions of a real symmetric matrix.
     static inline

--- a/source/module_hsolver/diago_david.cpp
+++ b/source/module_hsolver/diago_david.cpp
@@ -633,8 +633,10 @@ void DiagoDavid<FPTYPE, Device>::diag_zhegvx(const int& n, // nbase
         }
         else
         {
-            dngvx_op<FPTYPE,
-                     Device>()(this->ctx, n, this->nbase_x, this->hcc, this->scc, m, this->eigenvalue, this->vcc);
+            // dngvx_op<FPTYPE,
+            //          Device>()(this->ctx, n, this->nbase_x, this->hcc, this->scc, m, this->eigenvalue, this->vcc);
+            dnevx_op<FPTYPE,
+                     Device>()(this->ctx, n, this->nbase_x, this->hcc, m, this->eigenvalue, this->vcc);
         }
     }
 

--- a/source/module_hsolver/diago_david.cpp
+++ b/source/module_hsolver/diago_david.cpp
@@ -625,7 +625,7 @@ void DiagoDavid<FPTYPE, Device>::diag_zhegvx(const int& n, // nbase
             resmem_var_op()(this->ctx, eigenvalue_gpu, this->nbase_x);
             syncmem_var_h2d_op()(this->ctx, this->cpu_ctx, eigenvalue_gpu, eigenvalue, this->nbase_x);
 
-            dngvx_op<FPTYPE, Device>()(this->ctx, n, this->nbase_x, this->hcc, this->scc, m, eigenvalue_gpu, this->vcc);
+            dnevx_op<FPTYPE, Device>()(this->ctx, n, this->nbase_x, this->hcc, m, eigenvalue_gpu, this->vcc);
 
             syncmem_var_d2h_op()(this->cpu_ctx, this->ctx, eigenvalue, eigenvalue_gpu, this->nbase_x);
             delmem_var_op()(this->ctx, eigenvalue_gpu);
@@ -635,8 +635,7 @@ void DiagoDavid<FPTYPE, Device>::diag_zhegvx(const int& n, // nbase
         {
             // dngvx_op<FPTYPE,
             //          Device>()(this->ctx, n, this->nbase_x, this->hcc, this->scc, m, this->eigenvalue, this->vcc);
-            dnevx_op<FPTYPE,
-                     Device>()(this->ctx, n, this->nbase_x, this->hcc, m, this->eigenvalue, this->vcc);
+            dnevx_op<FPTYPE, Device>()(this->ctx, n, this->nbase_x, this->hcc, m, this->eigenvalue, this->vcc);
         }
     }
 

--- a/source/module_hsolver/diago_iter_assist.cpp
+++ b/source/module_hsolver/diago_iter_assist.cpp
@@ -432,7 +432,8 @@ void DiagoIterAssist<FPTYPE, Device>::diagH_LAPACK(
         //===========================
         // calculate all eigenvalues
         //===========================
-        dngv_op<FPTYPE, Device>()(ctx, nstart, ldh, hcc, scc, res, vcc);
+        // dngv_op<FPTYPE, Device>()(ctx, nstart, ldh, hcc, scc, res, vcc);
+        dngvd_op<FPTYPE, Device>()(ctx, nstart, ldh, hcc, scc, res, vcc);
     }
     else {
         //=====================================

--- a/source/module_hsolver/include/dngvd_op.h
+++ b/source/module_hsolver/include/dngvd_op.h
@@ -59,6 +59,30 @@ template <typename FPTYPE, typename Device> struct dngv_op
                     std::complex<FPTYPE>* V);
 };
 
+template <typename FPTYPE, typename Device> struct dngvd_op
+{
+    /// @brief DNGVD computes all the eigenvalues and eigenvectors of a complex generalized
+    /// Hermitian-definite eigenproblem. If eigenvectors are desired, it uses a divide and conquer algorithm.
+    /// API doc: https://netlib.org/lapack/explore-html/df/d9a/group__complex16_h_eeigen_ga74fdf9b5a16c90d8b7a589dec5ca058a.html
+    ///
+    /// Input Parameters
+    ///     @param d : the type of device
+    ///     @param nstart : the number of cols of the matrix
+    ///     @param ldh : the number of rows of the matrix
+    ///     @param A : the hermitian matrix A in A x=lambda B x (row major)
+    ///     @param B : the overlap matrix B in A x=lambda B x (row major)
+    /// Output Parameter
+    ///     @param W : calculated eigenvalues
+    ///     @param V : calculated eigenvectors (row major)
+    void operator()(const Device* d,
+                    const int nstart,
+                    const int ldh,
+                    const std::complex<FPTYPE>* A,
+                    const std::complex<FPTYPE>* B,
+                    double* W,
+                    std::complex<FPTYPE>* V);
+};
+
 #if __CUDA || __UT_USE_CUDA || __ROCM || __UT_USE_ROCM
 
 void createCUSOLVERhandle();

--- a/source/module_hsolver/include/dngvd_op.h
+++ b/source/module_hsolver/include/dngvd_op.h
@@ -16,6 +16,12 @@ template <typename FPTYPE, typename Device> struct dngvx_op
     /// @brief DNGVX computes the first m eigenvalues ​​and their corresponding eigenvectors of
     /// a complex generalized Hermitian-definite eigenproblem
     ///
+    /// In this op, the CPU version is implemented through the `gvx` interface, and the CUDA version
+    /// is implemented through the `gvd` interface and acquires the first m eigenpairs.
+    /// API doc:
+    /// 1. zhegvx: https://netlib.org/lapack/explore-html/df/d9a/group__complex16_h_eeigen_ga8ea76cbbb14edb5a22069e203fc8e8b2.html
+    /// 2. cusolverDnZhegvd: https://docs.nvidia.com/cuda/cusolver/index.html#cusolverdn-t-sygvd
+    ///
     /// Input Parameters
     ///     @param d : the type of device
     ///     @param nstart : the number of cols of the matrix
@@ -41,6 +47,12 @@ template <typename FPTYPE, typename Device> struct dngv_op
     /// @brief DNGV computes all the eigenvalues and eigenvectors of a complex generalized
     /// Hermitian-definite eigenproblem
     ///
+    /// In this op, the CPU version is implemented through the `gv` interface, and the CUDA version
+    /// is implemented through the `gvd` interface.
+    /// API doc:
+    /// 1. zhegv: https://netlib.org/lapack/explore-html/df/d9a/group__complex16_h_eeigen_gaf7b790b3b89de432a423c9006c1cc1ac.html
+    /// 2. cusolverDnZhegvd: https://docs.nvidia.com/cuda/cusolver/index.html#cusolverdn-t-sygvd
+    ///
     /// Input Parameters
     ///     @param d : the type of device
     ///     @param nstart : the number of cols of the matrix
@@ -63,7 +75,12 @@ template <typename FPTYPE, typename Device> struct dngvd_op
 {
     /// @brief DNGVD computes all the eigenvalues and eigenvectors of a complex generalized
     /// Hermitian-definite eigenproblem. If eigenvectors are desired, it uses a divide and conquer algorithm.
-    /// API doc: https://netlib.org/lapack/explore-html/df/d9a/group__complex16_h_eeigen_ga74fdf9b5a16c90d8b7a589dec5ca058a.html
+    ///
+    /// In this op, the CPU version is implemented through the `gvd` interface, and the CUDA version
+    /// is implemented through the `gvd` interface.
+    /// API doc:
+    /// 1. zhegvd: https://netlib.org/lapack/explore-html/df/d9a/group__complex16_h_eeigen_ga74fdf9b5a16c90d8b7a589dec5ca058a.html
+    /// 2. cusolverDnZhegvd: https://docs.nvidia.com/cuda/cusolver/index.html#cusolverdn-t-sygvd
     ///
     /// Input Parameters
     ///     @param d : the type of device
@@ -88,7 +105,12 @@ template <typename FPTYPE, typename Device> struct dnevx_op
 {
     /// @brief DNEVX computes the first m eigenvalues ​​and their corresponding eigenvectors of
     /// a complex generalized Hermitian-definite eigenproblem
-    /// API doc: https://netlib.org/lapack/explore-html/df/d9a/group__complex16_h_eeigen_gaabef68a9c7b10df7aef8f4fec89fddbe.html
+    ///
+    /// In this op, the CPU version is implemented through the `evx` interface, and the CUDA version
+    /// is implemented through the `evd` interface and acquires the first m eigenpairs.
+    /// API doc:
+    /// 1. zheevx: https://netlib.org/lapack/explore-html/df/d9a/group__complex16_h_eeigen_gaabef68a9c7b10df7aef8f4fec89fddbe.html
+    /// 2. cusolverDnZheevd: https://docs.nvidia.com/cuda/cusolver/index.html#cusolverdn-t-syevd
     ///
     /// Input Parameters
     ///     @param d : the type of device

--- a/source/module_hsolver/include/dngvd_op.h
+++ b/source/module_hsolver/include/dngvd_op.h
@@ -83,6 +83,31 @@ template <typename FPTYPE, typename Device> struct dngvd_op
                     std::complex<FPTYPE>* V);
 };
 
+
+template <typename FPTYPE, typename Device> struct dnevx_op
+{
+    /// @brief DNEVX computes the first m eigenvalues ​​and their corresponding eigenvectors of
+    /// a complex generalized Hermitian-definite eigenproblem
+    /// API doc: https://netlib.org/lapack/explore-html/df/d9a/group__complex16_h_eeigen_gaabef68a9c7b10df7aef8f4fec89fddbe.html
+    ///
+    /// Input Parameters
+    ///     @param d : the type of device
+    ///     @param nstart : the number of cols of the matrix
+    ///     @param ldh : the number of rows of the matrix
+    ///     @param A : the hermitian matrix A in A x=lambda B x (row major)
+    /// Output Parameter
+    ///     @param W : calculated eigenvalues
+    ///     @param V : calculated eigenvectors (row major)
+    void operator()(const Device* d,
+                    const int nstart,
+                    const int ldh,
+                    const std::complex<FPTYPE>* A,
+                    const int m,
+                    double* W,
+                    std::complex<FPTYPE>* V);
+};
+
+
 #if __CUDA || __UT_USE_CUDA || __ROCM || __UT_USE_ROCM
 
 void createCUSOLVERhandle();

--- a/source/module_hsolver/src/cuda/dngvd_op.cu
+++ b/source/module_hsolver/src/cuda/dngvd_op.cu
@@ -279,4 +279,193 @@ void dngv_op<double, psi::DEVICE_GPU>::operator()(const psi::DEVICE_GPU* d,
     cusolverErrcheck(cusolverDnDestroy(cusolverH));
 }
 
+template <>
+void dngvd_op<double, psi::DEVICE_GPU>::operator()(const psi::DEVICE_GPU* d,
+                                                   const int nstart,
+                                                   const int ldh,
+                                                   const std::complex<double>* A,
+                                                   const std::complex<double>* B,
+                                                   double* W,
+                                                   std::complex<double>* V)
+{
+    assert(nstart == ldh);
+    // init A_eigenvectors & transpose_B
+    double2 *A_eigenvectors, *transpose_B;
+    checkCudaErrors(cudaMalloc((void**)&A_eigenvectors, sizeof(double2) * ldh * nstart));
+    checkCudaErrors(cudaMalloc((void**)&transpose_B, sizeof(double2) * ldh * nstart));
+
+    // transpose A, B  to A_eigenvectors, transpose_B
+    matrixTranspose_op<double, psi::DEVICE_GPU>()(d, ldh, nstart, A, (std::complex<double>*)A_eigenvectors);
+    matrixTranspose_op<double, psi::DEVICE_GPU>()(d, ldh, nstart, B, (std::complex<double>*)transpose_B);
+
+    // init all_W
+    double* all_W;
+    checkCudaErrors(cudaMalloc((void**)&all_W, sizeof(double) * ldh));
+
+    // prepare some values for cusolverDnZhegvd_bufferSize
+    cusolverDnHandle_t cusolverH;
+    cusolverErrcheck(cusolverDnCreate(&cusolverH));
+    int* devInfo;
+    checkCudaErrors(cudaMalloc((void**)&devInfo, sizeof(int)));
+
+    // calculate the sizes needed for pre-allocated buffer.
+    int lwork = 0;
+    cusolverErrcheck(cusolverDnZhegvd_bufferSize(
+        cusolverH,
+        CUSOLVER_EIG_TYPE_1, // itype = CUSOLVER_EIG_TYPE_1: A*x = (lambda)*B*x.
+        CUSOLVER_EIG_MODE_VECTOR, // jobz = CUSOLVER_EIG_MODE_VECTOR : Compute eigenvalues and eigenvectors.
+        CUBLAS_FILL_MODE_UPPER,
+        ldh,
+        A_eigenvectors,
+        nstart,
+        transpose_B,
+        nstart,
+        all_W,
+        &lwork));
+
+    // allocate memery
+    cuDoubleComplex* d_work;
+    checkCudaErrors(cudaMalloc((void**)&d_work, sizeof(cuDoubleComplex) * lwork));
+
+    // compute eigenvalues and eigenvectors.
+    cusolverErrcheck(cusolverDnZhegvd(
+        cusolverH,
+        CUSOLVER_EIG_TYPE_1, // itype = CUSOLVER_EIG_TYPE_1: A*x = (lambda)*B*x.
+        CUSOLVER_EIG_MODE_VECTOR, // jobz = CUSOLVER_EIG_MODE_VECTOR : Compute eigenvalues and eigenvectors.
+        CUBLAS_FILL_MODE_UPPER,
+        ldh,
+        A_eigenvectors,
+        nstart,
+        transpose_B,
+        nstart,
+        all_W,
+        d_work,
+        lwork,
+        devInfo));
+
+    checkCudaErrors(cudaDeviceSynchronize());
+
+    // get all eigenvalues and eigenvectors.
+    checkCudaErrors(cudaMemcpy(W, all_W, sizeof(double) * ldh, cudaMemcpyDeviceToDevice));
+    matrixTranspose_op<double, psi::DEVICE_GPU>()(d, ldh, nstart, (std::complex<double>*)A_eigenvectors, V);
+
+    int info_gpu;
+    checkCudaErrors(cudaMemcpy(&info_gpu, devInfo, sizeof(int), cudaMemcpyDeviceToHost));
+    assert(0 == info_gpu);
+
+    // free the buffer
+    checkCudaErrors(cudaFree(d_work));
+    // free resources and destroy
+    checkCudaErrors(cudaFree(A_eigenvectors));
+    checkCudaErrors(cudaFree(transpose_B));
+    checkCudaErrors(cudaFree(all_W));
+    checkCudaErrors(cudaFree(devInfo));
+    cusolverErrcheck(cusolverDnDestroy(cusolverH));
+}
+
+template <>
+void dnevx_op<double, psi::DEVICE_GPU>::operator()(const psi::DEVICE_GPU* d,
+                                                   const int nstart,
+                                                   const int ldh,
+                                                   const std::complex<double>* A,
+                                                   const int m,
+                                                   double* W,
+                                                   std::complex<double>* V)
+{
+    // init A_eigenvectors, transpose_B and all_W
+    double2 *A_eigenvectors;
+    if (nstart == ldh)
+    {
+        checkCudaErrors(cudaMalloc((void**)&A_eigenvectors, sizeof(double2) * nstart * nstart));
+
+        matrixTranspose_op<double, psi::DEVICE_GPU>()(d, nstart, nstart, A, (std::complex<double>*)A_eigenvectors);
+    }
+    else if (nstart < ldh)
+    {
+        // nstart < ldh
+        checkCudaErrors(cudaMalloc((void**)&A_eigenvectors, sizeof(double2) * nstart * nstart));
+
+        matrixSetToAnother<double, psi::DEVICE_GPU>()(d, nstart, A, ldh, (std::complex<double>*)A_eigenvectors, nstart);
+
+        matrixTranspose_op<double, psi::DEVICE_GPU>()(d,
+                                                      nstart,
+                                                      nstart,
+                                                      (std::complex<double>*)A_eigenvectors,
+                                                      (std::complex<double>*)A_eigenvectors);
+    }
+    else if (nstart > ldh)
+    {
+        assert(nstart < ldh);
+    }
+
+    double* all_W;
+    checkCudaErrors(cudaMalloc((void**)&all_W, sizeof(double) * nstart));
+
+    // prepare some values for cusolverDnZhegvd_bufferSize
+    cusolverDnHandle_t cusolverH;
+    cusolverErrcheck(cusolverDnCreate(&cusolverH));
+    int* devInfo;
+    checkCudaErrors(cudaMalloc((void**)&devInfo, sizeof(int)));
+
+    // calculate the sizes needed for pre-allocated buffer.
+    int lwork = 0;
+    cusolverErrcheck(cusolverDnZheevd_bufferSize(
+        cusolverH,
+        CUSOLVER_EIG_MODE_VECTOR, // jobz = CUSOLVER_EIG_MODE_VECTOR : Compute eigenvalues and eigenvectors.
+        CUBLAS_FILL_MODE_LOWER,
+        nstart,
+        A_eigenvectors,
+        nstart,
+        all_W,
+        &lwork));
+
+    // allocate memery
+    cuDoubleComplex* d_work;
+    checkCudaErrors(cudaMalloc((void**)&d_work, sizeof(cuDoubleComplex) * lwork));
+
+    // compute eigenvalues and eigenvectors.
+    cusolverErrcheck(cusolverDnZheevd(
+        cusolverH,
+        CUSOLVER_EIG_MODE_VECTOR, // jobz = CUSOLVER_EIG_MODE_VECTOR : Compute eigenvalues and eigenvectors.
+        CUBLAS_FILL_MODE_LOWER,
+        nstart,
+        A_eigenvectors,
+        nstart,
+        all_W,
+        d_work,
+        lwork,
+        devInfo));
+
+    checkCudaErrors(cudaDeviceSynchronize());
+
+    // get eigenvalues and eigenvectors.  only m !
+    checkCudaErrors(cudaMemcpy(W, all_W, sizeof(double) * m, cudaMemcpyDeviceToDevice));
+
+    if (ldh == nstart)
+    {
+        matrixTranspose_op<double, psi::DEVICE_GPU>()(d, nstart, nstart, V, V);
+        checkCudaErrors(
+            cudaMemcpy(V, A_eigenvectors, sizeof(std::complex<double>) * nstart * m, cudaMemcpyDeviceToDevice));
+        matrixTranspose_op<double, psi::DEVICE_GPU>()(d, nstart, nstart, V, V);
+    }
+    else
+    {
+        matrixTranspose_op<double, psi::DEVICE_GPU>()(d, ldh, ldh, V, V);
+        matrixSetToAnother<double, psi::DEVICE_GPU>()(d, m, (std::complex<double>*)A_eigenvectors, nstart, V, ldh);
+        matrixTranspose_op<double, psi::DEVICE_GPU>()(d, ldh, ldh, V, V);
+    }
+
+    int info_gpu;
+    checkCudaErrors(cudaMemcpy(&info_gpu, devInfo, sizeof(int), cudaMemcpyDeviceToHost));
+    assert(0 == info_gpu);
+
+    // free the buffer
+    checkCudaErrors(cudaFree(d_work));
+    // free resources and destroy
+    checkCudaErrors(cudaFree(A_eigenvectors));
+    checkCudaErrors(cudaFree(all_W));
+    checkCudaErrors(cudaFree(devInfo));
+    cusolverErrcheck(cusolverDnDestroy(cusolverH));
+}
+
 } // namespace hsolver

--- a/source/module_hsolver/src/dngvd_op.cpp
+++ b/source/module_hsolver/src/dngvd_op.cpp
@@ -260,4 +260,84 @@ void dngvd_op<double, psi::DEVICE_CPU>::operator()(const psi::DEVICE_CPU* d,
     delete[] iwork;
 }
 
+
+
+template <>
+void dnevx_op<double, psi::DEVICE_CPU>::operator()(const psi::DEVICE_CPU* d,
+                                                   const int nstart,
+                                                   const int ldh,
+                                                   const std::complex<double>* hcc, // hcc
+                                                   const int nbands, // nbands
+                                                   double* eigenvalue, // eigenvalue
+                                                   std::complex<double>* vcc) // vcc
+{
+    int info = 0;
+    int lwork = 0;
+    int nb = LapackConnector::ilaenv(1, "ZHETRD", "L", nstart, -1, -1, -1);
+    if (nb < 1)
+    {
+        nb = std::max(1, nstart);
+    }
+
+    if (nb == 1 || nb >= nstart)
+    {
+        lwork = 2 * nstart; // qianrui fix a bug 2021-7-25 : lwork should be at least max(1,2*n)
+    }
+    else
+    {
+        lwork = (nb + 1) * nstart;
+    }
+    double* rwork = new double[7 * nstart];
+    int* iwork = new int[5 * nstart];
+    int* ifail = new int[nstart];
+    ModuleBase::GlobalFunc::ZEROS(rwork, 7 * nstart);
+    ModuleBase::GlobalFunc::ZEROS(iwork, 5 * nstart);
+    ModuleBase::GlobalFunc::ZEROS(ifail, nstart);
+    // important part:
+    // In davidson, the size of work is different from dnevx_op in diagH_subspace.
+    std::complex<double>* work = new std::complex<double>[2 * lwork];
+    ModuleBase::GlobalFunc::ZEROS(work, lwork); // qianrui change it, only first lwork numbers are used in zhegvx
+
+    // The A and B storage space is (nstart * ldh), and the data that really participates in the zhegvx
+    // operation is (nstart * nstart). In this function, the data that A and B participate in the operation will
+    // be extracted into the new local variables aux and bux (the internal of the function).
+    // V is the output of the function, the storage space is also (nstart * ldh), and the data size of valid V
+    // obtained by the zhegvx operation is (nstart * nstart) and stored in zux (internal to the function). When
+    // the function is output, the data of zux will be mapped to the corresponding position of V.
+    LapackConnector::zheevx(
+        1, // ITYPE = 1:  A*x = (lambda)*B*x
+        'V', // JOBZ = 'V':  Compute eigenvalues and eigenvectors.
+        'I', // RANGE = 'I': the IL-th through IU-th eigenvalues will be found.
+        'L', // UPLO = 'L':  Lower triangles of A and B are stored.
+        nstart, // N = base
+        hcc, // A is COMPLEX*16 array  dimension (LDA, N)
+        nstart, // LDA = base
+        0.0, // Not referenced if RANGE = 'A' or 'I'.
+        0.0, // Not referenced if RANGE = 'A' or 'I'.
+        1, // IL: If RANGE='I', the index of the smallest eigenvalue to be returned. 1 <= IL <= IU <= N,
+        nbands, // IU: If RANGE='I', the index of the largest eigenvalue to be returned. 1 <= IL <= IU <= N,
+        0.0, // ABSTOL
+        nbands, // M: The total number of eigenvalues found.  0 <= M <= N. if RANGE = 'I', M = IU-IL+1.
+        eigenvalue, // W store eigenvalues
+        vcc, // store eigenvector
+        nstart, // LDZ: The leading dimension of the array Z.
+        work,
+        lwork,
+        rwork,
+        iwork,
+        ifail,
+        info,
+        ldh);
+
+    delete[] work;
+    delete[] rwork;
+    delete[] iwork;
+    delete[] ifail;
+
+    assert(0 == info);
+};
+
+
+
+
 } // namespace hsolver

--- a/source/module_hsolver/src/dngvd_op.cpp
+++ b/source/module_hsolver/src/dngvd_op.cpp
@@ -12,7 +12,7 @@ void dngvx_op<double, psi::DEVICE_CPU>::operator()(const psi::DEVICE_CPU* d,
                                                    const std::complex<double>* hcc, // hcc
                                                    const std::complex<double>* scc, // scc
                                                    const int nbands, // nbands
-                                                   double* eigenvalue,  // eigenvalue
+                                                   double* eigenvalue, // eigenvalue
                                                    std::complex<double>* vcc) // vcc
 {
     int info = 0;
@@ -91,33 +91,29 @@ void dngv_op<double, psi::DEVICE_CPU>::operator()(const psi::DEVICE_CPU* d,
                                                   const std::complex<double>* scc,
                                                   double* eigenvalue,
                                                   std::complex<double>* vcc)
-                                                  
+
 {
 
     int lwork = 0;
-    psi::DEVICE_CPU * cpu_ctx = {};
+    psi::DEVICE_CPU* cpu_ctx = {};
 
     ModuleBase::ComplexMatrix sdum(nstart, ldh);
     ModuleBase::ComplexMatrix hdum;
 
     ModuleBase::ComplexMatrix hc(nstart, nstart);
     ModuleBase::ComplexMatrix hvec(nstart, nstart);
-    psi::memory::synchronize_memory_op<std::complex<double>, psi::DEVICE_CPU, psi::DEVICE_CPU>()(
-            cpu_ctx,
-            cpu_ctx,
-            hc.c,
-            hcc,
-            nstart * nstart
-    );
+    psi::memory::synchronize_memory_op<std::complex<double>, psi::DEVICE_CPU, psi::DEVICE_CPU>()(cpu_ctx,
+                                                                                                 cpu_ctx,
+                                                                                                 hc.c,
+                                                                                                 hcc,
+                                                                                                 nstart * nstart);
 
     ModuleBase::ComplexMatrix sc(nstart, nstart);
-    psi::memory::synchronize_memory_op<std::complex<double>, psi::DEVICE_CPU, psi::DEVICE_CPU>()(
-            cpu_ctx,
-            cpu_ctx,
-            sc.c,
-            scc,
-            nstart * nstart
-    );
+    psi::memory::synchronize_memory_op<std::complex<double>, psi::DEVICE_CPU, psi::DEVICE_CPU>()(cpu_ctx,
+                                                                                                 cpu_ctx,
+                                                                                                 sc.c,
+                                                                                                 scc,
+                                                                                                 nstart * nstart);
     sdum = sc;
 
     // workspace query
@@ -137,7 +133,7 @@ void dngv_op<double, psi::DEVICE_CPU>::operator()(const psi::DEVICE_CPU* d,
         lwork = (nb + 1) * nstart;
     }
 
-    std::complex<double> *work = new std::complex<double>[lwork];
+    std::complex<double>* work = new std::complex<double>[lwork];
     ModuleBase::GlobalFunc::ZEROS(work, lwork);
 
     //=====================================================================
@@ -147,7 +143,7 @@ void dngv_op<double, psi::DEVICE_CPU>::operator()(const psi::DEVICE_CPU* d,
     int info = 0;
     int rwork_dim = 3 * nstart - 2;
 
-    double *rwork = new double[rwork_dim];
+    double* rwork = new double[rwork_dim];
     ModuleBase::GlobalFunc::ZEROS(rwork, rwork_dim);
 
     //===========================
@@ -156,13 +152,11 @@ void dngv_op<double, psi::DEVICE_CPU>::operator()(const psi::DEVICE_CPU* d,
     hvec = hc;
     LapackConnector::zhegv(1, 'V', 'U', nstart, hvec, ldh, sdum, ldh, eigenvalue, work, lwork, rwork, info);
 
-    psi::memory::synchronize_memory_op<std::complex<double>, psi::DEVICE_CPU, psi::DEVICE_CPU>()(
-            cpu_ctx,
-            cpu_ctx,
-            vcc,
-            hvec.c,
-            nstart * nstart
-    );
+    psi::memory::synchronize_memory_op<std::complex<double>, psi::DEVICE_CPU, psi::DEVICE_CPU>()(cpu_ctx,
+                                                                                                 cpu_ctx,
+                                                                                                 vcc,
+                                                                                                 hvec.c,
+                                                                                                 nstart * nstart);
     delete[] rwork;
     delete[] work;
     // int info = 0;
@@ -192,7 +186,6 @@ void dngv_op<double, psi::DEVICE_CPU>::operator()(const psi::DEVICE_CPU* d,
     //     V[i] = A[i];
     // }
 
-
     // // The A and B storage space is (nstart * ldh), and the data that really participates in the zhegvx
     // // operation is (nstart * nstart). In this function, the data that A and B participate in the operation will
     // // be extracted into the new local variables aux and bux (the internal of the function).
@@ -205,6 +198,66 @@ void dngv_op<double, psi::DEVICE_CPU>::operator()(const psi::DEVICE_CPU* d,
 
     // delete[] work;
     // delete[] rwork;
+}
+
+template <>
+void dngvd_op<double, psi::DEVICE_CPU>::operator()(const psi::DEVICE_CPU* d,
+                                                   const int nstart,
+                                                   const int ldh,
+                                                   const std::complex<double>* hcc,
+                                                   const std::complex<double>* scc,
+                                                   double* eigenvalue,
+                                                   std::complex<double>* vcc)
+{
+    psi::DEVICE_CPU* cpu_ctx = {};
+
+    ModuleBase::ComplexMatrix sdum(nstart, ldh);
+    ModuleBase::ComplexMatrix hdum;
+
+    ModuleBase::ComplexMatrix hc(nstart, nstart);
+    ModuleBase::ComplexMatrix hvec(nstart, nstart);
+    psi::memory::synchronize_memory_op<std::complex<double>, psi::DEVICE_CPU, psi::DEVICE_CPU>()(cpu_ctx,
+                                                                                                 cpu_ctx,
+                                                                                                 hc.c,
+                                                                                                 hcc,
+                                                                                                 nstart * nstart);
+
+    ModuleBase::ComplexMatrix sc(nstart, nstart);
+    psi::memory::synchronize_memory_op<std::complex<double>, psi::DEVICE_CPU, psi::DEVICE_CPU>()(cpu_ctx,
+                                                                                                 cpu_ctx,
+                                                                                                 sc.c,
+                                                                                                 scc,
+                                                                                                 nstart * nstart);
+    sdum = sc;
+    hvec = hc;
+
+    int info = 0;
+
+    int lwork = 2 * nstart + nstart * nstart;
+    std::complex<double>* work = new std::complex<double>[lwork];
+    ModuleBase::GlobalFunc::ZEROS(work, lwork);
+
+    int lrwork = 1 + 5 * nstart + 2 * nstart * nstart;
+    double* rwork = new double[lrwork];
+    ModuleBase::GlobalFunc::ZEROS(rwork, lrwork);
+
+    int liwork = 3 + 5 * nstart;
+    int* iwork = new int[liwork];
+    ModuleBase::GlobalFunc::ZEROS(iwork, liwork);
+
+    //===========================
+    // calculate all eigenvalues
+    //===========================
+    LapackConnector::zhegvd(1, 'V', 'U', nstart, hvec, ldh, sdum, ldh, eigenvalue, work, lwork, rwork, lrwork, iwork, liwork, info);
+
+    psi::memory::synchronize_memory_op<std::complex<double>, psi::DEVICE_CPU, psi::DEVICE_CPU>()(cpu_ctx,
+                                                                                                 cpu_ctx,
+                                                                                                 vcc,
+                                                                                                 hvec.c,
+                                                                                                 nstart * nstart);
+    delete[] work;
+    delete[] rwork;
+    delete[] iwork;
 }
 
 } // namespace hsolver


### PR DESCRIPTION
* Add dngvd_op & dnevx_op in dngvd_op files.
* In CG-subspace, the otherwise inefficient dngv_op was replaced with a more efficient dngvd_op.
* In Davidson, the otherwise inefficient dngvx_op was replaced with a more efficient dnevx_op.