### PR TITLE
Update clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,27 +1,57 @@
 ---
+Language:        Cpp
 BasedOnStyle: Microsoft
-AccessModifierOffset: '-2'
-AlignAfterOpenBracket: Align
-AlignConsecutiveMacros: 'true'
-AlignEscapedNewlines: Left
-AlignOperands: 'true'
-AlignTrailingComments: 'false'
+
+AlignArrayOfStructures: Left
+AlwaysBreakTemplateDeclarations: Yes
+
 AllowAllArgumentsOnNextLine: 'false'
 AllowAllParametersOfDeclarationOnNextLine: 'false'
 BinPackArguments: 'false'
 BinPackParameters: 'false'
+
 BreakBeforeBinaryOperators: All
 BreakBeforeTernaryOperators: 'true'
+
 Cpp11BracedListStyle: 'true'
 DerivePointerAlignment: 'true'
 FixNamespaceComments: 'true'
-IncludeBlocks: Regroup
+
+# About include
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+
 IndentWidth: '4'
-Language: Cpp
+IndentWrappedFunctionNames: true
 PointerAlignment: Right
+# About Pointer
+PointerAlignment: Left
+
+PackConstructorInitializers: NextLine
+
 ReflowComments: 'true'
 SortIncludes: 'true'
 SortUsingDeclarations: 'true'
+
+# About space
 SpaceAfterCStyleCast: 'false'
 SpaceAfterLogicalNot: 'false'
 SpaceBeforeRangeBasedForLoopColon: 'false'
@@ -31,6 +61,7 @@ SpacesInCStyleCastParentheses: 'false'
 SpacesInContainerLiterals: 'false'
 SpacesInParentheses: 'false'
 SpacesInSquareBrackets: 'false'
+
 Standard: Cpp11
 TabWidth: '4'
 UseTab: Never


### PR DESCRIPTION
1. All pointers * are left-aligned
2. All { are on the second line
3. Include sorting
4. When the number of characters in a line exceeds 120, the arguments of the function will be on a separate line.
5. Template statements are on a separate line