### PR TITLE
fix memory leak problem of class Record_adj

### DIFF
--- a/source/module_hamilt_lcao/hamilt_lcaodft/DM_k.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/DM_k.cpp
@@ -62,7 +62,7 @@ void Local_Orbital_Charge::allocate_DM_k(void)
 #include "module_hamilt_lcao/hamilt_lcaodft/record_adj.h"
 inline void cal_DM_ATOM(const Grid_Technique &gt,
                         const std::complex<double> fac,
-                        Record_adj RA,
+                        const Record_adj &RA,
                         const int ia1,
                         const int iw1_lo,
                         const int nw1,
@@ -144,7 +144,7 @@ inline void cal_DM_ATOM(const Grid_Technique &gt,
 // added by zhengdy-soc, for non-collinear case
 inline void cal_DM_ATOM_nc(const Grid_Technique &gt,
                            const std::complex<double> fac,
-                           Record_adj RA,
+                           const Record_adj &RA,
                            const int ia1,
                            const int iw1_lo,
                            const int nw1,

--- a/source/module_hamilt_lcao/hamilt_lcaodft/record_adj.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/record_adj.cpp
@@ -3,12 +3,15 @@
 #include "module_hamilt_lcao/hamilt_lcaodft/global_fp.h"
 #include "module_base/timer.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
-
-Record_adj::Record_adj() : iat2ca(nullptr) {}
-Record_adj::~Record_adj(){}
+Record_adj::Record_adj() : iat2ca(nullptr) {info_modified=false;}
+Record_adj::~Record_adj(){
+	if(info_modified)
+		this->delete_grid();
+}
 
 void Record_adj::delete_grid(void)
 {
+	info_modified=false;
 	for(int i=0; i<na_proc; i++)
 	{
 		// how many 'numerical orbital' adjacents
@@ -152,7 +155,7 @@ void Record_adj::for_2d(Parallel_Orbitals &pv, bool gamma_only)
 	// info will identify each atom in each unitcell.
 	//------------------------------------------------
 	this->info = new int**[na_proc];
-
+	info_modified=true;
 #ifdef _OPENMP
 #pragma omp parallel
 {
@@ -283,7 +286,7 @@ void Record_adj::for_grid(const Grid_Technique &gt)
 	this->na_each = new int[na_proc];
 	ModuleBase::GlobalFunc::ZEROS(na_each, na_proc);
 	this->info = new int**[na_proc];
-
+	info_modified=true;
 #ifdef _OPENMP
 #pragma omp parallel
 {

--- a/source/module_hamilt_lcao/hamilt_lcaodft/record_adj.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/record_adj.cpp
@@ -3,7 +3,7 @@
 #include "module_hamilt_lcao/hamilt_lcaodft/global_fp.h"
 #include "module_base/timer.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
-Record_adj::Record_adj() : iat2ca(nullptr) {info_modified=false;}
+Record_adj::Record_adj() : iat2ca(nullptr) {}
 Record_adj::~Record_adj(){
 	if(info_modified)
 		this->delete_grid();
@@ -11,7 +11,6 @@ Record_adj::~Record_adj(){
 
 void Record_adj::delete_grid(void)
 {
-	info_modified=false;
 	for(int i=0; i<na_proc; i++)
 	{
 		// how many 'numerical orbital' adjacents
@@ -25,6 +24,7 @@ void Record_adj::delete_grid(void)
 	delete[] info;
 	delete[] na_each;
 	if (iat2ca) delete[] iat2ca;
+	info_modified=false;
 }
 
 
@@ -155,7 +155,6 @@ void Record_adj::for_2d(Parallel_Orbitals &pv, bool gamma_only)
 	// info will identify each atom in each unitcell.
 	//------------------------------------------------
 	this->info = new int**[na_proc];
-	info_modified=true;
 #ifdef _OPENMP
 #pragma omp parallel
 {
@@ -253,7 +252,7 @@ void Record_adj::for_2d(Parallel_Orbitals &pv, bool gamma_only)
 }
 #endif
 	ModuleBase::timer::tick("Record_adj","for_2d");
-
+	info_modified=true;
 	return;
 }
 
@@ -286,7 +285,6 @@ void Record_adj::for_grid(const Grid_Technique &gt)
 	this->na_each = new int[na_proc];
 	ModuleBase::GlobalFunc::ZEROS(na_each, na_proc);
 	this->info = new int**[na_proc];
-	info_modified=true;
 #ifdef _OPENMP
 #pragma omp parallel
 {
@@ -471,7 +469,7 @@ void Record_adj::for_grid(const Grid_Technique &gt)
 }
 #endif
 	ModuleBase::timer::tick("Record_adj","for_grid");
-
+	//info_modified=true;
 //	std::cout << " after for_grid" << std::endl;
 	return;
 }

--- a/source/module_hamilt_lcao/hamilt_lcaodft/record_adj.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/record_adj.cpp
@@ -469,7 +469,7 @@ void Record_adj::for_grid(const Grid_Technique &gt)
 }
 #endif
 	ModuleBase::timer::tick("Record_adj","for_grid");
-	//info_modified=true;
+	info_modified=true;
 //	std::cout << " after for_grid" << std::endl;
 	return;
 }

--- a/source/module_hamilt_lcao/hamilt_lcaodft/record_adj.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/record_adj.h
@@ -11,7 +11,7 @@
 class Record_adj
 {
 	private:
-		bool info_modified;
+		bool info_modified=false;
 	public:
 
 	Record_adj();

--- a/source/module_hamilt_lcao/hamilt_lcaodft/record_adj.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/record_adj.h
@@ -10,6 +10,8 @@
 //---------------------------------------------------
 class Record_adj
 {
+	private:
+		bool info_modified;
 	public:
 
 	Record_adj();


### PR DESCRIPTION
In class Record_adj defined in source/module_hamilt_lcao/hamilt_lcaodft/record_adj.h, its destructor doesn't work fine, which may cause memory leak.
Add a flag of info to distinguish whether it has been modified and then release the memory.
As this issue says, we can detect memory leak, and I reproduce it as below.
![image](https://user-images.githubusercontent.com/124672895/233772697-716eb14a-7d12-49d1-a6f6-317d5cd4b4c2.png)
After modified the source code as I say above, the leak cannot be detected.
<img width="245" alt="image" src="https://user-images.githubusercontent.com/124672895/233772917-f05d3c26-152c-462f-8485-d4967a91849e.png">

Close #2148 