### PR TITLE
Fix : modify calling of PAW subroutines when running parallel

### DIFF
--- a/source/module_cell/module_paw/paw_cell.cpp
+++ b/source/module_cell/module_paw/paw_cell.cpp
@@ -489,10 +489,16 @@ void Paw_Cell::accumulate_rhoij(const std::complex<double> * psi, const double w
 
 #ifdef __MPI
         Parallel_Reduce::reduce_pool(ca.data(), nproj);
-#endif
 
+        if(GlobalV::RANK_IN_POOL == 0)
+        {
+            paw_atom_list[iat].set_ca(ca, weight);
+            paw_atom_list[iat].accumulate_rhoij(current_spin);
+        }
+#else
         paw_atom_list[iat].set_ca(ca, weight);
         paw_atom_list[iat].accumulate_rhoij(current_spin);
+#endif
     }
 }
 

--- a/source/module_cell/module_paw/paw_cell.h
+++ b/source/module_cell/module_paw/paw_cell.h
@@ -174,10 +174,14 @@ class Paw_Cell
     // mode = 0 : V_{NL}|psi>, mode = 1 : (S+I)|psi>
     void paw_nl_psi(const int mode, const std::complex<double> * psi, std::complex<double> * vnlpsi);
 
+    // set by providing dij explicitly
     void set_dij(const int iat, double** dij_in){paw_atom_list[iat].set_dij(dij_in);}
+    // set by extracting dij from libpaw_interface
     void set_dij();
 
+    // set by providing sij explicitly
     void set_sij(const int iat, double* sij_in){paw_atom_list[iat].set_sij(sij_in);}
+    // set by extracting sij from libpaw_interface
     void set_sij();
 
 // Part III. Passing info for the initialization of PAW
@@ -266,8 +270,8 @@ class Paw_Cell
     void set_rhoij(int iat, int nrhoijsel, int size_rhoij, int* rhoijselect, double* rhoijp);
     void get_nhat(double** nhat, double* nhatgr);
     void calculate_dij(double* vks, double* vxc);
-    void get_dij(int iat, int size_dij, double* dij);
-    void get_sij(int iat, int size_sij, double* sij);
+    void extract_dij(int iat, int size_dij, double* dij);
+    void extract_sij(int iat, int size_sij, double* sij);
 
 // Part V. Relevant for parallel computing
 // Note about the parallelization of PAW: ABINIT supports the parallelization based on

--- a/source/module_cell/module_paw/paw_cell_libpaw.cpp
+++ b/source/module_cell/module_paw/paw_cell_libpaw.cpp
@@ -496,13 +496,13 @@ void Paw_Cell::calculate_dij(double* vks, double* vxc)
 #endif
 }
 
-void Paw_Cell::get_dij(int iat, int size_dij, double* dij)
+void Paw_Cell::extract_dij(int iat, int size_dij, double* dij)
 {
     int iat_fortran = iat + 1;
     get_dij_(iat_fortran,size_dij,nspden,dij);
 }
 
-void Paw_Cell::get_sij(int it, int size_sij, double* sij)
+void Paw_Cell::extract_sij(int it, int size_sij, double* sij)
 {
     int it_fortran = it + 1;
     get_sij_(it_fortran,size_sij,sij);
@@ -585,7 +585,7 @@ void Paw_Cell::set_dij()
            dij[is] = new double[nproj * nproj];
         }
 
-        get_dij(iat,size_dij,dij_libpaw);
+        extract_dij(iat,size_dij,dij_libpaw);
 
 #ifdef __MPI
         Parallel_Common::bcast_double(dij_libpaw,size_dij*nspden);
@@ -624,7 +624,7 @@ void Paw_Cell::set_sij()
         double* sij_libpaw = new double[size_sij];
         double* sij = new double[nproj * nproj];
 
-        get_sij(it,size_sij,sij_libpaw);
+        extract_sij(it,size_sij,sij_libpaw);
 
         for(int jproj = 0; jproj < nproj; jproj ++)
         {

--- a/source/module_cell/module_paw/paw_cell_libpaw.cpp
+++ b/source/module_cell/module_paw/paw_cell_libpaw.cpp
@@ -287,9 +287,19 @@ void Paw_Cell::get_vloc_ncoret(double* vloc, double* ncoret)
     double * vloc_tmp, * ncoret_tmp;
     vloc_tmp = new double[nfft];
     ncoret_tmp = new double[nfft];
-    
+
+#ifdef __MPI
+    if(GlobalV::RANK_IN_POOL == 0)
+    {
+        get_vloc_ncoret_(ngfftdg.data(), nfft, natom, ntypat, rprimd.data(), gprimd.data(),
+                gmet.data(), ucvol, xred.data(), ncoret_tmp, vloc_tmp);
+    }
+    Parallel_Common::bcast_double(vloc_tmp,nfft);
+    Parallel_Common::bcast_double(ncoret_tmp,nfft);
+#else
     get_vloc_ncoret_(ngfftdg.data(), nfft, natom, ntypat, rprimd.data(), gprimd.data(),
             gmet.data(), ucvol, xred.data(), ncoret_tmp, vloc_tmp);
+#endif
 
     for(int ix = 0; ix < nx; ix ++)
     {
@@ -316,6 +326,9 @@ void Paw_Cell::get_vloc_ncoret(double* vloc, double* ncoret)
 #endif
         }
     }
+
+    delete[] vloc_tmp;
+    delete[] ncoret_tmp;
 }
 
 void Paw_Cell::set_rhoij(int iat, int nrhoijsel, int size_rhoij, int* rhoijselect, double* rhoijp)

--- a/source/module_cell/module_paw/paw_cell_libpaw.cpp
+++ b/source/module_cell/module_paw/paw_cell_libpaw.cpp
@@ -328,6 +328,7 @@ void Paw_Cell::get_nhat(double** nhat, double* nhatgr)
 {
     ModuleBase::TITLE("Paw_Cell", "get_nhat");
 
+    nhatgr = new double[3*nfft];
     double* nhat_tmp;
     nhat_tmp = new double[nfft*nspden];
 
@@ -387,6 +388,7 @@ void Paw_Cell::get_nhat(double** nhat, double* nhatgr)
         }
     }
     delete[] nhat_tmp;
+    delete[] nhatgr;
 }
 
 void Paw_Cell::calculate_dij(double* vks, double* vxc)

--- a/source/module_cell/module_paw/paw_cell_libpaw.cpp
+++ b/source/module_cell/module_paw/paw_cell_libpaw.cpp
@@ -528,8 +528,17 @@ void Paw_Cell::init_rho(double ** rho)
     double* rho_tmp;
     rho_tmp = new double[nfft*nspden];
 
+#ifdef __MPI
+    if(GlobalV::RANK_IN_POOL == 0)
+    {
+        init_rho_(nspden, ngfftdg.data(), nfft, natom, ntypat, rprimd.data(), gprimd.data(),
+                gmet.data(), ucvol, xred.data(), rho_tmp);      
+    }
+    Parallel_Common::bcast_double(rho_tmp,nfft*nspden);
+#else
     init_rho_(nspden, ngfftdg.data(), nfft, natom, ntypat, rprimd.data(), gprimd.data(),
             gmet.data(), ucvol, xred.data(), rho_tmp);
+#endif
 
 #ifdef __MPI
     // I'm not sure about this yet !!!

--- a/source/module_cell/module_paw/paw_cell_libpaw.cpp
+++ b/source/module_cell/module_paw/paw_cell_libpaw.cpp
@@ -600,10 +600,13 @@ void Paw_Cell::set_dij()
            dij[is] = new double[nproj * nproj];
         }
 
-        extract_dij(iat,size_dij,dij_libpaw);
+        
 
 #ifdef __MPI
+        if(GlobalV::RANK_IN_POOL == 0) extract_dij(iat,size_dij,dij_libpaw);
         Parallel_Common::bcast_double(dij_libpaw,size_dij*nspden);
+#else
+        extract_dij(iat,size_dij,dij_libpaw);
 #endif
 
         for(int is = 0; is < nspden; is ++)
@@ -639,7 +642,12 @@ void Paw_Cell::set_sij()
         double* sij_libpaw = new double[size_sij];
         double* sij = new double[nproj * nproj];
 
+#ifdef __MPI
+        if(GlobalV::RANK_IN_POOL == 0) extract_sij(it,size_sij,sij_libpaw);
+        Parallel_Common::bcast_double(sij_libpaw,size_sij*nspden);
+#else
         extract_sij(it,size_sij,sij_libpaw);
+#endif
 
         for(int jproj = 0; jproj < nproj; jproj ++)
         {

--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -234,7 +234,11 @@ namespace ModuleESolver
             GlobalC::paw_cell.set_libpaw_fft(this->pw_wfc->nx,this->pw_wfc->ny,this->pw_wfc->nz,
                                             this->pw_wfc->nx,this->pw_wfc->ny,this->pw_wfc->nz,
                                             this->pw_wfc->startz,this->pw_wfc->numz);
+#ifdef __MPI
+            if(GlobalV::RANK_IN_POOL == 0) GlobalC::paw_cell.prepare_paw();
+#else
             GlobalC::paw_cell.prepare_paw();
+#endif
             GlobalC::paw_cell.set_sij();
 
             GlobalC::paw_cell.set_eigts(

--- a/source/module_esolver/esolver_ks_pw.cpp
+++ b/source/module_esolver/esolver_ks_pw.cpp
@@ -307,7 +307,11 @@ void ESolver_KS_PW<T, Device>::init_after_vc(Input& inp, UnitCell& ucell)
                                          this->pw_wfc->nx,this->pw_wfc->ny,this->pw_wfc->nz,
                                          this->pw_wfc->startz,this->pw_wfc->numz);
 
+#ifdef __MPI
+        if(GlobalV::RANK_IN_POOL == 0) GlobalC::paw_cell.prepare_paw();
+#else
         GlobalC::paw_cell.prepare_paw();
+#endif
         GlobalC::paw_cell.set_sij();
     }
 #endif

--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -254,6 +254,17 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
         std::vector<std::vector<int>> rhoijselect;
         std::vector<int> nrhoijsel;
 
+#ifdef __MPI
+        if(GlobalV::RANK_IN_POOL == 0)
+        {
+            GlobalC::paw_cell.get_rhoijp(rhoijp, rhoijselect, nrhoijsel);
+
+            for(int iat = 0; iat < GlobalC::ucell.nat; iat ++)
+            {
+                GlobalC::paw_cell.set_rhoij(iat,nrhoijsel[iat],rhoijselect[iat].size(),rhoijselect[iat].data(),rhoijp[iat].data());
+            }  
+        }
+#else
         GlobalC::paw_cell.get_rhoijp(rhoijp, rhoijselect, nrhoijsel);
 
         for(int iat = 0; iat < GlobalC::ucell.nat; iat ++)
@@ -261,10 +272,9 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
             GlobalC::paw_cell.set_rhoij(iat,nrhoijsel[iat],rhoijselect[iat].size(),rhoijselect[iat].data(),rhoijp[iat].data());
         }
 
+#endif
         double* nhatgr;
-        nhatgr = new double[3*GlobalC::paw_cell.get_nfft()];
         GlobalC::paw_cell.get_nhat(pes->charge->nhat,nhatgr);
-        delete[] nhatgr;
     }
 #endif
     ModuleBase::timer::tick("HSolverPW", "solve");


### PR DESCRIPTION
PAW subroutines are now only called from rank 0 to avoid duplicated screen output