### PR TITLE
Refactor: Add __ENABLE_FLOAT_FFTW macro to control the usage of single precision FFTW library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(ENABLE_LCAO "Enable LCAO calculation." ON)
 option(ENABLE_DEEPKS "Enable DeePKS functionality" OFF)
 option(ENABLE_LIBXC "Enable LibXC functionality" OFF)
 option(USE_CUDA "Enable support to CUDA for PW." OFF)
+option(ENABLE_FLOAT_FFTW "Enable support to single precision FFTW library." OFF)
 # option(USE_CUSOLVER_LCAO "Enable support to CUSOLVER for LCAO." OFF) # broken
 option(USE_ROCM "Enable support to ROCm." OFF)
 option(USE_OPENMP " Enable OpenMP in abacus." ON)
@@ -280,12 +281,15 @@ else()
   include_directories(${FFTW3_INCLUDE_DIRS})
   list(APPEND math_libs
     FFTW3::FFTW3
-    FFTW3::FFTW3_FLOAT
     LAPACK::LAPACK
     ScaLAPACK::ScaLAPACK
   )
   if(USE_OPENMP)
     list(APPEND math_libs FFTW3::FFTW3_OMP)
+  endif()
+  if (ENABLE_FLOAT_FFTW)
+    list(APPEND math_libs FFTW3::FFTW3_FLOAT)
+    add_definitions(-D__ENABLE_FLOAT_FFTW)
   endif()
   if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
     list(APPEND math_libs -lgfortran)

--- a/source/module_pw/fft.h
+++ b/source/module_pw/fft.h
@@ -22,7 +22,7 @@
 
 //Temporary: we donot need psi. However some GPU ops are defined in psi, which should be moved into module_base or module_gpu
 #include "module_psi/psi.h"
-// #ifdef __MIX_PRECISION
+// #ifdef __ENABLE_FLOAT_FFTW
 // #include "fftw3f.h"
 // #if defined(__FFTW3_MPI) && defined(__MPI)
 // #include "fftw3f-mpi.h"
@@ -50,7 +50,10 @@ public:
 
 	//destroy fftw_plans
 	void cleanFFT();
+
+#if defined(__ENABLE_FLOAT_FFTW)
 	void cleanfFFT();
+#endif // defined(__ENABLE_FLOAT_FFTW)
 
     template <typename FPTYPE> void fftzfor(std::complex<FPTYPE>* in, std::complex<FPTYPE>* out);
 	template <typename FPTYPE> void fftzbac(std::complex<FPTYPE>* in, std::complex<FPTYPE>* out);
@@ -68,7 +71,9 @@ public:
 	// We have not support mpi fftw yet.
 	// void initplan_mpi();
 	//init fftwf_plans
+#if defined(__ENABLE_FLOAT_FFTW)
 	void initplanf();
+#endif // defined(__ENABLE_FLOAT_FFTW)
 	// void initplanf_mpi();
 
 public:
@@ -116,6 +121,7 @@ private:
     hipfftHandle z_handle;
 #endif
 
+#if defined(__ENABLE_FLOAT_FFTW)
 	bool destroypf=true;
 	fftwf_plan planfzfor;
 	fftwf_plan planfzbac;
@@ -129,7 +135,7 @@ private:
 	fftwf_plan planfxc2r;
 	fftwf_plan planfyr2c;
 	fftwf_plan planfyc2r;
-
+#endif // defined(__ENABLE_FLOAT_FFTW)
 
     std::complex<float> * c_auxr_3d=nullptr; //fft space
     std::complex<double> * z_auxr_3d=nullptr; //fft space

--- a/source/module_pw/test/Makefile
+++ b/source/module_pw/test/Makefile
@@ -77,7 +77,7 @@ else
 endif
 
 ifeq ($(FLOAT), ON)
-    HONG += -D__MIX_PRECISION
+    HONG += -D__ENABLE_FLOAT_FFTW
     ifneq ($(INTEL), ON)
         LIBS += -lfftw3f
     endif

--- a/source/module_pw/test/pw_test.cpp
+++ b/source/module_pw/test/pw_test.cpp
@@ -36,8 +36,8 @@ int main(int argc, char **argv)
     
     int kpar;
     kpar = 1;
-#ifdef __MIX_PRECISION
-    //Temporary, pw_basis should not contains global variables
+#ifdef __ENABLE_FLOAT_FFTW
+    //Temporary, pw_basis should not contain global variables
     GlobalV::precision_flag = "single";
 #endif
 #ifdef __MPI

--- a/source/module_pw/test/test-big.cpp
+++ b/source/module_pw/test/test-big.cpp
@@ -68,7 +68,7 @@ TEST_F(PWTEST,test_big)
     delete p_pw;
     delete p_pwk;
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     fftwf_cleanup();
 #endif
 }

--- a/source/module_pw/test/test-other.cpp
+++ b/source/module_pw/test/test-other.cpp
@@ -40,7 +40,7 @@ TEST_F(PWTEST,test_other)
     pwktest.initparameters(true, 20, nks, kvec_d);
     pwktest.setuptransform();
     pwktest.collect_local_pw();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     GlobalV::precision_flag = "single";
 #endif
     pwktest.initparameters(true, 8, nks, kvec_d);
@@ -49,7 +49,7 @@ TEST_F(PWTEST,test_other)
     const int nrxx = pwktest.nrxx;
     complex<double> * rhor1 = new complex<double> [nrxx];
     complex<double> * rhor2 = new complex<double> [nrxx];
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     complex<float> * rhofr1 = new complex<float> [nrxx];
     complex<float> * rhofr2 = new complex<float> [nrxx];
 #endif
@@ -59,7 +59,7 @@ TEST_F(PWTEST,test_other)
         const int npwk = pwktest.npwk[ik];
         complex<double> * rhog1 = new complex<double> [npwk];
         complex<double> * rhog2 = new complex<double> [npwk];
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         complex<float> * rhofg1 = new complex<float> [npwk];
         complex<float> * rhofg2 = new complex<float> [npwk];
 #endif
@@ -68,7 +68,7 @@ TEST_F(PWTEST,test_other)
             rhog1[ig] = 1.0/(pwktest.getgk2(ik,ig)+1) + ModuleBase::IMAG_UNIT / (abs(pwktest.getgdirect(ik,ig).x+1) + 1);
             rhog2[ig] = 1.0/(pwktest.getgk2(ik,ig)+1) + ModuleBase::IMAG_UNIT / (abs(pwktest.getgdirect(ik,ig).x+1) + 1);
         }    
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         for(int ig = 0 ; ig < npwk ; ++ig)
         {
             rhofg1[ig] = 1.0/(pwktest.getgk2(ik,ig)+1) + ModuleBase::IMAG_UNIT / (abs(pwktest.getgdirect(ik,ig).x+1) + 1);
@@ -88,7 +88,7 @@ TEST_F(PWTEST,test_other)
         {
             EXPECT_NEAR(abs(rhog1[ig]),abs(rhog2[ig]),1e-8);
         }
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         pwktest.recip_to_real(ctx, rhofg1, rhofr1, ik);
         pwktest.recip2real(rhofg2, rhofr2, ik);
         for(int ir = 0 ; ir < nrxx; ++ir)
@@ -107,14 +107,14 @@ TEST_F(PWTEST,test_other)
 
         delete [] rhog1;
         delete [] rhog2;
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         delete [] rhofg1;
         delete [] rhofg2;
 #endif
     }
     delete [] rhor1;
     delete [] rhor2;
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     delete [] rhofr1;
     delete [] rhofr2;
 #endif
@@ -123,7 +123,7 @@ TEST_F(PWTEST,test_other)
     double* d_kvec_c = pwktest.get_kvec_c_data<double>();
     double* d_gcar = pwktest.get_gcar_data<double>();
     double* d_gk2 = pwktest.get_gk2_data<double>();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     float* s_kvec_c = pwktest.get_kvec_c_data<float>();
     float* s_gcar = pwktest.get_gcar_data<float>();
     float* s_gk2 = pwktest.get_gk2_data<float>();
@@ -136,7 +136,7 @@ TEST_F(PWTEST,test_other)
     delete p_pw;
     delete p_pwk;
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     fftwf_cleanup();
 #endif
 }

--- a/source/module_pw/test/test1-2.cpp
+++ b/source/module_pw/test/test1-2.cpp
@@ -113,7 +113,7 @@ TEST_F(PWTEST,test1_2)
         rhogr[ig] = 1.0/(pwtest.gg[ig]+1) + ModuleBase::IMAG_UNIT / (abs(pwtest.gdirect[ig].x+1) + 1);
     }    
     complex<double> * rhor = new complex<double> [nrxx];
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     complex<float> * rhofg = new complex<float> [npw];
     complex<float> * rhofgr = new complex<float> [nmaxgr];
     complex<float> * rhofgout = new complex<float> [npw];
@@ -129,7 +129,7 @@ TEST_F(PWTEST,test1_2)
 
     pwtest.recip2real(rhogr,rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     pwtest.recip2real(rhofg,rhofr);//check out-of-place transform
 
     pwtest.recip2real(rhofgr,rhofgr);//check in-place transform
@@ -144,7 +144,7 @@ TEST_F(PWTEST,test1_2)
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhor[ixy*nplane+iz].imag(),1e-6);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhogr[ixy*nplane+iz].real(),1e-6);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhogr[ixy*nplane+iz].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofr[ixy*nplane+iz].real(),1e-4);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhofr[ixy*nplane+iz].imag(),1e-4);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofgr[ixy*nplane+iz].real(),1e-4);
@@ -159,7 +159,7 @@ TEST_F(PWTEST,test1_2)
 
     pwtest.real2recip(rhogr,rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     pwtest.real2recip(rhofr,rhofgout);//check out-of-place transform
 
     pwtest.real2recip(rhofgr,rhofgr);//check in-place transform
@@ -171,7 +171,7 @@ TEST_F(PWTEST,test1_2)
         EXPECT_NEAR(rhog[ig].imag(),rhogout[ig].imag(),1e-6);
         EXPECT_NEAR(rhogr[ig].real(),rhogout[ig].real(),1e-6);
         EXPECT_NEAR(rhogr[ig].imag(),rhogout[ig].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         EXPECT_NEAR(rhofg[ig].real(),rhofgout[ig].real(),1e-4);
         EXPECT_NEAR(rhofg[ig].imag(),rhofgout[ig].imag(),1e-4);
         EXPECT_NEAR(rhofgr[ig].real(),rhofgout[ig].real(),1e-4);
@@ -186,7 +186,7 @@ TEST_F(PWTEST,test1_2)
     delete [] rhogr;
 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     delete [] rhofg;
     delete [] rhofgout;
     delete [] rhofr;

--- a/source/module_pw/test/test1-3.cpp
+++ b/source/module_pw/test/test1-3.cpp
@@ -114,7 +114,7 @@ TEST_F(PWTEST,test1_3)
         }
     }    
     double * rhor = new double [nrxx];
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     complex<float> * rhofg = new complex<float> [npw];
     complex<float> * rhofgr = new complex<float> [nmaxgr];
     complex<float> * rhofgout = new complex<float> [npw];
@@ -135,7 +135,7 @@ TEST_F(PWTEST,test1_3)
 
     pwtest.recip2real(rhogr,(double*)rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     pwtest.recip2real(rhofg,rhofr);//check out-of-place transform
 
     pwtest.recip2real(rhofgr,(float*)rhofgr);//check in-place transform
@@ -148,7 +148,7 @@ TEST_F(PWTEST,test1_3)
         {
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhor[ixy*nplane+iz],1e-6);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),((double*)rhogr)[ixy*nplane+iz],1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofr[ixy*nplane+iz],1e-4);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),((float*)rhofgr)[ixy*nplane+iz],1e-4);
 #endif
@@ -160,7 +160,7 @@ TEST_F(PWTEST,test1_3)
 
     pwtest.real2recip((double*)rhogr,rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     pwtest.real2recip(rhofr,rhofgout);//check out-of-place transform
 
     pwtest.real2recip((float*)rhofgr,rhofgr);//check in-place transform
@@ -172,7 +172,7 @@ TEST_F(PWTEST,test1_3)
         EXPECT_NEAR(rhog[ig].imag(),rhogout[ig].imag(),1e-6);
         EXPECT_NEAR(rhogr[ig].real(),rhogout[ig].real(),1e-6);
         EXPECT_NEAR(rhogr[ig].imag(),rhogout[ig].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         EXPECT_NEAR(rhofg[ig].real(),rhofgout[ig].real(),1e-4);
         EXPECT_NEAR(rhofg[ig].imag(),rhofgout[ig].imag(),1e-4);
         EXPECT_NEAR(rhofgr[ig].real(),rhofgout[ig].real(),1e-4);
@@ -187,7 +187,7 @@ TEST_F(PWTEST,test1_3)
     delete [] rhogr;
 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     delete [] rhofg;
     delete [] rhofgout;
     delete [] rhofr;

--- a/source/module_pw/test/test1-4.cpp
+++ b/source/module_pw/test/test1-4.cpp
@@ -69,7 +69,7 @@ TEST_F(PWTEST,test1_4)
     complex<double> *tmp = new complex<double> [nx*ny*nz];
     complex<double> * rhor = new complex<double> [nrxx];
     complex<double> * rhogr = new complex<double> [nmaxgr];
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     complex<float> * rhofr = new complex<float> [nrxx];
     complex<float> * rhofgr = new complex<float> [nmaxgr];
 #endif
@@ -122,7 +122,7 @@ TEST_F(PWTEST,test1_4)
 #endif
         complex<double> * rhog = new complex<double> [npwk];
         complex<double> * rhogout = new complex<double> [npwk];
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         complex<float> * rhofg = new complex<float> [npwk];
         complex<float> * rhofgout = new complex<float> [npwk];
 #endif
@@ -131,7 +131,7 @@ TEST_F(PWTEST,test1_4)
             rhog[ig] = 1.0/(pwtest.getgk2(ik,ig)+1) + ModuleBase::IMAG_UNIT / (abs(pwtest.getgdirect(ik,ig).x+1) + 1);
             rhogr[ig] = 1.0/(pwtest.getgk2(ik,ig)+1) + ModuleBase::IMAG_UNIT / (abs(pwtest.getgdirect(ik,ig).x+1) + 1);
         }    
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         for(int ig = 0 ; ig < npwk ; ++ig)
         {
             rhofg[ig] = 1.0/(pwtest.getgk2(ik,ig)+1) + ModuleBase::IMAG_UNIT / (abs(pwtest.getgdirect(ik,ig).x+1) + 1);
@@ -143,7 +143,7 @@ TEST_F(PWTEST,test1_4)
 
         pwtest.recip2real(rhogr,rhogr,ik); //check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         pwtest.recip2real(rhofg,rhofr,ik); //check out-of-place transform
 
         pwtest.recip2real(rhofgr,rhofgr,ik); //check in-place transform
@@ -158,7 +158,7 @@ TEST_F(PWTEST,test1_4)
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhor[ixy*nplane+iz].imag(),1e-6);
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhogr[ixy*nplane+iz].real(),1e-6);
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhogr[ixy*nplane+iz].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofr[ixy*nplane+iz].real(),1e-4);
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhofr[ixy*nplane+iz].imag(),1e-4);
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofgr[ixy*nplane+iz].real(),1e-4);
@@ -170,7 +170,7 @@ TEST_F(PWTEST,test1_4)
         pwtest.real2recip(rhor,rhogout,ik);
 
         pwtest.real2recip(rhogr,rhogr,ik);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         pwtest.real2recip(rhofr,rhofgout,ik);
 
         pwtest.real2recip(rhofgr,rhofgr,ik);
@@ -182,7 +182,7 @@ TEST_F(PWTEST,test1_4)
             EXPECT_NEAR(rhog[ig].imag(),rhogout[ig].imag(),1e-6);
             EXPECT_NEAR(rhog[ig].real(),rhogr[ig].real(),1e-6);
             EXPECT_NEAR(rhog[ig].imag(),rhogr[ig].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
             EXPECT_NEAR(rhofg[ig].real(),rhofgout[ig].real(),1e-4);
             EXPECT_NEAR(rhofg[ig].imag(),rhofgout[ig].imag(),1e-4);
             EXPECT_NEAR(rhofg[ig].real(),rhofgr[ig].real(),1e-4);
@@ -193,7 +193,7 @@ TEST_F(PWTEST,test1_4)
 
         delete [] rhog;
         delete [] rhogout;
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         delete [] rhofg;
         delete [] rhofgout;
 #endif
@@ -215,7 +215,7 @@ TEST_F(PWTEST,test1_4)
     delete[] kvec_d;
     delete[] rhogr;
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     delete[] rhofr;
     delete[] rhofgr;
     fftwf_cleanup();

--- a/source/module_pw/test/test1-5.cpp
+++ b/source/module_pw/test/test1-5.cpp
@@ -60,7 +60,7 @@ TEST_F(PWTEST,test1_5)
     complex<double> *tmp = new complex<double> [nx*ny*nz];
     complex<double> * rhogr = new complex<double> [nmaxgr];
     double * rhor = new double [nrxx];
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     float * rhofr = new float [nrxx];
     complex<float> * rhofgr = new complex<float> [nmaxgr];
 #endif
@@ -115,7 +115,7 @@ TEST_F(PWTEST,test1_5)
 #endif
         complex<double> * rhog = new complex<double> [npwk];
         complex<double> * rhogout = new complex<double> [npwk];
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         complex<float> * rhofg = new complex<float> [npwk];
         complex<float> * rhofgout = new complex<float> [npwk];
 #endif
@@ -130,7 +130,7 @@ TEST_F(PWTEST,test1_5)
                 rhogr[ig]+=ModuleBase::IMAG_UNIT / (abs(f.x+1) + 1);
             }
         }    
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         for(int ig = 0 ; ig < npwk ; ++ig)
         {
             rhofg[ig] = 1.0/(pwtest.getgk2(ik,ig)+1); 
@@ -148,7 +148,7 @@ TEST_F(PWTEST,test1_5)
 
         pwtest.recip2real(rhogr,(double*)rhogr,ik); //check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         pwtest.recip2real(rhofg,rhofr,ik); //check out-of-place transform
 
         pwtest.recip2real(rhofgr,(float*)rhofgr,ik); //check in-place transform
@@ -161,7 +161,7 @@ TEST_F(PWTEST,test1_5)
             {
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhor[ixy*nplane+iz],1e-6);
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),((double*)rhogr)[ixy*nplane+iz],1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofr[ixy*nplane+iz],1e-4);
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),((float*)rhofgr)[ixy*nplane+iz],1e-4);
 #endif
@@ -172,7 +172,7 @@ TEST_F(PWTEST,test1_5)
 
         pwtest.real2recip((double*)rhogr,rhogr,ik);
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         pwtest.real2recip(rhofr,rhofgout,ik);
 
         pwtest.real2recip((float*)rhofgr,rhofgr,ik);
@@ -184,7 +184,7 @@ TEST_F(PWTEST,test1_5)
             EXPECT_NEAR(rhog[ig].imag(),rhogout[ig].imag(),1e-6);
             EXPECT_NEAR(rhog[ig].real(),rhogr[ig].real(),1e-6);
             EXPECT_NEAR(rhog[ig].imag(),rhogr[ig].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
             EXPECT_NEAR(rhofg[ig].real(),rhofgout[ig].real(),1e-6);
             EXPECT_NEAR(rhofg[ig].imag(),rhofgout[ig].imag(),1e-6);
             EXPECT_NEAR(rhofg[ig].real(),rhofgr[ig].real(),1e-6);
@@ -195,7 +195,7 @@ TEST_F(PWTEST,test1_5)
 
         delete [] rhog;
         delete [] rhogout;
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         delete [] rhofg;
         delete [] rhofgout;
 #endif
@@ -216,7 +216,7 @@ TEST_F(PWTEST,test1_5)
     delete[] kvec_d;
     delete[] rhogr;
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     delete[] rhofr;
     delete[] rhofgr;
     fftwf_cleanup();

--- a/source/module_pw/test/test2-2.cpp
+++ b/source/module_pw/test/test2-2.cpp
@@ -129,7 +129,7 @@ TEST_F(PWTEST,test2_2)
     delete [] rhor;
     delete []tmp; 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     fftwf_cleanup();
 #endif
 }

--- a/source/module_pw/test/test2-3.cpp
+++ b/source/module_pw/test/test2-3.cpp
@@ -131,7 +131,7 @@ TEST_F(PWTEST,test2_3)
     delete [] tmp;
 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     fftwf_cleanup();
 #endif
 }

--- a/source/module_pw/test/test3-2.cpp
+++ b/source/module_pw/test/test3-2.cpp
@@ -145,7 +145,7 @@ TEST_F(PWTEST,test3_2)
     delete [] rhogr;
 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     fftwf_cleanup();
 #endif
 }

--- a/source/module_pw/test/test3-3-2.cpp
+++ b/source/module_pw/test/test3-3-2.cpp
@@ -157,7 +157,7 @@ TEST_F(PWTEST,test3_3_2)
     delete [] rhogr;
 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     fftwf_cleanup();
 #endif
 }

--- a/source/module_pw/test/test3-3.cpp
+++ b/source/module_pw/test/test3-3.cpp
@@ -152,7 +152,7 @@ TEST_F(PWTEST,test3_3)
     delete [] rhogr;
 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     fftwf_cleanup();
 #endif
 }

--- a/source/module_pw/test/test4-2.cpp
+++ b/source/module_pw/test/test4-2.cpp
@@ -107,7 +107,7 @@ TEST_F(PWTEST,test4_2)
     }    
     complex<double> * rhor = new complex<double> [nrxx];
     ModuleBase::GlobalFunc::ZEROS(rhor, nrxx);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     complex<float> * rhofg = new complex<float> [npw];
     complex<float> * rhofgr = new complex<float> [nmaxgr];
     complex<float> * rhofgout = new complex<float> [npw];
@@ -124,7 +124,7 @@ TEST_F(PWTEST,test4_2)
 
     pwtest.recip2real(rhogr,rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     pwtest.recip2real(rhofg,rhofr,true, float(1));//check out-of-place transform
 
     pwtest.recip2real(rhofgr,rhofgr);//check in-place transform
@@ -139,7 +139,7 @@ TEST_F(PWTEST,test4_2)
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhor[ixy*nplane+iz].imag(),1e-6);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhogr[ixy*nplane+iz].real(),1e-6);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhogr[ixy*nplane+iz].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofr[ixy*nplane+iz].real(),1e-4);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhofr[ixy*nplane+iz].imag(),1e-4);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofgr[ixy*nplane+iz].real(),1e-4);
@@ -154,7 +154,7 @@ TEST_F(PWTEST,test4_2)
 
     pwtest.real2recip(rhogr,rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     ModuleBase::GlobalFunc::ZEROS(rhofgout, npw);
     pwtest.real2recip(rhofr,rhofgout, true, float(1));//check out-of-place transform
 
@@ -167,7 +167,7 @@ TEST_F(PWTEST,test4_2)
         EXPECT_NEAR(rhog[ig].imag(),rhogout[ig].imag(),1e-6);
         EXPECT_NEAR(rhogr[ig].real(),rhogout[ig].real(),1e-6);
         EXPECT_NEAR(rhogr[ig].imag(),rhogout[ig].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         EXPECT_NEAR(rhofg[ig].real(),rhofgout[ig].real(),1e-4);
         EXPECT_NEAR(rhofg[ig].imag(),rhofgout[ig].imag(),1e-4);
         EXPECT_NEAR(rhofgr[ig].real(),rhofgout[ig].real(),1e-4);
@@ -182,7 +182,7 @@ TEST_F(PWTEST,test4_2)
     delete [] rhogr;
 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     delete [] rhofg;
     delete [] rhofgout;
     delete [] rhofr;

--- a/source/module_pw/test/test4-3.cpp
+++ b/source/module_pw/test/test4-3.cpp
@@ -115,7 +115,7 @@ TEST_F(PWTEST,test4_3)
     }    
     double * rhor = new double [nrxx];
     ModuleBase::GlobalFunc::ZEROS(rhor, nrxx);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     complex<float> * rhofg = new complex<float> [npw];
     complex<float> * rhofgr = new complex<float> [nmaxgr];
     complex<float> * rhofgout = new complex<float> [npw];
@@ -137,7 +137,7 @@ TEST_F(PWTEST,test4_3)
 
     pwtest.recip2real(rhogr,(double*)rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     pwtest.recip2real(rhofg,rhofr,true,float(1));//check out-of-place transform
 
     pwtest.recip2real(rhofgr,(float*)rhofgr);//check in-place transform
@@ -152,7 +152,7 @@ TEST_F(PWTEST,test4_3)
         {
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhor[ixy*nplane+iz],1e-6);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),((double*)rhogr)[ixy*nplane+iz],1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofr[ixy*nplane+iz],1e-4);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),((float*)rhofgr)[ixy*nplane+iz],1e-4);
 #endif
@@ -164,7 +164,7 @@ TEST_F(PWTEST,test4_3)
 
     pwtest.real2recip((double*)rhogr,rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     ModuleBase::GlobalFunc::ZEROS(rhofgout, npw);
     pwtest.real2recip(rhofr,rhofgout,true,float(1));//check out-of-place transform
 
@@ -177,7 +177,7 @@ TEST_F(PWTEST,test4_3)
         EXPECT_NEAR(rhog[ig].imag(),rhogout[ig].imag(),1e-6);
         EXPECT_NEAR(rhogr[ig].real(),rhogout[ig].real(),1e-6);
         EXPECT_NEAR(rhogr[ig].imag(),rhogout[ig].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         EXPECT_NEAR(rhofg[ig].real(),rhofgout[ig].real(),1e-4);
         EXPECT_NEAR(rhofg[ig].imag(),rhofgout[ig].imag(),1e-4);
         EXPECT_NEAR(rhofgr[ig].real(),rhofgout[ig].real(),1e-4);
@@ -192,7 +192,7 @@ TEST_F(PWTEST,test4_3)
     delete [] rhogr;
 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     delete [] rhofg;
     delete [] rhofgout;
     delete [] rhofr;

--- a/source/module_pw/test/test4-4.cpp
+++ b/source/module_pw/test/test4-4.cpp
@@ -62,7 +62,7 @@ TEST_F(PWTEST,test4_4)
     complex<double> *tmp = new complex<double> [nx*ny*nz];
     complex<double> * rhor = new complex<double> [nrxx];
     complex<double> * rhogr = new complex<double> [nmaxgr];
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     complex<float> * rhofr = new complex<float> [nrxx];
     complex<float> * rhofgr = new complex<float> [nmaxgr];
 #endif
@@ -115,7 +115,7 @@ TEST_F(PWTEST,test4_4)
 #endif
         complex<double> * rhog = new complex<double> [npwk];
         complex<double> * rhogout = new complex<double> [npwk];
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         complex<float> * rhofg = new complex<float> [npwk];
         complex<float> * rhofgout = new complex<float> [npwk];
 #endif
@@ -124,7 +124,7 @@ TEST_F(PWTEST,test4_4)
             rhog[ig] = 1.0/(pwtest.getgk2(ik,ig)+1) + ModuleBase::IMAG_UNIT / (abs(pwtest.getgdirect(ik,ig).x+1) + 1);
             rhogr[ig] = 1.0/(pwtest.getgk2(ik,ig)+1) + ModuleBase::IMAG_UNIT / (abs(pwtest.getgdirect(ik,ig).x+1) + 1);
         }    
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         for(int ig = 0 ; ig < npwk ; ++ig)
         {
             rhofg[ig] = 1.0/(pwtest.getgk2(ik,ig)+1) + ModuleBase::IMAG_UNIT / (abs(pwtest.getgdirect(ik,ig).x+1) + 1);
@@ -137,7 +137,7 @@ TEST_F(PWTEST,test4_4)
 
         pwtest.recip2real(rhogr,rhogr,ik); //check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         ModuleBase::GlobalFunc::ZEROS(rhofr, nrxx);
         pwtest.recip2real(rhofg,rhofr,ik, true, float(1)); //check out-of-place transform
 
@@ -153,7 +153,7 @@ TEST_F(PWTEST,test4_4)
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhor[ixy*nplane+iz].imag(),1e-6);
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhogr[ixy*nplane+iz].real(),1e-6);
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhogr[ixy*nplane+iz].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofr[ixy*nplane+iz].real(),1e-4);
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhofr[ixy*nplane+iz].imag(),1e-4);
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofgr[ixy*nplane+iz].real(),1e-4);
@@ -167,7 +167,7 @@ TEST_F(PWTEST,test4_4)
 
         pwtest.real2recip(rhogr,rhogr,ik);
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         ModuleBase::GlobalFunc::ZEROS(rhofgout, npwk);
         pwtest.real2recip(rhofr,rhofgout,ik, true, float(1));
 
@@ -180,7 +180,7 @@ TEST_F(PWTEST,test4_4)
             EXPECT_NEAR(rhog[ig].imag(),rhogout[ig].imag(),1e-6);
             EXPECT_NEAR(rhog[ig].real(),rhogr[ig].real(),1e-6);
             EXPECT_NEAR(rhog[ig].imag(),rhogr[ig].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
             EXPECT_NEAR(rhofg[ig].real(),rhofgout[ig].real(),1e-4);
             EXPECT_NEAR(rhofg[ig].imag(),rhofgout[ig].imag(),1e-4);
             EXPECT_NEAR(rhofg[ig].real(),rhofgr[ig].real(),1e-4);
@@ -191,7 +191,7 @@ TEST_F(PWTEST,test4_4)
 
         delete [] rhog;
         delete [] rhogout;
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         delete [] rhofg;
         delete [] rhofgout;
 #endif
@@ -226,7 +226,7 @@ TEST_F(PWTEST,test4_4)
     delete[] kvec_d;
     delete[] rhogr;
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     delete[] rhofr;
     delete[] rhofgr;
     fftwf_cleanup();

--- a/source/module_pw/test/test4-5.cpp
+++ b/source/module_pw/test/test4-5.cpp
@@ -61,7 +61,7 @@ TEST_F(PWTEST,test4_5)
     complex<double> *tmp = new complex<double> [nx*ny*nz];
     complex<double> * rhogr = new complex<double> [nmaxgr];
     double * rhor = new double [nrxx];
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     float * rhofr = new float [nrxx];
     complex<float> * rhofgr = new complex<float> [nmaxgr];
 #endif
@@ -116,7 +116,7 @@ TEST_F(PWTEST,test4_5)
 #endif
         complex<double> * rhog = new complex<double> [npwk];
         complex<double> * rhogout = new complex<double> [npwk];
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         complex<float> * rhofg = new complex<float> [npwk];
         complex<float> * rhofgout = new complex<float> [npwk];
 #endif
@@ -131,7 +131,7 @@ TEST_F(PWTEST,test4_5)
                 rhogr[ig]+=ModuleBase::IMAG_UNIT / (abs(f.x+1) + 1);
             }
         }    
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         for(int ig = 0 ; ig < npwk ; ++ig)
         {
             rhofg[ig] = 1.0/(pwtest.getgk2(ik,ig)+1); 
@@ -149,7 +149,7 @@ TEST_F(PWTEST,test4_5)
 
         pwtest.recip2real(rhogr,(double*)rhogr,ik); //check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         ModuleBase::GlobalFunc::ZEROS(rhofr, nrxx);
         pwtest.recip2real(rhofg,rhofr,ik); //check out-of-place transform
 
@@ -163,7 +163,7 @@ TEST_F(PWTEST,test4_5)
             {
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhor[ixy*nplane+iz],1e-6);
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),((double*)rhogr)[ixy*nplane+iz],1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofr[ixy*nplane+iz],1e-4);
                 EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),((float*)rhofgr)[ixy*nplane+iz],1e-4);
 #endif
@@ -175,7 +175,7 @@ TEST_F(PWTEST,test4_5)
 
         pwtest.real2recip((double*)rhogr,rhogr,ik);
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         ModuleBase::GlobalFunc::ZEROS(rhofgout, npwk);
         pwtest.real2recip<float>(rhofr,rhofgout,ik,true, 1.0);
 
@@ -188,7 +188,7 @@ TEST_F(PWTEST,test4_5)
             EXPECT_NEAR(rhog[ig].imag(),rhogout[ig].imag(),1e-6);
             EXPECT_NEAR(rhog[ig].real(),rhogr[ig].real(),1e-6);
             EXPECT_NEAR(rhog[ig].imag(),rhogr[ig].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
             EXPECT_NEAR(rhofg[ig].real(),rhofgout[ig].real(),1e-6);
             EXPECT_NEAR(rhofg[ig].imag(),rhofgout[ig].imag(),1e-6);
             EXPECT_NEAR(rhofg[ig].real(),rhofgr[ig].real(),1e-6);
@@ -199,7 +199,7 @@ TEST_F(PWTEST,test4_5)
 
         delete [] rhog;
         delete [] rhogout;
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         delete [] rhofg;
         delete [] rhofgout;
 #endif
@@ -221,7 +221,7 @@ TEST_F(PWTEST,test4_5)
     delete[] kvec_d;
     delete[] rhogr;
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     delete[] rhofr;
     delete[] rhofgr;
     fftwf_cleanup();

--- a/source/module_pw/test/test5-3-1.cpp
+++ b/source/module_pw/test/test5-3-1.cpp
@@ -117,7 +117,7 @@ TEST_F(PWTEST,test5_3_1)
         }
     }    
     double * rhor = new double [nrxx];
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     complex<float> * rhofg = new complex<float> [npw];
     complex<float> * rhofgr = new complex<float> [nmaxgr];
     complex<float> * rhofgout = new complex<float> [npw];
@@ -138,7 +138,7 @@ TEST_F(PWTEST,test5_3_1)
 
     pwtest.recip2real(rhogr,(double*)rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     pwtest.recip2real(rhofg,rhofr);//check out-of-place transform
 
     pwtest.recip2real(rhofgr,(float*)rhofgr);//check in-place transform
@@ -151,7 +151,7 @@ TEST_F(PWTEST,test5_3_1)
         {
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhor[ixy*nplane+iz],1e-6);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),((double*)rhogr)[ixy*nplane+iz],1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofr[ixy*nplane+iz],1e-4);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),((float*)rhofgr)[ixy*nplane+iz],1e-4);
 #endif
@@ -163,7 +163,7 @@ TEST_F(PWTEST,test5_3_1)
 
     pwtest.real2recip((double*)rhogr,rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     pwtest.real2recip(rhofr,rhofgout);//check out-of-place transform
 
     pwtest.real2recip((float*)rhofgr,rhofgr);//check in-place transform
@@ -175,7 +175,7 @@ TEST_F(PWTEST,test5_3_1)
         EXPECT_NEAR(rhog[ig].imag(),rhogout[ig].imag(),1e-6);
         EXPECT_NEAR(rhogr[ig].real(),rhogout[ig].real(),1e-6);
         EXPECT_NEAR(rhogr[ig].imag(),rhogout[ig].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         EXPECT_NEAR(rhofg[ig].real(),rhofgout[ig].real(),1e-4);
         EXPECT_NEAR(rhofg[ig].imag(),rhofgout[ig].imag(),1e-4);
         EXPECT_NEAR(rhofgr[ig].real(),rhofgout[ig].real(),1e-4);
@@ -190,7 +190,7 @@ TEST_F(PWTEST,test5_3_1)
     delete [] rhogr;
 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     delete [] rhofg;
     delete [] rhofgout;
     delete [] rhofr;

--- a/source/module_pw/test/test5-4-1.cpp
+++ b/source/module_pw/test/test5-4-1.cpp
@@ -108,7 +108,7 @@ TEST_F(PWTEST,test5_4_1)
         rhogr[ig] = 1.0/(pwtest.gg[ig]+1) + ModuleBase::IMAG_UNIT / (abs(pwtest.gdirect[ig].x+1) + 1);
     }    
     complex<double> * rhor = new complex<double> [nrxx];
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     complex<float> * rhofg = new complex<float> [npw];
     complex<float> * rhofgr = new complex<float> [nmaxgr];
     complex<float> * rhofgout = new complex<float> [npw];
@@ -124,7 +124,7 @@ TEST_F(PWTEST,test5_4_1)
 
     pwtest.recip2real(rhogr,rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     pwtest.recip2real(rhofg,rhofr);//check out-of-place transform
 
     pwtest.recip2real(rhofgr,rhofgr);//check in-place transform
@@ -139,7 +139,7 @@ TEST_F(PWTEST,test5_4_1)
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhor[ixy*nplane+iz].imag(),1e-6);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhogr[ixy*nplane+iz].real(),1e-6);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhogr[ixy*nplane+iz].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofr[ixy*nplane+iz].real(),1e-4);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhofr[ixy*nplane+iz].imag(),1e-4);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofgr[ixy*nplane+iz].real(),1e-4);
@@ -154,7 +154,7 @@ TEST_F(PWTEST,test5_4_1)
 
     pwtest.real2recip(rhogr,rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     pwtest.real2recip(rhofr,rhofgout);//check out-of-place transform
 
     pwtest.real2recip(rhofgr,rhofgr);//check in-place transform
@@ -166,7 +166,7 @@ TEST_F(PWTEST,test5_4_1)
         EXPECT_NEAR(rhog[ig].imag(),rhogout[ig].imag(),1e-6);
         EXPECT_NEAR(rhogr[ig].real(),rhogout[ig].real(),1e-6);
         EXPECT_NEAR(rhogr[ig].imag(),rhogout[ig].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         EXPECT_NEAR(rhofg[ig].real(),rhofgout[ig].real(),1e-4);
         EXPECT_NEAR(rhofg[ig].imag(),rhofgout[ig].imag(),1e-4);
         EXPECT_NEAR(rhofgr[ig].real(),rhofgout[ig].real(),1e-4);
@@ -181,7 +181,7 @@ TEST_F(PWTEST,test5_4_1)
     delete [] rhogr;
 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     delete [] rhofg;
     delete [] rhofgout;
     delete [] rhofr;

--- a/source/module_pw/test/test5-4-2.cpp
+++ b/source/module_pw/test/test5-4-2.cpp
@@ -108,7 +108,7 @@ TEST_F(PWTEST,test5_4_2)
         rhogr[ig] = 1.0/(pwtest.gg[ig]+1) + ModuleBase::IMAG_UNIT / (abs(pwtest.gdirect[ig].x+1) + 1);
     }    
     complex<double> * rhor = new complex<double> [nrxx];
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     complex<float> * rhofg = new complex<float> [npw];
     complex<float> * rhofgr = new complex<float> [nmaxgr];
     complex<float> * rhofgout = new complex<float> [npw];
@@ -124,7 +124,7 @@ TEST_F(PWTEST,test5_4_2)
 
     pwtest.recip2real(rhogr,rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     pwtest.recip2real(rhofg,rhofr);//check out-of-place transform
 
     pwtest.recip2real(rhofgr,rhofgr);//check in-place transform
@@ -139,7 +139,7 @@ TEST_F(PWTEST,test5_4_2)
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhor[ixy*nplane+iz].imag(),1e-6);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhogr[ixy*nplane+iz].real(),1e-6);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhogr[ixy*nplane+iz].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofr[ixy*nplane+iz].real(),1e-4);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhofr[ixy*nplane+iz].imag(),1e-4);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofgr[ixy*nplane+iz].real(),1e-4);
@@ -154,7 +154,7 @@ TEST_F(PWTEST,test5_4_2)
 
     pwtest.real2recip(rhogr,rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     pwtest.real2recip(rhofr,rhofgout);//check out-of-place transform
 
     pwtest.real2recip(rhofgr,rhofgr);//check in-place transform
@@ -166,7 +166,7 @@ TEST_F(PWTEST,test5_4_2)
         EXPECT_NEAR(rhog[ig].imag(),rhogout[ig].imag(),1e-6);
         EXPECT_NEAR(rhogr[ig].real(),rhogout[ig].real(),1e-6);
         EXPECT_NEAR(rhogr[ig].imag(),rhogout[ig].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         EXPECT_NEAR(rhofg[ig].real(),rhofgout[ig].real(),1e-4);
         EXPECT_NEAR(rhofg[ig].imag(),rhofgout[ig].imag(),1e-4);
         EXPECT_NEAR(rhofgr[ig].real(),rhofgout[ig].real(),1e-4);
@@ -181,7 +181,7 @@ TEST_F(PWTEST,test5_4_2)
     delete [] rhogr;
 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     delete [] rhofg;
     delete [] rhofgout;
     delete [] rhofr;

--- a/source/module_pw/test/test6-3-1.cpp
+++ b/source/module_pw/test/test6-3-1.cpp
@@ -117,7 +117,7 @@ TEST_F(PWTEST,test6_3_1)
         }
     }    
     double * rhor = new double [nrxx];
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     complex<float> * rhofg = new complex<float> [npw];
     complex<float> * rhofgr = new complex<float> [nmaxgr];
     complex<float> * rhofgout = new complex<float> [npw];
@@ -138,7 +138,7 @@ TEST_F(PWTEST,test6_3_1)
 
     pwtest.recip2real(rhogr,(double*)rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     pwtest.recip2real(rhofg,rhofr);//check out-of-place transform
 
     pwtest.recip2real(rhofgr,(float*)rhofgr);//check in-place transform
@@ -151,7 +151,7 @@ TEST_F(PWTEST,test6_3_1)
         {
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhor[ixy*nplane+iz],1e-6);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),((double*)rhogr)[ixy*nplane+iz],1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofr[ixy*nplane+iz],1e-4);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),((float*)rhofgr)[ixy*nplane+iz],1e-4);
 #endif
@@ -163,7 +163,7 @@ TEST_F(PWTEST,test6_3_1)
 
     pwtest.real2recip((double*)rhogr,rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     pwtest.real2recip(rhofr,rhofgout);//check out-of-place transform
 
     pwtest.real2recip((float*)rhofgr,rhofgr);//check in-place transform
@@ -175,7 +175,7 @@ TEST_F(PWTEST,test6_3_1)
         EXPECT_NEAR(rhog[ig].imag(),rhogout[ig].imag(),1e-6);
         EXPECT_NEAR(rhogr[ig].real(),rhogout[ig].real(),1e-6);
         EXPECT_NEAR(rhogr[ig].imag(),rhogout[ig].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         EXPECT_NEAR(rhofg[ig].real(),rhofgout[ig].real(),1e-4);
         EXPECT_NEAR(rhofg[ig].imag(),rhofgout[ig].imag(),1e-4);
         EXPECT_NEAR(rhofgr[ig].real(),rhofgout[ig].real(),1e-4);
@@ -190,7 +190,7 @@ TEST_F(PWTEST,test6_3_1)
     delete [] rhogr;
 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     delete [] rhofg;
     delete [] rhofgout;
     delete [] rhofr;

--- a/source/module_pw/test/test6-4-1.cpp
+++ b/source/module_pw/test/test6-4-1.cpp
@@ -108,7 +108,7 @@ TEST_F(PWTEST,test6_4_1)
         rhogr[ig] = 1.0/(pwtest.gg[ig]+1) + ModuleBase::IMAG_UNIT / (abs(pwtest.gdirect[ig].x+1) + 1);
     }    
     complex<double> * rhor = new complex<double> [nrxx];
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     complex<float> * rhofg = new complex<float> [npw];
     complex<float> * rhofgr = new complex<float> [nmaxgr];
     complex<float> * rhofgout = new complex<float> [npw];
@@ -124,7 +124,7 @@ TEST_F(PWTEST,test6_4_1)
 
     pwtest.recip2real(rhogr,rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     pwtest.recip2real(rhofg,rhofr);//check out-of-place transform
 
     pwtest.recip2real(rhofgr,rhofgr);//check in-place transform
@@ -139,7 +139,7 @@ TEST_F(PWTEST,test6_4_1)
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhor[ixy*nplane+iz].imag(),1e-6);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhogr[ixy*nplane+iz].real(),1e-6);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhogr[ixy*nplane+iz].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofr[ixy*nplane+iz].real(),1e-4);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhofr[ixy*nplane+iz].imag(),1e-4);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofgr[ixy*nplane+iz].real(),1e-4);
@@ -154,7 +154,7 @@ TEST_F(PWTEST,test6_4_1)
 
     pwtest.real2recip(rhogr,rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     pwtest.real2recip(rhofr,rhofgout);//check out-of-place transform
 
     pwtest.real2recip(rhofgr,rhofgr);//check in-place transform
@@ -166,7 +166,7 @@ TEST_F(PWTEST,test6_4_1)
         EXPECT_NEAR(rhog[ig].imag(),rhogout[ig].imag(),1e-6);
         EXPECT_NEAR(rhogr[ig].real(),rhogout[ig].real(),1e-6);
         EXPECT_NEAR(rhogr[ig].imag(),rhogout[ig].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         EXPECT_NEAR(rhofg[ig].real(),rhofgout[ig].real(),1e-4);
         EXPECT_NEAR(rhofg[ig].imag(),rhofgout[ig].imag(),1e-4);
         EXPECT_NEAR(rhofgr[ig].real(),rhofgout[ig].real(),1e-4);
@@ -181,7 +181,7 @@ TEST_F(PWTEST,test6_4_1)
     delete [] rhogr;
 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     delete [] rhofg;
     delete [] rhofgout;
     delete [] rhofr;

--- a/source/module_pw/test/test6-4-2.cpp
+++ b/source/module_pw/test/test6-4-2.cpp
@@ -108,7 +108,7 @@ TEST_F(PWTEST,test6_4_2)
         rhogr[ig] = 1.0/(pwtest.gg[ig]+1) + ModuleBase::IMAG_UNIT / (abs(pwtest.gdirect[ig].x+1) + 1);
     }    
     complex<double> * rhor = new complex<double> [nrxx];
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     complex<float> * rhofg = new complex<float> [npw];
     complex<float> * rhofgr = new complex<float> [nmaxgr];
     complex<float> * rhofgout = new complex<float> [npw];
@@ -124,7 +124,7 @@ TEST_F(PWTEST,test6_4_2)
 
     pwtest.recip2real(rhogr,rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     pwtest.recip2real(rhofg,rhofr);//check out-of-place transform
 
     pwtest.recip2real(rhofgr,rhofgr);//check in-place transform
@@ -139,7 +139,7 @@ TEST_F(PWTEST,test6_4_2)
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhor[ixy*nplane+iz].imag(),1e-6);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhogr[ixy*nplane+iz].real(),1e-6);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhogr[ixy*nplane+iz].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofr[ixy*nplane+iz].real(),1e-4);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].imag(),rhofr[ixy*nplane+iz].imag(),1e-4);
             EXPECT_NEAR(tmp[ixy * nz + startiz + iz].real(),rhofgr[ixy*nplane+iz].real(),1e-4);
@@ -154,7 +154,7 @@ TEST_F(PWTEST,test6_4_2)
 
     pwtest.real2recip(rhogr,rhogr);//check in-place transform
 
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     pwtest.real2recip(rhofr,rhofgout);//check out-of-place transform
 
     pwtest.real2recip(rhofgr,rhofgr);//check in-place transform
@@ -166,7 +166,7 @@ TEST_F(PWTEST,test6_4_2)
         EXPECT_NEAR(rhog[ig].imag(),rhogout[ig].imag(),1e-6);
         EXPECT_NEAR(rhogr[ig].real(),rhogout[ig].real(),1e-6);
         EXPECT_NEAR(rhogr[ig].imag(),rhogout[ig].imag(),1e-6);
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
         EXPECT_NEAR(rhofg[ig].real(),rhofgout[ig].real(),1e-4);
         EXPECT_NEAR(rhofg[ig].imag(),rhofgout[ig].imag(),1e-4);
         EXPECT_NEAR(rhofgr[ig].real(),rhofgout[ig].real(),1e-4);
@@ -181,7 +181,7 @@ TEST_F(PWTEST,test6_4_2)
     delete [] rhogr;
 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     delete [] rhofg;
     delete [] rhofgout;
     delete [] rhofr;

--- a/source/module_pw/test/test7-3-1.cpp
+++ b/source/module_pw/test/test7-3-1.cpp
@@ -148,7 +148,7 @@ TEST_F(PWTEST,test7_3_1)
     delete [] rhogr;
 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     fftwf_cleanup();
 #endif
 }

--- a/source/module_pw/test/test7-3-2.cpp
+++ b/source/module_pw/test/test7-3-2.cpp
@@ -149,7 +149,7 @@ TEST_F(PWTEST,test7_3_2)
     delete [] rhogr;
 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     fftwf_cleanup();
 #endif
 }

--- a/source/module_pw/test/test8-2-1.cpp
+++ b/source/module_pw/test/test8-2-1.cpp
@@ -156,7 +156,7 @@ TEST_F(PWTEST,test8_2_1)
     delete [] rhogr;
 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     fftwf_cleanup();
 #endif
 }

--- a/source/module_pw/test/test8-3-1.cpp
+++ b/source/module_pw/test/test8-3-1.cpp
@@ -148,7 +148,7 @@ TEST_F(PWTEST,test8_3_1)
     delete [] rhogr;
 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     fftwf_cleanup();
 #endif
 }

--- a/source/module_pw/test/test8-3-2.cpp
+++ b/source/module_pw/test/test8-3-2.cpp
@@ -149,7 +149,7 @@ TEST_F(PWTEST,test8_3_2)
     delete [] rhogr;
 
     fftw_cleanup();
-#ifdef __MIX_PRECISION
+#ifdef __ENABLE_FLOAT_FFTW
     fftwf_cleanup();
 #endif
 }


### PR DESCRIPTION
Remove the default dependence of single precision FFTW library.