### PR TITLE
Refactor: Remove GlobalC::rhopw from module_elecstate

### DIFF
--- a/source/module_elecstate/elecstate.cpp
+++ b/source/module_elecstate/elecstate.cpp
@@ -396,10 +396,12 @@ void ElecState::init_scf(const int istep, const ModuleBase::ComplexMatrix& struc
 void ElecState::init_ks(Charge* chg_in, // pointer for class Charge
                         const K_Vectors* klist_in,
                         int nk_in,
+                        ModulePW::PW_Basis* rhopw_in,
                         const ModulePW::PW_Basis_Big* bigpw_in)
 {
     this->charge = chg_in;
     this->klist = klist_in;
+    this->charge->set_rhopw(rhopw_in);
     this->bigpw = bigpw_in;
     // init nelec_spin with nelec and nupdown
     this->init_nelec_spin();

--- a/source/module_elecstate/elecstate.h
+++ b/source/module_elecstate/elecstate.h
@@ -14,9 +14,11 @@ class ElecState
   public:
     ElecState(){}
     ElecState(Charge* charge_in,
+              ModulePW::PW_Basis* rhopw_in,
               ModulePW::PW_Basis_Big* bigpw_in)
     {
         this->charge = charge_in;
+        this->charge->set_rhopw(rhopw_in);
         this->bigpw = bigpw_in;
     }
     virtual ~ElecState()

--- a/source/module_elecstate/elecstate.h
+++ b/source/module_elecstate/elecstate.h
@@ -13,7 +13,12 @@ class ElecState
 {
   public:
     ElecState(){}
-    ElecState(Charge* charge_in){this->charge = charge_in;}
+    ElecState(Charge* charge_in,
+              ModulePW::PW_Basis_Big* bigpw_in)
+    {
+        this->charge = charge_in;
+        this->bigpw = bigpw_in;
+    }
     virtual ~ElecState()
     {
         if(this->pot != nullptr) 
@@ -25,6 +30,7 @@ class ElecState
     void init_ks(Charge *chg_in, // pointer for class Charge
                       const K_Vectors *klist_in,
                       int nk_in, // number of k points
+                      ModulePW::PW_Basis* rhopw_in,
                       const ModulePW::PW_Basis_Big* bigpw_in); 
 
     // return current electronic density rho, as a input for constructing Hamiltonian

--- a/source/module_elecstate/elecstate_getters.cpp
+++ b/source/module_elecstate/elecstate_getters.cpp
@@ -4,14 +4,6 @@
 namespace elecstate
 {
 
-const int get_rhopw_nrxx()
-{
-    return GlobalC::rhopw->nrxx;
-}
-const int get_rhopw_nxyz()
-{
-    return GlobalC::rhopw->nxyz;
-}
 const double get_ucell_omega()
 {
     return GlobalC::ucell.omega;

--- a/source/module_elecstate/elecstate_getters.h
+++ b/source/module_elecstate/elecstate_getters.h
@@ -2,10 +2,6 @@
 namespace elecstate
 {
 
-// get the value of GlobalC::rhopw->nrxx
-const int get_rhopw_nrxx();
-// get the value of GlobalC::rhopw->nxyz
-const int get_rhopw_nxyz();
 // get the value of GlobalC::ucell.omega
 const double get_ucell_omega();
 

--- a/source/module_elecstate/elecstate_lcao.h
+++ b/source/module_elecstate/elecstate_lcao.h
@@ -12,15 +12,17 @@ namespace elecstate
 class ElecStateLCAO : public ElecState
 {
   public:
-    ElecStateLCAO(Charge* chg_in = nullptr,
-                  const K_Vectors* klist_in = nullptr,
-                  int nks_in = 1,
-                  Local_Orbital_Charge* loc_in = nullptr,
-                  LCAO_Hamilt* uhm_in = nullptr,
-                  Local_Orbital_wfc* lowf_in = nullptr,
-                  ModulePW::PW_Basis_Big* bigpw_in = nullptr)
+    ElecStateLCAO(){} // will be called by ElecStateLCAO_TDDFT
+    ElecStateLCAO(Charge* chg_in ,
+                  const K_Vectors* klist_in ,
+                  int nks_in,
+                  Local_Orbital_Charge* loc_in ,
+                  LCAO_Hamilt* uhm_in ,
+                  Local_Orbital_wfc* lowf_in ,
+                  ModulePW::PW_Basis* rhopw_in ,
+                  ModulePW::PW_Basis_Big* bigpw_in )
     {
-        init_ks(chg_in, klist_in, nks_in, bigpw_in);
+        init_ks(chg_in, klist_in, nks_in, rhopw_in, bigpw_in);
         this->loc = loc_in;
         this->uhm = uhm_in;
         this->lowf = lowf_in;

--- a/source/module_elecstate/elecstate_lcao_tddft.h
+++ b/source/module_elecstate/elecstate_lcao_tddft.h
@@ -13,15 +13,16 @@ namespace elecstate
 class ElecStateLCAO_TDDFT : public ElecStateLCAO
 {
   public:
-    ElecStateLCAO_TDDFT(Charge* chg_in = nullptr,
-                        const K_Vectors* klist_in = nullptr,
-                        int nks_in = 1,
-                        Local_Orbital_Charge* loc_in = nullptr,
-                        LCAO_Hamilt* uhm_in = nullptr,
-                        Local_Orbital_wfc* lowf_in = nullptr,
-                        ModulePW::PW_Basis_Big* bigpw_in = nullptr)
+    ElecStateLCAO_TDDFT(Charge* chg_in ,
+                        const K_Vectors* klist_in ,
+                        int nks_in,
+                        Local_Orbital_Charge* loc_in ,
+                        LCAO_Hamilt* uhm_in ,
+                        Local_Orbital_wfc* lowf_in ,
+                        ModulePW::PW_Basis* rhopw_in ,
+                        ModulePW::PW_Basis_Big* bigpw_in )
     {
-        init_ks(chg_in, klist_in, nks_in, bigpw_in);
+        init_ks(chg_in, klist_in, nks_in, rhopw_in, bigpw_in);        
         this->loc = loc_in;
         this->uhm = uhm_in;
         this->lowf = lowf_in;

--- a/source/module_elecstate/elecstate_pw.cpp
+++ b/source/module_elecstate/elecstate_pw.cpp
@@ -9,10 +9,10 @@
 namespace elecstate {
 
 template<typename FPTYPE, typename Device>
-ElecStatePW<FPTYPE, Device>::ElecStatePW(ModulePW::PW_Basis_K *wfc_basis_in, Charge* chg_in, K_Vectors *pkv_in, ModulePW::PW_Basis_Big* bigpw_in) : basis(wfc_basis_in)  
+ElecStatePW<FPTYPE, Device>::ElecStatePW(ModulePW::PW_Basis_K *wfc_basis_in, Charge* chg_in, K_Vectors *pkv_in, ModulePW::PW_Basis* rhopw_in, ModulePW::PW_Basis_Big* bigpw_in) : basis(wfc_basis_in)  
 {
     this->classname = "ElecStatePW";
-    this->init_ks(chg_in, pkv_in, pkv_in->nks, bigpw_in);
+    this->init_ks(chg_in, pkv_in, pkv_in->nks, rhopw_in, bigpw_in);
 }
 
 template<typename FPTYPE, typename Device>

--- a/source/module_elecstate/elecstate_pw.h
+++ b/source/module_elecstate/elecstate_pw.h
@@ -17,6 +17,7 @@ class ElecStatePW : public ElecState
       ModulePW::PW_Basis_K *wfc_basis_in, 
       Charge* chg_in, 
       K_Vectors *pkv_in,
+      ModulePW::PW_Basis* rhopw_in,
       ModulePW::PW_Basis_Big* bigpw_in
     );
     // void init(Charge* chg_in):charge(chg_in){} override;

--- a/source/module_elecstate/elecstate_pw_sdft.h
+++ b/source/module_elecstate/elecstate_pw_sdft.h
@@ -10,7 +10,8 @@ namespace elecstate
             ModulePW::PW_Basis_K *wfc_basis_in, 
             Charge* chg_in, 
             K_Vectors *pkv_in,
-            ModulePW::PW_Basis_Big* bigpw_in) : ElecStatePW(wfc_basis_in, chg_in, pkv_in, bigpw_in)
+            ModulePW::PW_Basis* rhopw_in,
+            ModulePW::PW_Basis_Big* bigpw_in) : ElecStatePW(wfc_basis_in, chg_in, pkv_in, rhopw_in, bigpw_in)
         {
             this->classname = "ElecStatePW_SDFT";
         }

--- a/source/module_elecstate/energy.cpp
+++ b/source/module_elecstate/energy.cpp
@@ -76,7 +76,7 @@ void energy::calculate_harris()
 	return;
 }
 
-void energy::calculate_etot(void)
+void energy::calculate_etot(const ModulePW::PW_Basis* rhopw)
 {
 	ModuleBase::TITLE("energy","calculate_etot");
 	//std::cout << "\n demet in etot = " << demet << std::endl;
@@ -92,8 +92,8 @@ void energy::calculate_etot(void)
 	+ evdw;							// Peize Lin add evdw 2021.03.09
 	if (GlobalV::imp_sol)
     {
-	this->etot += GlobalC::solvent_model.cal_Ael(GlobalC::ucell, GlobalC::rhopw)
-				 + GlobalC::solvent_model.cal_Acav(GlobalC::ucell, GlobalC::rhopw);
+	this->etot += GlobalC::solvent_model.cal_Ael(GlobalC::ucell, rhopw)
+				 + GlobalC::solvent_model.cal_Acav(GlobalC::ucell, rhopw);
 	}
 
     //Quxin adds for DFT+U energy correction on 20201029
@@ -128,6 +128,7 @@ void energy::calculate_etot(void)
 }
 
 void energy::print_etot(
+	const ModulePW::PW_Basis* rhopw,
 	const bool converged,
 	const int &iter_in,
 	const double &scf_thr,
@@ -169,8 +170,8 @@ void energy::print_etot(
         this->print_format("E_exx", exx);
         if (GlobalV::imp_sol)
         {
-            esol_el = GlobalC::solvent_model.cal_Ael(GlobalC::ucell, GlobalC::rhopw);
-            esol_cav = GlobalC::solvent_model.cal_Acav(GlobalC::ucell, GlobalC::rhopw);
+            esol_el = GlobalC::solvent_model.cal_Ael(GlobalC::ucell, rhopw);
+            esol_cav = GlobalC::solvent_model.cal_Acav(GlobalC::ucell, rhopw);
             this->print_format("E_sol_el", esol_el);
             this->print_format("E_sol_cav", esol_cav);
         }
@@ -381,7 +382,7 @@ double energy::delta_e(const elecstate::ElecState* pelec)
 		v_ofk = pelec->pot->get_effective_vofk(0);
 	}
 
-	for (int ir=0; ir<GlobalC::rhopw->nrxx; ir++)
+	for (int ir = 0; ir < pelec->charge->rhopw->nrxx; ir++)
 	{
 		deband_aux -= pelec->charge->rho[0][ir] * (v_eff[ir] - v_fixed[ir]);
 		if(XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5)
@@ -394,7 +395,7 @@ double energy::delta_e(const elecstate::ElecState* pelec)
 	{
 		v_eff = pelec->pot->get_effective_v(1);
 		v_ofk = pelec->pot->get_effective_vofk(1);
-		for (int ir=0; ir<GlobalC::rhopw->nrxx; ir++)
+		for (int ir = 0; ir < pelec->charge->rhopw->nrxx; ir++)
 		{
 			deband_aux -= pelec->charge->rho[1][ir] * (v_eff[ir] - v_fixed[ir]);
 			if(XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5)
@@ -408,7 +409,7 @@ double energy::delta_e(const elecstate::ElecState* pelec)
 		for(int is = 1;is<4;is++)
 		{
 			v_eff = pelec->pot->get_effective_v(is);
-			for(int ir=0; ir<GlobalC::rhopw->nrxx; ir++)
+			for(int ir = 0; ir < pelec->charge->rhopw->nrxx; ir++)
 			{
 				deband_aux -= pelec->charge->rho[is][ir] * v_eff[ir];
 			}
@@ -421,7 +422,7 @@ double energy::delta_e(const elecstate::ElecState* pelec)
     deband0 = deband_aux;
 #endif
 
-    deband0 *= GlobalC::ucell.omega / GlobalC::rhopw->nxyz;
+    deband0 *= GlobalC::ucell.omega / pelec->charge->rhopw->nxyz;
 
 	// \int rho(r) v_{exx}(r) dr = 2 E_{exx}[rho]
 	deband0 -= 2*exx;				// Peize Lin add 2017-10-16
@@ -450,7 +451,7 @@ void energy::delta_escf(const elecstate::ElecState* pelec)
 		v_ofk = pelec->pot->get_effective_vofk(0);
 	}
 
-	for (int ir=0; ir<GlobalC::rhopw->nrxx; ir++)
+	for (int ir=0; ir<pelec->charge->rhopw->nrxx; ir++)
 	{
 		this->descf -= ( pelec->charge->rho[0][ir] - pelec->charge->rho_save[0][ir] ) * (v_eff[ir] - v_fixed[ir]);
 		if(XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5)
@@ -466,7 +467,7 @@ void energy::delta_escf(const elecstate::ElecState* pelec)
 		{
 			v_ofk = pelec->pot->get_effective_vofk(1);
 		}
-		for (int ir=0; ir<GlobalC::rhopw->nrxx; ir++)
+		for (int ir=0; ir<pelec->charge->rhopw->nrxx; ir++)
 		{
 			this->descf -= ( pelec->charge->rho[1][ir] - pelec->charge->rho_save[1][ir] ) * (v_eff[ir] - v_fixed[ir]);
 			if(XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5)
@@ -480,7 +481,7 @@ void energy::delta_escf(const elecstate::ElecState* pelec)
 		for(int is = 1;is<4;is++)
 		{
 			v_eff = pelec->pot->get_effective_v(is);
-			for(int ir=0; ir<GlobalC::rhopw->nrxx; ir++)
+			for(int ir=0; ir<pelec->charge->rhopw->nrxx; ir++)
 			{
 				this->descf -= ( pelec->charge->rho[is][ir] - pelec->charge->rho_save[is][ir] ) * v_eff[ir];
 			}
@@ -489,7 +490,7 @@ void energy::delta_escf(const elecstate::ElecState* pelec)
 
     Parallel_Reduce::reduce_double_pool( descf );
 
-    this->descf *= GlobalC::ucell.omega / GlobalC::rhopw->nxyz;
+    this->descf *= GlobalC::ucell.omega / pelec->charge->rhopw->nxyz;
     return;
 }
 

--- a/source/module_elecstate/energy.cpp
+++ b/source/module_elecstate/energy.cpp
@@ -76,7 +76,7 @@ void energy::calculate_harris()
 	return;
 }
 
-void energy::calculate_etot(const ModulePW::PW_Basis* rhopw)
+void energy::calculate_etot(const int& nrxx, const int& nxyz)
 {
 	ModuleBase::TITLE("energy","calculate_etot");
 	//std::cout << "\n demet in etot = " << demet << std::endl;
@@ -92,8 +92,8 @@ void energy::calculate_etot(const ModulePW::PW_Basis* rhopw)
 	+ evdw;							// Peize Lin add evdw 2021.03.09
 	if (GlobalV::imp_sol)
     {
-	this->etot += GlobalC::solvent_model.cal_Ael(GlobalC::ucell, rhopw)
-				 + GlobalC::solvent_model.cal_Acav(GlobalC::ucell, rhopw);
+	this->etot += GlobalC::solvent_model.cal_Ael(GlobalC::ucell, nrxx, nxyz)
+				 + GlobalC::solvent_model.cal_Acav(GlobalC::ucell, nxyz);
 	}
 
     //Quxin adds for DFT+U energy correction on 20201029
@@ -128,7 +128,8 @@ void energy::calculate_etot(const ModulePW::PW_Basis* rhopw)
 }
 
 void energy::print_etot(
-	const ModulePW::PW_Basis* rhopw,
+	const int& nrxx,
+	const int& nxyz,
 	const bool converged,
 	const int &iter_in,
 	const double &scf_thr,
@@ -170,8 +171,8 @@ void energy::print_etot(
         this->print_format("E_exx", exx);
         if (GlobalV::imp_sol)
         {
-            esol_el = GlobalC::solvent_model.cal_Ael(GlobalC::ucell, rhopw);
-            esol_cav = GlobalC::solvent_model.cal_Acav(GlobalC::ucell, rhopw);
+            esol_el = GlobalC::solvent_model.cal_Ael(GlobalC::ucell, nrxx, nxyz);
+            esol_cav = GlobalC::solvent_model.cal_Acav(GlobalC::ucell, nxyz);
             this->print_format("E_sol_el", esol_el);
             this->print_format("E_sol_cav", esol_cav);
         }

--- a/source/module_elecstate/energy.h
+++ b/source/module_elecstate/energy.h
@@ -75,9 +75,10 @@ class energy
     // at first order in the charge density difference \delta
     // rho
     //=========================================================
-	void calculate_etot(const ModulePW::PW_Basis* rhopw);
+	void calculate_etot(const int& nrxx, const int& nxyz);
 	void print_etot(
-		const ModulePW::PW_Basis* rhopw, 
+		const int& nrxx,
+		const int& nxyz,
 		const bool converged, 
 		const int &iter,
 		const double &scf_thr, 

--- a/source/module_elecstate/energy.h
+++ b/source/module_elecstate/energy.h
@@ -75,17 +75,18 @@ class energy
     // at first order in the charge density difference \delta
     // rho
     //=========================================================
-	void calculate_etot(const int& nrxx, const int& nxyz);
-	void print_etot(
-		const int& nrxx,
-		const int& nxyz,
-		const bool converged, 
-		const int &iter,
-		const double &scf_thr, 
-		const double &duration, 
-		const double &pw_diag_thr=0, 
-		const double &avg_iter=0, 
-		bool print = true);
+	void calculate_etot(const int& nrxx, 	// num. of real space grids on current core
+						const int& nxyz		// total num. of real space grids
+	);
+	void print_etot(const int& nrxx,		// num. of real space grids on current core
+					const int& nxyz,		// total num. of real space grids
+					const bool converged, 
+					const int &iter,
+					const double &scf_thr, 
+					const double &duration, 
+					const double &pw_diag_thr=0, 
+					const double &avg_iter=0, 
+					bool print = true);
 
 	void print_format(const std::string &name, const double &value);
 

--- a/source/module_elecstate/energy.h
+++ b/source/module_elecstate/energy.h
@@ -75,9 +75,16 @@ class energy
     // at first order in the charge density difference \delta
     // rho
     //=========================================================
-	void calculate_etot(void);
-	void print_etot(const bool converged, const int &iter,
-	const double &scf_thr, const double &duration, const double &pw_diag_thr=0, const double &avg_iter=0, bool print = true);
+	void calculate_etot(const ModulePW::PW_Basis* rhopw);
+	void print_etot(
+		const ModulePW::PW_Basis* rhopw, 
+		const bool converged, 
+		const int &iter,
+		const double &scf_thr, 
+		const double &duration, 
+		const double &pw_diag_thr=0, 
+		const double &avg_iter=0, 
+		bool print = true);
 
 	void print_format(const std::string &name, const double &value);
 

--- a/source/module_elecstate/magnetism.cpp
+++ b/source/module_elecstate/magnetism.cpp
@@ -21,7 +21,7 @@ void Magnetism::compute_magnetization(const Charge* const chr, double* nelec_spi
         this->tot_magnetization = 0.00;
         this->abs_magnetization = 0.00;
 
-        for (int ir=0; ir<elecstate::get_rhopw_nrxx(); ir++)
+        for (int ir=0; ir<chr->nrxx; ir++)
         {
             double diff = chr->rho[0][ir] - chr->rho[1][ir];
             this->tot_magnetization += diff;
@@ -31,8 +31,8 @@ void Magnetism::compute_magnetization(const Charge* const chr, double* nelec_spi
         Parallel_Reduce::reduce_double_pool( this->tot_magnetization );
         Parallel_Reduce::reduce_double_pool( this->abs_magnetization );
 #endif
-        this->tot_magnetization *= elecstate::get_ucell_omega() / elecstate::get_rhopw_nxyz();
-        this->abs_magnetization *= elecstate::get_ucell_omega() / elecstate::get_rhopw_nxyz();
+        this->tot_magnetization *= elecstate::get_ucell_omega() / chr->rhopw->nxyz;
+        this->abs_magnetization *= elecstate::get_ucell_omega() / chr->rhopw->nxyz;
 
 		ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"total magnetism (Bohr mag/cell)",this->tot_magnetization);
 		ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"absolute magnetism (Bohr mag/cell)",this->abs_magnetization);
@@ -53,7 +53,7 @@ void Magnetism::compute_magnetization(const Charge* const chr, double* nelec_spi
 	{
 		for(int i=0;i<3;i++)this->tot_magnetization_nc[i] = 0.00;
 		this->abs_magnetization = 0.00;
-		for (int ir=0; ir<elecstate::get_rhopw_nrxx(); ir++)
+		for (int ir=0; ir<chr->nrxx; ir++)
 		{
 			double diff = sqrt(pow(chr->rho[1][ir], 2) + pow(chr->rho[2][ir], 2) +pow(chr->rho[3][ir], 2));
  
@@ -64,8 +64,8 @@ void Magnetism::compute_magnetization(const Charge* const chr, double* nelec_spi
 		Parallel_Reduce::reduce_double_pool( this->tot_magnetization_nc, 3 );
 		Parallel_Reduce::reduce_double_pool( this->abs_magnetization );
 #endif
-		for(int i=0;i<3;i++)this->tot_magnetization_nc[i] *= elecstate::get_ucell_omega() / elecstate::get_rhopw_nxyz();
-		this->abs_magnetization *= elecstate::get_ucell_omega() / elecstate::get_rhopw_nxyz();
+		for(int i=0;i<3;i++)this->tot_magnetization_nc[i] *= elecstate::get_ucell_omega() / chr->rhopw->nxyz;
+		this->abs_magnetization *= elecstate::get_ucell_omega() / chr->rhopw->nxyz;
 		GlobalV::ofs_running<<"total magnetism (Bohr mag/cell)"<<'\t'<<this->tot_magnetization_nc[0]<<'\t'<<this->tot_magnetization_nc[1]<<'\t'<<this->tot_magnetization_nc[2]<<'\n';
 		ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"absolute magnetism (Bohr mag/cell)",this->abs_magnetization);
 	}

--- a/source/module_elecstate/module_charge/charge.cpp
+++ b/source/module_elecstate/module_charge/charge.cpp
@@ -45,6 +45,11 @@ Charge::~Charge()
     this->destroy();
 }
 
+void Charge::set_rhopw(ModulePW::PW_Basis* rhopw_in)
+{
+	this->rhopw = rhopw_in;
+}
+
 void Charge::destroy()
 {
     if(allocate_rho || allocate_rho_final_scf) //LiuXh add 20180619

--- a/source/module_elecstate/module_charge/charge.cpp
+++ b/source/module_elecstate/module_charge/charge.cpp
@@ -80,9 +80,11 @@ void Charge::destroy()
     }
 }
 
-void Charge::allocate(const int &nspin_in, const int &nrxx_in, const int &ngmc_in)
+void Charge::allocate(const int &nspin_in)
 {
     ModuleBase::TITLE("Charge","allocate");
+	this->nrxx = this->rhopw->nrxx;
+	this->ngmc = this->rhopw->npw;
 
     if(allocate_rho == true)
     {
@@ -94,8 +96,6 @@ void Charge::allocate(const int &nspin_in, const int &nrxx_in, const int &ngmc_i
 
 	//  mohan add 2021-02-20
 	this->nspin = nspin_in;
-	this->nrxx = nrxx_in;
-	this->ngmc = ngmc_in;
 
     if (GlobalV::test_charge > 1)
     {

--- a/source/module_elecstate/module_charge/charge.cpp
+++ b/source/module_elecstate/module_charge/charge.cpp
@@ -163,7 +163,7 @@ void Charge::init_rho(const ModuleBase::ComplexMatrix &strucFac)
     std::cout << " START CHARGE      : " << GlobalV::init_chg << std::endl;
     if (GlobalV::init_chg == "atomic") // mohan add 2007-10-17
     {
-        this->atomic_rho(GlobalV::NSPIN, GlobalC::ucell.omega, rho, GlobalC::rhopw, strucFac);
+        this->atomic_rho(GlobalV::NSPIN, GlobalC::ucell.omega, rho, strucFac);
     }
     else if (GlobalV::init_chg == "file")
     {
@@ -182,9 +182,9 @@ void Charge::init_rho(const ModuleBase::ComplexMatrix &strucFac)
 			GlobalV::NSPIN,
 			ssc.str(),
 			this->rho[is],
-			GlobalC::rhopw->nx,
-			GlobalC::rhopw->ny,
-			GlobalC::rhopw->nz,
+			this->rhopw->nx,
+			this->rhopw->ny,
+			this->rhopw->nz,
 			ef_tmp,
 			&(GlobalC::ucell),
 			this->prenspin))
@@ -197,7 +197,7 @@ void Charge::init_rho(const ModuleBase::ComplexMatrix &strucFac)
 			{
 			    GlobalV::ofs_running << " Didn't read in the charge density but autoset it for spin " << is + 1
 			                         << std::endl;
-			    for (int ir = 0; ir < GlobalC::rhopw->nrxx; ir++)
+			    for (int ir = 0; ir < this->rhopw->nrxx; ir++)
 			    {
 			        this->rho[is][ir] = 0.0;
 			    }
@@ -217,7 +217,7 @@ void Charge::init_rho(const ModuleBase::ComplexMatrix &strucFac)
 			    else if (is == 3)
 			    {
 			        GlobalV::ofs_running << " rearrange charge density " << std::endl;
-			        for (int ir = 0; ir < GlobalC::rhopw->nrxx; ir++)
+			        for (int ir = 0; ir < this->rhopw->nrxx; ir++)
 			        {
 			            this->rho[3][ir] = this->rho[0][ir] - this->rho[1][ir];
 			            this->rho[0][ir] = this->rho[0][ir] + this->rho[1][ir];
@@ -251,9 +251,9 @@ void Charge::init_rho(const ModuleBase::ComplexMatrix &strucFac)
 							GlobalV::NSPIN,
 							ssc.str(),
 							this->kin_r[is],
-							GlobalC::rhopw->nx,
-							GlobalC::rhopw->ny,
-							GlobalC::rhopw->nz,
+							this->rhopw->nx,
+							this->rhopw->ny,
+							this->rhopw->nz,
 							GlobalC::en.ef,
 							&(GlobalC::ucell),
 							this->prenspin))
@@ -300,7 +300,7 @@ double Charge::sum_rho(void) const
 	}
 
 	// multiply the sum of charge density by a factor
-    sum_rho *= GlobalC::ucell.omega / static_cast<double>( GlobalC::rhopw->nxyz );
+    sum_rho *= GlobalC::ucell.omega / static_cast<double>( this->rhopw->nxyz );
     Parallel_Reduce::reduce_double_pool( sum_rho );
 
 	// mohan fixed bug 2010-01-18, 
@@ -343,7 +343,7 @@ void Charge::renormalize_rho(void)
 // rho_at (read from pseudopotential files)
 // allocate work space (psic must already be allocated)
 //-------------------------------------------------------
-void Charge::atomic_rho(const int spin_number_need, const double& omega, double** rho_in, ModulePW::PW_Basis* rho_basis, const ModuleBase::ComplexMatrix &strucFac)const		// Peize Lin refactor 2021.04.08
+void Charge::atomic_rho(const int spin_number_need, const double& omega, double** rho_in, const ModuleBase::ComplexMatrix &strucFac)const		// Peize Lin refactor 2021.04.08
 {
     ModuleBase::TITLE("Charge","atomic_rho");
     ModuleBase::timer::tick("Charge","atomic_rho");
@@ -351,7 +351,7 @@ void Charge::atomic_rho(const int spin_number_need, const double& omega, double*
 	ModuleBase::ComplexMatrix rho_g3d = [&]()->ModuleBase::ComplexMatrix
 	{
 		// use interpolation to get three dimension charge density.
-		ModuleBase::ComplexMatrix rho_g3d( spin_number_need, rho_basis->npw);
+		ModuleBase::ComplexMatrix rho_g3d( spin_number_need, this->rhopw->npw);
 
 		for (int it = 0;it < GlobalC::ucell.ntype;it++)
 		{
@@ -370,7 +370,7 @@ void Charge::atomic_rho(const int spin_number_need, const double& omega, double*
 				const std::vector<double> rho_lgl = [&]()->std::vector<double>
 				{
 					// one dimension of charge in G space.
-					std::vector<double> rho_lgl(rho_basis->ngg,0);
+					std::vector<double> rho_lgl(this->rhopw->ngg,0);
 
 					// mesh point of this element.
 					const int mesh = atom->ncpp.msh;
@@ -415,7 +415,7 @@ void Charge::atomic_rho(const int spin_number_need, const double& omega, double*
 					// Here we compute the G=0 term
 					//----------------------------------------------------------
 					int gstart = 0;
-					if(rho_basis->gg_uniq[0] < 1e-8)
+					if(this->rhopw->gg_uniq[0] < 1e-8)
 					{
 						std::vector<double> rho1d(GlobalC::ucell.meshx);
 						for (int ir = 0;ir < mesh;ir++)
@@ -442,9 +442,9 @@ void Charge::atomic_rho(const int spin_number_need, const double& omega, double*
 #ifdef _OPENMP
 #pragma omp for
 #endif
-					for (int igg = gstart; igg < rho_basis->ngg ;++igg)
+					for (int igg = gstart; igg < this->rhopw->ngg ;++igg)
 					{
-						const double gx = sqrt(rho_basis->gg_uniq[igg]) * GlobalC::ucell.tpiba;
+						const double gx = sqrt(this->rhopw->gg_uniq[igg]) * GlobalC::ucell.tpiba;
 						for (int ir = 0; ir < mesh;ir++)
 						{
 							if ( atom->ncpp.r[ir] < 1.0e-8 )
@@ -471,7 +471,7 @@ void Charge::atomic_rho(const int spin_number_need, const double& omega, double*
 #ifdef _OPENMP
 #pragma omp for
 #endif
-					for (int igg=0; igg< rho_basis->ngg ; igg++)
+					for (int igg=0; igg< this->rhopw->ngg ; igg++)
 						rho_lgl[igg] /= omega;
 #ifdef _OPENMP
 }
@@ -486,9 +486,9 @@ void Charge::atomic_rho(const int spin_number_need, const double& omega, double*
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-					for (int ig=0; ig< rho_basis->npw ;ig++)
+					for (int ig=0; ig< this->rhopw->npw ;ig++)
 					{
-						rho_g3d(0, ig) += strucFac(it, ig) * rho_lgl[ rho_basis->ig2igg[ig] ];
+						rho_g3d(0, ig) += strucFac(it, ig) * rho_lgl[ this->rhopw->ig2igg[ig] ];
 					}
 				}
 				// mohan add 2011-06-14, initialize the charge density according to each atom 
@@ -499,9 +499,9 @@ void Charge::atomic_rho(const int spin_number_need, const double& omega, double*
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-						for (int ig = 0; ig < rho_basis->npw ; ig++)
+						for (int ig = 0; ig < this->rhopw->npw ; ig++)
 						{
-							const std::complex<double> swap = strucFac(it, ig)* rho_lgl[rho_basis->ig2igg[ig]];
+							const std::complex<double> swap = strucFac(it, ig)* rho_lgl[this->rhopw->ig2igg[ig]];
 							const double up = 0.5 * ( 1 + GlobalC::ucell.magnet.start_magnetization[it] / atom->ncpp.zv );
 							const double dw = 0.5 * ( 1 - GlobalC::ucell.magnet.start_magnetization[it] / atom->ncpp.zv );
 							rho_g3d(0, ig) += swap * up;
@@ -522,14 +522,14 @@ void Charge::atomic_rho(const int spin_number_need, const double& omega, double*
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-							for (int ig = 0; ig < rho_basis->npw ; ig++)
+							for (int ig = 0; ig < this->rhopw->npw ; ig++)
 							{
 								const double Gtau =
-									rho_basis->gcar[ig][0] * atom->tau[ia].x + 
-									rho_basis->gcar[ig][1] * atom->tau[ia].y + 
-									rho_basis->gcar[ig][2] * atom->tau[ia].z;
+									this->rhopw->gcar[ig][0] * atom->tau[ia].x + 
+									this->rhopw->gcar[ig][1] * atom->tau[ia].y + 
+									this->rhopw->gcar[ig][2] * atom->tau[ia].z;
 
-								std::complex<double> swap = ModuleBase::libm::exp(ci_tpi * Gtau) * rho_lgl[rho_basis->ig2igg[ig]];
+								std::complex<double> swap = ModuleBase::libm::exp(ci_tpi * Gtau) * rho_lgl[this->rhopw->ig2igg[ig]];
 
 								rho_g3d(0, ig) += swap * up;
 								rho_g3d(1, ig) += swap * dw;
@@ -551,9 +551,9 @@ void Charge::atomic_rho(const int spin_number_need, const double& omega, double*
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-						for (int ig = 0; ig < rho_basis->npw ; ig++)
+						for (int ig = 0; ig < this->rhopw->npw ; ig++)
 						{
-							const std::complex<double> swap = strucFac(it, ig)* rho_lgl[rho_basis->ig2igg[ig]];
+							const std::complex<double> swap = strucFac(it, ig)* rho_lgl[this->rhopw->ig2igg[ig]];
 							rho_g3d(0, ig) += swap ;
 							if(GlobalV::DOMAG)
 							{//will not be used now, will be deleted later
@@ -589,14 +589,14 @@ void Charge::atomic_rho(const int spin_number_need, const double& omega, double*
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-							for (int ig = 0; ig < rho_basis->npw ; ig++)
+							for (int ig = 0; ig < this->rhopw->npw ; ig++)
 							{
 								const double Gtau =
-									rho_basis->gcar[ig][0] * atom->tau[ia].x + 
-									rho_basis->gcar[ig][1] * atom->tau[ia].y + 
-									rho_basis->gcar[ig][2] * atom->tau[ia].z;
+									this->rhopw->gcar[ig][0] * atom->tau[ia].x + 
+									this->rhopw->gcar[ig][1] * atom->tau[ia].y + 
+									this->rhopw->gcar[ig][2] * atom->tau[ia].z;
 
-								std::complex<double> swap = exp(ci_tpi * Gtau) * rho_lgl[rho_basis->ig2igg[ig]];
+								std::complex<double> swap = exp(ci_tpi * Gtau) * rho_lgl[this->rhopw->ig2igg[ig]];
 
 								//calculate rho_total
 								rho_g3d(0, ig) += swap;
@@ -636,11 +636,11 @@ void Charge::atomic_rho(const int spin_number_need, const double& omega, double*
 	std::vector<double> ne(spin_number_need);
     for (int is = 0; is < spin_number_need;is++)
     {
-        rho_basis->recip2real( &rho_g3d(is,0), rho_in[is]);
+        this->rhopw->recip2real( &rho_g3d(is,0), rho_in[is]);
 
-		for(int ir=0; ir<rho_basis->nrxx; ++ir)
+		for(int ir=0; ir<this->rhopw->nrxx; ++ir)
 			ne[is] += rho_in[is][ir];
-		ne[is] *= omega/(double)rho_basis->nxyz; 
+		ne[is] *= omega/(double)this->rhopw->nxyz; 
 		Parallel_Reduce::reduce_double_pool( ne[is] );
 
         // we check that everything is correct
@@ -648,12 +648,12 @@ void Charge::atomic_rho(const int spin_number_need, const double& omega, double*
         double rea = 0.0;
         double ima = 0.0;
 		double sumrea = 0.0;
-        for (int ir=0;ir < rho_basis->nrxx; ir++)
+        for (int ir=0;ir < this->rhopw->nrxx; ir++)
         {
-            rea = rho_basis->ft.get_auxr_data<double>()[ir].real();
+            rea = this->rhopw->ft.get_auxr_data<double>()[ir].real();
 			sumrea += rea;
             neg += std::min(0.0, rea);
-            ima += abs(rho_basis->ft.get_auxr_data<double>()[ir].imag());
+            ima += abs(this->rhopw->ft.get_auxr_data<double>()[ir].imag());
         }
 
 		Parallel_Reduce::reduce_double_pool( neg );	
@@ -661,9 +661,9 @@ void Charge::atomic_rho(const int spin_number_need, const double& omega, double*
 		Parallel_Reduce::reduce_double_pool( sumrea );	
 
 		// mohan fix bug 2011-04-03
-        neg = neg / (double)rho_basis->nxyz * omega;
-        ima = ima / (double)rho_basis->nxyz * omega;
-		sumrea = sumrea / (double)rho_basis->nxyz * omega;
+        neg = neg / (double)this->rhopw->nxyz * omega;
+        ima = ima / (double)this->rhopw->nxyz * omega;
+		sumrea = sumrea / (double)this->rhopw->nxyz * omega;
 
         if( ((neg<-1.0e-4) && (is==0||GlobalV::NSPIN==2)) || ima>1.0e-4)
         {
@@ -691,7 +691,7 @@ void Charge::atomic_rho(const int spin_number_need, const double& omega, double*
 	ModuleBase::GlobalFunc::OUT(GlobalV::ofs_warning,"total electron number from rho",ne_tot);
 	ModuleBase::GlobalFunc::OUT(GlobalV::ofs_warning,"should be",GlobalV::nelec);
 	for(int is=0; is<spin_number_need; ++is)
-		for(int ir=0; ir<rho_basis->nrxx; ++ir)
+		for(int ir=0; ir<this->rhopw->nrxx; ++ir)
 			rho_in[is][ir] = rho_in[is][ir] / ne_tot * GlobalV::nelec;
 
 	//wenfei 2021-7-29 : initial tau = 3/5 rho^2/3, Thomas-Fermi
@@ -702,7 +702,7 @@ void Charge::atomic_rho(const int spin_number_need, const double& omega, double*
 		int nspin = spin_number_need;
 		//ofstream test_tau0("tau0");
 		for(int is=0; is<spin_number_need; ++is)
-			for(int ir=0; ir<rho_basis->nrxx; ++ir)
+			for(int ir=0; ir<this->rhopw->nrxx; ++ir)
 			{
 				kin_r[is][ir] = fact * pow(abs(rho_in[is][ir])*nspin,5.0/3.0)/nspin;
 				//test_tau0 << rho_in[is][ir] << " " << kin_r[is][ir] << endl;
@@ -748,16 +748,16 @@ void Charge::set_rho_core(
 
     if (!bl)
     {
-        ModuleBase::GlobalFunc::ZEROS( this->rho_core, GlobalC::rhopw->nrxx);
+        ModuleBase::GlobalFunc::ZEROS( this->rho_core, this->rhopw->nrxx);
     	ModuleBase::timer::tick("Charge","set_rho_core");
         return;
     }
 
-    double *rhocg = new double[GlobalC::rhopw->ngg];
-    ModuleBase::GlobalFunc::ZEROS(rhocg, GlobalC::rhopw->ngg );
+    double *rhocg = new double[this->rhopw->ngg];
+    ModuleBase::GlobalFunc::ZEROS(rhocg, this->rhopw->ngg );
 
 	// three dimension.
-    std::complex<double> *vg = new std::complex<double>[GlobalC::rhopw->npw];	
+    std::complex<double> *vg = new std::complex<double>[this->rhopw->npw];	
 
     for (int it = 0; it < GlobalC::ucell.ntype;it++)
     {
@@ -773,33 +773,32 @@ void Charge::set_rho_core(
                 GlobalC::ucell.atoms[it].ncpp.r,
                 GlobalC::ucell.atoms[it].ncpp.rab,
                 GlobalC::ucell.atoms[it].ncpp.rho_atc,
-                rhocg,
-				GlobalC::rhopw);
+                rhocg);
 //----------------------------------------------------------
 // EXPLAIN : multiply by the structure factor and sum
 //----------------------------------------------------------
-            for (int ig = 0; ig < GlobalC::rhopw->npw ; ig++)
+            for (int ig = 0; ig < this->rhopw->npw ; ig++)
             {
-                vg[ig] += structure_factor(it, ig) * rhocg[GlobalC::rhopw->ig2igg[ig]];
+                vg[ig] += structure_factor(it, ig) * rhocg[this->rhopw->ig2igg[ig]];
             }
         }
     }
 
 	// for tmp use.
-	for(int ig=0; ig< GlobalC::rhopw->npw; ig++)
+	for(int ig=0; ig< this->rhopw->npw; ig++)
 	{
 		this->rhog_core[ig] = vg[ig];
 	}
 
-    GlobalC::rhopw->recip2real(vg, this->rho_core);
+    this->rhopw->recip2real(vg, this->rho_core);
 
     // test on the charge and computation of the core energy
     double rhoima = 0.0;
     double rhoneg = 0.0;
-    for (int ir = 0; ir < GlobalC::rhopw->nrxx; ir++)
+    for (int ir = 0; ir < this->rhopw->nrxx; ir++)
     {
-        rhoneg += min(0.0, GlobalC::rhopw->ft.get_auxr_data<double>()[ir].real());
-        rhoima += abs(GlobalC::rhopw->ft.get_auxr_data<double>()[ir].imag());
+        rhoneg += min(0.0, this->rhopw->ft.get_auxr_data<double>()[ir].real());
+        rhoima += abs(this->rhopw->ft.get_auxr_data<double>()[ir].imag());
         // NOTE: Core charge is computed in reciprocal space and brought to real
         // space by FFT. For non smooth core charges (or insufficient cut-off)
         // this may result in negative values in some grid points.
@@ -818,8 +817,8 @@ void Charge::set_rho_core(
 
 	// mohan changed 2010-2-2, make this same as in atomic_rho.
 	// still lack something......
-    rhoneg /= GlobalC::rhopw->nxyz * GlobalC::ucell.omega;
-    rhoima /= GlobalC::rhopw->nxyz * GlobalC::ucell.omega;
+    rhoneg /= this->rhopw->nxyz * GlobalC::ucell.omega;
+    rhoima /= this->rhopw->nxyz * GlobalC::ucell.omega;
 
     // calculate core_only exch-corr energy etxcc=E_xc[rho_core] if required
     // The term was present in previous versions of the code but it shouldn't
@@ -838,8 +837,7 @@ void Charge::non_linear_core_correction
     const double *r,
     const double *rab,
     const double *rhoc,
-    double *rhocg,
-	ModulePW::PW_Basis* rho_basis) const
+    double *rhocg) const
 {
     ModuleBase::TITLE("charge","drhoc");
 
@@ -858,7 +856,7 @@ void Charge::non_linear_core_correction
         // G=0 term
 
         int igl0 = 0;
-        if (rho_basis->gg_uniq [0] < 1.0e-8)
+        if (this->rhopw->gg_uniq [0] < 1.0e-8)
         {
 			// single thread term
 			if (thread_id == 0)
@@ -876,14 +874,14 @@ void Charge::non_linear_core_correction
 
 		int igl_beg, igl_end;
 		// exclude igl0
-		ModuleBase::TASK_DIST_1D(num_threads, thread_id, rho_basis->ngg - igl0, igl_beg, igl_end);
+		ModuleBase::TASK_DIST_1D(num_threads, thread_id, this->rhopw->ngg - igl0, igl_beg, igl_end);
 		igl_beg += igl0;
 		igl_end += igl_beg;
 
         // G <> 0 term
         for (int igl = igl_beg; igl < igl_end;igl++) 
         {
-            gx = sqrt(rho_basis->gg_uniq[igl] * GlobalC::ucell.tpiba2);
+            gx = sqrt(this->rhopw->gg_uniq[igl] * GlobalC::ucell.tpiba2);
             ModuleBase::Sphbes::Spherical_Bessel(mesh, r, gx, 0, aux);
             for (int ir = 0;ir < mesh; ir++) 
             {
@@ -968,7 +966,7 @@ void Charge::rho_mpi(const int& nbz, const int& bz)
     //====================================================
     int *rec = new int[GlobalV::NPROC_IN_POOL];
 	ModuleBase::GlobalFunc::ZEROS(rec, GlobalV::NPROC_IN_POOL);
-    const int ncxy = GlobalC::rhopw->nx * GlobalC::rhopw->ny;
+    const int ncxy = this->rhopw->nx * this->rhopw->ny;
     for (ip=0;ip<GlobalV::NPROC_IN_POOL;ip++)
     {
         rec[ip] = num_z[ip]*ncxy;
@@ -990,10 +988,10 @@ void Charge::rho_mpi(const int& nbz, const int& bz)
     // ( according to different k distribution,
     // so the rho in each pool is different
     //==========================================
-    double *rho_tmp = new double[GlobalC::rhopw->nrxx];
-    double *rho_tot = new double[GlobalC::rhopw->nxyz];
-    double *rho_tot_aux = new double[GlobalC::rhopw->nxyz];
-	ModuleBase::GlobalFunc::ZEROS(rho_tot_aux, GlobalC::rhopw->nxyz);
+    double *rho_tmp = new double[this->rhopw->nrxx];
+    double *rho_tot = new double[this->rhopw->nxyz];
+    double *rho_tot_aux = new double[this->rhopw->nxyz];
+	ModuleBase::GlobalFunc::ZEROS(rho_tot_aux, this->rhopw->nxyz);
 
 	double *tau_tmp;
 	double *tau_tot;
@@ -1001,18 +999,18 @@ void Charge::rho_mpi(const int& nbz, const int& bz)
 
 	if(XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5)
 	{
-    	tau_tmp = new double[GlobalC::rhopw->nrxx];
-	    tau_tot = new double[GlobalC::rhopw->nxyz];
-    	tau_tot_aux = new double[GlobalC::rhopw->nxyz];
-		ModuleBase::GlobalFunc::ZEROS(tau_tot_aux, GlobalC::rhopw->nxyz);
+    	tau_tmp = new double[this->rhopw->nrxx];
+	    tau_tot = new double[this->rhopw->nxyz];
+    	tau_tot_aux = new double[this->rhopw->nxyz];
+		ModuleBase::GlobalFunc::ZEROS(tau_tot_aux, this->rhopw->nxyz);
 	}
 
     for (int is=0; is< GlobalV::NSPIN; is++)
     {
-        ModuleBase::GlobalFunc::ZEROS(rho_tot, GlobalC::rhopw->nxyz);
-		if(XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5) ModuleBase::GlobalFunc::ZEROS(tau_tot, GlobalC::rhopw->nxyz);
+        ModuleBase::GlobalFunc::ZEROS(rho_tot, this->rhopw->nxyz);
+		if(XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5) ModuleBase::GlobalFunc::ZEROS(tau_tot, this->rhopw->nxyz);
 
-		for (ir=0;ir<GlobalC::rhopw->nrxx;ir++)
+		for (ir=0;ir<this->rhopw->nrxx;ir++)
 		{
 			rho_tmp[ir] = this->rho[is][ir] / static_cast<double>(GlobalV::NPROC_IN_POOL);
 			if(XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5)
@@ -1021,19 +1019,19 @@ void Charge::rho_mpi(const int& nbz, const int& bz)
 			}
 		}
 
-        MPI_Allgatherv(rho_tmp, GlobalC::rhopw->nrxx, MPI_DOUBLE, rho_tot, rec, dis, MPI_DOUBLE, POOL_WORLD);
+        MPI_Allgatherv(rho_tmp, this->rhopw->nrxx, MPI_DOUBLE, rho_tot, rec, dis, MPI_DOUBLE, POOL_WORLD);
 		if(XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5)
 		{
-        	MPI_Allgatherv(tau_tmp, GlobalC::rhopw->nrxx, MPI_DOUBLE, tau_tot, rec, dis, MPI_DOUBLE, POOL_WORLD);
+        	MPI_Allgatherv(tau_tmp, this->rhopw->nrxx, MPI_DOUBLE, tau_tot, rec, dis, MPI_DOUBLE, POOL_WORLD);
 		}
         //=================================================================
         // Change the order of rho_tot in each pool , make them consistent
         // this is the most complicated part !!
         //=================================================================
-        ModuleBase::GlobalFunc::ZEROS(rho_tot_aux, GlobalC::rhopw->nxyz);
+        ModuleBase::GlobalFunc::ZEROS(rho_tot_aux, this->rhopw->nxyz);
 		if(XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5)
 		{
-        	ModuleBase::GlobalFunc::ZEROS(tau_tot_aux, GlobalC::rhopw->nxyz);
+        	ModuleBase::GlobalFunc::ZEROS(tau_tot_aux, this->rhopw->nxyz);
 		}
 
         for (ip=0;ip<GlobalV::NPROC_IN_POOL;ip++)
@@ -1057,7 +1055,7 @@ void Charge::rho_mpi(const int& nbz, const int& bz)
 					// rot_tot_aux : suitable among all pools.
 					// (1) the data save along z direction.
 					// (2) and each element number of group 'z data' 
-					// is 'GlobalC::rhopw->nz'
+					// is 'this->rhopw->nz'
 					// (3) however, the data rearrange is occured
 					// between [ start_z[ip], start_z[ip]+num_z[ip] )
 					// (4) start_z[ip] + iz yields correct z coordiante.
@@ -1072,11 +1070,11 @@ void Charge::rho_mpi(const int& nbz, const int& bz)
 					// have large 'start position', which we label
 					// start_z[ip] * ncxy.
 					// -------------------------------------------------
-                    rho_tot_aux[GlobalC::rhopw->nz*ir    + start_z[ip]      + iz]
+                    rho_tot_aux[this->rhopw->nz*ir    + start_z[ip]      + iz]
                       = rho_tot[num_z[ip]*ir + start_z[ip]*ncxy + iz];
 					if(XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5)
 					{
-                    	tau_tot_aux[GlobalC::rhopw->nz*ir    + start_z[ip]      + iz]
+                    	tau_tot_aux[this->rhopw->nz*ir    + start_z[ip]      + iz]
                       	  = tau_tot[num_z[ip]*ir + start_z[ip]*ncxy + iz];
 					}	
                 }
@@ -1087,17 +1085,17 @@ void Charge::rho_mpi(const int& nbz, const int& bz)
         //==================================
 		if(GlobalV::ESOLVER_TYPE == "sdft") //qinarui add it temporarily.
 		{
-			MPI_Allreduce(rho_tot_aux,rho_tot,GlobalC::rhopw->nxyz,MPI_DOUBLE,MPI_SUM,STO_WORLD);
+			MPI_Allreduce(rho_tot_aux,rho_tot,this->rhopw->nxyz,MPI_DOUBLE,MPI_SUM,STO_WORLD);
 			if(XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5)
 			{
-				MPI_Allreduce(tau_tot_aux,tau_tot,GlobalC::rhopw->nxyz,MPI_DOUBLE,MPI_SUM,STO_WORLD);
+				MPI_Allreduce(tau_tot_aux,tau_tot,this->rhopw->nxyz,MPI_DOUBLE,MPI_SUM,STO_WORLD);
 			}
 		}
 		else
-        MPI_Allreduce(rho_tot_aux,rho_tot,GlobalC::rhopw->nxyz,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+        MPI_Allreduce(rho_tot_aux,rho_tot,this->rhopw->nxyz,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
 		if(XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5)
 		{
-   	    	MPI_Allreduce(tau_tot_aux,tau_tot,GlobalC::rhopw->nxyz,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+   	    	MPI_Allreduce(tau_tot_aux,tau_tot,this->rhopw->nxyz,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
 		}
         
 		//=====================================
@@ -1107,10 +1105,10 @@ void Charge::rho_mpi(const int& nbz, const int& bz)
         {
             for (iz=0;iz<num_z[GlobalV::RANK_IN_POOL];iz++)
             {
-                this->rho[is][num_z[GlobalV::RANK_IN_POOL]*ir+iz] = rho_tot[GlobalC::rhopw->nz*ir + GlobalC::rhopw->startz_current + iz ];
+                this->rho[is][num_z[GlobalV::RANK_IN_POOL]*ir+iz] = rho_tot[this->rhopw->nz*ir + this->rhopw->startz_current + iz ];
 				if(XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5)
 				{
-                	this->kin_r[is][num_z[GlobalV::RANK_IN_POOL]*ir+iz] = tau_tot[GlobalC::rhopw->nz*ir + GlobalC::rhopw->startz_current + iz ];
+                	this->kin_r[is][num_z[GlobalV::RANK_IN_POOL]*ir+iz] = tau_tot[this->rhopw->nz*ir + this->rhopw->startz_current + iz ];
 				}	
             }
         }
@@ -1140,8 +1138,8 @@ void Charge::save_rho_before_sum_band(void)
 {
 	for(int is=0; is<GlobalV::NSPIN; is++)
 	{
-    	ModuleBase::GlobalFunc::DCOPY( rho[is], rho_save[is], GlobalC::rhopw->nrxx);
-    	if(XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5) ModuleBase::GlobalFunc::DCOPY( kin_r[is], kin_r_save[is], GlobalC::rhopw->nrxx);
+    	ModuleBase::GlobalFunc::DCOPY( rho[is], rho_save[is], this->rhopw->nrxx);
+    	if(XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5) ModuleBase::GlobalFunc::DCOPY( kin_r[is], kin_r_save[is], this->rhopw->nrxx);
     }
     return;
 }
@@ -1150,12 +1148,12 @@ void Charge::save_rho_before_sum_band(void)
 double Charge::check_ne(const double *rho_in) const 
 {
 	double ne= 0.0;
-	for(int ir=0; ir<GlobalC::rhopw->nrxx; ir++)
+	for(int ir=0; ir<this->rhopw->nrxx; ir++)
 	{
 		ne += rho_in[ir];
 	}
 	Parallel_Reduce::reduce_double_pool( ne );
-	ne = ne * GlobalC::ucell.omega / (double)GlobalC::rhopw->nxyz;
+	ne = ne * GlobalC::ucell.omega / (double)this->rhopw->nxyz;
 	std::cout << std::setprecision(10);
 	std::cout << " check the electrons number from rho, ne =" << ne << std::endl;
 	std::cout << std::setprecision(6);
@@ -1173,7 +1171,7 @@ void Charge::init_final_scf()
     if (GlobalV::test_charge > 1)
     {
         std::cout << "\n spin_number = " << GlobalV::NSPIN
-             << " real_point_number = " << GlobalC::rhopw->nrxx;
+             << " real_point_number = " << this->rhopw->nrxx;
     }
 
 	// allocate memory
@@ -1184,29 +1182,29 @@ void Charge::init_final_scf()
 
 	for(int is=0; is<GlobalV::NSPIN; is++)
 	{
-		rho[is] = new double[GlobalC::rhopw->nrxx];
-		rhog[is] = new std::complex<double>[GlobalC::rhopw->npw];
-		rho_save[is] = new double[GlobalC::rhopw->nrxx];
-		rhog_save[is] = new std::complex<double>[GlobalC::rhopw->npw];			
-		ModuleBase::GlobalFunc::ZEROS(rho[is], GlobalC::rhopw->nrxx);
-		ModuleBase::GlobalFunc::ZEROS(rhog[is], GlobalC::rhopw->npw);
-		ModuleBase::GlobalFunc::ZEROS(rho_save[is], GlobalC::rhopw->nrxx);
-		ModuleBase::GlobalFunc::ZEROS(rhog_save[is], GlobalC::rhopw->npw);
+		rho[is] = new double[this->rhopw->nrxx];
+		rhog[is] = new std::complex<double>[this->rhopw->npw];
+		rho_save[is] = new double[this->rhopw->nrxx];
+		rhog_save[is] = new std::complex<double>[this->rhopw->npw];			
+		ModuleBase::GlobalFunc::ZEROS(rho[is], this->rhopw->nrxx);
+		ModuleBase::GlobalFunc::ZEROS(rhog[is], this->rhopw->npw);
+		ModuleBase::GlobalFunc::ZEROS(rho_save[is], this->rhopw->nrxx);
+		ModuleBase::GlobalFunc::ZEROS(rhog_save[is], this->rhopw->npw);
 	}
 
-    ModuleBase::Memory::record("Chg::rho", sizeof(double) * GlobalV::NSPIN*GlobalC::rhopw->nrxx);
-    ModuleBase::Memory::record("Chg::rho_save", sizeof(double) * GlobalV::NSPIN*GlobalC::rhopw->nrxx);
-    ModuleBase::Memory::record("Chg::rhog", sizeof(double) * GlobalV::NSPIN*GlobalC::rhopw->npw);
-    ModuleBase::Memory::record("Chg::rhog_save", sizeof(double) * GlobalV::NSPIN*GlobalC::rhopw->npw);
+    ModuleBase::Memory::record("Chg::rho", sizeof(double) * GlobalV::NSPIN*this->rhopw->nrxx);
+    ModuleBase::Memory::record("Chg::rho_save", sizeof(double) * GlobalV::NSPIN*this->rhopw->nrxx);
+    ModuleBase::Memory::record("Chg::rhog", sizeof(double) * GlobalV::NSPIN*this->rhopw->npw);
+    ModuleBase::Memory::record("Chg::rhog_save", sizeof(double) * GlobalV::NSPIN*this->rhopw->npw);
 
-    this->rho_core = new double[GlobalC::rhopw->nrxx]; // core charge in real space
-    ModuleBase::GlobalFunc::ZEROS( rho_core, GlobalC::rhopw->nrxx);
+    this->rho_core = new double[this->rhopw->nrxx]; // core charge in real space
+    ModuleBase::GlobalFunc::ZEROS( rho_core, this->rhopw->nrxx);
 
-	this->rhog_core = new std::complex<double>[GlobalC::rhopw->npw]; // reciprocal core charge
-	ModuleBase::GlobalFunc::ZEROS( rhog_core, GlobalC::rhopw->npw);
+	this->rhog_core = new std::complex<double>[this->rhopw->npw]; // reciprocal core charge
+	ModuleBase::GlobalFunc::ZEROS( rhog_core, this->rhopw->npw);
 
-    ModuleBase::Memory::record("Chg::rho_core", sizeof(double) * GlobalC::rhopw->nrxx);
-    ModuleBase::Memory::record("Chg::rhog_core", sizeof(double) * GlobalC::rhopw->npw);
+    ModuleBase::Memory::record("Chg::rho_core", sizeof(double) * this->rhopw->nrxx);
+    ModuleBase::Memory::record("Chg::rhog_core", sizeof(double) * this->rhopw->npw);
 
 	this->allocate_rho_final_scf = true;
     return;

--- a/source/module_elecstate/module_charge/charge.h
+++ b/source/module_elecstate/module_charge/charge.h
@@ -48,7 +48,7 @@ class Charge
 
     void init_rho(const ModuleBase::ComplexMatrix &strucFac);
     // mohan update 2021-02-20
-    void allocate(const int &nspin_in, const int &nrxx_in, const int &ngmc_in);
+    void allocate(const int &nspin_in);
 
     void atomic_rho(const int spin_number_need, const double& omega, double **rho_in, const ModuleBase::ComplexMatrix &strucFac) const;
 

--- a/source/module_elecstate/module_charge/charge.h
+++ b/source/module_elecstate/module_charge/charge.h
@@ -44,6 +44,8 @@ class Charge
 
     int prenspin = 1;
 
+    void set_rhopw(ModulePW::PW_Basis* rhopw_in);
+
     void init_rho(const ModuleBase::ComplexMatrix &strucFac);
     // mohan update 2021-02-20
     void allocate(const int &nspin_in, const int &nrxx_in, const int &ngmc_in);
@@ -82,6 +84,7 @@ class Charge
     int nrxx; // number of r vectors in this processor
     int ngmc; // number of g vectors in this processor
     int nspin; // number of spins
+    ModulePW::PW_Basis* rhopw = nullptr;
   private:
     double sum_rho(void) const;
 

--- a/source/module_elecstate/module_charge/charge.h
+++ b/source/module_elecstate/module_charge/charge.h
@@ -50,7 +50,7 @@ class Charge
     // mohan update 2021-02-20
     void allocate(const int &nspin_in, const int &nrxx_in, const int &ngmc_in);
 
-    void atomic_rho(const int spin_number_need, const double& omega, double **rho_in, ModulePW::PW_Basis *rho_basis, const ModuleBase::ComplexMatrix &strucFac) const;
+    void atomic_rho(const int spin_number_need, const double& omega, double **rho_in, const ModuleBase::ComplexMatrix &strucFac) const;
 
     void set_rho_core(const ModuleBase::ComplexMatrix &structure_factor);
 
@@ -68,8 +68,7 @@ class Charge
         const double *r,
         const double *rab,
         const double *rhoc,
-        double *rhocg,
-        ModulePW::PW_Basis* rho_basis
+        double *rhocg
     ) const;
 
 	double check_ne(const double *rho_in) const;

--- a/source/module_elecstate/module_charge/charge_broyden.cpp
+++ b/source/module_elecstate/module_charge/charge_broyden.cpp
@@ -29,7 +29,7 @@ void Charge_Mixing::Simplified_Broyden_mixing(const int &iter,
 #endif
 		for(int is=0; is<GlobalV::NSPIN; is++)
 		{
-			for(int ig = 0 ; ig < GlobalC::rhopw->npw; ++ig)
+			for(int ig = 0 ; ig < this->rhopw->npw; ++ig)
 			{
 				dF[ipos][is][ig] -= chr->rhog[is][ig];
 				dn[ipos][is][ig] -= chr->rhog_save[is][ig];
@@ -41,7 +41,7 @@ void Charge_Mixing::Simplified_Broyden_mixing(const int &iter,
 #endif
 	for(int is=0; is<GlobalV::NSPIN; is++)
 	{
-		for(int ig = 0 ; ig < GlobalC::rhopw->npw; ++ig)
+		for(int ig = 0 ; ig < this->rhopw->npw; ++ig)
 		{
 			dF[mixing_ndim][is][ig] = chr->rhog[is][ig];
 			dn[mixing_ndim][is][ig] = chr->rhog_save[is][ig];
@@ -93,7 +93,7 @@ void Charge_Mixing::Simplified_Broyden_mixing(const int &iter,
 #endif
 			for(int is=0; is<GlobalV::NSPIN; is++)
 			{
-				for(int ig = 0 ; ig < GlobalC::rhopw->npw; ++ig)
+				for(int ig = 0 ; ig < this->rhopw->npw; ++ig)
 				{
 					chr->rhog[is][ig] -= gamma0 * dF[i][is][ig];
 					chr->rhog_save[is][ig] -= gamma0 * dn[i][is][ig];
@@ -111,7 +111,7 @@ void Charge_Mixing::Simplified_Broyden_mixing(const int &iter,
 #endif
 	for(int is=0; is<GlobalV::NSPIN; is++)
 	{
-		for(int ig = 0 ; ig < GlobalC::rhopw->npw; ++ig)
+		for(int ig = 0 ; ig < this->rhopw->npw; ++ig)
 		{
 			dF[inext][is][ig] = dF[mixing_ndim][is][ig];
 			dn[inext][is][ig] = dn[mixing_ndim][is][ig];
@@ -124,11 +124,11 @@ void Charge_Mixing::Simplified_Broyden_mixing(const int &iter,
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static, 256)
 #endif
-		for(int ig = 0 ; ig < GlobalC::rhopw->npw; ++ig)
+		for(int ig = 0 ; ig < this->rhopw->npw; ++ig)
 		{
 			chr->rhog_save[is][ig] += mixing_beta * chr->rhog[is][ig];
 		}
-		GlobalC::rhopw->recip2real( chr->rhog_save[is], chr->rho[is]);
+		this->rhopw->recip2real( chr->rhog_save[is], chr->rho[is]);
 	}
 	ModuleBase::timer::tick("Charge", "Broyden_mixing");
 	return;
@@ -148,12 +148,12 @@ void Charge_Mixing::allocate_Broyden()
 			dn[i] = new std::complex<double>*[GlobalV::NSPIN]; 
 			for (int is=0; is<GlobalV::NSPIN; is++)
 			{
-				dF[i][is] = new std::complex<double>[GlobalC::rhopw->npw];
-				dn[i][is] = new std::complex<double>[GlobalC::rhopw->npw];
+				dF[i][is] = new std::complex<double>[this->rhopw->npw];
+				dn[i][is] = new std::complex<double>[this->rhopw->npw];
 			}
 		}
-		ModuleBase::Memory::record("ChgMix::dF", sizeof(std::complex<double>) * GlobalV::NSPIN*npdim*GlobalC::rhopw->npw);
-		ModuleBase::Memory::record("ChgMix::dn", sizeof(std::complex<double>) * GlobalV::NSPIN*npdim*GlobalC::rhopw->npw);
+		ModuleBase::Memory::record("ChgMix::dF", sizeof(std::complex<double>) * GlobalV::NSPIN*npdim*this->rhopw->npw);
+		ModuleBase::Memory::record("ChgMix::dn", sizeof(std::complex<double>) * GlobalV::NSPIN*npdim*this->rhopw->npw);
 		this->initb = true;
 	}
 

--- a/source/module_elecstate/module_charge/charge_extra.cpp
+++ b/source/module_elecstate/module_charge/charge_extra.cpp
@@ -120,7 +120,7 @@ void Charge_Extra::extrapolate_charge(Charge* chr, Structure_Factor* sf)
         
         ModuleBase::GlobalFunc::ZEROS(rho_atom[is], GlobalC::rhopw->nrxx);
     }
-    chr->atomic_rho(GlobalV::NSPIN, omega_old, rho_atom, GlobalC::rhopw, sf->strucFac);
+    chr->atomic_rho(GlobalV::NSPIN, omega_old, rho_atom, sf->strucFac);
 #ifdef _OPENMP
 #pragma omp parallel for collapse(2) schedule(static, 512)
 #endif
@@ -215,7 +215,7 @@ void Charge_Extra::extrapolate_charge(Charge* chr, Structure_Factor* sf)
             ModuleBase::GlobalFunc::ZEROS(rho_atom[is] + irbeg, irlen);
         }
     });
-    chr->atomic_rho(GlobalV::NSPIN, GlobalC::ucell.omega, rho_atom, GlobalC::rhopw, sf->strucFac);
+    chr->atomic_rho(GlobalV::NSPIN, GlobalC::ucell.omega, rho_atom, sf->strucFac);
 #ifdef _OPENMP
 #pragma omp parallel for collapse(2) schedule(static, 512)
 #endif

--- a/source/module_elecstate/module_charge/charge_extra.cpp
+++ b/source/module_elecstate/module_charge/charge_extra.cpp
@@ -29,7 +29,7 @@ Charge_Extra::~Charge_Extra()
     }
 }
 
-void Charge_Extra::Init_CE()
+void Charge_Extra::Init_CE(const int& nrxx)
 {
     if(GlobalV::chg_extrap == "none")
     {
@@ -58,10 +58,10 @@ void Charge_Extra::Init_CE()
         delta_rho2 = new double*[GlobalV::NSPIN];
         for(int is=0; is<GlobalV::NSPIN; is++)
         {
-            delta_rho1[is] = new double[GlobalC::rhopw->nrxx];
-            delta_rho2[is] = new double[GlobalC::rhopw->nrxx];
-            ModuleBase::GlobalFunc::ZEROS(delta_rho1[is], GlobalC::rhopw->nrxx);
-            ModuleBase::GlobalFunc::ZEROS(delta_rho2[is], GlobalC::rhopw->nrxx);
+            delta_rho1[is] = new double[nrxx];
+            delta_rho2[is] = new double[nrxx];
+            ModuleBase::GlobalFunc::ZEROS(delta_rho1[is], nrxx);
+            ModuleBase::GlobalFunc::ZEROS(delta_rho2[is], nrxx);
         }
     }
 
@@ -105,7 +105,7 @@ void Charge_Extra::extrapolate_charge(Charge* chr, Structure_Factor* sf)
     rho_extr = min(istep, pot_order);
     if(rho_extr == 0)
     {
-        sf->setup_structure_factor(&GlobalC::ucell, GlobalC::rhopw);
+        sf->setup_structure_factor(&GlobalC::ucell, chr->rhopw);
         GlobalV::ofs_running << " charge density from previous step !" << std::endl;
         return;
     }
@@ -116,9 +116,9 @@ void Charge_Extra::extrapolate_charge(Charge* chr, Structure_Factor* sf)
     double** rho_atom = new double*[GlobalV::NSPIN];
     for(int is=0; is<GlobalV::NSPIN; is++)
     {
-        rho_atom[is] = new double[GlobalC::rhopw->nrxx];
+        rho_atom[is] = new double[chr->rhopw->nrxx];
         
-        ModuleBase::GlobalFunc::ZEROS(rho_atom[is], GlobalC::rhopw->nrxx);
+        ModuleBase::GlobalFunc::ZEROS(rho_atom[is], chr->rhopw->nrxx);
     }
     chr->atomic_rho(GlobalV::NSPIN, omega_old, rho_atom, sf->strucFac);
 #ifdef _OPENMP
@@ -126,7 +126,7 @@ void Charge_Extra::extrapolate_charge(Charge* chr, Structure_Factor* sf)
 #endif
     for(int is=0; is<GlobalV::NSPIN; is++)
     {
-        for(int ir=0; ir<GlobalC::rhopw->nrxx; ir++)
+        for(int ir=0; ir<chr->rhopw->nrxx; ir++)
         {
             chr->rho[is][ir] -= rho_atom[is][ir];
             if(GlobalC::ucell.cell_parameter_updated)
@@ -147,7 +147,7 @@ void Charge_Extra::extrapolate_charge(Charge* chr, Structure_Factor* sf)
 #endif
             for(int is=0; is<GlobalV::NSPIN; is++)
             {
-                for(int ir=0; ir<GlobalC::rhopw->nrxx; ir++)
+                for(int ir=0; ir<chr->rhopw->nrxx; ir++)
                 {
                     delta_rho1[is][ir] = chr->rho[is][ir];
                 }
@@ -163,7 +163,7 @@ void Charge_Extra::extrapolate_charge(Charge* chr, Structure_Factor* sf)
 #endif
         for(int is=0; is<GlobalV::NSPIN; is++)
         {
-            for(int ir=0; ir<GlobalC::rhopw->nrxx; ir++)
+            for(int ir=0; ir<chr->rhopw->nrxx; ir++)
             {
                 delta_rho2[is][ir] = delta_rho1[is][ir];
                 delta_rho1[is][ir] = chr->rho[is][ir];
@@ -181,14 +181,14 @@ void Charge_Extra::extrapolate_charge(Charge* chr, Structure_Factor* sf)
         double **delta_rho3 = new double*[GlobalV::NSPIN];
         for(int is=0; is<GlobalV::NSPIN; is++)
         {
-            delta_rho3[is] = new double[GlobalC::rhopw->nrxx];
+            delta_rho3[is] = new double[chr->rhopw->nrxx];
         }
 #ifdef _OPENMP
 #pragma omp parallel for collapse(2) schedule(static, 64)
 #endif
         for(int is=0; is<GlobalV::NSPIN; is++)
         {
-            for(int ir=0; ir<GlobalC::rhopw->nrxx; ir++)
+            for(int ir=0; ir<chr->rhopw->nrxx; ir++)
             {
                 delta_rho3[is][ir] = delta_rho2[is][ir];
                 delta_rho2[is][ir] = delta_rho1[is][ir];
@@ -205,11 +205,11 @@ void Charge_Extra::extrapolate_charge(Charge* chr, Structure_Factor* sf)
         delete[] delta_rho3;
     }
 
-    sf->setup_structure_factor(&GlobalC::ucell, GlobalC::rhopw);
+    sf->setup_structure_factor(&GlobalC::ucell, chr->rhopw);
     ModuleBase::OMP_PARALLEL([&](int num_threads, int thread_id)
     {
         int irbeg, irlen;
-        ModuleBase::BLOCK_TASK_DIST_1D(num_threads, thread_id, GlobalC::rhopw->nrxx, 512, irbeg, irlen);
+        ModuleBase::BLOCK_TASK_DIST_1D(num_threads, thread_id, chr->rhopw->nrxx, 512, irbeg, irlen);
         for(int is=0; is<GlobalV::NSPIN; is++)
         {
             ModuleBase::GlobalFunc::ZEROS(rho_atom[is] + irbeg, irlen);
@@ -221,7 +221,7 @@ void Charge_Extra::extrapolate_charge(Charge* chr, Structure_Factor* sf)
 #endif
     for(int is=0; is<GlobalV::NSPIN; is++)
     {
-        for(int ir=0; ir<GlobalC::rhopw->nrxx; ir++)
+        for(int ir=0; ir<chr->rhopw->nrxx; ir++)
         {
             if(GlobalC::ucell.cell_parameter_updated)
             {

--- a/source/module_elecstate/module_charge/charge_extra.h
+++ b/source/module_elecstate/module_charge/charge_extra.h
@@ -23,7 +23,7 @@ class Charge_Extra
     //This is a temporary solution by delaying the allocation
     //But after ucell and Esolver are fully decoupled
     //Init_CE will be removed and everything put back in the constructor
-    void Init_CE();
+    void Init_CE(const int& nrxx);
     void extrapolate_charge(Charge* chr, Structure_Factor* sf);
     void update_all_dis(const UnitCell& ucell);
 

--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -107,17 +107,17 @@ double Charge_Mixing::get_drho(Charge* chr, const double nelec)
 	for (int is=0; is<GlobalV::NSPIN; is++)
     {
 		ModuleBase::GlobalFunc::NOTE("Perform FFT on rho(r) to obtain rho(G).");
-        GlobalC::rhopw->real2recip(chr->rho[is], chr->rhog[is]);
+        this->rhopw->real2recip(chr->rho[is], chr->rhog[is]);
 
 		ModuleBase::GlobalFunc::NOTE("Perform FFT on rho_save(r) to obtain rho_save(G).");
-        GlobalC::rhopw->real2recip(chr->rho_save[is], chr->rhog_save[is]);
+        this->rhopw->real2recip(chr->rho_save[is], chr->rhog_save[is]);
 
 
 		ModuleBase::GlobalFunc::NOTE("Calculate the charge difference between rho(G) and rho_save(G)");
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static, 512)
 #endif
-        for (int ig=0; ig<GlobalC::rhopw->npw; ig++)
+        for (int ig=0; ig<this->rhopw->npw; ig++)
         {
            chr->rhog[is][ig] -= chr->rhog_save[is][ig];
         }
@@ -144,7 +144,7 @@ double Charge_Mixing::get_drho(Charge* chr, const double nelec)
 #ifdef _OPENMP
 #pragma omp parallel for reduction(+:scf_thr2)
 #endif
-		for(int ir=0; ir<GlobalC::rhopw->nrxx; ir++)
+		for(int ir=0; ir<this->rhopw->nrxx; ir++)
 		{
 			scf_thr2 += abs( chr->rho[is][ir] - chr->rho_save[is][ir] );
 		}
@@ -153,8 +153,8 @@ double Charge_Mixing::get_drho(Charge* chr, const double nelec)
 	Parallel_Reduce::reduce_double_pool( scf_thr2 );
 	assert( nelec != 0);
 	assert( GlobalC::ucell.omega > 0);
-	assert( GlobalC::rhopw->nxyz > 0);
-	scf_thr2 *= GlobalC::ucell.omega / static_cast<double>( GlobalC::rhopw->nxyz );
+	assert( this->rhopw->nxyz > 0);
+	scf_thr2 *= GlobalC::ucell.omega / static_cast<double>( this->rhopw->nxyz );
 	scf_thr2 /= nelec;
 	if(GlobalV::test_charge)GlobalV::ofs_running << " scf_thr from real space grid is " << scf_thr2 << std::endl;
 
@@ -176,16 +176,16 @@ void Charge_Mixing::mix_rho(const int &iter, Charge* chr)
 	double **rho123 = new double*[GlobalV::NSPIN];
 	for(int is=0; is<GlobalV::NSPIN; ++is)
 	{
-		rho123[is] = new double[GlobalC::rhopw->nrxx];
+		rho123[is] = new double[this->rhopw->nrxx];
 		if(is!=0 && is!=3 && GlobalV::DOMAG_Z)
 		{
-			ModuleBase::GlobalFunc::ZEROS(rho123[is], GlobalC::rhopw->nrxx);
+			ModuleBase::GlobalFunc::ZEROS(rho123[is], this->rhopw->nrxx);
 			continue;
 		} 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static, 512)
 #endif
-		for(int ir=0; ir<GlobalC::rhopw->nrxx; ++ir)
+		for(int ir=0; ir<this->rhopw->nrxx; ++ir)
 		{
 			rho123[is][ir] = chr->rho[is][ir];
 		}
@@ -197,11 +197,11 @@ void Charge_Mixing::mix_rho(const int &iter, Charge* chr)
 		kin_r123 = new double*[GlobalV::NSPIN];
 		for(int is=0; is<GlobalV::NSPIN; ++is)
 		{
-			kin_r123[is] = new double[GlobalC::rhopw->nrxx];
+			kin_r123[is] = new double[this->rhopw->nrxx];
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static, 512)
 #endif
-			for(int ir=0; ir<GlobalC::rhopw->nrxx; ++ir)
+			for(int ir=0; ir<this->rhopw->nrxx; ++ir)
 			{
 				kin_r123[is][ir] = chr->kin_r[is][ir];
 			}
@@ -233,7 +233,7 @@ void Charge_Mixing::mix_rho(const int &iter, Charge* chr)
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static, 512)
 #endif
-		for(int ir=0; ir<GlobalC::rhopw->nrxx; ++ir)
+		for(int ir=0; ir<this->rhopw->nrxx; ++ir)
 		{
 			chr->rho_save[is][ir] = rho123[is][ir];
 		}
@@ -252,7 +252,7 @@ void Charge_Mixing::mix_rho(const int &iter, Charge* chr)
 #endif
 		for(int is=0; is<GlobalV::NSPIN; is++)
 		{
-			for(int ir=0; ir<GlobalC::rhopw->nrxx; ++ir)
+			for(int ir=0; ir<this->rhopw->nrxx; ++ir)
 			{
 				chr->kin_r_save[is][ir] = kin_r123[is][ir];
 			}
@@ -286,36 +286,36 @@ void Charge_Mixing::plain_mixing(Charge* chr) const
 	{
 		if(this->mixing_gg0 > 0.0)
 		{
-			double* Rrho = new double[GlobalC::rhopw->nrxx];
-			std::complex<double> *kerpulay = new std::complex<double>[GlobalC::rhopw->npw];
-			double* kerpulayR = new double[GlobalC::rhopw->nrxx];
+			double* Rrho = new double[this->rhopw->nrxx];
+			std::complex<double> *kerpulay = new std::complex<double>[this->rhopw->npw];
+			double* kerpulayR = new double[this->rhopw->nrxx];
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static, 512)
 #endif
-			for(int ir=0; ir<GlobalC::rhopw->nrxx; ir++)
+			for(int ir=0; ir<this->rhopw->nrxx; ir++)
 			{
 				Rrho[ir] = chr->rho[is][ir] - chr->rho_save[is][ir];
 			}
-			GlobalC::rhopw->real2recip(Rrho, kerpulay);
+			this->rhopw->real2recip(Rrho, kerpulay);
 
 			const double fac = this->mixing_gg0;
 			const double gg0 = std::pow(fac * 0.529177 / GlobalC::ucell.tpiba, 2);
-			double* filter_g = new double[GlobalC::rhopw->npw];
+			double* filter_g = new double[this->rhopw->npw];
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static, 256)
 #endif
-			for(int ig=0; ig<GlobalC::rhopw->npw; ig++)
+			for(int ig=0; ig<this->rhopw->npw; ig++)
 			{
-				double gg = GlobalC::rhopw->gg[ig];
+				double gg = this->rhopw->gg[ig];
 				filter_g[ig] = max(gg / (gg + gg0), 0.1);
 
 				kerpulay[ig] = (1 - filter_g[ig]) * kerpulay[ig];
 			}
-			GlobalC::rhopw->recip2real(kerpulay, kerpulayR);
+			this->rhopw->recip2real(kerpulay, kerpulayR);
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static, 128)
 #endif
-			for(int ir=0; ir<GlobalC::rhopw->nrxx; ir++)
+			for(int ir=0; ir<this->rhopw->nrxx; ir++)
 			{
 				Rrho[ir] = Rrho[ir] - kerpulayR[ir];
 				chr->rho[is][ir] = Rrho[ir] * mixing_beta + chr->rho_save[is][ir];
@@ -332,7 +332,7 @@ void Charge_Mixing::plain_mixing(Charge* chr) const
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static, 256)
 #endif
-			for (int ir=0; ir<GlobalC::rhopw->nrxx; ir++)
+			for (int ir=0; ir<this->rhopw->nrxx; ir++)
 			{
 				chr->rho[is][ir] = chr->rho[is][ir]*mixing_beta + mix_old*chr->rho_save[is][ir];
 				chr->rho_save[is][ir] = chr->rho[is][ir];
@@ -344,7 +344,7 @@ void Charge_Mixing::plain_mixing(Charge* chr) const
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static, 256)
 #endif
-			for (int ir=0; ir<GlobalC::rhopw->nrxx; ir++)
+			for (int ir=0; ir<this->rhopw->nrxx; ir++)
 			{
 				chr->kin_r[is][ir] = chr->kin_r[is][ir]*mixing_beta + mix_old*chr->kin_r_save[is][ir];
 				chr->kin_r_save[is][ir] = chr->kin_r[is][ir];
@@ -374,10 +374,10 @@ double Charge_Mixing::rhog_dot_product(
 #ifdef _OPENMP
 #pragma omp parallel for reduction(+:sum)
 #endif
-		for (int ig=0; ig<GlobalC::rhopw->npw; ++ig)
+		for (int ig=0; ig<this->rhopw->npw; ++ig)
 		{
-			if(GlobalC::rhopw->gg[ig]<1e-8) continue;
-			sum += ( conj( rhog1[0][ig] )* rhog2[0][ig] ).real() / GlobalC::rhopw->gg[ig];
+			if(this->rhopw->gg[ig]<1e-8) continue;
+			sum += ( conj( rhog1[0][ig] )* rhog2[0][ig] ).real() / this->rhopw->gg[ig];
 		}
 		sum *= fac;
 		return sum;
@@ -395,10 +395,10 @@ double Charge_Mixing::rhog_dot_product(
 #ifdef _OPENMP
 #pragma omp parallel for reduction(+:sum)
 #endif
-			for (int ig=0; ig<GlobalC::rhopw->npw; ++ig)
+			for (int ig=0; ig<this->rhopw->npw; ++ig)
 			{
-				if(GlobalC::rhopw->gg[ig]<1e-8) continue;
-				sum += ( conj( rhog1[0][ig]+rhog1[1][ig] ) * (rhog2[0][ig]+rhog2[1][ig]) ).real() / GlobalC::rhopw->gg[ig];
+				if(this->rhopw->gg[ig]<1e-8) continue;
+				sum += ( conj( rhog1[0][ig]+rhog1[1][ig] ) * (rhog2[0][ig]+rhog2[1][ig]) ).real() / this->rhopw->gg[ig];
 			}
 			sum *= fac;
 
@@ -417,7 +417,7 @@ double Charge_Mixing::rhog_dot_product(
 #ifdef _OPENMP
 #pragma omp parallel for reduction(+:mag)
 #endif
-			for (int ig=0; ig<GlobalC::rhopw->npw; ig++)
+			for (int ig=0; ig<this->rhopw->npw; ig++)
 			{
 				mag += ( conj( rhog1[0][ig]-rhog1[1][ig] ) * ( rhog2[0][ig]-rhog2[1][ig] ) ).real();
 			}
@@ -444,13 +444,13 @@ double Charge_Mixing::rhog_dot_product(
 #ifdef _OPENMP
 #pragma omp parallel for reduction(+:sum)
 #endif
-			for (int ig=0; ig<GlobalC::rhopw->npw; ig++)
+			for (int ig=0; ig<this->rhopw->npw; ig++)
 			{
-				if(ig==GlobalC::rhopw->ig_gge0) continue;
-				sum += ( conj( rhog1[0][ig] )* rhog2[0][ig] ).real() / GlobalC::rhopw->gg[ig];
+				if(ig==this->rhopw->ig_gge0) continue;
+				sum += ( conj( rhog1[0][ig] )* rhog2[0][ig] ).real() / this->rhopw->gg[ig];
 			}
 			sum *= fac;
-			const int ig0 = GlobalC::rhopw->ig_gge0;
+			const int ig0 = this->rhopw->ig_gge0;
 			if(ig0 > 0)
 			{
 				sum += fac2 * ((conj( rhog1[1][ig0])*rhog2[1][ig0]).real() +
@@ -465,7 +465,7 @@ double Charge_Mixing::rhog_dot_product(
 #ifdef _OPENMP
 #pragma omp parallel for reduction(+:sum)
 #endif
-			for (int ig=0; ig<GlobalC::rhopw->npw; ig++)
+			for (int ig=0; ig<this->rhopw->npw; ig++)
 			{
 				if(ig == ig0) continue;
 				sum += fac3 * ((conj( rhog1[1][ig])*rhog2[1][ig]).real() +

--- a/source/module_elecstate/module_charge/charge_mixing.h
+++ b/source/module_elecstate/module_charge/charge_mixing.h
@@ -44,6 +44,9 @@ class Charge_Mixing
     //if first electronic step, then reset charge mixing
 	void reset();
 
+	// init pwrho, sunliang add 2023-05-08
+	void set_rhopw(ModulePW::PW_Basis* rhopw_in);
+
     // extracting parameters
 	// normally these parameters will not be used
 	// outside charge mixing, but Exx is using them
@@ -71,6 +74,8 @@ class Charge_Mixing
 	bool mixing_tau;
 
     bool new_e_iteration;
+
+	ModulePW::PW_Basis* rhopw = nullptr;
 
 //======================================
 // simple plain mixing method, in charge_mixing.cpp

--- a/source/module_elecstate/potentials/pot_xc.cpp
+++ b/source/module_elecstate/potentials/pot_xc.cpp
@@ -11,7 +11,7 @@ void PotXC::cal_v_eff(const Charge* chg, const UnitCell* ucell, ModuleBase::matr
     ModuleBase::TITLE("PotXC", "cal_v_eff");
     ModuleBase::timer::tick("PotXC", "cal_v_eff");
     const int nrxx_current = chg->nrxx;
-
+    
     //----------------------------------------------------------
     //  calculate the exchange-correlation potential
     //----------------------------------------------------------
@@ -20,7 +20,7 @@ void PotXC::cal_v_eff(const Charge* chg, const UnitCell* ucell, ModuleBase::matr
     {
 #ifdef USE_LIBXC
         const std::tuple<double, double, ModuleBase::matrix, ModuleBase::matrix> etxc_vtxc_v
-            = XC_Functional::v_xc_meta(nrxx_current, ucell->omega, ucell->tpiba, chg, GlobalC::rhopw);
+            = XC_Functional::v_xc_meta(nrxx_current, ucell->omega, ucell->tpiba, chg);
         *(this->etxc_) = std::get<0>(etxc_vtxc_v);
         *(this->vtxc_) = std::get<1>(etxc_vtxc_v);
         v_eff += std::get<2>(etxc_vtxc_v);
@@ -32,7 +32,7 @@ void PotXC::cal_v_eff(const Charge* chg, const UnitCell* ucell, ModuleBase::matr
     else
     {
         const std::tuple<double, double, ModuleBase::matrix> etxc_vtxc_v
-            = XC_Functional::v_xc(nrxx_current, chg, GlobalC::rhopw, ucell);
+            = XC_Functional::v_xc(nrxx_current, chg, ucell);
         *(this->etxc_) = std::get<0>(etxc_vtxc_v);
         *(this->vtxc_) = std::get<1>(etxc_vtxc_v);
         v_eff += std::get<2>(etxc_vtxc_v);

--- a/source/module_elecstate/potentials/write_pot.cpp
+++ b/source/module_elecstate/potentials/write_pot.cpp
@@ -37,7 +37,7 @@ void Potential::write_potential(
     }
     else if (is == 1)
     {
-        temp_v = &(v.c[GlobalC::rhopw->nxyz]);
+        temp_v = &(v.c[nx * ny * nz]);
     }
 
     double ef_tmp = 0.;

--- a/source/module_elecstate/test/elecstate_magnetism_test.cpp
+++ b/source/module_elecstate/test/elecstate_magnetism_test.cpp
@@ -23,8 +23,6 @@
 Charge::Charge(){}
 Charge::~Charge(){}
 
-const int elecstate::get_rhopw_nrxx() { return 100; }
-const int elecstate::get_rhopw_nxyz() { return 1000; }
 const double elecstate::get_ucell_omega() { return 500.0; }
 
 class MagnetismTest : public ::testing::Test
@@ -50,8 +48,6 @@ TEST_F(MagnetismTest, Magnetism)
 
 TEST_F(MagnetismTest, GlobalInfo)
 {
-                  EXPECT_EQ(100, elecstate::get_rhopw_nrxx());
-                  EXPECT_EQ(1000, elecstate::get_rhopw_nxyz());
                   EXPECT_EQ(500.0, elecstate::get_ucell_omega());
 }
 
@@ -70,12 +66,13 @@ TEST_F(MagnetismTest, ComputeMagnetizationS2)
                   GlobalV::TWO_EFERMI = false;
                   GlobalV::nelec = 10.0;
                   Charge* chr = new Charge;
+                  chr->nrxx = 100;
                   chr->rho = new double*[GlobalV::NSPIN];
                   for (int i=0; i< GlobalV::NSPIN; i++)
                   {
-                                    chr->rho[i] = new double[elecstate::get_rhopw_nrxx()];
+                                    chr->rho[i] = new double[chr->nrxx];
                   }
-                  for (int ir=0; ir< elecstate::get_rhopw_nrxx(); ir++)
+                  for (int ir=0; ir< chr->nrxx; ir++)
                   {
                                     chr->rho[0][ir] = 1.00;
                                     chr->rho[1][ir] = 1.01;
@@ -101,11 +98,12 @@ TEST_F(MagnetismTest, ComputeMagnetizationS4)
                     GlobalV::NSPIN = 4;
                     Charge* chr = new Charge;
                     chr->rho = new double*[GlobalV::NSPIN];
+                    chr->nrxx =
                     for (int i=0; i< GlobalV::NSPIN; i++)
                     {
-                                        chr->rho[i] = new double[elecstate::get_rhopw_nrxx()];
+                                        chr->rho[i] = new double[chr->nrxx];
                     }
-                    for (int ir=0; ir< elecstate::get_rhopw_nrxx(); ir++)
+                    for (int ir=0; ir< chr->nrxx; ir++)
                     {
                                         chr->rho[0][ir] = 1.00;
                                         chr->rho[1][ir] = std::sqrt(2.0);

--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -310,7 +310,7 @@ namespace ModuleESolver
     template<typename FPTYPE, typename Device>
     void ESolver_KS<FPTYPE, Device>::printiter(const int iter, const FPTYPE drho, const FPTYPE duration, const FPTYPE ethr)
     {
-        GlobalC::en.print_etot(this->pw_rho, this->conv_elec, iter, drho, duration, ethr);
+        GlobalC::en.print_etot(this->pw_rho->nrxx, this->pw_rho->nxyz, this->conv_elec, iter, drho, duration, ethr);
     }
 
     template<typename FPTYPE, typename Device>

--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -100,7 +100,7 @@ namespace ModuleESolver
         GlobalC::sf.setup_structure_factor(&GlobalC::ucell, GlobalC::rhopw);
 
         // Initialize charge extrapolation
-        CE.Init_CE();
+        CE.Init_CE(this->pw_rho->nrxx);
     }
 
     template<typename FPTYPE, typename Device>

--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -35,6 +35,7 @@ namespace ModuleESolver
         GlobalC::wfcpw = this->pw_wfc; //Temporary
         ModulePW::PW_Basis_K_Big* tmp = static_cast<ModulePW::PW_Basis_K_Big*>(pw_wfc);
         tmp->setbxyz(INPUT.bx,INPUT.by,INPUT.bz);
+        GlobalC::CHR_MIX.set_rhopw(this->pw_rho);
     }
 
     template<typename FPTYPE, typename Device>
@@ -309,7 +310,7 @@ namespace ModuleESolver
     template<typename FPTYPE, typename Device>
     void ESolver_KS<FPTYPE, Device>::printiter(const int iter, const FPTYPE drho, const FPTYPE duration, const FPTYPE ethr)
     {
-        GlobalC::en.print_etot(this->conv_elec, iter, drho, duration, ethr);
+        GlobalC::en.print_etot(this->pw_rho, this->conv_elec, iter, drho, duration, ethr);
     }
 
     template<typename FPTYPE, typename Device>

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -838,7 +838,7 @@ void ESolver_KS_LCAO::eachiterfinish(int iter)
     }
 
     // (11) calculate the total energy.
-    GlobalC::en.calculate_etot(this->pw_rho);
+    GlobalC::en.calculate_etot(this->pw_rho->nrxx, this->pw_rho->nxyz);
 }
 
 void ESolver_KS_LCAO::afterscf(const int istep)

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -167,7 +167,7 @@ void ESolver_KS_LCAO::Init(Input& inp, UnitCell& ucell)
     }
 
     // Inititlize the charge density.
-    this->pelec->charge->allocate(GlobalV::NSPIN, GlobalC::rhopw->nrxx, GlobalC::rhopw->npw);
+    this->pelec->charge->allocate(GlobalV::NSPIN);
 
     // Initialize the potential.
     if (this->pelec->pot == nullptr)
@@ -208,7 +208,7 @@ void ESolver_KS_LCAO::init_after_vc(Input& inp, UnitCell& ucell)
 
         GlobalC::ppcell.init_vloc(GlobalC::ppcell.vloc, GlobalC::rhopw);
 
-        this->pelec->charge->allocate(GlobalV::NSPIN, GlobalC::rhopw->nrxx, GlobalC::rhopw->npw);
+        this->pelec->charge->allocate(GlobalV::NSPIN);
 
         if(this->pelec->pot != nullptr)
         {

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -91,6 +91,7 @@ void ESolver_KS_LCAO::Init(Input& inp, UnitCell& ucell)
                                                    &(this->LOC),
                                                    &(this->UHM),
                                                    &(this->LOWF),
+                                                   this->pw_rho,
                                                    GlobalC::bigpw);
     }
 
@@ -203,7 +204,7 @@ void ESolver_KS_LCAO::init_after_vc(Input& inp, UnitCell& ucell)
     if (GlobalV::md_prec_level == 2)
     {
         delete this->pelec;  
-        this->pelec = new elecstate::ElecStateLCAO(&(chr), &(GlobalC::kv), GlobalC::kv.nks, &(this->LOC), &(this->UHM), &(this->LOWF));
+        this->pelec = new elecstate::ElecStateLCAO(&(chr), &(GlobalC::kv), GlobalC::kv.nks, &(this->LOC), &(this->UHM), &(this->LOWF), this->pw_rho, GlobalC::bigpw);
 
         GlobalC::ppcell.init_vloc(GlobalC::ppcell.vloc, GlobalC::rhopw);
 
@@ -837,7 +838,7 @@ void ESolver_KS_LCAO::eachiterfinish(int iter)
     }
 
     // (11) calculate the total energy.
-    GlobalC::en.calculate_etot();
+    GlobalC::en.calculate_etot(this->pw_rho);
 }
 
 void ESolver_KS_LCAO::afterscf(const int istep)

--- a/source/module_esolver/esolver_ks_lcao_tddft.cpp
+++ b/source/module_esolver/esolver_ks_lcao_tddft.cpp
@@ -101,7 +101,7 @@ void ESolver_KS_LCAO_TDDFT::Init(Input& inp, UnitCell& ucell)
     }
 
     // Inititlize the charge density.
-    this->pelec->charge->allocate(GlobalV::NSPIN, GlobalC::rhopw->nrxx, GlobalC::rhopw->npw);
+    this->pelec->charge->allocate(GlobalV::NSPIN);
 
     // Initializee the potential.
     this->pelec->pot = new elecstate::Potential(GlobalC::rhopw,

--- a/source/module_esolver/esolver_ks_lcao_tddft.cpp
+++ b/source/module_esolver/esolver_ks_lcao_tddft.cpp
@@ -65,12 +65,13 @@ void ESolver_KS_LCAO_TDDFT::Init(Input& inp, UnitCell& ucell)
 
     if (this->pelec == nullptr)
     {
-        this->pelec = new elecstate::ElecStateLCAO_TDDFT(&(chr),
+        this->pelec = new elecstate::ElecStateLCAO_TDDFT(&(this->chr),
                                                          &(GlobalC::kv),
                                                          GlobalC::kv.nks,
                                                          &(this->LOC),
                                                          &(this->UHM),
                                                          &(this->LOWF),
+                                                         this->pw_rho,
                                                          GlobalC::bigpw);
     }
 

--- a/source/module_esolver/esolver_ks_pw.cpp
+++ b/source/module_esolver/esolver_ks_pw.cpp
@@ -167,7 +167,7 @@ namespace ModuleESolver
         }
 
         // Inititlize the charge density.
-        this->pelec->charge->allocate(GlobalV::NSPIN, GlobalC::rhopw->nrxx, GlobalC::rhopw->npw);
+        this->pelec->charge->allocate(GlobalV::NSPIN);
 
         // Initialize the potential.
         if(this->pelec->pot == nullptr)
@@ -218,7 +218,7 @@ namespace ModuleESolver
             delete this->pelec;  
             this->pelec = new elecstate::ElecStatePW<FPTYPE, Device>( GlobalC::wfcpw, &(this->chr), (K_Vectors*)(&(GlobalC::kv)), this->pw_rho, GlobalC::bigpw);
 
-            this->pelec->charge->allocate(GlobalV::NSPIN, GlobalC::rhopw->nrxx, GlobalC::rhopw->npw);
+            this->pelec->charge->allocate(GlobalV::NSPIN);
 
             delete this->pelec->pot;
             this->pelec->pot = new elecstate::Potential(

--- a/source/module_esolver/esolver_ks_pw.cpp
+++ b/source/module_esolver/esolver_ks_pw.cpp
@@ -457,7 +457,7 @@ namespace ModuleESolver
     void ESolver_KS_PW<FPTYPE, Device>::eachiterfinish(const int iter)
     {
         //print_eigenvalue(GlobalV::ofs_running);
-        GlobalC::en.calculate_etot(this->pw_rho);
+        GlobalC::en.calculate_etot(this->pw_rho->nrxx, this->pw_rho->nxyz);
         //We output it for restarting the scf.
         bool print = false;
         if (this->out_freq_elec && iter % this->out_freq_elec == 0)

--- a/source/module_esolver/esolver_ks_pw.cpp
+++ b/source/module_esolver/esolver_ks_pw.cpp
@@ -163,7 +163,7 @@ namespace ModuleESolver
         //init ElecState,
         if(this->pelec == nullptr)
         {
-            this->pelec = new elecstate::ElecStatePW<FPTYPE, Device>( GlobalC::wfcpw, &(this->chr), (K_Vectors*)(&(GlobalC::kv)), GlobalC::bigpw);
+            this->pelec = new elecstate::ElecStatePW<FPTYPE, Device>( GlobalC::wfcpw, &(this->chr), (K_Vectors*)(&(GlobalC::kv)), this->pw_rho, GlobalC::bigpw);
         }
 
         // Inititlize the charge density.
@@ -216,7 +216,7 @@ namespace ModuleESolver
             this->phsol = new hsolver::HSolverPW<FPTYPE, Device>(GlobalC::wfcpw, &GlobalC::wf);
 
             delete this->pelec;  
-            this->pelec = new elecstate::ElecStatePW<FPTYPE, Device>( GlobalC::wfcpw, &(this->chr), (K_Vectors*)(&(GlobalC::kv)), GlobalC::bigpw);
+            this->pelec = new elecstate::ElecStatePW<FPTYPE, Device>( GlobalC::wfcpw, &(this->chr), (K_Vectors*)(&(GlobalC::kv)), this->pw_rho, GlobalC::bigpw);
 
             this->pelec->charge->allocate(GlobalV::NSPIN, GlobalC::rhopw->nrxx, GlobalC::rhopw->npw);
 
@@ -457,7 +457,7 @@ namespace ModuleESolver
     void ESolver_KS_PW<FPTYPE, Device>::eachiterfinish(const int iter)
     {
         //print_eigenvalue(GlobalV::ofs_running);
-        GlobalC::en.calculate_etot();
+        GlobalC::en.calculate_etot(this->pw_rho);
         //We output it for restarting the scf.
         bool print = false;
         if (this->out_freq_elec && iter % this->out_freq_elec == 0)

--- a/source/module_esolver/esolver_of.cpp
+++ b/source/module_esolver/esolver_of.cpp
@@ -231,7 +231,7 @@ void ESolver_OF::Init(Input &inp, UnitCell &ucell)
     ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running, "INIT KEDF");
 
     // Initialize charge extrapolation
-    CE.Init_CE();
+    CE.Init_CE(this->pw_rho->nrxx);
 }
 
 void ESolver_OF::init_after_vc(Input &inp, UnitCell &ucell)

--- a/source/module_esolver/esolver_of.cpp
+++ b/source/module_esolver/esolver_of.cpp
@@ -111,7 +111,7 @@ void ESolver_OF::Init(Input &inp, UnitCell &ucell)
         this->pelec = new elecstate::ElecState((Charge*)(&chr), this->pw_rho, GlobalC::bigpw);
     }
 
-    this->pelec->charge->allocate(GlobalV::NSPIN, GlobalC::rhopw->nrxx, GlobalC::rhopw->npw);
+    this->pelec->charge->allocate(GlobalV::NSPIN);
 
     this->pelec->pot = new elecstate::Potential(
         GlobalC::rhopw,

--- a/source/module_esolver/esolver_of.cpp
+++ b/source/module_esolver/esolver_of.cpp
@@ -108,7 +108,7 @@ void ESolver_OF::Init(Input &inp, UnitCell &ucell)
 
     if(this->pelec == nullptr)
     {
-        this->pelec = new elecstate::ElecState((Charge*)(&chr), GlobalC::bigpw);
+        this->pelec = new elecstate::ElecState((Charge*)(&chr), this->pw_rho, GlobalC::bigpw);
     }
 
     this->pelec->charge->allocate(GlobalV::NSPIN, GlobalC::rhopw->nrxx, GlobalC::rhopw->npw);

--- a/source/module_esolver/esolver_of.cpp
+++ b/source/module_esolver/esolver_of.cpp
@@ -232,6 +232,10 @@ void ESolver_OF::Init(Input &inp, UnitCell &ucell)
 
     // Initialize charge extrapolation
     CE.Init_CE(this->pw_rho->nrxx);
+    delete this->ptempRho;
+    this->ptempRho = new Charge();
+    this->ptempRho->set_rhopw(this->pw_rho);
+    this->ptempRho->allocate(GlobalV::NSPIN);
 }
 
 void ESolver_OF::init_after_vc(Input &inp, UnitCell &ucell)
@@ -411,19 +415,13 @@ void ESolver_OF::solveV()
     }
     // initialize tempPhi and tempRho used in line search
     double **ptempPhi = new double*[GlobalV::NSPIN];
-    Charge* ptempRho = new Charge();
-    ptempRho->nspin = GlobalV::NSPIN;
-    ptempRho->nrxx = this->nrxx;
-    ptempRho->rho_core = this->pelec->charge->rho_core;
-    ptempRho->rho = new double*[GlobalV::NSPIN];
     for (int is = 0; is < GlobalV::NSPIN; ++is)
     {
         ptempPhi[is] = new double[this->nrxx];
-        ptempRho->rho[is] = new double[this->nrxx];
         for (int ir = 0; ir < this->nrxx; ++ir)
         {
             ptempPhi[is][ir] = this->pphi[is][ir];
-            ptempRho->rho[is][ir] = ptempPhi[is][ir] * ptempPhi[is][ir];
+            this->ptempRho->rho[is][ir] = ptempPhi[is][ir] * ptempPhi[is][ir];
         }
     }
 
@@ -438,7 +436,7 @@ void ESolver_OF::solveV()
     ModuleBase::GlobalFunc::ZEROS(tempTheta, GlobalV::NSPIN);
 
     double dEdthetaThre = 1e5; // threshould of dEdtheta, avoid the unstable optimization
-    this->caldEdtheta(ptempPhi, ptempRho, tempTheta, dEdtheta);
+    this->caldEdtheta(ptempPhi, this->ptempRho, tempTheta, dEdtheta);
 
     // Assert dEdtheta(theta = 0) < 0, otherwise line search will not work.
     for (int is = 0; is < GlobalV::NSPIN; ++is)
@@ -456,7 +454,7 @@ void ESolver_OF::solveV()
                 this->pdirect[is][ir] = - this->pdLdphi[is][ir];
             }
             this->getNextDirect();
-            this->caldEdtheta(ptempPhi, ptempRho, tempTheta, dEdtheta);
+            this->caldEdtheta(ptempPhi, this->ptempRho, tempTheta, dEdtheta);
             if (dEdtheta[is] > dEdthetaThre)
             {
                 cout << "dEdtheta    " << dEdtheta[is] << endl;
@@ -511,7 +509,7 @@ void ESolver_OF::solveV()
             GlobalC::en.calculate_etot(this->pw_rho);
             E = GlobalC::en.etot;
             eKE = this->kineticEnergy();
-            ePP = this->inner_product(this->pelec->pot->get_fixed_v(), ptempRho->rho[0], this->nrxx, this->dV);
+            ePP = this->inner_product(this->pelec->pot->get_fixed_v(), this->ptempRho->rho[0], this->nrxx, this->dV);
             Parallel_Reduce::reduce_double_all(ePP);
             E += eKE + ePP;
 
@@ -526,10 +524,10 @@ void ESolver_OF::solveV()
                 for (int i = 0; i < this->nrxx; ++i)
                 {
                     ptempPhi[0][i] = this->pphi[0][i] * cos(this->theta[0]) + this->pdirect[0][i] * sin(this->theta[0]);
-                    ptempRho->rho[0][i] = ptempPhi[0][i] * ptempPhi[0][i];
+                    this->ptempRho->rho[0][i] = ptempPhi[0][i] * ptempPhi[0][i];
                 }
                 // get dEdtheta of new tempPhi and tempRho
-                this->caldEdtheta(ptempPhi, ptempRho, this->theta, dEdtheta);
+                this->caldEdtheta(ptempPhi, this->ptempRho, this->theta, dEdtheta);
 
                 if (numDC > this->maxDCsrch)
                 {
@@ -659,11 +657,8 @@ void ESolver_OF::solveV()
     for (int is = 0; is < GlobalV::NSPIN; ++is)
     {
         delete[] ptempPhi[is];
-        delete[] ptempRho->rho[is];
     }
     delete[] ptempPhi;
-    delete[] ptempRho->rho;
-    delete ptempRho;
     delete[] dEdtheta;
 }
 
@@ -985,17 +980,9 @@ void ESolver_OF::calV(double *ptempPhi, double *rdLdphi)
     double **dEdtempPhi = new double*[GlobalV::NSPIN];
     double **tempPhi = new double*[GlobalV::NSPIN];
 
-    //here is a temporary charge, should use a constructor of class Charge in the future!
-    //modified by zhengdy-2022-11-15
-    Charge* tempRho = new Charge();
-    tempRho->nspin = GlobalV::NSPIN;
-    tempRho->nrxx = this->nrxx;
-    tempRho->rho_core = this->pelec->charge->rho_core;
-    tempRho->rho = new double*[GlobalV::NSPIN];
     for (int is = 0; is < GlobalV::NSPIN; ++is)
     {
         dEdtempPhi[is] = new double[this->nrxx];
-        tempRho->rho[is] = new double[this->nrxx];
         if (is == this->tnSpinFlag)
         {
             tempPhi[is] = ptempPhi;
@@ -1006,16 +993,15 @@ void ESolver_OF::calV(double *ptempPhi, double *rdLdphi)
         }
         for (int ir = 0; ir < this->nrxx; ++ir)
         {
-            tempRho->rho[is][ir] = tempPhi[is][ir] * tempPhi[is][ir];
+            this->ptempRho->rho[is][ir] = tempPhi[is][ir] * tempPhi[is][ir];
         }
     }
-    tempRho->rho_core = pelec->charge->rho_core;
 
     if(GlobalV::NSPIN==4) GlobalC::ucell.cal_ux();
-    this->pelec->pot->update_from_charge(tempRho, &GlobalC::ucell);
+    this->pelec->pot->update_from_charge(this->ptempRho, &GlobalC::ucell);
     ModuleBase::matrix& vr_eff = this->pelec->pot->get_effective_v();
 
-    this->kineticPotential(tempRho->rho, tempPhi, vr_eff);
+    this->kineticPotential(this->ptempRho->rho, tempPhi, vr_eff);
     for (int i = 0; i < this->nrxx; ++i)
     {
         dEdtempPhi[this->tnSpinFlag][i] = vr_eff(this->tnSpinFlag,i);
@@ -1028,11 +1014,8 @@ void ESolver_OF::calV(double *ptempPhi, double *rdLdphi)
     for (int is = 0; is < GlobalV::NSPIN; ++is)
     {
         delete[] dEdtempPhi[is];
-        delete[] tempRho->rho[is];
     }
     delete[] dEdtempPhi;
-    delete[] tempRho->rho;
-    delete tempRho;
     delete[] tempPhi;
 }
 
@@ -1041,15 +1024,15 @@ void ESolver_OF::calV(double *ptempPhi, double *rdLdphi)
 // dE/dTheta = <dE/dtempPhi|dtempPhi/dTheta>
 //           = <dE/dtempPhi|-phi*sin(theta)+d*cos(theta)>
 //
-void ESolver_OF::caldEdtheta(double **ptempPhi, Charge* ptempRho, double *ptheta, double *rdEdtheta)
+void ESolver_OF::caldEdtheta(double **ptempPhi, Charge* tempRho, double *ptheta, double *rdEdtheta)
 {
     double *pdPhidTheta = new double[this->nrxx];
 
     if(GlobalV::NSPIN==4) GlobalC::ucell.cal_ux();
-    this->pelec->pot->update_from_charge(ptempRho, &GlobalC::ucell);
+    this->pelec->pot->update_from_charge(tempRho, &GlobalC::ucell);
     ModuleBase::matrix& vr_eff = this->pelec->pot->get_effective_v();
 
-    this->kineticPotential(ptempRho->rho, ptempPhi, vr_eff);
+    this->kineticPotential(tempRho->rho, ptempPhi, vr_eff);
     for (int is = 0; is < GlobalV::NSPIN; ++is)
     {
         for (int ir = 0; ir < this->nrxx; ++ir)

--- a/source/module_esolver/esolver_of.cpp
+++ b/source/module_esolver/esolver_of.cpp
@@ -480,7 +480,7 @@ void ESolver_OF::solveV()
 //                 ptempRho->rho[0][ir] = ptempPhi[0][ir] * ptempPhi[0][ir];
 //             }
 //             this->caldEdtheta(ptempPhi, ptempRho, this->theta, dEdtheta);
-//             GlobalC::en.calculate_etot(this->pw_rho);
+//             GlobalC::en.calculate_etot(this->pw_rho->nrxx, this->pw_rho->nxyz);
 //             E = GlobalC::en.etot;
 //             double eKE = 0.;
 //             double ePP = 0.;
@@ -506,7 +506,7 @@ void ESolver_OF::solveV()
         while (true)
         {
             // update energy
-            GlobalC::en.calculate_etot(this->pw_rho);
+            GlobalC::en.calculate_etot(this->pw_rho->nrxx, this->pw_rho->nxyz);
             E = GlobalC::en.etot;
             eKE = this->kineticEnergy();
             ePP = this->inner_product(this->pelec->pot->get_fixed_v(), this->ptempRho->rho[0], this->nrxx, this->dV);
@@ -594,7 +594,7 @@ void ESolver_OF::solveV()
     //         numDC = 0;
     //         while(true)
     //         {
-    //             GlobalC::en.calculate_etot(this->pw_rho);
+    //             GlobalC::en.calculate_etot(this->pw_rho->nrxx, this->pw_rho->nxyz);
     //             E = GlobalC::en.etot;
     //             eKE = this->kineticEnergy();
     //             ePP = 0.;
@@ -1064,7 +1064,7 @@ double ESolver_OF::cal_mu(double *pphi, double *pdEdphi, double nelec)
 // =====================================================================
 void ESolver_OF::cal_Energy(double& etot)
 {
-    GlobalC::en.calculate_etot(this->pw_rho);
+    GlobalC::en.calculate_etot(this->pw_rho->nrxx, this->pw_rho->nxyz);
     double eKE = this->kineticEnergy(); // kinetic energy
     double ePP = 0.;                    // electron-ion interaction energy
     for (int is = 0; is < GlobalV::NSPIN; ++is)

--- a/source/module_esolver/esolver_of.cpp
+++ b/source/module_esolver/esolver_of.cpp
@@ -108,7 +108,7 @@ void ESolver_OF::Init(Input &inp, UnitCell &ucell)
 
     if(this->pelec == nullptr)
     {
-        this->pelec = new elecstate::ElecState((Charge*)(&chr));
+        this->pelec = new elecstate::ElecState((Charge*)(&chr), GlobalC::bigpw);
     }
 
     this->pelec->charge->allocate(GlobalV::NSPIN, GlobalC::rhopw->nrxx, GlobalC::rhopw->npw);
@@ -482,7 +482,7 @@ void ESolver_OF::solveV()
 //                 ptempRho->rho[0][ir] = ptempPhi[0][ir] * ptempPhi[0][ir];
 //             }
 //             this->caldEdtheta(ptempPhi, ptempRho, this->theta, dEdtheta);
-//             GlobalC::en.calculate_etot();
+//             GlobalC::en.calculate_etot(this->pw_rho);
 //             E = GlobalC::en.etot;
 //             double eKE = 0.;
 //             double ePP = 0.;
@@ -508,7 +508,7 @@ void ESolver_OF::solveV()
         while (true)
         {
             // update energy
-            GlobalC::en.calculate_etot();
+            GlobalC::en.calculate_etot(this->pw_rho);
             E = GlobalC::en.etot;
             eKE = this->kineticEnergy();
             ePP = this->inner_product(this->pelec->pot->get_fixed_v(), ptempRho->rho[0], this->nrxx, this->dV);
@@ -596,7 +596,7 @@ void ESolver_OF::solveV()
     //         numDC = 0;
     //         while(true)
     //         {
-    //             GlobalC::en.calculate_etot();
+    //             GlobalC::en.calculate_etot(this->pw_rho);
     //             E = GlobalC::en.etot;
     //             eKE = this->kineticEnergy();
     //             ePP = 0.;
@@ -1081,7 +1081,7 @@ double ESolver_OF::cal_mu(double *pphi, double *pdEdphi, double nelec)
 // =====================================================================
 void ESolver_OF::cal_Energy(double& etot)
 {
-    GlobalC::en.calculate_etot();
+    GlobalC::en.calculate_etot(this->pw_rho);
     double eKE = this->kineticEnergy(); // kinetic energy
     double ePP = 0.;                    // electron-ion interaction energy
     for (int is = 0; is < GlobalV::NSPIN; ++is)

--- a/source/module_esolver/esolver_of.h
+++ b/source/module_esolver/esolver_of.h
@@ -74,6 +74,7 @@ public:
         if (this->mu != NULL) delete[] this->mu;
         if (this->task != NULL) delete[] this->task;
         if (this->opt_cg_mag != NULL) delete this->opt_cg_mag;
+        delete this->ptempRho;
     }
 
     virtual void Init(Input &inp, UnitCell &ucell) override;
@@ -131,6 +132,8 @@ private:
     int tnSpinFlag = -1;                        // spin flag used in calV, which will be called by opt_tn
     int maxDCsrch = 200;                        // max no. of line search
     int flag = -1;                              // flag of TN
+
+    Charge* ptempRho = nullptr;                 // used in line search
 
     // // test rho convergence criterion
     // double *pdeltaRhoHar = NULL; // 4pi*rhog/k^2

--- a/source/module_esolver/esolver_sdft_pw.cpp
+++ b/source/module_esolver/esolver_sdft_pw.cpp
@@ -39,7 +39,7 @@ void ESolver_SDFT_PW::Init(Input &inp, UnitCell &ucell)
     ESolver_KS::Init(inp,ucell);
 
     
-    this->pelec = new elecstate::ElecStatePW_SDFT( GlobalC::wfcpw, &(chr), (K_Vectors*)(&(GlobalC::kv)), GlobalC::bigpw);
+    this->pelec = new elecstate::ElecStatePW_SDFT( GlobalC::wfcpw, &(chr), (K_Vectors*)(&(GlobalC::kv)), this->pw_rho, GlobalC::bigpw);
 
     // Inititlize the charge density.
     this->pelec->charge->allocate(GlobalV::NSPIN, GlobalC::rhopw->nrxx, GlobalC::rhopw->npw);
@@ -93,7 +93,7 @@ void ESolver_SDFT_PW::beforescf(const int istep)
 void ESolver_SDFT_PW::eachiterfinish(int iter)
 {
 	//this->pelec->print_eigenvalue(GlobalV::ofs_running);
-    GlobalC::en.calculate_etot();
+    GlobalC::en.calculate_etot(this->pw_rho);
 }
 void ESolver_SDFT_PW::afterscf(const int istep)
 {

--- a/source/module_esolver/esolver_sdft_pw.cpp
+++ b/source/module_esolver/esolver_sdft_pw.cpp
@@ -42,7 +42,7 @@ void ESolver_SDFT_PW::Init(Input &inp, UnitCell &ucell)
     this->pelec = new elecstate::ElecStatePW_SDFT( GlobalC::wfcpw, &(chr), (K_Vectors*)(&(GlobalC::kv)), this->pw_rho, GlobalC::bigpw);
 
     // Inititlize the charge density.
-    this->pelec->charge->allocate(GlobalV::NSPIN, GlobalC::rhopw->nrxx, GlobalC::rhopw->npw);
+    this->pelec->charge->allocate(GlobalV::NSPIN);
 
     // Initializee the potential.
     if(this->pelec->pot == nullptr)

--- a/source/module_esolver/esolver_sdft_pw.cpp
+++ b/source/module_esolver/esolver_sdft_pw.cpp
@@ -93,7 +93,7 @@ void ESolver_SDFT_PW::beforescf(const int istep)
 void ESolver_SDFT_PW::eachiterfinish(int iter)
 {
 	//this->pelec->print_eigenvalue(GlobalV::ofs_running);
-    GlobalC::en.calculate_etot(this->pw_rho);
+    GlobalC::en.calculate_etot(this->pw_rho->nrxx, this->pw_rho->nxyz);
 }
 void ESolver_SDFT_PW::afterscf(const int istep)
 {

--- a/source/module_hamilt_general/module_surchem/corrected_energy.cpp
+++ b/source/module_hamilt_general/module_surchem/corrected_energy.cpp
@@ -1,6 +1,6 @@
 #include "surchem.h"
 
-double surchem::cal_Ael(const UnitCell &cell, ModulePW::PW_Basis *rho_basis)
+double surchem::cal_Ael(const UnitCell &cell, const ModulePW::PW_Basis *rho_basis)
 {
     double Ael = 0.0;
     for (int ir = 0; ir < rho_basis->nrxx; ir++)
@@ -13,7 +13,7 @@ double surchem::cal_Ael(const UnitCell &cell, ModulePW::PW_Basis *rho_basis)
     return Ael;
 }
 
-double surchem::cal_Acav(const UnitCell &cell, ModulePW::PW_Basis *rho_basis)
+double surchem::cal_Acav(const UnitCell &cell, const ModulePW::PW_Basis *rho_basis)
 {
     double Acav = 0.0;
     Acav = GlobalV::tau * qs;

--- a/source/module_hamilt_general/module_surchem/corrected_energy.cpp
+++ b/source/module_hamilt_general/module_surchem/corrected_energy.cpp
@@ -1,23 +1,23 @@
 #include "surchem.h"
 
-double surchem::cal_Ael(const UnitCell &cell, const ModulePW::PW_Basis *rho_basis)
+double surchem::cal_Ael(const UnitCell &cell, const int& nrxx, const int& nxyz)
 {
     double Ael = 0.0;
-    for (int ir = 0; ir < rho_basis->nrxx; ir++)
+    for (int ir = 0; ir < nrxx; ir++)
     {
         Ael -= TOTN_real[ir] * delta_phi[ir];
     }
     Parallel_Reduce::reduce_double_pool(Ael);
-    Ael = Ael * cell.omega / rho_basis->nxyz;
+    Ael = Ael * cell.omega / nxyz;
     // cout << "Ael: " << Ael << endl;
     return Ael;
 }
 
-double surchem::cal_Acav(const UnitCell &cell, const ModulePW::PW_Basis *rho_basis)
+double surchem::cal_Acav(const UnitCell &cell, const int& nxyz)
 {
     double Acav = 0.0;
     Acav = GlobalV::tau * qs;
-    Acav = Acav * cell.omega / rho_basis->nxyz; // unit Ry
+    Acav = Acav * cell.omega / nxyz; // unit Ry
     Parallel_Reduce::reduce_double_pool(Acav);
     // cout << "Acav: " << Acav << endl;
     return Acav;

--- a/source/module_hamilt_general/module_surchem/surchem.h
+++ b/source/module_hamilt_general/module_surchem/surchem.h
@@ -62,9 +62,9 @@ class surchem
                                complex<double> *PS_TOTN,
                                int nspin);
 
-    double cal_Ael(const UnitCell &cell, ModulePW::PW_Basis *rho_basis);
+    double cal_Ael(const UnitCell &cell, const ModulePW::PW_Basis *rho_basis);
 
-    double cal_Acav(const UnitCell &cell, ModulePW::PW_Basis *rho_basis);
+    double cal_Acav(const UnitCell &cell, const ModulePW::PW_Basis *rho_basis);
 
     void cal_Acomp(const UnitCell &cell,
                    ModulePW::PW_Basis *rho_basis,

--- a/source/module_hamilt_general/module_surchem/surchem.h
+++ b/source/module_hamilt_general/module_surchem/surchem.h
@@ -62,9 +62,9 @@ class surchem
                                complex<double> *PS_TOTN,
                                int nspin);
 
-    double cal_Ael(const UnitCell &cell, const ModulePW::PW_Basis *rho_basis);
+    double cal_Ael(const UnitCell &cell, const int& nrxx, const int& nxyz);
 
-    double cal_Acav(const UnitCell &cell, const ModulePW::PW_Basis *rho_basis);
+    double cal_Acav(const UnitCell &cell, const int& nxyz);
 
     void cal_Acomp(const UnitCell &cell,
                    ModulePW::PW_Basis *rho_basis,

--- a/source/module_hamilt_general/module_surchem/surchem.h
+++ b/source/module_hamilt_general/module_surchem/surchem.h
@@ -62,9 +62,14 @@ class surchem
                                complex<double> *PS_TOTN,
                                int nspin);
 
-    double cal_Ael(const UnitCell &cell, const int& nrxx, const int& nxyz);
+    double cal_Ael(const UnitCell &cell, 
+                   const int& nrxx, // num. of real space grids on current core
+                   const int& nxyz  // total num. of real space grids
+    );
 
-    double cal_Acav(const UnitCell &cell, const int& nxyz);
+    double cal_Acav(const UnitCell &cell, 
+                    const int& nxyz   // total num. of real space grids
+    );
 
     void cal_Acomp(const UnitCell &cell,
                    ModulePW::PW_Basis *rho_basis,

--- a/source/module_hamilt_general/module_xc/test/test_xc5.cpp
+++ b/source/module_hamilt_general/module_xc/test/test_xc5.cpp
@@ -43,6 +43,8 @@ class XCTest_VXC : public testing::Test
             UnitCell ucell;
             Charge chr;
 
+            chr.set_rhopw(&(rhopw));
+
             rhopw.nrxx = 5;
             rhopw.npw = 5;
             rhopw.nmaxgr = 5;
@@ -83,14 +85,14 @@ class XCTest_VXC : public testing::Test
 
             GlobalV::NSPIN = 1;
             std::tuple<double, double, ModuleBase::matrix> etxc_vtxc_v
-                = XC_Functional::v_xc(rhopw.nrxx,&chr,&rhopw,&ucell);
+                = XC_Functional::v_xc(rhopw.nrxx,&chr,&ucell);
             et1 = std::get<0>(etxc_vtxc_v);
             vt1 = std::get<1>(etxc_vtxc_v);
             v1  = std::get<2>(etxc_vtxc_v);
 
             GlobalV::NSPIN = 2;
             etxc_vtxc_v
-                = XC_Functional::v_xc(rhopw.nrxx,&chr,&rhopw,&ucell);
+                = XC_Functional::v_xc(rhopw.nrxx,&chr,&ucell);
             et2 = std::get<0>(etxc_vtxc_v);
             vt2 = std::get<1>(etxc_vtxc_v);
             v2  = std::get<2>(etxc_vtxc_v);
@@ -98,7 +100,7 @@ class XCTest_VXC : public testing::Test
             GlobalV::NSPIN = 4;
             GlobalV::DOMAG = true;
             etxc_vtxc_v
-                = XC_Functional::v_xc(rhopw.nrxx,&chr,&rhopw,&ucell);
+                = XC_Functional::v_xc(rhopw.nrxx,&chr,&ucell);
             et4 = std::get<0>(etxc_vtxc_v);
             vt4 = std::get<1>(etxc_vtxc_v);
             v4  = std::get<2>(etxc_vtxc_v);
@@ -173,6 +175,8 @@ class XCTest_VXC_Libxc : public testing::Test
             UnitCell ucell;
             Charge chr;
 
+            chr.set_rhopw(&(rhopw));
+
             rhopw.nrxx = 5;
             rhopw.npw = 5;
             rhopw.nmaxgr = 5;
@@ -213,14 +217,14 @@ class XCTest_VXC_Libxc : public testing::Test
 
             GlobalV::NSPIN = 1;
             std::tuple<double, double, ModuleBase::matrix> etxc_vtxc_v
-                = XC_Functional::v_xc(rhopw.nrxx,&chr,&rhopw,&ucell);
+                = XC_Functional::v_xc(rhopw.nrxx,&chr,&ucell);
             et1 = std::get<0>(etxc_vtxc_v);
             vt1 = std::get<1>(etxc_vtxc_v);
             v1  = std::get<2>(etxc_vtxc_v);
 
             GlobalV::NSPIN = 2;
             etxc_vtxc_v
-                = XC_Functional::v_xc(rhopw.nrxx,&chr,&rhopw,&ucell);
+                = XC_Functional::v_xc(rhopw.nrxx,&chr,&ucell);
             et2 = std::get<0>(etxc_vtxc_v);
             vt2 = std::get<1>(etxc_vtxc_v);
             v2  = std::get<2>(etxc_vtxc_v);
@@ -228,7 +232,7 @@ class XCTest_VXC_Libxc : public testing::Test
             GlobalV::NSPIN = 4;
             GlobalV::DOMAG = true;
             etxc_vtxc_v
-                = XC_Functional::v_xc(rhopw.nrxx,&chr,&rhopw,&ucell);
+                = XC_Functional::v_xc(rhopw.nrxx,&chr,&ucell);
             et4 = std::get<0>(etxc_vtxc_v);
             vt4 = std::get<1>(etxc_vtxc_v);
             v4  = std::get<2>(etxc_vtxc_v);
@@ -299,6 +303,8 @@ class XCTest_VXC_meta : public testing::Test
             UnitCell ucell;
             Charge chr;
 
+            chr.set_rhopw(&(rhopw));
+
             rhopw.nrxx = 5;
             rhopw.npw = 5;
             rhopw.nmaxgr = 5;
@@ -349,7 +355,7 @@ class XCTest_VXC_meta : public testing::Test
 
             GlobalV::NSPIN = 1;
             std::tuple<double, double, ModuleBase::matrix, ModuleBase::matrix> etxc_vtxc_v
-                = XC_Functional::v_xc_meta(rhopw.nrxx,ucell.omega,ucell.tpiba,&chr,&rhopw);
+                = XC_Functional::v_xc_meta(rhopw.nrxx,ucell.omega,ucell.tpiba,&chr);
             et1 = std::get<0>(etxc_vtxc_v);
             vt1 = std::get<1>(etxc_vtxc_v);
             v1  = std::get<2>(etxc_vtxc_v);
@@ -357,7 +363,7 @@ class XCTest_VXC_meta : public testing::Test
 
             GlobalV::NSPIN = 2;
             etxc_vtxc_v
-                = XC_Functional::v_xc_meta(rhopw.nrxx,ucell.omega,ucell.tpiba,&chr,&rhopw);
+                = XC_Functional::v_xc_meta(rhopw.nrxx,ucell.omega,ucell.tpiba,&chr);
             et2 = std::get<0>(etxc_vtxc_v);
             vt2 = std::get<1>(etxc_vtxc_v);
             v2  = std::get<2>(etxc_vtxc_v);

--- a/source/module_hamilt_general/module_xc/test/test_xc5.cpp
+++ b/source/module_hamilt_general/module_xc/test/test_xc5.cpp
@@ -42,9 +42,7 @@ class XCTest_VXC : public testing::Test
             ModulePW::PW_Basis rhopw;
             UnitCell ucell;
             Charge chr;
-
-            chr.set_rhopw(&(rhopw));
-
+            
             rhopw.nrxx = 5;
             rhopw.npw = 5;
             rhopw.nmaxgr = 5;
@@ -56,6 +54,7 @@ class XCTest_VXC : public testing::Test
             ucell.cal_ux();
             ucell.omega = 1;
 
+            chr.rhopw = &(rhopw);
             chr.rho = new double*[4];
             chr.rho[0] = new double[5];
             chr.rho[1] = new double[5];
@@ -175,8 +174,6 @@ class XCTest_VXC_Libxc : public testing::Test
             UnitCell ucell;
             Charge chr;
 
-            chr.set_rhopw(&(rhopw));
-
             rhopw.nrxx = 5;
             rhopw.npw = 5;
             rhopw.nmaxgr = 5;
@@ -188,6 +185,7 @@ class XCTest_VXC_Libxc : public testing::Test
             ucell.cal_ux();
             ucell.omega = 1;
 
+            chr.rhopw = &(rhopw);
             chr.rho = new double*[4];
             chr.rho[0] = new double[5];
             chr.rho[1] = new double[5];
@@ -303,8 +301,6 @@ class XCTest_VXC_meta : public testing::Test
             UnitCell ucell;
             Charge chr;
 
-            chr.set_rhopw(&(rhopw));
-
             rhopw.nrxx = 5;
             rhopw.npw = 5;
             rhopw.nmaxgr = 5;
@@ -316,6 +312,7 @@ class XCTest_VXC_meta : public testing::Test
             ucell.cal_ux();
             ucell.omega = 1;
 
+            chr.rhopw = &(rhopw);
             chr.rho = new double*[2];
             chr.rho[0] = new double[5];
             chr.rho[1] = new double[5];

--- a/source/module_hamilt_general/module_xc/xc_functional.h
+++ b/source/module_hamilt_general/module_xc/xc_functional.h
@@ -46,7 +46,6 @@ class XC_Functional
     static std::tuple<double,double,ModuleBase::matrix> v_xc(
 		const int &nrxx, // number of real-space grid
 		const Charge* const chr,
-		ModulePW::PW_Basis* rhopw,
 		const UnitCell *ucell); // charge density
 
 	// using libxc
@@ -54,16 +53,14 @@ class XC_Functional
 		const int &nrxx, // number of real-space grid
 		const double &omega, // volume of cell
 		const double tpiba,
-		const Charge* const chr,
-		ModulePW::PW_Basis* rhopw); // charge density
+		const Charge* const chr); // charge density
 
 	// for mGGA functional
 	static std::tuple<double,double,ModuleBase::matrix,ModuleBase::matrix> v_xc_meta(
 		const int &nrxx, // number of real-space grid
 		const double &omega, // volume of cell
 		const double tpiba,
-		const Charge* const chr,
-		ModulePW::PW_Basis* rhopw);
+		const Charge* const chr);
 
 //-------------------
 //  xc_functional.cpp

--- a/source/module_hamilt_pw/hamilt_pwdft/forces.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/forces.cpp
@@ -825,8 +825,7 @@ void Forces<FPTYPE, Device>::cal_force_cc(ModuleBase::matrix& forcecc,
                                             GlobalC::ucell.atoms[it].ncpp.r,
                                             GlobalC::ucell.atoms[it].ncpp.rab,
                                             GlobalC::ucell.atoms[it].ncpp.rho_atc,
-                                            rhocg,
-                                            rho_basis);
+                                            rhocg);
 #ifdef _OPENMP
 #pragma omp parallel
             {

--- a/source/module_hamilt_pw/hamilt_pwdft/forces.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/forces.cpp
@@ -766,7 +766,7 @@ void Forces<FPTYPE, Device>::cal_force_cc(ModuleBase::matrix& forcecc,
     {
 #ifdef USE_LIBXC
         const auto etxc_vtxc_v
-            = XC_Functional::v_xc_meta(rho_basis->nrxx, GlobalC::ucell.omega, GlobalC::ucell.tpiba, chr, rho_basis);
+            = XC_Functional::v_xc_meta(rho_basis->nrxx, GlobalC::ucell.omega, GlobalC::ucell.tpiba, chr);
 
         GlobalC::en.etxc = std::get<0>(etxc_vtxc_v);
         GlobalC::en.vtxc = std::get<1>(etxc_vtxc_v);
@@ -779,7 +779,7 @@ void Forces<FPTYPE, Device>::cal_force_cc(ModuleBase::matrix& forcecc,
     {
         if (GlobalV::NSPIN == 4)
             GlobalC::ucell.cal_ux();
-        const auto etxc_vtxc_v = XC_Functional::v_xc(rho_basis->nrxx, chr, rho_basis, &GlobalC::ucell);
+        const auto etxc_vtxc_v = XC_Functional::v_xc(rho_basis->nrxx, chr, &GlobalC::ucell);
 
         GlobalC::en.etxc = std::get<0>(etxc_vtxc_v);
         GlobalC::en.vtxc = std::get<1>(etxc_vtxc_v);

--- a/source/module_hamilt_pw/hamilt_pwdft/stress_func_cc.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/stress_func_cc.cpp
@@ -46,7 +46,7 @@ void Stress_Func<FPTYPE, Device>::stress_cc(ModuleBase::matrix &sigma,
 	{
 #ifdef USE_LIBXC
         const auto etxc_vtxc_v
-            = XC_Functional::v_xc_meta(rho_basis->nrxx, GlobalC::ucell.omega, GlobalC::ucell.tpiba, chr, rho_basis);
+            = XC_Functional::v_xc_meta(rho_basis->nrxx, GlobalC::ucell.omega, GlobalC::ucell.tpiba, chr);
 
         GlobalC::en.etxc = std::get<0>(etxc_vtxc_v);
         GlobalC::en.vtxc = std::get<1>(etxc_vtxc_v);
@@ -58,7 +58,7 @@ void Stress_Func<FPTYPE, Device>::stress_cc(ModuleBase::matrix &sigma,
 	else
 	{
 		if(GlobalV::NSPIN==4) GlobalC::ucell.cal_ux();
-        const auto etxc_vtxc_v = XC_Functional::v_xc(rho_basis->nrxx, chr, rho_basis, &GlobalC::ucell);
+        const auto etxc_vtxc_v = XC_Functional::v_xc(rho_basis->nrxx, chr, &GlobalC::ucell);
         GlobalC::en.etxc    = std::get<0>(etxc_vtxc_v);			// may delete?
 		GlobalC::en.vtxc    = std::get<1>(etxc_vtxc_v);			// may delete?
 		vxc = std::get<2>(etxc_vtxc_v);

--- a/source/module_hamilt_pw/hamilt_pwdft/stress_func_cc.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/stress_func_cc.cpp
@@ -106,8 +106,7 @@ void Stress_Func<FPTYPE, Device>::stress_cc(ModuleBase::matrix &sigma,
 				GlobalC::ucell.atoms[nt].ncpp.r,
 				GlobalC::ucell.atoms[nt].ncpp.rab,
 				GlobalC::ucell.atoms[nt].ncpp.rho_atc,
-				rhocg,
-				rho_basis);
+				rhocg);
 
 
 			//diagonal term 

--- a/source/module_hsolver/test/hsolver_supplementary_mock.h
+++ b/source/module_hsolver/test/hsolver_supplementary_mock.h
@@ -48,6 +48,7 @@ void ElecState::init_scf(const int istep, const ModuleBase::ComplexMatrix& struc
 void ElecState::init_ks(Charge* chg_in, // pointer for class Charge
                         const K_Vectors* klist_in,
                         int nk_in,
+                        ModulePW::PW_Basis* rhopw_in,
                         const ModulePW::PW_Basis_Big* bigpw_in)
 {
     return;


### PR DESCRIPTION
1. Add `rhopw` as a member of `Charge`;
2. Add `rhopw` as a member of `Charge_Mixing`;
3. Remove the getors of `GlobalC::rhopw`.
fix #2318