### PR TITLE
Add description of unit for out_efield and init_vel

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -453,7 +453,7 @@ These variables are used to control general system parameters.
 ### init_vel
 
 - **Type**: Boolean
-- **Description**: Read the atom velocity from the atom file (STRU) if set to true.
+- **Description**: Read the atom velocity from the atom file (STRU) if set to true. (atomic unit)
 - **Default**: false
 
 ### nelec
@@ -2581,6 +2581,7 @@ These variables are used to control berry phase and wannier90 interface paramete
 - **Description**:
   - 1: Output efield.
   - 0: do not Output efield.
+  The unit of output file if atomic unit.
 - **Default**: 0
 
 ### ocp

--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -2581,7 +2581,7 @@ These variables are used to control berry phase and wannier90 interface paramete
 - **Description**:
   - 1: Output efield.
   - 0: do not Output efield.
-  The unit of output file is atomic unit ( 1 a.u. = 1 Ry / bohr = 51.422 V/Angstrom ).
+  The unit of output file is atomic unit ( 1 a.u. = 1 Ry/bohr = 51.422 V/Angstrom ).
 - **Default**: 0
 
 ### ocp

--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -453,7 +453,7 @@ These variables are used to control general system parameters.
 ### init_vel
 
 - **Type**: Boolean
-- **Description**: Read the atom velocity from the atom file (STRU) if set to true. (atomic unit : 1 a.u. = 21.87691 Angstrom/fs )
+- **Description**: Read the atom velocity from the atom file (STRU) if set to true. (atomic unit : 1 a.u. = 21.877 Angstrom/fs )
 - **Default**: false
 
 ### nelec

--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -2581,7 +2581,7 @@ These variables are used to control berry phase and wannier90 interface paramete
 - **Description**:
   - 1: Output efield.
   - 0: do not Output efield.
-  The unit of output file if atomic unit.
+  The unit of output file is atomic unit.
 - **Default**: 0
 
 ### ocp

--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -2581,7 +2581,7 @@ These variables are used to control berry phase and wannier90 interface paramete
 - **Description**:
   - 1: Output efield.
   - 0: do not Output efield.
-  The unit of output file is atomic unit ( 1 a.u. = 1 Ry/bohr = 51.422 V/Angstrom ).
+  The unit of output file is atomic unit ( 1 a.u. = 1 Ry/(bohr $\cdot$ e) = 51.422 V/Angstrom ).
 - **Default**: 0
 
 ### ocp

--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -453,7 +453,7 @@ These variables are used to control general system parameters.
 ### init_vel
 
 - **Type**: Boolean
-- **Description**: Read the atom velocity from the atom file (STRU) if set to true. (atomic unit)
+- **Description**: Read the atom velocity from the atom file (STRU) if set to true. (atomic unit : 1 a.u. = 21.87691 Angstrom/fs )
 - **Default**: false
 
 ### nelec
@@ -2581,7 +2581,7 @@ These variables are used to control berry phase and wannier90 interface paramete
 - **Description**:
   - 1: Output efield.
   - 0: do not Output efield.
-  The unit of output file is atomic unit.
+  The unit of output file is atomic unit ( 1 a.u. = 1 Ry / bohr = 51.422 V/Angstrom ).
 - **Default**: 0
 
 ### ocp


### PR DESCRIPTION
Add description of unit for out_efield and init_vel. They are both atomic units.
Close #2251 