### PR TITLE
Fix: wrong stress results of scan when NPROC_IN_POOLS is large

### DIFF
--- a/source/module_base/parallel_global.cpp
+++ b/source/module_base/parallel_global.cpp
@@ -262,7 +262,10 @@ void Parallel_Global::read_mpi_parameters(int argc,char **argv)
 void Parallel_Global::finalize_mpi()
 {
 	MPI_Comm_free(&POOL_WORLD);
-    MPI_Comm_free(&INTER_POOL);
+    if (GlobalV::NPROC_IN_STOGROUP % GlobalV::KPAR == 0)
+    {
+        MPI_Comm_free(&INTER_POOL);
+    }
 	MPI_Comm_free(&STO_WORLD);
 	MPI_Comm_free(&PARAPW_WORLD);
 	MPI_Comm_free(&GRID_WORLD);

--- a/source/module_hamilt_pw/hamilt_pwdft/stress_func_mgga.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/stress_func_mgga.cpp
@@ -32,7 +32,7 @@ void Stress_Func<FPTYPE, Device>::stress_mgga(ModuleBase::matrix& sigma,
     for (int is = 0; is < GlobalV::NSPIN; ++is)
     {
         crosstaus[is] = new FPTYPE[nrxx * 6];
-        ModuleBase::GlobalFunc::ZEROS(crosstaus[is], GlobalV::NSPIN);
+        ModuleBase::GlobalFunc::ZEROS(crosstaus[is], 6*nrxx);
     }
 
     for (int ik = 0; ik < p_kv->nks; ik++)


### PR DESCRIPTION
fix issue #2813 