### PR TITLE
Test: update dynamic analysis command

### DIFF
--- a/.github/workflows/dynamic.yml
+++ b/.github/workflows/dynamic.yml
@@ -2,7 +2,7 @@ name: Dynamic Analysis
 
 on:
   schedule:
-    - cron: '0 20 * * *'
+    - cron: '0 16 * * 0'
   workflow_dispatch:
 
 jobs:
@@ -16,8 +16,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Building
         run: |
-          cmake -B build -DENABLE_ASAN=1 -DBUILD_TESTING=ON -DENABLE_DEEPKS=1 -DENABLE_LIBXC=1
-          cmake --build build -j16
+          cmake -B build -DENABLE_ASAN=1 -DENABLE_DEEPKS=1 -DENABLE_LIBXC=1
+          cmake --build build -j8
           cmake --install build
       - name: Testing
         run: |


### PR DESCRIPTION
- Remove unit tests in dynamic analysis: it is less meaningful executing dynamic analysis over unit tests, and the results of them are not published.
- Update test schedule: 16:00 UTC (24:00 CST) on every Sunday