### PR TITLE
Fix: INPUT parameter dft_functional with any upper or lower letter

### DIFF
--- a/source/module_io/input.cpp
+++ b/source/module_io/input.cpp
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <vector>
+#include <algorithm>
 Input INPUT;
 
 void Input::Init(const std::string &fn)
@@ -2505,9 +2506,11 @@ void Input::Default_2(void) // jiyy add 2019-08-04
 
     if (exx_hybrid_alpha == "default")
     {
-        if (dft_functional == "hf" || INPUT.rpa)
+        std::string dft_functional_lower = dft_functional;
+        std::transform(dft_functional.begin(), dft_functional.end(), dft_functional_lower.begin(), tolower);
+        if (dft_functional_lower == "hf" || rpa)
             exx_hybrid_alpha = "1";
-        else if (dft_functional == "pbe0" || dft_functional == "hse" || dft_functional == "scan0")
+        else if (dft_functional_lower == "pbe0" || dft_functional_lower == "hse" || dft_functional_lower == "scan0")
             exx_hybrid_alpha = "0.25";
     }
     if (exx_real_number == "default")
@@ -2519,9 +2522,11 @@ void Input::Default_2(void) // jiyy add 2019-08-04
     }
     if (exx_ccp_rmesh_times == "default")
     {
-        if (dft_functional == "hf" || dft_functional == "pbe0" || dft_functional == "scan0")
+        std::string dft_functional_lower = dft_functional;
+        std::transform(dft_functional.begin(), dft_functional.end(), dft_functional_lower.begin(), tolower);
+        if (dft_functional_lower == "hf" || dft_functional_lower == "pbe0" || dft_functional_lower == "scan0")
             exx_ccp_rmesh_times = "5";
-        else if (dft_functional == "hse")
+        else if (dft_functional_lower == "hse")
             exx_ccp_rmesh_times = "1.5";
     }
     if (symmetry == "default")
@@ -3594,7 +3599,9 @@ void Input::Check(void)
         }
     }
 
-    if (dft_functional == "hf" || dft_functional == "pbe0" || dft_functional == "hse" || dft_functional == "scan0")
+    std::string dft_functional_lower = dft_functional;
+    std::transform(dft_functional.begin(), dft_functional.end(), dft_functional_lower.begin(), tolower);
+    if (dft_functional_lower == "hf" || dft_functional_lower == "pbe0" || dft_functional_lower == "hse" || dft_functional_lower == "scan0")
     {
         const double exx_hybrid_alpha_value = std::stod(exx_hybrid_alpha);
         if (exx_hybrid_alpha_value < 0 || exx_hybrid_alpha_value > 1)
@@ -3616,7 +3623,7 @@ void Input::Check(void)
             ModuleBase::WARNING_QUIT("INPUT", "exx_distribute_type must be htime or kmeans2 or kmeans1");
         }
     }
-    if (dft_functional == "opt_orb")
+    if (dft_functional_lower == "opt_orb")
     {
         if (exx_opt_orb_lmax < 0)
         {

--- a/source/module_io/input_conv.cpp
+++ b/source/module_io/input_conv.cpp
@@ -30,6 +30,8 @@
 #include "module_md/md_func.h"
 #include "module_psi/kernels/device.h"
 
+#include <algorithm>
+
 template <typename T>
 void Input_Conv::parse_expression(const std::string &fn, std::vector<T> &vec)
 {
@@ -480,10 +482,12 @@ void Input_Conv::Convert(void)
     //----------------------------------------------------------
     if (INPUT.restart_save)
     {
+        std::string dft_functional_lower = INPUT.dft_functional;
+        std::transform(INPUT.dft_functional.begin(), INPUT.dft_functional.end(), dft_functional_lower.begin(), tolower);
         GlobalC::restart.folder = GlobalV::global_readin_dir + "restart/";
         ModuleBase::GlobalFunc::MAKE_DIR(GlobalC::restart.folder);
-        if (INPUT.dft_functional == "hf" || INPUT.dft_functional == "pbe0" || INPUT.dft_functional == "hse"
-            || INPUT.dft_functional == "opt_orb" || INPUT.dft_functional == "scan0")
+        if (dft_functional_lower == "hf" || dft_functional_lower == "pbe0" || dft_functional_lower == "hse"
+            || dft_functional_lower == "opt_orb" || dft_functional_lower == "scan0")
         {
             GlobalC::restart.info_save.save_charge = true;
             GlobalC::restart.info_save.save_H = true;
@@ -495,9 +499,11 @@ void Input_Conv::Convert(void)
     }
     if (INPUT.restart_load)
     {
+        std::string dft_functional_lower = INPUT.dft_functional;
+        std::transform(INPUT.dft_functional.begin(), INPUT.dft_functional.end(), dft_functional_lower.begin(), tolower);
         GlobalC::restart.folder = GlobalV::global_readin_dir + "restart/";
-        if (INPUT.dft_functional == "hf" || INPUT.dft_functional == "pbe0" || INPUT.dft_functional == "hse"
-            || INPUT.dft_functional == "opt_orb" || INPUT.dft_functional == "scan0")
+        if (dft_functional_lower == "hf" || dft_functional_lower == "pbe0" || dft_functional_lower == "hse"
+            || dft_functional_lower == "opt_orb" || dft_functional_lower == "scan0")
         {
             GlobalC::restart.info_load.load_charge = true;
         }
@@ -519,17 +525,19 @@ void Input_Conv::Convert(void)
 #ifdef __EXX
 #ifdef __LCAO
 
-    if (INPUT.dft_functional == "hf" || INPUT.dft_functional == "pbe0" || INPUT.dft_functional == "scan0")
+    std::string dft_functional_lower = INPUT.dft_functional;
+    std::transform(INPUT.dft_functional.begin(), INPUT.dft_functional.end(), dft_functional_lower.begin(), tolower);
+    if (dft_functional_lower == "hf" || dft_functional_lower == "pbe0" || dft_functional_lower == "scan0")
     {
         GlobalC::exx_info.info_global.cal_exx = true;
         GlobalC::exx_info.info_global.ccp_type = Conv_Coulomb_Pot_K::Ccp_Type::Hf;
     }
-    else if (INPUT.dft_functional == "hse")
+    else if (dft_functional_lower == "hse")
     {
         GlobalC::exx_info.info_global.cal_exx = true;
         GlobalC::exx_info.info_global.ccp_type = Conv_Coulomb_Pot_K::Ccp_Type::Hse;
     }
-    else if (INPUT.dft_functional == "opt_orb")
+    else if (dft_functional_lower == "opt_orb")
     {
         GlobalC::exx_info.info_global.cal_exx = false;
         Exx_Abfs::Jle::generate_matrix = true;

--- a/tests/integrate/285_NO_KP_RE_HSE/INPUT
+++ b/tests/integrate/285_NO_KP_RE_HSE/INPUT
@@ -26,7 +26,7 @@ smearing_sigma		0.002
 mixing_type		pulay
 
 #Parameters (7.Hybrid)
-dft_functional				hse
+dft_functional				hsE
 exx_real_number				1
 exx_pca_threshold			1E-4
 exx_c_threshold 			1E-4


### PR DESCRIPTION
Fix issue #2945.
In INPUT, dft_functional=hse or dft_functional=HSE or even dft_functional=HsE will work successfully now.