### PR TITLE
Fix: stick to strict floating model with intel compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,12 @@ if(NOT CMAKE_BUILD_TYPE)
   add_compile_options(-O3 -g)
 endif()
 
+# stick to strict floating point model on Intel Compiler
+if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel") OR
+    ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "IntelLLVM"))
+    add_compile_options(-fp-model=strict)
+endif()
+
 # Force turn off USE_ABACUS_LIBM on Intel Compiler
 if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel") OR
     ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "IntelLLVM"))


### PR DESCRIPTION
According to 

https://www.intel.com/content/www/us/en/developer/articles/guide/porting-guide-for-icc-users-to-dpcpp-or-icx.html

new intel oneapi compiler "icpx" will use -fp-model=fast by default, which poses some risk in the calculation. This behavior also differs from GNU compilers where the equivalence of -fp-model=fast is roughly -Ofast while we only use -O3. 