### PR TITLE
Fix Psi(T*)

### DIFF
--- a/source/module_hamilt_general/operator.cpp
+++ b/source/module_hamilt_general/operator.cpp
@@ -61,7 +61,7 @@ typename Operator<T, Device>::hpsi_info Operator<T, Device>::hPsi(hpsi_info& inp
     }
 
     auto call_act = [&, this](const Operator* op) -> void {
-        switch (act_type)
+        switch (op->get_act_type())
         {
         case 2:
             op->act(*psi_input, *this->hpsi, nbands);

--- a/source/module_hamilt_general/operator.cpp
+++ b/source/module_hamilt_general/operator.cpp
@@ -61,10 +61,12 @@ typename Operator<T, Device>::hpsi_info Operator<T, Device>::hPsi(hpsi_info& inp
     }
 
     auto call_act = [&, this](const Operator* op) -> void {
+        // a "psi" with the bands of needed range
+        psi::Psi<T, Device> psi_wrapper(const_cast<T*>(tmpsi_in), 1, nbands, psi_input->get_nbasis());
         switch (op->get_act_type())
         {
         case 2:
-            op->act(*psi_input, *this->hpsi, nbands);
+            op->act(psi_wrapper, *this->hpsi, nbands);
             break;
         default:
             op->act(nbands, psi_input->get_nbasis(), psi_input->npol, tmpsi_in, this->hpsi->get_pointer(), psi_input->get_ngk(op->ik));

--- a/source/module_hamilt_general/operator.cpp
+++ b/source/module_hamilt_general/operator.cpp
@@ -64,7 +64,7 @@ typename Operator<T, Device>::hpsi_info Operator<T, Device>::hPsi(hpsi_info& inp
         switch (act_type)
         {
         case 2:
-            op->act(*psi_input, *this->hpsi);
+            op->act(*psi_input, *this->hpsi, nbands);
             break;
         default:
             op->act(nbands, psi_input->get_nbasis(), psi_input->npol, tmpsi_in, this->hpsi->get_pointer(), psi_input->get_ngk(op->ik));

--- a/source/module_hamilt_general/operator.h
+++ b/source/module_hamilt_general/operator.h
@@ -65,7 +65,8 @@ class Operator
 
     /// developer-friendly interfaces for act() function
     /// interface type 2: input and change the Psi-type HPsi
-    virtual void act(const psi::Psi<T, Device>& psi_in, psi::Psi<T, Device>& psi_out) const {};
+    // virtual void act(const psi::Psi<T, Device>& psi_in, psi::Psi<T, Device>& psi_out) const {};
+    virtual void act(const psi::Psi<T, Device>& psi_in, psi::Psi<T, Device>& psi_out, const int nbands) const {};
     /// interface type 3: return a Psi-type HPsi
     // virtual psi::Psi<T> act(const psi::Psi<T,Device>& psi_in) const { return psi_in; };
 

--- a/source/module_hamilt_general/operator.h
+++ b/source/module_hamilt_general/operator.h
@@ -72,6 +72,7 @@ class Operator
 
     Operator* next_op = nullptr;
 
+    virtual int get_act_type() const { return this->act_type; }
 protected:
     int ik = 0;
     int act_type = 1;   ///< determine which act() interface would be called in hPsi()

--- a/source/module_hamilt_general/operator.h
+++ b/source/module_hamilt_general/operator.h
@@ -72,7 +72,11 @@ class Operator
 
     Operator* next_op = nullptr;
 
-    virtual int get_act_type() const { return this->act_type; }
+    /// type 1 (default): pointer-only
+    ///         act(const T* psi_in, T* psi_out)
+    /// type 2: use the `Psi`class 
+    ///         act(const Psi& psi_in, Psi& psi_out)
+    int get_act_type() const { return this->act_type; }
 protected:
     int ik = 0;
     int act_type = 1;   ///< determine which act() interface would be called in hPsi()

--- a/source/module_psi/psi.cpp
+++ b/source/module_psi/psi.cpp
@@ -34,7 +34,7 @@ template <typename T, typename Device> Psi<T, Device>::Psi()
 
 template <typename T, typename Device> Psi<T, Device>::~Psi()
 {
-    delete_memory_op()(this->ctx, this->psi);
+    if (this->allocate_inside) delete_memory_op()(this->ctx, this->psi);
 }
 
 template <typename T, typename Device> Psi<T, Device>::Psi(const int* ngk_in)
@@ -103,6 +103,8 @@ Psi<T, Device>::Psi(T* psi_pointer, const Psi& psi_in, const int nk_in, int nban
     this->nbands = nband_in;
     this->nbasis = psi_in.nbasis;
     this->psi_current = psi_pointer;
+    this->allocate_inside = false;
+    this->psi = psi_pointer;
 }
 
 template <typename T, typename Device> Psi<T, Device>::Psi(const Psi& psi_in)

--- a/source/module_psi/psi.cpp
+++ b/source/module_psi/psi.cpp
@@ -61,6 +61,24 @@ template <typename T, typename Device> Psi<T, Device>::Psi(const int nk_in, cons
                                          sizeof(T) * nk_in * nbd_in * nbs_in);
 }
 
+template <typename T, typename Device> Psi<T, Device>::Psi(T* psi_pointer, const int nk_in, const int nbd_in, const int nbs_in, const int* ngk_in, const bool k_first_in)
+{
+    this->k_first = k_first_in;
+    this->ngk = ngk_in;
+    this->current_b = 0;
+    this->current_k = 0;
+    this->npol = GlobalV::NPOL;
+    this->device = device::get_device_type<Device>(this->ctx);
+    this->nk = nk_in;
+    this->nbands = nbd_in;
+    this->nbasis = nbs_in;
+    this->current_nbasis = nbs_in;
+    this->psi_current = this->psi = psi_pointer;
+    this->allocate_inside = false;
+    // Currently only GPU's implementation is supported for device recording!
+    device::print_device_info<Device>(this->ctx, GlobalV::ofs_device);
+}
+
 template <typename T, typename Device> Psi<T, Device>::Psi(const Psi& psi_in, const int nk_in, int nband_in)
 {
     assert(nk_in <= psi_in.get_nk());

--- a/source/module_psi/psi.h
+++ b/source/module_psi/psi.h
@@ -50,6 +50,8 @@ template <typename T, typename Device = DEVICE_CPU> class Psi
     // Constructor 7: initialize a new psi from the given psi_in with a different class template
     // in this case, psi_in may have a different device type.
     template <typename T_in, typename Device_in = Device> Psi(const Psi<T_in, Device_in>& psi_in);
+    // Constructor 8: a pointer version of constructor 3
+    Psi(T* psi_pointer, const int nk_in, const int nbd_in, const int nbs_in, const int* ngk_in = nullptr, const bool k_first_in = true);
     // Destructor for deleting the psi array manually
     ~Psi();
 

--- a/source/module_psi/psi.h
+++ b/source/module_psi/psi.h
@@ -138,6 +138,8 @@ template <typename T, typename Device = DEVICE_CPU> class Psi
 
     bool k_first = true;
 
+    bool allocate_inside = true;  ///<whether allocate psi inside Psi class
+
     using set_memory_op = psi::memory::set_memory_op<T, Device>;
     using delete_memory_op = psi::memory::delete_memory_op<T, Device>;
     using resize_memory_op = psi::memory::resize_memory_op<T, Device>;

--- a/source/module_psi/test/psi_test.cpp
+++ b/source/module_psi/test/psi_test.cpp
@@ -331,6 +331,28 @@ TEST_F(TestPsi, band_first)
     EXPECT_EQ(std::get<0>(psi_band_32->to_range(illegal_range1)), nullptr);
     EXPECT_EQ(std::get<1>(psi_band_32->to_range(illegal_range2)), 0);
 
+    // pointer constructor
+    // band-first to k-first
+    psi::Psi<float> psi_band_32_k(psi_band_32->get_pointer(), psi_band_32->get_nk(), psi_band_32->get_nbands(), psi_band_32->get_nbasis(), psi_band_32->get_ngk_pointer(), true);
+    // k-first to band-first
+    psi::Psi<float> psi_band_32_b(psi_band_32_k.get_pointer(), psi_band_32_k.get_nk(), psi_band_32_k.get_nbands(), psi_band_32_k.get_nbasis(), psi_band_32_k.get_ngk_pointer(), false);
+    EXPECT_EQ(psi_band_32_k.get_nk(), ink);
+    EXPECT_EQ(psi_band_32_k.get_nbands(), inbands);
+    EXPECT_EQ(psi_band_32_k.get_nbasis(), inbasis);
+    EXPECT_EQ(psi_band_32_b.get_nk(), ink);
+    EXPECT_EQ(psi_band_32_b.get_nbands(), inbands);
+    EXPECT_EQ(psi_band_32_b.get_nbasis(), inbasis);
+    for (int ik = 0;ik < ink;++ik)
+        for (int ib = 0;ib < inbands;++ib)
+        {
+            psi_band_32->fix_kb(ik, ib);
+            psi_band_32_k.fix_kb(ik, ib);
+            psi_band_32_b.fix_kb(ik, ib);
+            EXPECT_EQ(psi_band_32->get_psi_bias(), (ib * ink + ik) * inbasis);
+            EXPECT_EQ(psi_band_32_k.get_psi_bias(), (ik * inbands + ib) * inbasis);
+            EXPECT_EQ(psi_band_32_b.get_psi_bias(), (ib * ink + ik) * inbasis);
+        }
+
     delete psi_band_c64;
     delete psi_band_64;
     delete psi_band_c32;


### PR DESCRIPTION
- Fix: A nullptr-psi doesn't affect current usage, but will cause an error after a future call of `fix_k()`. 
- Add a common pointer-constructor for Psi, supporting conversion between k-first and band-first (useful in #2460).
- fix type-2 act interface: `nbands` is still needed to be passed in since it may be less than `psi_in.get_nbands()`