### PR TITLE
Fix FileNotFoundError in unit test io_bessel_basis

### DIFF
--- a/source/module_io/test/CMakeLists.txt
+++ b/source/module_io/test/CMakeLists.txt
@@ -4,7 +4,7 @@ remove_definitions(-D__ROCM)
 remove_definitions(-D__EXX)
 
 install(DIRECTORY support DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-install(FILES INPUTs ${CMAKE_CURRENT_BINARY_DIR})
+install(FILES INPUTs DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 AddTest(
   TARGET io_input_test

--- a/source/module_io/test/CMakeLists.txt
+++ b/source/module_io/test/CMakeLists.txt
@@ -4,6 +4,7 @@ remove_definitions(-D__ROCM)
 remove_definitions(-D__EXX)
 
 install(DIRECTORY support DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+install(FILES INPUTs ${CMAKE_CURRENT_BINARY_DIR})
 
 AddTest(
   TARGET io_input_test

--- a/source/module_io/test/bessel_basis_test.cpp
+++ b/source/module_io/test/bessel_basis_test.cpp
@@ -524,7 +524,11 @@ TEST_F(TestBesselBasis, PolynomialInterpolationTest) {
     /* 
       Therefore Faln is expected to have dimension 1*1*1*6
     */
-    
+    #ifdef __MPI
+        int argc = 0;
+        char** argv = NULL;
+        MPI_Init(&argc, &argv);
+    #endif
     besselBasis.init(
         b_TestFaln, d_EnergyCutoff, i_Ntype, i_Lmax, b_Smooth, 
         d_SmoothSigma, d_CutoffRadius, d_Tolerance, 

--- a/source/module_io/test/bessel_basis_test.cpp
+++ b/source/module_io/test/bessel_basis_test.cpp
@@ -524,11 +524,7 @@ TEST_F(TestBesselBasis, PolynomialInterpolationTest) {
     /* 
       Therefore Faln is expected to have dimension 1*1*1*6
     */
-    #ifdef __MPI
-        int argc = 0;
-        char** argv = NULL;
-        MPI_Init(&argc, &argv);
-    #endif
+    
     besselBasis.init(
         b_TestFaln, d_EnergyCutoff, i_Ntype, i_Lmax, b_Smooth, 
         d_SmoothSigma, d_CutoffRadius, d_Tolerance, 

--- a/source/module_io/test/support/BesselBasis_UnitTest_C4_AtomType0.html
+++ b/source/module_io/test/support/BesselBasis_UnitTest_C4_AtomType0.html
@@ -17,7 +17,10 @@ Final description:
 In unit test case, only one chi, one l is used, and EnergyCutoff, CutoffRadius are selected to have Nq=1.
 </COMMENT>
 <INPUTS>
-4 2 1 0.01
+4
+2
+1
+0.01
 </INPUTS>
 <C4>
 1

--- a/source/module_io/test/support/BesselBasis_UnitTest_C4_AtomType0.html
+++ b/source/module_io/test/support/BesselBasis_UnitTest_C4_AtomType0.html
@@ -17,10 +17,7 @@ Final description:
 In unit test case, only one chi, one l is used, and EnergyCutoff, CutoffRadius are selected to have Nq=1.
 </COMMENT>
 <INPUTS>
-4
-2
-1
-0.01
+4 2 1 0.01
 </INPUTS>
 <C4>
 1


### PR DESCRIPTION
1. INSTALL sentence was not added to CMakeLists file so INPUTs cannot be found, that caused abortion of the third unit test.    
2. modify the html file for C4 coefficients read-in procedure
3. add initialization of MPI before calling `Init()` function, where `MPI_Bcast()` is called.    