### PR TITLE
Feature: add energy output in lj/dp

### DIFF
--- a/source/module_esolver/esolver_dp.cpp
+++ b/source/module_esolver/esolver_dp.cpp
@@ -94,6 +94,8 @@ namespace ModuleESolver
         dp.compute(dp_potential, f, v, coord, atype, cell);
 
         dp_potential /= ModuleBase::Ry_to_eV;
+        GlobalV::ofs_running << " final etot is " << std::setprecision(11) << dp_potential * ModuleBase::Ry_to_eV
+                             << " eV" << std::endl;
 
         const double fact_f = ModuleBase::Ry_to_eV * ModuleBase::ANGSTROM_AU;
         const double fact_v = ucell.omega * ModuleBase::Ry_to_eV;

--- a/source/module_esolver/esolver_lj.cpp
+++ b/source/module_esolver/esolver_lj.cpp
@@ -69,6 +69,8 @@ namespace ModuleESolver
         }
 
         lj_potential /= 2.0;
+        GlobalV::ofs_running << " final etot is " << std::setprecision(11) << lj_potential * ModuleBase::Ry_to_eV
+                             << " eV" << std::endl;
 
         // Post treatment for virial
         for (int i = 0; i < 3; ++i)


### PR DESCRIPTION
In order to match the interface with dpdata, energy output with keyword must be added for lj/md esolver. 