### PR TITLE
Refactor: move cal_nelec from class Charge to UnitCell

### DIFF
--- a/source/module_cell/test/unitcell_test_readpp.cpp
+++ b/source/module_cell/test/unitcell_test_readpp.cpp
@@ -75,6 +75,8 @@ Magnetism::~Magnetism()
  *     - read_pseudo(): All DFT functional must consistent.
  *   - ReadPseudoWarning2
  *     - read_pseudo(): number valence electrons > corresponding minimum possible of an element
+ *   - CalNelec: UnitCell::cal_nelec
+ *     - calculate the total number of valence electrons from psp files
  */
 
 //mock function
@@ -352,6 +354,18 @@ TEST_F(UcellDeathTest,ReadPseudoWarning2)
 	EXPECT_NO_THROW(ucell->read_pseudo(ofs));
 	output = testing::internal::GetCapturedStdout();
 	EXPECT_THAT(output,testing::HasSubstr("Warning: the number of valence electrons in pseudopotential > 3 for Al: [Ne] 3s2 3p1"));
+}
+
+TEST_F(UcellTest, CalNelec)
+{
+    ucell->read_cell_pseudopots(pp_dir, ofs);
+    EXPECT_EQ(4,ucell->atoms[0].ncpp.zv);
+    EXPECT_EQ(1,ucell->atoms[1].ncpp.zv);
+    EXPECT_EQ(1,ucell->atoms[0].na);
+    EXPECT_EQ(2,ucell->atoms[1].na);
+    double nelec = 0;
+    ucell->cal_nelec(nelec);
+    EXPECT_DOUBLE_EQ(6,nelec);
 }
 
 #ifdef __MPI

--- a/source/module_cell/unitcell.cpp
+++ b/source/module_cell/unitcell.cpp
@@ -1527,3 +1527,26 @@ void UnitCell::remake_cell()
 		ModuleBase::WARNING_QUIT("UnitCell::read_atom_species","latname not supported!");
 	}
 }
+
+void UnitCell::cal_nelec(double& nelec)
+{
+    ModuleBase::TITLE("UnitCell", "cal_nelec");
+    GlobalV::ofs_running << "\n SETUP THE ELECTRONS NUMBER" << std::endl;
+
+    if (nelec == 0)
+    {
+        for (int it = 0; it < this->ntype; it++)
+        {
+            std::stringstream ss1, ss2;
+            ss1 << "electron number of element " << this->atoms[it].label;
+            const int nelec_it = this->atoms[it].ncpp.zv * this->atoms[it].na;
+            nelec += nelec_it;
+            ss2 << "total electron number of element " << this->atoms[it].label;
+
+            ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, ss1.str(), this->atoms[it].ncpp.zv);
+            ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, ss2.str(), nelec_it);
+        }
+        ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "AUTOSET number of electrons: ", nelec);
+    }
+    return;
+}

--- a/source/module_cell/unitcell.h
+++ b/source/module_cell/unitcell.h
@@ -248,6 +248,9 @@ public:
 			const std::string &fixed_axes_in);
 
 	void check_structure(double factor);
+
+    /// @brief calculate the total number of electrons in system (GlobalV::nelec)
+    void cal_nelec(double& nelec);
 };
 
 #endif //unitcell class

--- a/source/module_elecstate/module_charge/charge.cpp
+++ b/source/module_elecstate/module_charge/charge.cpp
@@ -664,36 +664,3 @@ void Charge::init_final_scf()
     this->allocate_rho_final_scf = true;
     return;
 }
-
-//=========================================================
-// calculate total number of electrons (GlobalV::nelec) and default
-// number of bands (GlobalV::NBANDS).
-//=========================================================
-//#include "module_elecstate/occupy.h"
-void Charge::cal_nelec(const UnitCell& ucell)
-{
-    ModuleBase::TITLE("UnitCell", "cal_nelec");
-    //=======================================================
-    // calculate the total number of electrons in the system
-    // if GlobalV::nelec <>0; use input number (setup.f90)
-    //=======================================================
-
-    GlobalV::ofs_running << "\n SETUP THE ELECTRONS NUMBER" << std::endl;
-
-    if (GlobalV::nelec == 0)
-    {
-        for (int it = 0; it < ucell.ntype; it++)
-        {
-            std::stringstream ss1, ss2;
-            ss1 << "electron number of element " << ucell.atoms[it].label;
-            const int nelec_it = ucell.atoms[it].ncpp.zv * ucell.atoms[it].na;
-            GlobalV::nelec += nelec_it;
-            ss2 << "total electron number of element " << ucell.atoms[it].label;
-
-            ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, ss1.str(), ucell.atoms[it].ncpp.zv);
-            ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, ss2.str(), nelec_it);
-        }
-        ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "AUTOSET number of electrons: ", GlobalV::nelec);
-    }
-    return;
-}

--- a/source/module_elecstate/module_charge/charge.h
+++ b/source/module_elecstate/module_charge/charge.h
@@ -62,8 +62,6 @@ class Charge
 
     void set_rho_core(const ModuleBase::ComplexMatrix &structure_factor);
 
-    void cal_nelec(const UnitCell& ucell); // calculate total number of electrons  Yu Liu add 2021-07-03
-
     void renormalize_rho(void);
 
     void save_rho_before_sum_band(void);

--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -79,7 +79,7 @@ namespace ModuleESolver
     void ESolver_KS<FPTYPE, Device>::Init(Input& inp, UnitCell& ucell)
     {
         ESolver_FP::Init(inp,ucell);
-        chr.cal_nelec(ucell);
+        ucell.cal_nelec(GlobalV::nelec);
 
         /* it has been established that that
          xc_func is same for all elements, therefore

--- a/source/module_esolver/esolver_of.cpp
+++ b/source/module_esolver/esolver_of.cpp
@@ -31,7 +31,7 @@ void ESolver_OF::Init(Input &inp, UnitCell &ucell)
     this->of_tolp = inp.of_tolp;
     this->maxIter = inp.scf_nmax;
 
-    chr.cal_nelec(ucell);
+    ucell.cal_nelec(GlobalV::nelec);
 
 	if(ucell.atoms[0].ncpp.xc_func=="HSE"||ucell.atoms[0].ncpp.xc_func=="PBE0")
 	{


### PR DESCRIPTION
Fix issues raised in PR #2527.

1. Move the function cal_nelec from class Charge to class UnitCell.
2. add a unit test for this function.