### PR TITLE
Test: delete non-folders in CASES

### DIFF
--- a/tests/integrate/CASES
+++ b/tests/integrate/CASES
@@ -284,12 +284,3 @@
 906_OF_LibxcPBE
 920_OF_MD_LDA
 920_OF_MD_LibxcPBE
-Autotest.sh
-CASES
-check_file.cpp
-clean.sh
-CMakeLists.txt
-log
-README.md
-Single_job.sh
-tools


### PR DESCRIPTION
Update CASES, which contains the folder names of intergrated tests. The PR deletes the filenames useless in CASES.