### PR TITLE
Tests: update result.ref due to the change of iweight function

### DIFF
--- a/tests/integrate/108_PW_RE/result.ref
+++ b/tests/integrate/108_PW_RE/result.ref
@@ -1,5 +1,5 @@
-etotref -211.5049348099904023
-etotperatomref -105.7524674050
-totalforceref 5.333658
-totalstressref 831.299650
-totaltimeref +0.89985
+etotref -211.6098046542826410
+etotperatomref -105.8049023271
+totalforceref 11.823856
+totalstressref 941.983060
+totaltimeref +0.87209

--- a/tests/integrate/120_PW_KP_MD_MSST/INPUT
+++ b/tests/integrate/120_PW_KP_MD_MSST/INPUT
@@ -14,6 +14,9 @@ scf_nmax			20
 basis_type		pw
 md_nstep           3
 
+smearing_method    gauss
+smearing_sigma     0.001
+
 cal_stress          1
 cal_force           1
 

--- a/tests/integrate/120_PW_KP_MD_MSST/result.ref
+++ b/tests/integrate/120_PW_KP_MD_MSST/result.ref
@@ -1,5 +1,5 @@
-etotref -250.4498774389878
-etotperatomref -125.2249387195
+etotref -250.4498774406744
+etotperatomref -125.2249387203
 totalforceref 7.138076
 totalstressref 322.546126
-totaltimeref +6.8592
+totaltimeref +6.5181

--- a/tests/integrate/120_PW_KP_MD_MSST_level2/INPUT
+++ b/tests/integrate/120_PW_KP_MD_MSST_level2/INPUT
@@ -12,6 +12,8 @@ basis_type      pw
 ks_solver       cg
 mixing_type     pulay
 mixing_beta     0.7
+smearing_method    gauss
+smearing_sigma     0.001
 
 cal_stress          1
 cal_force           1

--- a/tests/integrate/120_PW_KP_MD_MSST_level2/result.ref
+++ b/tests/integrate/120_PW_KP_MD_MSST_level2/result.ref
@@ -1,5 +1,5 @@
-etotref -209.0846269623494
+etotref -209.084626962348
 etotperatomref -104.5423134812
-totalforceref 0.015192
-totalstressref 60.108457
-totaltimeref +5.8338
+totalforceref 0.015190
+totalstressref 60.108455
+totaltimeref +6.1345

--- a/tests/integrate/208_NO_KP_CF_RE/result.ref
+++ b/tests/integrate/208_NO_KP_CF_RE/result.ref
@@ -1,5 +1,5 @@
-etotref -211.3956909660458336
-etotperatomref -105.6978454830
-totalforceref 5.243616
-totalstressref 828.586131
-totaltimeref +4.06753
+etotref -211.5085148058214202
+etotperatomref -105.7542574029
+totalforceref 11.695086
+totalstressref 709.316832
+totaltimeref +8.07383

--- a/tests/integrate/220_NO_KP_MD_MSST/INPUT
+++ b/tests/integrate/220_NO_KP_MD_MSST/INPUT
@@ -21,6 +21,8 @@ cal_force           1
 ks_solver       scalapack_gvx
 mixing_type     pulay
 mixing_beta     0.7
+smearing_method    gauss
+smearing_sigma     0.001
 
 md_type          msst
 md_tfirst        10

--- a/tests/integrate/220_NO_KP_MD_MSST/result.ref
+++ b/tests/integrate/220_NO_KP_MD_MSST/result.ref
@@ -1,5 +1,5 @@
-etotref -208.9490070804092
-etotperatomref -104.4745035402
-totalforceref 0.377012
+etotref -208.9490070792915
+etotperatomref -104.4745035396
+totalforceref 0.377008
 totalstressref 58.232661
-totaltimeref +2.1515
+totaltimeref +3.9513


### PR DESCRIPTION
update result.ref of related integrated tests caused by the iweight function, see #2463 in detail.