### PR TITLE
Build: use Release for default build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,9 +92,6 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
   add_compile_options(-g) # Add debug info by default
 endif()
-if(NOT USE_CUDA) # nvcc does not take -Ofast flag
-  set(CMAKE_CXX_FLAGS_RELEASE "-Ofast -DNDEBUG") # We use Ofast instead of O3 for a better performance
-endif()
 
 if(ENABLE_LCAO)
   find_package(Cereal REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,12 +76,25 @@ endif()
 #   this will disable all assertions.
 # Other default configurations are also available, see:
 # https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#default-and-custom-configurations
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  if(NOT ENABLE_COVERAGE)
-    add_compile_options(-O2 -g) # default flag
-  else()
-    add_compile_options(-g)
-  endif()
+# For default flags, see:
+# https://github.com/Kitware/CMake/blob/master/Modules/Compiler/GNU.cmake#L55
+
+if(ENABLE_COVERAGE)
+  set(CMAKE_BUILD_TYPE "Debug")
+endif()
+if(ENABLE_ASAN)
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+endif()
+
+if(NOT CMAKE_BUILD_TYPE)
+  message(STATUS "Build type not set - defaulting to Release")
+  # Choose the type of build from: Debug Release RelWithDebInfo MinSizeRel
+  set(CMAKE_BUILD_TYPE "Release")
+  add_compile_options(-g) # Add debug info by default
+endif()
+
+if(${CMAKE_BUILD_TYPE} MATCHES Release)
+  add_compile_options(-Ofast)
 endif()
 
 if(ENABLE_LCAO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ if (CCACHE)
   set (CMAKE_C_COMPILER_LAUNCHER ${CCACHE} ${CMAKE_C_COMPILER_LAUNCHER})
 endif()
 
+# Choose build type from: Debug Release RelWithDebInfo MinSizeRel
 # Select 'Release' configuration for best performance;
 #   this will disable all assertions.
 # Other default configurations are also available, see:
@@ -87,10 +88,7 @@ if(ENABLE_ASAN)
 endif()
 
 if(NOT CMAKE_BUILD_TYPE)
-  message(STATUS "Build type not set - defaulting to Release")
-  # Choose the type of build from: Debug Release RelWithDebInfo MinSizeRel
-  set(CMAKE_BUILD_TYPE "Release")
-  add_compile_options(-g) # Add debug info by default
+  add_compile_options(-O3 -g)
 endif()
 
 if(ENABLE_LCAO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,9 +92,8 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
   add_compile_options(-g) # Add debug info by default
 endif()
-
-if(${CMAKE_BUILD_TYPE} MATCHES Release)
-  add_compile_options(-Ofast)
+if(NOT USE_CUDA) # nvcc does not take -Ofast flag
+  set(CMAKE_CXX_FLAGS_RELEASE "-Ofast -DNDEBUG") # We use Ofast instead of O3 for a better performance
 endif()
 
 if(ENABLE_LCAO)


### PR DESCRIPTION
This PR sets the default build type of CMake to Release. It also sets '-Ofast' flag for Release build type. This modification on compilation flag(-Ofast) will makes the program run ~10% faster comparing with the default flag(-O2) before this PR, and will not affect the accuracy.