### PR TITLE
Build!: using icpx in replace of icpc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5)
   message(WARNING "GCC4 is not fully supported.")
 endif()
-add_compile_options(-Wno-write-strings)
+add_compile_options(-Wno-write-strings
+  -Wno-tautological-constant-compare # Suppress warnings introduced by Torch using a LLVM compiler
+)
 set(FETCHCONTENT_QUIET FALSE) # Notify user when cloning git repo
 
 find_program(CCACHE ccache)

--- a/Dockerfile.gnu
+++ b/Dockerfile.gnu
@@ -11,7 +11,7 @@ RUN git clone https://github.com/llohse/libnpy.git && \
     cp libnpy/include/npy.hpp /usr/local/include && \
     rm -r libnpy
 
-RUN wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.1%2Bcpu.zip \
+RUN wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.0.0%2Bcpu.zip \
         --no-check-certificate --quiet -O libtorch.zip && \
     unzip -q libtorch.zip -d /opt  && rm libtorch.zip
 

--- a/Dockerfile.intel
+++ b/Dockerfile.intel
@@ -31,29 +31,27 @@ ENV I_MPI_ROOT='/opt/intel/oneapi/mpi/latest' \
     CMAKE_PREFIX_PATH='/opt/intel/oneapi/vpl/latest:/opt/intel/oneapi/tbb/latest/env/..:/opt/intel/oneapi/dnnl/latest/cpu_dpcpp_gpu_dpcpp/../lib/cmake:/opt/intel/oneapi/dal/latest:/opt/intel/oneapi/compiler/latest/linux/IntelDPCPP' \
     CMPLR_ROOT='/opt/intel/oneapi/compiler/latest'
 
-# Using the Intel Compilers with mpi wrapper.
-# Further test on oneAPI Compilers needed: icx, icpx, ifx
-ENV CC=/opt/intel/oneapi/mpi/latest/bin/mpiicc \
-    CXX=/opt/intel/oneapi/mpi/latest/bin/mpiicpc \
-    FC=/opt/intel/oneapi/mpi/latest/bin/mpiifort
+ENV CC=mpiicc CXX=mpiicpc FC=mpiifort
 
 SHELL ["/bin/bash", "-c"]
-RUN source /opt/intel/oneapi/setvars.sh \
-    && cd /tmp \
-    && wget -q https://elpa.mpcdf.mpg.de/software/tarball-archive/Releases/2021.05.002/elpa-2021.05.002.tar.gz \
-    && tar xzf elpa-2021.05.002.tar.gz  && rm elpa-2021.05.002.tar.gz \
-    && cd elpa-2021.05.002 && mkdir build && cd build \
-    && ../configure FCFLAGS="-qmkl=cluster" --enable-openmp \
-    && make -j`nproc` \
-    && make PREFIX=/usr/local install \
-    && ln -s /usr/local/include/elpa_openmp-2021.05.002/elpa /usr/local/include/ \
-    && cd /tmp && rm -rf elpa-2021.05.002
+RUN source /opt/intel/oneapi/setvars.sh && \
+    cd /tmp && \
+    ELPA_VER=2021.05.002 && \
+    wget -q https://elpa.mpcdf.mpg.de/software/tarball-archive/Releases/$ELPA_VER/elpa-$ELPA_VER.tar.gz && \
+    tar xzf elpa-$ELPA_VER.tar.gz  && rm elpa-$ELPA_VER.tar.gz && \
+    cd elpa-$ELPA_VER && mkdir build && cd build && \
+    ../configure FCFLAGS="-qmkl=cluster" --enable-openmp && \
+    make -j`nproc` && \
+    make PREFIX=/usr/local install && \
+    ln -s /usr/local/include/elpa_openmp-$ELPA_VER/elpa /usr/local/include/ && \
+    cd /tmp && rm -rf elpa-$ELPA_VER
 
-RUN wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.1%2Bcpu.zip \
+RUN wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.0.0%2Bcpu.zip \
         --no-check-certificate --quiet -O libtorch.zip && \
     unzip -q libtorch.zip -d /opt  && rm libtorch.zip
 
-ENV CMAKE_PREFIX_PATH=/opt/libtorch/share/cmake
+ENV CMAKE_PREFIX_PATH=/opt/libtorch/share/cmake \
+    I_MPI_CXX=icpx
 
 ADD https://api.github.com/repos/deepmodeling/abacus-develop/git/refs/heads/develop /dev/null
 

--- a/docs/quick_start/easy_install.md
+++ b/docs/quick_start/easy_install.md
@@ -62,7 +62,7 @@ Here, 'build' is the path for building ABACUS; and '-D' is used for setting up s
 
 - `CMAKE_INSTALL_PREFIX`: the path of ABACUS binary to install; `/usr/local/bin/abacus` by default
 - Compilers
-  - `CMAKE_CXX_COMPILER`: C++ compiler; usually `g++`(GNU C++ compiler) or `icpc`(Intel C++ compiler). Can also set from environment variable `CXX`. It is OK to use MPI compiler here.
+  - `CMAKE_CXX_COMPILER`: C++ compiler; usually `g++`(GNU C++ compiler) or `icpx`(Intel C++ compiler). Can also set from environment variable `CXX`. It is OK to use MPI compiler here.
   - `MPI_CXX_COMPILER`: MPI wrapper for C++ compiler; usually `mpicxx` or `mpiicpc`(for Intel MPI).
 - Requirements: Unless indicated, CMake will try to find under default paths.
   - `MKLROOT`: If environment variable `MKLROOT` exists, `cmake` will take MKL as a preference, i.e. not using `LAPACK`, `ScaLAPACK` and `FFTW`. To disable MKL, unset environment variable `MKLROOT`, or pass `-DMKLROOT=OFF` to `cmake`.


### PR DESCRIPTION
Currently, one could notice that when using Intel oneAPI toolchain to compile abacus, there is a warning prompt for each source file:
`icpc: remark #10441: The Intel(R) C++ Compiler Classic (ICC) is deprecated and will be removed from product release in the second half of 2023. The Intel(R) oneAPI DPC++/C++ Compiler (ICX) is the recommended compiler moving forward. Please transition to use this compiler. Use '-diag-disable=10441' to disable this message.`
(Plz see [building logs](https://github.com/deepmodeling/abacus-develop/actions/runs/4604850729/jobs/8136200477#step:4:33).)

To avoid the chaos after the toolchain updates and removes icc&icpc, we switch to icpx in advance. Intel icx/icpx is a LLVM-based compiler, and behaves more similar to clang.

By now, one can use `export I_MPI_CXX=icpx` to make mpiicpc find the correct cpp compiler. 