### PR TITLE
only set zero if BaseMatrix is not a nullptr

### DIFF
--- a/source/module_hamilt_lcao/module_hcontainer/atom_pair.cpp
+++ b/source/module_hamilt_lcao/module_hcontainer/atom_pair.cpp
@@ -188,7 +188,10 @@ void AtomPair<T>::set_zero()
 {
     for(auto& value : values)
     {
+        if (value.get_pointer() != nullptr)
+        {
         value.set_zero();
+        }
     }
 }
 


### PR DESCRIPTION
fix #2848 
Ensure set_zero will not create bug if BaseMatrix is nullptr.