### PR TITLE
Fix: optimized printing of start magnetization

### DIFF
--- a/examples/compensating_charge/Pt-slab/running_scf.ref
+++ b/examples/compensating_charge/Pt-slab/running_scf.ref
@@ -55,33 +55,6 @@
                       L=1, number of zeta = 1
                       L=2, number of zeta = 1
              number of atom for this type = 27
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
 
                         TOTAL ATOM NUMBER = 27
 

--- a/examples/dipole_correction/Pt-slab/running_scf.ref1
+++ b/examples/dipole_correction/Pt-slab/running_scf.ref1
@@ -56,33 +56,6 @@
                       L=1, number of zeta = 1
                       L=2, number of zeta = 1
              number of atom for this type = 27
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
 
                         TOTAL ATOM NUMBER = 27
 

--- a/examples/dipole_correction/Pt-slab/running_scf.ref2
+++ b/examples/dipole_correction/Pt-slab/running_scf.ref2
@@ -56,33 +56,6 @@
                       L=1, number of zeta = 1
                       L=2, number of zeta = 1
              number of atom for this type = 27
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
 
                         TOTAL ATOM NUMBER = 27
 

--- a/examples/electric_field/Pt-slab/running_scf.ref
+++ b/examples/electric_field/Pt-slab/running_scf.ref
@@ -56,33 +56,6 @@
                       L=1, number of zeta = 1
                       L=2, number of zeta = 1
              number of atom for this type = 27
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
-                      start magnetization = FALSE
 
                         TOTAL ATOM NUMBER = 27
 

--- a/examples/hse/lcao_Si2/running_scf.log_ref
+++ b/examples/hse/lcao_Si2/running_scf.log_ref
@@ -56,8 +56,6 @@
                       L=1, number of zeta = 2
                       L=2, number of zeta = 1
              number of atom for this type = 2
-                      start magnetization = FALSE
-                      start magnetization = FALSE
 
                         TOTAL ATOM NUMBER = 2
 

--- a/source/module_base/global_function.h
+++ b/source/module_base/global_function.h
@@ -49,9 +49,7 @@ void OUT(std::ofstream &ofs,const std::string &name,const T &a)
 template <class T>
 void OUT(std::ofstream &ofs,const std::string &name,const T &x, const T&y)
 {
-	std::stringstream name2;
-	name2 << "[" << name << "]";
-    ofs<< " " << std::setw(40) <<name2.str() << " = " << x << ", " << y << std::endl;
+    ofs<< " " << std::setw(40) <<name << " = [ " << x << ", " << y <<" ]" << std::endl;
 //	ofs << " " << name << a << std::endl;
     return;
 }
@@ -59,9 +57,7 @@ void OUT(std::ofstream &ofs,const std::string &name,const T &x, const T&y)
 template <class T>
 void OUT(std::ofstream &ofs,const std::string &name,const T &x, const T &y, const T &z)
 {
-	std::stringstream name2;
-	name2 << "[" << name << "]";
-    ofs<< " " << std::setw(40) <<name2.str() << " = " << x << ", " << y << ", " << z << std::endl;
+    ofs<< " " << std::setw(40) <<name << " = [ " << x << ", " << y << ", " << z <<" ]" << std::endl;
     return;
 }
 

--- a/source/module_base/test/global_function_test.cpp
+++ b/source/module_base/test/global_function_test.cpp
@@ -316,9 +316,9 @@ TEST_F(GlobalFunctionTest, OutV3)
     ofs.close();
     ifs.open("tmp");
     getline(ifs, output);
-    EXPECT_THAT(output, testing::HasSubstr("[grid] = 100, 125, 375"));
+    EXPECT_THAT(output, testing::HasSubstr("grid = [ 100, 125, 375 ]"));
     getline(ifs, output);
-    EXPECT_THAT(output, testing::HasSubstr("[direct] = 1.1, 2.2, 3.3"));
+    EXPECT_THAT(output, testing::HasSubstr("direct = [ 1.1, 2.2, 3.3 ]"));
     ifs.close();
 }
 // P for parameters

--- a/source/module_cell/read_atoms.cpp
+++ b/source/module_cell/read_atoms.cpp
@@ -654,19 +654,40 @@ bool UnitCell::read_atom_positions(std::ifstream &ifpos, std::ofstream &ofs_runn
 							atoms[it].m_loc_[ia].z = atoms[it].mag[ia];
 						}
 
-						ModuleBase::GlobalFunc::OUT(ofs_running, "noncollinear magnetization_x",atoms[it].m_loc_[ia].x);
-						ModuleBase::GlobalFunc::OUT(ofs_running, "noncollinear magnetization_y",atoms[it].m_loc_[ia].y);
-						ModuleBase::GlobalFunc::OUT(ofs_running, "noncollinear magnetization_z",atoms[it].m_loc_[ia].z);
+						//print only ia==0 && mag>0 to avoid too much output
+						//print when ia!=0 && mag[ia] != mag[0] to avoid too much output
+						if(ia==0 || (ia!=0 
+						    && (atoms[it].m_loc_[ia].x != atoms[it].m_loc_[0].x 
+					        || atoms[it].m_loc_[ia].y != atoms[it].m_loc_[0].y 
+					        || atoms[it].m_loc_[ia].z != atoms[it].m_loc_[0].z)))
+						{
+							//use a stringstream to generate string: "concollinear magnetization of element it is:"
+							std::stringstream ss;
+							ss << "magnetization of element " << it+1;
+							if(ia!=0) 
+							{
+								ss<<" (atom"<<ia+1<<")";
+							}
+							ModuleBase::GlobalFunc::OUT(ofs_running, ss.str(),atoms[it].m_loc_[ia].x, atoms[it].m_loc_[ia].y, atoms[it].m_loc_[ia].z);
+						}
 						ModuleBase::GlobalFunc::ZEROS(magnet.ux_ ,3);
 					}
 					else if(GlobalV::NSPIN==2)
 					{
 						atoms[it].m_loc_[ia].x = atoms[it].mag[ia];
-						ModuleBase::GlobalFunc::OUT(ofs_running, "start magnetization",atoms[it].mag[ia]);
-					}
-					else if(GlobalV::NSPIN==1)
-					{
-						ModuleBase::GlobalFunc::OUT(ofs_running, "start magnetization","FALSE");
+						//print only ia==0 && mag>0 to avoid too much output
+						//print when ia!=0 && mag[ia] != mag[0] to avoid too much output
+						if(ia==0 || (ia!=0 && atoms[it].mag[ia] != atoms[it].mag[0]))
+						{
+							//use a stringstream to generate string: "cocollinear magnetization of element it is:"
+							std::stringstream ss;
+							ss << "magnetization of element " << it+1;
+							if(ia!=0) 
+							{
+								ss<<" (atom"<<ia+1<<")";
+							}
+							ModuleBase::GlobalFunc::OUT(ofs_running, ss.str(),atoms[it].mag[ia]);
+						}
 					}
 
 			


### PR DESCRIPTION
1. Print starting magnetization of first atom of each element.
2. Print starting magnetization of other atoms which has different starting magnetization with first atom.
3. change OUT(ofs, name, values...) format from "[name] = value1, value2, value3" to "name = [ value1, value2, value3 ]"

Format of starting magnetization would be :
```
        magnetization of element 2 = [ 0, 0, 0 ]
magnetization of element 2 (atom2) = [ 0, 0, 1 ]
```
for NSPIN=4 case and 
```
        magnetization of element 1 = 1
magnetization of element 1 (atom2) = -1
```
for NSPIN=2 case.