### PR TITLE
Refactor and move `act()` interface from OperatorPW to basic Operator

### DIFF
--- a/source/module_hamilt_general/operator.cpp
+++ b/source/module_hamilt_general/operator.cpp
@@ -118,7 +118,6 @@ FPTYPE* Operator<FPTYPE, Device>::get_hpsi(const hpsi_info& info) const
     return hpsi_pointer;
 }
 
-
 namespace hamilt {
 template class Operator<float, psi::DEVICE_CPU>;
 template class Operator<std::complex<float>, psi::DEVICE_CPU>;

--- a/source/module_hamilt_general/operator.h
+++ b/source/module_hamilt_general/operator.h
@@ -46,7 +46,16 @@ class Operator
 
     virtual void add(Operator* next);
 
-    virtual int get_ik() const {return this->ik;}
+    virtual int get_ik() const { return this->ik; }
+
+    //do operation : |hpsi_choosed> = V|psi_choosed>
+    //V is the target operator act on choosed psi, the consequence should be added to choosed hpsi
+    virtual void act(const int nbands,
+        const int nbasis,
+        const int npol,
+        const FPTYPE* tmpsi_in,
+        FPTYPE* tmhpsi,
+        const int ngk_ik = 0)const {};
 
     Operator* next_op = nullptr;
 

--- a/source/module_hamilt_pw/hamilt_pwdft/operator_pw/ekinetic_pw.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/operator_pw/ekinetic_pw.cpp
@@ -31,26 +31,27 @@ Ekinetic<OperatorPW<FPTYPE, Device>>::~Ekinetic() {}
 
 template<typename FPTYPE, typename Device>
 void Ekinetic<OperatorPW<FPTYPE, Device>>::act(
-    const psi::Psi<std::complex<FPTYPE>, Device> *psi_in, 
-    const int n_npwx, 
-    const std::complex<FPTYPE>* tmpsi_in, 
-    std::complex<FPTYPE>* tmhpsi)const
+    const int nbands,
+    const int nbasis,
+    const int npol,
+    const std::complex<FPTYPE>* tmpsi_in,
+    std::complex<FPTYPE>* tmhpsi,
+    const int ngk_ik)const
 {
-  ModuleBase::timer::tick("Operator", "EkineticPW");
-  const int npw = psi_in->get_ngk(this->ik);
-  this->max_npw = psi_in->get_nbasis() / psi_in->npol;
+    ModuleBase::timer::tick("Operator", "EkineticPW");
+    int max_npw = nbasis / npol;
 
   const FPTYPE *gk2_ik = &(this->gk2[this->ik * this->gk2_col]);
   // denghui added 20221019
-  ekinetic_op()(this->ctx, n_npwx, npw, this->max_npw, tpiba2, gk2_ik, tmhpsi, tmpsi_in);
-  // for (int ib = 0; ib < n_npwx; ++ib)
+  ekinetic_op()(this->ctx, nbands, ngk_ik, max_npw, tpiba2, gk2_ik, tmhpsi, tmpsi_in);
+  // for (int ib = 0; ib < nbands; ++ib)
   // {
-  //     for (int ig = 0; ig < npw; ++ig)
+  //     for (int ig = 0; ig < ngk_ik; ++ig)
   //     {
   //         tmhpsi[ig] += gk2_ik[ig] * tpiba2 * tmpsi_in[ig];
   //     }
-  //     tmhpsi += this->max_npw;
-  //     tmpsi_in += this->max_npw;
+  //     tmhpsi += max_npw;
+  //     tmpsi_in += max_npw;
   // }
   ModuleBase::timer::tick("Operator", "EkineticPW");
 }

--- a/source/module_hamilt_pw/hamilt_pwdft/operator_pw/ekinetic_pw.h
+++ b/source/module_hamilt_pw/hamilt_pwdft/operator_pw/ekinetic_pw.h
@@ -34,11 +34,12 @@ class Ekinetic<OperatorPW<FPTYPE, Device>> : public OperatorPW<FPTYPE, Device>
 
     virtual ~Ekinetic();
 
-    virtual void act(
-        const psi::Psi<std::complex<FPTYPE>, Device> *psi_in, 
-        const int n_npwx, 
-        const std::complex<FPTYPE>* tmpsi_in, 
-        std::complex<FPTYPE>* tmhpsi)const override;
+    virtual void act(const int nbands,
+        const int nbasis,
+        const int npol,
+        const std::complex<FPTYPE>* tmpsi_in,
+        std::complex<FPTYPE>* tmhpsi,
+        const int ngk_ik = 0)const override;
 
     // denghuilu added for copy construct at 20221105
     int get_gk2_row() const {return this->gk2_row;}
@@ -48,10 +49,6 @@ class Ekinetic<OperatorPW<FPTYPE, Device>> : public OperatorPW<FPTYPE, Device>
     Device* get_ctx() const {return this->ctx;}
 
   private:
-
-    mutable int max_npw = 0;
-
-    mutable int npol = 0;
 
     FPTYPE tpiba2 = 0.0;
     const FPTYPE* gk2 = nullptr;

--- a/source/module_hamilt_pw/hamilt_pwdft/operator_pw/meta_pw.h
+++ b/source/module_hamilt_pw/hamilt_pwdft/operator_pw/meta_pw.h
@@ -35,10 +35,12 @@ class Meta<OperatorPW<FPTYPE, Device>> : public OperatorPW<FPTYPE, Device>
 
       virtual ~Meta();
 
-      virtual void act(const psi::Psi<std::complex<FPTYPE>, Device>* psi_in,
-                       const int n_npwx,
-                       const std::complex<FPTYPE>* tmpsi_in,
-                       std::complex<FPTYPE>* tmhpsi) const override;
+      virtual void act(const int nbands,
+          const int nbasis,
+          const int npol,
+          const std::complex<FPTYPE>* tmpsi_in,
+          std::complex<FPTYPE>* tmhpsi,
+          const int ngk = 0)const override;
 
       // denghui added for copy constructor at 20221105
       FPTYPE get_tpiba() const

--- a/source/module_hamilt_pw/hamilt_pwdft/operator_pw/nonlocal_pw.h
+++ b/source/module_hamilt_pw/hamilt_pwdft/operator_pw/nonlocal_pw.h
@@ -37,12 +37,12 @@ class Nonlocal<OperatorPW<FPTYPE, Device>> : public OperatorPW<FPTYPE, Device>
 
     virtual void init(const int ik_in)override;
 
-    virtual void act(
-        const psi::Psi<std::complex<FPTYPE>, Device> *psi_in, 
-        const int n_npwx, 
-        const std::complex<FPTYPE>* tmpsi_in, 
-        std::complex<FPTYPE>* tmhpsi
-    )const override;
+    virtual void act(const int nbands,
+        const int nbasis,
+        const int npol,
+        const std::complex<FPTYPE>* tmpsi_in,
+        std::complex<FPTYPE>* tmhpsi,
+        const int ngk = 0)const override;
 
     const int *get_isk() const {return this->isk;}
     const pseudopot_cell_vnl *get_ppcell() const {return this->ppcell;}

--- a/source/module_hamilt_pw/hamilt_pwdft/operator_pw/operator_pw.h
+++ b/source/module_hamilt_pw/hamilt_pwdft/operator_pw/operator_pw.h
@@ -14,13 +14,6 @@ class OperatorPW : public Operator<std::complex<FPTYPE>, Device>
     using hpsi_info = typename hamilt::Operator<std::complex<FPTYPE>, Device>::hpsi_info;
     virtual hpsi_info hPsi(hpsi_info& input)const;
     //main function which should be modified in Operator for PW base
-    //do operation : |hpsi_choosed> = V|psi_choosed>
-    //V is the target operator act on choosed psi, the consequence should be added to choosed hpsi
-    virtual void act(
-        const psi::Psi<std::complex<FPTYPE>, Device> *psi_in, 
-        const int n_npwx, 
-        const std::complex<FPTYPE>* tmpsi_in, 
-        std::complex<FPTYPE>* tmhpsi)const;
 
     std::string classname = "";
     using syncmem_complex_op = psi::memory::synchronize_memory_op<std::complex<FPTYPE>, Device, Device>;

--- a/source/module_hamilt_pw/hamilt_pwdft/operator_pw/veff_pw.h
+++ b/source/module_hamilt_pw/hamilt_pwdft/operator_pw/veff_pw.h
@@ -33,18 +33,17 @@ class Veff<OperatorPW<FPTYPE, Device>> : public OperatorPW<FPTYPE, Device>
 
     virtual ~Veff();
 
-    virtual void act (
-        const psi::Psi<std::complex<FPTYPE>, Device> *psi_in, 
-        const int n_npwx, 
-        const std::complex<FPTYPE>* tmpsi_in, 
-        std::complex<FPTYPE>* tmhpsi
-    )const override;
+    virtual void act(const int nbands,
+        const int nbasis,
+        const int npol,
+        const std::complex<FPTYPE>* tmpsi_in,
+        std::complex<FPTYPE>* tmhpsi,
+        const int ngk_ik = 0)const override;
 
     // denghui added for copy constructor at 20221105
     const FPTYPE *get_veff() const {return this->veff;}
     int get_veff_col() const {return this->veff_col;}
-    int get_veff_row() const {return this->veff_row;}
-    int get_npol() const {return this->npol;}
+    int get_veff_row() const { return this->veff_row; }
     const int *get_isk() const {return isk;}
     const ModulePW::PW_Basis_K* get_wfcpw() const
     {
@@ -52,10 +51,6 @@ class Veff<OperatorPW<FPTYPE, Device>> : public OperatorPW<FPTYPE, Device>
     }
 
   private:
-
-    mutable int max_npw = 0;
-
-    mutable int npol = 0;
 
     const int* isk = nullptr;
 

--- a/source/module_hsolver/test/diago_mock.h
+++ b/source/module_hsolver/test/diago_mock.h
@@ -491,11 +491,12 @@ class OperatorMock_d : public hamilt::OperatorPW<double>
     }
     virtual void act
     (
-        const psi::Psi<std::complex<double>> *psi_in, 
-        const int n_npwx, 
-        const std::complex<double>* tmpsi_in, 
-        std::complex<double>* tmhpsi
-    )const 
+        const int nbands,
+        const int nbasis,
+        const int npol,
+        const std::complex<double>* tmpsi_in,
+        std::complex<double>* tmhpsi,
+        const int ngk_ik = 0)const
     {
         int nprocs=1, mypnum=0;
     #ifdef __MPI    
@@ -504,7 +505,7 @@ class OperatorMock_d : public hamilt::OperatorPW<double>
     #endif        
 
         std::complex<double> *hpsi0 = new std::complex<double>[DIAGOTEST::npw];
-        for(int m = 0; m< n_npwx; m++)
+        for (int m = 0; m < nbands; m++)
         {
             for(int i=0;i<DIAGOTEST::npw;i++)
             {
@@ -516,8 +517,8 @@ class OperatorMock_d : public hamilt::OperatorPW<double>
             }
             Parallel_Reduce::reduce_complex_double_pool(hpsi0, DIAGOTEST::npw);
             DIAGOTEST::divide_psi<std::complex<double>>(hpsi0, tmhpsi);
-            tmhpsi += psi_in->get_nbasis();
-            tmpsi_in += psi_in->get_nbasis();
+            tmhpsi += nbasis;
+            tmpsi_in += nbasis;
         }
         delete [] hpsi0;
     }
@@ -535,11 +536,12 @@ class OperatorMock_f : public hamilt::OperatorPW<float>
     }
     virtual void act
     (
-        const psi::Psi<std::complex<float>> *psi_in, 
-        const int n_npwx, 
-        const std::complex<float>* tmpsi_in, 
-        std::complex<float>* tmhpsi
-    )const 
+        const int nbands,
+        const int nbasis,
+        const int npol,
+        const std::complex<float>* tmpsi_in,
+        std::complex<float>* tmhpsi,
+        const int ngk_ik = 0)const
     {
         int nprocs=1, mypnum=0;
     #ifdef __MPI    
@@ -548,7 +550,7 @@ class OperatorMock_f : public hamilt::OperatorPW<float>
     #endif        
 
         std::complex<float> *hpsi0 = new std::complex<float>[DIAGOTEST::npw];
-        for(int m = 0; m< n_npwx; m++)
+        for (int m = 0; m < nbands; m++)
         {
             for(int i=0;i<DIAGOTEST::npw;i++)
             {
@@ -562,8 +564,8 @@ class OperatorMock_f : public hamilt::OperatorPW<float>
 	        MPI_Allreduce(MPI_IN_PLACE, hpsi0, DIAGOTEST::npw, MPI_C_FLOAT_COMPLEX, MPI_SUM, MPI_COMM_WORLD);
 #endif
             DIAGOTEST::divide_psi_f<std::complex<float>>(hpsi0, tmhpsi);	
-            tmhpsi += psi_in->get_nbasis();
-            tmpsi_in += psi_in->get_nbasis();
+            tmhpsi += nbasis;
+            tmpsi_in += nbasis;
         }
         delete [] hpsi0;
     }

--- a/source/module_psi/psi.cpp
+++ b/source/module_psi/psi.cpp
@@ -281,6 +281,7 @@ template <typename T, typename Device> int Psi<T, Device>::get_current_nbas() co
 
 template <typename T, typename Device> const int& Psi<T, Device>::get_ngk(const int ik_in) const
 {
+    if (!this->ngk) return this->nbasis;
     return this->ngk[ik_in];
 }
 


### PR DESCRIPTION
... so that the operators in LCAO and 2-particle Hamiltonian (#2460 ) can also use `act()` interface to calculate hPsi in the future.
For generality, the interface is made with no dependence on psi::Psi, and the name `n_npwx` is changed to `nbands`.