### PR TITLE
Fix: no coverage found in module_io in CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,7 +482,8 @@ target_link_libraries(${ABACUS_BIN_NAME}
     planewave
     surchem
     neighbor
-    io
+    io_basic
+    io_advanced
     relax
     driver
     xc_

--- a/source/module_hamilt_lcao/module_deepks/test/CMakeLists.txt
+++ b/source/module_hamilt_lcao/module_deepks/test/CMakeLists.txt
@@ -11,7 +11,7 @@ get_target_property(ABACUS_LINK_LIBRARIES ${ABACUS_BIN_NAME} LINK_LIBRARIES)
 target_link_libraries(
     test_deepks
     base cell symmetry md surchem xc_
-    neighbor orb io_basic relax gint driver esolver hsolver psi elecstate
+    neighbor orb io_basic io_advanced relax gint driver esolver hsolver psi elecstate
     hamilt_general hamilt_pwdft hamilt_lcao tddft hamilt_ofdft hamilt_stodft planewave
     pthread vdw dftu
     deepks device

--- a/source/module_hamilt_lcao/module_deepks/test/CMakeLists.txt
+++ b/source/module_hamilt_lcao/module_deepks/test/CMakeLists.txt
@@ -11,7 +11,7 @@ get_target_property(ABACUS_LINK_LIBRARIES ${ABACUS_BIN_NAME} LINK_LIBRARIES)
 target_link_libraries(
     test_deepks
     base cell symmetry md surchem xc_
-    neighbor orb io relax gint driver esolver hsolver psi elecstate 
+    neighbor orb io_basic relax gint driver esolver hsolver psi elecstate
     hamilt_general hamilt_pwdft hamilt_lcao tddft hamilt_ofdft hamilt_stodft planewave
     pthread vdw dftu
     deepks device

--- a/source/module_io/CMakeLists.txt
+++ b/source/module_io/CMakeLists.txt
@@ -14,7 +14,6 @@ list(APPEND objects
     read_rho.cpp
     restart.cpp
     rwstream.cpp
-    unk_overlap_pw.cpp
     write_wfc_pw.cpp
     write_input.cpp
     write_rho.cpp
@@ -23,6 +22,7 @@ list(APPEND objects
 )
 
 list(APPEND objects_advanced
+    unk_overlap_pw.cpp
     berryphase.cpp
     to_wannier90.cpp
     winput.cpp
@@ -38,7 +38,6 @@ if(ENABLE_LCAO)
       istate_charge.cpp
       istate_envelope.cpp
       read_dm.cpp
-      unk_overlap_lcao.cpp
       read_wfc_nao.cpp
       write_wfc_nao.cpp
       write_HS.cpp
@@ -48,6 +47,7 @@ if(ENABLE_LCAO)
       write_dm_sparse.cpp
   )
   list(APPEND objects_advanced
+      unk_overlap_lcao.cpp
       mulliken_charge.cpp
   )
 endif()

--- a/source/module_io/CMakeLists.txt
+++ b/source/module_io/CMakeLists.txt
@@ -53,19 +53,19 @@ if(ENABLE_LCAO)
 endif()
 
 add_library(
-    io
-    OBJECT
-    ${objects} ${objects_advanced}
-)
-
-add_library(
-    io_cov
+    io_basic
     OBJECT
     ${objects}
 )
 
+add_library(
+    io_advanced
+    OBJECT
+    ${objects_advanced}
+)
+
 if(ENABLE_COVERAGE)
-  add_coverage(io_cov)
+  add_coverage(io_basic)
 endif()
 
 if(BUILD_TESTING)


### PR DESCRIPTION
This bug is found after the acceptance of my last PR #2021 , which tried to separate advanced output codes for future coverage work, but not for present.