### PR TITLE
Fix: update Makefile and CMakeLists.txt for dp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,8 +394,6 @@ if(DEFINED DeePMD_DIR)
   else()
   target_link_libraries(${ABACUS_BIN_NAME}
     DeePMD::deepmd_cc
-    DeePMD::deepmd_op
-    DeePMD::deepmd_op_cuda
     DeePMD::tensorflow_cc
   )
   endif()

--- a/cmake/FindDeePMD.cmake
+++ b/cmake/FindDeePMD.cmake
@@ -40,38 +40,38 @@ find_library(tensorflow_cc
 # Handle the QUIET and REQUIRED arguments and
 # set DeePMD_FOUND to TRUE if all variables are non-zero.
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(DeePMDC DEFAULT_MSG deepmd_c DeePMD_INCLUDE_C_DIR)
-if (DeePMDC_FOUND)
-    set(DeePMDC_FOUND TRUE)
-    set(DeePMD_INCLUDE_DIR ${DeePMD_INCLUDE_C_DIR})
-    if(NOT TARGET DeePMD::deepmd_c)
-        add_library(DeePMD::deepmd_c UNKNOWN IMPORTED)
-        set_target_properties(DeePMD::deepmd_c PROPERTIES
-            IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-            IMPORTED_LOCATION "${deepmd_c}"
-            INTERFACE_INCLUDE_DIRECTORIES "${DeePMD_INCLUDE_DIR}")
+if (DeePMD_INCLUDE_C_DIR)
+    find_package_handle_standard_args(DeePMD DEFAULT_MSG deepmd_c DeePMD_INCLUDE_C_DIR)
+    if (DeePMD_FOUND)
+        set(DeePMDC_FOUND TRUE)
+        set(DeePMD_INCLUDE_DIR ${DeePMD_INCLUDE_C_DIR})
+        if(NOT TARGET DeePMD::deepmd_c)
+            add_library(DeePMD::deepmd_c UNKNOWN IMPORTED)
+            set_target_properties(DeePMD::deepmd_c PROPERTIES
+                IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                IMPORTED_LOCATION "${deepmd_c}"
+                INTERFACE_INCLUDE_DIRECTORIES "${DeePMD_INCLUDE_DIR}")
+        endif()
     endif()
 else()
-find_package_handle_standard_args(DeePMD DEFAULT_MSG deepmd_cc tensorflow_cc DeePMD_INCLUDE_DIR)
-
-if(DeePMD_FOUND)
-    set(DeePMD_INCLUDE_DIR ${DeePMD_INCLUDE_DIR})
-
-    if(NOT TARGET DeePMD::deepmd_cc)
-        add_library(DeePMD::deepmd_cc UNKNOWN IMPORTED)
-        set_target_properties(DeePMD::deepmd_cc PROPERTIES
-           IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-           IMPORTED_LOCATION "${deepmd_cc}"
-           INTERFACE_INCLUDE_DIRECTORIES "${DeePMD_INCLUDE_DIR}")
+    find_package_handle_standard_args(DeePMD DEFAULT_MSG deepmd_cc tensorflow_cc DeePMD_INCLUDE_DIR)
+    if(DeePMD_FOUND)
+        set(DeePMD_INCLUDE_DIR ${DeePMD_INCLUDE_DIR})
+        if(NOT TARGET DeePMD::deepmd_cc)
+            add_library(DeePMD::deepmd_cc UNKNOWN IMPORTED)
+            set_target_properties(DeePMD::deepmd_cc PROPERTIES
+                IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                IMPORTED_LOCATION "${deepmd_cc}"
+                INTERFACE_INCLUDE_DIRECTORIES "${DeePMD_INCLUDE_DIR}")
+        endif()
+        if(NOT TARGET DeePMD::tensorflow_cc)
+            add_library(DeePMD::tensorflow_cc UNKNOWN IMPORTED)
+            set_target_properties(DeePMD::tensorflow_cc PROPERTIES
+                IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                IMPORTED_LOCATION "${tensorflow_cc}"
+                INTERFACE_INCLUDE_DIRECTORIES "${DeePMD_INCLUDE_DIR}")
+        endif()
     endif()
-    if(NOT TARGET DeePMD::tensorflow_cc)
-        add_library(DeePMD::tensorflow_cc UNKNOWN IMPORTED)
-        set_target_properties(DeePMD::tensorflow_cc PROPERTIES
-           IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-           IMPORTED_LOCATION "${tensorflow_cc}"
-           INTERFACE_INCLUDE_DIRECTORIES "${DeePMD_INCLUDE_DIR}")
-    endif()
-endif()
 endif()
 
 set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${DeePMD_INCLUDE_DIR})

--- a/cmake/FindDeePMD.cmake
+++ b/cmake/FindDeePMD.cmake
@@ -31,16 +31,6 @@ find_library(deepmd_cc
     HINTS ${DeePMD_DIR}
     PATH_SUFFIXES "lib"
     )
-find_library(deepmd_op
-    NAMES deepmd_op
-    HINTS ${DeePMD_DIR}
-    PATH_SUFFIXES "lib"
-    )
-find_library(deepmd_op_cuda
-    NAMES deepmd_op_cuda
-    HINTS ${DeePMD_DIR}
-    PATH_SUFFIXES "lib"
-    )
 find_library(tensorflow_cc
     NAMES tensorflow_cc
     HINTS ${DeePMD_DIR}
@@ -50,8 +40,8 @@ find_library(tensorflow_cc
 # Handle the QUIET and REQUIRED arguments and
 # set DeePMD_FOUND to TRUE if all variables are non-zero.
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(DeePMD DEFAULT_MSG deepmd_c DeePMD_INCLUDE_C_DIR)
-if (DEEPMD_FOUND)
+find_package_handle_standard_args(DeePMDC DEFAULT_MSG deepmd_c DeePMD_INCLUDE_C_DIR)
+if (DeePMDC_FOUND)
     set(DeePMDC_FOUND TRUE)
     set(DeePMD_INCLUDE_DIR ${DeePMD_INCLUDE_C_DIR})
     if(NOT TARGET DeePMD::deepmd_c)
@@ -62,11 +52,9 @@ if (DEEPMD_FOUND)
             INTERFACE_INCLUDE_DIRECTORIES "${DeePMD_INCLUDE_DIR}")
     endif()
 else()
-find_package_handle_standard_args(DeePMD DEFAULT_MSG deepmd_cc deepmd_op deepmd_op_cuda tensorflow_cc DeePMD_INCLUDE_DIR)
+find_package_handle_standard_args(DeePMD DEFAULT_MSG deepmd_cc tensorflow_cc DeePMD_INCLUDE_DIR)
 
-# Copy the results to the output variables and target.
 if(DeePMD_FOUND)
-    #set(DeePMD_LIBRARIES ${DeePMD_LIBRARY})
     set(DeePMD_INCLUDE_DIR ${DeePMD_INCLUDE_DIR})
 
     if(NOT TARGET DeePMD::deepmd_cc)
@@ -74,20 +62,6 @@ if(DeePMD_FOUND)
         set_target_properties(DeePMD::deepmd_cc PROPERTIES
            IMPORTED_LINK_INTERFACE_LANGUAGES "C"
            IMPORTED_LOCATION "${deepmd_cc}"
-           INTERFACE_INCLUDE_DIRECTORIES "${DeePMD_INCLUDE_DIR}")
-    endif()
-    if(NOT TARGET DeePMD::deepmd_op)
-        add_library(DeePMD::deepmd_op UNKNOWN IMPORTED)
-        set_target_properties(DeePMD::deepmd_op PROPERTIES
-           IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-           IMPORTED_LOCATION "${deepmd_op}"
-           INTERFACE_INCLUDE_DIRECTORIES "${DeePMD_INCLUDE_DIR}")
-    endif()
-    if(NOT TARGET DeePMD::deepmd_op_cuda)
-        add_library(DeePMD::deepmd_op_cuda UNKNOWN IMPORTED)
-        set_target_properties(DeePMD::deepmd_op_cuda PROPERTIES
-           IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-           IMPORTED_LOCATION "${deepmd_op_cuda}"
            INTERFACE_INCLUDE_DIRECTORIES "${DeePMD_INCLUDE_DIR}")
     endif()
     if(NOT TARGET DeePMD::tensorflow_cc)
@@ -102,4 +76,4 @@ endif()
 
 set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${DeePMD_INCLUDE_DIR})
 
-mark_as_advanced(DeePMD_INCLUDE_DIR deepmd_c deepmd_cc deepmd_op deepmd_op_cuda tensorflow_cc)
+mark_as_advanced(DeePMD_INCLUDE_DIR deepmd_c deepmd_cc tensorflow_cc)

--- a/source/Makefile
+++ b/source/Makefile
@@ -137,7 +137,7 @@ ifdef DeePMD_DIR
     ## DeePMD-kit package
     ##==========================
     DeeP_LIB_DIR = ${DeePMD_DIR}/lib
-    LIBS += -L${DeeP_LIB_DIR} -ldeepmd_cc -ldeepmd_op -ldeepmd_op_cuda -Wl,-rpath=${DeeP_LIB_DIR}
+    LIBS += -L${DeeP_LIB_DIR} -ldeepmd_cc -Wl,-rpath=${DeeP_LIB_DIR}
     DeeP_INCLUDE_DIR = ${DeePMD_DIR}/include
     INCLUDES += -I${DeeP_INCLUDE_DIR}
 


### PR DESCRIPTION
Note that the current `cmake/FindDeePMD.cmake` cannot be used to compile with the C++ interface of DeePMD-kit v2.1.5