### PR TITLE
fix deepks compile error provided libnpy path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,6 +378,8 @@ if(ENABLE_DEEPKS)
       GIT_PROGRESS TRUE
     )
     FetchContent_MakeAvailable(libnpy)
+  else()
+    include_directories(${libnpy_INCLUDE_DIR})	   
   endif()
   include_directories(${libnpy_SOURCE_DIR}/include)
   add_compile_definitions(__DEEPKS)


### PR DESCRIPTION
Before this fix, ABACUS still cannot find `npy.hpp` file with `-Dlibnpy_INCLUDE_DIR=XXX/libnpy/include` provided (no download).