### PR TITLE
Feature: output the hardware information in both the command line and the running_scf log

### DIFF
--- a/source/module_esolver/esolver.cpp
+++ b/source/module_esolver/esolver.cpp
@@ -87,8 +87,10 @@ namespace ModuleESolver
                 c = std::toupper(c);
             }
         }
-        std::cout << " RUNNING WITH DEVICE     : " << device_info << " / "
-                  << psi::device::get_device_info(GlobalV::device_flag) << std::endl;
+        if (GlobalV::MY_RANK == 0) {
+            std::cout << " RUNNING WITH DEVICE     : " << device_info << " / "
+                      << psi::device::get_device_info(GlobalV::device_flag) << std::endl;
+        }
         GlobalV::ofs_running << "\n RUNNING WITH DEVICE     : " << device_info << " / "
                   << psi::device::get_device_info(GlobalV::device_flag) << std::endl;
         return esolver_type;

--- a/source/module_esolver/esolver.cpp
+++ b/source/module_esolver/esolver.cpp
@@ -1,5 +1,5 @@
 #include "esolver.h"
-
+#include "module_psi/kernels/device.h"
 #include "esolver_ks_pw.h"
 #include "esolver_sdft_pw.h"
 #ifdef __LCAO
@@ -81,6 +81,16 @@ namespace ModuleESolver
         }
 
         GlobalV::ofs_running << " The esolver type has been set to : " << esolver_type << std::endl;
+        auto device_info = GlobalV::device_flag;
+        for (char &c : device_info) {
+            if (std::islower(c)) {
+                c = std::toupper(c);
+            }
+        }
+        std::cout << " RUNNING WITH DEVICE     : " << device_info << " / "
+                  << psi::device::get_device_info(GlobalV::device_flag) << std::endl;
+        GlobalV::ofs_running << "\n RUNNING WITH DEVICE     : " << device_info << " / "
+                  << psi::device::get_device_info(GlobalV::device_flag) << std::endl;
         return esolver_type;
     }
 

--- a/source/module_psi/kernels/device.cpp
+++ b/source/module_psi/kernels/device.cpp
@@ -609,5 +609,43 @@ int get_device_kpar(const int& kpar) {
     return kpar;
 }
 
+std::string get_device_info(std::string device_flag) 
+{
+    std::string device_info = "Unknown";
+
+#if defined(__CUDA)
+    if (device_flag == "gpu") {
+        int dev = 0;
+        cudaDeviceProp deviceProp;
+        cudaGetDeviceProperties(&deviceProp, dev);
+        device_info = deviceProp.name;
+    }
+#elif defined(__ROCM)
+    if (device_flag == "gpu") {
+
+    }
+#endif
+    if (device_flag == "cpu") {
+        std::ifstream cpuinfo("/proc/cpuinfo");
+        std::string line = "", cpu_name = "";
+
+        while (std::getline(cpuinfo, line)) {
+            if (line.find("model name") != std::string::npos) {
+                // Extract the CPU name from the line
+                size_t colonPos = line.find(":");
+                if (colonPos != std::string::npos) {
+                    cpu_name = line.substr(colonPos + 2); // Skip the colon and space
+                    break; // Stop after the first match
+                }
+            }
+        }
+        if (cpu_name != "") {
+            device_info = cpu_name;
+        }
+        cpuinfo.close();
+    }
+    return device_info;
+}
+
 } // end of namespace device
 } // end of namespace psi

--- a/source/module_psi/kernels/device.cpp
+++ b/source/module_psi/kernels/device.cpp
@@ -622,7 +622,10 @@ std::string get_device_info(std::string device_flag)
     }
 #elif defined(__ROCM)
     if (device_flag == "gpu") {
-
+        int dev = 0;
+        hipDeviceProp_t deviceProp;
+        hipGetDeviceProperties(&deviceProp, dev);
+        device_info = deviceProp.name;
     }
 #endif
     if (device_flag == "cpu") {

--- a/source/module_psi/kernels/device.h
+++ b/source/module_psi/kernels/device.h
@@ -34,6 +34,8 @@ template<typename Device> void print_device_info (const Device* dev, std::ofstre
 
 template<typename Device> void record_device_memory (const Device* dev, std::ofstream& ofs_device, std::string str, size_t size) {return;}
 
+std::string get_device_info(std::string device_flag);
+
 int get_device_kpar(const int& kpar);
 std::string get_device_flag(const std::string& device, const std::string& ks_solver, const std::string& basis_type);
 


### PR DESCRIPTION
An example output:
```
[root@bohrium-1635-1051355:pw_Si2]$ OMP_NUM_THREADS=1 /root/abacus-develop/build/abacus
WARNING: Total thread number on this node mismatches with hardware availability. This may cause poor performance.
Info: Local MPI proc number: 1,OpenMP thread number: 1,Total thread number: 1,Local thread limit: 12
                                                                                     
                              ABACUS v3.4.1

               Atomic-orbital Based Ab-initio Computation at UStc                    

                     Website: http://abacus.ustc.edu.cn/                             
               Documentation: https://abacus.deepmodeling.com/                       
                  Repository: https://github.com/abacusmodeling/abacus-develop       
                              https://github.com/deepmodeling/abacus-develop         
                      Commit: a7f3e70d4 (Tue Oct 31 18:01:51 2023 +0800)

 Tue Oct 31 18:06:24 2023
 MAKE THE DIR         : OUT.ABACUS/
 RUNNING WITH DEVICE     : GPU / Tesla V100-SXM2-32GB
 UNIFORM GRID DIM        : 36 * 36 * 36
 UNIFORM GRID DIM(BIG)   : 36 * 36 * 36
 DONE(1.41468    SEC) : SETUP UNITCELL
 DONE(1.4499     SEC) : SYMMETRY
 DONE(1.55484    SEC) : INIT K-POINTS
```


### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
