### PR TITLE
Docs: update issue templates with reminder for developers

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,7 +1,7 @@
 name: Docs
 description: For users or developers to report issues related to software documentation, such as missing or incomplete documentation, or documentation that is difficult to understand.
 labels: [Docs]
-assignees: hongriTianqi
+assignees: [insert assignee here]
 body:
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -27,6 +27,14 @@ body:
 
 - type: textarea
   attributes:
+    label: Notice Possible Change of Behavior (Reminder only for developers)
+    description: |
+      Please ensure that you have carefully considered the possible change of behavior your code changes might introduce. Make sure to provide a detailed explanation of these changes and their potential impact on the application. This will help reviewers to better understand your changes and assess their implications.
+    placeholder: |
+      Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...
+
+- type: textarea
+  attributes:
     label: Additional Context
     description: |
       Add any other context or references about the feature request here.

--- a/.github/ISSUE_TEMPLATE/tests.yml
+++ b/.github/ISSUE_TEMPLATE/tests.yml
@@ -1,7 +1,7 @@
 name: Tests
 description: For developers to report issues related to software testing, such as test failures, missing or incomplete tests, or issues with test automation.
 labels: [Tests]
-assignees: hongriTianqi
+assignees: [insert assignee here]
 
 body:
 - type: textarea


### PR DESCRIPTION
1. Add a reminder for developers to notice possible change of behavior of code in the "feature request" issue template.
2. remove default assignee of hongriTianqi in the documentation and tests issue template, as he can't follow all these issues.