### PR TITLE
Fix: autoset bx/by/bz when set nx/ny/nz manually

### DIFF
--- a/source/module_basis/module_pw/pw_basis_big.h
+++ b/source/module_basis/module_pw/pw_basis_big.h
@@ -283,6 +283,36 @@ public:
         this->nx = nx_in;
         this->ny = ny_in;
         this->nz = nz_in;
+        // autoset bx/by/bz if not set in INPUT
+        if (!this->bz)
+        {
+        this->autoset_big_cell_size(this->bz, nz, this->poolnproc);
+        }
+        if (!this->bx)
+        {
+        // if cz == cx, autoset bx==bz for keeping same symmetry
+        if (nx == nz)
+        {
+            this->bx = this->bz;
+        }
+        else
+        {
+            this->autoset_big_cell_size(this->bx, nx);
+        }
+        }
+        if (!this->by)
+        {
+        // if cz == cy, autoset by==bz for keeping same symmetry
+        if (ny == nz)
+        {
+            this->by = this->bz;
+        }
+        else
+        {
+            this->autoset_big_cell_size(this->by, ny);
+        }
+        }
+        this->bxyz = this->bx * this->by * this->bz;
         if(this->nx%this->bx != 0) this->nx += (this->bx - this->nx % this->bx);
         if(this->ny%this->by != 0) this->ny += (this->by - this->ny % this->by);
         if(this->nz%this->bz != 0) this->nz += (this->bz - this->nz % this->bz);

--- a/source/module_io/input.cpp
+++ b/source/module_io/input.cpp
@@ -2712,10 +2712,17 @@ void Input::Default_2(void) // jiyy add 2019-08-04
             ModuleBase::GlobalFunc::AUTO_SET("lcao_ecut", ecutwfc);
         }
 
-        // set bx, by, bz
-        if (!bx) bx = 1;
-        if (!by) by = 1;
-        if (!bz) bz = 1;
+        // if calculation is get_wf, function source/module_basis/module_pw/pw_basis_k_big.h/distribute_r()
+        // will calculate nbx/nby/nbz by divide nx/ny/nz by bx/by/bz, so bx/by/bz should not be 0
+        if (calculation == "get_wf")
+        {
+            if (!bx)
+                bx = 1;
+            if (!by)
+                by = 1;
+            if (!bz)
+                bz = 1;
+        }
     }
 
     if (basis_type == "pw" || basis_type == "lcao_in_pw")

--- a/source/module_io/input.cpp
+++ b/source/module_io/input.cpp
@@ -2712,6 +2712,7 @@ void Input::Default_2(void) // jiyy add 2019-08-04
             ModuleBase::GlobalFunc::AUTO_SET("lcao_ecut", ecutwfc);
         }
 
+        // set bx, by, bz
         if (!bx) bx = 1;
         if (!by) by = 1;
         if (!bz) bz = 1;

--- a/source/module_io/input.cpp
+++ b/source/module_io/input.cpp
@@ -2712,17 +2712,9 @@ void Input::Default_2(void) // jiyy add 2019-08-04
             ModuleBase::GlobalFunc::AUTO_SET("lcao_ecut", ecutwfc);
         }
 
-        // if calculation is get_wf, function source/module_basis/module_pw/pw_basis_k_big.h/distribute_r()
-        // will calculate nbx/nby/nbz by divide nx/ny/nz by bx/by/bz, so bx/by/bz should not be 0
-        if (calculation == "get_wf")
-        {
-            if (!bx)
-                bx = 1;
-            if (!by)
-                by = 1;
-            if (!bz)
-                bz = 1;
-        }
+        if (!bx) bx = 1;
+        if (!by) by = 1;
+        if (!bz) bz = 1;
     }
 
     if (basis_type == "pw" || basis_type == "lcao_in_pw")


### PR DESCRIPTION
Fix #2726 

The bug in #2726 happens because 0 is put in the denominator:
This happens only in LCAO calculation. In pw, bx = by = bz = 1 is set in input.cpp line 2693. It happens in
```
void ESolver_FP::Init
{
...
            if (inp.nx * inp.ny * inp.nz == 0)
            this->pw_rho->initgrids(inp.ref_cell_factor * cell.lat0, cell.latvec, inp.ecutrho);
	    else
            this->pw_rho->initgrids(inp.ref_cell_factor * cell.lat0, cell.latvec, inp.nx, inp.ny, inp.nz);
...
}
```
where, if users have set nx, ny, nz, it will go to the second branch, then in the following function:
```
virtual void initgrids(
    const double lat0_in,
    const ModuleBase::Matrix3 latvec_in, // Unitcell lattice vectors
    const int nx_in, int ny_in, int nz_in
    )
{
...
        if(this->nx%this->bx != 0) this->nx += (this->bx - this->nx % this->bx);
        if(this->ny%this->by != 0) this->ny += (this->by - this->ny % this->by);
        if(this->nz%this->bz != 0) this->nz += (this->bz - this->nz % this->bz);
...
}
```
bx, by, bz are now zero, aborting the whole process.