### PR TITLE
Fix: fix err in compiling with coverage on

### DIFF
--- a/source/module_elecstate/test/CMakeLists.txt
+++ b/source/module_elecstate/test/CMakeLists.txt
@@ -10,9 +10,9 @@ if(ENABLE_LCAO)
     LIBS ${math_libs} planewave_serial base_serial psi device
     SOURCES updaterhok_pw_test.cpp
             ../elecstate_pw.cpp ../elecstate.cpp
-            ../../module_elecstate/module_charge/charge.cpp ../../src_parallel/parallel_reduce.cpp
+            ../module_charge/charge.cpp ../../src_parallel/parallel_reduce.cpp
             ../../module_hamilt_pw/hamilt_pwdft/structure_factor.cpp
-            ../../module_cell/klist.cpp ../../src_parallel/parallel_kpoints.cpp ../../module_elecstate/occupy.cpp
+            ../../module_cell/klist.cpp ../../src_parallel/parallel_kpoints.cpp ../occupy.cpp
             ../kernels/elecstate_op.cpp ../../module_io/rwstream.cpp ../../module_io/wf_io.cpp
   )
 


### PR DESCRIPTION
Code coverage workflow shows compiling errors:
```
geninfo: ERROR: cannot read /__w/abacus-develop/abacus-develop/build/source/module_elecstate/test/CMakeFiles/EState_updaterhok_pw.dir/__/__/module_elecstate/module_charge/charge.cpp.gcno!
[11842](https://github.com/deepmodeling/abacus-develop/actions/runs/4042453611/jobs/6951613787#step:5:11843)
gmake[2]: *** [source/module_elecstate/test/CMakeFiles/EState_updaterhok_pw-capture-init.dir/build.make:97: source/module_elecstate/test/CMakeFiles/EState_updaterhok_pw.dir/__/__/module_elecstate/module_charge/charge.cpp.info.init] Error 9
[11843](https://github.com/deepmodeling/abacus-develop/actions/runs/4042453611/jobs/6951613787#step:5:11844)
gmake[2]: *** Waiting for unfinished jobs....

```