### PR TITLE
Fix: change type of nloc from long to size_t

### DIFF
--- a/source/module_base/blas_connector.h
+++ b/source/module_base/blas_connector.h
@@ -19,8 +19,8 @@ extern "C"
 	void caxpy_(const int *N, const std::complex<float> *alpha, const std::complex<float> *X, const int *incX, std::complex<float> *Y, const int *incY);
 	void zaxpy_(const int *N, const std::complex<double> *alpha, const std::complex<double> *X, const int *incX, std::complex<double> *Y, const int *incY);
 
-	void dcopy_(long const *n, const double *a, int const *incx, double *b, int const *incy);
-	void zcopy_(long const *n, const std::complex<double> *a, int const *incx, std::complex<double> *b, int const *incy);
+	void dcopy_(size_t const *n, const double *a, int const *incx, double *b, int const *incy);
+	void zcopy_(size_t const *n, const std::complex<double> *a, int const *incx, std::complex<double> *b, int const *incy);
 
 	//reason for passing results as argument instead of returning it:
 	//see https://www.numbercrunch.de/blog/2014/07/lost-in-translation/
@@ -236,12 +236,12 @@ public:
 
 	// copies a into b
 	static inline
-	void copy(const long n, const double *a, const int incx, double *b, const int incy)
+	void copy(const size_t n, const double *a, const int incx, double *b, const int incy)
 	{
 		dcopy_(&n, a, &incx, b, &incy);
 	}
 	static inline
-	void copy(const long n, const std::complex<double> *a, const int incx, std::complex<double> *b, const int incy)
+	void copy(const size_t n, const std::complex<double> *a, const int incx, std::complex<double> *b, const int incy)
 	{
 		zcopy_(&n, a, &incx, b, &incy);
 	}

--- a/source/module_base/global_function.h
+++ b/source/module_base/global_function.h
@@ -167,17 +167,17 @@ static inline void DCOPY( const T &a, T &b, const int &dim)
 }
 
 template<typename T>
-inline void COPYARRAY(const T* a, T* b, const long dim);
+inline void COPYARRAY(const T* a, T* b, const size_t dim);
 
 template<>
-inline void COPYARRAY(const std::complex<double>* a, std::complex<double>* b, const long dim)
+inline void COPYARRAY(const std::complex<double>* a, std::complex<double>* b, const size_t dim)
 {
     const int one = 1;
     zcopy_(&dim, a, &one, b, &one);
 }
 
 template<>
-inline void COPYARRAY(const double* a, double* b, const long dim)
+inline void COPYARRAY(const double* a, double* b, const size_t dim)
 {
     const int one = 1;
     dcopy_(&dim, a, &one, b, &one);

--- a/source/module_base/module_container/base/third_party/blas.h
+++ b/source/module_base/module_container/base/third_party/blas.h
@@ -25,8 +25,8 @@ void daxpy_(const int *N, const double *alpha, const double *x, const int *incx,
 void caxpy_(const int *N, const std::complex<float> *alpha, const std::complex<float> *x, const int *incx, std::complex<float> *y, const int *incy);
 void zaxpy_(const int *N, const std::complex<double> *alpha, const std::complex<double> *x, const int *incx, std::complex<double> *y, const int *incy);
 
-void dcopy_(long const *n, const double *a, int const *incx, double *b, int const *incy);
-void zcopy_(long const *n, const std::complex<double> *a, int const *incx, std::complex<double> *b, int const *incy);
+void dcopy_(size_t const *n, const double *a, int const *incx, double *b, int const *incy);
+void zcopy_(size_t const *n, const std::complex<double> *a, int const *incx, std::complex<double> *b, int const *incy);
 
 //reason for passing results as argument instead of returning it:
 //see https://www.numbercrunch.de/blog/2014/07/lost-in-translation/
@@ -323,12 +323,12 @@ double nrm2( const int n, const std::complex<double> *x, const int incx )
 
 // copies a into b
 static inline
-void copy(const long n, const double *a, const int incx, double *b, const int incy)
+void copy(const size_t n, const double *a, const int incx, double *b, const int incy)
 {
     dcopy_(&n, a, &incx, b, &incy);
 }
 static inline
-void copy(const long n, const std::complex<double> *a, const int incx, std::complex<double> *b, const int incy)
+void copy(const size_t n, const std::complex<double> *a, const int incx, std::complex<double> *b, const int incy)
 {
     zcopy_(&n, a, &incx, b, &incy);
 }

--- a/source/module_base/test/blas_connector_test.cpp
+++ b/source/module_base/test/blas_connector_test.cpp
@@ -138,7 +138,7 @@ TEST(blas_connector, zaxpy_) {
 
 TEST(blas_connector, dcopy_) {
     typedef double T;
-    long const size = 8;
+    size_t const size = 8;
     int const incx = 1;
     int const incy = 1;
     std::array<T, size> x_const, result, answer;
@@ -153,7 +153,7 @@ TEST(blas_connector, dcopy_) {
 
 TEST(blas_connector, zcopy_) {
     typedef std::complex<double> T;
-    long const size = 8;
+    size_t const size = 8;
     int const incx = 1;
     int const incy = 1;
     std::array<T, size> x_const, result, answer;

--- a/source/module_basis/module_ao/parallel_2d.h
+++ b/source/module_basis/module_ao/parallel_2d.h
@@ -18,7 +18,7 @@ public:
     /// local size (nloc = nrow * ncol)
     int nrow;
     int ncol;
-    long nloc;
+    size_t nloc;
 
     /// block size,
     /// the default value of nb is 1,

--- a/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.cpp
@@ -67,7 +67,7 @@ void LCAO_Matrix::divide_HS_in_frag(const bool isGamma, Parallel_Orbitals &pv, c
 }
 
 
-void LCAO_Matrix::allocate_HS_gamma(const long &nloc)
+void LCAO_Matrix::allocate_HS_gamma(const size_t &nloc)
 {
     ModuleBase::TITLE("LCAO_Matrix","allocate_HS_gamma");
 
@@ -90,7 +90,7 @@ void LCAO_Matrix::allocate_HS_gamma(const long &nloc)
 }
 
 
-void LCAO_Matrix::allocate_HS_k(const long &nloc)
+void LCAO_Matrix::allocate_HS_k(const size_t &nloc)
 {
     ModuleBase::TITLE("LCAO_Matrix","allocate_HS_k");
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h
@@ -36,11 +36,11 @@ class LCAO_Matrix
     std::vector< std::map<int, std::map<TAC, RI::Tensor<std::complex<double>>>>> *Hexxc;
 #endif
 
-    void allocate_HS_k(const long &nloc);
+    void allocate_HS_k(const size_t &nloc);
 
 private:
 
-    void allocate_HS_gamma(const long &nloc);
+    void allocate_HS_gamma(const size_t &nloc);
 
 
     public:


### PR DESCRIPTION

### Linked Issue
Fix #...

### What's changed?
- type of Parallel_2D::nloc changed from long to size_t, which can avoid error when NLOCAL>sqrt(INT_MAX).

