### PR TITLE
Build: respect user defined CUDAARCHS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,12 +233,25 @@ if(USE_CUDA OR USE_CUSOLVER_LCAO)
   set(CMAKE_CUDA_STANDARD_REQUIRED ON)
   set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
   if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    find_package(CUDAToolkit REQUIRED)
+    # check https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/Internal/CMakeCUDAArchitecturesAll.cmake
+    # for available architechures in different CUDA versions
     set(CMAKE_CUDA_ARCHITECTURES
       60 # P100
       70 # V100
-      75 # T4
-      80 # A100
     )
+    if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL 10.0)
+      list(APPEND CMAKE_CUDA_ARCHITECTURES 75) # T4
+    endif()
+    if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL 11.0)
+      list(APPEND CMAKE_CUDA_ARCHITECTURES 80) # A100
+    endif()
+    if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL 11.1)
+      list(APPEND CMAKE_CUDA_ARCHITECTURES 86)
+    endif()
+    if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL 11.8)
+      list(APPEND CMAKE_CUDA_ARCHITECTURES 89)
+    endif()
   endif()
   enable_language(CUDA)
   target_link_libraries(${ABACUS_BIN_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,9 +241,6 @@ if(USE_CUDA OR USE_CUSOLVER_LCAO)
     )
   endif()
   enable_language(CUDA)
-  set_property(
-    TARGET ${ABACUS_BIN_NAME}
-  )
   target_link_libraries(${ABACUS_BIN_NAME}
     -lcudart
     -lnvToolsExt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,12 @@ if(USE_CUDA OR USE_CUSOLVER_LCAO)
     endif()
   endif()
   enable_language(CUDA)
+  # ${ABACUS_BIN_NAME} is added before CUDA is enabled
+  set_property(
+    TARGET ${ABACUS_BIN_NAME}
+    PROPERTY CUDA_ARCHITECTURES
+    ${CMAKE_CUDA_ARCHITECTURES}
+  )
   target_link_libraries(${ABACUS_BIN_NAME}
     -lcudart
     -lnvToolsExt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,14 +232,17 @@ if(USE_CUDA OR USE_CUSOLVER_LCAO)
   set(CMAKE_CUDA_STANDARD ${CMAKE_CXX_STANDARD})
   set(CMAKE_CUDA_STANDARD_REQUIRED ON)
   set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
+  if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    set(CMAKE_CUDA_ARCHITECTURES
+      60 # P100
+      70 # V100
+      75 # T4
+      80 # A100
+    )
+  endif()
   enable_language(CUDA)
   set_property(
     TARGET ${ABACUS_BIN_NAME}
-    PROPERTY CUDA_ARCHITECTURES
-    60 # P100
-    70 # V100
-    75 # T4
-    80 # A100
   )
   target_link_libraries(${ABACUS_BIN_NAME}
     -lcudart

--- a/docs/advanced/acceleration/cuda.md
+++ b/docs/advanced/acceleration/cuda.md
@@ -40,11 +40,7 @@ We provides [examples](https://github.com/deepmodeling/abacus-develop/tree/devel
 - CG, BPCG and Davidson methods are supported, so the input keyword `ks_solver` can take the values `cg`, `bpcg` or `dav`,
 - Only PW basis is supported, so the input keyword `basis_type` can only take the value `pw`,
 - Only k point parallelization is supported, so the input keyword `kpar` will be set to match the number of MPI tasks automatically.
-- Supported CUDA architectures:
-  - 60 # P100, 1080ti
-  - 70 # V100
-  - 75 # T4
-  - 80 # A100, 3090
+- By default, CUDA architectures 60, 70, 75, 80, 86, and 89 are compiled (if supported). It can be overriden using the CMake variable [`CMAKE_CUDA_ARCHITECTURES`](https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_ARCHITECTURES.html) or the environmental variable [`CUDAARCHS`](https://cmake.org/cmake/help/latest/envvar/CUDAARCHS.html).
 
 ## FAQ
 ```

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -88,9 +88,6 @@ if(USE_CUDA)
     cublas 
     cufft
   )
-  set_property(
-    TARGET device
-  )
 elseif(USE_ROCM)
   target_link_libraries(
     device 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -90,11 +90,6 @@ if(USE_CUDA)
   )
   set_property(
     TARGET device
-    PROPERTY CUDA_ARCHITECTURES
-    60 # P100
-    70 # V100
-    75 # T4
-    80 # A100
   )
 elseif(USE_ROCM)
   target_link_libraries(


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### What's changed?
Only override CUDA_ARCHITECTURES when user doesn't set set it via [CMAKE_CUDA_ARCHITECTURES](https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_ARCHITECTURES.html)  or [CUDAARCHS](https://cmake.org/cmake/help/latest/envvar/CUDAARCHS.html#envvar:CUDAARCHS).

### Any changes of core modules? (ignore if not applicable)
