### PR TITLE
Fix: Simpson's integration for uneven intervals

### DIFF
--- a/source/module_base/math_integral.h
+++ b/source/module_base/math_integral.h
@@ -86,6 +86,17 @@ class Integral
         double * const asum
     );     
 
+    //! Numerical integration on an evenly-spaced grid using Simpson's rule
+    static double simpson(const int n,           //!< number of grid points
+                          const double* const f, //!< function values at grid points
+                          const double dx        //!< grid spacing
+    );
+
+    //! Numerical integration on an irregularly-spaced grid using Simpson's rule
+    static double simpson(const int n,           //!< number of grid points
+                          const double* const f, //!< function values at grid points
+                          const double* const h  //!< grid spacing of length n-1, must be positive
+    );
 };
 
 }


### PR DESCRIPTION
This PR should address https://github.com/deepmodeling/abacus-develop/issues/2570

PS: a careful error analysis for Simpson's rule on uneven intervals is yet to be done.