### PR TITLE
Fix the error when using DFT+U without setting ks_solver

### DIFF
--- a/source/module_io/input.cpp
+++ b/source/module_io/input.cpp
@@ -2234,10 +2234,11 @@ bool Input::Read(const std::string &fn)
             exit(0);
         }
 
-        if (strcmp("genelpa", ks_solver.c_str()) != 0 && strcmp(ks_solver.c_str(), "scalapack_gvx") != 0)
+        if (strcmp("genelpa", ks_solver.c_str()) != 0 && strcmp(ks_solver.c_str(), "scalapack_gvx") != 0 && strcmp(ks_solver.c_str(), "default") != 0 )
         {
             std::cout << " WRONG ARGUMENTS OF ks_solver in DFT+U routine, only genelpa and scalapack_gvx are supported "
                       << std::endl;
+            std::cout << " You'are using " << ks_solver.c_str() << std::endl;
             exit(0);
         }
     }


### PR DESCRIPTION
To fix https://github.com/deepmodeling/abacus-develop/issues/2216

when using dft+u, abacus would determine if `ks_solver` is `genelpa` or `scalapack_gvx` by using `strcmp`, but if not assign `ks_solver` explicitly, the value of `ks_solver` would be `default`, which is `genelpa ` with LCAO basis. 