### PR TITLE
Refactor: Add `scf_thr_type` to choose the convergence criterion of scf calculation.

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -69,6 +69,7 @@
 		- [printe](#printe)
 		- [scf\_nmax](#scf_nmax)
 		- [scf\_thr](#scf_thr)
+		- [scf\_thr\_type](#scf_thr_type)
 		- [chg\_extrap](#chg_extrap)
 		- [lspinorb](#lspinorb)
 		- [noncolin](#noncolin)
@@ -854,6 +855,12 @@ calculations.
 - **Type**: Real
 - **Description**: An important parameter in ABACUS. It's the threshold for electronic iteration. It represents the charge density error between two sequential densities from electronic iterations. Usually for local orbitals, usually 1e-6 may be accurate enough.
 - **Default**: 1.0e-9 for PW, and 1.0e-7 for LCAO.
+
+### scf_thr_type
+
+- **Type**: Int
+- **Description**: Choose the calculation method of convergence criterion. If set to 1, the criterion is defined as $\Delta\rho_G = \frac{1}{2}\iint{\frac{\Delta\rho(r)\Delta\rho(r')}{|r-r'|}d^3r d^3r'}$. If set to 2, the criterion is defined as $\Delta\rho_R = \int{|\Delta\rho(r)|d^3r}$. Note that this parameter is still under testing and the default setting is usually sufficient.
+- **Default**: 1 for PW, and 2 for LCAO.
 
 ### chg_extrap
 

--- a/source/module_base/global_variable.cpp
+++ b/source/module_base/global_variable.cpp
@@ -74,6 +74,7 @@ double PW_DIAG_THR = 1.0e-2;
 int NB2D = 1;
 
 double SCF_THR = 1.0e-9;
+int SCF_THR_TYPE = 1;
 
 double DQ = 0.010; // space between Q points of the reciprocal radial tab
 int NQX = 10000; // number of points describing reciprocal radial tab

--- a/source/module_base/global_variable.h
+++ b/source/module_base/global_variable.h
@@ -86,6 +86,7 @@ extern double PW_DIAG_THR; // 15 pw_diag_thr
 extern int NB2D; // 16.5 dividsion of 2D_matrix.
 
 extern double SCF_THR; // 17
+extern int SCF_THR_TYPE; // type of the criterion of scf_thr, 1: reci drho for pw, 2: real drho for lcao
 
 extern double DQ; // 19 mohan add 2009-09-10
 extern int NQX; // 20 mohan add 2009-09-10

--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -128,7 +128,9 @@ double Charge_Mixing::get_drho(Charge* chr, const double nelec)
 	
 	if(GlobalV::test_charge)GlobalV::ofs_running << " scf_thr from rhog_dot_product is " << scf_thr << std::endl;
 	
-	if(GlobalV::BASIS_TYPE=="pw" && !GlobalV::test_charge)
+	// This is a temporary method to choose the type of scf_thr, in order to test different scf_thr_type.
+	// Charge mixing will be refactored later.
+	if(GlobalV::SCF_THR_TYPE == 1 && !GlobalV::test_charge)
 	{
 		return scf_thr;
 	}
@@ -160,7 +162,7 @@ double Charge_Mixing::get_drho(Charge* chr, const double nelec)
 
 	// mohan add 2011-01-22
 	//if(LINEAR_SCALING && LOCAL_BASIS) xiaohui modify 2013-09-01
-	if(GlobalV::BASIS_TYPE=="lcao" )
+	if(GlobalV::SCF_THR_TYPE == 2)
 	{
 		scf_thr = scf_thr2;	
 	}

--- a/source/module_io/input.cpp
+++ b/source/module_io/input.cpp
@@ -3628,11 +3628,6 @@ void Input::Check(void)
 		}
 	}
 
-    // if(scf_thr_type != 1 and scf_thr_type != 2)
-    // {
-    //     ModuleBase::WARNING_QUIT("INPUT", "scf_thr_type must be 1 (for pw) or 2 (for lcao)");
-    // }
-
     return;
 }
 

--- a/source/module_io/input.cpp
+++ b/source/module_io/input.cpp
@@ -263,6 +263,7 @@ void Input::Default(void)
     // iteration
     //----------------------------------------------------------
     scf_thr = -1.0; // the default value (1e-9 for pw, and 1e-7 for lcao) will be set in Default_2
+    scf_thr_type = -1; // the default value (1 for pw, and 2 for lcao) will be set in Default_2
     scf_nmax = 100;
     relax_nmax = 0;
     out_stru = 0;
@@ -1078,6 +1079,10 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("scf_thr", word) == 0)
         {
             read_value(ifs, scf_thr);
+        }
+        else if (strcmp("scf_thr_type", word) == 0)
+        {
+            read_value(ifs, scf_thr_type);
         }
         else if (strcmp("scf_nmax", word) == 0)
         {
@@ -2730,6 +2735,18 @@ void Input::Default_2(void) // jiyy add 2019-08-04
             scf_thr = 1.0e-9;
         }
     }
+
+    if (scf_thr_type == -1)
+    {
+        if (basis_type == "lcao" || basis_type == "lcao_in_pw")
+        {
+            scf_thr_type = 2;
+        }
+        else if (basis_type == "pw")
+        {
+            scf_thr_type = 1;
+        }
+    }
 }
 #ifdef __MPI
 void Input::Bcast()
@@ -2855,6 +2872,7 @@ void Input::Bcast()
     Parallel_Common::bcast_bool(test_stress);
 
     Parallel_Common::bcast_double(scf_thr);
+    Parallel_Common::bcast_int(scf_thr_type);
     Parallel_Common::bcast_int(scf_nmax);
     Parallel_Common::bcast_int(this->relax_nmax);
     Parallel_Common::bcast_bool(out_stru); // mohan add 2012-03-23
@@ -3609,6 +3627,11 @@ void Input::Check(void)
 			ModuleBase::WARNING_QUIT("INPUT", "bessel_descriptor_rcut must >=0");
 		}
 	}
+
+    // if(scf_thr_type != 1 and scf_thr_type != 2)
+    // {
+    //     ModuleBase::WARNING_QUIT("INPUT", "scf_thr_type must be 1 (for pw) or 2 (for lcao)");
+    // }
 
     return;
 }

--- a/source/module_io/input.h
+++ b/source/module_io/input.h
@@ -189,6 +189,7 @@ class Input
     // iteration
     //==========================================================
     double scf_thr; // \sum |rhog_out - rhog_in |^2
+    int scf_thr_type; // type of the criterion of scf_thr, 1: reci drho, 2: real drho
     int scf_nmax; // number of max elec iter
     int relax_nmax; // number of max ionic iter
     bool out_stru; // outut stru file each ion step

--- a/source/module_io/input_conv.cpp
+++ b/source/module_io/input_conv.cpp
@@ -348,6 +348,7 @@ void Input_Conv::Convert(void)
     // iteration (1/3)
     //----------------------------------------------------------
     GlobalV::SCF_THR = INPUT.scf_thr;
+    GlobalV::SCF_THR_TYPE = INPUT.scf_thr_type;
 
     //----------------------------------------------------------
     // wavefunction / charge / potential / (2/4)

--- a/source/module_io/test/input_conv_test.cpp
+++ b/source/module_io/test/input_conv_test.cpp
@@ -103,6 +103,7 @@ TEST_F(InputConvTest, Conv)
 	EXPECT_EQ(GlobalV::TEST_STRESS,0);
 	EXPECT_EQ(GlobalV::test_skip_ewald,0);
 	EXPECT_DOUBLE_EQ(GlobalV::SCF_THR,0.00000001);
+	EXPECT_EQ(GlobalV::SCF_THR_TYPE,2);
 	EXPECT_EQ(GlobalC::wf.init_wfc,"atomic");
     EXPECT_EQ(GlobalC::wf.mem_saver, 0);
     EXPECT_EQ(GlobalV::LSPINORB,false);

--- a/source/module_io/test/input_test.cpp
+++ b/source/module_io/test/input_test.cpp
@@ -131,6 +131,7 @@ TEST_F(InputTest, Default)
         EXPECT_EQ(INPUT.test_force,0);
         EXPECT_EQ(INPUT.test_stress,0);
         EXPECT_DOUBLE_EQ(INPUT.scf_thr,-1.0);
+        EXPECT_EQ(INPUT.scf_thr_type,-1);
         EXPECT_EQ(INPUT.scf_nmax,100);
         EXPECT_EQ(INPUT.relax_nmax,0);
         EXPECT_EQ(INPUT.out_stru,0);
@@ -724,6 +725,7 @@ TEST_F(InputTest, Default_2)
 	INPUT.ks_solver = "default";
 	INPUT.lcao_ecut = 0;
 	INPUT.scf_thr = -1.0;
+	INPUT.scf_thr_type = -1;
         EXPECT_DOUBLE_EQ(INPUT.ecutwfc,20.0);
 	INPUT.nbndsto_str = "all";
 	// the 1st calling
@@ -742,6 +744,7 @@ TEST_F(InputTest, Default_2)
 	EXPECT_EQ(INPUT.mem_saver,0);
 	EXPECT_EQ(INPUT.relax_nmax,1);
 	EXPECT_DOUBLE_EQ(INPUT.scf_thr,1.0e-7);
+	EXPECT_EQ(INPUT.scf_thr_type,2);
 #ifdef __ELPA
 	EXPECT_EQ(INPUT.ks_solver,"genelpa");
 #else
@@ -769,6 +772,7 @@ TEST_F(InputTest, Default_2)
 	INPUT.ks_solver = "default";
 	INPUT.gamma_only_local = 1;
 	INPUT.scf_thr = -1.0;
+	INPUT.scf_thr_type = -1;
     INPUT.nbndsto_str = "0";
     INPUT.esolver_type = "sdft";
     // the 2nd calling
@@ -792,6 +796,7 @@ TEST_F(InputTest, Default_2)
 	EXPECT_EQ(INPUT.by,1);
 	EXPECT_EQ(INPUT.bz,1);
 	EXPECT_DOUBLE_EQ(INPUT.scf_thr,1.0e-9);
+	EXPECT_EQ(INPUT.scf_thr_type,1);
 	EXPECT_EQ(INPUT.esolver_type, "ksdft");
 	//==================================================
 	// prepare default parameters for the 3rd calling

--- a/source/module_io/test/input_test_para.cpp
+++ b/source/module_io/test/input_test_para.cpp
@@ -137,6 +137,7 @@ TEST_F(InputParaTest,Bcast)
         EXPECT_EQ(INPUT.test_force,0);
         EXPECT_EQ(INPUT.test_stress,0);
         EXPECT_DOUBLE_EQ(INPUT.scf_thr,-1.0);
+        EXPECT_EQ(INPUT.scf_thr_type,-1);
         EXPECT_EQ(INPUT.scf_nmax,100);
         EXPECT_EQ(INPUT.relax_nmax,0);
         EXPECT_EQ(INPUT.out_stru,0);

--- a/source/module_io/test/support/INPUT
+++ b/source/module_io/test/support/INPUT
@@ -46,6 +46,7 @@ device                         cpu #the computing device for ABACUS
 ecutwfc                        20 ##energy cutoff for wave functions
 pw_diag_thr                    0.01 #threshold for eigenvalues is cg electron iterations
 scf_thr                        1e-08 #charge density error
+scf_thr_type                   2 #type of the criterion of scf_thr, 1: reci drho for pw, 2: real drho for lcao
 init_wfc                       atomic #start wave functions are from 'atomic', 'atomic+random', 'random' or 'file'
 init_chg                       atomic #start charge is from 'atomic' or file
 chg_extrap                     atomic #atomic; first-order; second-order; dm:coefficients of SIA

--- a/source/module_io/test/support/witestfile
+++ b/source/module_io/test/support/witestfile
@@ -46,6 +46,7 @@ device                         cpu #the computing device for ABACUS
 ecutwfc                        20 ##energy cutoff for wave functions
 pw_diag_thr                    0.01 #threshold for eigenvalues is cg electron iterations
 scf_thr                        1e-08 #charge density error
+scf_thr_type                   2 #type of the criterion of scf_thr, 1: reci drho for pw, 2: real drho for lcao
 init_wfc                       atomic #start wave functions are from 'atomic', 'atomic+random', 'random' or 'file'
 init_chg                       atomic #start charge is from 'atomic' or file
 chg_extrap                     atomic #atomic; first-order; second-order; dm:coefficients of SIA

--- a/source/module_io/test/write_input_test.cpp
+++ b/source/module_io/test/write_input_test.cpp
@@ -75,6 +75,7 @@ TEST_F(write_input,print)
         EXPECT_THAT(output,testing::HasSubstr("ecutwfc                        20 ##energy cutoff for wave functions"));
         EXPECT_THAT(output,testing::HasSubstr("pw_diag_thr                    0.01 #threshold for eigenvalues is cg electron iterations"));
         EXPECT_THAT(output,testing::HasSubstr("scf_thr                        1e-08 #charge density error"));
+        EXPECT_THAT(output,testing::HasSubstr("scf_thr_type                   2 #type of the criterion of scf_thr, 1: reci drho for pw, 2: real drho for lcao"));
         EXPECT_THAT(output,testing::HasSubstr("init_wfc                       atomic #start wave functions are from 'atomic', 'atomic+random', 'random' or 'file'"));
         EXPECT_THAT(output,testing::HasSubstr("init_chg                       atomic #start charge is from 'atomic' or file"));
         EXPECT_THAT(output,testing::HasSubstr("chg_extrap                     atomic #atomic; first-order; second-order; dm:coefficients of SIA"));

--- a/source/module_io/write_input.cpp
+++ b/source/module_io/write_input.cpp
@@ -101,6 +101,7 @@ void Input::Print(const std::string &fn) const
                                  pw_diag_thr,
                                  "threshold for eigenvalues is cg electron iterations");
     ModuleBase::GlobalFunc::OUTP(ofs, "scf_thr", scf_thr, "charge density error");
+    ModuleBase::GlobalFunc::OUTP(ofs, "scf_thr_type", scf_thr_type, "type of the criterion of scf_thr, 1: reci drho for pw, 2: real drho for lcao");
     ModuleBase::GlobalFunc::OUTP(ofs, "init_wfc", init_wfc, "start wave functions are from 'atomic', 'atomic+random', 'random' or 'file'");
     ModuleBase::GlobalFunc::OUTP(ofs, "init_chg", init_chg, "start charge is from 'atomic' or file");
     ModuleBase::GlobalFunc::OUTP(ofs,


### PR DESCRIPTION
Fix #2469 
Currently, the convergence criterion for SCF calculation is determined according to the basis type. To further optimize the choice of `scf_thr` and `mixing_method`, as mentioned in #484 , an input parameter is needed to select this criterion. 
Once sufficient tests have been conducted, Charge Mixing will be refactored, and this parameter will be updated, too.
1. Add `scf_thr_type` to choose the convergence criterion of scf calculation.
2. Update corresponding unit tests and doc.