### PR TITLE
Feature: Band-first Psi

### DIFF
--- a/source/module_psi/psi.cpp
+++ b/source/module_psi/psi.cpp
@@ -44,8 +44,9 @@ template <typename T, typename Device> Psi<T, Device>::Psi(const int* ngk_in)
     this->device = device::get_device_type<Device>(this->ctx);
 }
 
-template <typename T, typename Device> Psi<T, Device>::Psi(int nk_in, int nbd_in, int nbs_in, const int* ngk_in)
+template <typename T, typename Device> Psi<T, Device>::Psi(const int nk_in, const int nbd_in, const int nbs_in, const int* ngk_in, const bool k_first_in)
 {
+    this->k_first = k_first_in;
     this->ngk = ngk_in;
     this->current_b = 0;
     this->current_k = 0;
@@ -67,6 +68,7 @@ template <typename T, typename Device> Psi<T, Device>::Psi(const Psi& psi_in, co
     {
         nband_in = psi_in.get_nbands();
     }
+    this->k_first = psi_in.get_k_first();
     this->device = psi_in.device;
     this->resize(nk_in, nband_in, psi_in.get_nbasis());
     this->ngk = psi_in.ngk;
@@ -87,6 +89,7 @@ template <typename T, typename Device> Psi<T, Device>::Psi(const Psi& psi_in, co
 template <typename T, typename Device>
 Psi<T, Device>::Psi(T* psi_pointer, const Psi& psi_in, const int nk_in, int nband_in)
 {
+    this->k_first = psi_in.get_k_first();
     this->device = device::get_device_type<Device>(this->ctx);
     assert(this->device == psi_in.device);
     assert(nk_in <= psi_in.get_nk());
@@ -169,10 +172,11 @@ template <typename T, typename Device> T* Psi<T, Device>::get_pointer() const
     return this->psi_current;
 }
 
-template <typename T, typename Device> T* Psi<T, Device>::get_pointer(const int& ibands) const
+template <typename T, typename Device> T* Psi<T, Device>::get_pointer(const int& ikb) const
 {
-    assert(ibands >= 0 && ibands < this->nbands);
-    return &this->psi_current[ibands * this->nbasis];
+    assert(ikb >= 0);
+    assert(this->k_first ? ikb < this->nbands : ikb < this->nk);
+    return &this->psi_current[ikb * this->nbasis];
 }
 
 template <typename T, typename Device> const int* Psi<T, Device>::get_ngk_pointer() const
@@ -227,41 +231,78 @@ template <typename T, typename Device> void Psi<T, Device>::fix_k(const int ik) 
         this->current_nbasis = this->ngk[ik];
     else
         this->current_nbasis = this->nbasis;
-    this->current_b = 0;
+
+    if (this->k_first)this->current_b = 0;
+    int base = this->current_b * this->nk * this->nbasis;
     if (ik >= this->nk)
     {
-        // mem_saver case
-        this->psi_current = const_cast<T*>(&(this->psi[0]));
-        this->psi_bias = 0;
+        // mem_saver: fix to base
+        this->psi_bias = base;
+        this->psi_current = const_cast<T*>(&(this->psi[base]));
     }
     else
     {
-        this->psi_current = const_cast<T*>(&(this->psi[ik * this->nbands * this->nbasis]));
-        this->psi_bias = ik * this->nbands * this->nbasis;
+        this->psi_bias = k_first ? ik * this->nbands * this->nbasis : base + ik * this->nbasis;
+        this->psi_current = const_cast<T*>(&(this->psi[psi_bias]));
+    }
+}
+template <typename T, typename Device> void Psi<T, Device>::fix_b(const int ib) const
+{
+    assert(ib >= 0);
+    this->current_b = ib;
+
+    if (!this->k_first)this->current_k = 0;
+    int base = this->current_k * this->nbands * this->nbasis;
+    if (ib >= this->nbands)
+    {
+        // mem_saver: fix to base
+        this->psi_bias = base;
+        this->psi_current = const_cast<T*>(&(this->psi[base]));
+    }
+    else
+    {
+        this->psi_bias = k_first ? base + ib * this->nbasis : ib * this->nk * this->nbasis;
+        this->psi_current = const_cast<T*>(&(this->psi[psi_bias]));
+    }
+}
+
+template <typename T, typename Device> void Psi<T, Device>::fix_kb(const int ik, const int ib)const
+{
+    assert(ik >= 0 && ib >= 0);
+    this->current_k = ik;
+    this->current_b = ib;
+    if (ik >= this->nk || ib >= this->nbands)
+    {   // fix to 0
+        this->psi_bias = 0;
+        this->psi_current = const_cast<T*>(&(this->psi[0]));
+    }
+    else
+    {
+        this->psi_bias = k_first ? (ik * this->nbands + ib) * this->nbasis : (ib * this->nk + ik) * this->nbasis;
+        this->psi_current = const_cast<T*>(&(this->psi[psi_bias]));
     }
 }
 
 template <typename T, typename Device>
-T& Psi<T, Device>::operator()(const int ik, const int ibands, const int ibasis) const
+T& Psi<T, Device>::operator()(const int ikb1, const int ikb2, const int ibasis) const
 {
-    assert(ik >= 0 && ik < this->nk);
-    assert(ibands >= 0 && ibands < this->nbands);
-    assert(ibasis >= 0 && ibasis < this->nbasis);
-    return this->psi[(ik * this->nbands + ibands) * this->nbasis + ibasis];
+    assert(ikb1 >= 0 && ikb2 >= 0 && ibasis >= 0);
+    assert(this->k_first ? ikb1 < this->nk && ikb2 < this->nbands : ikb1 < this->nbands && ikb2 < this->nk);
+    return this->k_first ? this->psi[(ikb1 * this->nbands + ikb2) * this->nbasis + ibasis] : this->psi[(ikb1 * this->nk + ikb2) * this->nbasis + ibasis];
 }
 
-template <typename T, typename Device> T& Psi<T, Device>::operator()(const int ibands, const int ibasis) const
+template <typename T, typename Device> T& Psi<T, Device>::operator()(const int ikb2, const int ibasis) const
 {
-    assert(this->current_b == 0);
-    assert(ibands >= 0 && ibands < this->nbands);
+    assert(this->k_first ? this->current_b == 0 : this->current_k == 0);
+    assert(this->k_first ? ikb2 >= 0 && ikb2 < this->nbands : ikb2 >= 0 && ikb2 < this->nk);
     assert(ibasis >= 0 && ibasis < this->nbasis);
-    return this->psi_current[ibands * this->nbasis + ibasis];
+    return this->psi_current[ikb2 * this->nbasis + ibasis];
 }
 
 template <typename T, typename Device> T& Psi<T, Device>::operator()(const int ibasis) const
 {
     assert(ibasis >= 0 && ibasis < this->nbasis);
-    return this->psi_current[this->current_b * this->nbasis + ibasis];
+    return this->psi_current[ibasis];
 }
 
 template <typename T, typename Device> int Psi<T, Device>::get_current_k() const
@@ -293,22 +334,29 @@ template <typename T, typename Device> void Psi<T, Device>::zero_out()
 
 template <typename T, typename Device> std::tuple<const T*, int> Psi<T, Device>::to_range(const Range& range) const
 {
-    int index_1_in = range.index_1;
-    // mem_saver=1 case, only k==0 memory space is avaliable
-    if (index_1_in > 0 & this->nk == 1)
-    {
-        index_1_in = 0;
-    }
-    if (range.k_first != this->k_first || index_1_in < 0 || range.range_1 < 0 || range.range_2 < range.range_1
-        || (range.k_first && range.range_2 >= this->nbands)
-        || (!range.k_first && (range.range_2 >= this->nk || range.index_1 >= this->nbands)))
+    const int& i1 = range.index_1;
+    const int& r1 = range.range_1;
+    const int& r2 = range.range_2;
+
+    if (range.k_first != this->k_first || r1 < 0 || r2 < r1
+        // || (range.k_first && (r2 >= this->nbands || i1 >= this->nk))
+        // || (!range.k_first && (r2 >= this->nk || i1 >= this->nbands)))
+        || (range.k_first ? (i1 >= this->nk) : (i1 >= this->nbands))    // illegal index 1
+        || (range.k_first ? (i1 > 0 && r2 >= this->nbands) : (i1 > 0 && r2 >= this->nk)) // illegal range of index 2
+        || (range.k_first ? (i1 < 0 && r2 >= this->nk) : (i1 < 0 && r2 >= this->nbands))) // illegal range of index 1
     {
         return std::tuple<const T*, int>(nullptr, 0);
     }
-    else
+    else if (i1 < 0)    // [r1, r2] is the range of index1 with length m
     {
-        const T* p = &this->psi[(index_1_in * this->nbands + range.range_1) * this->nbasis];
-        int m = (range.range_2 - range.range_1 + 1) * this->npol;
+        const T* p = &this->psi[r1 * (k_first ? this->nbands : this->nk) * this->nbasis];
+        int m = (r2 - r1 + 1) * this->npol;
+        return std::tuple<const T*, int>(p, m);
+    }
+    else   // [r1, r2] is the range of index2 with length m
+    {
+        const T* p = &this->psi[(i1 * (k_first ? this->nbands : this->nk) + r1) * this->nbasis];
+        int m = (r2 - r1 + 1) * this->npol;
         return std::tuple<const T*, int>(p, m);
     }
 }

--- a/source/module_psi/psi.h
+++ b/source/module_psi/psi.h
@@ -11,16 +11,17 @@ namespace psi
 
 // structure for getting range of Psi
 // two display method: k index first or bands index first
-// only one k point with multi bands and one band with multi k-points are available for hPsi()
 struct Range
 {
-    // k_first = 0: Psi(nbands, nks, nbasis) ; 1: Psi(nks, nbands, nbasis)
+    /// k_first = 0: Psi(nbands, nks, nbasis) ; 1: Psi(nks, nbands, nbasis)
     bool k_first;
-    // index_1 is target first index
+    /// index_1> 0: target first index; index_1<0: no use
     size_t index_1;
-    // range_1 is the begin of second index
+    /// if index_1>0,  range_1 is the begin of second index with index_1 fixed
+    /// if index_1<0,  range_1 is the begin of first index
     size_t range_1;
-    // range_2 is the end of second index
+    /// if index_1>0,  range_2 is the end of second index with index_1 fixed
+    /// if index_1<0,  range_2 is the end of first index
     size_t range_2;
     // this is simple constructor for hPsi return
     Range(const size_t range_in);
@@ -38,7 +39,7 @@ template <typename T, typename Device = DEVICE_CPU> class Psi
     // Constructor 2: specify ngk only, should call resize() later
     Psi(const int* ngk_in);
     // Constructor 3: specify nk, nbands, nbasis, ngk, and do not need to call resize() later
-    Psi(int nk_in, int nbd_in, int nbs_in, const int* ngk_in = nullptr);
+    Psi(const int nk_in, const int nbd_in, const int nbs_in, const int* ngk_in = nullptr, const bool k_first_in = true);
     // Constructor 4: copy a new Psi which have several k-points and several bands from inputted psi_in
     Psi(const Psi& psi_in, const int nk_in, int nband_in = 0);
     // Constructor 5: a wrapper of a data pointer, used for Operator::hPsi()
@@ -55,10 +56,10 @@ template <typename T, typename Device = DEVICE_CPU> class Psi
     // allocate psi for three dimensions
     void resize(const int nks_in, const int nbands_in, const int nbasis_in);
 
-    // get the pointer for current k point
+    // get the pointer for the 1st index
     T* get_pointer() const;
-    // get the pointer for current band
-    T* get_pointer(const int& ibands) const;
+    // get the pointer for the 2nd index (iband for k_first = true, ik for k_first = false)
+    T* get_pointer(const int& ikb) const;
 
     // interface to get three dimension size
     const int& get_nk() const;
@@ -67,13 +68,25 @@ template <typename T, typename Device = DEVICE_CPU> class Psi
     // size_t size() const {return this->psi.size();}
     size_t size() const;
 
-    // choose k-point index , then Psi(iband, ibasis) can reach Psi(ik, iband, ibasis)
+    /// if k_first=true: choose k-point index , then Psi(iband, ibasis) can reach Psi(ik, iband, ibasis)
+    /// if k_first=false: choose k-point index, then Psi(ibasis) can reach Psi(iband, ik, ibasis)
     void fix_k(const int ik) const;
+    /// if k_first=true: choose band index, then Psi(ibasis) can reach Psi(ik, iband, ibasis)
+    /// if k_first=false: choose band index, then Psi(ik, ibasis) can reach Psi(iband, ik, ibasis)
+    void fix_b(const int ib) const;
+    /// choose k-point index and band index, then Psi(ibasis) can reach 
+    /// Psi(ik, iband, ibasis) for k_first=true or Psi(iband, ik, ibasis) for k_first=false
+    void fix_kb(const int ik, const int ib) const;
 
-    // use operator "(ik, iband, ibasis)" to reach target element
-    T& operator()(const int ik, const int ibands, const int ibasis) const;
-    // use operator "(iband, ibasis)" to reach target element for current k
-    T& operator()(const int ibands, const int ibasis) const;
+
+    /// use operator "(ikb1, ikb2, ibasis)" to reach target element
+    /// if k_first=true, ikb=ik, ikb2=iband
+    /// if k_first=false, ikb=iband, ikb2=ik
+    T& operator()(const int ikb1, const int ikb2, const int ibasis) const;
+    /// use operator "(ikb2, ibasis)" to reach target element for current k
+    /// if k_first=true, ikb2=iband
+    /// if k_first=false, ikb2=ik
+    T& operator()(const int ikb2, const int ibasis) const;
     // use operator "(ibasis)" to reach target element for current k and current band
     T& operator()(const int ibasis) const;
 

--- a/source/module_psi/psi.h
+++ b/source/module_psi/psi.h
@@ -15,12 +15,12 @@ struct Range
 {
     /// k_first = 0: Psi(nbands, nks, nbasis) ; 1: Psi(nks, nbands, nbasis)
     bool k_first;
-    /// index_1> 0: target first index; index_1<0: no use
+    /// index_1>= 0: target first index; index_1<0: no use
     size_t index_1;
-    /// if index_1>0,  range_1 is the begin of second index with index_1 fixed
+    /// if index_1>=0,  range_1 is the begin of second index with index_1 fixed
     /// if index_1<0,  range_1 is the begin of first index
     size_t range_1;
-    /// if index_1>0,  range_2 is the end of second index with index_1 fixed
+    /// if index_1>=0,  range_2 is the end of second index with index_1 fixed
     /// if index_1<0,  range_2 is the end of first index
     size_t range_2;
     // this is simple constructor for hPsi return


### PR DESCRIPTION
Implement Psi with index (nbands, nks, nbasis), i.e. `k_first=false`, which will be useful in #2460 
- interfaces updated to support both k-first and band-first: 
  - constructors
  - get_pointer
  - operator
  - to_range
  - fix_k
- new interfaces
  - fix_b
  - fix_kb