### PR TITLE
set urllib3 to version 1.26.15

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+urllib3 == 1.26.15
 myst_parser[linkify]
 sphinx_rtd_theme
 deepmodeling_sphinx >= 0.1.2


### PR DESCRIPTION
Set urllib3 to version 1.26.15, as urllib3 2.0 breaks readthedocs building env.
fix #2379