### PR TITLE
Fix: stress&force error with PW code and large smearing_sigma

### DIFF
--- a/source/module_elecstate/elecstate_pw.cpp
+++ b/source/module_elecstate/elecstate_pw.cpp
@@ -151,8 +151,9 @@ void ElecStatePW<FPTYPE, Device>::rhoBandK(const psi::Psi<std::complex<FPTYPE>, 
         {
             ///
             /// only occupied band should be calculated.
+            /// be care of when smearing_sigma is large, wg would less than 0
             ///
-            if (this->wg(ik, ibnd) < threshold) {
+            if (std::fabs(this->wg(ik, ibnd)) < threshold) {
                 continue;
             }
 

--- a/source/module_hamilt_pw/hamilt_pwdft/forces.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/forces.cpp
@@ -978,7 +978,7 @@ void Forces<FPTYPE, Device>::cal_force_nl(ModuleBase::matrix& forcenl, const Mod
         ///
         int nbands_occ = GlobalV::NBANDS;
         const double threshold = ModuleBase::threshold_wg * wg(ik, 0);
-        while (wg(ik, nbands_occ - 1) < threshold)
+        while (std::fabs(wg(ik, nbands_occ - 1)) < threshold)
         {
             nbands_occ--;
             if(nbands_occ == 0) 

--- a/source/module_hamilt_pw/hamilt_pwdft/stress_func_kin.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/stress_func_kin.cpp
@@ -50,6 +50,7 @@ void Stress_Func<FPTYPE, Device>::stress_kin(ModuleBase::matrix& sigma, const Mo
 			{
 				for(int ibnd=0;ibnd<GlobalV::NBANDS;ibnd++)
 				{
+					if( std::fabs(wg(ik, ibnd)) < ModuleBase::threshold_wg * wg(ik, 0) ) continue;
 					const std::complex<FPTYPE>* ppsi=nullptr;
 					if(psi_in!=nullptr)
 					{

--- a/source/module_hamilt_pw/hamilt_pwdft/stress_func_nl.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/stress_func_nl.cpp
@@ -120,7 +120,7 @@ void Stress_Func<FPTYPE, Device>::stress_nl(ModuleBase::matrix& sigma, const Mod
         ///
         int nbands_occ = GlobalV::NBANDS;
 		const double threshold = ModuleBase::threshold_wg * wg(ik, 0);
-        while(wg(ik, nbands_occ - 1) < threshold) 
+        while(std::fabs(wg(ik, nbands_occ - 1)) < threshold) 
 		{
             nbands_occ--;
 			if(nbands_occ == 0) 


### PR DESCRIPTION
large smearing_sigma would lead to occupations of band less than 0, the cutoff should be careful