### PR TITLE
Fix: fix single precision error while in examples/scf/pw_Si2 case

### DIFF
--- a/source/module_hamilt_pw/hamilt_pwdft/structure_factor_k.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/structure_factor_k.cpp
@@ -59,11 +59,11 @@ void Structure_Factor::get_sk(Device *ctx,
     using syncmem_var_op = psi::memory::synchronize_memory_op<FPTYPE, Device, psi::DEVICE_CPU>;
 
     int iat = 0, _npw = wfc_basis->npwk[ik], eigts1_nc = this->eigts1.nc, eigts2_nc = this->eigts2.nc,
-        eigts3_nc = this->eigts3.nc;
+            eigts3_nc = this->eigts3.nc;
     int *igl2isz = nullptr, *is2fftixy = nullptr, *atom_na = nullptr, *h_atom_na = new int[GlobalC::ucell.ntype];
-    FPTYPE *atom_tau = nullptr, *h_atom_tau = new FPTYPE[GlobalC::ucell.nat * 3], *kvec = nullptr;
+    FPTYPE *atom_tau = nullptr, *h_atom_tau = new FPTYPE[GlobalC::ucell.nat * 3], *kvec = wfc_basis->get_kvec_c_data<FPTYPE>();
     std::complex<FPTYPE> *eigts1 = this->get_eigts1_data<FPTYPE>(), *eigts2 = this->get_eigts2_data<FPTYPE>(),
-                         *eigts3 = this->get_eigts3_data<FPTYPE>();
+            *eigts3 = this->get_eigts3_data<FPTYPE>();
     for (int it = 0; it < GlobalC::ucell.ntype; it++)
     {
         h_atom_na[it] = GlobalC::ucell.atoms[it].na;
@@ -86,9 +86,7 @@ void Structure_Factor::get_sk(Device *ctx,
         syncmem_int_op()(ctx, cpu_ctx, atom_na, h_atom_na, GlobalC::ucell.ntype);
 
         resmem_var_op()(ctx, atom_tau, GlobalC::ucell.nat * 3);
-        resmem_var_op()(ctx, kvec, wfc_basis->nks * 3);
         syncmem_var_op()(ctx, cpu_ctx, atom_tau, h_atom_tau, GlobalC::ucell.nat * 3);
-        syncmem_var_op()(ctx, cpu_ctx, kvec, reinterpret_cast<FPTYPE *>(wfc_basis->kvec_c), wfc_basis->nks * 3);
 
         igl2isz = wfc_basis->d_igl2isz_k;
         is2fftixy = wfc_basis->d_is2fftixy;
@@ -99,7 +97,6 @@ void Structure_Factor::get_sk(Device *ctx,
         atom_tau = h_atom_tau;
         igl2isz = wfc_basis->igl2isz_k;
         is2fftixy = wfc_basis->is2fftixy;
-        kvec = reinterpret_cast<FPTYPE *>(wfc_basis->kvec_c);
     }
 
     cal_sk_op()(ctx,


### PR DESCRIPTION
This may result in abnormal program interruption in a single precision setting.