### PR TITLE
Refactor: update the initialization method of temperature

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -477,7 +477,7 @@ These variables are used to control general system parameters.
 - **Type**: Boolean
 - **Description**: 
 
-  - True: read the atom velocity from the atom file (STRU) if set to true. (atomic unit : 1 a.u. = 21.877 Angstrom/fs)
+  - True: read the atom velocity (atomic unit : 1 a.u. = 21.877 Angstrom/fs) from the atom file (`STRU`) and determine the initial temperature [md_tfirst](#md_tfirst-md_tlast).  If [md_tfirst](#md_tfirst-md_tlast) is unset or less than zero, `init_vel` is autoset to be `true`.
   - False: assign value to atom velocity using Gaussian distributed random numbers.
 - **Default**: False
 
@@ -2091,7 +2091,12 @@ These variables are used to control molecular dynamics calculations. For more in
 - **Type**: Real
 - **Description**: The temperature used in molecular dynamics calculations. 
 
-  Note that `md_tlast` is only used in NVT simulations. The default value of `md_tlast` is `md_tfirst`. If `md_tlast` is set to be different from `md_tfirst`, ABACUS will automatically change the temperature from `md_tfirst` to `md_tlast`.
+  If `md_tfirst` is unset or less than zero, [init_vel](#init_vel) is autoset to be `true`. If [init_vel](#init_vel) is `true`, the initial temperature will be determined by the velocities read from `STRU`. In this case, if velocities are unspecified in `STRU`, the initial temperature is set to zero. 
+
+  If `md_tfirst` is set to a positive value and [init_vel](#init_vel) is `true` simultaneously, please make sure they are consistent, otherwise abacus will exit immediately.
+
+
+  Note that `md_tlast` is only used in NVT/NPT simulations. If `md_tlast` is unset or less than zero, `md_tlast` is set to `md_tfirst`. If `md_tlast` is set to be different from `md_tfirst`, ABACUS will automatically change the temperature from `md_tfirst` to `md_tlast`.
 - **Default**: No default
 - **Unit**: K
 

--- a/source/module_io/input.cpp
+++ b/source/module_io/input.cpp
@@ -2617,8 +2617,6 @@ void Input::Default_2(void) // jiyy add 2019-08-04
         }
         if (!out_md_control)
             out_level = "m"; // zhengdy add 2019-04-07
-        if (mdp.md_tlast < 0.0)
-            mdp.md_tlast = mdp.md_tfirst;
         if (mdp.md_plast < 0.0)
             mdp.md_plast = mdp.md_pfirst;
 
@@ -2630,7 +2628,7 @@ void Input::Default_2(void) // jiyy add 2019-08-04
         {
             mdp.md_pfreq = 1.0 / 400 / mdp.md_dt;
         }
-        if (mdp.md_restart)
+        if (mdp.md_tfirst < 0 || mdp.md_restart)
         {
             init_vel = 1;
         }
@@ -3304,8 +3302,6 @@ void Input::Check(void)
         // deal with input parameters , 2019-04-30
         if (mdp.md_dt < 0)
             ModuleBase::WARNING_QUIT("Input::Check", "time interval of MD calculation should be set!");
-        if (mdp.md_tfirst < 0 && esolver_type != "tddft")
-            ModuleBase::WARNING_QUIT("Input::Check", "temperature of MD calculation should be set!");
         if (mdp.md_type == "npt" && mdp.md_pfirst < 0)
             ModuleBase::WARNING_QUIT("Input::Check", "pressure of MD calculation should be set!");
         if (mdp.md_type == "msst")

--- a/source/module_io/test/input_test.cpp
+++ b/source/module_io/test/input_test.cpp
@@ -893,10 +893,9 @@ TEST_F(InputTest, Default_2)
 	EXPECT_EQ(INPUT.symmetry,"0");
 	EXPECT_EQ(INPUT.cal_force,1);
 	EXPECT_EQ(INPUT.mdp.md_nstep,50);
-	EXPECT_EQ(INPUT.out_level,"m");
-	EXPECT_DOUBLE_EQ(INPUT.mdp.md_tlast,INPUT.mdp.md_tfirst);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.md_plast,INPUT.mdp.md_pfirst);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.md_tfreq,1.0/40/INPUT.mdp.md_dt);
+    EXPECT_EQ(INPUT.out_level, "m");
+    EXPECT_DOUBLE_EQ(INPUT.mdp.md_plast, INPUT.mdp.md_pfirst);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.md_tfreq,1.0/40/INPUT.mdp.md_dt);
 	EXPECT_DOUBLE_EQ(INPUT.mdp.md_pfreq,1.0/400/INPUT.mdp.md_dt);
 	EXPECT_EQ(INPUT.init_vel,1);
 	EXPECT_EQ(INPUT.cal_stress,1);
@@ -1031,16 +1030,8 @@ TEST_F(InputTest, Check)
 	output = testing::internal::GetCapturedStdout();
 	EXPECT_THAT(output,testing::HasSubstr("time interval of MD calculation should be set!"));
 	INPUT.mdp.md_dt = 1.0;
-	//
-	INPUT.mdp.md_tfirst = -1.0;
-	INPUT.esolver_type = "sdft";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("temperature of MD calculation should be set!"));
-	INPUT.mdp.md_tfirst = 1.0;
-	//
-	INPUT.mdp.md_type = "npt";
+    //
+    INPUT.mdp.md_type = "npt";
 	INPUT.mdp.md_pmode = "iso";
 	INPUT.mdp.md_pfirst = -1.0;
 	testing::internal::CaptureStdout();

--- a/source/module_md/md_base.cpp
+++ b/source/module_md/md_base.cpp
@@ -32,7 +32,39 @@ MD_base::MD_base(MD_para& MD_para_in, UnitCell& unit_in) : mdp(MD_para_in), ucel
     step_ = 0;
     step_rst_ = 0;
 
+    std::cout << " ----------------------------------- INIT VEL ---------------------------------------" << std::endl;
     MD_func::init_vel(ucell, mdp.md_tfirst, mdp.my_rank, allmass, frozen_freedom_, ionmbl, vel);
+    t_current = MD_func::current_temp(kinetic, ucell.nat, frozen_freedom_, allmass, vel);
+    if (unit_in.init_vel)
+    {
+        std::cout << " READ VEL FROM STRU" << std::endl;
+        if (mdp.md_tfirst < 0)
+        {
+            std::cout << " UNSET INITIAL TEMPERATURE, AUTOSET TO " << t_current * ModuleBase::Hartree_to_K << " K"
+                      << std::endl;
+        }
+        else if (std::fabs(mdp.md_tfirst - t_current) > 1e-8)
+        {
+            std::cout << " INITIAL TEMPERATURE IN INPUT  = " << mdp.md_tfirst * ModuleBase::Hartree_to_K << " K"
+                      << std::endl;
+            std::cout << " READING TEMPERATURE FROM STRU = " << t_current * ModuleBase::Hartree_to_K << " K"
+                      << std::endl;
+            std::cout << " INCONSISTENCE, PLEASE CHECK" << std::endl;
+            std::cout << " ------------------------------------- DONE -----------------------------------------"
+                      << std::endl;
+            exit(0);
+        }
+    }
+    else
+    {
+        std::cout << " RANDOM VEL ACCORDING TO INITIAL TEMPERATURE: " << t_current * ModuleBase::Hartree_to_K << " K"
+                  << std::endl;
+    }
+    if (mdp.md_tlast < 0)
+    {
+        mdp.md_tlast = mdp.md_tfirst;
+    }
+    std::cout << " ------------------------------------- DONE -----------------------------------------" << std::endl;
 }
 
 MD_base::~MD_base()
@@ -55,7 +87,6 @@ void MD_base::setup(ModuleESolver::ESolver* p_esolver, const std::string& global
 
     MD_func::force_virial(p_esolver, step_, ucell, potential, force, mdp.cal_stress, virial);
     MD_func::compute_stress(ucell, vel, allmass, mdp.cal_stress, virial, stress);
-    t_current = MD_func::current_temp(kinetic, ucell.nat, frozen_freedom_, allmass, vel);
     ucell.ionic_position_updated = true;
 }
 

--- a/source/module_md/md_base.cpp
+++ b/source/module_md/md_base.cpp
@@ -32,39 +32,12 @@ MD_base::MD_base(MD_para& MD_para_in, UnitCell& unit_in) : mdp(MD_para_in), ucel
     step_ = 0;
     step_rst_ = 0;
 
-    std::cout << " ----------------------------------- INIT VEL ---------------------------------------" << std::endl;
-    MD_func::init_vel(ucell, mdp.md_tfirst, mdp.my_rank, allmass, frozen_freedom_, ionmbl, vel);
+    MD_func::init_vel(ucell, mdp.my_rank, mdp.md_tfirst, allmass, frozen_freedom_, ionmbl, vel);
     t_current = MD_func::current_temp(kinetic, ucell.nat, frozen_freedom_, allmass, vel);
-    if (unit_in.init_vel)
-    {
-        std::cout << " READ VEL FROM STRU" << std::endl;
-        if (mdp.md_tfirst < 0)
-        {
-            std::cout << " UNSET INITIAL TEMPERATURE, AUTOSET TO " << t_current * ModuleBase::Hartree_to_K << " K"
-                      << std::endl;
-        }
-        else if (std::fabs(mdp.md_tfirst - t_current) > 1e-8)
-        {
-            std::cout << " INITIAL TEMPERATURE IN INPUT  = " << mdp.md_tfirst * ModuleBase::Hartree_to_K << " K"
-                      << std::endl;
-            std::cout << " READING TEMPERATURE FROM STRU = " << t_current * ModuleBase::Hartree_to_K << " K"
-                      << std::endl;
-            std::cout << " INCONSISTENCE, PLEASE CHECK" << std::endl;
-            std::cout << " ------------------------------------- DONE -----------------------------------------"
-                      << std::endl;
-            exit(0);
-        }
-    }
-    else
-    {
-        std::cout << " RANDOM VEL ACCORDING TO INITIAL TEMPERATURE: " << t_current * ModuleBase::Hartree_to_K << " K"
-                  << std::endl;
-    }
     if (mdp.md_tlast < 0)
     {
         mdp.md_tlast = mdp.md_tfirst;
     }
-    std::cout << " ------------------------------------- DONE -----------------------------------------" << std::endl;
 }
 
 MD_base::~MD_base()

--- a/source/module_md/md_func.cpp
+++ b/source/module_md/md_func.cpp
@@ -185,7 +185,6 @@ void init_vel(const UnitCell& unit_in,
     {
         rand_vel(unit_in.nat, temperature, allmass, frozen_freedom, frozen, ionmbl, my_rank, vel);
     }
-    std::cout << "--------------------------------- INITVEL DONE ------------------------------------" << std::endl;
 }
 
 void force_virial(ModuleESolver::ESolver* p_esolver,

--- a/source/module_md/md_func.cpp
+++ b/source/module_md/md_func.cpp
@@ -160,13 +160,14 @@ void rand_vel(const int& natom,
 }
 
 void init_vel(const UnitCell& unit_in,
-              const double& temperature,
               const int& my_rank,
+              double& temperature,
               double* allmass,
               int& frozen_freedom,
               ModuleBase::Vector3<int>* ionmbl,
               ModuleBase::Vector3<double>* vel)
 {
+    std::cout << " ----------------------------------- INIT VEL ---------------------------------------" << std::endl;
     ModuleBase::Vector3<int> frozen;
     get_mass_mbl(unit_in, allmass, frozen, ionmbl);
     frozen_freedom = frozen.x + frozen.y + frozen.z;
@@ -179,12 +180,35 @@ void init_vel(const UnitCell& unit_in,
 
     if (unit_in.init_vel)
     {
+        std::cout << " READ VEL FROM STRU" << std::endl;
         read_vel(unit_in, vel);
+        double kinetic = 0.0;
+        double t_current = MD_func::current_temp(kinetic, unit_in.nat, frozen_freedom, allmass, vel);
+        if (temperature < 0)
+        {
+            std::cout << " UNSET INITIAL TEMPERATURE, AUTOSET TO " << t_current * ModuleBase::Hartree_to_K << " K"
+                      << std::endl;
+            temperature = t_current;
+        }
+        else if (std::fabs(temperature - t_current) > 1e-8)
+        {
+            std::cout << " INITIAL TEMPERATURE IN INPUT  = " << temperature * ModuleBase::Hartree_to_K << " K"
+                      << std::endl;
+            std::cout << " READING TEMPERATURE FROM STRU = " << t_current * ModuleBase::Hartree_to_K << " K"
+                      << std::endl;
+            std::cout << " INCONSISTENCE, PLEASE CHECK" << std::endl;
+            std::cout << " ------------------------------------- DONE -----------------------------------------"
+                      << std::endl;
+            exit(0);
+        }
     }
     else
     {
+        std::cout << " RANDOM VEL ACCORDING TO INITIAL TEMPERATURE: " << temperature * ModuleBase::Hartree_to_K << " K"
+                  << std::endl;
         rand_vel(unit_in.nat, temperature, allmass, frozen_freedom, frozen, ionmbl, my_rank, vel);
     }
+    std::cout << " ------------------------------------- DONE -----------------------------------------" << std::endl;
 }
 
 void force_virial(ModuleESolver::ESolver* p_esolver,

--- a/source/module_md/md_func.h
+++ b/source/module_md/md_func.h
@@ -22,16 +22,16 @@ double gaussrand();
  * @brief initialize the atomic velocities
  *
  * @param unit_in unitcell information
- * @param temperature ion temperature
  * @param my_rank MPI rank of the processor
+ * @param temperature ion temperature
  * @param allmass atomic mass
  * @param frozen_freedom the fixed freedom
  * @param ionmbl determine whether the atomic freedom is fixed
  * @param vel the genarated atomic velocities
  */
 void init_vel(const UnitCell& unit_in,
-              const double& temperature,
               const int& my_rank,
+              double& temperature,
               double* allmass,
               int& frozen_freedom,
               ModuleBase::Vector3<int>* ionmbl,

--- a/source/module_md/nhchain.cpp
+++ b/source/module_md/nhchain.cpp
@@ -15,7 +15,7 @@ Nose_Hoover::Nose_Hoover(MD_para& MD_para_in, UnitCell& unit_in) : MD_base(MD_pa
 
     if (mdp.md_tfirst == 0)
     {
-        ModuleBase::WARNING_QUIT("Nose_Hoover", " md_tfirst must be larger than 0 in NHC !!! ");
+        ModuleBase::WARNING_QUIT("Nose_Hoover", " md_tfirst must be larger than 0 in NHC");
     }
 
     /// init NPT related variables

--- a/source/module_md/test/md_func_test.cpp
+++ b/source/module_md/test/md_func_test.cpp
@@ -25,6 +25,9 @@
  *   - MD_func::read_vel
  *     - read atomic velocity from STRU
  *
+ *   - MD_func::init_vel
+ *     - initialize the atomic velocities
+ *
  *   - MD_func::compute_stress
  *     - calculate the contribution of classical kinetic energy of atoms to stress
  *
@@ -92,7 +95,7 @@ TEST_F(MD_func_test, randomvel)
 {
     ucell.init_vel = 0;
     temperature = 300 / ModuleBase::Hartree_to_K;
-    MD_func::init_vel(ucell, temperature, GlobalV::MY_RANK, allmass, frozen_freedom, ionmbl, vel);
+    MD_func::init_vel(ucell, GlobalV::MY_RANK, temperature, allmass, frozen_freedom, ionmbl, vel);
 
     EXPECT_NEAR(vel[0].x, 9.9105892783200826e-06, doublethreshold);
     EXPECT_NEAR(vel[0].y, -3.343699576563167e-05, doublethreshold);
@@ -112,7 +115,7 @@ TEST_F(MD_func_test, getmassmbl)
 {
     ucell.init_vel = 0;
     temperature = 300 / ModuleBase::Hartree_to_K;
-    MD_func::init_vel(ucell, temperature, GlobalV::MY_RANK, allmass, frozen_freedom, ionmbl, vel);
+    MD_func::init_vel(ucell, GlobalV::MY_RANK, temperature, allmass, frozen_freedom, ionmbl, vel);
 
     for (int i = 0; i < natom; ++i)
     {
@@ -143,9 +146,46 @@ TEST_F(MD_func_test, readvel)
     EXPECT_DOUBLE_EQ(vel[3].z, -2.83313122596e-05);
 }
 
+TEST_F(MD_func_test, InitVelCase1)
+{
+    ucell.init_vel = 1;
+    temperature = -1.0;
+    MD_func::init_vel(ucell, GlobalV::MY_RANK, temperature, allmass, frozen_freedom, ionmbl, vel);
+
+    EXPECT_NEAR(temperature, 300.0 / ModuleBase::Hartree_to_K, doublethreshold);
+}
+
+TEST_F(MD_func_test, InitVelCase2)
+{
+    ucell.init_vel = 1;
+    temperature = 300.0 / ModuleBase::Hartree_to_K;
+    MD_func::init_vel(ucell, GlobalV::MY_RANK, temperature, allmass, frozen_freedom, ionmbl, vel);
+
+    EXPECT_DOUBLE_EQ(temperature, 300.0 / ModuleBase::Hartree_to_K);
+}
+
+TEST_F(MD_func_test, InitVelCase3)
+{
+    ucell.init_vel = 1;
+    temperature = 310.0 / ModuleBase::Hartree_to_K;
+
+    EXPECT_EXIT(MD_func::init_vel(ucell, GlobalV::MY_RANK, temperature, allmass, frozen_freedom, ionmbl, vel),
+                ::testing::ExitedWithCode(0),
+                "");
+}
+
+TEST_F(MD_func_test, InitVelCase4)
+{
+    ucell.init_vel = 0;
+    temperature = 300.0 / ModuleBase::Hartree_to_K;
+    MD_func::init_vel(ucell, GlobalV::MY_RANK, temperature, allmass, frozen_freedom, ionmbl, vel);
+
+    EXPECT_DOUBLE_EQ(temperature, 300.0 / ModuleBase::Hartree_to_K);
+}
+
 TEST_F(MD_func_test, compute_stress)
 {
-    MD_func::init_vel(ucell, temperature, GlobalV::MY_RANK, allmass, frozen_freedom, ionmbl, vel);
+    MD_func::init_vel(ucell, GlobalV::MY_RANK, temperature, allmass, frozen_freedom, ionmbl, vel);
     MD_func::compute_stress(ucell, vel, allmass, true, virial, stress);
     EXPECT_DOUBLE_EQ(stress(0, 0), 5.2064533063673623e-06);
     EXPECT_DOUBLE_EQ(stress(0, 1), -1.6467487572445481e-06);

--- a/tests/integrate/601_NO_TDDFT_H2_restart/INPUT
+++ b/tests/integrate/601_NO_TDDFT_H2_restart/INPUT
@@ -32,7 +32,6 @@ force_thr_ev    1.0e-3
 md_type		nve
 md_dt			0.05
 md_restart		1
-md_tfirst	30
 init_vel                1
 ocp			1
 ocp_set			1*1 1*1 3*0	


### PR DESCRIPTION
In MD calculations, users should set a proper initial temperature.
However, if `init_vel` is true, velocities are read from `STRU`, which determines the current temperature.
Thus, the program should report the message and exit when they are different. 