### PR TITLE
Refactor: remove "using namespace std" to avoid namespace pollution

### DIFF
--- a/source/module_base/parallel_global.cpp
+++ b/source/module_base/parallel_global.cpp
@@ -250,7 +250,7 @@ void Parallel_Global::read_mpi_parameters(int argc,char **argv)
     if (GlobalV::MY_RANK != 0 )
     {
         //std::cout.rdbuf(NULL);
-		std::cout.setstate(ios::failbit);//qianrui modify 2020-10-14
+		std::cout.setstate(std::ios::failbit);//qianrui modify 2020-10-14
     }
 	// end test
 #endif //__MPI
@@ -327,7 +327,7 @@ void Parallel_Global::divide_pools(void)
     if(GlobalV::NPROC%GlobalV::NSTOGROUP!=0)
     {
         std::cout<<"\n Error! NPROC="<<GlobalV::NPROC
-        <<" must be divided evenly by BNDPAR="<<GlobalV::NSTOGROUP<<endl;
+        <<" must be divided evenly by BNDPAR="<<GlobalV::NSTOGROUP<<std::endl;
         exit(0);
     }
     GlobalV::NPROC_IN_STOGROUP = GlobalV::NPROC/GlobalV::NSTOGROUP;

--- a/source/module_base/parallel_global.h
+++ b/source/module_base/parallel_global.h
@@ -7,7 +7,7 @@
 #define PARALLEL_GLOBAL_H
 
 #include <complex>
-using namespace std;
+//using namespace std;
 
 #ifdef __MPI
 #include "mpi.h"

--- a/source/module_cell/parallel_kpoints.cpp
+++ b/source/module_cell/parallel_kpoints.cpp
@@ -299,7 +299,7 @@ void Parallel_Kpoints::pool_collection(std::complex<double> *value, const Module
 #else
     // data transfer ends.
     const int begin = ik * dim2 * dim3 * dim4;
-    complex<double> * p = &w.ptr[begin];
+    std::complex<double> * p = &w.ptr[begin];
     for (int i=0; i<dim; i++)
     {
         value[i] = *p;

--- a/source/module_elecstate/magnetism.cpp
+++ b/source/module_elecstate/magnetism.cpp
@@ -25,7 +25,7 @@ void Magnetism::compute_magnetization(const int& nrxx, const int& nxyz, const do
         {
             double diff = rho[0][ir] - rho[1][ir];
             this->tot_magnetization += diff;
-            this->abs_magnetization += abs(diff);
+            this->abs_magnetization += std::abs(diff);
         }
 #ifdef __MPI
         Parallel_Reduce::reduce_double_pool( this->tot_magnetization );


### PR DESCRIPTION
To avoid namespace pollution, "using namespace std" in the header file should be avoided as explained in the following issue https://github.com/deepmodeling/abacus-develop/issues/2551