### PR TITLE
Fix gpu compiler warnings

### DIFF
--- a/source/module_basis/module_pw/fft.cpp
+++ b/source/module_basis/module_pw/fft.cpp
@@ -365,16 +365,16 @@ void FFT:: cleanFFT()
     if (this->device == "gpu") {
         if (this->precision == "single") {
         #if defined(__CUDA)
-            if(c_handle) { cufftDestroy(c_handle);  c_handle = NULL;}
+            if(c_handle) { cufftDestroy(c_handle);  c_handle = {};}
         #elif defined(__ROCM)
-            if(c_handle) { hipfftDestroy(c_handle); c_handle = NULL;}
+            if(c_handle) { hipfftDestroy(c_handle); c_handle = {};}
         #endif
         }
         else {
         #if defined(__CUDA)
-            if(z_handle) { cufftDestroy(z_handle);  z_handle = NULL;}
+            if(z_handle) { cufftDestroy(z_handle);  z_handle = {};}
         #elif defined(__ROCM)
-            if(z_handle) { hipfftDestroy(z_handle); z_handle = NULL;}
+            if(z_handle) { hipfftDestroy(z_handle); z_handle = {};}
         #endif
         }
     }

--- a/source/module_basis/module_pw/fft.h
+++ b/source/module_basis/module_pw/fft.h
@@ -127,11 +127,11 @@ public:
 //	fftw_plan plan3dbackward;
 
 #if defined(__CUDA)
-    cufftHandle c_handle = NULL;
-    cufftHandle z_handle = NULL;
+    cufftHandle c_handle = {};
+    cufftHandle z_handle = {};
 #elif defined(__ROCM)
-    hipfftHandle c_handle = NULL;
-    hipfftHandle z_handle = NULL;
+    hipfftHandle c_handle = {};
+    hipfftHandle z_handle = {};
 #endif
 
 #if defined(__ENABLE_FLOAT_FFTW)


### PR DESCRIPTION
Address the compiler warnings that have arisen within a CUDA environment. 
```
warning: converting to non-pointer type ‘cufftHandle’ {aka ‘int’} from NULL [-Wconversion-null]
```


### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
