### PR TITLE
Fix: bugs of reading STRU ABFS_ORBITAL when NPROC>1 or RPA

### DIFF
--- a/source/module_cell/read_atoms.cpp
+++ b/source/module_cell/read_atoms.cpp
@@ -110,7 +110,7 @@ int UnitCell::read_atom_species(std::ifstream &ifa, std::ofstream &ofs_running)
 	// Peize Lin add 2016-09-23
 #ifdef __MPI 
 #ifdef __EXX
-	if( GlobalC::exx_info.info_global.cal_exx )
+	if( GlobalC::exx_info.info_global.cal_exx || INPUT.rpa )
 	{
 		if( ModuleBase::GlobalFunc::SCAN_BEGIN(ifa, "ABFS_ORBITAL") )
 		{

--- a/source/module_cell/unitcell.cpp
+++ b/source/module_cell/unitcell.cpp
@@ -17,6 +17,11 @@
 #include "module_base/element_elec_config.h"
 #include "module_base/element_covalent_radius.h"
 
+#ifdef __EXX
+#include "module_hamilt_pw/hamilt_pwdft/global.h"
+#include "module_ri/serialization_cereal.h"
+#endif
+
 UnitCell::UnitCell()
 {
     if (GlobalV::test_unitcell)
@@ -145,6 +150,10 @@ void UnitCell::bcast_unitcell(void)
     {
         atoms[i].bcast_atom(); // init tau and mbl array
     }
+
+#ifdef __EXX
+    ModuleBase::bcast_data_cereal(GlobalC::exx_info.info_ri.files_abfs, MPI_COMM_WORLD, 0);
+#endif
     return;
 }
 


### PR DESCRIPTION
fix issue #2883 