### PR TITLE
Fix: numerical issue fixed for bandgap printing in NSCF case

### DIFF
--- a/source/src_pw/energy.cpp
+++ b/source/src_pw/energy.cpp
@@ -519,11 +519,11 @@ void energy::cal_bandgap(const elecstate::ElecState* pelec)
 	{
 		for (int ik=0; ik<nks; ik++)
         {
-            if (!(pelec->ekb(ik,ib) > ef) && homo < pelec->ekb(ik,ib))
+            if (!(pelec->ekb(ik,ib) - this->ef > 1e-5) && homo < pelec->ekb(ik,ib))
             {
                 homo = pelec->ekb(ik,ib);
             }
-            if (pelec->ekb(ik,ib) > ef && lumo > pelec->ekb(ik,ib))
+            if (pelec->ekb(ik,ib) - this->ef > 1e-5 && lumo > pelec->ekb(ik,ib))
             {
                 lumo = pelec->ekb(ik,ib);
             }
@@ -544,19 +544,19 @@ void energy::cal_bandgap_updw(const elecstate::ElecState* pelec)
 	{
 		for (int ik=0; ik<nks; ik++)
         {
-            if (!(pelec->ekb(ik,ib) > this->ef_up) && homo_up < pelec->ekb(ik,ib))
+            if (!(pelec->ekb(ik,ib) - this->ef_up > 1e-5) && homo_up < pelec->ekb(ik,ib))
             {
                 homo_up = pelec->ekb(ik,ib);
             }
-            if (pelec->ekb(ik,ib) > this->ef_up && lumo_up > pelec->ekb(ik,ib))
+            if (pelec->ekb(ik,ib) - this->ef_up > 1e-5 && lumo_up > pelec->ekb(ik,ib))
             {
                 lumo_up = pelec->ekb(ik,ib);
             }
-			if (!(pelec->ekb(ik,ib) > this->ef_dw) && homo_dw < pelec->ekb(ik,ib))
+			if (!(pelec->ekb(ik,ib) - this->ef_dw > 1e-5) && homo_dw < pelec->ekb(ik,ib))
             {
                 homo_dw = pelec->ekb(ik,ib);
             }
-            if (pelec->ekb(ik,ib) > this->ef_dw && lumo_dw > pelec->ekb(ik,ib))
+            if (pelec->ekb(ik,ib) - this->ef_dw > 1e-5 && lumo_dw > pelec->ekb(ik,ib))
             {
                 lumo_dw = pelec->ekb(ik,ib);
             }


### PR DESCRIPTION
This PR fixed the numerical issue encountered in NSCF bandgap printing #1829 . The reason that we have abnormal bandgap values is because the read-in Fermi energy only has 6 decimals, while the HOMO energy in NSCF contains 10 decimals. Extra decimals in HOMO energy makes it larger when compared to the Fermi energy, and hence the HOMO band is mistakenly recognized as LUMO. 
The way to fix this is to change the criteria for HOMO/LUMO justification. If E_bands - E_Fermi > 1e-5, then such bands can be recognized as unoccupied bands. 