### PR TITLE
Refactor: CubicSpline class stores derivatives instead of polynomial coefficients

### DIFF
--- a/source/module_base/test/cubic_spline_test.cpp
+++ b/source/module_base/test/cubic_spline_test.cpp
@@ -92,7 +92,7 @@ TEST_F(CubicSplineTest, NotAKnot)
     y_ref_[4] = 0.1510153464180796;
     y_ref_[5] = 0.1411200080598672;
 
-    cubspl.get(ni, x_interp_, y_interp_);
+    cubspl.interp(ni, x_interp_, y_interp_);
     for (int i = 0; i != ni; ++i)
     {
         EXPECT_NEAR(y_interp_[i], y_ref_[i], tol);
@@ -125,7 +125,7 @@ TEST_F(CubicSplineTest, PeriodicAndUniform)
     y_ref_[3] = 1.4356324132349871e-04;
     y_ref_[4] = 1.0000000000000000e+00;
 
-    cubspl.get(ni, x_interp_, y_interp_);
+    cubspl.interp(ni, x_interp_, y_interp_);
     for (int i = 0; i != ni; ++i)
     {
         EXPECT_NEAR(y_interp_[i], y_ref_[i], tol);
@@ -166,7 +166,7 @@ TEST_F(CubicSplineTest, FirstDeriv)
     y_ref_[4] = 0.0798871927951471;
     y_ref_[5] = 0.0497870683678639;
 
-    cubspl.get(ni, x_interp_, y_interp_);
+    cubspl.interp(ni, x_interp_, y_interp_);
     for (int i = 0; i != ni; ++i)
     {
         EXPECT_NEAR(y_interp_[i], y_ref_[i], tol);
@@ -207,7 +207,7 @@ TEST_F(CubicSplineTest, SecondDeriv)
     y_ref_[4] = 0.0788753653329337;
     y_ref_[5] = 0.0497870683678639;
 
-    cubspl.get(ni, x_interp_, y_interp_);
+    cubspl.interp(ni, x_interp_, y_interp_);
     for (int i = 0; i != ni; ++i)
     {
         EXPECT_NEAR(y_interp_[i], y_ref_[i], tol);
@@ -245,7 +245,7 @@ TEST_F(CubicSplineTest, TwoPoints)
     y_ref_[3] = 4.159700000000001;
     y_ref_[4] = 4.33;
 
-    cubspl.get(ni, x_interp_, y_interp_);
+    cubspl.interp(ni, x_interp_, y_interp_);
     for (int i = 0; i != ni; ++i)
     {
         EXPECT_NEAR(y_interp_[i], y_ref_[i], tol);
@@ -266,7 +266,7 @@ TEST_F(CubicSplineTest, TwoPoints)
     y_ref_[3] = 4.074050000000001;
     y_ref_[4] = 4.33;
 
-    cubspl.get(ni, x_interp_, y_interp_);
+    cubspl.interp(ni, x_interp_, y_interp_);
     for (int i = 0; i != ni; ++i)
     {
         EXPECT_NEAR(y_interp_[i], y_ref_[i], tol);
@@ -276,7 +276,7 @@ TEST_F(CubicSplineTest, TwoPoints)
     y_[1] = y_[0];
     cubspl.build(2, x_, y_, CubicSpline::BoundaryCondition::periodic, CubicSpline::BoundaryCondition::periodic);
 
-    cubspl.get(ni, x_interp_, y_interp_);
+    cubspl.interp(ni, x_interp_, y_interp_);
     for (int i = 0; i != ni; ++i)
     {
         EXPECT_NEAR(y_interp_[i], 2.33, tol);
@@ -313,7 +313,7 @@ TEST_F(CubicSplineTest, ThreePoints)
     y_ref_[3] = 4.3875;
     y_ref_[4] = 4.8;
 
-    cubspl.get(ni, x_interp_, y_interp_);
+    cubspl.interp(ni, x_interp_, y_interp_);
     for (int i = 0; i != ni; ++i)
     {
         EXPECT_NEAR(y_interp_[i], y_ref_[i], tol);
@@ -329,7 +329,7 @@ TEST_F(CubicSplineTest, ThreePoints)
     y_ref_[3] = 1.2361111111111112;
     y_ref_[4] = 1.2;
 
-    cubspl.get(ni, x_interp_, y_interp_);
+    cubspl.interp(ni, x_interp_, y_interp_);
     for (int i = 0; i != ni; ++i)
     {
         EXPECT_NEAR(y_interp_[i], y_ref_[i], tol);

--- a/source/module_basis/module_nao/numerical_radial.cpp
+++ b/source/module_basis/module_nao/numerical_radial.cpp
@@ -240,7 +240,7 @@ void NumericalRadial::set_grid(const bool for_r_space, const int ngrid, const do
         // grid_end is the first grid point that is strictly greater than grid_tbu[ngrid_tbu-1]
         double* grid_end = std::upper_bound(grid_new, grid_new + ngrid, grid_tbu[ngrid_tbu - 1]);
 
-        cubspl.get(std::distance(grid_start, grid_end), grid_start, value_new + std::distance(grid_new, grid_start));
+        cubspl.interp(std::distance(grid_start, grid_end), grid_start, value_new + std::distance(grid_new, grid_start));
 
         delete[] grid_tbu;
         delete[] value_tbu;


### PR DESCRIPTION
This PR :
1. changes the data stored in CubicSpline from polynomial coefficients of the interpolants to derivatives at the knots. This should save ~40% of the space.
2.  enable the evaluation of derivatives