### PR TITLE
Fix: title of force output

### DIFF
--- a/source/module_esolver/esolver_dp.cpp
+++ b/source/module_esolver/esolver_dp.cpp
@@ -130,7 +130,7 @@ namespace ModuleESolver
     void ESolver_DP::cal_Force(ModuleBase::matrix& force)
     {
         force = dp_force;
-        ModuleIO::print_force(GlobalV::ofs_running, *ucell_, "   TOTAL-FORCE (eV/Angstrom)", force, false);
+        ModuleIO::print_force(GlobalV::ofs_running, *ucell_, "TOTAL-FORCE (eV/Angstrom)", force, false);
     }
 
     void ESolver_DP::cal_Stress(ModuleBase::matrix& stress)

--- a/source/module_esolver/esolver_lj.cpp
+++ b/source/module_esolver/esolver_lj.cpp
@@ -101,7 +101,7 @@ namespace ModuleESolver
     void ESolver_LJ::cal_Force(ModuleBase::matrix& force)
     {
         force = lj_force;
-        ModuleIO::print_force(GlobalV::ofs_running, *ucell_, "   TOTAL-FORCE (eV/Angstrom)", force, false);
+        ModuleIO::print_force(GlobalV::ofs_running, *ucell_, "TOTAL-FORCE (eV/Angstrom)", force, false);
     }
 
     void ESolver_LJ::cal_Stress(ModuleBase::matrix& stress)

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
@@ -481,7 +481,7 @@ void Force_Stress_LCAO<T>::getForceStress(const bool isforce,
         GlobalV::ofs_running << std::setiosflags(std::ios::left);
 
         // this->printforce_total(ry, istestf, fcs);
-        ModuleIO::print_force(GlobalV::ofs_running, GlobalC::ucell, "   TOTAL-FORCE (eV/Angstrom)", fcs, 0);
+        ModuleIO::print_force(GlobalV::ofs_running, GlobalC::ucell, "TOTAL-FORCE (eV/Angstrom)", fcs, 0);
         if (istestf)
         {
             GlobalV::ofs_running << "\n FORCE INVALID TABLE." << std::endl;

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
@@ -53,9 +53,6 @@ class Force_Stress_LCAO
     Stress_Func<double> sc_pw;
     Forces<double> f_pw;
 
-    void print_force(const std::string& name, ModuleBase::matrix& f, const bool screen, bool ry) const;
-    void printforce_total(const bool ry, const bool istestf, ModuleBase::matrix& fcs);
-
     void forceSymmetry(ModuleBase::matrix& fcs, ModuleSymmetry::Symmetry* symm);
 
     void calForcePwPart(ModuleBase::matrix& fvl_dvl,

--- a/source/module_hamilt_pw/hamilt_pwdft/forces.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/forces.cpp
@@ -259,7 +259,7 @@ void Forces<FPTYPE, Device>::cal_force(ModuleBase::matrix& force,
         if (GlobalV::imp_sol)
             ModuleIO::print_force(GlobalV::ofs_running, GlobalC::ucell, "IMP_SOL   FORCE (eV/Angstrom)", forcesol, 0);
     }
-    ModuleIO::print_force(GlobalV::ofs_running, GlobalC::ucell, "   TOTAL-FORCE (eV/Angstrom)", force, 0);
+    ModuleIO::print_force(GlobalV::ofs_running, GlobalC::ucell, "TOTAL-FORCE (eV/Angstrom)", force, 0);
 
     return;
 }

--- a/source/module_hamilt_pw/hamilt_stodft/sto_forces.cpp
+++ b/source/module_hamilt_pw/hamilt_stodft/sto_forces.cpp
@@ -164,7 +164,7 @@ void Sto_Forces::cal_stoforce(ModuleBase::matrix& force,
                                   force_gate,
                                   0);
     }
-    ModuleIO::print_force(GlobalV::ofs_running, GlobalC::ucell, "   TOTAL-FORCE (eV/Angstrom)", force, 0);
+    ModuleIO::print_force(GlobalV::ofs_running, GlobalC::ucell, "TOTAL-FORCE (eV/Angstrom)", force, 0);
     ModuleBase::timer::tick("Sto_Force", "cal_force");
     return;
 }

--- a/source/module_io/output_log.cpp
+++ b/source/module_io/output_log.cpp
@@ -47,7 +47,7 @@ void print_force(std::ofstream& ofs_running,
     std::vector<double> force_y;
     std::vector<double> force_z;
     std::string table;
-    context.set_context({"title", "force", "force", "force"});
+    context.set_context({"short_title", "force", "force", "force"});
     int iat = 0;
     for (int it = 0; it < cell.ntype; it++)
     {
@@ -67,9 +67,8 @@ void print_force(std::ofstream& ofs_running,
     }
 
     context.enable_title();
-    context << "atom" << atom_label << "x" << force_x << "y" << force_y << "z" << force_z;
+    context << name.c_str() << atom_label << "" << force_x << "" << force_y << "" << force_z;
     context.center_title();
-    context.set_overall_title("TOTAL-FORCE (eV/Angstrom)");
     table = context.str();
     ofs_running << table << std::endl;
     if (GlobalV::TEST_FORCE)

--- a/source/module_io/test/outputlog_test.cpp
+++ b/source/module_io/test/outputlog_test.cpp
@@ -180,22 +180,22 @@ TEST(PrintForce, PrintForce)
     std::ifstream ifs("test.txt");
     std::string output_str;
     getline(ifs, output_str);
-    EXPECT_THAT(output_str, testing::HasSubstr("TOTAL-FORCE (eV/Angstrom)"));
+    EXPECT_THAT(output_str,
+                testing::HasSubstr("---------------------------------------------------------------------------"));
+    getline(ifs, output_str);
+    EXPECT_THAT(output_str, testing::HasSubstr("test"));
     getline(ifs, output_str);
     EXPECT_THAT(output_str,
-                testing::HasSubstr("---------------------------------------------------------------------"));
-    getline(ifs, output_str);
-    EXPECT_THAT(output_str, testing::HasSubstr("atom          x                    y                    z          "));
+                testing::HasSubstr("---------------------------------------------------------------------------"));
     getline(ifs, output_str);
     EXPECT_THAT(output_str,
-                testing::HasSubstr("---------------------------------------------------------------------"));
-    getline(ifs, output_str);
-    EXPECT_THAT(output_str, testing::HasSubstr(" Al1        25.7110532015        51.4221064030        77.1331596044"));
-    getline(ifs, output_str);
-    EXPECT_THAT(output_str, testing::HasSubstr(" Al2         0.0000000000         0.0000000000         0.0000000000"));
+                testing::HasSubstr("Al1               25.7110532015        51.4221064030        77.1331596044"));
     getline(ifs, output_str);
     EXPECT_THAT(output_str,
-                testing::HasSubstr("---------------------------------------------------------------------"));
+                testing::HasSubstr("Al2                0.0000000000         0.0000000000         0.0000000000"));
+    getline(ifs, output_str);
+    EXPECT_THAT(output_str,
+                testing::HasSubstr("---------------------------------------------------------------------------"));
     ifs.close();
     std::remove("test.txt");
 }

--- a/tests/integrate/tools/catch_properties.sh
+++ b/tests/integrate/tools/catch_properties.sh
@@ -77,7 +77,7 @@ fi
 #echo $etot
 #echo "hasforce:"$has_force
 if ! test -z "$has_force" && [ $has_force == 1 ]; then
-	nn3=`echo "$natom + 4" |bc`
+	nn3=`echo "$natom + 1" |bc`
 	#nn1=`echo "$natom + 1" |bc`
 	#nn5=`echo "$natom + 6" |bc`
 	#grep -A$nn3 "TOTAL-FORCE" $running_path|sed '1,5d'|sed ''$nn1','$nn5'd'|awk '{printf $2"\t"$3"\t"$4"\n"}' > force.txt


### PR DESCRIPTION
### What's changed?
- Force output will print a tile accordingly. However, PR #3067 fixed the tile as "TOTAL-FORCE", which is incorrect.
