### PR TITLE
Refactor: more grid type support for NumericalRadial & new sphbesj

### DIFF
--- a/source/module_base/math_sphbes.cpp
+++ b/source/module_base/math_sphbes.cpp
@@ -2,6 +2,8 @@
 #include "timer.h"
 #include "constants.h"
 
+#include <cassert>
+
 namespace ModuleBase
 {
 
@@ -680,6 +682,109 @@ void Sphbes::dSpherical_Bessel_dx
     }
     ModuleBase::timer::tick("Sphbes","dSpherical_Bessel_dq");
     return;
+}
+
+double Sphbes::_sphbesj_ascending_recurrence(int l, double x) {
+
+    // should be used when x > l && l > 0
+    
+    double invx = 1.0 / x;
+    double j0 = std::sin(x) * invx;
+    double j1 = ( j0 - std::cos(x) ) * invx;
+
+    double jl;
+    for (int i = 2; i <= l; ++i) {
+        jl = (2*i-1) * invx * j1 - j0;
+        j0 = j1;
+        j1 = jl;
+    }
+
+    return j1; // at the end of the loop j1 == jl
+}
+
+double Sphbes::_sphbesj_series(int l, double x) {
+
+    // should be used when x < l
+
+    // the absolute ratio between the k-th and (k-1)-th terms is x^2 / k / (4l+4k+2) (k >= 1)
+    // terms are guaranteed to be monotonically decreasing from the beginning for x < sqrt(4l+6).
+    // terms are guaranteed to be monotonically decreasing from the (l/4)-th term for x < l
+
+    double jl = 0.0;
+    constexpr double eps = 1e-17; // series terminate when the k-th term is less than eps * jl
+
+    // zeroth order term: x^l / (2l+1)!!
+    int k = 0;
+    double kth_term = 1.0;
+    for (int i = 1; i <= l; ++i) {
+        kth_term *= x / (2 * i + 1);
+    }
+
+    double x_sqr_half = 0.5 * x * x;
+    do {
+        jl += kth_term;
+        k += 1;
+        kth_term *= -x_sqr_half / ( k * (2*(l+k)+1) );
+    } while ( std::abs(kth_term) > std::abs(eps * jl) );
+
+    return jl;
+}
+
+double Sphbes::sphbesj(const int l, const double x)
+{
+    assert( l >= 0 );
+    assert( x >= 0 );
+
+    // j_l(0)
+    if ( x == 0 )
+    {
+        return l ? 0.0 : 1.0;
+    }
+
+    if ( x < l )
+    {
+        return _sphbesj_series(l, x);
+    }
+    else
+    {
+        double invx = 1.0 / x;
+        switch (l)
+        {
+          case 0:
+            return std::sin(x) * invx;
+          case 1:
+            return ( std::sin(x) * invx - std::cos(x) ) * invx; 
+            // NOTE: the following explicit expressions are not necessarily faster than ascending recurrence,
+            // but we keep them just in case we need them in the future.
+          //case 2:
+          //  return ( (3.0 * invx  - x) * std::sin(x) - 3.0 * std::cos(x) ) * (invx * invx);
+          //case 3:
+          //  return ( std::sin(x) * (15.0 * invx - 6.0 * x) + std::cos(x) * (x * x - 15.0) ) * std::pow(invx, 3); 
+          //case 4:
+          //  return ( std::sin(x) * (std::pow(x,3) - 45.0 * x + 105.0 * invx) 
+          //          + std::cos(x) * (10.0 * x * x - 105.0) ) * std::pow(invx, 4);
+          //case 5:
+          //  return ( std::sin(x) * (15.0 * std::pow(x,3) - 420.0 * x + 945.0 * invx) 
+          //          + std::cos(x) * (-std::pow(x, 4) + 105.0 * x * x - 945.0) ) * std::pow(invx, 5);
+          //case 6:
+          //  return ( std::sin(x) * (-std::pow(x, 5) + 210.0 * std::pow(x, 3) - 4725.0 * x + 10395.0 * invx) 
+          //          + std::cos(x) * (-21.0 * std::pow(x, 4) + 1260.0 * x * x - 10395.0) ) * std::pow(invx, 6);
+          default:
+            return _sphbesj_ascending_recurrence(l, x);
+        }
+    }
+}
+
+void Sphbes::sphbesj(const int n,
+             const double* const r,
+             const double q,
+             const int l,
+             double* const jl)
+{
+    for (int i = 0; i != n; ++i)
+    {
+        jl[i] = Sphbes::sphbesj(l, q * r[i]);
+    }
 }
 
 }

--- a/source/module_base/math_sphbes.h
+++ b/source/module_base/math_sphbes.h
@@ -88,6 +88,22 @@ class Sphbes
         const double &rcut
     );
 
+    //! spherical Bessel function of the first kind
+    /*!
+     *  This function computes j_l(x) by series expansion for x < l
+     *  and by ascending recurrence for x >= l.
+     *                                                              */
+    static double sphbesj(const int l,   //!< [in] order
+                          const double x //!< [in] argument
+    );
+
+    static void sphbesj(const int n,
+                        const double* const r,
+                        const double q,
+                        const int l,
+                        double* const jl
+    );
+
 private:
 
     static double Spherical_Bessel_7(const int n, const double &x);
@@ -100,6 +116,10 @@ private:
     static double CHEBEV(double a, double b, double c[], int m, double x);
 
     static int IMAX(int a, int b);
+
+    // utility functions for sphbesj
+    static double _sphbesj_ascending_recurrence(int l, double x);
+    static double _sphbesj_series(int l, double x);
 };
 
 }

--- a/source/module_base/test/math_sphbes_test.cpp
+++ b/source/module_base/test/math_sphbes_test.cpp
@@ -199,8 +199,10 @@ TEST_F(Sphbes,SphericalBesselRoots)
 
 TEST_F(Sphbes, SeriesAndRecurrence)
 {
-    // This test checks that the old and new versions of the spherical Bessel function agree with each other
+    // This test checks whether Spherical_Bessel and sphbesj agree with each other
     // on a coarse grid for a range of l and q values.
+    //
+    // NOTE: this test should be removed once Spherical_Bessel is removed from the code.
     int lmax = 8;
     int nr = 5000;
     double rcut = 50;
@@ -226,6 +228,9 @@ TEST_F(Sphbes, SeriesAndRecurrence)
         }
     }
 
+    delete[] r;
+    delete[] jl_old;
+    delete[] jl_new;
 }
 
 int main(int argc, char **argv)

--- a/source/module_base/test/math_sphbes_test.cpp
+++ b/source/module_base/test/math_sphbes_test.cpp
@@ -24,6 +24,7 @@
  *      - Spherical_Bessel.
  *      - Spherical_Bessel_Roots
  *      - overloading of Spherical_Bessel. This funnction sets sjp[i] to 1.0 when i < msh.
+ *      - sphbesj
  */
 
 double mean(const double* vect, const int totN)
@@ -195,6 +196,37 @@ TEST_F(Sphbes,SphericalBesselRoots)
     delete [] eign;
 }
 
+
+TEST_F(Sphbes, SeriesAndRecurrence)
+{
+    // This test checks that the old and new versions of the spherical Bessel function agree with each other
+    // on a coarse grid for a range of l and q values.
+    int lmax = 8;
+    int nr = 5000;
+    double rcut = 50;
+    double dr = rcut / (nr - 1);
+    double* r = new double[nr];
+    for (int i = 0; i < nr; ++i)
+    {
+        r[i] = i * dr;
+    }
+
+    double* jl_old = new double[nr];
+    double* jl_new = new double[nr];
+    for (int l = 0; l <= lmax; ++l)
+    {
+        for (double q = 0.1; q < 10; q += 0.1)
+        {
+            ModuleBase::Sphbes::Spherical_Bessel(nr, r, q, 0, jl_old);
+            ModuleBase::Sphbes::sphbesj(nr, r, q, 0, jl_new);
+            for (int i = 0; i < nr; ++i)
+            {
+                EXPECT_NEAR(jl_old[i], jl_new[i], 1e-12);
+            }
+        }
+    }
+
+}
 
 int main(int argc, char **argv)
 {

--- a/source/module_basis/module_nao/numerical_radial.cpp
+++ b/source/module_basis/module_nao/numerical_radial.cpp
@@ -75,6 +75,10 @@ NumericalRadial& NumericalRadial::operator=(const NumericalRadial& rhs)
         return *this;
     }
 
+    // wipe off r & k space data
+    wipe(true);
+    wipe(false);
+
     symbol_ = rhs.symbol_;
     itype_ = rhs.itype_;
     izeta_ = rhs.izeta_;
@@ -87,15 +91,6 @@ NumericalRadial& NumericalRadial::operator=(const NumericalRadial& rhs)
 
     pr_ = rhs.pr_;
     pk_ = rhs.pk_;
-
-    delete[] rgrid_;
-    delete[] rvalue_;
-    delete[] kgrid_;
-    delete[] kvalue_;
-    rgrid_ = nullptr;
-    kgrid_ = nullptr;
-    rvalue_ = nullptr;
-    kvalue_ = nullptr;
 
     // deep copy
     if (rhs.ptr_rgrid())
@@ -165,19 +160,14 @@ void NumericalRadial::build(const int l,
     assert(std::is_sorted(grid, grid + ngrid, std::less_equal<double>())); // std::less<>() would allow equal values
     assert(grid[0] >= 0.0);
 
+    // wipe off any existing r & k space data
+    wipe(true);
+    wipe(false);
+
     symbol_ = symbol;
     itype_ = itype;
     izeta_ = izeta;
     l_ = l;
-
-    delete[] rgrid_;
-    delete[] kgrid_;
-    delete[] rvalue_;
-    delete[] kvalue_;
-    rgrid_ = nullptr;
-    kgrid_ = nullptr;
-    rvalue_ = nullptr;
-    kvalue_ = nullptr;
 
     if (for_r_space)
     {
@@ -263,7 +253,7 @@ void NumericalRadial::set_grid(const bool for_r_space, const int ngrid, const do
         ngrid_tbu = ngrid;
         std::memcpy(grid_tbu, grid, ngrid * sizeof(double));
 
-        check_fft_compliancy();
+        is_fft_compliant_ = is_fft_compliant(nr_, rgrid_, nk_, kgrid_);
         transform(!for_r_space); // transform(true): r -> k; transform(false): k -> r
     }
     else
@@ -299,7 +289,7 @@ void NumericalRadial::set_grid(const bool for_r_space, const int ngrid, const do
         value_tbu = value_new;
         ngrid_tbu = ngrid;
 
-        check_fft_compliancy();
+        is_fft_compliant_ = is_fft_compliant(nr_, rgrid_, nk_, kgrid_);
         transform(for_r_space); // transform(true): r -> k; transform(false): k -> r
     }
 }
@@ -322,7 +312,6 @@ void NumericalRadial::set_uniform_grid(const bool for_r_space,
     if (enable_fft)
     {
         set_uniform_grid(!for_r_space, ngrid, PI / dx, 't', false);
-        is_fft_compliant_ = true;
     }
 
     delete[] grid;
@@ -416,19 +405,30 @@ void NumericalRadial::radtab(const char op,
                              const NumericalRadial& ket,
                              const int l,
                              double* const table,
-                             const bool deriv)
+                             const bool deriv,
+                             int ntab,
+                             const double* tabgrid) const
 {
     assert(op == 'S' || op == 'I' || op == 'T' || op == 'U');
     assert(l >= 0);
 
-    // currently only FFT-compliant grids are supported!
-    // FFT-based transform requires that two NumericalRadial objects have exactly the same grid
-    assert(is_fft_compliant_ && ket.is_fft_compliant_);
-    assert(nr_ == ket.nr_);
-    assert(rcut() == ket.rcut());
+    // radtab requires that two NumericalRadial objects have exactly the same kgrid_
+    assert(nk_ > 0 && nk_ == ket.nk_);
+    assert(std::equal(kgrid_, kgrid_ + nk_, ket.kgrid_));
 
-    double* ktmp = new double[nk_];
-    std::transform(kvalue_, kvalue_ + nk_, ket.kvalue_, ktmp, std::multiplies<double>());
+    // either tabgrid or rgrid_ exists
+    assert((tabgrid && ntab > 0) || (!tabgrid && ntab == 0 && rgrid_ && nr_ > 0));
+
+    ntab = ntab ? ntab : nr_;
+    tabgrid = tabgrid ? tabgrid : rgrid_;
+    bool use_radrfft = is_fft_compliant(ntab, tabgrid, nk_, kgrid_);
+
+    // function to undergo a spherical Bessel transform:
+    // overlap: chi1(k) * chi2(k)
+    // kinetic: k^2 * chi1(k) * chi2(k)
+    // Coulomb: k^(-2) * chi1(k) * chi2(k)
+    double* fk = new double[nk_];
+    std::transform(kvalue_, kvalue_ + nk_, ket.kvalue_, fk, std::multiplies<double>());
 
     int op_pk = 0;
     switch (op)
@@ -446,26 +446,53 @@ void NumericalRadial::radtab(const char op,
     { // derivative of the radial table
         if (l == 0)
         { // j'_0(x) = -j_1(x)
-            sbt_->radrfft(1, nk_, kcut(), ktmp, table, pk_ + ket.pk_ + op_pk - 1);
+            if (use_radrfft)
+            {
+                sbt_->radrfft(1, nk_, kcut(), fk, table, pk_ + ket.pk_ + op_pk - 1);
+            }
+            else
+            {
+                sbt_->direct(1, nk_, kgrid_, fk, ntab, tabgrid, table, pk_ + ket.pk_ + op_pk - 1);
+            }
             std::for_each(table, table + nr_, [](double& x) { x *= -1; });
         }
         else
         { // (2*l+1) * j'_l(x) = l * j_{l-1}(x) - (l+1) * j_{l+1}(x)
-            double* rtmp = new double[nr_];
-            sbt_->radrfft(l + 1, nk_, kcut(), ktmp, table, pk_ + ket.pk_ + op_pk - 1);
-            sbt_->radrfft(l - 1, nk_, kcut(), ktmp, rtmp, pk_ + ket.pk_ + op_pk - 1);
-            std::transform(table, table + nr_, rtmp, table, [l](double x, double y) {
+            double* frtmp = new double[ntab];
+            if (use_radrfft)
+            {
+                sbt_->radrfft(l + 1, nk_, kcut(), fk, table, pk_ + ket.pk_ + op_pk - 1);
+                sbt_->radrfft(l - 1, nk_, kcut(), fk, frtmp, pk_ + ket.pk_ + op_pk - 1);
+            }
+            else
+            {
+                sbt_->direct(l + 1, nk_, kgrid_, fk, ntab, tabgrid, table, pk_ + ket.pk_ + op_pk - 1);
+                sbt_->direct(l - 1, nk_, kgrid_, fk, ntab, tabgrid, frtmp, pk_ + ket.pk_ + op_pk - 1);
+            }
+            std::transform(table, table + ntab, frtmp, table, [l](double x, double y) {
                 return (l * y - (l + 1) * x) / (2 * l + 1);
             });
-            delete[] rtmp;
+            delete[] frtmp;
         }
     }
     else
     { // radial table
-        sbt_->radrfft(l, nk_, kcut(), ktmp, table, pk_ + ket.pk_ + op_pk);
+        if (use_radrfft)
+        {
+            sbt_->radrfft(l, nk_, kcut(), fk, table, pk_ + ket.pk_ + op_pk);
+        }
+        else
+        {
+            sbt_->direct(l, nk_, kgrid_, fk, ntab, tabgrid, table, pk_ + ket.pk_ + op_pk);
+        }
     }
 
-    delete[] ktmp;
+    delete[] fk;
+
+    // spherical Bessel transform has a prefactor of sqrt(2/pi) while the prefactor for the radial table 
+    // of two-center integrals is 4*pi
+    double pref = ModuleBase::FOUR_PI * std::sqrt(ModuleBase::PI / 2.0);
+    std::for_each(table, table + ntab, [pref](double& x) { x *= pref; });
 }
 
 void NumericalRadial::normalize(bool for_r_space)
@@ -484,57 +511,67 @@ void NumericalRadial::normalize(bool for_r_space)
     std::transform(value_tbu, value_tbu + ngrid, grid_tbu, integrand, std::multiplies<double>());
     std::for_each(integrand, integrand + ngrid, [](double& x) { x *= x; });
 
-    // FIXME Simpson_Integral should use only ngrid-1 rab points!
-    rab[ngrid - 1] = rab[ngrid - 2];
-    ModuleBase::Integral::Simpson_Integral(ngrid, integrand, rab, factor);
+    factor = ModuleBase::Integral::simpson(ngrid, integrand, &rab[1]);
     factor = 1. / std::sqrt(factor);
 
     std::for_each(value_tbu, value_tbu + ngrid, [factor](double& x) { x *= factor; });
     transform(for_r_space);
     delete[] rab;
     delete[] integrand;
-    // unit test TBD!
 }
 
 void NumericalRadial::transform(const bool forward)
 {
+    // grid & value must exist in the initial space
     assert(forward ? (rgrid_ && rvalue_) : (kgrid_ && kvalue_));
+
+    // do nothing if there is no grid in the destination space
     if ((forward && !kgrid_) || (!forward && !rgrid_))
     {
         return;
     }
 
-    // currently only FFT-compliant grid is supported!
-    assert(is_fft_compliant_);
-
-    // value array must be pre-allocated
     if (forward)
     { // r -> k
-        sbt_->radrfft(l_, nr_, rgrid_[nr_ - 1], rvalue_, kvalue_, pr_);
+        if (is_fft_compliant_)
+        {
+            sbt_->radrfft(l_, nr_, rgrid_[nr_ - 1], rvalue_, kvalue_, pr_);
+        }
+        else
+        {
+            sbt_->direct(l_, nr_, rgrid_, rvalue_, nk_, kgrid_, kvalue_, pr_);
+        }
         pk_ = 0;
     }
     else
     { // k -> r
-        sbt_->radrfft(l_, nk_, kgrid_[nk_ - 1], kvalue_, rvalue_, pk_);
+        if (is_fft_compliant_)
+        {
+            sbt_->radrfft(l_, nk_, kgrid_[nk_ - 1], kvalue_, rvalue_, pk_);
+        }
+        else
+        {
+            sbt_->direct(l_, nk_, kgrid_, kvalue_, nr_, rgrid_, rvalue_, pk_);
+        }
         pr_ = 0;
     }
 }
 
-void NumericalRadial::check_fft_compliancy()
+bool NumericalRadial::is_fft_compliant(const int nr,
+                                       const double* const rgrid,
+                                       const int nk,
+                                       const double* const kgrid) const
 {
-    is_fft_compliant_ = rgrid_ && kgrid_ && nr_ == nk_ && nr_ >= 2;
-    if (!is_fft_compliant_)
+    if (!rgrid || !kgrid || nr != nk || nr < 2)
     {
-        return;
+        return false;
     }
 
-    double dr = rgrid_[nr_ - 1] / (nr_ - 1);
-    double dk = kgrid_[nk_ - 1] / (nk_ - 1);
+    double dr = rgrid[nr - 1] / (nr - 1);
+    double dk = kgrid[nk - 1] / (nk - 1);
     double tol = 4.0 * std::numeric_limits<double>::epsilon();
 
-    is_fft_compliant_ = std::abs(dr * dk - PI / (nr_ - 1)) < tol
-                        && std::all_of(rgrid_, rgrid_ + nr_,
-                                [&](double& r) { return std::abs(r - std::distance(rgrid_, &r) * dr) < tol; })
-                        && std::all_of(kgrid_, kgrid_ + nk_, 
-                                [&](double& k) { return std::abs(k - std::distance(kgrid_, &k) * dk) < tol; });
+    return std::abs(dr * dk - PI / (nr - 1)) < tol
+           && std::all_of(rgrid, rgrid + nr, [&](const double& r) { return std::abs(r - (&r - rgrid) * dr) < tol; })
+           && std::all_of(kgrid, kgrid + nk, [&](const double& k) { return std::abs(k - (&k - kgrid) * dk) < tol; });
 }

--- a/source/module_basis/module_nao/numerical_radial.h
+++ b/source/module_basis/module_nao/numerical_radial.h
@@ -155,10 +155,12 @@ class NumericalRadial
 
     //! Computes the radial table for two-center integrals.
     /*!
-     *  TODO add support for non-FFT-compliant grid
-     *  Currently this function requires that "this" and "ket" have exactly the same
-     *  grid and are FFT-compliant. On finish, table is filled with values on the same
-     *  rgrid_ of each object.
+     *  This function requires that both "this" and "ket" have existing kgrid_, and the
+     *  two kgrid_ be identical.
+     *
+     *  On finish, table is filled with values on tabgrid. If tabgrid is not given, the
+     *  rgrid_ of "this" is assumed (it would be an error if rgrid_ does not exist in
+     *  this case).
      *
      *  op could be:
      *
@@ -189,17 +191,20 @@ class NumericalRadial
      *                          /  0                  l
      *
      *                                                                                  */
-    void radtab(const char op,              //!< operator, could be:
-                                            //!< - 'S' or 'I': overlap
-                                            //!< - 'T': kinetic
-                                            //!< - 'U': Coulomb
+    void radtab(const char op,              //!< [in] operator, could be:
+                                            //!<        - 'S' or 'I': overlap
+                                            //!<        - 'T': kinetic
+                                            //!<        - 'U': Coulomb
                 const NumericalRadial& ket, //!< [in] the other NumericalRadial object with which
                                             //!       the two-center integral is computed
                 const int l,                //!< [in] angular momentum of the table
                 double* const table,        //!< [out] on finish, contain the computed table
-                const bool deriv = false    //!< [in] if true, "table" would contain the derivative
+                const bool deriv = false,   //!< [in] if true, "table" would contain the derivative
                                             //!<      of the table
-    );
+                int ntab = 0,               //!< [in] size of tabgrid
+                const double* tabgrid = nullptr  //!< [in] grid on which the table is calculated.
+                                                 //!< if nullptr, this->rgrid_ is assumed.
+    ) const;
 
     void normalize(bool for_r_space = true);
 
@@ -226,18 +231,10 @@ class NumericalRadial
     int nk() const { return nk_; }
 
     //! gets r-space grid cutoff distance
-    double rcut() const
-    {
-        assert(rgrid_);
-        return rgrid_[nr_ - 1];
-    }
+    double rcut() const { return rgrid_ ? rgrid_[nr_ - 1] : 0.0; }
 
     //! gets k-space grid cutoff distance
-    double kcut() const
-    {
-        assert(kgrid_);
-        return kgrid_[nk_ - 1];
-    }
+    double kcut() const { return kgrid_ ? kgrid_[nk_ - 1] : 0.0; }
 
     //! gets the pointer to r-space grid points
     const double* ptr_rgrid() const { return rgrid_; }
@@ -339,11 +336,11 @@ class NumericalRadial
      *                                                                              */
     void transform(const bool forward);
 
-    //! Checks whether r & k grids are FFT-compliant and set the corresponding flag.
+    //! Checks whether the given two grids are FFT-compliant
     /*!
      *  @see is_fft_compliant
      *                                                                              */
-    void check_fft_compliancy();
+    bool is_fft_compliant(const int nr, const double* const rgrid, const int nk, const double* const kgrid) const;
 };
 
 #endif


### PR DESCRIPTION
This PR 
1. add a new function to ModuleBase::Sphbes which is supposed to agree with the previous "Spherical_Bessel" in most cases and is more numerically stable for small function arguments. (fix https://github.com/deepmodeling/abacus-develop/issues/2676, but old one is still kept for now)
2. extends the grid type allowed by NumericalRadial; NumericalRadial now accepts arbitrary grids. This enhances the usability of NumericalRadial class and is neccessary in order to check the consistency between old & new two-center integral table.

