### PR TITLE
 Fix: If SCF unconverge in relax metod, there will be give a waring

### DIFF
--- a/source/driver_run.cpp
+++ b/source/driver_run.cpp
@@ -52,8 +52,16 @@ void Driver::driver_run()
     }
     else // scf; cell relaxation; nscf; etc
     {
-        Relax_Driver rl_driver;
-        rl_driver.relax_driver(p_esolver);
+        if (GlobalV::precision_flag == "single")
+        {
+            Relax_Driver<float, psi::DEVICE_CPU> rl_driver;
+            rl_driver.relax_driver(p_esolver);
+        }
+        else
+        {
+            Relax_Driver<double, psi::DEVICE_CPU> rl_driver;
+            rl_driver.relax_driver(p_esolver);
+        }
     }
     //---------------------------MD/Relax------------------
 

--- a/source/module_relax/relax_driver.cpp
+++ b/source/module_relax/relax_driver.cpp
@@ -98,10 +98,20 @@ void Relax_Driver<FPTYPE, Device>::relax_driver(ModuleESolver::ESolver *p_esolve
                 }
 
                 ModuleESolver::ESolver_KS<FPTYPE, Device>* p_esolver_ks = dynamic_cast<ModuleESolver::ESolver_KS<FPTYPE, Device>*>(p_esolver);
-                if (stop && p_esolver_ks->maxniter == p_esolver_ks->niter && !(p_esolver_ks->conv_elec))
+                if (p_esolver_ks && stop && p_esolver_ks->maxniter == p_esolver_ks->niter && !(p_esolver_ks->conv_elec))
                 {
-                    std::cout << " Relaxation is converged, but the SCF is unconverge!" << std::endl;
-                    GlobalV::ofs_running << "\n Relaxation is converged, but the SCF is unconverge!" << std::endl;
+                    std::cout << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
+                    std::cout << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
+                    std::cout << " Relaxation is converged, but the SCF is unconverged! The results are unreliable. " << std::endl;
+                    std::cout << " It is suggested to increase the maximum SCF step and/or perform the relaxation again." << std::endl;
+                    std::cout << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
+                    std::cout << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
+                    GlobalV::ofs_running << "\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
+                    GlobalV::ofs_running << "\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
+                    GlobalV::ofs_running << "\n Relaxation is converged, but the SCF is unconverged! The results are unreliable.. " << std::endl;
+                    GlobalV::ofs_running << "\n It is suggested to increase the maximum SCF step and/or perform the relaxation again. " << std::endl;
+                    GlobalV::ofs_running << "\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
+                    GlobalV::ofs_running << "\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
                 }
             }
         }

--- a/source/module_relax/relax_driver.cpp
+++ b/source/module_relax/relax_driver.cpp
@@ -4,7 +4,8 @@
 #include "module_io/print_info.h"
 #include "module_io/write_wfc_r.h"
 
-void Relax_Driver::relax_driver(ModuleESolver::ESolver *p_esolver)
+template<typename FPTYPE, typename Device>
+void Relax_Driver<FPTYPE, Device>::relax_driver(ModuleESolver::ESolver *p_esolver)
 {
     ModuleBase::TITLE("Ions", "opt_ions");
     ModuleBase::timer::tick("Ions", "opt_ions");
@@ -95,6 +96,13 @@ void Relax_Driver::relax_driver(ModuleESolver::ESolver *p_esolver)
 
                     GlobalC::ucell.print_cell_cif("STRU_NOW.cif");
                 }
+
+                ModuleESolver::ESolver_KS<FPTYPE, Device>* p_esolver_ks = dynamic_cast<ModuleESolver::ESolver_KS<FPTYPE, Device>*>(p_esolver);
+                if (stop && p_esolver_ks->maxniter == p_esolver_ks->niter && !(p_esolver_ks->conv_elec))
+                {
+                    std::cout << " Relaxation is converged, but the SCF is unconverge!" << std::endl;
+                    GlobalV::ofs_running << "\n Relaxation is converged, but the SCF is unconverge!" << std::endl;
+                }
             }
         }
         time_t fend = time(NULL);
@@ -110,3 +118,6 @@ void Relax_Driver::relax_driver(ModuleESolver::ESolver *p_esolver)
     ModuleBase::timer::tick("Ions", "opt_ions");
     return;
 }
+
+template class Relax_Driver<float, psi::DEVICE_CPU>;
+template class Relax_Driver<double, psi::DEVICE_CPU>;

--- a/source/module_relax/relax_driver.h
+++ b/source/module_relax/relax_driver.h
@@ -2,9 +2,11 @@
 #define RELAX_DRIVER_H
 
 #include "module_esolver/esolver.h"
+#include "module_esolver/esolver_ks.h"
 #include "relax_new/relax.h"
 #include "relax_old/relax_old.h"
 
+template<typename FPTYPE, typename Device = psi::DEVICE_CPU>
 class Relax_Driver
 {
 


### PR DESCRIPTION
'Relaxation is converged, but the SCF is unconverge!' This PR is used to solve the issue of #2627 