### PR TITLE
Feature:  Add get_value and inner_most_ptr method for container

### DIFF
--- a/source/module_base/module_container/tensor.h
+++ b/source/module_base/module_container/tensor.h
@@ -100,7 +100,13 @@ class Tensor {
      */
     template <typename T>
     T* data() const {
-        if (!do_type_check<T>()) {
+        if ((std::is_same<T, float>::value && data_type_ != DataType::DT_FLOAT) ||
+            (std::is_same<T, int>::value && data_type_ != DataType::DT_INT) ||
+            (std::is_same<T, int64_t>::value && data_type_ != DataType::DT_INT64) ||
+            (std::is_same<T, double>::value && data_type_ != DataType::DT_DOUBLE) ||
+            (std::is_same<T, std::complex<float>>::value && data_type_ != DataType::DT_COMPLEX) ||
+            (std::is_same<T, std::complex<double>>::value && data_type_ != DataType::DT_COMPLEX_DOUBLE))
+        {
             std::cerr << "Tensor data type does not match requested type." << std::endl;
             exit(EXIT_FAILURE);
         }
@@ -300,9 +306,8 @@ class Tensor {
         if (index > shape_.dim_size(static_cast<int>(shape_.ndim() - 1))) {
             throw std::invalid_argument("Invalid index, index of the inner-most must less than the inner-most shape size!");
         }
-        do_type_check<T>();
 
-        return buffer_.base<T>() + index * shape_.dim_size(static_cast<int>(shape_.ndim()) - 1);
+        return data<T>() + index * shape_.dim_size(static_cast<int>(shape_.ndim()) - 1);
     }
 
 private:
@@ -331,30 +336,6 @@ private:
      * @brief The TensorBuffer object that holds the data of the tensor.
      */
     TensorBuffer buffer_;
-
-    /**
-     * @brief Performs a type check to verify if the given data type matches the tensor's data type.
-     *
-     * @tparam T The data type to check.
-     *
-     * @return True if the data type matches, false otherwise.
-     *
-     * @note This function compares the template parameter `T` with the data type of the tensor.
-     * If the data type does not match, an error message is printed and the program exits.
-     */
-    template <typename T>
-    bool do_type_check() const {
-        if ((std::is_same<T, float>::value && data_type_ != DataType::DT_FLOAT) ||
-            (std::is_same<T, int>::value && data_type_ != DataType::DT_INT) ||
-            (std::is_same<T, int64_t>::value && data_type_ != DataType::DT_INT64) ||
-            (std::is_same<T, double>::value && data_type_ != DataType::DT_DOUBLE) ||
-            (std::is_same<T, std::complex<float>>::value && data_type_ != DataType::DT_COMPLEX) ||
-            (std::is_same<T, std::complex<double>>::value && data_type_ != DataType::DT_COMPLEX_DOUBLE))
-        {
-            return false;
-        }
-        return true;
-    }
 
     /**
      * @brief Calculates the linear index corresponding to the given indices.

--- a/source/module_base/module_container/tests/tensor_test.cpp
+++ b/source/module_base/module_container/tests/tensor_test.cpp
@@ -194,6 +194,21 @@ TEST(Tensor, Reshape) {
     EXPECT_EQ(t1.shape(), new_shape1);
 }
 
+TEST(Tensor, GetValueAndInnerMostPtr) {
+    container::Tensor t(container::DataType::DT_INT, container::DeviceType::CpuDevice, {2, 2, 4});
+    std::vector<int> vec = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    EXPECT_EQ(t.shape().NumElements(), vec.size());
+    memcpy(t.data<int>(), vec.data(), sizeof(int) * vec.size());
+    EXPECT_EQ(t.get_value<int>(0, 0, 1), 2);
+    EXPECT_EQ(t.get_value<int>(1, 1, 2), 15);
+    t.reshape({4, 4});
+
+    // check the inner_most_ptr meshod
+    auto row_ptr = t.inner_most_ptr<int>(2);
+    EXPECT_EQ(row_ptr[0], 9);
+    EXPECT_EQ(row_ptr[3], 12);
+}
+
 TEST(Tensor, ReshapeDeathTest) {
     container::Tensor t(container::DataType::DT_FLOAT, container::DeviceType::CpuDevice, {2, 3, 4});
     container::TensorShape new_shape({-1, 8});


### PR DESCRIPTION
This PR add new data access methods for tensor object:

- `get_value` for accessing the specified item within tensor object;
- `inner_most_prt` for accessing the inner-most pointers.

```
    container::Tensor t(container::DataType::DT_INT, container::DeviceType::CpuDevice, {2, 2, 4});
    std::vector<int> vec = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
    EXPECT_EQ(t.shape().NumElements(), vec.size());
    memcpy(t.data<int>(), vec.data(), sizeof(int) * vec.size());
    EXPECT_EQ(t.get_value<int>(0, 0, 1), 2);
    EXPECT_EQ(t.get_value<int>(1, 1, 2), 15);
    t.reshape({4, 4});

    // check the inner_most_ptr meshod
    auto row_ptr = t.inner_most_ptr<int>(2);
    EXPECT_EQ(row_ptr[0], 9);
    EXPECT_EQ(row_ptr[3], 12);
```
Close #2577