### PR TITLE
Fix: Bump cuda base image version

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.7.0-devel-ubuntu22.04
+FROM nvidia/cuda:12.2.0-devel-ubuntu22.04
 
 RUN apt update && apt install -y --no-install-recommends \
     libopenblas-openmp-dev liblapack-dev libscalapack-mpi-dev libelpa-dev libfftw3-dev libcereal-dev \


### PR DESCRIPTION
According to the [container support policy of nvidia](https://gitlab.com/nvidia/container-images/cuda/-/blob/master/doc/support-policy.md), the image will be marked as deprecated after a new minor version releases and be removed after 6 months. The expiration of 11.7.0 image yields [failure](https://github.com/deepmodeling/abacus-develop/actions/runs/5454982900/jobs/9925813538) on container building.