### PR TITLE
Fix: fix icpx compilation warnings within wf_atomic.cpp

### DIFF
--- a/source/module_hamilt_pw/hamilt_pwdft/wf_atomic.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/wf_atomic.cpp
@@ -353,7 +353,7 @@ void WF_atomic::atomic_wfc(const int ik,
                                 std::complex<double> fup,fdown;
                                 int nc;
                                 //This routine creates two functions only in the case j=l+1/2 or exit in the other case
-                                if(fabs(j-l+0.5<1e-4)) continue;
+                                if(fabs(j-l+0.5)<1e-4) continue;
                                 delete[] chiaux;
                                 chiaux = new double [np];
                                 //Find the functions j= l- 1/2


### PR DESCRIPTION
Warnings:
![cf0b1d83-804e-4608-8747-a89eeb624af6](https://github.com/deepmodeling/abacus-develop/assets/21070560/7f5291dd-fa6c-41ac-84f3-4b8009a5a78f)
Code:
![06898763-aba1-492a-a39b-1c981871f655](https://github.com/deepmodeling/abacus-develop/assets/21070560/32f9c5e5-56ef-4066-a5a0-1b6fa94d6ecb)

### Reminder
- [x] Have you linked an issue with this pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [x] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #3174 

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
