### PR TITLE
Refactor: remove a useless head file in cal_dm.h

### DIFF
--- a/source/module_elecstate/cal_dm.h
+++ b/source/module_elecstate/cal_dm.h
@@ -5,7 +5,6 @@
 #include "module_base/timer.h"
 #include "module_base/matrix.h"
 #include "module_base/complexmatrix.h"
-#include "module_hamilt_lcao/hamilt_lcaodft/local_orbital_charge.h"
 
 namespace elecstate
 {


### PR DESCRIPTION
cal_dm.h does not use any definition of "module_hamilt_lcao/hamilt_lcaodft/local_orbital_charge.h".