### PR TITLE
Refactor: Change the default scf_thr to 1e-7 for LCAO.

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -245,8 +245,8 @@
 		- [md\_damp](#md_damp)
 		- [md\_tolerance](#md_tolerance)
 		- [md\_nraise](#md_nraise)
-	- [cal_syns](#cal_syns)
-	- [dmax](#dmax)
+		- [cal\_syns](#cal_syns)
+		- [dmax](#dmax)
 	- [DFT+*U* correction](#dftu-correction)
 		- [dft\_plus\_u](#dft_plus_u)
 		- [orbital\_corr](#orbital_corr)
@@ -852,7 +852,7 @@ calculations.
 
 - **Type**: Real
 - **Description**: An important parameter in ABACUS. It's the threshold for electronic iteration. It represents the charge density error between two sequential densities from electronic iterations. Usually for local orbitals, usually 1e-6 may be accurate enough.
-- **Default**: 1.0e-9
+- **Default**: 1.0e-9 for PW, and 1.0e-7 for LCAO.
 
 ### chg_extrap
 

--- a/source/module_io/input.cpp
+++ b/source/module_io/input.cpp
@@ -252,7 +252,7 @@ void Input::Default(void)
     //----------------------------------------------------------
     // iteration
     //----------------------------------------------------------
-    scf_thr = 1.0e-9;
+    scf_thr = -1.0; // the default value (1e-9 for pw, and 1e-7 for lcao) will be set in Default_2
     scf_nmax = 100;
     relax_nmax = 0;
     out_stru = 0;
@@ -2691,6 +2691,18 @@ void Input::Default_2(void) // jiyy add 2019-08-04
     if (mdp.md_prec_level != 1)
     {
         ref_cell_factor = 1.0;
+    }
+
+    if (scf_thr == -1.0)
+    {
+        if (basis_type == "lcao" || basis_type == "lcao_in_pw")
+        {
+            scf_thr = 1.0e-7;
+        }
+        else if (basis_type == "pw")
+        {
+            scf_thr = 1.0e-9;
+        }
     }
 }
 #ifdef __MPI

--- a/source/module_io/test/input_test.cpp
+++ b/source/module_io/test/input_test.cpp
@@ -719,6 +719,7 @@ TEST_F(InputTest, Default_2)
 	EXPECT_EQ(INPUT.basis_type,"lcao");
 	INPUT.ks_solver = "default";
 	INPUT.lcao_ecut = 0;
+	INPUT.scf_thr = -1.0;
         EXPECT_DOUBLE_EQ(INPUT.ecutwfc,20.0);
 	// the 1st calling
 	INPUT.Default_2();
@@ -761,6 +762,7 @@ TEST_F(InputTest, Default_2)
 	INPUT.basis_type = "pw";
 	INPUT.ks_solver = "default";
 	INPUT.gamma_only_local = 1;
+	INPUT.scf_thr = -1.0;
 	// the 2nd calling
 	INPUT.Default_2();
 	// ^^^^^^^^^^^^^^

--- a/source/module_io/test/input_test.cpp
+++ b/source/module_io/test/input_test.cpp
@@ -131,7 +131,7 @@ TEST_F(InputTest, Default)
         EXPECT_EQ(INPUT.vion_in_h,1);
         EXPECT_EQ(INPUT.test_force,0);
         EXPECT_EQ(INPUT.test_stress,0);
-        EXPECT_DOUBLE_EQ(INPUT.scf_thr,1.0e-9);
+        EXPECT_DOUBLE_EQ(INPUT.scf_thr,-1.0);
         EXPECT_EQ(INPUT.scf_nmax,100);
         EXPECT_EQ(INPUT.relax_nmax,0);
         EXPECT_EQ(INPUT.out_stru,0);
@@ -735,6 +735,7 @@ TEST_F(InputTest, Default_2)
 	EXPECT_EQ(INPUT.diago_proc,1);
 	EXPECT_EQ(INPUT.mem_saver,0);
 	EXPECT_EQ(INPUT.relax_nmax,1);
+	EXPECT_DOUBLE_EQ(INPUT.scf_thr,1.0e-7);
 #ifdef __ELPA
 	EXPECT_EQ(INPUT.ks_solver,"genelpa");
 #else
@@ -780,6 +781,7 @@ TEST_F(InputTest, Default_2)
 	EXPECT_EQ(INPUT.bx,1);
 	EXPECT_EQ(INPUT.by,1);
 	EXPECT_EQ(INPUT.bz,1);
+	EXPECT_DOUBLE_EQ(INPUT.scf_thr,1.0e-9);
 	//==================================================
 	// prepare default parameters for the 3rd calling
 	INPUT.vdw_method = "d3_bj";

--- a/source/module_io/test/input_test_para.cpp
+++ b/source/module_io/test/input_test_para.cpp
@@ -137,7 +137,7 @@ TEST_F(InputParaTest,Bcast)
         EXPECT_EQ(INPUT.vion_in_h,1);
         EXPECT_EQ(INPUT.test_force,0);
         EXPECT_EQ(INPUT.test_stress,0);
-        EXPECT_DOUBLE_EQ(INPUT.scf_thr,1.0e-9);
+        EXPECT_DOUBLE_EQ(INPUT.scf_thr,-1.0);
         EXPECT_EQ(INPUT.scf_nmax,100);
         EXPECT_EQ(INPUT.relax_nmax,0);
         EXPECT_EQ(INPUT.out_stru,0);


### PR DESCRIPTION
1. The default `scf_thr` is 1.0e-9 for PW, and 1.0e-7 for LCAO now.
2. Update the corresponding documents.