### PR TITLE
Build: fix torch build on cuda-12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,9 @@ if(USE_CUDA OR USE_CUSOLVER_LCAO)
     set(CMAKE_CUDA_ARCHITECTURES
       60 # P100
       70 # V100
+      # Add your CUDA arch here
+      # Check the Compute Capability version of your GPU at:
+      # https://en.wikipedia.org/wiki/CUDA#GPUs_supported
     )
     if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL 10.0)
       list(APPEND CMAKE_CUDA_ARCHITECTURES 75) # T4
@@ -250,7 +253,7 @@ if(USE_CUDA OR USE_CUSOLVER_LCAO)
       list(APPEND CMAKE_CUDA_ARCHITECTURES 86)
     endif()
     if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL 11.8)
-      list(APPEND CMAKE_CUDA_ARCHITECTURES 89)
+      list(APPEND CMAKE_CUDA_ARCHITECTURES 89 90)
     endif()
   endif()
   enable_language(CUDA)
@@ -387,6 +390,9 @@ endif()
 
 if(ENABLE_DEEPKS)
   set(CMAKE_CXX_STANDARD 14)
+  # Torch uses outdated components to detech CUDA arch, causing failure on latest CUDA kits.
+  # See above for setting CMAKE_CUDA_ARCHITECTURES
+  set(TORCH_CUDA_ARCH_LIST CMAKE_CUDA_ARCHITECTURES)
   find_package(Torch REQUIRED)
   include_directories(${TORCH_INCLUDE_DIRS})
   target_link_libraries(${ABACUS_BIN_NAME} deepks)


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
https://github.com/conda-forge/abacus-feedstock/pull/11

### What's changed?
Torch will try to detect all applicable architectures for nvcc.
However, for TorchConfig -> Caffe2Config -> FindCUDA (outdated) -> select_compute_arch, it fails to remove unsupported arch for new CUDA toolkits. 
This cause error when building with CUDA 12+: 
`nvcc fatal   : Unsupported gpu architecture 'compute_35'`

This PR will re-use the detected arch at the CUDA component part for Torch.

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
