### PR TITLE
Fix: dynamically enlarge `symmetry_prec` in cell-relax and optimize the error message

### DIFF
--- a/source/module_cell/klist.cpp
+++ b/source/module_cell/klist.cpp
@@ -97,7 +97,7 @@ void K_Vectors::set(
         if (!match)
         {
             ModuleBase::WARNING_QUIT("K_Vectors:ibz_kpoint",
-            "symmetry operation of reciprocal lattice is wrong! ");
+            "Symmetry operation in reciprocal lattice cannot match the equivalent k-points. Maybe a higher `symmetry_prec` is needed?  ");
         }
         if (ModuleSymmetry::Symmetry::symm_flag || is_mp)
         {

--- a/source/module_cell/klist.cpp
+++ b/source/module_cell/klist.cpp
@@ -89,8 +89,17 @@ void K_Vectors::set(
     //if symm_flag is not set, only time-reversal symmetry would be considered.
     if(!berryphase::berry_phase_flag && ModuleSymmetry::Symmetry::symm_flag != -1)
     {
-        this->ibz_kpoint(symm, ModuleSymmetry::Symmetry::symm_flag, skpt1, GlobalC::ucell);
-        if(ModuleSymmetry::Symmetry::symm_flag || is_mp)
+        bool match = true;
+        this->ibz_kpoint(symm, ModuleSymmetry::Symmetry::symm_flag, skpt1, GlobalC::ucell, match);
+#ifdef __MPI
+	    Parallel_Common::bcast_bool(match);
+#endif
+        if (!match)
+        {
+            ModuleBase::WARNING_QUIT("K_Vectors:ibz_kpoint",
+            "symmetry operation of reciprocal lattice is wrong! ");
+        }
+        if (ModuleSymmetry::Symmetry::symm_flag || is_mp)
         {
             this->update_use_ibz();
             this->nks = this->nkstot = this->nkstot_ibz;
@@ -547,9 +556,9 @@ void K_Vectors::update_use_ibz( void )
     return;
 }
 
-void K_Vectors::ibz_kpoint(const ModuleSymmetry::Symmetry &symm, bool use_symm,std::string& skpt, const UnitCell &ucell)
+void K_Vectors::ibz_kpoint(const ModuleSymmetry::Symmetry &symm, bool use_symm,std::string& skpt, const UnitCell &ucell, bool& match)
 {
-    if (GlobalV::MY_RANK!=0) return;
+    if (GlobalV::MY_RANK != 0) return;
     ModuleBase::TITLE("K_Vectors", "ibz_kpoint");
 
     // k-lattice: "pricell" of reciprocal space
@@ -613,17 +622,12 @@ void K_Vectors::ibz_kpoint(const ModuleSymmetry::Symmetry &symm, bool use_symm,s
         };
         for(int i=0;i<symm.nrotk;++i)
         {
-            bool match = false;
+            match = false;
             for(int j=0;j<bnop;++j) 
             {
                 if (matequal(symm.kgmatrix[i], bsymop[j])) {match=true; break;}
             }
-            if(!match) 
-            {
-                std::cout<<"match failed:"<<std::endl;
-                ModuleBase::WARNING_QUIT("K_Vectors:ibz_kpoint", 
-                "symmetry operation of reciprocal lattice is wrong! ");
-            }
+            if (!match) return;
         }
         nrotkm = symm.nrotk;// change if inv not included
         for (int i = 0; i < nrotkm; ++i)

--- a/source/module_cell/klist.cpp
+++ b/source/module_cell/klist.cpp
@@ -97,7 +97,7 @@ void K_Vectors::set(
         if (!match)
         {
             ModuleBase::WARNING_QUIT("K_Vectors:ibz_kpoint",
-            "Symmetry operation in reciprocal lattice cannot match the equivalent k-points. Maybe a higher `symmetry_prec` is needed?  ");
+            "Symmetry operation in reciprocal lattice cannot match the equivalent k-points. Maybe a larger (coarser) `symmetry_prec` is needed?  ");
         }
         if (ModuleSymmetry::Symmetry::symm_flag || is_mp)
         {

--- a/source/module_cell/klist.h
+++ b/source/module_cell/klist.h
@@ -38,7 +38,7 @@ public:
         const ModuleBase::Matrix3 &reciprocal_vec,
         const ModuleBase::Matrix3 &latvec);
 
-    void ibz_kpoint(const ModuleSymmetry::Symmetry &symm, bool use_symm,std::string& skpt, const UnitCell &ucell);
+    void ibz_kpoint(const ModuleSymmetry::Symmetry &symm, bool use_symm,std::string& skpt, const UnitCell &ucell, bool& match);
     //LiuXh add 20180515
     void set_after_vc(
             const ModuleSymmetry::Symmetry &symm,

--- a/source/module_cell/module_symmetry/symmetry.cpp
+++ b/source/module_cell/module_symmetry/symmetry.cpp
@@ -138,8 +138,12 @@ void Symmetry::analy_sys(const UnitCell &ucell, std::ofstream &ofs_running)
             this->getgroup(tmp_nrot, tmp_nrotk, ofs_running);
         }
         if (epsilon > MAX_EPS)
+        {
             ofs_running << "ERROR: Symmetry cannot be kept due to the lost of accuracy with atom position during cell-relax." << std::endl
-            << "Please set `symmetry` to 0 or -1 in INPUT file.  "<< std::endl;
+                << "Please set `symmetry` to 0 or -1 in INPUT file.  " << std::endl;
+            ModuleBase::QUIT();
+        }
+            
         if (eps_changed)
         {
             ofs_running << "WARNING: current `symmetry_prec` is too small to give the right number of symmtry operations." << std::endl
@@ -148,7 +152,7 @@ void Symmetry::analy_sys(const UnitCell &ucell, std::ofstream &ofs_running)
         assert(tmp_nrotk == this->nrotk);
     }
     else
-	this->getgroup(this->nrot, this->nrotk, ofs_running);
+        this->getgroup(this->nrot, this->nrotk, ofs_running);
 
 	this->pointgroup(this->nrot, this->pgnumber, this->pgname, this->gmatrix, ofs_running);
 	ModuleBase::GlobalFunc::OUT(ofs_running,"POINT GROUP", this->pgname);

--- a/source/module_cell/module_symmetry/symmetry.cpp
+++ b/source/module_cell/module_symmetry/symmetry.cpp
@@ -104,11 +104,11 @@ void Symmetry::analy_sys(const UnitCell &ucell, std::ofstream &ofs_running)
     this->lattice_type(this->a1, this->a2, this->a3, this->s1, this->s2, this->s3, 
              this->cel_const, this->pre_const, this->real_brav, ilattname, ucell, true, this->newpos);
              
-    GlobalV::ofs_running<<"(for optimal symmetric configuration:)"<<std::endl;
-    ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"BRAVAIS TYPE", real_brav);
-    ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"BRAVAIS LATTICE NAME", ilattname);
-    ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"ibrav", real_brav);
-    Symm_Other::print1(real_brav, cel_const, GlobalV::ofs_running);
+    ofs_running<<"(for optimal symmetric configuration:)"<<std::endl;
+    ModuleBase::GlobalFunc::OUT(ofs_running,"BRAVAIS TYPE", real_brav);
+    ModuleBase::GlobalFunc::OUT(ofs_running,"BRAVAIS LATTICE NAME", ilattname);
+    ModuleBase::GlobalFunc::OUT(ofs_running,"ibrav", real_brav);
+    Symm_Other::print1(real_brav, cel_const, ofs_running);
   //      std::cout << "a1 = " << a1.x << " " << a1.y << " " << a1.z <<std::endl;
   //      std::cout << "a1 = " << a2.x << " " << a2.y << " " << a2.z <<std::endl;
   //      std::cout << "a1 = " << a3.x << " " << a3.y << " " << a3.z <<std::endl;
@@ -139,15 +139,15 @@ void Symmetry::analy_sys(const UnitCell &ucell, std::ofstream &ofs_running)
         }
         if (epsilon > MAX_EPS)
         {
-            ofs_running << "ERROR: Symmetry cannot be kept due to the lost of accuracy with atom position during cell-relax." << std::endl
-                << "Please set `symmetry` to 0 or -1 in INPUT file.  " << std::endl;
+            ofs_running << "ERROR: Symmetry cannot be kept due to the lost of accuracy with atom position during cell-relax." << std::endl;
+            ofs_running << "Please set `symmetry` to 0 or -1 in INPUT file.  " << std::endl;
             ModuleBase::QUIT();
         }
             
         if (eps_changed)
         {
-            ofs_running << "WARNING: current `symmetry_prec` is too small to give the right number of symmtry operations." << std::endl
-                << " Changed `symmetry_prec` to " << std::setiosflags(ios::scientific) << epsilon <<"." << std::endl;
+            ofs_running << "WARNING: current `symmetry_prec` is too small to give the right number of symmtry operations." << std::endl;
+            ofs_running << " Changed `symmetry_prec` to " << epsilon <<"." << std::endl;
         }
         assert(tmp_nrotk == this->nrotk);
     }

--- a/source/module_cell/module_symmetry/symmetry.cpp
+++ b/source/module_cell/module_symmetry/symmetry.cpp
@@ -25,8 +25,8 @@ int Symmetry::symm_flag=0;
 
 void Symmetry::analy_sys(const UnitCell &ucell, std::ofstream &ofs_running)
 {
-    constexpr double MAX_EPS = 1e-3;
-    constexpr double MULT_EPS = 2.0;
+    const double MAX_EPS = 1e-3;
+    const double MULT_EPS = 2.0;
     if (available == false) return;
     ModuleBase::TITLE("Symmetry","init");
 	ModuleBase::timer::tick("Symmetry","analy_sys");
@@ -147,7 +147,7 @@ void Symmetry::analy_sys(const UnitCell &ucell, std::ofstream &ofs_running)
         if (eps_changed)
         {
             ofs_running << "WARNING: current `symmetry_prec` is too small to give the right number of symmtry operations." << std::endl
-                << " Changed `symmetry_prec` to " << setiosflags(ios::scientific) << epsilon << "." << std::endl;
+                << " Changed `symmetry_prec` to " << std::setiosflags(ios::scientific) << epsilon <<"." << std::endl;
         }
         assert(tmp_nrotk == this->nrotk);
     }

--- a/source/module_cell/module_symmetry/symmetry.cpp
+++ b/source/module_cell/module_symmetry/symmetry.cpp
@@ -25,7 +25,7 @@ int Symmetry::symm_flag=0;
 
 void Symmetry::analy_sys(const UnitCell &ucell, std::ofstream &ofs_running)
 {
-    const double MAX_EPS = 1e-3;
+    const double MAX_EPS = std::max(1e-3, epsilon);
     const double MULT_EPS = 2.0;
     if (available == false) return;
     ModuleBase::TITLE("Symmetry","init");

--- a/source/module_cell/module_symmetry/symmetry.h
+++ b/source/module_cell/module_symmetry/symmetry.h
@@ -62,7 +62,7 @@ public:
 	int nop;	//the number of point group operations of the pure bravais lattice without basis
 	int s_flag;	//whether the current matrix is one of all space group operations
 	int nrot;	//the number of pure point group rotations
-	int nrotk; 	//the number of all space group operations
+	int nrotk=-1; 	//the number of all space group operations
 	int pgnumber;	//the serial number of point group
 	int spgnumber;	//the serial number of point group in space group
 	std::string pgname;	//the Schoenflies name of the point group R in {R|0}

--- a/source/module_cell/test/klist_test.cpp
+++ b/source/module_cell/test/klist_test.cpp
@@ -734,8 +734,9 @@ TEST_F(KlistTest, IbzKpoint)
 	EXPECT_EQ(kv->nkstot,512);
 	//calculate ibz_kpoint
 	std::string skpt;
-	ModuleSymmetry::Symmetry::symm_flag=1;
-	kv->ibz_kpoint(symm,ModuleSymmetry::Symmetry::symm_flag,skpt, ucell);
+    ModuleSymmetry::Symmetry::symm_flag = 1;
+    bool match = true;
+    kv->ibz_kpoint(symm, ModuleSymmetry::Symmetry::symm_flag, skpt, ucell, match);
 	EXPECT_EQ(kv->nkstot_ibz,35);
 	GlobalV::ofs_running<<skpt<<std::endl;
 	GlobalV::ofs_running.close();
@@ -758,8 +759,9 @@ TEST_F(KlistTest, IbzKpointIsMP)
 	EXPECT_TRUE(kv->is_mp);
 	//calculate ibz_kpoint
 	std::string skpt;
-	ModuleSymmetry::Symmetry::symm_flag=0;
-	kv->ibz_kpoint(symm,ModuleSymmetry::Symmetry::symm_flag,skpt, ucell);
+    ModuleSymmetry::Symmetry::symm_flag = 0;
+    bool match = true;
+    kv->ibz_kpoint(symm, ModuleSymmetry::Symmetry::symm_flag, skpt, ucell, match);
 	EXPECT_EQ(kv->nkstot_ibz,260);
 	GlobalV::ofs_running<<skpt<<std::endl;
 	GlobalV::ofs_running.close();


### PR DESCRIPTION
- fix #2349 : bcast the error message
- fix #2346 by dynamically enlarge `symmetry_prec` in cell-relax. 
  - The precision of atom coordinate loses during cell-relax, then with a too-tight `symmetry_prec` like the default `1e-5` will the symmetry operators found by `getgroup` incomplete, which caused the bug.
