### PR TITLE
Feature: Add single precision support for ROCm operators

### DIFF
--- a/cmake/FindFFTW3.cmake
+++ b/cmake/FindFFTW3.cmake
@@ -35,7 +35,7 @@ endif()
 # set FFTW3_FOUND to TRUE if all variables are non-zero.
 include(FindPackageHandleStandardArgs)
 if (USE_OPENMP)
-find_package_handle_standard_args(FFTW3 DEFAULT_MSG FFTW3_OMP_LIBRARY FFTW3_LIBRARY FFTW3_INCLUDE_DIR)
+find_package_handle_standard_args(FFTW3 DEFAULT_MSG FFTW3_OMP_LIBRARY FFTW3_LIBRARY FFTW3_LIBRARY_FLOAT FFTW3_INCLUDE_DIR)
 else()
 find_package_handle_standard_args(FFTW3 DEFAULT_MSG FFTW3_LIBRARY FFTW3_LIBRARY_FLOAT FFTW3_INCLUDE_DIR)
 endif()

--- a/cmake/FindFFTW3.cmake
+++ b/cmake/FindFFTW3.cmake
@@ -35,9 +35,9 @@ endif()
 # set FFTW3_FOUND to TRUE if all variables are non-zero.
 include(FindPackageHandleStandardArgs)
 if (USE_OPENMP)
-find_package_handle_standard_args(FFTW3 DEFAULT_MSG FFTW3_OMP_LIBRARY FFTW3_LIBRARY FFTW3_LIBRARY_FLOAT FFTW3_INCLUDE_DIR)
+find_package_handle_standard_args(FFTW3 DEFAULT_MSG FFTW3_OMP_LIBRARY FFTW3_LIBRARY FFTW3_FLOAT_LIBRARY FFTW3_INCLUDE_DIR)
 else()
-find_package_handle_standard_args(FFTW3 DEFAULT_MSG FFTW3_LIBRARY FFTW3_LIBRARY_FLOAT FFTW3_INCLUDE_DIR)
+find_package_handle_standard_args(FFTW3 DEFAULT_MSG FFTW3_LIBRARY FFTW3_FLOAT_LIBRARY FFTW3_INCLUDE_DIR)
 endif()
 
 # Copy the results to the output variables and target.

--- a/cmake/FindFFTW3.cmake
+++ b/cmake/FindFFTW3.cmake
@@ -37,7 +37,7 @@ include(FindPackageHandleStandardArgs)
 if (USE_OPENMP)
 find_package_handle_standard_args(FFTW3 DEFAULT_MSG FFTW3_OMP_LIBRARY FFTW3_LIBRARY FFTW3_INCLUDE_DIR)
 else()
-find_package_handle_standard_args(FFTW3 DEFAULT_MSG FFTW3_LIBRARY FFTW3_INCLUDE_DIR)
+find_package_handle_standard_args(FFTW3 DEFAULT_MSG FFTW3_LIBRARY FFTW3_LIBRARY_FLOAT FFTW3_INCLUDE_DIR)
 endif()
 
 # Copy the results to the output variables and target.

--- a/source/module_base/kernels/rocm/math_op.hip.cu
+++ b/source/module_base/kernels/rocm/math_op.hip.cu
@@ -1,4 +1,4 @@
-#include "module_base/include/math_multi_device.h"
+#include "module_base/kernels/math_op.h"
 
 #include <hip/hip_runtime.h>
 
@@ -149,6 +149,7 @@ void cal_ylm_real_op<FPTYPE, psi::DEVICE_GPU>::operator() (
         ylm);
 }
 
+template struct cal_ylm_real_op<float, psi::DEVICE_GPU>;
 template struct cal_ylm_real_op<double, psi::DEVICE_GPU>;
 
 }  // namespace src_pw

--- a/source/module_elecstate/kernels/rocm/elecstate_op.hip.cu
+++ b/source/module_elecstate/kernels/rocm/elecstate_op.hip.cu
@@ -1,11 +1,11 @@
-#include "module_elecstate/include/elecstate_multi_device.h"
+#include "module_elecstate/kernels/elecstate_op.h"
 #include <thrust/complex.h>
 
 #include <hip/hip_runtime.h>
 
 #define THREADS_PER_BLOCK 256
 
-namespace elecstate{
+namespace elecstate {
 
 template<typename FPTYPE>
 __global__ void elecstate_pw(
@@ -91,5 +91,6 @@ void elecstate_pw_op<FPTYPE, psi::DEVICE_GPU>::operator()(
   );
 }
 
+template struct elecstate_pw_op<float, psi::DEVICE_GPU>;
 template struct elecstate_pw_op<double, psi::DEVICE_GPU>;
 }

--- a/source/module_gint/gint_gamma.h
+++ b/source/module_gint/gint_gamma.h
@@ -10,7 +10,9 @@
 #include "../module_base/global_variable.h"
 #include "grid_technique.h"
 #include "../src_lcao/LCAO_matrix.h"
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 
 //=========================================================
 // ModuleBase::Integral On 3D Grids, different from Grid_Integral

--- a/source/module_hamilt/kernels/rocm/ekinetic_op.hip.cu
+++ b/source/module_hamilt/kernels/rocm/ekinetic_op.hip.cu
@@ -1,4 +1,4 @@
-#include "module_hamilt/include/ekinetic.h"
+#include "module_hamilt/kernels/ekinetic_op.h"
 
 #include <complex>
 #include <thrust/complex.h>
@@ -55,5 +55,6 @@ void hamilt::ekinetic_pw_op<FPTYPE, psi::DEVICE_GPU>::operator() (
 }
 
 namespace hamilt{
+template struct ekinetic_pw_op<float, psi::DEVICE_GPU>;
 template struct ekinetic_pw_op<double, psi::DEVICE_GPU>;
 }

--- a/source/module_hamilt/kernels/rocm/meta_op.hip.cu
+++ b/source/module_hamilt/kernels/rocm/meta_op.hip.cu
@@ -1,0 +1,66 @@
+#include "module_hamilt/kernels/meta_op.h"
+
+#include <complex>
+
+#include <thrust/complex.h>
+#include <hip/hip_runtime.h>
+
+namespace hamilt {
+
+#define THREADS_PER_BLOCK 256
+
+
+template <typename FPTYPE>
+__global__ void meta_pw(
+        const int ik,
+        const int pol,
+        const int npw,
+        const int npwx,
+        const FPTYPE tpiba,
+        const FPTYPE* gcar,
+        const FPTYPE* kvec_c,
+        const thrust::complex<FPTYPE>* in,
+        thrust::complex<FPTYPE>* out,
+        const bool add)
+{
+    int ig = blockIdx.x * blockDim.x + threadIdx.x;
+    if (ig >= npw) {return;}
+
+    FPTYPE fact = (gcar[(ik * npwx + ig) * 3 + pol] +
+                   kvec_c[ik * 3 + pol]) * tpiba;
+    if (add) {
+        out[ig] -= in[ig] * thrust::complex<FPTYPE>(0.0, fact);
+    }
+    else {
+        out[ig] = in[ig] * thrust::complex<FPTYPE>(0.0, fact);
+    }
+}
+
+template <typename FPTYPE>
+void meta_pw_op<FPTYPE, psi::DEVICE_GPU>::operator() (
+        const psi::DEVICE_GPU* dev,
+        const int& ik,
+        const int& pol,
+        const int& npw,
+        const int& npwx,
+        const FPTYPE& tpiba,
+        const FPTYPE* gcar,
+        const FPTYPE* kvec_c,
+        const std::complex<FPTYPE>* in,
+        std::complex<FPTYPE>* out,
+        const bool add)
+{
+    const int block = (npw + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(meta_pw<FPTYPE>), dim3(block), dim3(THREADS_PER_BLOCK), 0, 0, 
+        ik, pol, npw, npwx,
+        tpiba,
+        gcar, kvec_c,
+        reinterpret_cast<const thrust::complex<FPTYPE> * >(in),
+        reinterpret_cast<thrust::complex<FPTYPE> * >(out),
+        add);
+}
+
+template struct meta_pw_op<float, psi::DEVICE_GPU>;
+template struct meta_pw_op<double, psi::DEVICE_GPU>;
+
+}  // namespace hamilt

--- a/source/module_hamilt/kernels/rocm/nonlocal_op.hip.cu
+++ b/source/module_hamilt/kernels/rocm/nonlocal_op.hip.cu
@@ -1,4 +1,4 @@
-#include "module_hamilt/include/nonlocal.h"
+#include "module_hamilt/kernels/nonlocal_op.h"
 
 #include <complex>
 #include <thrust/complex.h>
@@ -147,5 +147,6 @@ void hamilt::nonlocal_pw_op<FPTYPE, psi::DEVICE_GPU>::operator() (
 }
 
 namespace hamilt{
+template struct nonlocal_pw_op<float, psi::DEVICE_GPU>;
 template struct nonlocal_pw_op<double, psi::DEVICE_GPU>;
 }

--- a/source/module_hamilt/kernels/rocm/veff_op.hip.cu
+++ b/source/module_hamilt/kernels/rocm/veff_op.hip.cu
@@ -1,4 +1,4 @@
-#include "module_hamilt/include/veff.h"
+#include "module_hamilt/kernels/veff_op.h"
 
 #include <complex>
 #include <thrust/complex.h>
@@ -88,6 +88,7 @@ void veff_pw_op<FPTYPE, psi::DEVICE_GPU>::operator() (
     // }
 }
 
+template struct veff_pw_op<float, psi::DEVICE_GPU>;
 template struct veff_pw_op<double, psi::DEVICE_GPU>;
 
 }  // namespace hamilt

--- a/source/module_hsolver/kernels/rocm/dngvd_op.hip.cu
+++ b/source/module_hsolver/kernels/rocm/dngvd_op.hip.cu
@@ -1,4 +1,4 @@
-#include "module_hsolver/include/dngvd_op.h"
+#include "module_hsolver/kernels/dngvd_op.h"
 
 #include <hip/hip_runtime.h>
 
@@ -13,47 +13,24 @@ void destoryCUSOLVERhandle() {
 }
 
 template <>
-void dngvx_op<double, psi::DEVICE_GPU>::operator()(const psi::DEVICE_GPU* ctx,
+void dngvd_op<float, psi::DEVICE_GPU>::operator()(const psi::DEVICE_GPU* ctx,
                                                    const int nstart,
                                                    const int ldh,
-                                                   const std::complex<double>* _hcc, // hcc
-                                                   const std::complex<double>* _scc, // scc
-                                                   const int nbands, // nbands
-                                                   double* _eigenvalue,  // eigenvalue
-                                                   std::complex<double>* _vcc) // vcc
+                                                   const std::complex<float>* _hcc,
+                                                   const std::complex<float>* _scc,
+                                                   float* _eigenvalue,
+                                                   std::complex<float>* _vcc)
 {
-    std::vector<std::complex<double>> hcc(nstart * nstart, {0, 0});
-    std::vector<std::complex<double>> scc(nstart * nstart, {0, 0});
-    std::vector<std::complex<double>> vcc(nstart * nstart, {0, 0});
-    std::vector<double> eigenvalue(nbands, 0);
-    hipMemcpy(hcc.data(), _hcc, sizeof(std::complex<double>) * hcc.size(), hipMemcpyDeviceToHost);
-    hipMemcpy(scc.data(), _scc, sizeof(std::complex<double>) * scc.size(), hipMemcpyDeviceToHost);
+    std::vector<std::complex<float>> hcc(nstart * nstart, {0, 0});
+    std::vector<std::complex<float>> scc(nstart * nstart, {0, 0});
+    std::vector<std::complex<float>> vcc(nstart * nstart, {0, 0});
+    std::vector<float> eigenvalue(nstart, 0);
+    hipMemcpy(hcc.data(), _hcc, sizeof(std::complex<float>) * hcc.size(), hipMemcpyDeviceToHost);
+    hipMemcpy(scc.data(), _scc, sizeof(std::complex<float>) * scc.size(), hipMemcpyDeviceToHost);
     psi::DEVICE_CPU * cpu_ctx = {};
-    dngvx_op<double, psi::DEVICE_CPU>()(cpu_ctx, nstart, ldh, hcc.data(), scc.data(), nbands, eigenvalue.data(), vcc.data());
-    hipMemcpy(_vcc, vcc.data(), sizeof(std::complex<double>) * vcc.size(), hipMemcpyHostToDevice);
-    hipMemcpy(_eigenvalue, eigenvalue.data(), sizeof(double) * eigenvalue.size(), hipMemcpyHostToDevice);
-};
-
-template <>
-void dngv_op<double, psi::DEVICE_GPU>::operator()(const psi::DEVICE_GPU* ctx,
-                                                  const int nstart,
-                                                  const int ldh,
-                                                  const std::complex<double>* _hcc,
-                                                  const std::complex<double>* _scc,
-                                                  double* _eigenvalue,
-                                                  std::complex<double>* _vcc)
-                                                  
-{
-    std::vector<std::complex<double>> hcc(nstart * nstart, {0, 0});
-    std::vector<std::complex<double>> scc(nstart * nstart, {0, 0});
-    std::vector<std::complex<double>> vcc(nstart * nstart, {0, 0});
-    std::vector<double> eigenvalue(nstart, 0);
-    hipMemcpy(hcc.data(), _hcc, sizeof(std::complex<double>) * hcc.size(), hipMemcpyDeviceToHost);
-    hipMemcpy(scc.data(), _scc, sizeof(std::complex<double>) * scc.size(), hipMemcpyDeviceToHost);
-    psi::DEVICE_CPU * cpu_ctx = {};
-    dngv_op<double, psi::DEVICE_CPU>()(cpu_ctx, nstart, ldh, hcc.data(), scc.data(), eigenvalue.data(), vcc.data());
-    hipMemcpy(_vcc, vcc.data(), sizeof(std::complex<double>) * vcc.size(), hipMemcpyHostToDevice);
-    hipMemcpy(_eigenvalue, eigenvalue.data(), sizeof(double) * eigenvalue.size(), hipMemcpyHostToDevice);
+    dngvd_op<float, psi::DEVICE_CPU>()(cpu_ctx, nstart, ldh, hcc.data(), scc.data(), eigenvalue.data(), vcc.data());
+    hipMemcpy(_vcc, vcc.data(), sizeof(std::complex<float>) * vcc.size(), hipMemcpyHostToDevice);
+    hipMemcpy(_eigenvalue, eigenvalue.data(), sizeof(float) * eigenvalue.size(), hipMemcpyHostToDevice);
 }
 
 template <>
@@ -75,6 +52,26 @@ void dngvd_op<double, psi::DEVICE_GPU>::operator()(const psi::DEVICE_GPU* ctx,
     dngvd_op<double, psi::DEVICE_CPU>()(cpu_ctx, nstart, ldh, hcc.data(), scc.data(), eigenvalue.data(), vcc.data());
     hipMemcpy(_vcc, vcc.data(), sizeof(std::complex<double>) * vcc.size(), hipMemcpyHostToDevice);
     hipMemcpy(_eigenvalue, eigenvalue.data(), sizeof(double) * eigenvalue.size(), hipMemcpyHostToDevice);
+}
+
+
+template <>
+void dnevx_op<float, psi::DEVICE_GPU>::operator()(const psi::DEVICE_GPU* ctx,
+                                                   const int nstart,
+                                                   const int ldh,
+                                                   const std::complex<float>* _hcc,
+                                                   const int m,
+                                                   float* _eigenvalue,
+                                                   std::complex<float>* _vcc)
+{
+    std::vector<std::complex<float>> hcc(ldh * ldh, {0, 0});
+    std::vector<std::complex<float>> vcc(ldh * ldh, {0, 0});
+    std::vector<float> eigenvalue(ldh, 0);
+    hipMemcpy(hcc.data(), _hcc, sizeof(std::complex<float>) * hcc.size(), hipMemcpyDeviceToHost);
+    psi::DEVICE_CPU * cpu_ctx = {};
+    dnevx_op<float, psi::DEVICE_CPU>()(cpu_ctx, nstart, ldh, hcc.data(), m, eigenvalue.data(), vcc.data());
+    hipMemcpy(_vcc, vcc.data(), sizeof(std::complex<float>) * vcc.size(), hipMemcpyHostToDevice);
+    hipMemcpy(_eigenvalue, eigenvalue.data(), sizeof(float) * eigenvalue.size(), hipMemcpyHostToDevice);
 }
 
 template <>

--- a/source/module_hsolver/kernels/rocm/math_kernel_op.hip.cu
+++ b/source/module_hsolver/kernels/rocm/math_kernel_op.hip.cu
@@ -1,18 +1,25 @@
-#include "module_hsolver/include/math_kernel.h"
+#include "module_hsolver/kernels/math_kernel_op.h"
 #include "module_psi/psi.h"
-#include "module_psi/include/memory.h"
+#include "module_psi/kernels/memory_op.h"
 
 #include <hipblas.h>
-#include <hip/hip_runtime.h>
 #include <thrust/complex.h>
-#include <thrust/inner_product.h>
-#include <thrust/execution_policy.h>
+#include <hip/hip_runtime.h>
 
 namespace hsolver {
 
 
 static hipblasHandle_t cublas_handle = nullptr;
 
+static inline
+void xdot_wrapper(const int &n, const float * x, const int &incx, const float * y, const int &incy, float &result) {
+    hipblasSdot(cublas_handle, n, x, incx, y, incy, &result);
+}
+
+static inline
+void xdot_wrapper(const int &n, const double * x, const int &incx, const double * y, const int &incy, double &result) {
+    hipblasDdot(cublas_handle, n, x, incx, y, incy, &result);
+}
 
 void createBLAShandle(){
     if (cublas_handle == nullptr) {
@@ -86,6 +93,42 @@ __global__ void constantvector_addORsub_constantVector_kernel(
     }
 }
 
+template <typename FPTYPE>
+__global__ void matrix_transpose_kernel(
+        const int row,
+        const int col,
+        const thrust::complex<FPTYPE>* in,
+        thrust::complex<FPTYPE>* out)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < row)
+    {
+        for (int j = 0; j < col; j++)
+        {
+            out[j * row + i] = in[i * col + j];
+        }
+    }
+}
+
+
+template <typename FPTYPE>
+__global__ void matrix_setTo_another_kernel(
+        const int n,
+        const int LDA,
+        const int LDB,
+        const thrust::complex<FPTYPE>* matrix_A,
+        thrust::complex<FPTYPE>* matrix_B)
+{
+    int j = blockIdx.x * blockDim.x + threadIdx.x;
+    if (j < LDA && j < LDB)
+    {
+        for (int i = 0; i < n; i++)
+        {
+            matrix_B[i * LDB + j] = matrix_A[i * LDA + j];
+        }
+    }
+}
+
 
 // for this implementation, please check
 // https://thrust.github.io/doc/group__transformed__reductions_ga321192d85c5f510e52300ae762c7e995.html denghui modify
@@ -104,7 +147,7 @@ FPTYPE zdot_real_op<FPTYPE, psi::DEVICE_GPU>::operator()(
   const FPTYPE* pL = reinterpret_cast<const FPTYPE*>(psi_L);
   const FPTYPE* pR = reinterpret_cast<const FPTYPE*>(psi_R);
   FPTYPE result = 0.0;
-  hipblasDdot(cublas_handle, dim * 2, pL, 1, pR, 1, &result);
+  xdot_wrapper(dim * 2, pL, 1, pR, 1, result);
   if (reduce) {
       Parallel_Reduce::reduce_double_pool(result);
   }
@@ -224,7 +267,7 @@ void gemv_op<float, psi::DEVICE_GPU>::operator()(
     std::complex<float> *Y, 
     const int& incy)
 {
-    hipblasOperation_t cutrans;
+    hipblasOperation_t cutrans = {};
     if (trans == 'N'){
         cutrans = HIPBLAS_OP_N;
     } 
@@ -252,7 +295,7 @@ void gemv_op<double, psi::DEVICE_GPU>::operator()(
     std::complex<double> *Y, 
     const int& incy)
 {
-    hipblasOperation_t cutrans;
+    hipblasOperation_t cutrans = {};
     if (trans == 'N'){
         cutrans = HIPBLAS_OP_N;
     } 
@@ -265,7 +308,15 @@ void gemv_op<double, psi::DEVICE_GPU>::operator()(
     hipblasZgemv(cublas_handle, cutrans, m, n, (hipblasDoubleComplex*)alpha, (hipblasDoubleComplex*)A, lda, (hipblasDoubleComplex*)X, incx, (hipblasDoubleComplex*)beta, (hipblasDoubleComplex*)Y, incx);
 }
 
-
+template <>
+void scal_op<float, psi::DEVICE_GPU>::operator()(const psi::DEVICE_GPU* d,
+                                                 const int& N,
+                                                 const std::complex<float>* alpha,
+                                                 std::complex<float>* X,
+                                                 const int& incx)
+{
+    hipblasCscal(cublas_handle, N, (hipblasComplex*)alpha, (hipblasComplex*)X, incx);
+}
 
 template <>
 void scal_op<double, psi::DEVICE_GPU>::operator()(const psi::DEVICE_GPU* d,
@@ -275,17 +326,6 @@ void scal_op<double, psi::DEVICE_GPU>::operator()(const psi::DEVICE_GPU* d,
                                                   const int& incx)
 {
     hipblasZscal(cublas_handle, N, (hipblasDoubleComplex*)alpha, (hipblasDoubleComplex*)X, incx);
-}
-
-template <>
-void scal_op<float, psi::DEVICE_GPU>::operator()(const psi::DEVICE_GPU* d,
-                                                 const int& N,
-                                                 const std::complex<float>* alpha,
-                                                 std::complex<float>* X,
-                                                 const int& incx)
-
-{
-    hipblasCscal(cublas_handle, N, (hipblasComplex*)alpha, (hipblasComplex*)X, incx);
 }
 
 
@@ -305,8 +345,8 @@ void gemm_op<float, psi::DEVICE_GPU>::operator()(const psi::DEVICE_GPU* d,
                                                  std::complex<float> *c, 
                                                  const int& ldc)
 {
-    hipblasOperation_t cutransA;
-    hipblasOperation_t cutransB;
+    hipblasOperation_t cutransA = {};
+    hipblasOperation_t cutransB = {};
     // cutransA
     if (transa == 'N'){
         cutransA = HIPBLAS_OP_N;
@@ -371,22 +411,38 @@ void gemm_op<double, psi::DEVICE_GPU>::operator()(const psi::DEVICE_GPU* d,
     hipblasZgemm(cublas_handle, cutransA, cutransB, m, n ,k, (hipblasDoubleComplex*)alpha, (hipblasDoubleComplex*)a , lda, (hipblasDoubleComplex*)b, ldb, (hipblasDoubleComplex*)beta, (hipblasDoubleComplex*)c, ldc);
 }
 
-
-template <typename FPTYPE>
-__global__ void matrix_transpose_kernel(
-        const int row,
-        const int col,
-        const thrust::complex<FPTYPE>* in,
-        thrust::complex<FPTYPE>* out) 
+template <>
+void matrixTranspose_op<float, psi::DEVICE_GPU>::operator()(const psi::DEVICE_GPU* d,
+                                                             const int& row,
+                                                             const int& col,
+                                                             const std::complex<float>* input_matrix,
+                                                             std::complex<float>* output_matrix)
 {
-    int i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i < row)
+    std::complex<float>* device_temp = nullptr;
+    psi::memory::resize_memory_op<std::complex<float>, psi::DEVICE_GPU>()(d, device_temp, row * col);
+
+    if (row == col)
     {
-        for (int j = 0; j < col; j++)
-        {
-            out[j * row + i] = in[i * col + j];
-        }
+        float2 ONE, ZERO;
+        ONE.x = 1.0;
+        ONE.y = 0.0;
+        ZERO.x = ZERO.y = 0.0;
+
+        // use 'geam' API todo transpose.
+        hipblasCgeam(cublas_handle, HIPBLAS_OP_T, HIPBLAS_OP_N, col, row,
+                                   reinterpret_cast<const hipblasComplex *>(&ONE), (hipblasComplex*)input_matrix, col,
+                                   reinterpret_cast<const hipblasComplex *>(&ZERO), (hipblasComplex*)input_matrix, col, (hipblasComplex*)device_temp, col);
+    } else
+    {
+        int thread = 1024;
+        int block = (row + col + thread - 1) / thread;
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(matrix_transpose_kernel<float>), dim3(block), dim3(thread), 0, 0, row, col, (thrust::complex<float>*)input_matrix, (thrust::complex<float>*)device_temp);
     }
+
+    psi::memory::synchronize_memory_op<std::complex<float>, psi::DEVICE_GPU, psi::DEVICE_GPU>()(d, d, output_matrix, device_temp, row * col);
+
+    psi::memory::delete_memory_op<std::complex<float>, psi::DEVICE_GPU>()(d, device_temp);
+
 }
 
 template <>
@@ -401,13 +457,9 @@ void matrixTranspose_op<double, psi::DEVICE_GPU>::operator()(const psi::DEVICE_G
 
     if (row == col)
     {
-        double2 ONE, ZERO;
-        ONE.x = 1.0;
-        ONE.y = 0.0;
-        ZERO.x = ZERO.y = 0.0;
-
+        hipblasDoubleComplex ONE{1.0, 0.0}, ZERO{0.0, 0.0};
         // use 'geam' API todo transpose.
-        hipblasZgeam(cublas_handle, HIPBLAS_OP_T, HIPBLAS_OP_N, col, row, (hipblasDoubleComplex*)&ONE, (hipblasDoubleComplex*)input_matrix, col, (hipblasDoubleComplex*)&ZERO, (hipblasDoubleComplex*)input_matrix, col, (hipblasDoubleComplex*)device_temp, col);
+        hipblasZgeam(cublas_handle, HIPBLAS_OP_T, HIPBLAS_OP_N, col, row, &ONE, (hipblasDoubleComplex*)input_matrix, col, &ZERO, (hipblasDoubleComplex*)input_matrix, col, (hipblasDoubleComplex*)device_temp, col);
     } else
     {
         int thread = 1024;
@@ -422,25 +474,6 @@ void matrixTranspose_op<double, psi::DEVICE_GPU>::operator()(const psi::DEVICE_G
 }
 
 
-template <typename FPTYPE>
-__global__ void matrix_setTo_another_kernel(
-        const int n,
-        const int LDA,
-        const int LDB,
-        const thrust::complex<FPTYPE>* matrix_A,
-        thrust::complex<FPTYPE>* matrix_B)
-{
-    int j = blockIdx.x * blockDim.x + threadIdx.x;    
-    if (j < LDA && j < LDB)
-    {
-        for (int i = 0; i < n; i++)
-        {
-            matrix_B[i * LDB + j] = matrix_A[i * LDA + j];
-        }
-    }
-}
-
-
 template <typename FPTYPE> 
 void matrixSetToAnother<FPTYPE, psi::DEVICE_GPU>::operator()(
             const psi::DEVICE_GPU* d,
@@ -452,18 +485,24 @@ void matrixSetToAnother<FPTYPE, psi::DEVICE_GPU>::operator()(
 {
     int thread = 1024;
     int block = (LDA + thread - 1) / thread;
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(matrix_setTo_another_kernel<FPTYPE>), dim3(block), dim3(thread), 0, 0, n, LDA, LDB, (thrust::complex<double>*)A, (thrust::complex<double>*)B);
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(matrix_setTo_another_kernel<FPTYPE>), dim3(block), dim3(thread), 0, 0, n, LDA, LDB, reinterpret_cast<const thrust::complex<FPTYPE>*>(A), reinterpret_cast<thrust::complex<FPTYPE>*>(B));
 }
 
 
 
 // Explicitly instantiate functors for the types of functor registered.
+template struct zdot_real_op<float, psi::DEVICE_GPU>;
+template struct vector_div_constant_op<float, psi::DEVICE_GPU>;
+template struct vector_mul_vector_op<float, psi::DEVICE_GPU>;
+template struct vector_div_vector_op<float, psi::DEVICE_GPU>;
+template struct constantvector_addORsub_constantVector_op<float, psi::DEVICE_GPU>;
+template struct matrixSetToAnother<float, psi::DEVICE_GPU>;
+
 template struct zdot_real_op<double, psi::DEVICE_GPU>;
 template struct vector_div_constant_op<double, psi::DEVICE_GPU>;
 template struct vector_mul_vector_op<double, psi::DEVICE_GPU>;
 template struct vector_div_vector_op<double, psi::DEVICE_GPU>;
 template struct constantvector_addORsub_constantVector_op<double, psi::DEVICE_GPU>;
-
 template struct matrixSetToAnother<double, psi::DEVICE_GPU>;
 
-}
+}  // namespace hsolver

--- a/source/module_hsolver/kernels/rocm/math_kernel_op.hip.cu
+++ b/source/module_hsolver/kernels/rocm/math_kernel_op.hip.cu
@@ -36,6 +36,7 @@ void destoryBLAShandle(){
 
 // Define the CUDA kernel:
 template <typename FPTYPE>
+__launch_bounds__(1024) 
 __global__ void vector_div_constant_kernel(
     const int size, 
     thrust::complex<FPTYPE>* result, 
@@ -50,6 +51,7 @@ __global__ void vector_div_constant_kernel(
 }
 
 template <typename FPTYPE>
+__launch_bounds__(1024) 
 __global__ void vector_mul_vector_kernel(
     const int size, 
     thrust::complex<FPTYPE>* result, 
@@ -64,6 +66,7 @@ __global__ void vector_mul_vector_kernel(
 }
 
 template <typename FPTYPE>
+__launch_bounds__(1024) 
 __global__ void vector_div_vector_kernel(
     const int size, 
     thrust::complex<FPTYPE>* result, 
@@ -78,6 +81,7 @@ __global__ void vector_div_vector_kernel(
 }
 
 template <typename FPTYPE>
+__launch_bounds__(1024) 
 __global__ void constantvector_addORsub_constantVector_kernel(
     const int size,
     thrust::complex<FPTYPE>* result,
@@ -94,6 +98,7 @@ __global__ void constantvector_addORsub_constantVector_kernel(
 }
 
 template <typename FPTYPE>
+__launch_bounds__(1024) 
 __global__ void matrix_transpose_kernel(
         const int row,
         const int col,
@@ -112,6 +117,7 @@ __global__ void matrix_transpose_kernel(
 
 
 template <typename FPTYPE>
+__launch_bounds__(1024) 
 __global__ void matrix_setTo_another_kernel(
         const int n,
         const int LDA,

--- a/source/module_psi/kernels/rocm/memory_op.hip.cu
+++ b/source/module_psi/kernels/rocm/memory_op.hip.cu
@@ -1,14 +1,38 @@
-#include "module_psi/include/memory.h"
+#include "module_psi/kernels/memory_op.h"
 
-#include <vector>
-#include <stdio.h>
 #include <complex>
-#include <assert.h>
 
 #include <hip/hip_runtime.h>
+#include <thrust/complex.h>
+
+#define THREADS_PER_BLOCK 256
 
 namespace psi {
 namespace memory {
+
+template <typename FPTYPE_out, typename FPTYPE_in>
+__global__ void cast_memory(
+        FPTYPE_out* out,
+        const FPTYPE_in* in,
+        const int size)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if(idx >= size) {return;}
+    out[idx] = static_cast<FPTYPE_out>(in[idx]);
+}
+
+template <typename FPTYPE_out, typename FPTYPE_in>
+__global__ void cast_memory(
+        std::complex<FPTYPE_out>* out,
+        const std::complex<FPTYPE_in>* in,
+        const int size)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if(idx >= size) {return;}
+    auto* _out = reinterpret_cast<thrust::complex<FPTYPE_out>*>(out);
+    const auto* _in = reinterpret_cast<const thrust::complex<FPTYPE_in>*>(in);
+    _out[idx] = static_cast<thrust::complex<FPTYPE_out>>(_in[idx]);
+}
 
 template <typename FPTYPE>
 void resize_memory_op<FPTYPE, psi::DEVICE_GPU>::operator()(
@@ -65,6 +89,50 @@ void synchronize_memory_op<FPTYPE, psi::DEVICE_GPU, psi::DEVICE_GPU>::operator()
   hipMemcpy(arr_out, arr_in, sizeof(FPTYPE) * size, hipMemcpyDeviceToDevice);  
 }
 
+template <typename FPTYPE_out, typename FPTYPE_in>
+struct cast_memory_op<FPTYPE_out, FPTYPE_in, psi::DEVICE_GPU, psi::DEVICE_GPU> {
+    void operator()(const psi::DEVICE_GPU* dev_out,
+                    const psi::DEVICE_GPU* dev_in,
+                    FPTYPE_out* arr_out,
+                    const FPTYPE_in* arr_in,
+                    const size_t size) {
+        const int block = (size + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
+        hipLaunchKernelGGL(cast_memory, dim3(block), dim3(THREADS_PER_BLOCK), 0, 0, arr_out, arr_in, size);
+    }
+};
+
+template <typename FPTYPE_out, typename FPTYPE_in>
+struct cast_memory_op<FPTYPE_out, FPTYPE_in, psi::DEVICE_GPU, psi::DEVICE_CPU> {
+    void operator()(const psi::DEVICE_GPU* dev_out,
+                    const psi::DEVICE_CPU* dev_in,
+                    FPTYPE_out* arr_out,
+                    const FPTYPE_in* arr_in,
+                    const size_t size) {
+        FPTYPE_in * arr = nullptr;
+        hipMalloc((void **)&arr, sizeof(FPTYPE_in) * size);
+        hipMemcpy(arr, arr_in, sizeof(FPTYPE_in) * size, hipMemcpyHostToDevice);
+        const int block = (size + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
+        hipLaunchKernelGGL(cast_memory, dim3(block), dim3(THREADS_PER_BLOCK), 0, 0, arr_out, arr, size);
+        hipFree(arr);
+    }
+};
+
+template <typename FPTYPE_out, typename FPTYPE_in>
+struct cast_memory_op<FPTYPE_out, FPTYPE_in, psi::DEVICE_CPU, psi::DEVICE_GPU> {
+    void operator()(const psi::DEVICE_CPU* dev_out,
+                    const psi::DEVICE_GPU* dev_in,
+                    FPTYPE_out* arr_out,
+                    const FPTYPE_in* arr_in,
+                    const size_t size) {
+        auto * arr = (FPTYPE_in*) malloc(sizeof(FPTYPE_in) * size);
+        hipMemcpy(arr, arr_in, sizeof(FPTYPE_in) * size, hipMemcpyDeviceToHost);
+        for (int ii = 0; ii < size; ii++) {
+            arr_out[ii] = static_cast<FPTYPE_out>(arr[ii]);
+        }
+        free(arr);
+    }
+};
+
 template <typename FPTYPE>
 void delete_memory_op<FPTYPE, psi::DEVICE_GPU>::operator() (
     const psi::DEVICE_GPU* dev, 
@@ -74,25 +142,62 @@ void delete_memory_op<FPTYPE, psi::DEVICE_GPU>::operator() (
 }
 
 template struct resize_memory_op<int, psi::DEVICE_GPU>;
+template struct resize_memory_op<float, psi::DEVICE_GPU>;
 template struct resize_memory_op<double, psi::DEVICE_GPU>;
+template struct resize_memory_op<std::complex<float>, psi::DEVICE_GPU>;
 template struct resize_memory_op<std::complex<double>, psi::DEVICE_GPU>;
 
 template struct set_memory_op<int, psi::DEVICE_GPU>;
+template struct set_memory_op<float, psi::DEVICE_GPU>;
 template struct set_memory_op<double, psi::DEVICE_GPU>;
+template struct set_memory_op<std::complex<float>, psi::DEVICE_GPU>;
 template struct set_memory_op<std::complex<double>, psi::DEVICE_GPU>;
 
 template struct synchronize_memory_op<int, psi::DEVICE_CPU, psi::DEVICE_GPU>;
 template struct synchronize_memory_op<int, psi::DEVICE_GPU, psi::DEVICE_CPU>;
 template struct synchronize_memory_op<int, psi::DEVICE_GPU, psi::DEVICE_GPU>;
+template struct synchronize_memory_op<float, psi::DEVICE_CPU, psi::DEVICE_GPU>;
+template struct synchronize_memory_op<float, psi::DEVICE_GPU, psi::DEVICE_CPU>;
+template struct synchronize_memory_op<float, psi::DEVICE_GPU, psi::DEVICE_GPU>;
 template struct synchronize_memory_op<double, psi::DEVICE_CPU, psi::DEVICE_GPU>;
 template struct synchronize_memory_op<double, psi::DEVICE_GPU, psi::DEVICE_CPU>;
 template struct synchronize_memory_op<double, psi::DEVICE_GPU, psi::DEVICE_GPU>;
+template struct synchronize_memory_op<std::complex<float>, psi::DEVICE_CPU, psi::DEVICE_GPU>;
+template struct synchronize_memory_op<std::complex<float>, psi::DEVICE_GPU, psi::DEVICE_CPU>;
+template struct synchronize_memory_op<std::complex<float>, psi::DEVICE_GPU, psi::DEVICE_GPU>;
 template struct synchronize_memory_op<std::complex<double>, psi::DEVICE_CPU, psi::DEVICE_GPU>;
 template struct synchronize_memory_op<std::complex<double>, psi::DEVICE_GPU, psi::DEVICE_CPU>;
 template struct synchronize_memory_op<std::complex<double>, psi::DEVICE_GPU, psi::DEVICE_GPU>;
 
+template struct cast_memory_op<float, float, psi::DEVICE_GPU, psi::DEVICE_GPU>;
+template struct cast_memory_op<double, double, psi::DEVICE_GPU, psi::DEVICE_GPU>;
+template struct cast_memory_op<float, double, psi::DEVICE_GPU, psi::DEVICE_GPU>;
+template struct cast_memory_op<double, float, psi::DEVICE_GPU, psi::DEVICE_GPU>;
+template struct cast_memory_op<std::complex<float>, std::complex<float>, psi::DEVICE_GPU, psi::DEVICE_GPU>;
+template struct cast_memory_op<std::complex<double>, std::complex<double>, psi::DEVICE_GPU, psi::DEVICE_GPU>;
+template struct cast_memory_op<std::complex<float>, std::complex<double>, psi::DEVICE_GPU, psi::DEVICE_GPU>;
+template struct cast_memory_op<std::complex<double>, std::complex<float>, psi::DEVICE_GPU, psi::DEVICE_GPU>;
+template struct cast_memory_op<float, float, psi::DEVICE_GPU, psi::DEVICE_CPU>;
+template struct cast_memory_op<double, double, psi::DEVICE_GPU, psi::DEVICE_CPU>;
+template struct cast_memory_op<float, double, psi::DEVICE_GPU, psi::DEVICE_CPU>;
+template struct cast_memory_op<double, float, psi::DEVICE_GPU, psi::DEVICE_CPU>;
+template struct cast_memory_op<std::complex<float>, std::complex<float>, psi::DEVICE_GPU, psi::DEVICE_CPU>;
+template struct cast_memory_op<std::complex<double>, std::complex<double>, psi::DEVICE_GPU, psi::DEVICE_CPU>;
+template struct cast_memory_op<std::complex<float>, std::complex<double>, psi::DEVICE_GPU, psi::DEVICE_CPU>;
+template struct cast_memory_op<std::complex<double>, std::complex<float>, psi::DEVICE_GPU, psi::DEVICE_CPU>;
+template struct cast_memory_op<float, float, psi::DEVICE_CPU, psi::DEVICE_GPU>;
+template struct cast_memory_op<double, double, psi::DEVICE_CPU, psi::DEVICE_GPU>;
+template struct cast_memory_op<float, double, psi::DEVICE_CPU, psi::DEVICE_GPU>;
+template struct cast_memory_op<double, float, psi::DEVICE_CPU, psi::DEVICE_GPU>;
+template struct cast_memory_op<std::complex<float>, std::complex<float>, psi::DEVICE_CPU, psi::DEVICE_GPU>;
+template struct cast_memory_op<std::complex<double>, std::complex<double>, psi::DEVICE_CPU, psi::DEVICE_GPU>;
+template struct cast_memory_op<std::complex<float>, std::complex<double>, psi::DEVICE_CPU, psi::DEVICE_GPU>;
+template struct cast_memory_op<std::complex<double>, std::complex<float>, psi::DEVICE_CPU, psi::DEVICE_GPU>;
+
 template struct delete_memory_op<int, psi::DEVICE_GPU>;
+template struct delete_memory_op<float, psi::DEVICE_GPU>;
 template struct delete_memory_op<double, psi::DEVICE_GPU>;
+template struct delete_memory_op<std::complex<float>, psi::DEVICE_GPU>;
 template struct delete_memory_op<std::complex<double>, psi::DEVICE_GPU>;
 
 } // end of namespace gpu_cuda

--- a/source/module_pw/fft.cpp
+++ b/source/module_pw/fft.cpp
@@ -371,14 +371,14 @@ void FFT:: cleanFFT()
         #if defined(__CUDA)
             cufftDestroy(c_handle);
         #elif defined(__ROCM)
-            cufftDestroy(c_handle);
+            hipfftDestroy(c_handle);
         #endif
         }
         else {
         #if defined(__CUDA)
             cufftDestroy(z_handle);
         #elif defined(__ROCM)
-            cufftDestroy(z_handle);
+            hipfftDestroy(z_handle);
         #endif
         }
     }

--- a/source/module_pw/kernels/rocm/pw_op.hip.cu
+++ b/source/module_pw/kernels/rocm/pw_op.hip.cu
@@ -1,10 +1,10 @@
-#include "module_pw/include/pw_multi_device.h"
+#include "module_pw/kernels/pw_op.h"
 
 #include <thrust/complex.h>
 
 #include <hip/hip_runtime.h>
 
-namespace ModulePW{
+namespace ModulePW {
 
 #define THREADS_PER_BLOCK 256
 
@@ -70,7 +70,7 @@ void set_3d_fft_box_op<FPTYPE, psi::DEVICE_GPU>::operator()(
     std::complex<FPTYPE>* out)
 {
     const int block = (npwk + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(set_3d_fft_box<double>), dim3(block), dim3(THREADS_PER_BLOCK), 0, 0, 
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(set_3d_fft_box<FPTYPE>), dim3(block), dim3(THREADS_PER_BLOCK), 0, 0, 
         npwk,
         box_index,
         reinterpret_cast<const thrust::complex<FPTYPE>*>(in),
@@ -87,7 +87,7 @@ void set_recip_to_real_output_op<FPTYPE, psi::DEVICE_GPU>::operator()(
     std::complex<FPTYPE>* out)
 {
     const int block = (nrxx + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(set_recip_to_real_output<double>), dim3(block), dim3(THREADS_PER_BLOCK), 0, 0, 
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(set_recip_to_real_output<FPTYPE>), dim3(block), dim3(THREADS_PER_BLOCK), 0, 0, 
         nrxx,
         add,
         factor,
@@ -107,7 +107,7 @@ void set_real_to_recip_output_op<FPTYPE, psi::DEVICE_GPU>::operator()(
     std::complex<FPTYPE>* out)
 {
     const int block = (npwk + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(set_real_to_recip_output<double>), dim3(block), dim3(THREADS_PER_BLOCK), 0, 0, 
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(set_real_to_recip_output<FPTYPE>), dim3(block), dim3(THREADS_PER_BLOCK), 0, 0, 
         npwk,
         nxyz,
         add,
@@ -116,6 +116,10 @@ void set_real_to_recip_output_op<FPTYPE, psi::DEVICE_GPU>::operator()(
         reinterpret_cast<const thrust::complex<FPTYPE>*>(in),
         reinterpret_cast<thrust::complex<FPTYPE>*>(out));
 }
+
+template struct set_3d_fft_box_op<float, psi::DEVICE_GPU>;
+template struct set_recip_to_real_output_op<float, psi::DEVICE_GPU>;
+template struct set_real_to_recip_output_op<float, psi::DEVICE_GPU>;
 
 template struct set_3d_fft_box_op<double, psi::DEVICE_GPU>;
 template struct set_recip_to_real_output_op<double, psi::DEVICE_GPU>;

--- a/source/src_pw/kernels/rocm/force_op.hip.cu
+++ b/source/src_pw/kernels/rocm/force_op.hip.cu
@@ -1,4 +1,4 @@
-#include "src_pw/include/force_multi_device.h"
+#include "src_pw/kernels/force_op.h"
 
 #include <complex>
 
@@ -7,174 +7,165 @@
 
 #define THREADS_PER_BLOCK 256
 
-namespace src_pw{
+namespace src_pw {
 
-    __device__ double atomicAdd(double* address, double val) {
-        unsigned long long int* address_as_ull = (unsigned long long int*)address;
-        unsigned long long int old = *address_as_ull, assumed;
-        do {
-            assumed = old;
-            old = atomicCAS(address_as_ull, assumed,
-                            __double_as_longlong(val + __longlong_as_double(assumed)));
-        } while (assumed != old);
-        return __longlong_as_double(old);
+template <typename FPTYPE>
+__global__ void cal_vkb1_nl(
+        const int npwx,
+        const int npwk_max,
+        const int vkb_nc,
+        const int nbasis,
+        const int ik,
+        const int ipol,
+        const thrust::complex<FPTYPE> NEG_IMAG_UNIT,
+        const thrust::complex<FPTYPE> *vkb,
+        const FPTYPE *gcar,
+        thrust::complex<FPTYPE> *vkb1)
+{
+    thrust::complex<FPTYPE> *pvkb1 = vkb1 + blockIdx.x * npwx;
+    const thrust::complex<FPTYPE> *pvkb = vkb + blockIdx.x * vkb_nc;
+    for (int ig = threadIdx.x; ig < nbasis; ig += blockDim.x) {
+        pvkb1[ig] = pvkb[ig] * NEG_IMAG_UNIT * gcar[(ik * npwk_max + ig) * 3 + ipol];
+    }
+}
+
+template <typename FPTYPE>
+__global__ void cal_force_nl(
+        const bool multi_proj,
+        const int wg_nc,
+        const int ntype,
+        const int spin,
+        const int deeq_2,
+        const int deeq_3,
+        const int deeq_4,
+        const int forcenl_nc,
+        const int nbands,
+        const int ik,
+        const int nkb,
+        const int *atom_nh,
+        const int *atom_na,
+        const FPTYPE tpiba,
+        const FPTYPE *d_wg,
+        const FPTYPE *deeq,
+        const thrust::complex<FPTYPE> *becp,
+        const thrust::complex<FPTYPE> *dbecp,
+        FPTYPE *force)
+{
+    const int ib = blockIdx.x / ntype;
+    const int it = blockIdx.x % ntype;
+
+    int iat = 0, sum = 0;
+    for (int ii = 0; ii < it; ii++) {
+        iat += atom_na[ii];
+        sum += atom_na[ii] * atom_nh[ii];
     }
 
+    int Nprojs = atom_nh[it];
+    double fac = d_wg[ik * wg_nc + ib] * 2.0 * tpiba;
+    for (int ia = 0; ia < atom_na[it]; ia++) {
+        for (int ip = threadIdx.x; ip < Nprojs; ip += blockDim.x) {
+            // double ps = GlobalC::ppcell.deeq[GlobalV::CURRENT_SPIN, iat, ip, ip];
+            double ps = deeq[((spin * deeq_2 + iat) * deeq_3 + ip) * deeq_4 + ip];
+            const int inkb = sum + ip;
+            //out<<"\n ps = "<<ps;
 
-    template <typename FPTYPE>
-    __global__ void cal_vkb1_nl(
-            const int npwx,
-            const int npwk_max,
-            const int vkb_nc,
-            const int nbasis,
-            const int ik,
-            const int ipol,
-            const thrust::complex<FPTYPE> NEG_IMAG_UNIT,
-            const thrust::complex<FPTYPE> *vkb,
-            const FPTYPE *gcar,
-            thrust::complex<FPTYPE> *vkb1)
-    {
-        thrust::complex<FPTYPE> *pvkb1 = vkb1 + blockIdx.x * npwx;
-        const thrust::complex<FPTYPE> *pvkb = vkb + blockIdx.x * vkb_nc;
-        for (int ig = threadIdx.x; ig < nbasis; ig += blockDim.x) {
-            pvkb1[ig] = pvkb[ig] * NEG_IMAG_UNIT * gcar[(ik * npwk_max + ig) * 3 + ipol];
-        }
-    }
+            for (int ipol = 0; ipol < 3; ipol++) {
+                const double dbb = (conj(dbecp[ipol * nbands * nkb + ib * nkb + inkb]) *
+                                    becp[ib * nkb + inkb]).real();
+                // force[iat * forcenl_nc + ipol] -= ps * fac * dbb;
+                atomicAdd(force + iat * forcenl_nc + ipol, -ps * fac * dbb);
+                //cf[iat*3+ipol] += ps * fac * dbb;
+            }
 
-    template <typename FPTYPE>
-    __global__ void cal_force_nl(
-            const bool multi_proj,
-            const int wg_nc,
-            const int ntype,
-            const int spin,
-            const int deeq_2,
-            const int deeq_3,
-            const int deeq_4,
-            const int forcenl_nc,
-            const int nbands,
-            const int ik,
-            const int nkb,
-            const int *atom_nh,
-            const int *atom_na,
-            const FPTYPE tpiba,
-            const FPTYPE *d_wg,
-            const FPTYPE *deeq,
-            const thrust::complex<FPTYPE> *becp,
-            const thrust::complex<FPTYPE> *dbecp,
-            FPTYPE *force)
-    {
-        const int ib = blockIdx.x / ntype;
-        const int it = blockIdx.x % ntype;
-
-        int iat = 0, sum = 0;
-        for (int ii = 0; ii < it; ii++) {
-            iat += atom_na[ii];
-            sum += atom_na[ii] * atom_nh[ii];
-        }
-
-        int Nprojs = atom_nh[it];
-        double fac = d_wg[ik * wg_nc + ib] * 2.0 * tpiba;
-        for (int ia = 0; ia < atom_na[it]; ia++) {
-            for (int ip = threadIdx.x; ip < Nprojs; ip += blockDim.x) {
-                // double ps = GlobalC::ppcell.deeq[GlobalV::CURRENT_SPIN, iat, ip, ip];
-                double ps = deeq[((spin * deeq_2 + iat) * deeq_3 + ip) * deeq_4 + ip];
-                const int inkb = sum + ip;
-                //out<<"\n ps = "<<ps;
-
-                for (int ipol = 0; ipol < 3; ipol++) {
-                    const double dbb = (conj(dbecp[ipol * nbands * nkb + ib * nkb + inkb]) *
-                                        becp[ib * nkb + inkb]).real();
-                    // force[iat * forcenl_nc + ipol] -= ps * fac * dbb;
-                    atomicAdd(force + iat * forcenl_nc + ipol, -ps * fac * dbb);
-                    //cf[iat*3+ipol] += ps * fac * dbb;
-                }
-
-                if (multi_proj) {
-                    //for (int ip2=0; ip2<Nprojs; ip2++)
-                    for (int ip2 = 0; ip2 < Nprojs; ip2++) {
-                        if (ip != ip2) {
-                            const int jnkb = sum + ip2;
-                            ps = deeq[((spin * deeq_2 + iat) * deeq_3 + ip) * deeq_4 + ip2];
-                            for (int ipol = 0; ipol < 3; ipol++) {
-                                const double dbb = (conj(dbecp[ipol * nbands * nkb + ib * nkb + inkb]) *
-                                                    becp[ib * nkb + jnkb]).real();
-                                atomicAdd(force + iat * forcenl_nc + ipol, -ps * fac * dbb);
-                            }
+            if (multi_proj) {
+                //for (int ip2=0; ip2<Nprojs; ip2++)
+                for (int ip2 = 0; ip2 < Nprojs; ip2++) {
+                    if (ip != ip2) {
+                        const int jnkb = sum + ip2;
+                        ps = deeq[((spin * deeq_2 + iat) * deeq_3 + ip) * deeq_4 + ip2];
+                        for (int ipol = 0; ipol < 3; ipol++) {
+                            const double dbb = (conj(dbecp[ipol * nbands * nkb + ib * nkb + inkb]) *
+                                                becp[ib * nkb + jnkb]).real();
+                            atomicAdd(force + iat * forcenl_nc + ipol, -ps * fac * dbb);
                         }
                     }
                 }
             }
-            iat += 1;
-            sum += Nprojs;
         }
+        iat += 1;
+        sum += Nprojs;
     }
+}
 
-    template <typename FPTYPE>
-    void cal_vkb1_nl_op<FPTYPE, psi::DEVICE_GPU>::operator() (
-            const psi::DEVICE_GPU *ctx,
-            const int &nkb,
-            const int &npwx,
-            const int &npwk_max,
-            const int &vkb_nc,
-            const int &nbasis,
-            const int &ik,
-            const int &ipol,
-            const std::complex<FPTYPE> &NEG_IMAG_UNIT,
-            const std::complex<FPTYPE> *vkb,
-            const FPTYPE *gcar,
-            std::complex<FPTYPE> *vkb1)
-    {
-        hipLaunchKernelGGL(HIP_KERNEL_NAME(cal_vkb1_nl<FPTYPE>), dim3(nkb), dim3(THREADS_PER_BLOCK), 0, 0, 
-                npwx,
-                npwk_max,
-                vkb_nc,
-                nbasis,
-                ik,
-                ipol,
-                static_cast<const thrust::complex<FPTYPE>>(NEG_IMAG_UNIT), // array of data
-                reinterpret_cast<const thrust::complex<FPTYPE>*>(vkb),
-                gcar,// array of data
-                reinterpret_cast<thrust::complex<FPTYPE>*>(vkb1)); // array of data
-    }
+template <typename FPTYPE>
+void cal_vkb1_nl_op<FPTYPE, psi::DEVICE_GPU>::operator() (
+        const psi::DEVICE_GPU *ctx,
+        const int &nkb,
+        const int &npwx,
+        const int &npwk_max,
+        const int &vkb_nc,
+        const int &nbasis,
+        const int &ik,
+        const int &ipol,
+        const std::complex<FPTYPE> &NEG_IMAG_UNIT,
+        const std::complex<FPTYPE> *vkb,
+        const FPTYPE *gcar,
+        std::complex<FPTYPE> *vkb1)
+{
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(cal_vkb1_nl<FPTYPE>), dim3(nkb), dim3(THREADS_PER_BLOCK), 0, 0, 
+            npwx,
+            npwk_max,
+            vkb_nc,
+            nbasis,
+            ik,
+            ipol,
+            static_cast<const thrust::complex<FPTYPE>>(NEG_IMAG_UNIT), // array of data
+            reinterpret_cast<const thrust::complex<FPTYPE>*>(vkb),
+            gcar,// array of data
+            reinterpret_cast<thrust::complex<FPTYPE>*>(vkb1)); // array of data
+}
 
-    template <typename FPTYPE>
-    void cal_force_nl_op<FPTYPE, psi::DEVICE_GPU>::operator() (
-            const psi::DEVICE_GPU *ctx,
-            const bool &multi_proj,
-            const int &nbands_occ,
-            const int &wg_nc,
-            const int &ntype,
-            const int &spin,
-            const int &deeq_2,
-            const int &deeq_3,
-            const int &deeq_4,
-            const int &forcenl_nc,
-            const int &nbands,
-            const int &ik,
-            const int &nkb,
-            const int *atom_nh,
-            const int *atom_na,
-            const FPTYPE &tpiba,
-            const FPTYPE *d_wg,
-            const FPTYPE *deeq,
-            const std::complex<FPTYPE> *becp,
-            const std::complex<FPTYPE> *dbecp,
-            FPTYPE *force)
-    {
-        hipLaunchKernelGGL(HIP_KERNEL_NAME(cal_force_nl<FPTYPE>), dim3(nbands_occ * ntype), dim3(THREADS_PER_BLOCK), 0, 0, 
-                multi_proj,
-                wg_nc, ntype, spin,
-                deeq_2, deeq_3, deeq_4,
-                forcenl_nc, nbands, ik, nkb,
-                atom_nh, atom_na,
-                tpiba,
-                d_wg, deeq,
-                reinterpret_cast<const thrust::complex<FPTYPE>*>(becp),
-                reinterpret_cast<const thrust::complex<FPTYPE>*>(dbecp),
-                force);// array of data
-    }
+template <typename FPTYPE>
+void cal_force_nl_op<FPTYPE, psi::DEVICE_GPU>::operator() (
+        const psi::DEVICE_GPU *ctx,
+        const bool &multi_proj,
+        const int &nbands_occ,
+        const int &wg_nc,
+        const int &ntype,
+        const int &spin,
+        const int &deeq_2,
+        const int &deeq_3,
+        const int &deeq_4,
+        const int &forcenl_nc,
+        const int &nbands,
+        const int &ik,
+        const int &nkb,
+        const int *atom_nh,
+        const int *atom_na,
+        const FPTYPE &tpiba,
+        const FPTYPE *d_wg,
+        const FPTYPE *deeq,
+        const std::complex<FPTYPE> *becp,
+        const std::complex<FPTYPE> *dbecp,
+        FPTYPE *force)
+{
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(cal_force_nl<FPTYPE>), dim3(nbands_occ * ntype), dim3(THREADS_PER_BLOCK), 0, 0, 
+            multi_proj,
+            wg_nc, ntype, spin,
+            deeq_2, deeq_3, deeq_4,
+            forcenl_nc, nbands, ik, nkb,
+            atom_nh, atom_na,
+            tpiba,
+            d_wg, deeq,
+            reinterpret_cast<const thrust::complex<FPTYPE>*>(becp),
+            reinterpret_cast<const thrust::complex<FPTYPE>*>(dbecp),
+            force);// array of data
+}
 
-    template struct cal_vkb1_nl_op<double, psi::DEVICE_GPU>;
-    template struct cal_force_nl_op<double, psi::DEVICE_GPU>;
+template struct cal_vkb1_nl_op<float, psi::DEVICE_GPU>;
+template struct cal_force_nl_op<float, psi::DEVICE_GPU>;
+
+template struct cal_vkb1_nl_op<double, psi::DEVICE_GPU>;
+template struct cal_force_nl_op<double, psi::DEVICE_GPU>;
 
 }  // namespace hamilt

--- a/source/src_pw/kernels/rocm/stress_op.hip.cu
+++ b/source/src_pw/kernels/rocm/stress_op.hip.cu
@@ -1,4 +1,4 @@
-#include "src_pw/include/stress_multi_device.h"
+#include "src_pw/kernels/stress_op.h"
 
 #include <complex>
 
@@ -9,213 +9,205 @@
 #define FULL_MASK 0xffffffff
 #define WARP_SIZE 64
 
-namespace src_pw{
+namespace src_pw {
 
-    __device__ double stress_atomic_add(double* address, double val) {
-        unsigned long long int* address_as_ull = (unsigned long long int*)address;
-        unsigned long long int old = *address_as_ull, assumed;
-        do {
-            assumed = old;
-            old = atomicCAS(address_as_ull, assumed,
-                            __double_as_longlong(val + __longlong_as_double(assumed)));
-        } while (assumed != old);
-        return __longlong_as_double(old);
+template <typename FPTYPE>
+__forceinline__ 
+__device__
+void warp_reduce(FPTYPE & val) {
+    for (int offset = 32; offset > 0; offset >>= 1) {
+        val += __shfl_down( val, offset);//########????
     }
+}
 
-    template <typename FPTYPE>
-    __forceinline__ 
-    __device__
-    void warp_reduce(FPTYPE & val) {
-        for (int offset = 32; offset > 0; offset >>= 1) {
-            val += __shfl_down( val, offset);//########????
+template <typename FPTYPE>
+__global__ void cal_dbecp_noevc_nl(
+        const int ipol,
+        const int jpol,
+        const int npw,
+        const int npwx,
+        const int ik,
+        const FPTYPE tpiba,
+        const FPTYPE *gcar,
+        const FPTYPE *kvec_c,
+        thrust::complex<FPTYPE> *vkbi,
+        thrust::complex<FPTYPE> *vkbj,
+        thrust::complex<FPTYPE> *vkb,
+        thrust::complex<FPTYPE> *vkb1,
+        thrust::complex<FPTYPE> *vkb2,
+        thrust::complex<FPTYPE> *dbecp_noevc)
+{
+    int i = blockIdx.x;
+    const thrust::complex<FPTYPE>* pvkb0i = vkbi + i * npwx;
+    const thrust::complex<FPTYPE>* pvkb0j = vkbj + i * npwx;
+    thrust::complex<FPTYPE>* pvkb = nullptr;
+    thrust::complex<FPTYPE>* pdbecp_noevc = dbecp_noevc + i * npwx;
+    // third term of dbecp_noevc
+    //std::complex<FPTYPE>* pvkb = &vkb2(i,0);
+    //std::complex<FPTYPE>* pdbecp_noevc = &dbecp_noevc(i, 0);
+    FPTYPE qvec[3] = {0, 0, 0};
+    for (int ig = threadIdx.x; ig < npw; ig += blockDim.x)
+    {
+        pvkb = vkb1 + i * npwx;
+        qvec[ipol] = gcar[(ik * npwx + ig) * 3 + ipol] + kvec_c[ik * 3 + ipol];
+        qvec[jpol] = gcar[(ik * npwx + ig) * 3 + jpol] + kvec_c[ik * 3 + jpol];
+        pvkb[ig] += 0.5 * qvec[ipol] * pvkb0j[ig] +
+                    0.5 * qvec[jpol] * pvkb0i[ig];
+        pdbecp_noevc[ig] -= 2.0 * pvkb[ig];
+        if (ipol == jpol) {
+            pvkb = vkb + i * npwx;
+            pdbecp_noevc[ig] -= pvkb[ig];
         }
-    }
-
-    template <typename FPTYPE>
-    __global__ void cal_dbecp_noevc_nl(
-            const int ipol,
-            const int jpol,
-            const int npw,
-            const int npwx,
-            const int ik,
-            const FPTYPE tpiba,
-            const FPTYPE *gcar,
-            const FPTYPE *kvec_c,
-            thrust::complex<FPTYPE> *vkbi,
-            thrust::complex<FPTYPE> *vkbj,
-            thrust::complex<FPTYPE> *vkb,
-            thrust::complex<FPTYPE> *vkb1,
-            thrust::complex<FPTYPE> *vkb2,
-            thrust::complex<FPTYPE> *dbecp_noevc)
-    {
-        int i = blockIdx.x;
-        const thrust::complex<FPTYPE>* pvkb0i = vkbi + i * npwx;
-        const thrust::complex<FPTYPE>* pvkb0j = vkbj + i * npwx;
-        thrust::complex<FPTYPE>* pvkb = nullptr;
-        thrust::complex<FPTYPE>* pdbecp_noevc = dbecp_noevc + i * npwx;
-        // third term of dbecp_noevc
-        //std::complex<FPTYPE>* pvkb = &vkb2(i,0);
-        //std::complex<FPTYPE>* pdbecp_noevc = &dbecp_noevc(i, 0);
-        FPTYPE qvec[3] = {0, 0, 0};
-        for (int ig = threadIdx.x; ig < npw; ig += blockDim.x)
-        {
-            pvkb = vkb1 + i * npwx;
-            qvec[ipol] = gcar[(ik * npwx + ig) * 3 + ipol] + kvec_c[ik * 3 + ipol];
-            qvec[jpol] = gcar[(ik * npwx + ig) * 3 + jpol] + kvec_c[ik * 3 + jpol];
-            pvkb[ig] += 0.5 * qvec[ipol] * pvkb0j[ig] +
-                        0.5 * qvec[jpol] * pvkb0i[ig];
-            pdbecp_noevc[ig] -= 2.0 * pvkb[ig];
-            if (ipol == jpol) {
-                pvkb = vkb + i * npwx;
-                pdbecp_noevc[ig] -= pvkb[ig];
-            }
-            pvkb = vkb2 + i * npwx;
-            for (int ii = 0; ii < 3; ii++) {
-                qvec[ii] = gcar[(ik * npwx + ig) * 3 + ii] + kvec_c[ik * 3 + ii];
-            }
-            FPTYPE qvec_norm2 = qvec[0] * qvec[0] + qvec[1] * qvec[1] + qvec[2] * qvec[2];
-            FPTYPE qm1 = qvec_norm2 > 1e-16 ? 1.0 / sqrt(qvec_norm2) : 0;
-            pdbecp_noevc[ig] -= 2.0 * pvkb[ig] * qvec[ipol] *
-                                qvec[jpol] * qm1 *	tpiba;
-        } // end ig
-    }
-
-    template <typename FPTYPE>
-    __global__ void cal_stress_nl(
-            const bool multi_proj,
-            const int ipol,
-            const int jpol,
-            const int nkb,
-            const int ntype,
-            const int spin,
-            const int wg_nc,
-            const int ik,
-            const int deeq_2,
-            const int deeq_3,
-            const int deeq_4,
-            const int *atom_nh,
-            const int *atom_na,
-            const FPTYPE *d_wg,
-            const FPTYPE *deeq,
-            const thrust::complex<FPTYPE> *becp,
-            const thrust::complex<FPTYPE> *dbecp,
-            FPTYPE *stress)
-    {
-        int ib = blockIdx.x / ntype;
-        int it = blockIdx.x % ntype;
-
-        int iat = 0, sum = 0;
-        for (int ii = 0; ii < it; ii++) {
-            iat += atom_na[ii];
-            sum += atom_na[ii] * atom_nh[ii];
+        pvkb = vkb2 + i * npwx;
+        for (int ii = 0; ii < 3; ii++) {
+            qvec[ii] = gcar[(ik * npwx + ig) * 3 + ii] + kvec_c[ik * 3 + ii];
         }
+        FPTYPE qvec_norm2 = qvec[0] * qvec[0] + qvec[1] * qvec[1] + qvec[2] * qvec[2];
+        FPTYPE qm1 = qvec_norm2 > 1e-16 ? 1.0 / sqrt(qvec_norm2) : 0;
+        pdbecp_noevc[ig] -= 2.0 * pvkb[ig] * qvec[ipol] *
+                            qvec[jpol] * qm1 *	tpiba;
+    } // end ig
+}
 
-        FPTYPE stress_var = 0, fac = d_wg[ik * wg_nc + ib] * 1.0;
-        const int Nprojs = atom_nh[it];
-        for (int ia = 0; ia < atom_na[it]; ia++)
-        {
-            for (int ii = threadIdx.x; ii < Nprojs * Nprojs; ii += blockDim.x) {
-                int ip1 = ii / Nprojs, ip2 = ii % Nprojs;
-                if(!multi_proj && ip1 != ip2) {
-                    continue;
-                }
-                FPTYPE ps = deeq[((spin * deeq_2 + iat) * deeq_3 + ip1) * deeq_4 + ip2];
-                const int inkb1 = sum + ip1;
-                const int inkb2 = sum + ip2;
-                //out<<"\n ps = "<<ps;
-                const FPTYPE dbb = ( conj( dbecp[ ib * nkb + inkb1] ) * becp[ ib * nkb + inkb2] ).real();
-                stress_var -= ps * fac * dbb;
+template <typename FPTYPE>
+__global__ void cal_stress_nl(
+        const bool multi_proj,
+        const int ipol,
+        const int jpol,
+        const int nkb,
+        const int ntype,
+        const int spin,
+        const int wg_nc,
+        const int ik,
+        const int deeq_2,
+        const int deeq_3,
+        const int deeq_4,
+        const int *atom_nh,
+        const int *atom_na,
+        const FPTYPE *d_wg,
+        const FPTYPE *deeq,
+        const thrust::complex<FPTYPE> *becp,
+        const thrust::complex<FPTYPE> *dbecp,
+        FPTYPE *stress)
+{
+    int ib = blockIdx.x / ntype;
+    int it = blockIdx.x % ntype;
+
+    int iat = 0, sum = 0;
+    for (int ii = 0; ii < it; ii++) {
+        iat += atom_na[ii];
+        sum += atom_na[ii] * atom_nh[ii];
+    }
+
+    FPTYPE stress_var = 0, fac = d_wg[ik * wg_nc + ib] * 1.0;
+    const int Nprojs = atom_nh[it];
+    for (int ia = 0; ia < atom_na[it]; ia++)
+    {
+        for (int ii = threadIdx.x; ii < Nprojs * Nprojs; ii += blockDim.x) {
+            int ip1 = ii / Nprojs, ip2 = ii % Nprojs;
+            if(!multi_proj && ip1 != ip2) {
+                continue;
             }
-            ++iat;
-            sum+=Nprojs;
-        }//ia
-        warp_reduce(stress_var);
-        if (threadIdx.x % WARP_SIZE == 0) {
-            stress_atomic_add(stress + ipol * 3 + jpol, stress_var);
+            FPTYPE ps = deeq[((spin * deeq_2 + iat) * deeq_3 + ip1) * deeq_4 + ip2];
+            const int inkb1 = sum + ip1;
+            const int inkb2 = sum + ip2;
+            //out<<"\n ps = "<<ps;
+            const FPTYPE dbb = ( conj( dbecp[ ib * nkb + inkb1] ) * becp[ ib * nkb + inkb2] ).real();
+            stress_var -= ps * fac * dbb;
         }
+        ++iat;
+        sum+=Nprojs;
+    }//ia
+    warp_reduce(stress_var);
+    if (threadIdx.x % WARP_SIZE == 0) {
+        atomicAdd(stress + ipol * 3 + jpol, stress_var);
     }
+}
 
-    template <typename FPTYPE>
-    void cal_dbecp_noevc_nl_op<FPTYPE, psi::DEVICE_GPU>::operator() (
-            const psi::DEVICE_GPU *ctx,
-            const int &ipol,
-            const int &jpol,
-            const int &nkb,
-            const int &npw,
-            const int &npwx,
-            const int &ik,
-            const FPTYPE &tpiba,
-            const FPTYPE *gcar,
-            const FPTYPE *kvec_c,
-            std::complex<FPTYPE> *vkbi,
-            std::complex<FPTYPE> *vkbj,
-            std::complex<FPTYPE> *vkb,
-            std::complex<FPTYPE> *vkb1,
-            std::complex<FPTYPE> *vkb2,
-            std::complex<FPTYPE> *dbecp_noevc)
-    {
-        hipLaunchKernelGGL(HIP_KERNEL_NAME(cal_dbecp_noevc_nl<FPTYPE>), dim3(nkb), dim3(THREADS_PER_BLOCK), 0, 0, 
-                ipol,
-                jpol,
-                npw,
-                npwx,
-                ik,
-                tpiba,
-                gcar,
-                kvec_c,
-                reinterpret_cast<thrust::complex<FPTYPE>*>(vkbi),
-                reinterpret_cast<thrust::complex<FPTYPE>*>(vkbj),
-                reinterpret_cast<thrust::complex<FPTYPE>*>(vkb),
-                reinterpret_cast<thrust::complex<FPTYPE>*>(vkb1),
-                reinterpret_cast<thrust::complex<FPTYPE>*>(vkb2),
-                reinterpret_cast<thrust::complex<FPTYPE>*>(dbecp_noevc));
-    }
+template <typename FPTYPE>
+void cal_dbecp_noevc_nl_op<FPTYPE, psi::DEVICE_GPU>::operator() (
+        const psi::DEVICE_GPU *ctx,
+        const int &ipol,
+        const int &jpol,
+        const int &nkb,
+        const int &npw,
+        const int &npwx,
+        const int &ik,
+        const FPTYPE &tpiba,
+        const FPTYPE *gcar,
+        const FPTYPE *kvec_c,
+        std::complex<FPTYPE> *vkbi,
+        std::complex<FPTYPE> *vkbj,
+        std::complex<FPTYPE> *vkb,
+        std::complex<FPTYPE> *vkb1,
+        std::complex<FPTYPE> *vkb2,
+        std::complex<FPTYPE> *dbecp_noevc)
+{
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(cal_dbecp_noevc_nl<FPTYPE>), dim3(nkb), dim3(THREADS_PER_BLOCK), 0, 0, 
+            ipol,
+            jpol,
+            npw,
+            npwx,
+            ik,
+            tpiba,
+            gcar,
+            kvec_c,
+            reinterpret_cast<thrust::complex<FPTYPE>*>(vkbi),
+            reinterpret_cast<thrust::complex<FPTYPE>*>(vkbj),
+            reinterpret_cast<thrust::complex<FPTYPE>*>(vkb),
+            reinterpret_cast<thrust::complex<FPTYPE>*>(vkb1),
+            reinterpret_cast<thrust::complex<FPTYPE>*>(vkb2),
+            reinterpret_cast<thrust::complex<FPTYPE>*>(dbecp_noevc));
+}
 
-    template <typename FPTYPE>
-    void cal_stress_nl_op<FPTYPE, psi::DEVICE_GPU>::operator() (
-            const psi::DEVICE_GPU *ctx,
-            const bool &multi_proj,
-            const int &ipol,
-            const int &jpol,
-            const int &nkb,
-            const int &nbands_occ,
-            const int &ntype,
-            const int &spin,
-            const int &wg_nc,
-            const int &ik,
-            const int &deeq_2,
-            const int &deeq_3,
-            const int &deeq_4,
-            const int *atom_nh,
-            const int *atom_na,
-            const FPTYPE *d_wg,
-            const FPTYPE *deeq,
-            const std::complex<FPTYPE> *becp,
-            const std::complex<FPTYPE> *dbecp,
-            FPTYPE *stress)
-    {
-         hipLaunchKernelGGL(HIP_KERNEL_NAME(cal_stress_nl<FPTYPE>), dim3(nbands_occ * ntype), dim3(THREADS_PER_BLOCK), 0, 0, 
-                 multi_proj,
-                 ipol,
-                 jpol,
-                 nkb,
-                 ntype,
-                 spin,
-                 wg_nc,
-                 ik,
-                 deeq_2,
-                 deeq_3,
-                 deeq_4,
-                 atom_nh,
-                 atom_na,
-                 d_wg,
-                 deeq,
-                 reinterpret_cast<const thrust::complex<FPTYPE>*>(becp),
-                 reinterpret_cast<const thrust::complex<FPTYPE>*>(dbecp),
-                 stress);// array of data
-    }
+template <typename FPTYPE>
+void cal_stress_nl_op<FPTYPE, psi::DEVICE_GPU>::operator() (
+        const psi::DEVICE_GPU *ctx,
+        const bool &multi_proj,
+        const int &ipol,
+        const int &jpol,
+        const int &nkb,
+        const int &nbands_occ,
+        const int &ntype,
+        const int &spin,
+        const int &wg_nc,
+        const int &ik,
+        const int &deeq_2,
+        const int &deeq_3,
+        const int &deeq_4,
+        const int *atom_nh,
+        const int *atom_na,
+        const FPTYPE *d_wg,
+        const FPTYPE *deeq,
+        const std::complex<FPTYPE> *becp,
+        const std::complex<FPTYPE> *dbecp,
+        FPTYPE *stress)
+{
+     hipLaunchKernelGGL(HIP_KERNEL_NAME(cal_stress_nl<FPTYPE>), dim3(nbands_occ * ntype), dim3(THREADS_PER_BLOCK), 0, 0, 
+             multi_proj,
+             ipol,
+             jpol,
+             nkb,
+             ntype,
+             spin,
+             wg_nc,
+             ik,
+             deeq_2,
+             deeq_3,
+             deeq_4,
+             atom_nh,
+             atom_na,
+             d_wg,
+             deeq,
+             reinterpret_cast<const thrust::complex<FPTYPE>*>(becp),
+             reinterpret_cast<const thrust::complex<FPTYPE>*>(dbecp),
+             stress);// array of data
+}
 
-    template struct cal_dbecp_noevc_nl_op<double, psi::DEVICE_GPU>;
-    template struct cal_stress_nl_op<double, psi::DEVICE_GPU>;
+template struct cal_dbecp_noevc_nl_op<float, psi::DEVICE_GPU>;
+template struct cal_stress_nl_op<float, psi::DEVICE_GPU>;
+
+template struct cal_dbecp_noevc_nl_op<double, psi::DEVICE_GPU>;
+template struct cal_stress_nl_op<double, psi::DEVICE_GPU>;
 
 }  // namespace hamilt

--- a/source/src_pw/kernels/rocm/vnl_op.hip.cu
+++ b/source/src_pw/kernels/rocm/vnl_op.hip.cu
@@ -1,4 +1,4 @@
-#include "src_pw/include/vnl_multi_device.h"
+#include "src_pw/kernels/vnl_op.h"
 
 #include <complex>
 
@@ -7,7 +7,7 @@
 
 #define THREADS_PER_BLOCK 256
 
-namespace src_pw{
+namespace src_pw {
 
 template <typename FPTYPE>
 __device__ FPTYPE _polynomial_interpolation(
@@ -136,6 +136,7 @@ void cal_vnl_op<FPTYPE, psi::DEVICE_GPU>::operator() (
             reinterpret_cast<thrust::complex<FPTYPE>*>(vkb_in));
 }
 
+template struct cal_vnl_op<float, psi::DEVICE_GPU>;
 template struct cal_vnl_op<double, psi::DEVICE_GPU>;
 
 }  // namespace hamilt

--- a/source/src_pw/kernels/rocm/wf_op.hip.cu
+++ b/source/src_pw/kernels/rocm/wf_op.hip.cu
@@ -1,4 +1,4 @@
-#include "src_pw/include/wf_multi_device.h"
+#include "src_pw/kernels/wf_op.h"
 
 #include <complex>
 
@@ -7,7 +7,7 @@
 
 #define THREADS_PER_BLOCK 256
 
-namespace src_pw{
+namespace src_pw {
 
 template<typename FPTYPE>
 __global__ void cal_sk(
@@ -101,6 +101,7 @@ void cal_sk_op<FPTYPE, psi::DEVICE_GPU>::operator() (
          reinterpret_cast<thrust::complex<FPTYPE>*>(sk));
 }
 
+template struct cal_sk_op<float, psi::DEVICE_GPU>;
 template struct cal_sk_op<double, psi::DEVICE_GPU>;
 
 }  // namespace hamilt


### PR DESCRIPTION
Also fix some ROCm compilation error. #933 

This is the third step to solve the mix precision issue of ABACUS.

TODO:

- Add the precision flag into the INPUT file: single, double and mix, double by default.
