### PR TITLE
Test: simplify compiling ucell info in UNIT tests

### DIFF
--- a/source/module_cell/CMakeLists.txt
+++ b/source/module_cell/CMakeLists.txt
@@ -21,6 +21,22 @@ add_library(
     parallel_kpoints.cpp
 )
 
+list(APPEND cell_simple_srcs
+    unitcell.cpp
+    read_atoms.cpp
+    read_cell_pseudopots.cpp
+    atom_spec.cpp
+    atom_pseudo.cpp
+    pseudo_nc.cpp
+    read_pp.cpp
+    read_pp_upf201.cpp
+    read_pp_upf100.cpp
+    read_pp_vwr.cpp
+    read_pp_blps.cpp
+)
+
+add_library(cell_simple OBJECT ${cell_simple_srcs})
+
 if(ENABLE_COVERAGE)
   add_coverage(cell)
 endif()
@@ -29,4 +45,3 @@ if(BUILD_TESTING)
   add_subdirectory(test)
   add_subdirectory(test_pw)
 endif()
-

--- a/source/module_cell/CMakeLists.txt
+++ b/source/module_cell/CMakeLists.txt
@@ -21,22 +21,6 @@ add_library(
     parallel_kpoints.cpp
 )
 
-list(APPEND cell_simple_srcs
-    unitcell.cpp
-    read_atoms.cpp
-    read_cell_pseudopots.cpp
-    atom_spec.cpp
-    atom_pseudo.cpp
-    pseudo_nc.cpp
-    read_pp.cpp
-    read_pp_upf201.cpp
-    read_pp_upf100.cpp
-    read_pp_vwr.cpp
-    read_pp_blps.cpp
-)
-
-add_library(cell_simple OBJECT ${cell_simple_srcs})
-
 if(ENABLE_COVERAGE)
   add_coverage(cell)
 endif()

--- a/source/module_cell/module_neighbor/test/CMakeLists.txt
+++ b/source/module_cell/module_neighbor/test/CMakeLists.txt
@@ -15,21 +15,21 @@ AddTest(
 
 AddTest(
   TARGET cell_neighbor_sltk_atom_input
-  LIBS ${math_libs} base device cell_simple
+  LIBS ${math_libs} base device cell_info
   SOURCES sltk_atom_input_test.cpp ../sltk_atom_input.cpp ../sltk_atom.cpp ../sltk_adjacent_set.cpp
      ../../../module_io/output.cpp
 )
 
 AddTest(
   TARGET cell_neighbor_sltk_grid
-  LIBS ${math_libs} base device cell_simple
+  LIBS ${math_libs} base device cell_info
   SOURCES sltk_grid_test.cpp ../sltk_grid.cpp ../sltk_atom_input.cpp ../sltk_atom.cpp ../sltk_adjacent_set.cpp
     ../../../module_io/output.cpp
 )
 
 AddTest(
   TARGET cell_neighbor_sltk_atom_arrange
-  LIBS ${math_libs} base device cell_simple
+  LIBS ${math_libs} base device cell_info
   SOURCES sltk_atom_arrange_test.cpp  ../sltk_atom_arrange.cpp ../sltk_grid_driver.cpp ../sltk_grid.cpp
   ../sltk_atom_input.cpp ../sltk_atom.cpp ../sltk_adjacent_set.cpp
   ../../../module_io/output.cpp

--- a/source/module_cell/module_neighbor/test/CMakeLists.txt
+++ b/source/module_cell/module_neighbor/test/CMakeLists.txt
@@ -15,31 +15,22 @@ AddTest(
 
 AddTest(
   TARGET cell_neighbor_sltk_atom_input
-  LIBS ${math_libs} base device
+  LIBS ${math_libs} base device cell_simple
   SOURCES sltk_atom_input_test.cpp ../sltk_atom_input.cpp ../sltk_atom.cpp ../sltk_adjacent_set.cpp
-    ../../unitcell.cpp ../../read_atoms.cpp ../../read_cell_pseudopots.cpp
-    ../../atom_spec.cpp ../../atom_pseudo.cpp ../../pseudo_nc.cpp
-    ../../read_pp.cpp ../../read_pp_upf201.cpp ../../read_pp_upf100.cpp
-    ../../read_pp_vwr.cpp ../../read_pp_blps.cpp ../../../module_io/output.cpp
+     ../../../module_io/output.cpp
 )
 
 AddTest(
   TARGET cell_neighbor_sltk_grid
-  LIBS ${math_libs} base device
+  LIBS ${math_libs} base device cell_simple
   SOURCES sltk_grid_test.cpp ../sltk_grid.cpp ../sltk_atom_input.cpp ../sltk_atom.cpp ../sltk_adjacent_set.cpp
-    ../../unitcell.cpp ../../read_atoms.cpp ../../read_cell_pseudopots.cpp
-    ../../atom_spec.cpp ../../atom_pseudo.cpp ../../pseudo_nc.cpp
-    ../../read_pp.cpp ../../read_pp_upf201.cpp ../../read_pp_upf100.cpp
-    ../../read_pp_vwr.cpp ../../read_pp_blps.cpp ../../../module_io/output.cpp
+    ../../../module_io/output.cpp
 )
 
 AddTest(
   TARGET cell_neighbor_sltk_atom_arrange
-  LIBS ${math_libs} base device
+  LIBS ${math_libs} base device cell_simple
   SOURCES sltk_atom_arrange_test.cpp  ../sltk_atom_arrange.cpp ../sltk_grid_driver.cpp ../sltk_grid.cpp
   ../sltk_atom_input.cpp ../sltk_atom.cpp ../sltk_adjacent_set.cpp
-  ../../unitcell.cpp ../../read_atoms.cpp ../../read_cell_pseudopots.cpp
-  ../../atom_spec.cpp ../../atom_pseudo.cpp ../../pseudo_nc.cpp
-  ../../read_pp.cpp ../../read_pp_upf201.cpp ../../read_pp_upf100.cpp
-  ../../read_pp_vwr.cpp ../../read_pp_blps.cpp ../../../module_io/output.cpp
+  ../../../module_io/output.cpp
 )

--- a/source/module_cell/test/CMakeLists.txt
+++ b/source/module_cell/test/CMakeLists.txt
@@ -82,34 +82,26 @@ add_test(NAME cell_parallel_kpoints_test
 
 AddTest(
   TARGET cell_unitcell_test
-  LIBS ${math_libs} base device
-  SOURCES unitcell_test.cpp ../unitcell.cpp ../read_atoms.cpp ../read_cell_pseudopots.cpp ../atom_spec.cpp
-	../atom_pseudo.cpp ../pseudo_nc.cpp ../read_pp.cpp ../read_pp_upf201.cpp ../read_pp_upf100.cpp
-	../read_pp_vwr.cpp ../read_pp_blps.cpp ../../module_io/output.cpp
+  LIBS ${math_libs} base device cell_simple
+  SOURCES unitcell_test.cpp ../../module_io/output.cpp
 )
 
 AddTest(
   TARGET cell_unitcell_test_readpp
-  LIBS ${math_libs} base device
-  SOURCES unitcell_test_readpp.cpp ../unitcell.cpp ../read_atoms.cpp ../read_cell_pseudopots.cpp ../atom_spec.cpp
-	../atom_pseudo.cpp ../pseudo_nc.cpp ../read_pp.cpp ../read_pp_upf201.cpp ../read_pp_upf100.cpp
-	../read_pp_vwr.cpp ../read_pp_blps.cpp ../../module_io/output.cpp
+  LIBS ${math_libs} base device cell_simple
+  SOURCES unitcell_test_readpp.cpp ../../module_io/output.cpp
 )
 
 AddTest(
   TARGET cell_unitcell_test_para
-  LIBS ${math_libs} base device
-  SOURCES unitcell_test_para.cpp ../unitcell.cpp ../read_atoms.cpp ../read_cell_pseudopots.cpp ../atom_spec.cpp
-	../atom_pseudo.cpp ../pseudo_nc.cpp ../read_pp.cpp ../read_pp_upf201.cpp ../read_pp_upf100.cpp
-	../read_pp_vwr.cpp ../read_pp_blps.cpp ../../module_io/output.cpp
+  LIBS ${math_libs} base device cell_simple
+  SOURCES unitcell_test_para.cpp ../../module_io/output.cpp
 )
 
 AddTest(
   TARGET cell_unitcell_test_setupcell
-  LIBS ${math_libs} base device
-  SOURCES unitcell_test_setupcell.cpp ../unitcell.cpp ../read_atoms.cpp ../read_cell_pseudopots.cpp ../atom_spec.cpp
-	../atom_pseudo.cpp ../pseudo_nc.cpp ../read_pp.cpp ../read_pp_upf201.cpp ../read_pp_upf100.cpp
-	../read_pp_vwr.cpp ../read_pp_blps.cpp ../../module_io/output.cpp
+  LIBS ${math_libs} base device cell_simple
+  SOURCES unitcell_test_setupcell.cpp ../../module_io/output.cpp
 )
 
 add_test(NAME cell_unitcell_test_parallel

--- a/source/module_cell/test/CMakeLists.txt
+++ b/source/module_cell/test/CMakeLists.txt
@@ -25,7 +25,7 @@ list(APPEND cell_simple_srcs
     ../read_pp_blps.cpp
 )
 
-add_library(cell_simple OBJECT ${cell_simple_srcs})
+add_library(cell_info OBJECT ${cell_simple_srcs})
 
 AddTest(
   TARGET cell_read_pp
@@ -98,25 +98,25 @@ add_test(NAME cell_parallel_kpoints_test
 
 AddTest(
   TARGET cell_unitcell_test
-  LIBS ${math_libs} base device cell_simple
+  LIBS ${math_libs} base device cell_info
   SOURCES unitcell_test.cpp ../../module_io/output.cpp
 )
 
 AddTest(
   TARGET cell_unitcell_test_readpp
-  LIBS ${math_libs} base device cell_simple
+  LIBS ${math_libs} base device cell_info
   SOURCES unitcell_test_readpp.cpp ../../module_io/output.cpp
 )
 
 AddTest(
   TARGET cell_unitcell_test_para
-  LIBS ${math_libs} base device cell_simple
+  LIBS ${math_libs} base device cell_info
   SOURCES unitcell_test_para.cpp ../../module_io/output.cpp
 )
 
 AddTest(
   TARGET cell_unitcell_test_setupcell
-  LIBS ${math_libs} base device cell_simple
+  LIBS ${math_libs} base device cell_info
   SOURCES unitcell_test_setupcell.cpp ../../module_io/output.cpp
 )
 

--- a/source/module_cell/test/CMakeLists.txt
+++ b/source/module_cell/test/CMakeLists.txt
@@ -11,6 +11,22 @@ install(FILES parallel_kpoints_test.sh DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 install(FILES klist_test_para.sh DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 install(FILES unitcell_test_parallel.sh DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
+list(APPEND cell_simple_srcs
+    ../unitcell.cpp
+    ../read_atoms.cpp
+    ../read_cell_pseudopots.cpp
+    ../atom_spec.cpp
+    ../atom_pseudo.cpp
+    ../pseudo_nc.cpp
+    ../read_pp.cpp
+    ../read_pp_upf201.cpp
+    ../read_pp_upf100.cpp
+    ../read_pp_vwr.cpp
+    ../read_pp_blps.cpp
+)
+
+add_library(cell_simple OBJECT ${cell_simple_srcs})
+
 AddTest(
   TARGET cell_read_pp
   LIBS ${math_libs} base device

--- a/source/module_elecstate/test/CMakeLists.txt
+++ b/source/module_elecstate/test/CMakeLists.txt
@@ -75,14 +75,14 @@ AddTest(
 
 AddTest(
   TARGET charge_test
-  LIBS ${math_libs} planewave_serial base device cell_simple
+  LIBS ${math_libs} planewave_serial base device cell_info
   SOURCES charge_test.cpp ../module_charge/charge.cpp
     ../../module_io/output.cpp
 )
 
 AddTest(
   TARGET charge_mixing
-  LIBS  base ${math_libs}  psi  device planewave_serial cell_simple
+  LIBS  base ${math_libs}  psi  device planewave_serial cell_info
   SOURCES charge_mixing_test.cpp  
   ../module_charge/charge_mixing.cpp
   ../module_charge/charge_broyden.cpp
@@ -92,7 +92,7 @@ AddTest(
 
 AddTest(
   TARGET charge_extra
-  LIBS ${math_libs} base device cell_simple
+  LIBS ${math_libs} base device cell_info
   SOURCES charge_extra_test.cpp ../module_charge/charge_extra.cpp ../../module_io/read_cube.cpp ../../module_io/write_cube.cpp
   ../../module_io/output.cpp
 )

--- a/source/module_elecstate/test/CMakeLists.txt
+++ b/source/module_elecstate/test/CMakeLists.txt
@@ -80,19 +80,34 @@ AddTest(
     ../../module_io/output.cpp
 )
 
+list(APPEND cell_simple_srcs
+    ../../module_cell/unitcell.cpp
+    ../../module_cell/read_atoms.cpp
+    ../../module_cell/read_cell_pseudopots.cpp
+    ../../module_cell/atom_spec.cpp
+    ../../module_cell/atom_pseudo.cpp
+    ../../module_cell/pseudo_nc.cpp
+    ../../module_cell/read_pp.cpp
+    ../../module_cell/read_pp_upf201.cpp
+    ../../module_cell/read_pp_upf100.cpp
+    ../../module_cell/read_pp_vwr.cpp
+    ../../module_cell/read_pp_blps.cpp
+)
+
 AddTest(
   TARGET charge_mixing
-  LIBS  base ${math_libs}  psi  device planewave_serial cell_simple
+  LIBS  base ${math_libs}  psi  device planewave_serial
   SOURCES charge_mixing_test.cpp  
   ../module_charge/charge_mixing.cpp
   ../module_charge/charge_broyden.cpp
   ../module_charge/charge_pulay.cpp
   ../../module_io/output.cpp
+  ${cell_simple_srcs}
 )
 
 AddTest(
   TARGET charge_extra
-  LIBS ${math_libs} base device cell_simple
+  LIBS ${math_libs} base device
   SOURCES charge_extra_test.cpp ../module_charge/charge_extra.cpp ../../module_io/read_cube.cpp ../../module_io/write_cube.cpp
-  ../../module_io/output.cpp
+  ../../module_io/output.cpp ${cell_simple_srcs}
 )

--- a/source/module_elecstate/test/CMakeLists.txt
+++ b/source/module_elecstate/test/CMakeLists.txt
@@ -75,60 +75,24 @@ AddTest(
 
 AddTest(
   TARGET charge_test
-  LIBS ${math_libs} planewave_serial base device
+  LIBS ${math_libs} planewave_serial base device cell_simple
   SOURCES charge_test.cpp ../module_charge/charge.cpp
-    # UnitCell dependencies
-    ../../module_cell/unitcell.cpp
-    ../../module_cell/read_atoms.cpp
-    ../../module_cell/read_cell_pseudopots.cpp
-    ../../module_cell/atom_spec.cpp
-    ../../module_cell/atom_pseudo.cpp
-    ../../module_cell/pseudo_nc.cpp
-    ../../module_cell/read_pp.cpp
-    ../../module_cell/read_pp_upf201.cpp
-    ../../module_cell/read_pp_upf100.cpp
-    ../../module_cell/read_pp_vwr.cpp
-    ../../module_cell/read_pp_blps.cpp
     ../../module_io/output.cpp
 )
 
 AddTest(
   TARGET charge_mixing
-  LIBS  base ${math_libs}  psi  device planewave_serial
+  LIBS  base ${math_libs}  psi  device planewave_serial cell_simple
   SOURCES charge_mixing_test.cpp  
   ../module_charge/charge_mixing.cpp
   ../module_charge/charge_broyden.cpp
   ../module_charge/charge_pulay.cpp
-      # UnitCell dependencies
-      ../../module_cell/unitcell.cpp
-      ../../module_cell/read_atoms.cpp
-      ../../module_cell/read_cell_pseudopots.cpp
-      ../../module_cell/atom_spec.cpp
-      ../../module_cell/atom_pseudo.cpp
-      ../../module_cell/pseudo_nc.cpp
-      ../../module_cell/read_pp.cpp
-      ../../module_cell/read_pp_upf201.cpp
-      ../../module_cell/read_pp_upf100.cpp
-      ../../module_cell/read_pp_vwr.cpp
-      ../../module_cell/read_pp_blps.cpp
-      ../../module_io/output.cpp
+  ../../module_io/output.cpp
 )
 
 AddTest(
   TARGET charge_extra
-  LIBS ${math_libs} base device
+  LIBS ${math_libs} base device cell_simple
   SOURCES charge_extra_test.cpp ../module_charge/charge_extra.cpp ../../module_io/read_cube.cpp ../../module_io/write_cube.cpp
-  # UnitCell dependencies
-  ../../module_cell/unitcell.cpp
-  ../../module_cell/read_atoms.cpp
-  ../../module_cell/read_cell_pseudopots.cpp
-  ../../module_cell/atom_spec.cpp
-  ../../module_cell/atom_pseudo.cpp
-  ../../module_cell/pseudo_nc.cpp
-  ../../module_cell/read_pp.cpp
-  ../../module_cell/read_pp_upf201.cpp
-  ../../module_cell/read_pp_upf100.cpp
-  ../../module_cell/read_pp_vwr.cpp
-  ../../module_cell/read_pp_blps.cpp
   ../../module_io/output.cpp
 )

--- a/source/module_elecstate/test/CMakeLists.txt
+++ b/source/module_elecstate/test/CMakeLists.txt
@@ -80,34 +80,19 @@ AddTest(
     ../../module_io/output.cpp
 )
 
-list(APPEND cell_simple_srcs
-    ../../module_cell/unitcell.cpp
-    ../../module_cell/read_atoms.cpp
-    ../../module_cell/read_cell_pseudopots.cpp
-    ../../module_cell/atom_spec.cpp
-    ../../module_cell/atom_pseudo.cpp
-    ../../module_cell/pseudo_nc.cpp
-    ../../module_cell/read_pp.cpp
-    ../../module_cell/read_pp_upf201.cpp
-    ../../module_cell/read_pp_upf100.cpp
-    ../../module_cell/read_pp_vwr.cpp
-    ../../module_cell/read_pp_blps.cpp
-)
-
 AddTest(
   TARGET charge_mixing
-  LIBS  base ${math_libs}  psi  device planewave_serial
+  LIBS  base ${math_libs}  psi  device planewave_serial cell_simple
   SOURCES charge_mixing_test.cpp  
   ../module_charge/charge_mixing.cpp
   ../module_charge/charge_broyden.cpp
   ../module_charge/charge_pulay.cpp
   ../../module_io/output.cpp
-  ${cell_simple_srcs}
 )
 
 AddTest(
   TARGET charge_extra
-  LIBS ${math_libs} base device
+  LIBS ${math_libs} base device cell_simple
   SOURCES charge_extra_test.cpp ../module_charge/charge_extra.cpp ../../module_io/read_cube.cpp ../../module_io/write_cube.cpp
-  ../../module_io/output.cpp ${cell_simple_srcs}
+  ../../module_io/output.cpp
 )

--- a/source/module_hamilt_general/module_surchem/test/CMakeLists.txt
+++ b/source/module_hamilt_general/module_surchem/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 remove_definitions(-D__LCAO )
 remove_definitions(-DUSE_LIBXC)
+remove_definitions(-D__EXX)
 install(DIRECTORY support DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 list(APPEND depend_files 

--- a/source/module_hamilt_general/module_surchem/test/CMakeLists.txt
+++ b/source/module_hamilt_general/module_surchem/test/CMakeLists.txt
@@ -1,6 +1,5 @@
 remove_definitions(-D__LCAO )
 remove_definitions(-DUSE_LIBXC)
-remove_definitions(-D__EXX)
 install(DIRECTORY support DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 list(APPEND depend_files 

--- a/source/module_io/test/CMakeLists.txt
+++ b/source/module_io/test/CMakeLists.txt
@@ -67,7 +67,7 @@ AddTest(
 
 AddTest(
   TARGET io_print_info
-  LIBS ${math_libs} base device symmetry cell_simple
+  LIBS ${math_libs} base device symmetry cell_info
   SOURCES print_info_test.cpp ../print_info.cpp ../input.cpp ../output.cpp ../../module_cell/klist.cpp ../../module_cell/parallel_kpoints.cpp
 )
 
@@ -95,7 +95,7 @@ AddTest(
 
 AddTest(
   TARGET io_write_orb_info
-  LIBS ${math_libs} base device cell_simple
+  LIBS ${math_libs} base device cell_info
   SOURCES write_orb_info_test.cpp ../write_orb_info.cpp ../output.cpp
 )
 

--- a/source/module_io/test/CMakeLists.txt
+++ b/source/module_io/test/CMakeLists.txt
@@ -67,12 +67,8 @@ AddTest(
 
 AddTest(
   TARGET io_print_info
-  LIBS ${math_libs} base device symmetry
-  SOURCES print_info_test.cpp ../print_info.cpp ../input.cpp ../output.cpp ../../module_cell/unitcell.cpp
-  ../../module_cell/read_atoms.cpp ../../module_cell/read_cell_pseudopots.cpp ../../module_cell/atom_spec.cpp
-  ../../module_cell/atom_pseudo.cpp ../../module_cell/pseudo_nc.cpp ../../module_cell/read_pp.cpp
-  ../../module_cell/read_pp_upf201.cpp ../../module_cell/read_pp_upf100.cpp ../../module_cell/read_pp_vwr.cpp
-  ../../module_cell/read_pp_blps.cpp ../../module_cell/klist.cpp ../../module_cell/parallel_kpoints.cpp
+  LIBS ${math_libs} base device symmetry cell_simple
+  SOURCES print_info_test.cpp ../print_info.cpp ../input.cpp ../output.cpp ../../module_cell/klist.cpp ../../module_cell/parallel_kpoints.cpp
 )
 
 AddTest(
@@ -99,12 +95,8 @@ AddTest(
 
 AddTest(
   TARGET io_write_orb_info
-  LIBS ${math_libs} base device
-  SOURCES write_orb_info_test.cpp ../write_orb_info.cpp ../output.cpp ../../module_cell/unitcell.cpp
-	../../module_cell/read_atoms.cpp ../../module_cell/read_cell_pseudopots.cpp ../../module_cell/atom_spec.cpp
-	../../module_cell/atom_pseudo.cpp ../../module_cell/pseudo_nc.cpp ../../module_cell/read_pp.cpp
-	../../module_cell/read_pp_upf201.cpp ../../module_cell/read_pp_upf100.cpp ../../module_cell/read_pp_vwr.cpp
-	../../module_cell/read_pp_blps.cpp
+  LIBS ${math_libs} base device cell_simple
+  SOURCES write_orb_info_test.cpp ../write_orb_info.cpp ../output.cpp
 )
 
 AddTest(

--- a/source/module_io/test_serial/CMakeLists.txt
+++ b/source/module_io/test_serial/CMakeLists.txt
@@ -7,13 +7,13 @@ install(DIRECTORY support DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 AddTest(
   TARGET io_rho_io
-  LIBS ${math_libs} base device cell_simple
+  LIBS ${math_libs} base device cell_info
   SOURCES rho_io_test.cpp ../read_cube.cpp ../write_cube.cpp ../read_rho.cpp ../write_rho.cpp ../output.cpp
 )
 
 AddTest(
   TARGET io_dm_io
-  LIBS ${math_libs} base device cell_simple
+  LIBS ${math_libs} base device cell_info
   SOURCES dm_io_test.cpp ../read_dm.cpp ../write_dm.cpp ../output.cpp
 )
 

--- a/source/module_io/test_serial/CMakeLists.txt
+++ b/source/module_io/test_serial/CMakeLists.txt
@@ -7,22 +7,14 @@ install(DIRECTORY support DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 AddTest(
   TARGET io_rho_io
-  LIBS ${math_libs} base device
-  SOURCES rho_io_test.cpp ../read_cube.cpp ../write_cube.cpp ../read_rho.cpp ../write_rho.cpp ../output.cpp ../../module_cell/unitcell.cpp
-  	../../module_cell/read_atoms.cpp ../../module_cell/read_cell_pseudopots.cpp ../../module_cell/atom_spec.cpp
-	../../module_cell/atom_pseudo.cpp ../../module_cell/pseudo_nc.cpp ../../module_cell/read_pp.cpp
-	../../module_cell/read_pp_upf201.cpp ../../module_cell/read_pp_upf100.cpp ../../module_cell/read_pp_vwr.cpp
-	../../module_cell/read_pp_blps.cpp
+  LIBS ${math_libs} base device cell_simple
+  SOURCES rho_io_test.cpp ../read_cube.cpp ../write_cube.cpp ../read_rho.cpp ../write_rho.cpp ../output.cpp
 )
 
 AddTest(
   TARGET io_dm_io
-  LIBS ${math_libs} base device
-  SOURCES dm_io_test.cpp ../read_dm.cpp ../write_dm.cpp ../output.cpp ../../module_cell/unitcell.cpp
-	../../module_cell/read_atoms.cpp ../../module_cell/read_cell_pseudopots.cpp ../../module_cell/atom_spec.cpp
-	../../module_cell/atom_pseudo.cpp ../../module_cell/pseudo_nc.cpp ../../module_cell/read_pp.cpp
-	../../module_cell/read_pp_upf201.cpp ../../module_cell/read_pp_upf100.cpp ../../module_cell/read_pp_vwr.cpp
-	../../module_cell/read_pp_blps.cpp
+  LIBS ${math_libs} base device cell_simple
+  SOURCES dm_io_test.cpp ../read_dm.cpp ../write_dm.cpp ../output.cpp
 )
 
 AddTest(


### PR DESCRIPTION
Fix #2732 