### PR TITLE
Refactor EXX:  pack EXX-process to `Exx_LRI_Interface` and remove GlobalC::exx_lri

### DIFF
--- a/source/module_elecstate/elecstate.h
+++ b/source/module_elecstate/elecstate.h
@@ -111,7 +111,8 @@ class ElecState
     void cal_energies(const int type);
 #ifdef __EXX
 #ifdef __LCAO
-    void set_exx();
+    void set_exx(const double& Eexx);
+    void set_exx(const std::complex<double>& Eexx);
 #endif //__LCAO
 #endif //__EXX
  

--- a/source/module_elecstate/elecstate_exx.cpp
+++ b/source/module_elecstate/elecstate_exx.cpp
@@ -8,33 +8,24 @@ namespace elecstate
 #ifdef __LCAO
 /// @brief calculation if converged
 /// @date Peize Lin add 2016-12-03
-void ElecState::set_exx()
+void ElecState::set_exx(const double& Eexx)
 {
     ModuleBase::TITLE("energy", "set_exx");
 
-    auto exx_energy = []() -> double {
-        if ("lcao_in_pw" == GlobalV::BASIS_TYPE)
-        {
-            return GlobalC::exx_lip.get_exx_energy();
-        }
-        else if ("lcao" == GlobalV::BASIS_TYPE)
-        {
-            if (GlobalC::exx_info.info_ri.real_number)
-                return GlobalC::exx_lri_double.Eexx;
-            else
-                return std::real(GlobalC::exx_lri_complex.Eexx);
-        }
-        else
-        {
-            throw std::invalid_argument(ModuleBase::GlobalFunc::TO_STRING(__FILE__)
-                                        + ModuleBase::GlobalFunc::TO_STRING(__LINE__));
-        }
-    };
     if (GlobalC::exx_info.info_global.cal_exx)
     {
-        this->f_en.exx = GlobalC::exx_info.info_global.hybrid_alpha * exx_energy();
+        this->f_en.exx = GlobalC::exx_info.info_global.hybrid_alpha * Eexx;
     }
+    return;
+}
+void ElecState::set_exx(const std::complex<double>& Eexx)
+{
+    ModuleBase::TITLE("energy", "set_exx");
 
+    if (GlobalC::exx_info.info_global.cal_exx)
+    {
+        this->f_en.exx = GlobalC::exx_info.info_global.hybrid_alpha * std::real(Eexx);
+    }
     return;
 }
 #endif //__LCAO

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -259,6 +259,10 @@ void ESolver_KS_LCAO::cal_Force(ModuleBase::matrix& force)
                        force,
                        this->scs,
                        this->sf,
+#ifdef __EXX
+                        GlobalC::exx_lri_double,
+                        GlobalC::exx_lri_complex,
+#endif  
                        this->kv,
                        this->pw_rho,
                        &this->symm);
@@ -915,9 +919,9 @@ void ESolver_KS_LCAO::afterscf(const int istep)
     {
         const std::string file_name_exx = GlobalV::global_out_dir + "HexxR_" + std::to_string(GlobalV::MY_RANK);
         if (GlobalC::exx_info.info_ri.real_number)
-            GlobalC::exx_lri_double.write_Hexxs(file_name_exx);
+            this->exd->write_Hexxs(file_name_exx);
         else
-            GlobalC::exx_lri_complex.write_Hexxs(file_name_exx);
+            this->exc->write_Hexxs(file_name_exx);
     }
 #endif
 

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -50,14 +50,14 @@ ESolver_KS_LCAO::ESolver_KS_LCAO()
 #ifdef __EXX
     if (GlobalC::exx_info.info_ri.real_number)
     {
-        this->exx_lri_double = new Exx_LRI<double>(GlobalC::exx_info.info_ri);
-        this->exd = new Exx_LRI_Interface<double>(this->exx_lri_double);
+        this->exx_lri_double = std::make_shared<Exx_LRI<double>>(GlobalC::exx_info.info_ri);
+        this->exd = std::make_shared<Exx_LRI_Interface<double>>(this->exx_lri_double);
         this->LM.Hexxd = &this->exd->get_Hexxs();
     }
     else
     {
-        this->exx_lri_complex = new Exx_LRI <std::complex<double>>(GlobalC::exx_info.info_ri);
-        this->exc = new Exx_LRI_Interface<std::complex<double>>(this->exx_lri_complex);
+        this->exx_lri_complex = std::make_shared<Exx_LRI<std::complex<double>>>(GlobalC::exx_info.info_ri);
+        this->exc = std::make_shared<Exx_LRI_Interface<std::complex<double>>>(this->exx_lri_complex);
         this->LM.Hexxc = &this->exc->get_Hexxs();
     }
 #endif
@@ -65,19 +65,6 @@ ESolver_KS_LCAO::ESolver_KS_LCAO()
 ESolver_KS_LCAO::~ESolver_KS_LCAO()
 {
     this->orb_con.clear_after_ions(GlobalC::UOT, GlobalC::ORB, GlobalV::deepks_setorb, GlobalC::ucell.infoNL.nproj);
-#ifdef __EXX
-    if (GlobalC::exx_info.info_ri.real_number)
-    {
-        delete this->exd;
-        delete this->exx_lri_double;
-    }
-    else
-    {
-        delete this->exc;
-        delete this->exx_lri_complex;
-    }
-        
-#endif
 }
 
 void ESolver_KS_LCAO::Init(Input& inp, UnitCell& ucell)

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -35,7 +35,6 @@
 //-----HSolver ElecState Hamilt--------
 #include "module_elecstate/elecstate_lcao.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h"
-#include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/op_exx_lcao.h"
 #include "module_hsolver/hsolver_lcao.h"
 // function used by deepks
 #include "module_elecstate/cal_dm.h"
@@ -48,10 +47,18 @@ ESolver_KS_LCAO::ESolver_KS_LCAO()
 {
     classname = "ESolver_KS_LCAO";
     basisname = "LCAO";
+#ifdef __EXX
+    this->exd = new Exx_LRI_Interface<double>(GlobalC::exx_lri_double);
+    this->exc = new Exx_LRI_Interface<std::complex<double>>(GlobalC::exx_lri_complex);
+#endif
 }
 ESolver_KS_LCAO::~ESolver_KS_LCAO()
 {
     this->orb_con.clear_after_ions(GlobalC::UOT, GlobalC::ORB, GlobalV::deepks_setorb, GlobalC::ucell.infoNL.nproj);
+#ifdef __EXX
+    delete this->exd;
+    delete this->exc;
+#endif
 }
 
 void ESolver_KS_LCAO::Init(Input& inp, UnitCell& ucell)
@@ -469,26 +476,10 @@ void ESolver_KS_LCAO::eachiterinit(const int istep, const int iter)
 
 #ifdef __EXX
     // calculate exact-exchange
-    if (GlobalC::exx_info.info_global.cal_exx)
-    {
-        if (!GlobalC::exx_info.info_global.separate_loop && this->two_level_step)
-        {
-            this->mix_DMk_2D.set_mixing_beta(this->p_chgmix->get_mixing_beta());
-            if (this->p_chgmix->get_mixing_mode() == "pulay")
-                this->mix_DMk_2D.set_coef_pulay(iter, *(this->p_chgmix));
-            const bool flag_restart = (iter == 1) ? true : false;
-            if(GlobalV::GAMMA_ONLY_LOCAL)
-				this->mix_DMk_2D.mix(this->LOC.dm_gamma, flag_restart);
-			else
-				this->mix_DMk_2D.mix(this->LOC.dm_k, flag_restart);
-
-            // GlobalC::exx_lcao.cal_exx_elec(this->LOC, this->LOWF.wfc_k_grid);
-            if (GlobalC::exx_info.info_ri.real_number)
-                GlobalC::exx_lri_double.cal_exx_elec(this->mix_DMk_2D, *this->LOWF.ParaV);
-            else
-                GlobalC::exx_lri_complex.cal_exx_elec(this->mix_DMk_2D, *this->LOWF.ParaV);
-        }
-    }
+    if (GlobalC::exx_info.info_ri.real_number)
+        this->exd->exx_eachiterinit(this->LOC, *(this->p_chgmix), iter);
+    else
+        this->exc->exx_eachiterinit(this->LOC, *(this->p_chgmix), iter);
 #endif
 
     if (GlobalV::dft_plus_u)
@@ -550,29 +541,10 @@ void ESolver_KS_LCAO::hamilt2density(int istep, int iter, double ethr)
     }
 
 #ifdef __EXX
-    // Peize Lin add 2020.04.04
-    if (XC_Functional::get_func_type() == 4 || XC_Functional::get_func_type() == 5)
-    {
-        // add exx
-        // Peize Lin add 2016-12-03
-        this->pelec->set_exx();
-
-        if (GlobalC::restart.info_load.load_H && GlobalC::restart.info_load.load_H_finish
-            && !GlobalC::restart.info_load.restart_exx)
-        {
-            XC_Functional::set_xc_type(GlobalC::ucell.atoms[0].ncpp.xc_func);
-            // GlobalC::exx_lcao.cal_exx_elec(this->LOC, this->LOWF.wfc_k_grid);
-            if (GlobalC::exx_info.info_ri.real_number)
-                GlobalC::exx_lri_double.cal_exx_elec(this->mix_DMk_2D, *this->LOWF.ParaV);
-            else
-                GlobalC::exx_lri_complex.cal_exx_elec(this->mix_DMk_2D, *this->LOWF.ParaV);
-            GlobalC::restart.info_load.restart_exx = true;
-        }
-    }
+    if (GlobalC::exx_info.info_ri.real_number)
+        this->exd->exx_hamilt2density(*this->pelec, *this->LOWF.ParaV);
     else
-    {
-        this->pelec->f_en.exx = 0.;
-    }
+        this->exc->exx_hamilt2density(*this->pelec, *this->LOWF.ParaV);
 #endif
 
     // if DFT+U calculation is needed, this function will calculate
@@ -1038,17 +1010,11 @@ void ESolver_KS_LCAO::afterscf(const int istep)
 #ifdef __EXX
     if (INPUT.rpa)
     {
-		this->mix_DMk_2D.set_mixing_mode(Mixing_Mode::No);
-		if(GlobalV::GAMMA_ONLY_LOCAL)
-			this->mix_DMk_2D.mix(this->LOC.dm_gamma, true);
-		else
-			this->mix_DMk_2D.mix(this->LOC.dm_k, true);
-
         // ModuleRPA::DFT_RPA_interface rpa_interface(GlobalC::exx_info.info_global);
         // rpa_interface.rpa_exx_lcao().info.files_abfs = GlobalV::rpa_orbitals;
         // rpa_interface.out_for_RPA(*(this->LOWF.ParaV), *(this->psi), this->LOC, this->pelec);
         RPA_LRI<double> rpa_lri_double(GlobalC::exx_info.info_ri);
-        rpa_lri_double.cal_postSCF_exx(MPI_COMM_WORLD, kv, this->mix_DMk_2D, *this->LOWF.ParaV);
+        rpa_lri_double.cal_postSCF_exx(this->LOC, MPI_COMM_WORLD, kv, *this->LOWF.ParaV);
         rpa_lri_double.init(MPI_COMM_WORLD, kv);
         rpa_lri_double.out_for_RPA(*(this->LOWF.ParaV), *(this->psi), this->pelec);
     }
@@ -1113,90 +1079,10 @@ void ESolver_KS_LCAO::afterscf(const int istep)
 bool ESolver_KS_LCAO::do_after_converge(int& iter)
 {
 #ifdef __EXX
-
-    // Add EXX operator
-    auto add_exx_operator = [&]() {
-        if (GlobalV::GAMMA_ONLY_LOCAL)
-        {
-            hamilt::Operator<double>* exx
-                = new hamilt::OperatorEXX<hamilt::OperatorLCAO<double>>(&LM,
-                                                                        nullptr, // no explicit call yet
-                                                                        &(LM.Hloc),
-                                                                        kv);
-            p_hamilt->opsd->add(exx);
-        }
-        else
-        {
-            hamilt::Operator<std::complex<double>>* exx
-                = new hamilt::OperatorEXX<hamilt::OperatorLCAO<std::complex<double>>>(&LM,
-                                                                                      nullptr, // no explicit call yet
-                                                                                      &(LM.Hloc2),
-                                                                                      kv);
-            p_hamilt->ops->add(exx);
-        }
-    };
-
-    if (GlobalC::exx_info.info_global.cal_exx)
-    {
-        // no separate_loop case
-        if (!GlobalC::exx_info.info_global.separate_loop)
-        {
-            GlobalC::exx_info.info_global.hybrid_step = 1;
-
-            // in no_separate_loop case, scf loop only did twice
-            // in first scf loop, exx updated once in beginning,
-            // in second scf loop, exx updated every iter
-
-            if (this->two_level_step)
-            {
-                return true;
-            }
-            else
-            {
-                // update exx and redo scf
-                XC_Functional::set_xc_type(GlobalC::ucell.atoms[0].ncpp.xc_func);
-                iter = 0;
-                std::cout << " Entering 2nd SCF, where EXX is updated" << std::endl;
-                this->two_level_step++;
-
-                add_exx_operator();
-
-                return false;
-            }
-        }
-        // has separate_loop case
-        // exx converged or get max exx steps
-        else if (this->two_level_step == GlobalC::exx_info.info_global.hybrid_step
-                 || (iter == 1 && this->two_level_step != 0))
-        {
-            return true;
-        }
-        else
-        {
-            // update exx and redo scf
-            if (two_level_step == 0)
-            {
-                add_exx_operator();
-                XC_Functional::set_xc_type(GlobalC::ucell.atoms[0].ncpp.xc_func);
-            }
-
-			const bool flag_restart = (two_level_step==0) ? true : false;
-			if(GlobalV::GAMMA_ONLY_LOCAL)
-				this->mix_DMk_2D.mix(this->LOC.dm_gamma, flag_restart);
-			else
-				this->mix_DMk_2D.mix(this->LOC.dm_k, flag_restart);
-
-            // GlobalC::exx_lcao.cal_exx_elec(this->LOC, this->LOWF.wfc_k_grid);
-            if (GlobalC::exx_info.info_ri.real_number)
-                GlobalC::exx_lri_double.cal_exx_elec(this->mix_DMk_2D, *this->LOWF.ParaV);
-            else
-                GlobalC::exx_lri_complex.cal_exx_elec(this->mix_DMk_2D, *this->LOWF.ParaV);
-            iter = 0;
-            std::cout << " Updating EXX and rerun SCF" << std::endl;
-            this->two_level_step++;
-            return false;
-        }
-    }
+    if (GlobalC::exx_info.info_ri.real_number)
+        return this->exd->exx_after_converge(*this->p_hamilt, this->LM, this->LOC, kv, iter);
+    else
+        return this->exc->exx_after_converge(*this->p_hamilt, this->LM, this->LOC, kv, iter);
 #endif // __EXX
     return true;
 }

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -50,6 +50,8 @@ ESolver_KS_LCAO::ESolver_KS_LCAO()
 #ifdef __EXX
     this->exd = new Exx_LRI_Interface<double>(GlobalC::exx_lri_double);
     this->exc = new Exx_LRI_Interface<std::complex<double>>(GlobalC::exx_lri_complex);
+    this->LM.Hexxd = &this->exd->get_Hexxs();
+    this->LM.Hexxc = &this->exc->get_Hexxs();
 #endif
 }
 ESolver_KS_LCAO::~ESolver_KS_LCAO()

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -265,12 +265,12 @@ void ESolver_KS_LCAO::cal_Force(ModuleBase::matrix& force)
                        force,
                        this->scs,
                        this->sf,
+                       this->kv,
+                       this->pw_rho,
 #ifdef __EXX
                         *this->exx_lri_double,
                         *this->exx_lri_complex,
 #endif  
-                       this->kv,
-                       this->pw_rho,
                        &this->symm);
     // delete RA after cal_Force
     this->RA.delete_grid();

--- a/source/module_esolver/esolver_ks_lcao.h
+++ b/source/module_esolver/esolver_ks_lcao.h
@@ -9,6 +9,7 @@
 #include "module_basis/module_ao/ORB_control.h"
 #ifdef __EXX
 #include "module_ri/Mix_DMk_2D.h"
+#include "module_ri/Exx_LRI_interface.h"
 #endif
 
 namespace ModuleESolver
@@ -38,7 +39,6 @@ namespace ModuleESolver
         virtual void eachiterfinish(const int iter) override;
         virtual void afterscf(const int istep) override;
         virtual bool do_after_converge(int& iter) override;
-        int two_level_step = 0;
 
         virtual void othercalculation(const int istep)override;
         ORB_control orb_con;    //Basis_LCAO
@@ -48,9 +48,6 @@ namespace ModuleESolver
         LCAO_Hamilt UHM;
         LCAO_Matrix LM;
         Grid_Technique GridT;
-#ifdef __EXX
-		Mix_DMk_2D mix_DMk_2D;
-#endif
 
         // Temporarily store the stress to unify the interface with PW,
         // because it's hard to seperate force and stress calculation in LCAO.
@@ -66,6 +63,10 @@ namespace ModuleESolver
         void set_matrix_grid(Record_adj& ra);
         void beforesolver(const int istep);
         //----------------------------------------------------------------------
+#ifdef __EXX
+        Exx_LRI_Interface<double>* exd = nullptr;
+        Exx_LRI_Interface<std::complex<double>>* exc = nullptr;
+#endif
     };
 
 

--- a/source/module_esolver/esolver_ks_lcao.h
+++ b/source/module_esolver/esolver_ks_lcao.h
@@ -66,6 +66,8 @@ namespace ModuleESolver
 #ifdef __EXX
         Exx_LRI_Interface<double>* exd = nullptr;
         Exx_LRI_Interface<std::complex<double>>* exc = nullptr;
+        Exx_LRI<double>* exx_lri_double = nullptr; // Peize Lin add 2022-08-06
+        Exx_LRI<std::complex<double>>* exx_lri_complex = nullptr; // Peize Lin add 2022-08-06
 #endif
     };
 

--- a/source/module_esolver/esolver_ks_lcao.h
+++ b/source/module_esolver/esolver_ks_lcao.h
@@ -64,10 +64,10 @@ namespace ModuleESolver
         void beforesolver(const int istep);
         //----------------------------------------------------------------------
 #ifdef __EXX
-        Exx_LRI_Interface<double>* exd = nullptr;
-        Exx_LRI_Interface<std::complex<double>>* exc = nullptr;
-        Exx_LRI<double>* exx_lri_double = nullptr; // Peize Lin add 2022-08-06
-        Exx_LRI<std::complex<double>>* exx_lri_complex = nullptr; // Peize Lin add 2022-08-06
+        std::shared_ptr<Exx_LRI_Interface<double>> exd = nullptr;
+        std::shared_ptr<Exx_LRI_Interface<std::complex<double>>> exc = nullptr;
+        std::shared_ptr<Exx_LRI<double>> exx_lri_double = nullptr;
+        std::shared_ptr<Exx_LRI<std::complex<double>>> exx_lri_complex = nullptr;
 #endif
     };
 

--- a/source/module_esolver/esolver_ks_lcao_elec.cpp
+++ b/source/module_esolver/esolver_ks_lcao_elec.cpp
@@ -309,9 +309,9 @@ namespace ModuleESolver
 //Peize Lin add 2016-12-03
 #ifdef __EXX
         if (GlobalC::exx_info.info_ri.real_number)
-            this->eld->exx_beforescf(kv);
+            this->exd->exx_beforescf(kv);
         else
-            this->elc->exx_beforescf(kv);
+            this->exc->exx_beforescf(kv);
 #endif // __EXX
         // 1. calculate ewald energy.
         // mohan update 2021-02-25
@@ -462,9 +462,9 @@ namespace ModuleESolver
             //GlobalC::exx_lcao.cal_exx_elec_nscf(this->LOWF.ParaV[0]);
 			const std::string file_name_exx = GlobalV::global_out_dir + "HexxR_" + std::to_string(GlobalV::MY_RANK);
 			if(GlobalC::exx_info.info_ri.real_number)
-				GlobalC::exx_lri_double.read_Hexxs(file_name_exx);
+				this->exd->read_Hexxs(file_name_exx);
 			else
-				GlobalC::exx_lri_complex.read_Hexxs(file_name_exx);
+				this->exc->read_Hexxs(file_name_exx);
 
             // This is a temporary fix
             if(GlobalV::GAMMA_ONLY_LOCAL)

--- a/source/module_esolver/esolver_ks_lcao_elec.cpp
+++ b/source/module_esolver/esolver_ks_lcao_elec.cpp
@@ -309,9 +309,9 @@ namespace ModuleESolver
 //Peize Lin add 2016-12-03
 #ifdef __EXX
         if (GlobalC::exx_info.info_ri.real_number)
-            this->exd->exx_beforescf(kv);
+            this->exd->exx_beforescf(kv, *this->p_chgmix);
         else
-            this->exc->exx_beforescf(kv);
+            this->exc->exx_beforescf(kv, *this->p_chgmix);
 #endif // __EXX
         // 1. calculate ewald energy.
         // mohan update 2021-02-25

--- a/source/module_esolver/esolver_ks_lcao_elec.cpp
+++ b/source/module_esolver/esolver_ks_lcao_elec.cpp
@@ -9,11 +9,6 @@
 #include "module_io/istate_charge.h"
 #include "module_io/istate_envelope.h"
 #include "module_io/write_HS_R.h"
-//
-#ifdef __EXX
-#include "module_ri/exx_abfs-jle.h"
-#include "module_ri/exx_opt_orb.h"
-#endif
 
 #include "module_io/berryphase.h"
 #include "module_io/to_wannier90.h"
@@ -313,59 +308,10 @@ namespace ModuleESolver
         }
 //Peize Lin add 2016-12-03
 #ifdef __EXX
-#ifdef __MPI
-		if ( GlobalC::exx_info.info_global.cal_exx )
-		{
-            if (GlobalC::ucell.atoms[0].ncpp.xc_func == "HSE" || GlobalC::ucell.atoms[0].ncpp.xc_func == "PBE0")
-            {
-                XC_Functional::set_xc_type("pbe");
-            }
-            else if (GlobalC::ucell.atoms[0].ncpp.xc_func == "SCAN0")
-            {
-                XC_Functional::set_xc_type("scan");
-            }
-
-			//GlobalC::exx_lcao.cal_exx_ions(*this->LOWF.ParaV);
-			if(GlobalC::exx_info.info_ri.real_number)
-				GlobalC::exx_lri_double.cal_exx_ions();
-			else
-				GlobalC::exx_lri_complex.cal_exx_ions();
-		}
-
-		if (Exx_Abfs::Jle::generate_matrix)
-		{
-			//program should be stopped after this judgement
-			Exx_Opt_Orb exx_opt_orb;
-            exx_opt_orb.generate_matrix(this->kv);
-            ModuleBase::timer::tick("ESolver_KS_LCAO", "beforescf");
-            return;
-        }
-		
-		// set initial parameter for mix_DMk_2D
-		if(GlobalC::exx_info.info_global.cal_exx)
-		{
-            this->mix_DMk_2D.set_nks(this->kv.nks, GlobalV::GAMMA_ONLY_LOCAL);
-            if (GlobalC::exx_info.info_global.separate_loop)
-            {
-                if(GlobalC::exx_info.info_global.mixing_beta_for_loop1==1.0)
-					this->mix_DMk_2D.set_mixing_mode(Mixing_Mode::No);
-				else
-					this->mix_DMk_2D.set_mixing_mode(Mixing_Mode::Plain)
-					                .set_mixing_beta(GlobalC::exx_info.info_global.mixing_beta_for_loop1);
-            }
-            else
-			{
-                if (this->p_chgmix->get_mixing_mode() == "plain")
-                    this->mix_DMk_2D.set_mixing_mode(Mixing_Mode::Plain);
-                else if (this->p_chgmix->get_mixing_mode() == "pulay")
-                    this->mix_DMk_2D.set_mixing_mode(Mixing_Mode::Pulay);
-				else
-                    throw std::invalid_argument("mixing_mode = " + this->p_chgmix->get_mixing_mode()
-                                                + ", mix_DMk_2D unsupported.\n" + std::string(__FILE__) + " line "
-                                                + std::to_string(__LINE__));
-            }
-		}
-#endif // __MPI
+        if (GlobalC::exx_info.info_ri.real_number)
+            this->eld->exx_beforescf(kv);
+        else
+            this->elc->exx_beforescf(kv);
 #endif // __EXX
         // 1. calculate ewald energy.
         // mohan update 2021-02-25
@@ -375,9 +321,6 @@ namespace ModuleESolver
         }
 
         p_hamilt->non_first_scf = istep;
-
-        // for exx two_level scf
-        this->two_level_step = 0;
 
         ModuleBase::timer::tick("ESolver_KS_LCAO", "beforescf");
         return;

--- a/source/module_esolver/esolver_ks_pw.cpp
+++ b/source/module_esolver/esolver_ks_pw.cpp
@@ -426,7 +426,7 @@ void ESolver_KS_PW<FPTYPE, Device>::hamilt2density(const int istep, const int it
     // add exx
 #ifdef __LCAO
 #ifdef __EXX
-    this->pelec->set_exx(); // Peize Lin add 2019-03-09
+    this->pelec->set_exx(GlobalC::exx_lip.get_exx_energy()); // Peize Lin add 2019-03-09
 #endif
 #endif
     // calculate the delta_harris energy

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
@@ -33,12 +33,12 @@ void Force_Stress_LCAO::getForceStress(
     ModuleBase::matrix& fcs,
     ModuleBase::matrix & scs,
     const Structure_Factor& sf,
+	const K_Vectors& kv,
+    ModulePW::PW_Basis* rhopw,
 #ifdef __EXX
     Exx_LRI<double>& exx_lri_double,
     Exx_LRI<std::complex<double>>& exx_lri_complex,
 #endif
-	const K_Vectors& kv,
-    ModulePW::PW_Basis* rhopw,
     ModuleSymmetry::Symmetry* symm)
 {
     ModuleBase::TITLE("Force_Stress_LCAO", "getForceStress");

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
@@ -20,21 +20,26 @@ Force_Stress_LCAO::Force_Stress_LCAO(Record_adj& ra, const int nat_in) :
     RA(&ra), f_pw(nat_in), nat(nat_in){}
 Force_Stress_LCAO::~Force_Stress_LCAO() {}
 
-void Force_Stress_LCAO::getForceStress(const bool isforce,
-                                       const bool isstress,
-                                       const bool istestf,
-                                       const bool istests,
-                                       Local_Orbital_Charge& loc,
-                                       const elecstate::ElecState* pelec,
-                                       const psi::Psi<double>* psid,
-                                       const psi::Psi<std::complex<double>>* psi,
-                                       LCAO_Hamilt& uhm,
-                                       ModuleBase::matrix& fcs,
-                                       ModuleBase::matrix& scs,
-                                       const Structure_Factor& sf,
-                                       const K_Vectors& kv,
-                                       ModulePW::PW_Basis* rhopw,
-                                       ModuleSymmetry::Symmetry* symm)
+void Force_Stress_LCAO::getForceStress(
+	const bool isforce,
+	const bool isstress,
+	const bool istestf,
+    const bool istests,
+    Local_Orbital_Charge& loc,
+	const elecstate::ElecState* pelec,
+    const psi::Psi<double>* psid,
+	const psi::Psi<std::complex<double>>* psi,
+    LCAO_Hamilt &uhm,
+    ModuleBase::matrix& fcs,
+    ModuleBase::matrix & scs,
+    const Structure_Factor& sf,
+#ifdef __EXX
+    Exx_LRI<double>& exx_lri_double,
+    Exx_LRI<std::complex<double>>& exx_lri_complex,
+#endif
+	const K_Vectors& kv,
+    ModulePW::PW_Basis* rhopw,
+    ModuleSymmetry::Symmetry* symm)
 {
     ModuleBase::TITLE("Force_Stress_LCAO", "getForceStress");
     ModuleBase::timer::tick("Force_Stress_LCAO", "getForceStress");
@@ -234,26 +239,26 @@ void Force_Stress_LCAO::getForceStress(const bool isforce,
         {
             if (GlobalC::exx_info.info_ri.real_number)
             {
-                GlobalC::exx_lri_double.cal_exx_force();
-                force_exx = GlobalC::exx_info.info_global.hybrid_alpha * GlobalC::exx_lri_double.force_exx;
+                exx_lri_double.cal_exx_force();
+                force_exx = GlobalC::exx_info.info_global.hybrid_alpha * exx_lri_double.force_exx;
             }
             else
             {
-                GlobalC::exx_lri_complex.cal_exx_force();
-                force_exx = GlobalC::exx_info.info_global.hybrid_alpha * GlobalC::exx_lri_complex.force_exx;
+                exx_lri_complex.cal_exx_force();
+                force_exx = GlobalC::exx_info.info_global.hybrid_alpha * exx_lri_complex.force_exx;
             }
         }
         if (isstress)
         {
             if (GlobalC::exx_info.info_ri.real_number)
             {
-                GlobalC::exx_lri_double.cal_exx_stress();
-                stress_exx = GlobalC::exx_info.info_global.hybrid_alpha * GlobalC::exx_lri_double.stress_exx;
+                exx_lri_double.cal_exx_stress();
+                stress_exx = GlobalC::exx_info.info_global.hybrid_alpha * exx_lri_double.stress_exx;
             }
             else
             {
-                GlobalC::exx_lri_complex.cal_exx_stress();
-                stress_exx = GlobalC::exx_info.info_global.hybrid_alpha * GlobalC::exx_lri_complex.stress_exx;
+                exx_lri_complex.cal_exx_stress();
+                stress_exx = GlobalC::exx_info.info_global.hybrid_alpha * exx_lri_complex.stress_exx;
             }
         }
     }

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
@@ -10,6 +10,9 @@
 #include "module_hamilt_pw/hamilt_pwdft/structure_factor.h"
 #include "module_io/input_conv.h"
 #include "module_psi/psi.h"
+#ifdef __EXX
+#include "module_ri/Exx_LRI.h"
+#endif
 
 class Force_Stress_LCAO
 {
@@ -34,6 +37,10 @@ class Force_Stress_LCAO
                         ModuleBase::matrix& fcs,
                         ModuleBase::matrix& scs,
                         const Structure_Factor& sf,
+#ifdef __EXX
+                        Exx_LRI<double>& exx_lri_double,
+                        Exx_LRI<std::complex<double>>& exx_lri_complex,
+#endif  
                         const K_Vectors& kv,
                         ModulePW::PW_Basis* rhopw,
                         ModuleSymmetry::Symmetry* symm);

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
@@ -37,12 +37,12 @@ class Force_Stress_LCAO
                         ModuleBase::matrix& fcs,
                         ModuleBase::matrix& scs,
                         const Structure_Factor& sf,
+                        const K_Vectors& kv,
+                        ModulePW::PW_Basis* rhopw,
 #ifdef __EXX
                         Exx_LRI<double>& exx_lri_double,
                         Exx_LRI<std::complex<double>>& exx_lri_complex,
 #endif  
-                        const K_Vectors& kv,
-                        ModulePW::PW_Basis* rhopw,
                         ModuleSymmetry::Symmetry* symm);
 
   private:

--- a/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_hamilt.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_hamilt.cpp
@@ -334,9 +334,9 @@ void LCAO_Hamilt::calculate_HSR_sparse(const int &current_spin, const double &sp
     if( GlobalC::exx_info.info_global.cal_exx )
     {
         if(GlobalC::exx_info.info_ri.real_number)
-            this->calculate_HR_exx_sparse(current_spin, sparse_threshold, nmp, GlobalC::exx_lri_double.Hexxs);
+            this->calculate_HR_exx_sparse(current_spin, sparse_threshold, nmp, *this->LM->Hexxd);
         else
-            this->calculate_HR_exx_sparse(current_spin, sparse_threshold, nmp, GlobalC::exx_lri_complex.Hexxs);
+            this->calculate_HR_exx_sparse(current_spin, sparse_threshold, nmp, *this->LM->Hexxc);
     }
 #endif // __MPI
 #endif // __EXX

--- a/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h
@@ -9,6 +9,9 @@
 
 // add by jingan for map<> in 2021-12-2, will be deleted in the future
 #include "module_base/abfs-vector3_order.h"
+#ifdef __EXX
+#include <RI/global/Tensor.h>
+#endif
 
 class LCAO_Matrix
 {
@@ -26,6 +29,12 @@ class LCAO_Matrix
                         bool cal_syns = false);
 
     Parallel_Orbitals *ParaV;
+    
+#ifdef __EXX
+    using TAC = std::pair<int, std::array<int, 3>>;
+    std::vector< std::map<int, std::map<TAC, RI::Tensor<double>>>> *Hexxd;
+    std::vector< std::map<int, std::map<TAC, RI::Tensor<std::complex<double>>>>> *Hexxc;
+#endif
 
     void allocate_HS_k(const long &nloc);
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/global_fp.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/global_fp.cpp
@@ -4,9 +4,4 @@
 namespace GlobalC
 {
 Grid_Driver GridD(GlobalV::test_deconstructor, GlobalV::test_grid_driver,GlobalV::test_grid);
-
-#ifdef __EXX
-Exx_LRI<double> exx_lri_double(GlobalC::exx_info.info_ri); // Peize Lin add 2022-08-06
-Exx_LRI<std::complex<double>> exx_lri_complex(GlobalC::exx_info.info_ri); // Peize Lin add 2022-08-06
-#endif
 }

--- a/source/module_hamilt_lcao/hamilt_lcaodft/global_fp.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/global_fp.h
@@ -10,16 +10,9 @@
 #include "module_hamilt_lcao/hamilt_lcaodft/LCAO_hamilt.h" 
 #include "module_basis/module_ao/ORB_read.h"
 #include "module_basis/module_ao/ORB_gen_tables.h"
-#ifdef __EXX
-#include "module_ri/Exx_LRI.h"
-#endif
 
 namespace GlobalC
 {
 extern Grid_Driver GridD;
-#ifdef __EXX
-extern Exx_LRI<double> exx_lri_double; // Peize Lin add 2022-08-06
-extern Exx_LRI<std::complex<double>> exx_lri_complex; // Peize Lin add 2022-08-06
-#endif
 }
 #endif

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/op_exx_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/op_exx_lcao.cpp
@@ -27,20 +27,18 @@ void OperatorEXX<OperatorLCAO<double>>::contributeHk(int ik)
     if(XC_Functional::get_func_type()==4 || XC_Functional::get_func_type()==5)
     {
 		if(GlobalC::exx_info.info_ri.real_number)
-            RI_2D_Comm::add_Hexx(
-                kv,
-                ik,
-				GlobalC::exx_info.info_global.hybrid_alpha,
-				GlobalC::exx_lri_double.Hexxs,
-				*this->LM->ParaV,
+        RI_2D_Comm::add_Hexx(
+            kv,
+            ik,
+            GlobalC::exx_info.info_global.hybrid_alpha,
+				*this->LM->Hexxd,
 				*this->LM);
 		else
             RI_2D_Comm::add_Hexx(
                 kv,
                 ik,
 				GlobalC::exx_info.info_global.hybrid_alpha,
-				GlobalC::exx_lri_complex.Hexxs,
-				*this->LM->ParaV,
+				*this->LM->Hexxc,
 				*this->LM);
     }
 #endif
@@ -58,16 +56,14 @@ void OperatorEXX<OperatorLCAO<std::complex<double>>>::contributeHk(int ik)
                 kv,
                 ik,
 				GlobalC::exx_info.info_global.hybrid_alpha,
-				GlobalC::exx_lri_double.Hexxs,
-				*this->LM->ParaV,
+				*this->LM->Hexxd,
 				*this->LM);
 		else
             RI_2D_Comm::add_Hexx(
                 kv,
                 ik,
 				GlobalC::exx_info.info_global.hybrid_alpha,
-				GlobalC::exx_lri_complex.Hexxs,
-				*this->LM->ParaV,
+				*this->LM->Hexxc,
 				*this->LM);
     }
 #endif

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/op_exx_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/op_exx_lcao.cpp
@@ -1,3 +1,4 @@
+#ifdef __EXX
 #include "op_exx_lcao.h"
 #include "module_base/timer.h"
 #include "module_base/tool_title.h"
@@ -23,7 +24,6 @@ void OperatorEXX<OperatorLCAO<T>>::contributeHR()
 template<>
 void OperatorEXX<OperatorLCAO<double>>::contributeHk(int ik)
 {
-#ifdef __EXX
     // Peize Lin add 2016-12-03
     if(XC_Functional::get_func_type()==4 || XC_Functional::get_func_type()==5)
     {
@@ -42,13 +42,11 @@ void OperatorEXX<OperatorLCAO<double>>::contributeHk(int ik)
 				*this->LM->Hexxc,
 				*this->LM);
     }
-#endif
 }
 
 template<>
 void OperatorEXX<OperatorLCAO<std::complex<double>>>::contributeHk(int ik)
 {
-#ifdef __EXX
     // Peize Lin add 2016-12-03
     if(XC_Functional::get_func_type()==4 || XC_Functional::get_func_type()==5)
     {
@@ -67,6 +65,6 @@ void OperatorEXX<OperatorLCAO<std::complex<double>>>::contributeHk(int ik)
 				*this->LM->Hexxc,
 				*this->LM);
     }
-#endif
 }
 } // namespace hamilt
+#endif

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/op_exx_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/op_exx_lcao.cpp
@@ -4,6 +4,7 @@
 #include "module_hamilt_general/module_xc/xc_functional.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/global_fp.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
+#include "module_ri/RI_2D_Comm.h"
 
 namespace hamilt
 {

--- a/source/module_ri/Exx_LRI.h
+++ b/source/module_ri/Exx_LRI.h
@@ -10,6 +10,7 @@
 #include "module_hamilt_general/module_xc/exx_info.h"
 #include "module_basis/module_ao/ORB_atomic_lm.h"
 #include "module_base/matrix.h"
+#include "module_ri/Mix_DMk_2D.h"
 #include <RI/physics/Exx.h>
 
 #include <vector>
@@ -20,10 +21,12 @@
 
 	class Local_Orbital_Charge;
 	class Parallel_Orbitals;
-	class Mix_DMk_2D;
 	
 	template<typename Tdata>
 	class RPA_LRI;
+
+    template<typename Tdata>
+    class Exx_LRI_Interface;
 
 template<typename Tdata>
 class Exx_LRI
@@ -40,8 +43,6 @@ public:
 	Exx_LRI( const Exx_Info::Exx_Info_RI &info_in ) :info(info_in){}
 
 	void init(const MPI_Comm &mpi_comm_in, const K_Vectors &kv_in);
-	void cal_exx_ions();
-	void cal_exx_elec(const Mix_DMk_2D &mix_DMk_2D, const Parallel_Orbitals &pv);
 	void cal_exx_force();
 	void cal_exx_stress();
 
@@ -65,10 +66,16 @@ private:
 	LRI_CV<Tdata> cv;
 	RI::Exx<TA,Tcell,Ndim,Tdata> exx_lri;
 
+	void cal_exx_ions();
+	void cal_exx_elec(const Parallel_Orbitals &pv);
 	void post_process_Hexx( std::map<TA, std::map<TAC, RI::Tensor<Tdata>>> &Hexxs_io ) const;
 	Tdata post_process_Eexx( const Tdata &Eexx_in ) const;
 
+    int two_level_step = 0;
+    Mix_DMk_2D mix_DMk_2D;
+    
 	friend class RPA_LRI<Tdata>;
+    friend class Exx_LRI_Interface<Tdata>;
 };
 
 #include "Exx_LRI.hpp"

--- a/source/module_ri/Exx_LRI.h
+++ b/source/module_ri/Exx_LRI.h
@@ -51,9 +51,6 @@ public:
 	ModuleBase::matrix force_exx;
 	ModuleBase::matrix stress_exx;
 
-	void write_Hexxs(const std::string &file_name) const;
-	void read_Hexxs(const std::string &file_name);
-
 private:
 	const Exx_Info::Exx_Info_RI &info;
     MPI_Comm mpi_comm;

--- a/source/module_ri/Exx_LRI.hpp
+++ b/source/module_ri/Exx_LRI.hpp
@@ -161,7 +161,7 @@ void Exx_LRI<Tdata>::cal_exx_ions()
 }
 
 template<typename Tdata>
-void Exx_LRI<Tdata>::cal_exx_elec(const Mix_DMk_2D &mix_DMk_2D, const Parallel_Orbitals &pv)
+void Exx_LRI<Tdata>::cal_exx_elec(const Parallel_Orbitals &pv)
 {
 	ModuleBase::TITLE("Exx_LRI","cal_exx_elec");
 	ModuleBase::timer::tick("Exx_LRI", "cal_exx_elec");
@@ -170,8 +170,8 @@ void Exx_LRI<Tdata>::cal_exx_elec(const Mix_DMk_2D &mix_DMk_2D, const Parallel_O
 
 	std::vector<std::map<TA,std::map<TAC,RI::Tensor<Tdata>>>> Ds =
 		GlobalV::GAMMA_ONLY_LOCAL
-		? RI_2D_Comm::split_m2D_ktoR<Tdata>(*p_kv, mix_DMk_2D.get_DMk_gamma_out(), pv)
-		: RI_2D_Comm::split_m2D_ktoR<Tdata>(*p_kv, mix_DMk_2D.get_DMk_k_out(), pv);
+		? RI_2D_Comm::split_m2D_ktoR<Tdata>(*p_kv, this->mix_DMk_2D.get_DMk_gamma_out(), pv)
+		: RI_2D_Comm::split_m2D_ktoR<Tdata>(*p_kv, this->mix_DMk_2D.get_DMk_k_out(), pv);
 
 	this->exx_lri.set_csm_threshold(this->info.cauchy_threshold);
 

--- a/source/module_ri/Exx_LRI.hpp
+++ b/source/module_ri/Exx_LRI.hpp
@@ -283,26 +283,5 @@ void Exx_LRI<Tdata>::cal_exx_stress()
 	ModuleBase::timer::tick("Exx_LRI", "cal_exx_stress");
 }
 
-template<typename Tdata>
-void Exx_LRI<Tdata>::write_Hexxs(const std::string &file_name) const
-{
-	ModuleBase::TITLE("Exx_LRI","write_Hexxs");
-	ModuleBase::timer::tick("Exx_LRI", "write_Hexxs");
-	std::ofstream ofs(file_name, std::ofstream::binary);
-	cereal::BinaryOutputArchive oar(ofs);
-	oar(this->Hexxs);
-	ModuleBase::timer::tick("Exx_LRI", "write_Hexxs");
-}
-
-template<typename Tdata>
-void Exx_LRI<Tdata>::read_Hexxs(const std::string &file_name)
-{
-	ModuleBase::TITLE("Exx_LRI","read_Hexxs");
-	ModuleBase::timer::tick("Exx_LRI", "read_Hexxs");
-	std::ifstream ifs(file_name, std::ofstream::binary);
-	cereal::BinaryInputArchive iar(ifs);
-	iar(this->Hexxs);
-	ModuleBase::timer::tick("Exx_LRI", "read_Hexxs");
-}
 
 #endif

--- a/source/module_ri/Exx_LRI_interface.h
+++ b/source/module_ri/Exx_LRI_interface.h
@@ -4,6 +4,7 @@
 
 class Local_Orbital_Charge;
 class LCAO_Matrix;
+class Charge_Mixing;
 namespace elecstate
 {
 class ElecState;
@@ -15,7 +16,7 @@ class Exx_LRI_Interface
 public:
     /// @brief  Constructor for Exx_LRI_Interface
     /// @param exx_lri
-    Exx_LRI_Interface(Exx_LRI<Tdata>* exx_lri) : exx_lri(exx_lri) {}
+    Exx_LRI_Interface(std::shared_ptr<Exx_LRI<Tdata>> exx_lri) : exx_lri(exx_lri) {}
     Exx_LRI_Interface() = delete;
 
     void write_Hexxs(const std::string &file_name) const;
@@ -28,7 +29,7 @@ public:
 
     // Processes in ESolver_KS_LCAO
     /// @brief in beforescf: set xc type, opt_orb, do DM mixing
-    void exx_beforescf(const K_Vectors& kv);
+    void exx_beforescf(const K_Vectors& kv, const Charge_Mixing& chgmix);
 
     /// @brief in eachiterinit:  do DM mixing and calculate Hexx when entering 2nd SCF
     void exx_eachiterinit(const Local_Orbital_Charge& loc, const Charge_Mixing& chgmix, const int& iter);
@@ -45,6 +46,6 @@ public:
         int& iter);
     
 private:
-    Exx_LRI<Tdata>* exx_lri;
+    std::shared_ptr<Exx_LRI<Tdata>> exx_lri;
 };
 #include "Exx_LRI_interface.hpp"

--- a/source/module_ri/Exx_LRI_interface.h
+++ b/source/module_ri/Exx_LRI_interface.h
@@ -15,6 +15,9 @@ public:
     Exx_LRI_Interface(Exx_LRI<Tdata>& exx_lri) : exx_lri(&exx_lri) {}
     Exx_LRI_Interface() = delete;
 
+    void write_Hexxs(const std::string &file_name) const;
+	void read_Hexxs(const std::string &file_name);
+
     // Processes in ESolver_KS_LCAO
     /// @brief in beforescf: set xc type, opt_orb, do DM mixing
     void exx_beforescf(const K_Vectors& kv);

--- a/source/module_ri/Exx_LRI_interface.h
+++ b/source/module_ri/Exx_LRI_interface.h
@@ -1,0 +1,39 @@
+#pragma once
+#include "Exx_LRI.h"
+#include "module_elecstate/elecstate.h"
+#include "module_hamilt_lcao/hamilt_lcaodft/local_orbital_charge.h"
+#include "module_hamilt_lcao/hamilt_lcaodft/local_orbital_wfc.h"
+#include "module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h"
+#include <memory>
+
+template<typename Tdata>
+class Exx_LRI_Interface
+{
+public:
+    /// @brief  Constructor for Exx_LRI_Interface
+    /// @param exx_lri
+    Exx_LRI_Interface(Exx_LRI<Tdata>& exx_lri) : exx_lri(&exx_lri) {}
+    Exx_LRI_Interface() = delete;
+
+    // Processes in ESolver_KS_LCAO
+    /// @brief in beforescf: set xc type, opt_orb, do DM mixing
+    void exx_beforescf(const K_Vectors& kv);
+
+        /// @brief in eachiterinit:  do DM mixing and calculate Hexx when entering 2nd SCF
+    void exx_eachiterinit(const Local_Orbital_Charge& loc, const Charge_Mixing& chgmix, const int& iter);
+
+    /// @brief in hamilt2density: calcate Hexx and Eexx
+    void exx_hamilt2density(elecstate::ElecState& elec, const Parallel_Orbitals& pv);
+
+    /// @brief: in do_after_converge: add exx operators; do DM mixing if seperate loop
+    bool exx_after_converge(
+        hamilt::Hamilt<double>& hamilt,
+        LCAO_Matrix& lm,
+        const Local_Orbital_Charge& loc,
+        const K_Vectors& kv,
+        int& iter);
+    
+private:
+    Exx_LRI<Tdata>* exx_lri;
+};
+#include "Exx_LRI_interface.hpp"

--- a/source/module_ri/Exx_LRI_interface.h
+++ b/source/module_ri/Exx_LRI_interface.h
@@ -15,22 +15,22 @@ class Exx_LRI_Interface
 public:
     /// @brief  Constructor for Exx_LRI_Interface
     /// @param exx_lri
-    Exx_LRI_Interface(Exx_LRI<Tdata>& exx_lri) : exx_lri(&exx_lri) {}
+    Exx_LRI_Interface(Exx_LRI<Tdata>* exx_lri) : exx_lri(exx_lri) {}
     Exx_LRI_Interface() = delete;
 
     void write_Hexxs(const std::string &file_name) const;
     void read_Hexxs(const std::string& file_name);
     
     using TAC = std::pair<int, std::array<int, 3>>;
-    std::vector< std::map<int, std::map<TAC, RI::Tensor<Tdata>>>>& get_Hexxs() { return this->exx_lri->Hexxs; }
+    std::vector< std::map<int, std::map<TAC, RI::Tensor<Tdata>>>>& get_Hexxs() const { return this->exx_lri->Hexxs; }
     
-    Tdata& get_Eexx() const { return &this->exx_lri->Eexx; }
+    Tdata& get_Eexx() const { return this->exx_lri->Eexx; }
 
     // Processes in ESolver_KS_LCAO
     /// @brief in beforescf: set xc type, opt_orb, do DM mixing
     void exx_beforescf(const K_Vectors& kv);
 
-        /// @brief in eachiterinit:  do DM mixing and calculate Hexx when entering 2nd SCF
+    /// @brief in eachiterinit:  do DM mixing and calculate Hexx when entering 2nd SCF
     void exx_eachiterinit(const Local_Orbital_Charge& loc, const Charge_Mixing& chgmix, const int& iter);
 
     /// @brief in hamilt2density: calcate Hexx and Eexx

--- a/source/module_ri/Exx_LRI_interface.h
+++ b/source/module_ri/Exx_LRI_interface.h
@@ -1,10 +1,13 @@
 #pragma once
 #include "Exx_LRI.h"
-#include "module_elecstate/elecstate.h"
-#include "module_hamilt_lcao/hamilt_lcaodft/local_orbital_charge.h"
-#include "module_hamilt_lcao/hamilt_lcaodft/local_orbital_wfc.h"
-#include "module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h"
 #include <memory>
+
+class Local_Orbital_Charge;
+class LCAO_Matrix;
+namespace elecstate
+{
+class ElecState;
+}
 
 template<typename Tdata>
 class Exx_LRI_Interface
@@ -16,7 +19,12 @@ public:
     Exx_LRI_Interface() = delete;
 
     void write_Hexxs(const std::string &file_name) const;
-	void read_Hexxs(const std::string &file_name);
+    void read_Hexxs(const std::string& file_name);
+    
+    using TAC = std::pair<int, std::array<int, 3>>;
+    std::vector< std::map<int, std::map<TAC, RI::Tensor<Tdata>>>>& get_Hexxs() { return this->exx_lri->Hexxs; }
+    
+    Tdata& get_Eexx() const { return &this->exx_lri->Eexx; }
 
     // Processes in ESolver_KS_LCAO
     /// @brief in beforescf: set xc type, opt_orb, do DM mixing

--- a/source/module_ri/Exx_LRI_interface.hpp
+++ b/source/module_ri/Exx_LRI_interface.hpp
@@ -110,7 +110,7 @@ void Exx_LRI_Interface<Tdata>::exx_hamilt2density(elecstate::ElecState& elec, co
     {
         // add exx
         // Peize Lin add 2016-12-03
-        elec.set_exx();
+        elec.set_exx(this->get_Eexx());
 
         if (GlobalC::restart.info_load.load_H && GlobalC::restart.info_load.load_H_finish
             && !GlobalC::restart.info_load.restart_exx)

--- a/source/module_ri/Exx_LRI_interface.hpp
+++ b/source/module_ri/Exx_LRI_interface.hpp
@@ -4,7 +4,27 @@
 #include "module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/op_exx_lcao.h"
 
+template<typename Tdata>
+void Exx_LRI_Interface<Tdata>::write_Hexxs(const std::string &file_name) const
+{
+	ModuleBase::TITLE("Exx_LRI","write_Hexxs");
+	ModuleBase::timer::tick("Exx_LRI", "write_Hexxs");
+	std::ofstream ofs(file_name, std::ofstream::binary);
+	cereal::BinaryOutputArchive oar(ofs);
+	oar(exx_lri->Hexxs);
+	ModuleBase::timer::tick("Exx_LRI", "write_Hexxs");
+}
 
+template<typename Tdata>
+void Exx_LRI_Interface<Tdata>::read_Hexxs(const std::string &file_name)
+{
+	ModuleBase::TITLE("Exx_LRI","read_Hexxs");
+	ModuleBase::timer::tick("Exx_LRI", "read_Hexxs");
+	std::ifstream ifs(file_name, std::ofstream::binary);
+	cereal::BinaryInputArchive iar(ifs);
+	iar(exx_lri->Hexxs);
+	ModuleBase::timer::tick("Exx_LRI", "read_Hexxs");
+}
 template<typename Tdata>
 void Exx_LRI_Interface<Tdata>::exx_beforescf(const K_Vectors& kv)
 {

--- a/source/module_ri/Exx_LRI_interface.hpp
+++ b/source/module_ri/Exx_LRI_interface.hpp
@@ -26,7 +26,7 @@ void Exx_LRI_Interface<Tdata>::read_Hexxs(const std::string &file_name)
 	ModuleBase::timer::tick("Exx_LRI", "read_Hexxs");
 }
 template<typename Tdata>
-void Exx_LRI_Interface<Tdata>::exx_beforescf(const K_Vectors& kv)
+void Exx_LRI_Interface<Tdata>::exx_beforescf(const K_Vectors& kv, const Charge_Mixing& chgmix)
 {
 #ifdef __MPI
 		if ( GlobalC::exx_info.info_global.cal_exx )
@@ -66,13 +66,13 @@ void Exx_LRI_Interface<Tdata>::exx_beforescf(const K_Vectors& kv)
 			}
 			else
 			{
-				if(GlobalC::CHR_MIX.get_mixing_mode() == "plain")
+				if(chgmix.get_mixing_mode() == "plain")
 					exx_lri->mix_DMk_2D.set_mixing_mode(Mixing_Mode::Plain);
-				else if(GlobalC::CHR_MIX.get_mixing_mode() == "pulay")
+				else if(chgmix.get_mixing_mode() == "pulay")
 					exx_lri->mix_DMk_2D.set_mixing_mode(Mixing_Mode::Pulay);
 				else
 					throw std::invalid_argument(
-						"mixing_mode = " + GlobalC::CHR_MIX.get_mixing_mode() + ", mix_DMk_2D unsupported.\n"
+						"mixing_mode = " + chgmix.get_mixing_mode() + ", mix_DMk_2D unsupported.\n"
 						+ std::string(__FILE__) + " line " + std::to_string(__LINE__));
             }
         }

--- a/source/module_ri/Exx_LRI_interface.hpp
+++ b/source/module_ri/Exx_LRI_interface.hpp
@@ -1,0 +1,199 @@
+#include "Exx_LRI_interface.h"
+#include "module_ri/exx_abfs-jle.h"
+#include "module_ri/exx_opt_orb.h"
+#include "module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h"
+#include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/op_exx_lcao.h"
+
+
+template<typename Tdata>
+void Exx_LRI_Interface<Tdata>::exx_beforescf(const K_Vectors& kv)
+{
+#ifdef __MPI
+		if ( GlobalC::exx_info.info_global.cal_exx )
+		{
+            if (GlobalC::ucell.atoms[0].ncpp.xc_func == "HSE" || GlobalC::ucell.atoms[0].ncpp.xc_func == "PBE0")
+            {
+                XC_Functional::set_xc_type("pbe");
+            }
+            else if (GlobalC::ucell.atoms[0].ncpp.xc_func == "SCAN0")
+            {
+                XC_Functional::set_xc_type("scan");
+            }
+
+			exx_lri->cal_exx_ions();
+		}
+
+		if (Exx_Abfs::Jle::generate_matrix)
+		{
+			//program should be stopped after this judgement
+			Exx_Opt_Orb exx_opt_orb;
+			exx_opt_orb.generate_matrix(kv);
+			ModuleBase::timer::tick("ESolver_KS_LCAO", "beforescf");
+			return;
+		}
+		
+		// set initial parameter for mix_DMk_2D
+		if(GlobalC::exx_info.info_global.cal_exx)
+		{
+			exx_lri->mix_DMk_2D.set_nks(kv.nks, GlobalV::GAMMA_ONLY_LOCAL);
+			if(GlobalC::exx_info.info_global.separate_loop)
+			{
+				if(GlobalC::exx_info.info_global.mixing_beta_for_loop1==1.0)
+					exx_lri->mix_DMk_2D.set_mixing_mode(Mixing_Mode::No);
+				else
+					exx_lri->mix_DMk_2D.set_mixing_mode(Mixing_Mode::Plain)
+					                .set_mixing_beta(GlobalC::exx_info.info_global.mixing_beta_for_loop1);
+			}
+			else
+			{
+				if(GlobalC::CHR_MIX.get_mixing_mode() == "plain")
+					exx_lri->mix_DMk_2D.set_mixing_mode(Mixing_Mode::Plain);
+				else if(GlobalC::CHR_MIX.get_mixing_mode() == "pulay")
+					exx_lri->mix_DMk_2D.set_mixing_mode(Mixing_Mode::Pulay);
+				else
+					throw std::invalid_argument(
+						"mixing_mode = " + GlobalC::CHR_MIX.get_mixing_mode() + ", mix_DMk_2D unsupported.\n"
+						+ std::string(__FILE__) + " line " + std::to_string(__LINE__));
+            }
+        }
+        // for exx two_level scf
+        exx_lri->two_level_step = 0;
+#endif // __MPI
+}
+
+template<typename Tdata>
+void Exx_LRI_Interface<Tdata>::exx_eachiterinit(const Local_Orbital_Charge& loc, const Charge_Mixing& chgmix, const int& iter)
+{
+    if (GlobalC::exx_info.info_global.cal_exx)
+    {
+        if (!GlobalC::exx_info.info_global.separate_loop && exx_lri->two_level_step)
+        {
+			exx_lri->mix_DMk_2D.set_mixing_beta(chgmix.get_mixing_beta());
+			if(chgmix.get_mixing_mode() == "pulay")
+				exx_lri->mix_DMk_2D.set_coef_pulay(iter, chgmix);
+			const bool flag_restart = (iter==1) ? true : false;
+			if(GlobalV::GAMMA_ONLY_LOCAL)
+				exx_lri->mix_DMk_2D.mix(loc.dm_gamma, flag_restart);
+			else
+				exx_lri->mix_DMk_2D.mix(loc.dm_k, flag_restart);
+
+            exx_lri->cal_exx_elec(*loc.LOWF->ParaV);
+        }
+    }
+}
+
+template<typename Tdata>
+void Exx_LRI_Interface<Tdata>::exx_hamilt2density(elecstate::ElecState& elec, const Parallel_Orbitals& pv)
+{
+    // Peize Lin add 2020.04.04
+    if (XC_Functional::get_func_type() == 4 || XC_Functional::get_func_type() == 5)
+    {
+        // add exx
+        // Peize Lin add 2016-12-03
+        elec.set_exx();
+
+        if (GlobalC::restart.info_load.load_H && GlobalC::restart.info_load.load_H_finish
+            && !GlobalC::restart.info_load.restart_exx)
+        {
+            XC_Functional::set_xc_type(GlobalC::ucell.atoms[0].ncpp.xc_func);
+
+            exx_lri->cal_exx_elec(pv);
+            GlobalC::restart.info_load.restart_exx = true;
+        }
+    }
+    else
+    {
+        elec.f_en.exx = 0.;
+    }
+}
+
+template<typename Tdata>
+bool Exx_LRI_Interface<Tdata>::exx_after_converge(
+    hamilt::Hamilt<double>& hamilt,
+    LCAO_Matrix& lm,
+    const Local_Orbital_Charge& loc,
+    const K_Vectors& kv,
+    int& iter)
+{
+    // Add EXX operator
+    auto add_exx_operator = [&]() {
+        if (GlobalV::GAMMA_ONLY_LOCAL)
+        {
+            hamilt::Operator<double>* exx
+                = new hamilt::OperatorEXX<hamilt::OperatorLCAO<double>>(&lm,
+                                                                        nullptr, // no explicit call yet
+                                                                        &(lm.Hloc),
+                                                                        kv);
+            hamilt.opsd->add(exx);
+        }
+        else
+        {
+            hamilt::Operator<std::complex<double>>* exx
+                = new hamilt::OperatorEXX<hamilt::OperatorLCAO<std::complex<double>>>(&lm,
+                                                                                      nullptr, // no explicit call yet
+                                                                                      &(lm.Hloc2),
+                                                                                      kv);
+            hamilt.ops->add(exx);
+        }
+    };
+    
+    if (GlobalC::exx_info.info_global.cal_exx)
+    {
+        // no separate_loop case
+        if (!GlobalC::exx_info.info_global.separate_loop)
+        {
+            GlobalC::exx_info.info_global.hybrid_step = 1;
+
+            // in no_separate_loop case, scf loop only did twice
+            // in first scf loop, exx updated once in beginning,
+            // in second scf loop, exx updated every iter
+
+            if (exx_lri->two_level_step)
+            {
+                return true;
+            }
+            else
+            {
+                // update exx and redo scf
+                XC_Functional::set_xc_type(GlobalC::ucell.atoms[0].ncpp.xc_func);
+                iter = 0;
+                std::cout << " Entering 2nd SCF, where EXX is updated" << std::endl;
+                exx_lri->two_level_step++;
+
+                add_exx_operator();
+
+                return false;
+            }
+        }
+        // has separate_loop case
+        // exx converged or get max exx steps
+        else if (exx_lri->two_level_step == GlobalC::exx_info.info_global.hybrid_step
+                 || (iter == 1 && exx_lri->two_level_step != 0))
+        {
+            return true;
+        }
+        else
+        {
+            // update exx and redo scf
+            if (exx_lri->two_level_step == 0)
+            {
+                add_exx_operator();
+                XC_Functional::set_xc_type(GlobalC::ucell.atoms[0].ncpp.xc_func);
+            }
+
+			const bool flag_restart = (exx_lri->two_level_step==0) ? true : false;
+			if (GlobalV::GAMMA_ONLY_LOCAL)
+				exx_lri->mix_DMk_2D.mix(loc.dm_gamma, flag_restart);
+			else
+				exx_lri->mix_DMk_2D.mix(loc.dm_k, flag_restart);
+
+            // GlobalC::exx_lcao.cal_exx_elec(p_esolver->LOC, p_esolver->LOWF.wfc_k_grid);
+            exx_lri->cal_exx_elec(*loc.LOWF->ParaV);
+            iter = 0;
+            std::cout << " Updating EXX and rerun SCF" << std::endl;
+            exx_lri->two_level_step++;
+            return false;
+        }
+    }
+    return true;
+}

--- a/source/module_ri/RI_2D_Comm.h
+++ b/source/module_ri/RI_2D_Comm.h
@@ -42,7 +42,6 @@ namespace RI_2D_Comm
 		const int ik,
 		const double alpha,
 		const std::vector<std::map<TA,std::map<TAC,RI::Tensor<Tdata>>>> &Hs,
-		const Parallel_Orbitals &pv,
 		LCAO_Matrix &lm);
 
 	template<typename Tdata>

--- a/source/module_ri/RI_2D_Comm.hpp
+++ b/source/module_ri/RI_2D_Comm.hpp
@@ -88,11 +88,12 @@ void RI_2D_Comm::add_Hexx(
 	const int ik,
 	const double alpha,
 	const std::vector<std::map<TA,std::map<TAC,RI::Tensor<Tdata>>>> &Hs,
-	const Parallel_Orbitals &pv,
 	LCAO_Matrix &lm)
 {
 	ModuleBase::TITLE("RI_2D_Comm","add_Hexx");
 	ModuleBase::timer::tick("RI_2D_Comm", "add_Hexx");
+  
+    const Parallel_Orbitals& pv = *lm.ParaV;
 
 	const std::map<int, std::vector<int>> is_list = {{1,{0}}, {2,{kv.isk[ik]}}, {4,{0,1,2,3}}};
 	for(const int is_b : is_list.at(GlobalV::NSPIN))

--- a/source/module_ri/RPA_LRI.h
+++ b/source/module_ri/RPA_LRI.h
@@ -6,6 +6,7 @@
 #ifndef RPA_LRI_H
 #define RPA_LRI_H
 
+#include "module_esolver/esolver_ks_lcao.h"
 #include "LRI_CV.h"
 // #include "module_xc/exx_info.h"
 // #include "module_basis/module_ao/ORB_atomic_lm.h"
@@ -39,9 +40,9 @@ template <typename Tdata> class RPA_LRI
     ~RPA_LRI(){};
     void init(const MPI_Comm &mpi_comm_in, const K_Vectors &kv_in);
     void cal_rpa_cv();
-    void cal_postSCF_exx(const MPI_Comm& mpi_comm_in,
+    void cal_postSCF_exx(const Local_Orbital_Charge& loc,
+                    const MPI_Comm& mpi_comm_in,
                     const K_Vectors& kv,
-                    const Mix_DMk_2D &mix_DMk_2D,
                     const Parallel_Orbitals& pv);
     void out_for_RPA(const Parallel_Orbitals& parav,
                      const psi::Psi<std::complex<double>> &psi,

--- a/source/module_ri/RPA_LRI.hpp
+++ b/source/module_ri/RPA_LRI.hpp
@@ -60,15 +60,19 @@ template <typename Tdata> void RPA_LRI<Tdata>::cal_rpa_cv()
 }
 
 template <typename Tdata>
-void RPA_LRI<Tdata>::cal_postSCF_exx(
+void RPA_LRI<Tdata>::cal_postSCF_exx(const Local_Orbital_Charge& loc,
                 const MPI_Comm& mpi_comm_in,
                 const K_Vectors& kv,
-				const Mix_DMk_2D &mix_DMk_2D,
                 const Parallel_Orbitals& pv)
 {
+    exx_lri_rpa.mix_DMk_2D.set_mixing_mode(Mixing_Mode::No);
+    if(GlobalV::GAMMA_ONLY_LOCAL)
+        exx_lri_rpa.mix_DMk_2D.mix(loc.dm_gamma, true);
+    else
+        exx_lri_rpa.mix_DMk_2D.mix(loc.dm_k, true);
     exx_lri_rpa.init(mpi_comm_in, kv);
     exx_lri_rpa.cal_exx_ions();
-    exx_lri_rpa.cal_exx_elec(mix_DMk_2D, pv);
+    exx_lri_rpa.cal_exx_elec(pv);
     // cout<<"postSCF_Eexx: "<<exx_lri_rpa.Eexx<<endl;
 }
 

--- a/source/module_ri/exx_abfs-construct_orbs.cpp
+++ b/source/module_ri/exx_abfs-construct_orbs.cpp
@@ -7,6 +7,7 @@
 
 #include "module_ri/test_code/exx_abfs-construct_orbs-test.h"		// Peize Lin test
 #include "module_hamilt_lcao/hamilt_lcaodft/global_fp.h"
+#include "module_hamilt_pw/hamilt_pwdft/global.h"   //for ucell
 
 std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_Orbs::change_orbs(
 	const LCAO_Orbitals &orbs_in,


### PR DESCRIPTION
fix #2512 
- move some EXX-process from `ESolver_KS_LCAO` to the new class `Exx_LRI_Interface`
- remove `GlobalC::exx_lri_double/complex` as a member of ESolver_KS_LCAO