### PR TITLE
Docs: add task list in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -64,6 +64,28 @@ body:
       Add any other context about the problem here.
     placeholder: |
       Example: The issue seems to occur only when using a specific input file, which I have attached below ...
+
+- type: checkboxes
+  attributes:
+    label: Task list for Issue attackers
+    options:
+      - label: Verify the issue is not a duplicate.
+      - label: Describe the bug.
+      - label: Steps to reproduce.
+      - label: Expected behavior.
+      - label: Error message.
+      - label: Environment details.
+      - label: Additional context.
+      - label: Assign a priority level (low, medium, high, urgent).
+      - label: Assign the issue to a team member.
+      - label: Label the issue with relevant tags.
+      - label: Identify possible related issues.
+      - label: Create a unit test or automated test to reproduce the bug (if applicable).
+      - label: Fix the bug.
+      - label: Test the fix.
+      - label: Update documentation (if necessary).
+      - label: Close the issue and inform the reporter (if applicable).
+
 - type: markdown
   attributes:
     value: >

--- a/.github/ISSUE_TEMPLATE/code-quality.yml
+++ b/.github/ISSUE_TEMPLATE/code-quality.yml
@@ -20,6 +20,19 @@ body:
     description: |
       Add any other context or screenshots about the code quality issue here.
 
+- type: checkboxes
+  attributes:
+    label: Task list for Issue attackers
+    options:
+      - label: Identify the specific code file or section with the code quality issue.
+      - label: Investigate the issue and determine the root cause.
+      - label: Research best practices and potential solutions for the identified issue.
+      - label: Refactor the code to improve code quality, following the suggested solution.
+      - label: Ensure the refactored code adheres to the project's coding standards.
+      - label: Test the refactored code to ensure it functions as expected.
+      - label: Update any relevant documentation, if necessary.
+      - label: Submit a pull request with the refactored code and a description of the changes made.
+
 - type: markdown
   attributes:
     value: >

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -19,6 +19,18 @@ body:
     options:
       - label: Yes, I have read the online manual.
         required: true
+- type: checkboxes
+  attributes:
+    label: Task list for Issue attackers
+    options:
+      - label: Identify the specific section of the documentation with the issue.
+      - label: Investigate the issue and determine the root cause.
+      - label: Research best practices and potential solutions for the identified issue.
+      - label: Update the documentation to address the issue, following the suggested improvement.
+      - label: Ensure the updated documentation adheres to the project's documentation standards.
+      - label: Test the updated documentation to ensure it is clear and accurate.
+      - label: Review and incorporate any relevant feedback from users or developers.
+      - label: Publish the updated documentation and notify the issue reporter.
 - type: markdown
   attributes:
     value: >

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -33,6 +33,23 @@ body:
     placeholder: |
       Example: Here is a mockup of the proposed feature (insert screenshot or link to design), along with relevant research articles and resources that support the implementation of this feature...
 
+- type: checkboxes
+  attributes:
+    label: Task list for Issue attackers
+    options:
+      - label: Review and understand the proposed feature and its importance.
+      - label: Research on the existing solutions and relevant research articles/resources.
+      - label: Discuss with the team to evaluate the feasibility of implementing the feature.
+      - label: Create a design document outlining the proposed solution and implementation details.
+      - label: Get feedback from the team and stakeholders on the design document.
+      - label: Develop the feature following the agreed design.
+      - label: Write unit tests and integration tests for the feature.
+      - label: Update the documentation to include the new feature.
+      - label: Perform code review and address any issues.
+      - label: Merge the feature into the main branch.
+      - label: Monitor for any issues or bugs reported by users after the feature is released.
+      - label: Address any issues or bugs reported by users and continuously improve the feature.
+
 - type: markdown
   attributes:
     value: >

--- a/.github/ISSUE_TEMPLATE/performance.yml
+++ b/.github/ISSUE_TEMPLATE/performance.yml
@@ -13,6 +13,19 @@ body:
       Example: I am calculate a system with 200 atoms, and the SCF calculation is very slow. I am performing the calculation on a cluster with 4 nodes, each with 32 cores and 128 GB memory. I have tried to increase the number of MPI processes, but the calculation is still slow ...
   validations:
       required: true
+- type: checkboxes
+  attributes:
+    label: Task list for Issue attackers
+    options:
+      - label: Reproduce the performance issue on a similar system or environment.
+      - label: Identify the specific section of the code causing the performance issue.
+      - label: Investigate the issue and determine the root cause.
+      - label: Research best practices and potential solutions for the identified performance issue.
+      - label: Implement the chosen solution to address the performance issue.
+      - label: Test the implemented solution to ensure it improves performance without introducing new issues.
+      - label: Optimize the solution if necessary, considering trade-offs between performance and other factors (e.g., code complexity, readability, maintainability).
+      - label: Review and incorporate any relevant feedback from users or developers.
+      - label: Merge the improved solution into the main codebase and notify the issue reporter.
 - type: markdown
   attributes:
     value: >

--- a/.github/ISSUE_TEMPLATE/questions.yml
+++ b/.github/ISSUE_TEMPLATE/questions.yml
@@ -1,6 +1,6 @@
 name: Questions
 description: For users or developers who need help with software installation, usability, or other issues.
-labels: [Help wanted]
+labels: [Questions]
 assignees: dyzheng
 
 body:

--- a/.github/ISSUE_TEMPLATE/questions.yml
+++ b/.github/ISSUE_TEMPLATE/questions.yml
@@ -1,6 +1,6 @@
 name: Questions
 description: For users or developers who need help with software installation, usability, or other issues.
-labels: [Questions]
+labels: [Help wanted]
 assignees: dyzheng
 
 body:
@@ -20,6 +20,19 @@ body:
     options:
       - label: Yes, I have read the FAQ part on online manual.
         required: true
+- type: checkboxes
+  attributes:
+    label: Task list for Issue attackers
+    options:
+      - label: Understand the problem or question described by the user.
+      - label: Check if the issue is a known problem or has been addressed in the documentation.
+      - label: Test the issue or problem on a similar system or environment, if possible.
+      - label: Identify the root cause or provide clarification on the user's question.
+      - label: Provide a step-by-step guide, including any necessary resources, to resolve the issue or answer the question.
+      - label: If the issue is related to documentation, update the documentation to prevent future confusion (optional).
+      - label: If the issue is related to code, consider implementing a fix or improvement (optional).
+      - label: Review and incorporate any relevant feedback from users or developers.
+      - label: Ensure the user's issue is resolved or their question is answered and close the ticket.
 - type: markdown
   attributes:
     value: >

--- a/.github/ISSUE_TEMPLATE/tests.yml
+++ b/.github/ISSUE_TEMPLATE/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 description: For developers to report issues related to software testing, such as test failures, missing or incomplete tests, or issues with test automation.
-labels: [Test]
+labels: [Tests]
 assignees: hongriTianqi
 
 body:

--- a/.github/ISSUE_TEMPLATE/tests.yml
+++ b/.github/ISSUE_TEMPLATE/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 description: For developers to report issues related to software testing, such as test failures, missing or incomplete tests, or issues with test automation.
-labels: [Tests]
+labels: [Test]
 assignees: hongriTianqi
 
 body:
@@ -19,6 +19,20 @@ body:
     label: Additional Context
     description: |
       Add any other context or screenshots about the testing issue here.
+
+- type: checkboxes
+  attributes:
+    label: Task list for Issue attackers
+    options:
+      - label: Understand the testing issue described by the developer.
+      - label: Review the specific test case, expected and actual results, and any error messages.
+      - label: Identify the root cause of the test failure or issue.
+      - label: If a possible solution is suggested, evaluate its feasibility and effectiveness.
+      - label: Implement a fix for the test failure or issue, or create a new test case if needed.
+      - label: Verify that the fix resolves the testing issue and the test case passes.
+      - label: Review and update any relevant documentation, such as test plans or user guides.
+      - label: Ensure the testing issue is resolved and close the ticket.
+      - label: Share any lessons learned or best practices with the team to prevent similar issues in the future.
 
 - type: markdown
   attributes:


### PR DESCRIPTION
By adding task list in issue templates, one can easily check the progress of issues:
<img width="1318" alt="截屏2023-09-08 11 11 32" src="https://github.com/deepmodeling/abacus-develop/assets/18049272/380b0a64-a83e-417f-98ef-f36f8f9bce0f">

