### PR TITLE
modify the default of symmetry_prec to 1e-6

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -428,7 +428,7 @@ These variables are used to control general system parameters.
 - **Type**: Real
 - **Description**: The accuracy for symmetry judgment. Usually the default value is good enough, but if the lattice parameters or atom positions in STRU file is not accurate enough, this value should be enlarged. 
   > Note: if *[calculation](#calculation)==cell_relax*, this value can be dynamically changed corresponding to the variation of accuracy of the lattice parameters and atom positions during the relaxation. The new value will be printed in `OUT.${suffix}/running_cell-relax.log` in that case.
-- **Default**: 1.0e-5
+- **Default**: 1.0e-6
 - **Unit**:  Bohr
 
 ### symmetry_autoclose

--- a/source/module_io/DEFAULT_VALUE.conf
+++ b/source/module_io/DEFAULT_VALUE.conf
@@ -59,7 +59,7 @@
     symmetry  "default"
     init_vel  false
     ref_cell_factor  1.0
-    symmetry_prec  1.0e-5 
+    symmetry_prec  1.0e-6 
     cal_force  0
     force_thr  1.0e-3
     force_thr_ev2  0

--- a/source/module_io/input.cpp
+++ b/source/module_io/input.cpp
@@ -210,7 +210,7 @@ void Input::Default(void)
     symmetry = "default";
     init_vel = false;
     ref_cell_factor = 1.0;
-    symmetry_prec = 1.0e-5; // LiuXh add 2021-08-12, accuracy for symmetry
+    symmetry_prec = 1.0e-6; // LiuXh add 2021-08-12, accuracy for symmetry
     symmetry_autoclose = false; // whether to close symmetry automatically when error occurs in symmetry analysis
     cal_force = 0;
     force_thr = 1.0e-3;

--- a/source/module_io/test/input_test.cpp
+++ b/source/module_io/test/input_test.cpp
@@ -88,7 +88,7 @@ TEST_F(InputTest, Default)
         EXPECT_EQ(INPUT.symmetry,"default");
         EXPECT_FALSE(INPUT.init_vel);
         EXPECT_DOUBLE_EQ(INPUT.ref_cell_factor,1.0);
-        EXPECT_DOUBLE_EQ(INPUT.symmetry_prec, 1.0e-5);
+        EXPECT_DOUBLE_EQ(INPUT.symmetry_prec, 1.0e-6);
         EXPECT_FALSE(INPUT.symmetry_autoclose);
         EXPECT_EQ(INPUT.cal_force, 0);
         EXPECT_DOUBLE_EQ(INPUT.force_thr,1.0e-3);
@@ -445,7 +445,7 @@ TEST_F(InputTest, Read)
         EXPECT_TRUE(INPUT.search_pbc);
         EXPECT_EQ(INPUT.symmetry,"1");
         EXPECT_FALSE(INPUT.init_vel);
-        EXPECT_DOUBLE_EQ(INPUT.symmetry_prec, 1.0e-5);
+        EXPECT_DOUBLE_EQ(INPUT.symmetry_prec, 1.0e-6);
         EXPECT_FALSE(INPUT.symmetry_autoclose);
         EXPECT_EQ(INPUT.cal_force, 0);
         EXPECT_NEAR(INPUT.force_thr,1.0e-3,1.0e-7);

--- a/source/module_io/test/input_test_para.cpp
+++ b/source/module_io/test/input_test_para.cpp
@@ -94,7 +94,7 @@ TEST_F(InputParaTest,Bcast)
         EXPECT_TRUE(INPUT.search_pbc);
         EXPECT_EQ(INPUT.symmetry,"default");
         EXPECT_FALSE(INPUT.init_vel);
-        EXPECT_DOUBLE_EQ(INPUT.symmetry_prec, 1.0e-5);
+        EXPECT_DOUBLE_EQ(INPUT.symmetry_prec, 1.0e-6);
         EXPECT_FALSE(INPUT.symmetry_autoclose);
         EXPECT_EQ(INPUT.cal_force, 0);
         EXPECT_DOUBLE_EQ(INPUT.force_thr,1.0e-3);

--- a/tests/deepks/603_NO_deepks_SiO2_bandgap_multik/INPUT
+++ b/tests/deepks/603_NO_deepks_SiO2_bandgap_multik/INPUT
@@ -20,3 +20,4 @@ deepks_scf 1
 deepks_out_labels 1
 deepks_bandgap 1
 deepks_model ./model.ptg
+symmetry_prec 1e-5

--- a/tests/integrate/110_PW_SY_symmetry_LiRh/INPUT
+++ b/tests/integrate/110_PW_SY_symmetry_LiRh/INPUT
@@ -35,3 +35,4 @@ force_thr_ev            0.01
 stress_thr              2
 relax_nmax              32
 out_stru                1
+symmetry_prec 1e-5

--- a/tests/integrate/186_PW_SKG_10D10S/INPUT
+++ b/tests/integrate/186_PW_SKG_10D10S/INPUT
@@ -41,3 +41,4 @@ cond_dw          0.02
 cond_dt          0.237464
 cond_dtbatch     1
 cond_nonlocal    0
+symmetry_prec 1e-5

--- a/tests/integrate/186_PW_SNLKG_10D10S/INPUT
+++ b/tests/integrate/186_PW_SNLKG_10D10S/INPUT
@@ -42,3 +42,4 @@ cond_dw          0.02
 cond_dt          0.237464
 cond_dtbatch     4
 cond_nonlocal    1
+symmetry_prec 1e-5

--- a/tests/integrate/284_NO_KP_symmetry/INPUT
+++ b/tests/integrate/284_NO_KP_symmetry/INPUT
@@ -25,3 +25,4 @@ smearing_sigma		0.002
 mixing_type             broyden
 mixing_beta             0.1
 ks_solver 		genelpa
+symmetry_prec 1e-5


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #3141 

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
