### PR TITLE
Refactor: use `rho`/`kin_r` rather than `Charge` in `Gint_inout` interface

### DIFF
--- a/source/module_elecstate/elecstate_lcao.cpp
+++ b/source/module_elecstate/elecstate_lcao.cpp
@@ -51,13 +51,13 @@ void ElecStateLCAO::psiToRho(const psi::Psi<std::complex<double>>& psi)
     //------------------------------------------------------------
 
     ModuleBase::GlobalFunc::NOTE("Calculate the charge on real space grid!");
-    Gint_inout inout(this->loc->DM_R, this->charge, Gint_Tools::job_type::rho);
+    Gint_inout inout(this->loc->DM_R, this->charge->rho, Gint_Tools::job_type::rho);
     this->uhm->GK.cal_gint(&inout);
 
     if (XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5)
     {
         ModuleBase::GlobalFunc::ZEROS(this->charge->kin_r[0], this->charge->nrxx);
-        Gint_inout inout1(this->loc->DM_R, this->charge, Gint_Tools::job_type::tau);
+        Gint_inout inout1(this->loc->DM_R, this->charge->kin_r, Gint_Tools::job_type::tau);
         this->uhm->GK.cal_gint(&inout1);
     }
 
@@ -107,7 +107,7 @@ void ElecStateLCAO::psiToRho(const psi::Psi<double>& psi)
     // calculate the charge density on real space grid.
     //------------------------------------------------------------
     ModuleBase::GlobalFunc::NOTE("Calculate the charge on real space grid!");
-    Gint_inout inout(this->loc->DM, this->charge, Gint_Tools::job_type::rho);
+    Gint_inout inout(this->loc->DM, this->charge->rho, Gint_Tools::job_type::rho);
     this->uhm->GG.cal_gint(&inout);
     if (XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5)
     {
@@ -115,7 +115,7 @@ void ElecStateLCAO::psiToRho(const psi::Psi<double>& psi)
         {
             ModuleBase::GlobalFunc::ZEROS(this->charge->kin_r[0], this->charge->nrxx);
         }
-        Gint_inout inout1(this->loc->DM, this->charge, Gint_Tools::job_type::tau);
+        Gint_inout inout1(this->loc->DM, this->charge->kin_r, Gint_Tools::job_type::tau);
         this->uhm->GG.cal_gint(&inout1);
     }
 

--- a/source/module_elecstate/elecstate_lcao_tddft.cpp
+++ b/source/module_elecstate/elecstate_lcao_tddft.cpp
@@ -48,7 +48,7 @@ void ElecStateLCAO_TDDFT::psiToRho_td(const psi::Psi<std::complex<double>>& psi)
     //------------------------------------------------------------
 
     ModuleBase::GlobalFunc::NOTE("Calculate the charge on real space grid!");
-    Gint_inout inout(this->loc->DM_R, this->charge, Gint_Tools::job_type::rho);
+    Gint_inout inout(this->loc->DM_R, this->charge->rho, Gint_Tools::job_type::rho);
     this->uhm->GK.cal_gint(&inout);
 
     this->charge->renormalize_rho();

--- a/source/module_esolver/esolver_ks_lcao_elec.cpp
+++ b/source/module_esolver/esolver_ks_lcao_elec.cpp
@@ -211,7 +211,7 @@ namespace ModuleESolver
             // calculate the charge density
             if (GlobalV::GAMMA_ONLY_LOCAL)
             {
-                Gint_inout inout(this->LOC.DM, pelec->charge, Gint_Tools::job_type::rho);
+                Gint_inout inout(this->LOC.DM, pelec->charge->rho, Gint_Tools::job_type::rho);
                 this->UHM.GG.cal_gint(&inout);
                 if (XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type()==5)
                 {
@@ -219,13 +219,13 @@ namespace ModuleESolver
                     {
                         ModuleBase::GlobalFunc::ZEROS(pelec->charge->kin_r[0], pw_rho->nrxx);
                     }
-                    Gint_inout inout1(this->LOC.DM, pelec->charge, Gint_Tools::job_type::tau);
+                    Gint_inout inout1(this->LOC.DM, pelec->charge->kin_r, Gint_Tools::job_type::tau);
                     this->UHM.GG.cal_gint(&inout1);
                 }
             }
             else
             {
-                Gint_inout inout(this->LOC.DM_R, pelec->charge, Gint_Tools::job_type::rho);
+                Gint_inout inout(this->LOC.DM_R, pelec->charge->rho, Gint_Tools::job_type::rho);
                 this->UHM.GK.cal_gint(&inout);
                 if (XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type()==5)
                 {
@@ -233,7 +233,7 @@ namespace ModuleESolver
                     {
                         ModuleBase::GlobalFunc::ZEROS(pelec->charge->kin_r[0], pw_rho->nrxx);
                     }
-                    Gint_inout inout1(this->LOC.DM_R, pelec->charge, Gint_Tools::job_type::tau);
+                    Gint_inout inout1(this->LOC.DM_R, pelec->charge->kin_r, Gint_Tools::job_type::tau);
                     this->UHM.GK.cal_gint(&inout1);
                 }
             }

--- a/source/module_hamilt_lcao/module_gint/gint_rho.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_rho.cpp
@@ -61,7 +61,7 @@ void Gint::gint_kernel_rho(
 		this->cal_meshball_rho(
 			na_grid, block_index,
 			vindex, psir_ylm.ptr_2D,
-			psir_DM.ptr_2D, inout->chr->rho[is]);
+			psir_DM.ptr_2D, inout->rho[is]);
 	}
 	delete[] block_iw;
 	delete[] block_index;

--- a/source/module_hamilt_lcao/module_gint/gint_tau.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_tau.cpp
@@ -106,7 +106,7 @@ void Gint::gint_kernel_tau(
 				vindex,
 				dpsir_ylm_x.ptr_2D, dpsir_ylm_y.ptr_2D, dpsir_ylm_z.ptr_2D,
 				dpsix_DM.ptr_2D, dpsiy_DM.ptr_2D, dpsiz_DM.ptr_2D,
-				inout->chr->kin_r[is]);
+				inout->rho[is]);
 		}
 	}
 

--- a/source/module_hamilt_lcao/module_gint/gint_tools.h
+++ b/source/module_hamilt_lcao/module_gint/gint_tools.h
@@ -31,17 +31,17 @@ class Gint_inout
 		LCAO_Matrix *lm;
 
     //output
-        Charge* chr;
+        double** rho;
         ModuleBase::matrix* fvl_dphi;
         ModuleBase::matrix* svl_dphi;
 
         Gint_Tools::job_type job;
 
-	// electron density, multi-k
-        Gint_inout(double **DM_R_in, Charge* chr_in, Gint_Tools::job_type job_in)
+	// electron density and kin_r, multi-k
+        Gint_inout(double **DM_R_in, double** rho_in, Gint_Tools::job_type job_in)
         {
             DM_R = DM_R_in;
-            chr = chr_in;
+            rho = rho_in;
             job = job_in;
         }
 
@@ -91,11 +91,11 @@ class Gint_inout
             job = job_in;
         }
 
-	// electron density, gamma point
-        Gint_inout(double ***DM_in, Charge* chr_in, Gint_Tools::job_type job_in)
+	// electron density and kin_r, gamma point
+        Gint_inout(double ***DM_in, double** rho_in, Gint_Tools::job_type job_in)
         {
             DM = DM_in;
-            chr = chr_in;
+            rho = rho_in;
             job = job_in;
         }
 

--- a/source/module_io/istate_charge.cpp
+++ b/source/module_io/istate_charge.cpp
@@ -137,7 +137,7 @@ void IState_Charge::begin(Gint_Gamma& gg,
 
             // (3) calculate charge density for a particular
             // band.
-            Gint_inout inout(this->loc->DM, pelec->charge, Gint_Tools::job_type::rho);
+            Gint_inout inout(this->loc->DM, pelec->charge->rho, Gint_Tools::job_type::rho);
             gg.cal_gint(&inout);
             pelec->charge->save_rho_before_sum_band(); // xiaohui add 2014-12-09
             std::stringstream ssc;

--- a/source/module_ri/Exx_LRI_interface.h
+++ b/source/module_ri/Exx_LRI_interface.h
@@ -34,7 +34,7 @@ public:
     /// @brief in eachiterinit:  do DM mixing and calculate Hexx when entering 2nd SCF
     void exx_eachiterinit(const Local_Orbital_Charge& loc, const Charge_Mixing& chgmix, const int& iter);
 
-    /// @brief in hamilt2density: calcate Hexx and Eexx
+    /// @brief in hamilt2density: calculate Hexx and Eexx
     void exx_hamilt2density(elecstate::ElecState& elec, const Parallel_Orbitals& pv);
 
     /// @brief: in do_after_converge: add exx operators; do DM mixing if seperate loop


### PR DESCRIPTION
In my future LR-TDDFT implementation(#2460), I will directly use `Gint::cal_gint` and`Gint_inout` interface by passing in my new "charge density" as an 2D array(double**), without using class `Charge`. That's why I do this refactor. 