### PR TITLE
Refactor: control components written in MD_dump

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -23,7 +23,7 @@
   [relax_nmax](#relax_nmax) | [relax_method](#relax_method) | [relax_cg_thr](#relax_cg_thr) | [relax_bfgs_w1](#relax_bfgs_w1) | [relax_bfgs_w2](#relax_bfgs_w2) | [relax_bfgs_rmax](#relax_bfgs_rmax) | [relax_bfgs_rmin](#relax_bfgs_rmin) | [relax_bfgs_init](#relax_bfgs_init) | [cal_force](#cal_force) | [force_thr](#force_thr) | [force_thr_ev](#force_thr_ev) | [force_thr_ev2](#force_thr_ev2) | [cal_stress](#cal_stress) | [stress_thr](#stress_thr) | [press1, press2, press3](#press1-press2-press3) | [fixed_axes](#fixed_axes) | [cell_factor](#cell_factor) | [fixed_ibrav](#fixed_ibrav) | [relax_new](#relax_new) | [relax_scale_force](#relax_scale_force)
 - [Variables related to output information](#variables-related-to-output-information)
 
-  [out_force](#out_force) | [out_mul](#out_mul) | [out_freq_elec](#out_freq_elec) | [out_freq_ion](#out_freq_ion) | [out_chg](#out_chg) | [out_pot](#out_pot) | [out_dm](#out_dm) | [out_wfc_pw](#out_wfc_pw) | [out_wfc_r](#out_wfc_r) | [out_wfc_lcao](#out_wfc_lcao) | [out_dos](#out_dos) | [out_band](#out_band) | [out_proj_band](#out_proj_band) | [out_stru](#out_stru) | [out_bandgap](#out_bandgap) | [out_level](#out_level) | [out_alllog](#out_alllog) | [out_mat_hs](#out_mat_hs) | [out_mat_r](#out_mat_r) | [out_mat_hs2](#out_mat_hs2) | [out_mat_t](#out_mat_t) | [out_mat_dh](#out_mat_dh) | [out_hs2_interval](#out_hs2_interval) | [out_element_info](#out_element_info) | [restart_save](#restart_save) | [restart_load](#restart_load) | [dft_plus_dmft](#dft_plus_dmft) | [rpa](#rpa)
+  [out_mul](#out_mul) | [out_freq_elec](#out_freq_elec) | [out_freq_ion](#out_freq_ion) | [out_chg](#out_chg) | [out_pot](#out_pot) | [out_dm](#out_dm) | [out_wfc_pw](#out_wfc_pw) | [out_wfc_r](#out_wfc_r) | [out_wfc_lcao](#out_wfc_lcao) | [out_dos](#out_dos) | [out_band](#out_band) | [out_proj_band](#out_proj_band) | [out_stru](#out_stru) | [out_bandgap](#out_bandgap) | [out_level](#out_level) | [out_alllog](#out_alllog) | [out_mat_hs](#out_mat_hs) | [out_mat_r](#out_mat_r) | [out_mat_hs2](#out_mat_hs2) | [out_mat_t](#out_mat_t) | [out_mat_dh](#out_mat_dh) | [out_hs2_interval](#out_hs2_interval) | [out_element_info](#out_element_info) | [restart_save](#restart_save) | [restart_load](#restart_load) | [dft_plus_dmft](#dft_plus_dmft) | [rpa](#rpa)
 - [Density of states](#density-of-states)
 
   [dos_edelta_ev](#dos_edelta_ev) | [dos_sigma](#dos_sigma) | [dos_scale](#dos_scale) | [dos_emin_ev](#dos_emin_ev) | [dos_emax_ev](#dos_emax_ev) | [dos_nche](#dos_nche)
@@ -32,7 +32,7 @@
   [exx_hybrid_alpha](#exx_hybrid_alpha) | [exx_hse_omega](#exx_hse_omega) | [exx_separate_loop](#exx_separate_loop) | [exx_hybrid_step](#exx_hybrid_step) | [exx_lambda](#exx_lambda) | [exx_pca_threshold](#exx_pca_threshold) | [exx_c_threshold](#exx_c_threshold) | [exx_v_threshold](#exx_v_threshold) | [exx_c_grad_threshold](#exx_c_grad_threshold) | [exx_v_grad_threshold](#exx_v_grad_threshold) | [exx_dm_threshold](#exx_dm_threshold) | [exx_schwarz_threshold](#exx_schwarz_threshold) | [exx_cauchy_threshold](#exx_cauchy_threshold) | [exx_cauchy_grad_threshold](#exx_cauchy_grad_threshold) | [exx_ccp_threshold](#exx_ccp_threshold) | [exx_ccp_rmesh_times](#exx_ccp_rmesh_times) | [exx_distribute_type](#exx_distribute_type) | [exx_opt_orb_lmax](#exx_opt_orb_lmax) | [exx_opt_orb_ecut](#exx_opt_orb_ecut) | [exx_opt_orb_tolerence](#exx_opt_orb_tolerence) | [exx_real_number](#exx_real_number)
 - [Molecular dynamics](#molecular-dynamics)
 
-  [md_type](#md_type) | [md_thermostat](#md_thermostat) | [md_nstep](#md_nstep) | [md_restart](#md_restart) | [md_dt](#md_dt) | [md_tfirst, md_tlast](#md_tfirst-md_tlast) | [md_dumpfreq](#md_dumpfreq) | [md_restartfreq](#md_restartfreq) | [md_seed](#md_seed) | [md_tfreq](#md_tfreq) | [md_tchain](#md_tchain) | [md_pmode](#md_pmode) | [md_pcouple](#md_pcouple) | [md_pfirst, md_plast](#md_pfirst-md_plast) | [md_pfreq](#md_pfreq) | [md_pchain](#md_pchain) | [lj_rcut](#lj_rcut) | [lj_epsilon](#lj_epsilon) | [lj_sigma](#lj_sigma) | [pot_file](#pot_file) | [msst_direction](#msst_direction) | [msst_vel](#msst_vel) | [msst_vis](#msst_vis) | [msst_tscale](#msst_tscale) | [msst_qmass](#msst_qmass) | [md_damp](#md_damp) | [md_tolerance](#md_tolerance) | [md_nraise](#md_nraise)
+  [md_type](#md_type) | [md_thermostat](#md_thermostat) | [md_nstep](#md_nstep) | [md_restart](#md_restart) | [md_dt](#md_dt) | [md_tfirst, md_tlast](#md_tfirst-md_tlast) | [md_dumpfreq](#md_dumpfreq) | [md_restartfreq](#md_restartfreq) | [md_seed](#md_seed) | [md_tfreq](#md_tfreq) | [md_tchain](#md_tchain) | [md_pmode](#md_pmode) | [md_pcouple](#md_pcouple) | [md_pfirst, md_plast](#md_pfirst-md_plast) | [md_pfreq](#md_pfreq) | [md_pchain](#md_pchain) | [out_force](#out_force) | [out_vel](#out_vel) | [out_virial](#out_virial) | [lj_rcut](#lj_rcut) | [lj_epsilon](#lj_epsilon) | [lj_sigma](#lj_sigma) | [pot_file](#pot_file) | [msst_direction](#msst_direction) | [msst_vel](#msst_vel) | [msst_vis](#msst_vis) | [msst_tscale](#msst_tscale) | [msst_qmass](#msst_qmass) | [md_damp](#md_damp) | [md_tolerance](#md_tolerance) | [md_nraise](#md_nraise)
 - [vdW correction](#vdw-correction)
 
   [vdw_method](#vdw_method) | [vdw_s6](#vdw_s6) | [vdw_s8](#vdw_s8) | [vdw_a1](#vdw_a1) | [vdw_a2](#vdw_a2) | [vdw_d](#vdw_d) | [vdw_abc](#vdw_abc) | [vdw_C6_file](#vdw_c6_file) | [vdw_C6_unit](#vdw_c6_unit) | [vdw_R0_file](#vdw_r0_file) | [vdw_R0_unit](#vdw_r0_unit) | [vdw_cutoff_type](#vdw_cutoff_type) | [vdw_cutoff_radius](#vdw_cutoff_radius) | [vdw_radius_unit](#vdw_radius_unit) | [vdw_cutoff_period](#vdw_cutoff_period) | [vdw_cn_thr](#vdw_cn_thr) | [vdw_cn_thr_unit](#vdw_cn_thr_unit)
@@ -824,12 +824,6 @@ These variables are used to control the geometry relaxation.
 ## Variables related to output information
 
 These variables are used to control the output of properties.
-
-### out_force
-
-- **Type**: Boolean
-- **Description**: Determines whether to output the out_force into a file named `Force.dat` or not. If 1, then force will be written; if 0, then the force will not be written.
-- **Default**: 0
 
 ### out_mul
 
@@ -1667,6 +1661,24 @@ These variables are used to control the molecular dynamics calculations.
 - **Type**: Integer
 - **Description**: number of thermostats coupled with the barostat in the Nose Hoover Chain method.
 - **Default**: 1
+
+### out_force
+
+- **Type**: Boolean
+- **Description**: Output atomic forces into the file `MD_dump` or not. If `true`, forces will be written, otherwise forces will not be written.
+- **Default**: false
+
+### out_vel
+
+- **Type**: Boolean
+- **Description**: Output atomic velocities into the file `MD_dump` or not. If `true`, velocities will be written, otherwise velocities will not be written.
+- **Default**: false
+
+### out_virial
+
+- **Type**: Boolean
+- **Description**: Output lattice virial into the file `MD_dump` or not. If `true`, lattice virial will be written, otherwise lattice virial will not be written.
+- **Default**: false
 
 ### lj_rcut
 

--- a/docs/advanced/md.md
+++ b/docs/advanced/md.md
@@ -30,6 +30,8 @@ Furthermore, ABACUS also provides a [list of keywords](./input_files/input-main.
 To employ CMD calculations, `esolver_type` should be set to be `lj` or `dp`.
 If DP model is selected, the filename of DP model is specified by keyword `pot_file`.
 
+The MD output information will be written into the file `MD_dump`， in which the atomic forces, atomic velocities, and lattice virial are controlled by keyword `out_force`, `out_vel`, and `out_virial`, respectively.
+
 [Examples](https://github.com/deepmodeling/abacus-develop/tree/develop/examples/md/lcao_gammaonly_Sn64) of MD simulations are also provided.
 There are eight INPUT files corresponding to eight different MD evolution methods in the directory.
 For examlpe, `INPUT_0` shows how to employ the NVE simulation.

--- a/examples/fixed_occupations/INPUT
+++ b/examples/fixed_occupations/INPUT
@@ -17,7 +17,6 @@ relax_nmax                    50
 cal_force                     1
 force_thr_ev                  0.01
 relax_method                  cg
-out_force                     1
 out_stru                      1
 ocp                           1
 ocp_set                       128*1 92*0 125*1 0 0.5 0.5 92*0

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -719,6 +719,11 @@ void ESolver_KS_LCAO::afterscf(const int istep)
 
         std::stringstream ssc;
         std::stringstream ss1;
+        ss1 << GlobalV::global_out_dir << "tmp_SPIN" << is + 1 << "_CHG";
+        std::remove(ss1.str().c_str());    // remove tmp_SPIN_CHG when scf is finished    liuyu 2023-03-01
+        ss1 << ".cube";
+        std::remove(ss1.str().c_str());    // remove tmp_SPIN_CHG.cube when scf is finished    liuyu 2023-03-01
+
         ssc << GlobalV::global_out_dir << "SPIN" << is + 1 << "_CHG";
         ModuleIO::write_rho(pelec->charge->rho_save[is], is, 0, ssc.str()); // mohan add 2007-10-17
 

--- a/source/module_esolver/esolver_ks_pw.cpp
+++ b/source/module_esolver/esolver_ks_pw.cpp
@@ -480,6 +480,11 @@ namespace ModuleESolver
         {
             std::stringstream ssc;
             std::stringstream ss1;
+            ss1 << GlobalV::global_out_dir << "tmp_SPIN" << is + 1 << "_CHG";
+            std::remove(ss1.str().c_str());    // remove tmp_SPIN_CHG when scf is finished    liuyu 2023-03-01
+            ss1 << ".cube";
+            std::remove(ss1.str().c_str());    // remove tmp_SPIN_CHG.cube when scf is finished    liuyu 2023-03-01
+
             ssc << GlobalV::global_out_dir << "SPIN" << is + 1 << "_CHG";
             ModuleIO::write_rho(this->pelec->charge->rho_save[is], is, 0, ssc.str());//mohan add 2007-10-17
         }

--- a/source/module_esolver/esolver_of.cpp
+++ b/source/module_esolver/esolver_of.cpp
@@ -905,7 +905,7 @@ void ESolver_OF::afterOpt()
         {
             std::stringstream ssc;
             std::stringstream ss1;
-            ssc << GlobalV::global_out_dir << "tmp" << "_SPIN" << is + 1 << "_CHG";
+            ssc << GlobalV::global_out_dir << "SPIN" << is + 1 << "_CHG";
             ModuleIO::write_rho(pelec->charge->rho[is], is, iter, ssc.str(), 3);//mohan add 2007-10-17
         }
     }

--- a/source/module_io/input.cpp
+++ b/source/module_io/input.cpp
@@ -187,6 +187,8 @@ void Input::Default(void)
     symmetry_prec = 1.0e-5; // LiuXh add 2021-08-12, accuracy for symmetry
     cal_force = 0;
     out_force = false;
+    out_vel = false;
+    out_virial = false;
     force_thr = 1.0e-3;
     force_thr_ev2 = 0;
     stress_thr = 1.0e-2; // LiuXh add 20180515
@@ -845,6 +847,14 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("out_force", word) == 0)
         {
             read_bool(ifs, out_force);
+        }
+        else if (strcmp("out_vel", word) == 0)
+        {
+            read_bool(ifs, out_vel);
+        }
+        else if (strcmp("out_virial", word) == 0)
+        {
+            read_bool(ifs, out_virial);
         }
         else if (strcmp("force_thr", word) == 0)
         {
@@ -2700,6 +2710,8 @@ void Input::Bcast()
     Parallel_Common::bcast_double(symmetry_prec); // LiuXh add 2021-08-12, accuracy for symmetry
     Parallel_Common::bcast_bool(cal_force);
     Parallel_Common::bcast_bool(out_force);
+    Parallel_Common::bcast_bool(out_vel);
+    Parallel_Common::bcast_bool(out_virial);
     Parallel_Common::bcast_double(force_thr);
     Parallel_Common::bcast_double(force_thr_ev2);
     Parallel_Common::bcast_double(stress_thr); // LiuXh add 20180515

--- a/source/module_io/input.h
+++ b/source/module_io/input.h
@@ -46,6 +46,7 @@ class Input
     int pw_seed; // random seed for initializing wave functions qianrui 2021-8-12
 
     bool init_vel; // read velocity from STRU or not  liuyu 2021-07-14
+    bool out_vel;    // output atomic velocities into the file MD_dump or not. liuyu 2023-03-01
 
     /* symmetry level: 
       -1, no symmetry at all; 
@@ -106,7 +107,7 @@ class Input
     // Forces
     //==========================================================
     bool cal_force;
-    bool out_force;
+    bool out_force;    // output atomic forces into the file MD_dump or not. liuyu 2023-03-01
     double force_thr; // threshold of force in unit (Ry/Bohr)
     double force_thr_ev2; // invalid force threshold, mohan add 2011-04-17
 
@@ -118,6 +119,7 @@ class Input
     double press2;
     double press3;
     bool cal_stress; // calculate the stress
+    bool out_virial;    // output lattice virial into the file MD_dump or not. liuyu 2023-03-01
 
     std::string fixed_axes; // which axes are fixed
     bool fixed_ibrav; //whether to keep type of lattice; must be used along with latname

--- a/source/module_io/write_input.cpp
+++ b/source/module_io/write_input.cpp
@@ -146,7 +146,6 @@ void Input::Print(const std::string &fn) const
                                  GlobalV::KS_SOLVER,
                                  "cg; dav; lapack; genelpa; scalapack_gvx; cusolver");
     ModuleBase::GlobalFunc::OUTP(ofs, "scf_nmax", scf_nmax, "#number of electron iterations");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_force", out_force, "output the out_force or not");
     ModuleBase::GlobalFunc::OUTP(ofs, "relax_nmax", relax_nmax, "number of ion iteration steps");
     ModuleBase::GlobalFunc::OUTP(ofs, "out_stru", out_stru, "output the structure files after each ion step");
     ModuleBase::GlobalFunc::OUTP(ofs, "force_thr", force_thr, "force threshold, unit: Ry/Bohr");
@@ -268,6 +267,9 @@ ModuleBase::GlobalFunc::OUTP(ofs, "out_bandgap", out_bandgap, "if true, print ou
     ModuleBase::GlobalFunc::OUTP(ofs,"md_pfirst",mdp.md_pfirst,"initial target pressure");
     ModuleBase::GlobalFunc::OUTP(ofs,"md_plast",mdp.md_plast,"final target pressure");
     ModuleBase::GlobalFunc::OUTP(ofs,"md_pfreq",mdp.md_pfreq,"oscillation frequency, used to determine qmass of thermostats coupled with barostat");
+    ModuleBase::GlobalFunc::OUTP(ofs, "out_force", out_force, "output atomic forces into the file MD_dump or not");
+    ModuleBase::GlobalFunc::OUTP(ofs, "out_vel", out_vel, "output atomic velocities into the file MD_dump or not");
+    ModuleBase::GlobalFunc::OUTP(ofs, "out_virial", out_virial, "output atomic velocities into the file MD_dump or not");
 
     ofs << "\n#Parameters (10.Electric field and dipole correction)" << std::endl;
     ModuleBase::GlobalFunc::OUTP(ofs,"efield_flag",efield_flag,"add electric field");

--- a/source/module_md/MD_func.h
+++ b/source/module_md/MD_func.h
@@ -58,11 +58,13 @@ class MD_func
 
 	static void outStress(const ModuleBase::matrix &virial, const ModuleBase::matrix &stress);
 
-	static void MDdump(
-		const int &step, 
-		const UnitCell &unit_in,
-		const ModuleBase::matrix &virial, 
-		const ModuleBase::Vector3<double> *force);
+    static void MDdump(
+        const int &step, 
+        const UnitCell &unit_in,
+        const Input &inp,
+        const ModuleBase::matrix &virial, 
+        const ModuleBase::Vector3<double> *force,
+        const ModuleBase::Vector3<double> *vel);
 
 	static void getMassMbl(const UnitCell &unit_in, 
 		double* allmass, 

--- a/source/module_md/run_md.cpp
+++ b/source/module_md/run_md.cpp
@@ -68,7 +68,12 @@ void Run_MD::md_line(UnitCell &unit_in, ModuleESolver::ESolver *p_esolver)
             // Print_Info::print_screen(0, 0, mdrun->step_ + mdrun->step_rst_);
             mdrun->outputMD(GlobalV::ofs_running, GlobalV::CAL_STRESS);
 
-            MD_func::MDdump(mdrun->step_ + mdrun->step_rst_, mdrun->ucell, mdrun->virial, mdrun->force);
+            MD_func::MDdump(mdrun->step_ + mdrun->step_rst_, 
+                            mdrun->ucell, 
+                            INPUT, 
+                            mdrun->virial, 
+                            mdrun->force, 
+                            mdrun->vel);
         }
 
         if((mdrun->step_ + mdrun->step_rst_) % mdrun->mdp.md_restartfreq == 0)

--- a/source/module_md/test/MD_func_test.cpp
+++ b/source/module_md/test/MD_func_test.cpp
@@ -175,7 +175,7 @@ TEST_F(MD_func_test, compute_stress)
 TEST_F(MD_func_test, MDdump)
 {
     MD_func::InitPos(ucell, pos);
-    MD_func::MDdump(0, ucell, virial, force);
+    MD_func::MDdump(0, ucell, INPUT, virial, force, vel);
     std::ifstream ifs("MD_dump");
     std::string output_str;
     getline(ifs,output_str);
@@ -191,7 +191,7 @@ TEST_F(MD_func_test, MDdump)
     getline(ifs,output_str);
     EXPECT_THAT(output_str,testing::HasSubstr("  0.000000000000  0.000000000000  10.000000000000"));
     getline(ifs,output_str);
-    EXPECT_THAT(output_str,testing::HasSubstr("VIRIAL (KBAR)"));
+    EXPECT_THAT(output_str,testing::HasSubstr("VIRIAL (kBar)"));
     getline(ifs,output_str);
     EXPECT_THAT(output_str,testing::HasSubstr("  0.000000000000  0.000000000000  0.000000000000"));
     getline(ifs,output_str);
@@ -199,19 +199,19 @@ TEST_F(MD_func_test, MDdump)
     getline(ifs,output_str);
     EXPECT_THAT(output_str,testing::HasSubstr("  0.000000000000  0.000000000000  0.000000000000"));
     getline(ifs,output_str);
-    EXPECT_THAT(output_str,testing::HasSubstr("INDEX    LABEL    POSITIONS    FORCE (eV/Angstrom)"));
+    EXPECT_THAT(output_str,testing::HasSubstr("INDEX    LABEL    POSITION (Angstrom)    FORCE (eV/Angstrom)    VELOCITY (Angstrom/fs)"));
     getline(ifs,output_str);
-    EXPECT_THAT(output_str,testing::HasSubstr("  0  Ar  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000"));
+    EXPECT_THAT(output_str,testing::HasSubstr("  0  Ar  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000"));
     getline(ifs,output_str);
-    EXPECT_THAT(output_str,testing::HasSubstr("  1  Ar  5.200000000000  5.200000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000"));
+    EXPECT_THAT(output_str,testing::HasSubstr("  1  Ar  2.751720222021  2.751720222021  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000"));
     getline(ifs,output_str);
-    EXPECT_THAT(output_str,testing::HasSubstr("  2  Ar  5.100000000000  0.000000000000  5.000000000000  0.000000000000  0.000000000000  0.000000000000"));
+    EXPECT_THAT(output_str,testing::HasSubstr("  2  Ar  2.698802525444  0.000000000000  2.645884828867  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000"));
     getline(ifs,output_str);
-    EXPECT_THAT(output_str,testing::HasSubstr("  3  Ar  0.000000000000  5.300000000000  5.000000000000  0.000000000000  0.000000000000  0.000000000000"));
+    EXPECT_THAT(output_str,testing::HasSubstr("  3  Ar  0.000000000000  2.804637918599  2.645884828867  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000"));
     ifs.close();
 
     // append
-    MD_func::MDdump(1, ucell, virial, force);
+    MD_func::MDdump(1, ucell, INPUT, virial, force, vel);
     std::ifstream ifs2("MD_dump");
     getline(ifs2,output_str);
     EXPECT_THAT(output_str,testing::HasSubstr("MDSTEP:  0"));
@@ -226,7 +226,7 @@ TEST_F(MD_func_test, MDdump)
     getline(ifs2,output_str);
     EXPECT_THAT(output_str,testing::HasSubstr("  0.000000000000  0.000000000000  10.000000000000"));
     getline(ifs2,output_str);
-    EXPECT_THAT(output_str,testing::HasSubstr("VIRIAL (KBAR)"));
+    EXPECT_THAT(output_str,testing::HasSubstr("VIRIAL (kBar)"));
     getline(ifs2,output_str);
     EXPECT_THAT(output_str,testing::HasSubstr("  0.000000000000  0.000000000000  0.000000000000"));
     getline(ifs2,output_str);
@@ -234,15 +234,15 @@ TEST_F(MD_func_test, MDdump)
     getline(ifs2,output_str);
     EXPECT_THAT(output_str,testing::HasSubstr("  0.000000000000  0.000000000000  0.000000000000"));
     getline(ifs2,output_str);
-    EXPECT_THAT(output_str,testing::HasSubstr("INDEX    LABEL    POSITIONS    FORCE (eV/Angstrom)"));
+    EXPECT_THAT(output_str,testing::HasSubstr("INDEX    LABEL    POSITION (Angstrom)    FORCE (eV/Angstrom)    VELOCITY (Angstrom/fs)"));
     getline(ifs2,output_str);
-    EXPECT_THAT(output_str,testing::HasSubstr("  0  Ar  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000"));
+    EXPECT_THAT(output_str,testing::HasSubstr("  0  Ar  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000"));
     getline(ifs2,output_str);
-    EXPECT_THAT(output_str,testing::HasSubstr("  1  Ar  5.200000000000  5.200000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000"));
+    EXPECT_THAT(output_str,testing::HasSubstr("  1  Ar  2.751720222021  2.751720222021  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000"));
     getline(ifs2,output_str);
-    EXPECT_THAT(output_str,testing::HasSubstr("  2  Ar  5.100000000000  0.000000000000  5.000000000000  0.000000000000  0.000000000000  0.000000000000"));
+    EXPECT_THAT(output_str,testing::HasSubstr("  2  Ar  2.698802525444  0.000000000000  2.645884828867  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000"));
     getline(ifs2,output_str);
-    EXPECT_THAT(output_str,testing::HasSubstr("  3  Ar  0.000000000000  5.300000000000  5.000000000000  0.000000000000  0.000000000000  0.000000000000"));
+    EXPECT_THAT(output_str,testing::HasSubstr("  3  Ar  0.000000000000  2.804637918599  2.645884828867  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000"));
     getline(ifs2,output_str);
     getline(ifs2,output_str);
     getline(ifs2,output_str);
@@ -258,7 +258,7 @@ TEST_F(MD_func_test, MDdump)
     getline(ifs2,output_str);
     EXPECT_THAT(output_str,testing::HasSubstr("  0.000000000000  0.000000000000  10.000000000000"));
     getline(ifs2,output_str);
-    EXPECT_THAT(output_str,testing::HasSubstr("VIRIAL (KBAR)"));
+    EXPECT_THAT(output_str,testing::HasSubstr("VIRIAL (kBar)"));
     getline(ifs2,output_str);
     EXPECT_THAT(output_str,testing::HasSubstr("  0.000000000000  0.000000000000  0.000000000000"));
     getline(ifs2,output_str);
@@ -266,15 +266,15 @@ TEST_F(MD_func_test, MDdump)
     getline(ifs2,output_str);
     EXPECT_THAT(output_str,testing::HasSubstr("  0.000000000000  0.000000000000  0.000000000000"));
     getline(ifs2,output_str);
-    EXPECT_THAT(output_str,testing::HasSubstr("INDEX    LABEL    POSITIONS    FORCE (eV/Angstrom)"));
+    EXPECT_THAT(output_str,testing::HasSubstr("INDEX    LABEL    POSITION (Angstrom)    FORCE (eV/Angstrom)    VELOCITY (Angstrom/fs)"));
     getline(ifs2,output_str);
-    EXPECT_THAT(output_str,testing::HasSubstr("  0  Ar  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000"));
+    EXPECT_THAT(output_str,testing::HasSubstr("  0  Ar  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000"));
     getline(ifs2,output_str);
-    EXPECT_THAT(output_str,testing::HasSubstr("  1  Ar  5.200000000000  5.200000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000"));
+    EXPECT_THAT(output_str,testing::HasSubstr("  1  Ar  2.751720222021  2.751720222021  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000"));
     getline(ifs2,output_str);
-    EXPECT_THAT(output_str,testing::HasSubstr("  2  Ar  5.100000000000  0.000000000000  5.000000000000  0.000000000000  0.000000000000  0.000000000000"));
+    EXPECT_THAT(output_str,testing::HasSubstr("  2  Ar  2.698802525444  0.000000000000  2.645884828867  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000"));
     getline(ifs2,output_str);
-    EXPECT_THAT(output_str,testing::HasSubstr("  3  Ar  0.000000000000  5.300000000000  5.000000000000  0.000000000000  0.000000000000  0.000000000000"));
+    EXPECT_THAT(output_str,testing::HasSubstr("  3  Ar  0.000000000000  2.804637918599  2.645884828867  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000  0.000000000000"));
     ifs2.close();
 
     remove("MD_dump");

--- a/source/module_md/test/setcell.h
+++ b/source/module_md/test/setcell.h
@@ -111,6 +111,10 @@ public:
         GlobalV::SEARCH_RADIUS = 8.5 * ModuleBase::ANGSTROM_AU;
         GlobalV::CAL_STRESS = 1;
 
+        INPUT.out_virial = true;
+        INPUT.out_force = true;
+        INPUT.out_vel = true;
+
         INPUT.mdp.md_restart = 0;
         INPUT.mdp.md_dt = 1;
         INPUT.mdp.md_tfirst = INPUT.mdp.md_tlast = 300;


### PR DESCRIPTION
fix #1981 

1. remove tmp_SPIN_CHG when scf is finish;
2. add paras out_vel and out_virial for md;
3. control components written in MD_dump.