### PR TITLE
Fix: initial magnetization with both element and atoms

### DIFF
--- a/source/module_cell/read_atoms.cpp
+++ b/source/module_cell/read_atoms.cpp
@@ -606,7 +606,9 @@ bool UnitCell::read_atom_positions(std::ifstream &ifpos, std::ofstream &ofs_runn
                                                 }
 												else if ( tmpid == "mag" || tmpid == "magmom")
 												{
+#ifndef __CMD
 													set_element_mag_zero = true;
+#endif
 													double tmpamg=0;
 													ifpos >> tmpamg;
 													tmp=ifpos.get();
@@ -790,10 +792,12 @@ bool UnitCell::read_atom_positions(std::ifstream &ifpos, std::ofstream &ofs_runn
 				}//endj
 			}// end na
 			//reset some useless parameters
+#ifndef __CMD
 			if(set_element_mag_zero)
 			{
 				magnet.start_magnetization[it] = 0.0;
 			}
+#endif
 		}//end for ntype
 	}// end scan_begin
 

--- a/source/module_cell/read_atoms.cpp
+++ b/source/module_cell/read_atoms.cpp
@@ -472,7 +472,7 @@ bool UnitCell::read_atom_positions(std::ifstream &ifpos, std::ofstream &ofs_runn
 			ModuleBase::GlobalFunc::OUT(ofs_running, "atom label",atoms[it].label);
 
 #ifndef __CMD
-
+			bool set_element_mag_zero = false;
 			ModuleBase::GlobalFunc::READ_VALUE(ifpos, magnet.start_magnetization[it] );
 #endif
 
@@ -606,6 +606,7 @@ bool UnitCell::read_atom_positions(std::ifstream &ifpos, std::ofstream &ofs_runn
                                                 }
 												else if ( tmpid == "mag" || tmpid == "magmom")
 												{
+													set_element_mag_zero = true;
 													double tmpamg=0;
 													ifpos >> tmpamg;
 													tmp=ifpos.get();
@@ -788,6 +789,11 @@ bool UnitCell::read_atom_positions(std::ifstream &ifpos, std::ofstream &ofs_runn
 					atoms[it].tau_original[ia] = atoms[it].tau[ia];
 				}//endj
 			}// end na
+			//reset some useless parameters
+			if(set_element_mag_zero)
+			{
+				magnet.start_magnetization[it] = 0.0;
+			}
 		}//end for ntype
 	}// end scan_begin
 

--- a/source/src_pw/charge.cpp
+++ b/source/src_pw/charge.cpp
@@ -305,20 +305,17 @@ void Charge::atomic_rho(const int spin_number_need, double** rho_in, ModulePW::P
 	{
 		// use interpolation to get three dimension charge density.
 		ModuleBase::ComplexMatrix rho_g3d( spin_number_need, rho_basis->npw);
-		
-		// check the start magnetization
-		const int startmag_type = [&]()->int
-		{
-			for(int it=0; it<GlobalC::ucell.ntype; it++)
-			{
-				if( GlobalC::ucell.magnet.start_magnetization[it] != 0.0) return 1;
-			}
-			return 2;
-		}();
-		ModuleBase::GlobalFunc::OUT(GlobalV::ofs_warning,"startmag_type",startmag_type);
 
 		for (int it = 0;it < GlobalC::ucell.ntype;it++)
 		{
+			// check the start magnetization
+			const int startmag_type = [&]()->int
+			{
+				if( GlobalC::ucell.magnet.start_magnetization[it] != 0.0) return 1;
+				return 2;
+			}();
+			ModuleBase::GlobalFunc::OUT(GlobalV::ofs_warning,"startmag_type",startmag_type);
+
 			const Atom* const atom = &GlobalC::ucell.atoms[it];
 
 			if(!atom->flag_empty_element)		// Peize Lin add for bsse 2021.04.07
@@ -436,8 +433,6 @@ void Charge::atomic_rho(const int spin_number_need, double** rho_in, ModulePW::P
 						for (int ig = 0; ig < rho_basis->npw ; ig++)
 						{
 							const std::complex<double> swap = GlobalC::sf.strucFac(it, ig)* rho_lgl[rho_basis->ig2igg[ig]];
-							//rho_g3d(0, ig) += swap * GlobalC::ucell.magnet.nelup_percent(it);
-							//rho_g3d(1, ig) += swap * GlobalC::ucell.magnet.neldw_percent(it);
 							const double up = 0.5 * ( 1 + GlobalC::ucell.magnet.start_magnetization[it] / atom->ncpp.zv );
 							const double dw = 0.5 * ( 1 - GlobalC::ucell.magnet.start_magnetization[it] / atom->ncpp.zv );
 							rho_g3d(0, ig) += swap * up;
@@ -584,12 +579,6 @@ void Charge::atomic_rho(const int spin_number_need, double** rho_in, ModulePW::P
 //		std::cout << " sum rho for spin " << is << " = " << sumrea << std::endl;
 
     }//end is
-
-//	for(int it=0; it<GlobalC::ucell.ntype; it++)
-//	{
-		//std::cout << " nelup_percent = " << GlobalC::ucell.magnet.nelup_percent(it) << std::endl;
-		//std::cout << " neldw_percent = " << GlobalC::ucell.magnet.neldw_percent(it) << std::endl;
-//	}
 
 
 	double ne_tot = 0.0;

--- a/source/src_pw/magnetism.h
+++ b/source/src_pw/magnetism.h
@@ -21,13 +21,6 @@ public:
     double tot_magnetization_nc[3];
     double abs_magnetization;
 
-    double nelup_percent(const int &it) {
-        return 0.5 * (1.0 + start_magnetization[it]) ;
-    }
-    double neldw_percent(const int &it) {
-        return 0.5 * (1.0 - start_magnetization[it]) ;
-    }
-
     void compute_magnetization(const Charge* const chr, double* nelec_spin = nullptr);
 
     ModuleBase::Vector3<double> *m_loc_;   //magnetization for each element along c-axis


### PR DESCRIPTION
This PR enable initializing magnetization using:

ATOMIC_SPECIES
Fe 1.000 Fe_ONCV_PBE-1.0.upf
...

ATOMIC_POSITIONS
Direct
Fe
4.0 //by element 
2
0.00 0.00 0.00                //4.0 for this atom
0.50 0.50 0.50 mag -4.0 //by atomic