### PR TITLE
Fix: remove PR check skipping the docs directory.

### DIFF
--- a/.github/workflows/build_test_cmake.yml
+++ b/.github/workflows/build_test_cmake.yml
@@ -1,11 +1,7 @@
 name: Build Test
 on:
   push:
-    paths-ignore:
-      - "docs/**"
   pull_request:
-    paths-ignore:
-      - "docs/**"
 
 jobs:
   test:

--- a/.github/workflows/build_test_makefile.yml
+++ b/.github/workflows/build_test_makefile.yml
@@ -1,11 +1,7 @@
 name: Build Test
 on:
   push:
-    paths-ignore:
-      - 'docs/**'
   pull_request:
-    paths-ignore:
-      - 'docs/**'
 
 jobs:
   test:
@@ -23,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Build
         run: |
-          export I_MPI_CXX=icpx       
-          cd source 
+          export I_MPI_CXX=icpx
+          cd source
           make -j2 ${{ matrix.build_args }}
-          
+

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -2,8 +2,6 @@ name: Container
 
 on:
   push:
-    paths-ignore:
-      - 'docs/**'
     branches:
       - develop
 

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -2,8 +2,6 @@ name: Static Analysis
 
 on:
   pull_request_target:
-    paths-ignore:
-      - 'docs/**'
 
 jobs:
   clang-tidy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: Integration Test and Unit Test
 
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
 
 jobs:
   test:


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [x] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #3091 

### What's changed?
All check-related actions have been set to skip the "docs" directory, which causes the PR check to hang. Thus, skipping the "docs" directory should be removed.

### Any changes of core modules? (ignore if not applicable)
None