### PR TITLE
Fix: fix various deepks memory leak

### DIFF
--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks.cpp
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks.cpp
@@ -36,6 +36,8 @@ LCAO_Deepks::LCAO_Deepks()
     inl_l = nullptr;
     H_V_delta = nullptr;
     H_V_deltaR = nullptr;
+    gedm = nullptr;
+    H_V_delta_k = nullptr;
 }
 
 //Desctructor of the class
@@ -45,6 +47,7 @@ LCAO_Deepks::~LCAO_Deepks()
     delete[] inl_index;
     delete[] inl_l;
     delete[] H_V_delta;
+    delete[] H_V_deltaR;
 
     //=======1. to use deepks, pdm is required==========
     //delete pdm**
@@ -54,7 +57,8 @@ LCAO_Deepks::~LCAO_Deepks()
     }
     delete[] pdm;
     //=======2. "deepks_scf" part==========
-    if (GlobalV::deepks_scf)
+    //if (GlobalV::deepks_scf)
+    if (gedm)
     {
         //delete gedm**
         for (int inl = 0;inl < this->inlmax;inl++)
@@ -63,6 +67,16 @@ LCAO_Deepks::~LCAO_Deepks()
         }
         delete[] gedm;
     }
+
+    if (H_V_delta_k)
+    {
+        for (int ik = 0; ik < this->nks_V_delta; ++ik)
+        {
+            delete[] H_V_delta_k[ik];
+        }
+        delete[] H_V_delta_k;
+    }
+    del_gdmx();
 }
 
 void LCAO_Deepks::init(
@@ -205,12 +219,14 @@ void LCAO_Deepks::init_gdmx(const int nat)
             ModuleBase::GlobalFunc::ZEROS(gdmz[iat][inl], (2 * lmaxd + 1) * (2 * lmaxd + 1));
         }
     }
+    this->nat_gdm = nat;
     return;
 }
 
-void LCAO_Deepks::del_gdmx(const int nat)
+//void LCAO_Deepks::del_gdmx(const int nat)
+void LCAO_Deepks::del_gdmx()
 {
-    for (int iat = 0;iat < nat;iat++)
+    for (int iat = 0;iat < nat_gdm;iat++)
     {
         for (int inl = 0;inl < inlmax;inl++)
         {
@@ -262,6 +278,7 @@ void LCAO_Deepks::del_gdmepsl()
 void LCAO_Deepks::allocate_V_delta(const int nat, const int nks)
 {
     ModuleBase::TITLE("LCAO_Deepks", "allocate_V_delta");
+    nks_V_delta = nks;
 
     //initialize the H matrix H_V_delta
     if(GlobalV::GAMMA_ONLY_LOCAL)

--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks.h
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks.h
@@ -85,6 +85,8 @@ private:
 	int lmaxd = 0; //max l of descirptors
 	int nmaxd = 0; //#. descriptors per l
 	int inlmax = 0; //tot. number {i,n,l} - atom, n, l
+    int nat_gdm = 0;
+    int nks_V_delta = 0;
 
     bool init_pdm = false; //for DeePKS NSCF calculation
     
@@ -198,7 +200,8 @@ public:
 
     // array for storing gdmx, used for calculating gvx
 	void init_gdmx(const int nat);
-	void del_gdmx(const int nat);
+	//void del_gdmx(const int nat);
+	void del_gdmx();
 
     // array for storing gdm_epsl, used for calculating gvx
 	void init_gdmepsl();


### PR DESCRIPTION
This PR is supposed to address issues #2099.
PS: #2100 #2101 #2102 should already be fixed by the new two-center integral module.