### PR TITLE
correct Autotest.sh

### DIFF
--- a/tests/integrate/Autotest.sh
+++ b/tests/integrate/Autotest.sh
@@ -9,8 +9,7 @@ threshold=0.0000001
 # check accuracy
 ca=8
 # regex of case name
-case="^[^#].*PINT.*$"
-#case="^[^#].*_.*$"
+case="^[^#].*_.*$"
 # enable AddressSanitizer
 sanitize=false
 


### PR DESCRIPTION
recover the regex of case "case="^[^#].*PINT.*$"" to "case="^[^#].*_.*$""