### PR TITLE
Fix: bug of extreme large number of k-points during skipping non-occupied bands

### DIFF
--- a/source/module_base/constants.h
+++ b/source/module_base/constants.h
@@ -94,7 +94,7 @@ const double RYDBERG_SI =  HARTREE_SI/2.0; //J
 
 // zero up to a given accuracy
 //const double epsr  = 1.0e-6;
-const double threshold_wg  = 1.0e-14;
+const double threshold_wg  = 1.0e-10;
 }
 
 #endif 

--- a/source/module_elecstate/elecstate_pw.cpp
+++ b/source/module_elecstate/elecstate_pw.cpp
@@ -142,6 +142,7 @@ void ElecStatePW<FPTYPE, Device>::rhoBandK(const psi::Psi<std::complex<FPTYPE>, 
         current_spin = this->klist->isk[ik];
     }
     int nbands = psi.get_nbands();
+    const double threshold = ModuleBase::threshold_wg * this->wg(ik, 0);
     //  here we compute the band energy: the sum of the eigenvalues
     if (GlobalV::NSPIN == 4)
     {
@@ -151,7 +152,7 @@ void ElecStatePW<FPTYPE, Device>::rhoBandK(const psi::Psi<std::complex<FPTYPE>, 
             ///
             /// only occupied band should be calculated.
             ///
-            if (this->wg(ik, ibnd) < ModuleBase::threshold_wg) {
+            if (this->wg(ik, ibnd) < threshold) {
                 continue;
             }
 
@@ -172,7 +173,7 @@ void ElecStatePW<FPTYPE, Device>::rhoBandK(const psi::Psi<std::complex<FPTYPE>, 
             ///
             /// only occupied band should be calculated.
             ///
-            if (this->wg(ik, ibnd) < ModuleBase::threshold_wg) {
+            if (this->wg(ik, ibnd) < threshold) {
                 continue;
             }
 

--- a/source/src_pw/forces.cpp
+++ b/source/src_pw/forces.cpp
@@ -970,9 +970,14 @@ void Forces<FPTYPE, Device>::cal_force_nl(ModuleBase::matrix& forcenl, const Mod
         /// only occupied band should be calculated.
         ///
         int nbands_occ = GlobalV::NBANDS;
-        while (wg(ik, nbands_occ - 1) < ModuleBase::threshold_wg)
+        const double threshold = ModuleBase::threshold_wg * wg(ik, 0);
+        while (wg(ik, nbands_occ - 1) < threshold)
         {
             nbands_occ--;
+            if(nbands_occ == 0) 
+            {
+                break;
+            }
         }
         int npm = GlobalV::NPOL * nbands_occ;
         gemm_op()(

--- a/source/src_pw/stress_func_nl.cpp
+++ b/source/src_pw/stress_func_nl.cpp
@@ -119,8 +119,14 @@ void Stress_Func<FPTYPE, Device>::stress_nl(ModuleBase::matrix& sigma, const Mod
         ///only occupied band should be calculated.
         ///
         int nbands_occ = GlobalV::NBANDS;
-        while(wg(ik, nbands_occ - 1) < ModuleBase::threshold_wg) {
+		const double threshold = ModuleBase::threshold_wg * wg(ik, 0);
+        while(wg(ik, nbands_occ - 1) < threshold) 
+		{
             nbands_occ--;
+			if(nbands_occ == 0) 
+            {
+                break;
+            }
         }
         int npm = GlobalV::NPOL * nbands_occ;
         gemm_op()(


### PR DESCRIPTION
When k-points is 20*20*20 and number of electrons is small, a bug would occur, this PR fixed it.