### PR TITLE
Refactor: move "hPsi-call-act" procedure from `OperatorPW` into basic `Operator` and redesign `act()` interface

### DIFF
--- a/source/module_hamilt_general/operator.cpp
+++ b/source/module_hamilt_general/operator.cpp
@@ -1,4 +1,5 @@
 #include "module_hamilt_general/operator.h"
+#include "module_base/timer.h"
 
 using namespace hamilt;
 
@@ -34,10 +35,42 @@ Operator<FPTYPE, Device>::~Operator()
 }
 
 template<typename FPTYPE, typename Device>
-typename Operator<FPTYPE, Device>::hpsi_info Operator<FPTYPE, Device>::hPsi(hpsi_info&) const 
+typename Operator<FPTYPE, Device>::hpsi_info Operator<FPTYPE, Device>::hPsi(hpsi_info& input) const
 {
-    ModuleBase::WARNING_QUIT("Operator::hPsi", "hPsi error!");
-    return hpsi_info(nullptr, 0, nullptr);
+    ModuleBase::timer::tick("Operator", "hPsi");
+    using syncmem_op = psi::memory::synchronize_memory_op<FPTYPE, Device, Device>;
+    auto psi_input = std::get<0>(input);
+    std::tuple<const FPTYPE*, int> psi_info = psi_input->to_range(std::get<1>(input));
+    int nbands = std::get<1>(psi_info);
+
+    FPTYPE* tmhpsi = this->get_hpsi(input);
+    const FPTYPE* tmpsi_in = std::get<0>(psi_info);
+    //if range in hpsi_info is illegal, the first return of to_range() would be nullptr
+    if (tmpsi_in == nullptr)
+    {
+        ModuleBase::WARNING_QUIT("Operator", "please choose correct range of psi for hPsi()!");
+    }
+
+    this->act(nbands, psi_input->get_nbasis(), psi_input->npol, tmpsi_in, tmhpsi, psi_input->get_ngk(this->ik));
+    Operator* node((Operator*)this->next_op);
+    while (node != nullptr)
+    {
+        node->act(nbands, psi_input->get_nbasis(), psi_input->npol, tmpsi_in, tmhpsi, psi_input->get_ngk(node->ik));
+        node = (Operator*)(node->next_op);
+    }
+
+    ModuleBase::timer::tick("Operator", "hPsi");
+
+    //if in_place, copy temporary hpsi to target hpsi_pointer, then delete hpsi and new a wrapper for return
+    FPTYPE* hpsi_pointer = std::get<2>(input);
+    if (this->in_place)
+    {
+        // ModuleBase::GlobalFunc::COPYARRAY(this->hpsi->get_pointer(), hpsi_pointer, this->hpsi->size());
+        syncmem_op()(this->ctx, this->ctx, hpsi_pointer, this->hpsi->get_pointer(), this->hpsi->size());
+        delete this->hpsi;
+        this->hpsi = new psi::Psi<FPTYPE, Device>(hpsi_pointer, *psi_input, 1, nbands / psi_input->npol);
+    }
+    return hpsi_info(this->hpsi, psi::Range(1, 0, 0, nbands / psi_input->npol), hpsi_pointer);
 }
 
 template<typename FPTYPE, typename Device>

--- a/source/module_hamilt_general/operator.cpp
+++ b/source/module_hamilt_general/operator.cpp
@@ -118,7 +118,6 @@ FPTYPE* Operator<FPTYPE, Device>::get_hpsi(const hpsi_info& info) const
     return hpsi_pointer;
 }
 
-
 namespace hamilt {
 template class Operator<float, psi::DEVICE_CPU>;
 template class Operator<std::complex<float>, psi::DEVICE_CPU>;

--- a/source/module_hamilt_general/operator.h
+++ b/source/module_hamilt_general/operator.h
@@ -51,14 +51,17 @@ class Operator
 
     virtual int get_ik() const { return this->ik; }
 
-    //do operation : |hpsi_choosed> = V|psi_choosed>
-    //V is the target operator act on choosed psi, the consequence should be added to choosed hpsi
+    ///do operation : |hpsi_choosed> = V|psi_choosed>
+    ///V is the target operator act on choosed psi, the consequence should be added to choosed hpsi
     virtual void act(const int nbands,
         const int nbasis,
         const int npol,
         const FPTYPE* tmpsi_in,
         FPTYPE* tmhpsi,
         const int ngk_ik = 0)const {};
+
+    /// an developer-friendly interface for act() function
+    virtual psi::Psi<FPTYPE> act(const psi::Psi<FPTYPE>& psi_in) const { return psi_in; };
 
     Operator* next_op = nullptr;
 

--- a/source/module_hamilt_general/operator.h
+++ b/source/module_hamilt_general/operator.h
@@ -38,7 +38,10 @@ class Operator
     //this is the core function for Operator
     // do H|psi> from input |psi> , 
 
-    // output of hpsi would be first member of the returned tuple 
+    /// as default, different operators donate hPsi independently
+    /// run this->act function for the first operator and run all act() for other nodes in chain table 
+    /// if this procedure is not suitable for your operator, just override this function.
+    /// output of hpsi would be first member of the returned tuple 
     typedef std::tuple<const psi::Psi<FPTYPE, Device>*, const psi::Range, FPTYPE*> hpsi_info;
     virtual hpsi_info hPsi(hpsi_info& input)const;
 

--- a/source/module_hamilt_general/operator.h
+++ b/source/module_hamilt_general/operator.h
@@ -46,7 +46,16 @@ class Operator
 
     virtual void add(Operator* next);
 
-    virtual int get_ik() const {return this->ik;}
+    virtual int get_ik() const { return this->ik; }
+
+    //do operation : |hpsi_choosed> = V|psi_choosed>
+    //V is the target operator act on choosed psi, the consequence should be added to choosed hpsi
+    virtual void act(const int nbands,
+        const int nbasis,
+        const int npol,
+        const FPTYPE* tmpsi_in,
+        FPTYPE* tmhpsi,
+        const int ngk_ik = 0)const {};
 
     Operator* next_op = nullptr;
 

--- a/source/module_hamilt_pw/hamilt_pwdft/operator_pw/ekinetic_pw.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/operator_pw/ekinetic_pw.cpp
@@ -31,26 +31,27 @@ Ekinetic<OperatorPW<FPTYPE, Device>>::~Ekinetic() {}
 
 template<typename FPTYPE, typename Device>
 void Ekinetic<OperatorPW<FPTYPE, Device>>::act(
-    const psi::Psi<std::complex<FPTYPE>, Device> *psi_in, 
-    const int n_npwx, 
-    const std::complex<FPTYPE>* tmpsi_in, 
-    std::complex<FPTYPE>* tmhpsi)const
+    const int nbands,
+    const int nbasis,
+    const int npol,
+    const std::complex<FPTYPE>* tmpsi_in,
+    std::complex<FPTYPE>* tmhpsi,
+    const int ngk_ik)const
 {
-  ModuleBase::timer::tick("Operator", "EkineticPW");
-  const int npw = psi_in->get_ngk(this->ik);
-  this->max_npw = psi_in->get_nbasis() / psi_in->npol;
+    ModuleBase::timer::tick("Operator", "EkineticPW");
+    int max_npw = nbasis / npol;
 
   const FPTYPE *gk2_ik = &(this->gk2[this->ik * this->gk2_col]);
   // denghui added 20221019
-  ekinetic_op()(this->ctx, n_npwx, npw, this->max_npw, tpiba2, gk2_ik, tmhpsi, tmpsi_in);
-  // for (int ib = 0; ib < n_npwx; ++ib)
+  ekinetic_op()(this->ctx, nbands, ngk_ik, max_npw, tpiba2, gk2_ik, tmhpsi, tmpsi_in);
+  // for (int ib = 0; ib < nbands; ++ib)
   // {
-  //     for (int ig = 0; ig < npw; ++ig)
+  //     for (int ig = 0; ig < ngk_ik; ++ig)
   //     {
   //         tmhpsi[ig] += gk2_ik[ig] * tpiba2 * tmpsi_in[ig];
   //     }
-  //     tmhpsi += this->max_npw;
-  //     tmpsi_in += this->max_npw;
+  //     tmhpsi += max_npw;
+  //     tmpsi_in += max_npw;
   // }
   ModuleBase::timer::tick("Operator", "EkineticPW");
 }

--- a/source/module_hamilt_pw/hamilt_pwdft/operator_pw/ekinetic_pw.h
+++ b/source/module_hamilt_pw/hamilt_pwdft/operator_pw/ekinetic_pw.h
@@ -34,11 +34,12 @@ class Ekinetic<OperatorPW<FPTYPE, Device>> : public OperatorPW<FPTYPE, Device>
 
     virtual ~Ekinetic();
 
-    virtual void act(
-        const psi::Psi<std::complex<FPTYPE>, Device> *psi_in, 
-        const int n_npwx, 
-        const std::complex<FPTYPE>* tmpsi_in, 
-        std::complex<FPTYPE>* tmhpsi)const override;
+    virtual void act(const int nbands,
+        const int nbasis,
+        const int npol,
+        const std::complex<FPTYPE>* tmpsi_in,
+        std::complex<FPTYPE>* tmhpsi,
+        const int ngk_ik = 0)const override;
 
     // denghuilu added for copy construct at 20221105
     int get_gk2_row() const {return this->gk2_row;}
@@ -48,10 +49,6 @@ class Ekinetic<OperatorPW<FPTYPE, Device>> : public OperatorPW<FPTYPE, Device>
     Device* get_ctx() const {return this->ctx;}
 
   private:
-
-    mutable int max_npw = 0;
-
-    mutable int npol = 0;
 
     FPTYPE tpiba2 = 0.0;
     const FPTYPE* gk2 = nullptr;

--- a/source/module_hamilt_pw/hamilt_pwdft/operator_pw/meta_pw.h
+++ b/source/module_hamilt_pw/hamilt_pwdft/operator_pw/meta_pw.h
@@ -35,10 +35,12 @@ class Meta<OperatorPW<FPTYPE, Device>> : public OperatorPW<FPTYPE, Device>
 
       virtual ~Meta();
 
-      virtual void act(const psi::Psi<std::complex<FPTYPE>, Device>* psi_in,
-                       const int n_npwx,
-                       const std::complex<FPTYPE>* tmpsi_in,
-                       std::complex<FPTYPE>* tmhpsi) const override;
+      virtual void act(const int nbands,
+          const int nbasis,
+          const int npol,
+          const std::complex<FPTYPE>* tmpsi_in,
+          std::complex<FPTYPE>* tmhpsi,
+          const int ngk = 0)const override;
 
       // denghui added for copy constructor at 20221105
       FPTYPE get_tpiba() const

--- a/source/module_hamilt_pw/hamilt_pwdft/operator_pw/nonlocal_pw.h
+++ b/source/module_hamilt_pw/hamilt_pwdft/operator_pw/nonlocal_pw.h
@@ -37,12 +37,12 @@ class Nonlocal<OperatorPW<FPTYPE, Device>> : public OperatorPW<FPTYPE, Device>
 
     virtual void init(const int ik_in)override;
 
-    virtual void act(
-        const psi::Psi<std::complex<FPTYPE>, Device> *psi_in, 
-        const int n_npwx, 
-        const std::complex<FPTYPE>* tmpsi_in, 
-        std::complex<FPTYPE>* tmhpsi
-    )const override;
+    virtual void act(const int nbands,
+        const int nbasis,
+        const int npol,
+        const std::complex<FPTYPE>* tmpsi_in,
+        std::complex<FPTYPE>* tmhpsi,
+        const int ngk = 0)const override;
 
     const int *get_isk() const {return this->isk;}
     const pseudopot_cell_vnl *get_ppcell() const {return this->ppcell;}

--- a/source/module_hamilt_pw/hamilt_pwdft/operator_pw/operator_pw.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/operator_pw/operator_pw.cpp
@@ -7,45 +7,6 @@ using namespace hamilt;
 template<typename FPTYPE, typename Device>
 OperatorPW<FPTYPE, Device>::~OperatorPW(){};
 
-template<typename FPTYPE, typename Device>
-typename OperatorPW<FPTYPE, Device>::hpsi_info OperatorPW<FPTYPE, Device>::hPsi(
-    hpsi_info& input) const 
-{
-  ModuleBase::timer::tick("OperatorPW", "hPsi");
-  auto psi_input = std::get<0>(input);
-  std::tuple<const std::complex<FPTYPE>*, int> psi_info = psi_input->to_range(std::get<1>(input));
-  int nbands = std::get<1>(psi_info);
-
-  std::complex<FPTYPE> *tmhpsi = this->get_hpsi(input);
-  const std::complex<FPTYPE> *tmpsi_in = std::get<0>(psi_info);
-  //if range in hpsi_info is illegal, the first return of to_range() would be nullptr
-  if(tmpsi_in == nullptr)
-  {
-      ModuleBase::WARNING_QUIT("OperatorPW", "please choose correct range of psi for hPsi()!");
-  }
-
-  this->act(nbands, psi_input->get_nbasis(), psi_input->npol, tmpsi_in, tmhpsi, psi_input->get_ngk(this->ik));
-  OperatorPW* node((OperatorPW*)this->next_op);
-  while(node != nullptr)
-  {
-      node->act(nbands, psi_input->get_nbasis(), psi_input->npol, tmpsi_in, tmhpsi, psi_input->get_ngk(node->ik));
-      node = (OperatorPW*)(node->next_op);
-  }
-
-  ModuleBase::timer::tick("OperatorPW", "hPsi");
-  
-  //if in_place, copy temporary hpsi to target hpsi_pointer, then delete hpsi and new a wrapper for return
-  std::complex<FPTYPE>* hpsi_pointer = std::get<2>(input);
-  if(this->in_place)
-  {
-      // ModuleBase::GlobalFunc::COPYARRAY(this->hpsi->get_pointer(), hpsi_pointer, this->hpsi->size());
-      syncmem_complex_op()(this->ctx, this->ctx, hpsi_pointer, this->hpsi->get_pointer(), this->hpsi->size());
-      delete this->hpsi;
-      this->hpsi = new psi::Psi<std::complex<FPTYPE>, Device>(hpsi_pointer, *psi_input, 1, nbands / psi_input->npol);
-  }      
-  return hpsi_info(this->hpsi, psi::Range(1, 0, 0, nbands / psi_input->npol), hpsi_pointer);
-}
-
 namespace hamilt {
 template class OperatorPW<float, psi::DEVICE_CPU>;
 template class OperatorPW<double, psi::DEVICE_CPU>;

--- a/source/module_hamilt_pw/hamilt_pwdft/operator_pw/operator_pw.h
+++ b/source/module_hamilt_pw/hamilt_pwdft/operator_pw/operator_pw.h
@@ -14,13 +14,6 @@ class OperatorPW : public Operator<std::complex<FPTYPE>, Device>
     using hpsi_info = typename hamilt::Operator<std::complex<FPTYPE>, Device>::hpsi_info;
     virtual hpsi_info hPsi(hpsi_info& input)const;
     //main function which should be modified in Operator for PW base
-    //do operation : |hpsi_choosed> = V|psi_choosed>
-    //V is the target operator act on choosed psi, the consequence should be added to choosed hpsi
-    virtual void act(
-        const psi::Psi<std::complex<FPTYPE>, Device> *psi_in, 
-        const int n_npwx, 
-        const std::complex<FPTYPE>* tmpsi_in, 
-        std::complex<FPTYPE>* tmhpsi)const;
 
     std::string classname = "";
     using syncmem_complex_op = psi::memory::synchronize_memory_op<std::complex<FPTYPE>, Device, Device>;

--- a/source/module_hamilt_pw/hamilt_pwdft/operator_pw/operator_pw.h
+++ b/source/module_hamilt_pw/hamilt_pwdft/operator_pw/operator_pw.h
@@ -7,16 +7,8 @@ template<typename FPTYPE, typename Device = psi::DEVICE_CPU>
 class OperatorPW : public Operator<std::complex<FPTYPE>, Device>
 {
     public:
-    virtual ~OperatorPW();
-    
-    //in PW code, different operators donate hPsi independently
-    //run this->act function for the first operator and run all act() for other nodes in chain table 
-    using hpsi_info = typename hamilt::Operator<std::complex<FPTYPE>, Device>::hpsi_info;
-    virtual hpsi_info hPsi(hpsi_info& input)const;
-    //main function which should be modified in Operator for PW base
-
-    std::string classname = "";
-    using syncmem_complex_op = psi::memory::synchronize_memory_op<std::complex<FPTYPE>, Device, Device>;
+        virtual ~OperatorPW();
+        std::string classname = "";
 };
 
 }//end namespace hamilt

--- a/source/module_hamilt_pw/hamilt_pwdft/operator_pw/veff_pw.h
+++ b/source/module_hamilt_pw/hamilt_pwdft/operator_pw/veff_pw.h
@@ -33,18 +33,17 @@ class Veff<OperatorPW<FPTYPE, Device>> : public OperatorPW<FPTYPE, Device>
 
     virtual ~Veff();
 
-    virtual void act (
-        const psi::Psi<std::complex<FPTYPE>, Device> *psi_in, 
-        const int n_npwx, 
-        const std::complex<FPTYPE>* tmpsi_in, 
-        std::complex<FPTYPE>* tmhpsi
-    )const override;
+    virtual void act(const int nbands,
+        const int nbasis,
+        const int npol,
+        const std::complex<FPTYPE>* tmpsi_in,
+        std::complex<FPTYPE>* tmhpsi,
+        const int ngk_ik = 0)const override;
 
     // denghui added for copy constructor at 20221105
     const FPTYPE *get_veff() const {return this->veff;}
     int get_veff_col() const {return this->veff_col;}
-    int get_veff_row() const {return this->veff_row;}
-    int get_npol() const {return this->npol;}
+    int get_veff_row() const { return this->veff_row; }
     const int *get_isk() const {return isk;}
     const ModulePW::PW_Basis_K* get_wfcpw() const
     {
@@ -52,10 +51,6 @@ class Veff<OperatorPW<FPTYPE, Device>> : public OperatorPW<FPTYPE, Device>
     }
 
   private:
-
-    mutable int max_npw = 0;
-
-    mutable int npol = 0;
 
     const int* isk = nullptr;
 

--- a/source/module_hsolver/test/diago_mock.h
+++ b/source/module_hsolver/test/diago_mock.h
@@ -491,11 +491,12 @@ class OperatorMock_d : public hamilt::OperatorPW<double>
     }
     virtual void act
     (
-        const psi::Psi<std::complex<double>> *psi_in, 
-        const int n_npwx, 
-        const std::complex<double>* tmpsi_in, 
-        std::complex<double>* tmhpsi
-    )const 
+        const int nbands,
+        const int nbasis,
+        const int npol,
+        const std::complex<double>* tmpsi_in,
+        std::complex<double>* tmhpsi,
+        const int ngk_ik = 0)const
     {
         int nprocs=1, mypnum=0;
     #ifdef __MPI    
@@ -504,7 +505,7 @@ class OperatorMock_d : public hamilt::OperatorPW<double>
     #endif        
 
         std::complex<double> *hpsi0 = new std::complex<double>[DIAGOTEST::npw];
-        for(int m = 0; m< n_npwx; m++)
+        for (int m = 0; m < nbands; m++)
         {
             for(int i=0;i<DIAGOTEST::npw;i++)
             {
@@ -516,8 +517,8 @@ class OperatorMock_d : public hamilt::OperatorPW<double>
             }
             Parallel_Reduce::reduce_complex_double_pool(hpsi0, DIAGOTEST::npw);
             DIAGOTEST::divide_psi<std::complex<double>>(hpsi0, tmhpsi);
-            tmhpsi += psi_in->get_nbasis();
-            tmpsi_in += psi_in->get_nbasis();
+            tmhpsi += nbasis;
+            tmpsi_in += nbasis;
         }
         delete [] hpsi0;
     }
@@ -535,11 +536,12 @@ class OperatorMock_f : public hamilt::OperatorPW<float>
     }
     virtual void act
     (
-        const psi::Psi<std::complex<float>> *psi_in, 
-        const int n_npwx, 
-        const std::complex<float>* tmpsi_in, 
-        std::complex<float>* tmhpsi
-    )const 
+        const int nbands,
+        const int nbasis,
+        const int npol,
+        const std::complex<float>* tmpsi_in,
+        std::complex<float>* tmhpsi,
+        const int ngk_ik = 0)const
     {
         int nprocs=1, mypnum=0;
     #ifdef __MPI    
@@ -548,7 +550,7 @@ class OperatorMock_f : public hamilt::OperatorPW<float>
     #endif        
 
         std::complex<float> *hpsi0 = new std::complex<float>[DIAGOTEST::npw];
-        for(int m = 0; m< n_npwx; m++)
+        for (int m = 0; m < nbands; m++)
         {
             for(int i=0;i<DIAGOTEST::npw;i++)
             {
@@ -562,8 +564,8 @@ class OperatorMock_f : public hamilt::OperatorPW<float>
 	        MPI_Allreduce(MPI_IN_PLACE, hpsi0, DIAGOTEST::npw, MPI_C_FLOAT_COMPLEX, MPI_SUM, MPI_COMM_WORLD);
 #endif
             DIAGOTEST::divide_psi_f<std::complex<float>>(hpsi0, tmhpsi);	
-            tmhpsi += psi_in->get_nbasis();
-            tmpsi_in += psi_in->get_nbasis();
+            tmhpsi += nbasis;
+            tmpsi_in += nbasis;
         }
         delete [] hpsi0;
     }

--- a/source/module_psi/psi.cpp
+++ b/source/module_psi/psi.cpp
@@ -281,6 +281,7 @@ template <typename T, typename Device> int Psi<T, Device>::get_current_nbas() co
 
 template <typename T, typename Device> const int& Psi<T, Device>::get_ngk(const int ik_in) const
 {
+    if (!this->ngk) return this->nbasis;
     return this->ngk[ik_in];
 }
 


### PR DESCRIPTION
fix #2911