### PR TITLE
GenELPA upgrades to compatible with the latest version of ELPA

### DIFF
--- a/source/module_hsolver/genelpa/README
+++ b/source/module_hsolver/genelpa/README
@@ -1,4 +1,10 @@
 GenELPA, v1.1.1, customized for ABACUS
 
+changelog:
+
+- 2023/3/30
+    - Add new interface for elpa 2021.11.001 and later.
+    - Remove the `#define __MPI ...` conditional inclusion codes around MPI functions. Because ELPA and genelpa are both MPI programs, it is nonsense to only wrap some MPI functions in these codes.
+
 Project: <https://github.com/pplab/GenELPA>
 

--- a/source/module_hsolver/genelpa/elpa_generic.hpp
+++ b/source/module_hsolver/genelpa/elpa_generic.hpp
@@ -1,408 +1,444 @@
-// `elpa_generic.h` replacement for version 2021.05.002 and earlier versions
-// If the file `elpa_generic.h` has keywords `elpa_eigenvectors_all_host_arrays_dc`,
-// it is the new version of 2021.11.002; otherwise it is the old version.
 #pragma once
 #include "elpa_new.h"
-static inline void elpa_set(elpa_t e, const char *name, int value, int *error)
+#include <complex>
+/*! \brief generic C method for elpa_set
+ *
+ *  \details
+ *  \param  handle  handle of the ELPA object for which a key/value pair should be set
+ *  \param  name    the name of the key
+ *  \param  value   integer/double value to be set for the key
+ *  \param  error   on return the error code, which can be queried with elpa_strerr()
+ *  \result void
+ */
+inline void elpa_set(elpa_t handle, const char *name, int value, int *error)
 {
-    elpa_set_integer(e, name, value, error);
+    elpa_set_integer(handle, name, value, error);
+}
+inline void elpa_set(elpa_t handle, const char *name, double value, int *error)
+{
+    elpa_set_double(handle, name, value, error);
 }
 
-static inline void elpa_set(elpa_t e, const char *name, double value, int *error)
+/*! \brief generic C method for elpa_get
+ *
+ *  \details
+ *  \param  handle  handle of the ELPA object for which a key/value pair should be queried
+ *  \param  name    the name of the key
+ *  \param  value   integer/double value to be queried
+ *  \param  error   on return the error code, which can be queried with elpa_strerr()
+ *  \result void
+ */
+inline void elpa_get(elpa_t handle, const char *name, int *value, int *error)
 {
-    elpa_set_double(e, name, value, error);
+    elpa_get_integer(handle, name, value, error);
+}
+inline void elpa_get(elpa_t handle, const char *name, double *value, int *error)
+{
+    elpa_get_double(handle, name, value, error);
 }
 
-static inline void elpa_get(elpa_t e, const char *name, int *value, int *error)
-{
-    elpa_get_integer(e, name, value, error);
-}
-
-static inline void elpa_get(elpa_t e, const char *name, double *value, int *error)
-{
-    elpa_get_double(e, name, value, error);
-}
-
-#if ELPA_API_VERSION <= 20210430 // ELPA 2021.05.002 and earlier versions
-
-static inline void elpa_eigenvectors(elpa_t handle, double *a, double *ev, double *q, int *error)
+/*! \brief generic C method for elpa_eigenvectors
+ *
+ *  \details
+ *  \param  handle  handle of the ELPA object, which defines the problem
+ *  \param  a       float/double float complex/double complex pointer to matrix a
+ *  \param  ev      on return: float/double pointer to eigenvalues
+ *  \param  q       on return: float/double float complex/double complex pointer to eigenvectors
+ *  \param  error   on return the error code, which can be queried with elpa_strerr()
+ *  \result void
+ */
+#if ELPA_API_VERSION <= 20210502 // ELPA 2021.05.002 and earlier versions
+inline void elpa_eigenvectors(const elpa_t handle, double *a, double *ev, double *q, int *error)
 {
     elpa_eigenvectors_d(handle, a, ev, q, error);
 }
 
-static inline void elpa_eigenvectors(elpa_t handle, float *a, float *ev, float *q, int *error)
+inline void elpa_eigenvectors(const elpa_t handle, float  *a, float  *ev, float  *q, int *error)
 {
     elpa_eigenvectors_f(handle, a, ev, q, error);
 }
 
-static inline void elpa_eigenvectors(elpa_t handle, double complex *a, double *ev, double complex *q, int *error)
+inline void elpa_eigenvectors(const elpa_t handle, std::complex<double> *a, double *ev, std::complex<double> *q, int *error)
 {
-    elpa_eigenvectors_dc(handle, a, ev, q, error);
+    elpa_eigenvectors_dc(handle, reinterpret_cast<double _Complex*>(a), ev, reinterpret_cast<double _Complex*>(q), error);
 }
 
-static inline void elpa_eigenvectors(elpa_t handle, float complex *a, float *ev, float complex *q, int *error)
+inline void elpa_eigenvectors(const elpa_t handle, std::complex<float>  *a, float  *ev, std::complex<float>  *q, int *error)
 {
-    elpa_eigenvectors_fc(handle, a, ev, q, error);
+    elpa_eigenvectors_fc(handle, reinterpret_cast<float _Complex*>(a), ev, reinterpret_cast<float _Complex*>(q), error);
+}
+#elif ELPA_API_VERSION < 20220501   // ELPA version between 2021.11.001 and 2022.05.001
+inline void elpa_eigenvectors(const elpa_t handle, double *a, double *ev, double *q, int *error)
+{
+    elpa_eigenvectors_all_host_arrays_d(handle, a, ev, q, error);
 }
 
-static inline void elpa_skew_eigenvectors(elpa_t handle, double *a, double *ev, double *q, int *error)
+inline void elpa_eigenvectors(const elpa_t handle, float *a, float *ev, float *q, int *error)
+{
+    elpa_eigenvectors_all_host_arrays_f(handle, a, ev, q, error);
+}
+
+inline void elpa_eigenvectors(const elpa_t handle, std::complex<double> *a, double *ev, std::complex<double> *q, int *error)
+{
+    elpa_eigenvectors_all_host_arrays_dc(handle, reinterpret_cast<double _Complex*>(a),
+                                         ev, reinterpret_cast<double _Complex*>(q), error);
+}
+
+inline void elpa_eigenvectors(const elpa_t handle, std::complex<float>  *a, float  *ev, std::complex<float>  *q, int *error)
+{
+    elpa_eigenvectors_all_host_arrays_fc(handle, reinterpret_cast<float _Complex*>(a),
+                                         ev, reinterpret_cast<float _Complex*>(q), error);
+}
+#else // ELPA version 2022.05.001, ELPA has its own c++ interface from version 2022.11.001
+inline void elpa_eigenvectors(const elpa_t handle, double *a, double *ev, double *q, int *error)
+{
+    elpa_eigenvectors_a_h_a_d(handle, a, ev, q, error);
+}
+
+inline void elpa_eigenvectors(const elpa_t handle, float *a, float *ev, float *q, int *error)
+{
+    elpa_eigenvectors_a_h_a_f(handle, a, ev, q, error);
+}
+
+inline void elpa_eigenvectors(const elpa_t handle, std::complex<double> *a, double *ev, std::complex<double> *q, int *error)
+{
+    elpa_eigenvectors_a_h_a_dc(handle, reinterpret_cast<double _Complex*>(a),
+                               ev, reinterpret_cast<double _Complex*>(q), error);
+}
+
+inline void elpa_eigenvectors(const elpa_t handle, std::complex<float>  *a, float  *ev, std::complex<float>  *q, int *error)
+{
+    elpa_eigenvectors_a_h_a_fc(handle, reinterpret_cast<float _Complex*>(a),
+                               ev, reinterpret_cast<float _Complex*>(q), error);
+}
+#endif
+
+/*! \brief generic C method for elpa_skew_eigenvectors
+ *
+ *  \details
+ *  \param  handle  handle of the ELPA object, which defines the problem
+ *  \param  a       float/double float complex/double complex pointer to matrix a
+ *  \param  ev      on return: float/double pointer to eigenvalues
+ *  \param  q       on return: float/double float complex/double complex pointer to eigenvectors
+ *  \param  error   on return the error code, which can be queried with elpa_strerr()
+ *  \result void
+ */
+#if ELPA_API_VERSION <= 20210502 // ELPA 2021.05.002 and earlier versions
+inline void elpa_skew_eigenvectors(const elpa_t handle, double *a, double *ev, double *q, int *error)
 {
     elpa_eigenvectors_d(handle, a, ev, q, error);
 }
 
-static inline void elpa_skew_eigenvectors(elpa_t handle, float *a, float *ev, float *q, int *error)
+inline void elpa_skew_eigenvectors(const elpa_t handle, float  *a, float  *ev, float  *q, int *error)
 {
     elpa_eigenvectors_f(handle, a, ev, q, error);
 }
+#elif ELPA_API_VERSION < 20220501   // ELPA version between 2021.11.001 and 2022.05.001
+inline void elpa_skew_eigenvectors(const elpa_t handle, double *a, double *ev, double *q, int *error)
+{
+    elpa_eigenvectors_all_host_arrays_d(handle, a, ev, q, error);
+}
 
-static inline void elpa_generalized_eigenvectors(elpa_t handle,
-                                                 double *a,
-                                                 double *b,
-                                                 double *ev,
-                                                 double *q,
-                                                 int is_already_decomposed,
-                                                 int *error)
+inline void elpa_skew_eigenvectors(const elpa_t handle, float  *a, float  *ev, float  *q, int *error)
+{
+    elpa_eigenvectors_all_host_arrays_f(handle, a, ev, q, error);
+}
+#else // ELPA version 2022.05.001, ELPA has its own c++ interface from version 2022.11.001
+inline void elpa_skew_eigenvectors(const elpa_t handle, double *a, double *ev, double *q, int *error)
+{
+    elpa_skew_eigenvectors_a_h_a_d(handle, a, ev, q, error);
+}
+
+inline void elpa_skew_eigenvectors(const elpa_t handle, float  *a, float  *ev, float  *q, int *error)
+{
+    elpa_skew_eigenvectors_a_h_a_f(handle, a, ev, q, error);
+}
+#endif
+
+
+
+/*! \brief generic C method for elpa_generalized_eigenvectors
+ *
+ *  \details
+ *  \param  handle  handle of the ELPA object, which defines the problem
+ *  \param  a       float/double float complex/double complex pointer to matrix a
+ *  \param  b       float/double float complex/double complex pointer to matrix b
+ *  \param  ev      on return: float/double pointer to eigenvalues
+ *  \param  q       on return: float/double float complex/double complex pointer to eigenvectors
+ *  \param  is_already_decomposed   set to 1, if b already decomposed by previous call to elpa_generalized
+ *  \param  error   on return the error code, which can be queried with elpa_strerr()
+ *  \result void
+ */
+inline void elpa_generalized_eigenvectors(elpa_t handle, double *a, double *b, double *ev, double *q, int is_already_decomposed, int *error)
 {
     elpa_generalized_eigenvectors_d(handle, a, b, ev, q, is_already_decomposed, error);
 }
 
-static inline void elpa_generalized_eigenvectors(elpa_t handle,
-                                                 float *a,
-                                                 float *b,
-                                                 float *ev,
-                                                 float *q,
-                                                 int is_already_decomposed,
-                                                 int *error)
+inline void elpa_generalized_eigenvectors(elpa_t handle, float  *a, float  *b, float  *ev, float  *q, int is_already_decomposed, int *error)
 {
     elpa_generalized_eigenvectors_f(handle, a, b, ev, q, is_already_decomposed, error);
 }
 
-static inline void elpa_generalized_eigenvectors(elpa_t handle,
-                                                 double complex *a,
-                                                 double complex *b,
-                                                 double *ev,
-                                                 double complex *q,
-                                                 int is_already_decomposed,
-                                                 int *error)
+inline void elpa_generalized_eigenvectors(elpa_t handle, std::complex<double> *a, std::complex<double> *b, double *ev, std::complex<double> *q, int is_already_decomposed, int *error)
 {
-    elpa_generalized_eigenvectors_dc(handle, a, b, ev, q, is_already_decomposed, error);
+    elpa_generalized_eigenvectors_dc(handle, reinterpret_cast<double _Complex*>(a), reinterpret_cast<double _Complex*>(b),
+                                     ev, reinterpret_cast<double _Complex*>(q), is_already_decomposed, error);
 }
 
-static inline void elpa_generalized_eigenvectors(elpa_t handle,
-                                                 float complex *a,
-                                                 float complex *b,
-                                                 float *ev,
-                                                 float complex *q,
-                                                 int is_already_decomposed,
-                                                 int *error)
+inline void elpa_generalized_eigenvectors(elpa_t handle, std::complex<float>  *a, std::complex<float>  *b, float  *ev, std::complex<float>  *q, int is_already_decomposed, int *error)
 {
-    elpa_generalized_eigenvectors_fc(handle, a, b, ev, q, is_already_decomposed, error);
+    elpa_generalized_eigenvectors_fc(handle, reinterpret_cast<float _Complex*>(a), reinterpret_cast<float _Complex*>(b),
+                                     ev, reinterpret_cast<float _Complex*>(q), is_already_decomposed, error);
 }
 
-static inline void elpa_eigenvalues(elpa_t handle, double *a, double *ev, int *error)
-{
-    elpa_eigenvalues_d(handle, a, ev, error);
-}
-
-static inline void elpa_eigenvalues(elpa_t handle, float *a, float *ev, int *error)
-{
-    elpa_eigenvalues_f(handle, a, ev, error);
-}
-
-static inline void elpa_eigenvalues(elpa_t handle, double complex *a, double *ev, int *error)
-{
-    elpa_eigenvalues_dc(handle, a, ev, error);
-}
-
-static inline void elpa_eigenvalues(elpa_t handle, float complex *a, float *ev, int *error)
-{
-    elpa_eigenvalues_fc(handle, a, ev, error);
-}
-
-static inline void elpa_skew_eigenvalues(elpa_t handle, double *a, double *ev, int *error)
+/*! \brief generic C method for elpa_eigenvalues
+ *
+ *  \details
+ *  \param  handle  handle of the ELPA object, which defines the problem
+ *  \param  a       float/double float complex/double complex pointer to matrix a
+ *  \param  ev      on return: float/double pointer to eigenvalues
+ *  \param  error   on return the error code, which can be queried with elpa_strerr()
+ *  \result void
+ */
+#if ELPA_API_VERSION <= 20210502 // ELPA 2021.05.002 and earlier versions
+inline void elpa_eigenvalues(elpa_t handle, double *a, double *ev, int *error)
 {
     elpa_eigenvalues_d(handle, a, ev, error);
 }
-
-static inline void elpa_skew_eigenvalues(elpa_t handle, float *a, float *ev, int *error)
+inline void elpa_eigenvalues(elpa_t handle, float  *a, float  *ev, int *error)
 {
     elpa_eigenvalues_f(handle, a, ev, error);
 }
+inline void elpa_eigenvalues(elpa_t handle, std::complex<double> *a, double *ev, int *error)
+{
+    elpa_eigenvalues_dc(handle, reinterpret_cast<double _Complex*>(a), ev, error);
+}
+inline void elpa_eigenvalues(elpa_t handle, std::complex<float>  *a, float  *ev, int *error)
+{
+    elpa_eigenvalues_fc (handle, reinterpret_cast<float _Complex*>(a), ev, error);
+}
+#elif ELPA_API_VERSION < 20220501   // ELPA version between 2021.11.001 and 2022.05.001
+inline void elpa_eigenvalues(elpa_t handle, double *a, double *ev, int *error)
+{
+    elpa_eigenvalues_all_host_arrays_d(handle, a, ev, error);
+}
+inline void elpa_eigenvalues(elpa_t handle, float  *a, float  *ev, int *error)
+{
+    elpa_eigenvalues_all_host_arrays_f(handle, a, ev, error);
+}
+inline void elpa_eigenvalues(elpa_t handle, std::complex<double> *a, double *ev, int *error)
+{
+    elpa_eigenvalues_all_host_arrays_dc(handle, reinterpret_cast<double _Complex*>(a), ev, error);
+}
+inline void elpa_eigenvalues(elpa_t handle, std::complex<float>  *a, float  *ev, int *error)
+{
+    elpa_eigenvalues_all_host_arrays_fc(handle, reinterpret_cast<float _Complex*>(a), ev, error);
+}
+#else // ELPA version 2022.05.001, ELPA has its own c++ interface from version 2022.11.001
+inline void elpa_eigenvalues(elpa_t handle, double *a, double *ev, int *error)
+{
+    elpa_eigenvalues_a_h_a_d(handle, a, ev, error);
+}
+inline void elpa_eigenvalues(elpa_t handle, float  *a, float  *ev, int *error)
+{
+    elpa_eigenvalues_a_h_a_f(handle, a, ev, error);
+}
+inline void elpa_eigenvalues(elpa_t handle, std::complex<double> *a, double *ev, int *error)
+{
+    elpa_eigenvalues_a_h_a_dc(handle, reinterpret_cast<double _Complex*>(a), ev, error);
+}
+inline void elpa_eigenvalues(elpa_t handle, std::complex<float>  *a, float  *ev, int *error)
+{
+    elpa_eigenvalues_a_h_a_fc(handle, reinterpret_cast<float _Complex*>(a), ev, error);
+}
+#endif
 
-static inline void elpa_cholesky(elpa_t handle, double *a, int *error)
+/*! \brief generic C method for elpa_skew_eigenvalues
+ *
+ *  \details
+ *  \param  handle  handle of the ELPA object, which defines the problem
+ *  \param  a       float/double float complex/double complex pointer to matrix a
+ *  \param  ev      on return: float/double pointer to eigenvalues
+ *  \param  error   on return the error code, which can be queried with elpa_strerr()
+ *  \result void
+ */
+#if ELPA_API_VERSION <= 20210502 // ELPA 2021.05.002 and earlier versions
+inline void elpa_skew_eigenvalues(elpa_t handle, double *a, double *ev, int *error)
+{
+    elpa_eigenvalues_d(handle, a, ev, error);
+}
+inline void elpa_skew_eigenvalues(elpa_t handle, float  *a, float  *ev, int *error)
+{
+    elpa_eigenvalues_f(handle, a, ev, error);
+}
+#elif ELPA_API_VERSION < 20220501   // ELPA version between 2021.11.001 and 2022.05.001
+inline void elpa_skew_eigenvalues(elpa_t handle, double *a, double *ev, int *error)
+{
+    elpa_eigenvalues_all_host_arrays_d(handle, a, ev, error);
+}
+inline void elpa_skew_eigenvalues(elpa_t handle, float  *a, float  *ev, int *error)
+{
+    elpa_eigenvalues_all_host_arrays_f(handle, a, ev, error);
+}
+#else // ELPA version 2022.05.001, ELPA has its own c++ interface from version 2022.11.001
+inline void elpa_skew_eigenvalues(elpa_t handle, double *a, double *ev, int *error)
+{
+    elpa_eigenvalues_a_h_a_d(handle, a, ev, error);
+}
+inline void elpa_skew_eigenvalues(elpa_t handle, float  *a, float  *ev, int *error)
+{
+    elpa_eigenvalues_a_h_a_f(handle, a, ev, error);
+}
+#endif
+
+/*! \brief generic C method for elpa_cholesky
+ *
+ *  \details
+ *  \param  handle  handle of the ELPA object, which defines the problem
+ *  \param  a       float/double float complex/double complex pointer to matrix a, for which
+ *                  the cholesky factorizaion will be computed
+ *  \param  error   on return the error code, which can be queried with elpa_strerr()
+ *  \result void
+ */
+
+#if ELPA_API_VERSION < 20220501   // ELPA version before 2022.05.001
+inline void elpa_cholesky(elpa_t handle, double *a, int *error)
 {
     elpa_cholesky_d(handle, a, error);
 }
-
-static inline void elpa_cholesky(elpa_t handle, float *a, int *error)
+inline void elpa_cholesky(elpa_t handle, float  *a, int *error)
 {
     elpa_cholesky_f(handle, a, error);
 }
-#else // ELPA version >= 2021.11.002
-static inline void elpa_eigenvectors(elpa_t handle, double *a, double *ev, double *q, int *error)
+inline void elpa_cholesky(elpa_t handle, std::complex<double> *a, int *error)
 {
-    elpa_eigenvectors_all_host_arrays_d(handle, a, ev, q, error);
+    elpa_cholesky_dc(handle, reinterpret_cast<double _Complex*>(a), error);
 }
-
-static inline void elpa_eigenvectors(elpa_t handle, float *a, float *ev, float *q, int *error)
+inline void elpa_cholesky(elpa_t handle, std::complex<float>  *a, int *error)
 {
-    elpa_eigenvectors_all_host_arrays_f(handle, a, ev, q, error);
+    elpa_cholesky_fc(handle, reinterpret_cast<float _Complex*>(a), error);
 }
-
-static inline void elpa_eigenvectors(elpa_t handle, double complex *a, double *ev, double complex *q, int *error)
+#else
+inline void elpa_cholesky(elpa_t handle, double *a, int *error)
 {
-    elpa_eigenvectors_all_host_arrays_dc(handle, a, ev, q, error);
+    elpa_cholesky_a_h_a_d(handle, a, error);
 }
-
-static inline void elpa_eigenvectors(elpa_t handle, float complex *a, float *ev, float complex *q, int *error)
+inline void elpa_cholesky(elpa_t handle, float  *a, int *error)
 {
-    elpa_eigenvectors_all_host_arrays_fc(handle, a, ev, q, error);
+    elpa_cholesky_a_h_a_f(handle, a, error);
 }
-
-static inline void elpa_eigenvectors_double(elpa_t handle, double *a, double *ev, double *q, int *error)
+inline void elpa_cholesky(elpa_t handle, std::complex<double> *a, int *error)
 {
-    elpa_eigenvectors_device_pointer_d(handle, a, ev, q, error);
+    elpa_cholesky_a_h_a_dc(handle, reinterpret_cast<double _Complex*>(a), error);
 }
-
-static inline void elpa_eigenvectors_float(elpa_t handle, float *a, float *ev, float *q, int *error)
+inline void elpa_cholesky(elpa_t handle, std::complex<float>  *a, int *error)
 {
-    elpa_eigenvectors_device_pointer_f(handle, a, ev, q, error);
+    elpa_cholesky_a_h_a_fc(handle, reinterpret_cast<float _Complex*>(a), error);
 }
+#endif
 
-static inline void elpa_eigenvectors_double_complex(elpa_t handle,
-                                                    double complex *a,
-                                                    double *ev,
-                                                    double complex *q,
-                                                    int *error)
-{
-    elpa_eigenvectors_device_pointer_dc(handle, a, ev, q, error);
-}
-
-static inline void elpa_eigenvectors_float_complex(elpa_t handle,
-                                                   float complex *a,
-                                                   float *ev,
-                                                   float complex *q,
-                                                   int *error)
-{
-    elpa_eigenvectors_device_pointer_fc(handle, a, ev, q, error);
-}
-
-static inline void elpa_skew_eigenvectors(elpa_t handle, double *a, double *ev, double *q, int *error)
-{
-    elpa_eigenvectors_all_host_arrays_d(handle, a, ev, q, error);
-}
-
-static inline void elpa_skew_eigenvectors(elpa_t handle, float *a, float *ev, float *q, int *error)
-{
-    elpa_eigenvectors_all_host_arrays_f(handle, a, ev, q, error);
-}
-
-static inline void elpa_skew_eigenvectors_double(elpa_t handle, double *a, double *ev, double *q, int *error)
-{
-    elpa_eigenvectors_device_pointer_d(handle, a, ev, q, error);
-}
-
-static inline void elpa_skew_eigenvectors_float(elpa_t handle, float *a, float *ev, float *q, int *error)
-{
-    elpa_eigenvectors_device_pointer_f(handle, a, ev, q, error);
-}
-
-static inline void elpa_generalized_eigenvectors(elpa_t handle,
-                                                 double *a,
-                                                 double *b,
-                                                 double *ev,
-                                                 double *q,
-                                                 int is_already_decomposed,
-                                                 int *error)
-{
-    elpa_generalized_eigenvectors_d(handle, a, b, ev, q, is_already_decomposed, error);
-}
-
-static inline void elpa_generalized_eigenvectors(elpa_t handle,
-                                                 float *a,
-                                                 float *b,
-                                                 float *ev,
-                                                 float *q,
-                                                 int is_already_decomposed,
-                                                 int *error)
-{
-    elpa_generalized_eigenvectors_f(handle, a, b, ev, q, is_already_decomposed, error);
-}
-
-static inline void elpa_generalized_eigenvectors(elpa_t handle,
-                                                 double complex *a,
-                                                 double complex *b,
-                                                 double *ev,
-                                                 double complex *q,
-                                                 int is_already_decomposed,
-                                                 int *error)
-{
-    elpa_generalized_eigenvectors_dc(handle, a, b, ev, q, is_already_decomposed, error);
-}
-
-static inline void elpa_generalized_eigenvectors(elpa_t handle,
-                                                 float complex *a,
-                                                 float complex *b,
-                                                 float *ev,
-                                                 float complex *q,
-                                                 int is_already_decomposed,
-                                                 int *error)
-{
-    elpa_generalized_eigenvectors_fc(handle, a, b, ev, q, is_already_decomposed, error);
-}
-
-static inline void elpa_eigenvalues(elpa_t handle, double *a, double *ev, int *error)
-{
-    elpa_eigenvalues_all_host_arrays_d(handle, a, ev, error);
-}
-
-static inline void elpa_eigenvalues(elpa_t handle, float *a, float *ev, int *error)
-{
-    elpa_eigenvalues_all_host_arrays_f(handle, a, ev, error);
-}
-
-static inline void elpa_eigenvalues(elpa_t handle, double complex *a, double *ev, int *error)
-{
-    elpa_eigenvalues_all_host_arrays_dc(handle, a, ev, error);
-}
-
-static inline void elpa_eigenvalues(elpa_t handle, float complex *a, float *ev, int *error)
-{
-    elpa_eigenvalues_all_host_arrays_fc(handle, a, ev, error);
-}
-
-static inline void elpa_eigenvalues_double(elpa_t handle, double *a, double *ev, int *error)
-{
-    elpa_eigenvalues_device_pointer_d(handle, a, ev, error);
-}
-
-static inline void elpa_eigenvalues_float(elpa_t handle, float *a, float *ev, int *error)
-{
-    elpa_eigenvalues_device_pointer_f(handle, a, ev, error);
-}
-
-static inline void elpa_eigenvalues_double_complex(elpa_t handle, double complex *a, double *ev, int *error)
-{
-    elpa_eigenvalues_device_pointer_dc(handle, a, ev, error);
-}
-
-static inline void elpa_eigenvalues_float_complex(elpa_t handle, float complex *a, float *ev, int *error)
-{
-    elpa_eigenvalues_device_pointer_fc(handle, a, ev, error);
-}
-
-static inline void elpa_skew_eigenvalues(elpa_t handle, double *a, double *ev, int *error)
-{
-    elpa_eigenvalues_all_host_arrays_d(handle, a, ev, error);
-}
-
-static inline void elpa_skew_eigenvalues(elpa_t handle, float *a, float *ev, int *error)
-{
-    elpa_eigenvalues_all_host_arrays_f(handle, a, ev, error);
-}
-
-static inline void elpa_skew_eigenvalues_double(elpa_t handle, double *a, double *ev, int *error)
-{
-    elpa_eigenvalues_device_pointer_d(handle, a, ev, error);
-}
-
-static inline void elpa_skew_eigenvalues_float(elpa_t handle, float *a, float *ev, int *error)
-{
-    elpa_eigenvalues_device_pointer_f(handle, a, ev, error);
-}
-
-#endif // ELPA_API_VERSION <= 20210430
-
-static inline void elpa_cholesky(elpa_t handle, double complex *a, int *error)
-{
-    elpa_cholesky_dc(handle, a, error);
-}
-
-static inline void elpa_cholesky(elpa_t handle, float complex *a, int *error)
-{
-    elpa_cholesky_fc(handle, a, error);
-}
-
-static inline void elpa_hermitian_multiply(elpa_t handle,
-                                           char uplo_a,
-                                           char uplo_c,
-                                           int ncb,
-                                           double *a,
-                                           double *b,
-                                           int nrows_b,
-                                           int ncols_b,
-                                           double *c,
-                                           int nrows_c,
-                                           int ncols_c,
-                                           int *error)
+/*! \brief generic C method for elpa_hermitian_multiply
+ *
+ *  \details
+ *  \param  handle  handle of the ELPA object, which defines the problem
+ *  \param  uplo_a  descriptor for matrix a
+ *  \param  uplo_c  descriptor for matrix c
+ *  \param  ncb     int
+ *  \param  a       float/double float complex/double complex pointer to matrix a
+ *  \param  b       float/double float complex/double complex pointer to matrix b
+ *  \param  nrows_b number of rows for matrix b
+ *  \param  ncols_b number of cols for matrix b
+ *  \param  c       float/double float complex/double complex pointer to matrix c
+ *  \param  nrows_c number of rows for matrix c
+ *  \param  ncols_c number of cols for matrix c
+ *  \param  error   on return the error code, which can be queried with elpa_strerr()
+ *  \result void
+ */
+#if ELPA_API_VERSION < 20220501   // ELPA version before 2022.05.001
+inline void elpa_hermitian_multiply(elpa_t handle, char uplo_a, char uplo_c, int ncb, double *a, double *b, int nrows_b, int ncols_b, double *c, int nrows_c, int ncols_c, int *error)
 {
     elpa_hermitian_multiply_d(handle, uplo_a, uplo_c, ncb, a, b, nrows_b, ncols_b, c, nrows_c, ncols_c, error);
 }
-
-static inline void elpa_hermitian_multiply(elpa_t handle,
-                                           char uplo_a,
-                                           char uplo_c,
-                                           int ncb,
-                                           float *a,
-                                           float *b,
-                                           int nrows_b,
-                                           int ncols_b,
-                                           float *c,
-                                           int nrows_c,
-                                           int ncols_c,
-                                           int *error)
+inline void elpa_hermitian_multiply(elpa_t handle, char uplo_a, char uplo_c, int ncb, float  *a, float  *b, int nrows_b, int ncols_b, float  *c, int nrows_c, int ncols_c, int *error)
 {
     elpa_hermitian_multiply_df(handle, uplo_a, uplo_c, ncb, a, b, nrows_b, ncols_b, c, nrows_c, ncols_c, error);
 }
-
-static inline void elpa_hermitian_multiply(elpa_t handle,
-                                           char uplo_a,
-                                           char uplo_c,
-                                           int ncb,
-                                           double complex *a,
-                                           double complex *b,
-                                           int nrows_b,
-                                           int ncols_b,
-                                           double complex *c,
-                                           int nrows_c,
-                                           int ncols_c,
-                                           int *error)
+inline void elpa_hermitian_multiply(elpa_t handle, char uplo_a, char uplo_c, int ncb, std::complex<double> *a, std::complex<double> *b, int nrows_b, int ncols_b, std::complex<double> *c, int nrows_c, int ncols_c, int *error)
 {
-    elpa_hermitian_multiply_dc(handle, uplo_a, uplo_c, ncb, a, b, nrows_b, ncols_b, c, nrows_c, ncols_c, error);
+    elpa_hermitian_multiply_dc(handle, uplo_a, uplo_c, ncb, reinterpret_cast<double _Complex*>(a),
+                               reinterpret_cast<double _Complex*>(b), nrows_b, ncols_b,
+                               reinterpret_cast<double _Complex*>(c), nrows_c, ncols_c, error);
 }
-
-static inline void elpa_hermitian_multiply(elpa_t handle,
-                                           char uplo_a,
-                                           char uplo_c,
-                                           int ncb,
-                                           float complex *a,
-                                           float complex *b,
-                                           int nrows_b,
-                                           int ncols_b,
-                                           float complex *c,
-                                           int nrows_c,
-                                           int ncols_c,
-                                           int *error)
+inline void elpa_hermitian_multiply(elpa_t handle, char uplo_a, char uplo_c, int ncb, std::complex<float>  *a, std::complex<float>  *b, int nrows_b, int ncols_b, std::complex<float>  *c, int nrows_c, int ncols_c, int *error)
 {
-    elpa_hermitian_multiply_fc(handle, uplo_a, uplo_c, ncb, a, b, nrows_b, ncols_b, c, nrows_c, ncols_c, error);
+    elpa_hermitian_multiply_fc(handle, uplo_a, uplo_c, ncb, reinterpret_cast<float _Complex*>(a),
+                               reinterpret_cast<float _Complex*>(b), nrows_b, ncols_b,
+                               reinterpret_cast<float _Complex*>(c), nrows_c, ncols_c, error);
 }
+#else
+inline void elpa_hermitian_multiply(elpa_t handle, char uplo_a, char uplo_c, int ncb, double *a, double *b, int nrows_b, int ncols_b, double *c, int nrows_c, int ncols_c, int *error)
+{
+    elpa_hermitian_multiply_a_h_a_d(handle, uplo_a, uplo_c, ncb, a, b, nrows_b, ncols_b, c, nrows_c, ncols_c, error);
+}
+inline void elpa_hermitian_multiply(elpa_t handle, char uplo_a, char uplo_c, int ncb, float  *a, float  *b, int nrows_b, int ncols_b, float  *c, int nrows_c, int ncols_c, int *error)
+{
+    elpa_hermitian_multiply_a_h_a_f(handle, uplo_a, uplo_c, ncb, a, b, nrows_b, ncols_b, c, nrows_c, ncols_c, error);
+}
+inline void elpa_hermitian_multiply(elpa_t handle, char uplo_a, char uplo_c, int ncb, std::complex<double> *a, std::complex<double> *b, int nrows_b, int ncols_b, std::complex<double> *c, int nrows_c, int ncols_c, int *error)
+{
+    elpa_hermitian_multiply_a_h_a_dc(handle, uplo_a, uplo_c, ncb, reinterpret_cast<double _Complex*>(a),
+                               reinterpret_cast<double _Complex*>(b), nrows_b, ncols_b,
+                               reinterpret_cast<double _Complex*>(c), nrows_c, ncols_c, error);
+}
+inline void elpa_hermitian_multiply(elpa_t handle, char uplo_a, char uplo_c, int ncb, std::complex<float>  *a, std::complex<float>  *b, int nrows_b, int ncols_b, std::complex<float>  *c, int nrows_c, int ncols_c, int *error)
+{
+    elpa_hermitian_multiply_a_h_a_fc(handle, uplo_a, uplo_c, ncb, reinterpret_cast<float _Complex*>(a),
+                               reinterpret_cast<float _Complex*>(b), nrows_b, ncols_b,
+                               reinterpret_cast<float _Complex*>(c), nrows_c, ncols_c, error);
+}
+#endif
 
-static inline void elpa_invert_triangular(elpa_t handle, double *a, int *error)
+/*! \brief generic C method for elpa_invert_triangular
+ *
+ *  \details
+ *  \param  handle  handle of the ELPA object, which defines the problem
+ *  \param  a       float/double float complex/double complex pointer to matrix a, which
+ *                  should be inverted
+ *  \param  error   on return the error code, which can be queried with elpa_strerr()
+ *  \result void
+ */
+#if ELPA_API_VERSION < 20220501   // ELPA version before 2022.05.001
+inline void elpa_invert_triangular(elpa_t handle, double *a, int *error)
 {
     elpa_invert_trm_d(handle, a, error);
 }
-
-static inline void elpa_invert_triangular(elpa_t handle, float *a, int *error)
+inline void elpa_invert_triangular(elpa_t handle, float  *a, int *error)
 {
     elpa_invert_trm_f(handle, a, error);
 }
-
-static inline void elpa_invert_triangular(elpa_t handle, double complex *a, int *error)
+inline void elpa_invert_triangular(elpa_t handle, std::complex<double> *a, int *error)
 {
-    elpa_invert_trm_dc(handle, a, error);
+    elpa_invert_trm_dc(handle, reinterpret_cast<double _Complex*>(a), error);
 }
-
-static inline void elpa_invert_triangular(elpa_t handle, float complex *a, int *error)
+inline void elpa_invert_triangular(elpa_t handle, std::complex<float>  *a, int *error)
 {
-    elpa_invert_trm_fc(handle, a, error);
+    elpa_invert_trm_fc(handle, reinterpret_cast<float _Complex*>(a), error);
 }
+#else
+inline void elpa_invert_triangular(elpa_t handle, double *a, int *error)
+{
+    elpa_invert_trm_a_h_a_d(handle, a, error);
+}
+inline void elpa_invert_triangular(elpa_t handle, float  *a, int *error)
+{
+    elpa_invert_trm_a_h_a_f(handle, a, error);
+}
+inline void elpa_invert_triangular(elpa_t handle, std::complex<double> *a, int *error)
+{
+    elpa_invert_trm_a_h_a_dc(handle, reinterpret_cast<double _Complex*>(a), error);
+}
+inline void elpa_invert_triangular(elpa_t handle, std::complex<float>  *a, int *error)
+{
+    elpa_invert_trm_a_h_a_fc(handle, reinterpret_cast<float _Complex*>(a), error);
+}
+#endif

--- a/source/module_hsolver/genelpa/elpa_new.cpp
+++ b/source/module_hsolver/genelpa/elpa_new.cpp
@@ -21,7 +21,7 @@
 using namespace std;
 
 map<int, elpa_t> NEW_ELPA_HANDLE_POOL;
-#ifdef __MPI
+
 ELPA_Solver::ELPA_Solver(const bool isReal,
                          const MPI_Comm comm,
                          const int nev,
@@ -57,7 +57,7 @@ ELPA_Solver::ELPA_Solver(const bool isReal,
 
 #ifdef _OPENMP
     int num_threads = omp_get_max_threads();
-#else  
+#else
     int num_threads = 1;
 #endif
 
@@ -125,7 +125,7 @@ ELPA_Solver::ELPA_Solver(const bool isReal,
 
 #ifdef _OPENMP
     int num_threads = omp_get_max_threads();
-#else  
+#else
     int num_threads = 1;
 #endif
 
@@ -137,25 +137,24 @@ ELPA_Solver::ELPA_Solver(const bool isReal,
     NEW_ELPA_HANDLE_POOL[handle_id] = handle;
 
 #ifdef _OPENMP
-    elpa_set_integer(NEW_ELPA_HANDLE_POOL[handle_id], "omp_threads", num_threads, &error);
+    elpa_set(NEW_ELPA_HANDLE_POOL[handle_id], "omp_threads", num_threads, &error);
 #endif
-    elpa_set_integer(NEW_ELPA_HANDLE_POOL[handle_id], "na", nFull, &error);
-    elpa_set_integer(NEW_ELPA_HANDLE_POOL[handle_id], "nev", nev, &error);
-    elpa_set_integer(NEW_ELPA_HANDLE_POOL[handle_id], "local_nrows", narows, &error);
-    elpa_set_integer(NEW_ELPA_HANDLE_POOL[handle_id], "local_ncols", nacols, &error);
-    elpa_set_integer(NEW_ELPA_HANDLE_POOL[handle_id], "nblk", nblk, &error);
-    elpa_set_integer(NEW_ELPA_HANDLE_POOL[handle_id], "mpi_comm_parent", MPI_Comm_c2f(comm), &error);
-    elpa_set_integer(NEW_ELPA_HANDLE_POOL[handle_id], "process_row", myprow, &error);
-    elpa_set_integer(NEW_ELPA_HANDLE_POOL[handle_id], "process_col", mypcol, &error);
-    elpa_set_integer(NEW_ELPA_HANDLE_POOL[handle_id], "blacs_context", cblacs_ctxt, &error);
-    elpa_set_integer(NEW_ELPA_HANDLE_POOL[handle_id], "solver", ELPA_SOLVER_2STAGE, &error);
-    elpa_set_integer(NEW_ELPA_HANDLE_POOL[handle_id], "debug", wantDebug, &error);
-    elpa_set_integer(NEW_ELPA_HANDLE_POOL[handle_id], "qr", useQR, &error);
+    elpa_set(NEW_ELPA_HANDLE_POOL[handle_id], "na", nFull, &error);
+    elpa_set(NEW_ELPA_HANDLE_POOL[handle_id], "nev", nev, &error);
+    elpa_set(NEW_ELPA_HANDLE_POOL[handle_id], "local_nrows", narows, &error);
+    elpa_set(NEW_ELPA_HANDLE_POOL[handle_id], "local_ncols", nacols, &error);
+    elpa_set(NEW_ELPA_HANDLE_POOL[handle_id], "nblk", nblk, &error);
+    elpa_set(NEW_ELPA_HANDLE_POOL[handle_id], "mpi_comm_parent", MPI_Comm_c2f(comm), &error);
+    elpa_set(NEW_ELPA_HANDLE_POOL[handle_id], "process_row", myprow, &error);
+    elpa_set(NEW_ELPA_HANDLE_POOL[handle_id], "process_col", mypcol, &error);
+    elpa_set(NEW_ELPA_HANDLE_POOL[handle_id], "blacs_context", cblacs_ctxt, &error);
+    elpa_set(NEW_ELPA_HANDLE_POOL[handle_id], "solver", ELPA_SOLVER_2STAGE, &error);
+    elpa_set(NEW_ELPA_HANDLE_POOL[handle_id], "debug", wantDebug, &error);
+    elpa_set(NEW_ELPA_HANDLE_POOL[handle_id], "qr", useQR, &error);
     this->setQR(useQR);
     this->setKernel(isReal, kernel_id);
     this->setLoglevel(loglevel);
 }
-#endif
 
 void ELPA_Solver::setLoglevel(int loglevel)
 {
@@ -166,8 +165,8 @@ void ELPA_Solver::setLoglevel(int loglevel)
     if (loglevel >= 2)
     {
         wantDebug = 1;
-        elpa_set_integer(NEW_ELPA_HANDLE_POOL[handle_id], "verbose", 1, &error);
-        elpa_set_integer(NEW_ELPA_HANDLE_POOL[handle_id], "debug", wantDebug, &error);
+        elpa_set(NEW_ELPA_HANDLE_POOL[handle_id], "verbose", 1, &error);
+        elpa_set(NEW_ELPA_HANDLE_POOL[handle_id], "debug", wantDebug, &error);
         if (!isLogfileInited)
         {
             stringstream logfilename;
@@ -189,16 +188,16 @@ void ELPA_Solver::setKernel(bool isReal, int kernel)
     this->kernel_id = kernel;
     int error;
     if (isReal)
-        elpa_set_integer(NEW_ELPA_HANDLE_POOL[handle_id], "real_kernel", kernel, &error);
+        elpa_set(NEW_ELPA_HANDLE_POOL[handle_id], "real_kernel", kernel, &error);
     else
-        elpa_set_integer(NEW_ELPA_HANDLE_POOL[handle_id], "complex_kernel", kernel, &error);
+        elpa_set(NEW_ELPA_HANDLE_POOL[handle_id], "complex_kernel", kernel, &error);
 }
 
 void ELPA_Solver::setQR(int useQR)
 {
     this->useQR = useQR;
     int error;
-    elpa_set_integer(NEW_ELPA_HANDLE_POOL[handle_id], "qr", useQR, &error);
+    elpa_set(NEW_ELPA_HANDLE_POOL[handle_id], "qr", useQR, &error);
 }
 
 void ELPA_Solver::exit()
@@ -405,8 +404,6 @@ int ELPA_Solver::read_complex_kernel()
             kernel_id = ELPA_2STAGE_COMPLEX_NVIDIA_GPU;
         else if (strcmp(env, "ELPA_2STAGE_COMPLEX_AMD_GPU") == 0)
             kernel_id = ELPA_2STAGE_COMPLEX_AMD_GPU;
-        else if (strcmp(env, "ELPA_2STAGE_COMPLEX_INTEL_GPU") == 0)
-            kernel_id = ELPA_2STAGE_COMPLEX_INTEL_GPU;
         else
             kernel_id = ELPA_2STAGE_COMPLEX_GENERIC;
     }
@@ -439,11 +436,8 @@ int ELPA_Solver::allocate_work()
 {
     unsigned long nloc = narows * nacols; // local size
     unsigned long maxloc; // maximum local size
-#ifdef __MPI
     MPI_Allreduce(&nloc, &maxloc, 1, MPI_UNSIGNED_LONG, MPI_MAX, comm);
-#else
     maxloc = nloc;
-#endif
 
     if (isReal)
         dwork.resize(maxloc);
@@ -457,20 +451,14 @@ void ELPA_Solver::timer(int myid, const char function[], const char step[], doub
     double t1;
     if (t0 < 0) // t0 < 0 means this is the init call before the function
     {
-#ifdef __MPI
         t0 = MPI_Wtime();
-#else
         t0 = (double)clock()/CLOCKS_PER_SEC;
-#endif
         logfile << "DEBUG: Process " << myid << " Call " << function << endl;
     }
     else
     {
-#ifdef __MPI
         t1 = MPI_Wtime();
-#else
         t1 = (double)clock()/CLOCKS_PER_SEC;
-#endif
         logfile << "DEBUG: Process " << myid << " Step " << step << " " << function << " time: " << t1 - t0 << " s"
                 << endl;
     }

--- a/source/module_hsolver/genelpa/elpa_new.h
+++ b/source/module_hsolver/genelpa/elpa_new.h
@@ -1,8 +1,12 @@
 #pragma once
 
+#include <elpa/elpa_version.h>
+
+#if ELPA_API_VERSION >= 20221101
+#include <elpa/elpa.h>
+#else
 extern "C"
 {
-#include <elpa/elpa_version.h>
 #include <limits.h>
 
     struct elpa_struct;
@@ -24,6 +28,5 @@ extern "C"
     const char *elpa_strerr(int elpa_error);
 }
 
-#define complex _Complex
 #include "elpa_generic.hpp" // This is a wrapper for `elpa/elpa_generic.h`.
-#undef complex
+#endif

--- a/source/module_hsolver/genelpa/elpa_new_real.cpp
+++ b/source/module_hsolver/genelpa/elpa_new_real.cpp
@@ -132,11 +132,8 @@ int ELPA_Solver::generalized_eigenvector(double* A,
     {
         timer(myid, "elpa_eigenvectors", "2", t);
     }
-#ifdef __MPI
     MPI_Allreduce(&info, &allinfo, 1, MPI_INT, MPI_MAX, comm);
-#else
     allinfo = info;
-#endif
     if (loglevel > 2)
         saveMatrix("EigenVector_tilde.dat", nFull, EigenVector, desc, cblacs_ctxt);
 
@@ -185,11 +182,8 @@ int ELPA_Solver::decomposeRightMatrix(double* B, double* EigenValue, double* Eig
         {
             timer(myid, "pdpotrf_", "1", t);
         }
-#ifdef __MPI
         MPI_Allreduce(&info, &allinfo, 1, MPI_INT, MPI_MAX, comm);
-#else
         allinfo = info;
-#endif
         if (allinfo != 0) // pdpotrf fail, try elpa_cholesky_real
         {
             DecomposedState = 2;
@@ -198,16 +192,13 @@ int ELPA_Solver::decomposeRightMatrix(double* B, double* EigenValue, double* Eig
                 t = -1;
                 timer(myid, "elpa_cholesky_d", "2", t);
             }
-            elpa_cholesky_d(NEW_ELPA_HANDLE_POOL[handle_id], B, &info);
+            elpa_cholesky(NEW_ELPA_HANDLE_POOL[handle_id], B, &info);
             if (loglevel > 1)
             {
                 timer(myid, "elpa_cholesky_d", "2", t);
             }
-#ifdef __MPI
             MPI_Allreduce(&info, &allinfo, 1, MPI_INT, MPI_MAX, comm);
-#else
             allinfo = info;
-#endif
         }
     }
     else
@@ -218,16 +209,13 @@ int ELPA_Solver::decomposeRightMatrix(double* B, double* EigenValue, double* Eig
             t = -1;
             timer(myid, "elpa_cholesky_d", "1", t);
         }
-        elpa_cholesky_d(NEW_ELPA_HANDLE_POOL[handle_id], B, &info);
+        elpa_cholesky(NEW_ELPA_HANDLE_POOL[handle_id], B, &info);
         if (loglevel > 1)
         {
             timer(myid, "elpa_cholesky_d", "1", t);
         }
-#ifdef __MPI
         MPI_Allreduce(&info, &allinfo, 1, MPI_INT, MPI_MAX, comm);
-#else
-            allinfo = info;
-#endif
+        allinfo = info;
         if (allinfo != 0)
         {
             DecomposedState = 1;
@@ -241,11 +229,8 @@ int ELPA_Solver::decomposeRightMatrix(double* B, double* EigenValue, double* Eig
             {
                 timer(myid, "pdpotrf_", "2", t);
             }
-#ifdef __MPI
             MPI_Allreduce(&info, &allinfo, 1, MPI_INT, MPI_MAX, comm);
-#else
             allinfo = info;
-#endif
         }
     }
 
@@ -279,7 +264,7 @@ int ELPA_Solver::decomposeRightMatrix(double* B, double* EigenValue, double* Eig
             t = -1;
             timer(myid, "invert U", "1", t);
         }
-        elpa_invert_trm_d(NEW_ELPA_HANDLE_POOL[handle_id], B, &info);
+        elpa_invert_triangular(NEW_ELPA_HANDLE_POOL[handle_id], B, &info);
         if (loglevel > 1)
         {
             timer(myid, "invert U", "1", t);
@@ -303,11 +288,8 @@ int ELPA_Solver::decomposeRightMatrix(double* B, double* EigenValue, double* Eig
         {
             timer(myid, "calculate eigenvalue and eigenvector of B", "1", t);
         }
-#ifdef __MPI
         MPI_Allreduce(&info, &allinfo, 1, MPI_INT, MPI_MAX, comm);
-#else
-            allinfo = info;
-#endif
+        allinfo = info;
         // calculate q*ev^{-1/2} and put to work
         for (int i = 0; i < nacols; ++i)
         {


### PR DESCRIPTION
	modified:   source/module_hsolver/genelpa/README
	modified:   source/module_hsolver/genelpa/elpa_generic.hpp
	modified:   source/module_hsolver/genelpa/elpa_new.cpp
	modified:   source/module_hsolver/genelpa/elpa_new.h
	modified:   source/module_hsolver/genelpa/elpa_new_complex.cpp
	modified:   source/module_hsolver/genelpa/elpa_new_real.cpp

    ELPA changed its interface (twice!) from version 2021.11.001,
    and the c++ interface was finally added from version 2022.11.001.

    This version of GenELPA can support all current versions of ELPA
    by automatically choosing the right interface functions.

    Also, some `#define __MPI ...` conditional inclusion codes are
    removed cause it is nonsense to only wrap some MPI functions
    by these codes while the whole GenELPA package depends on MPI.