### PR TITLE
Refactor: PW_Basis_Big inherits from PW_Basis_Sup

### DIFF
--- a/source/module_basis/module_pw/pw_basis.h
+++ b/source/module_basis/module_pw/pw_basis.h
@@ -293,5 +293,5 @@ protected:
 }
 #endif // PWBASIS_H
 
-#include "./pw_basis_big.h" //temporary it will be removed
 #include "pw_basis_sup.h"
+#include "pw_basis_big.h" //temporary it will be removed

--- a/source/module_basis/module_pw/pw_basis_big.h
+++ b/source/module_basis/module_pw/pw_basis_big.h
@@ -12,7 +12,7 @@
 namespace ModulePW
 {
 
-class PW_Basis_Big: public PW_Basis
+class PW_Basis_Big : public PW_Basis_Sup
 {
 public:
   // combine [bx,by,bz] FFT grids into a big one
@@ -21,7 +21,9 @@ public:
   PW_Basis_Big()
   {
   }
-    PW_Basis_Big(std::string device_, std::string precision_) : PW_Basis(device_, precision_) {}
+  PW_Basis_Big(std::string device_, std::string precision_) : PW_Basis_Sup(device_, precision_)
+  {
+  }
 
     ~PW_Basis_Big(){};
     void setbxyz(const int bx_in, const int by_in, const int bz_in)

--- a/source/module_basis/module_pw/pw_basis_sup.cpp
+++ b/source/module_basis/module_pw/pw_basis_sup.cpp
@@ -1,6 +1,5 @@
-#include "pw_basis_sup.h"
-
 #include "module_base/timer.h"
+#include "pw_basis.h"
 
 namespace ModulePW
 {

--- a/source/module_basis/module_pw/pw_basis_sup.h
+++ b/source/module_basis/module_pw/pw_basis_sup.h
@@ -2,7 +2,6 @@
 #define PWBASIS_SUP_H
 
 #include "module_base/complexmatrix.h"
-#include "pw_basis.h"
 
 namespace ModulePW
 {

--- a/source/module_basis/module_pw/test/test-big.cpp
+++ b/source/module_basis/module_pw/test/test-big.cpp
@@ -53,7 +53,7 @@ TEST_F(PWTEST,test_big)
     pwktest.initgrids(lat0,latvec, pwtest.nx, pwtest.ny, pwtest.nz);
     pwtest.initparameters(gamma_only,wfcecut,distribution_type,xprime);
     pwktest.initparameters(gamma_only,wfcecut,nks,kvec_d,distribution_type, xprime);
-    pwtest.setuptransform();
+    static_cast<ModulePW::PW_Basis>(pwtest).setuptransform();
     pwktest.setuptransform();
     EXPECT_EQ(pwtest.nx%2, 0);
     EXPECT_EQ(pwtest.ny%2, 0);

--- a/source/module_elecstate/test/elecstate_base_test.cpp
+++ b/source/module_elecstate/test/elecstate_base_test.cpp
@@ -41,6 +41,9 @@ ModulePW::PW_Basis::PW_Basis()
 ModulePW::PW_Basis::~PW_Basis()
 {
 }
+ModulePW::PW_Basis_Sup::~PW_Basis_Sup()
+{
+}
 ModulePW::FFT::FFT()
 {
 }

--- a/source/module_esolver/esolver.cpp
+++ b/source/module_esolver/esolver.cpp
@@ -88,11 +88,11 @@ namespace ModuleESolver
             }
         }
         if (GlobalV::MY_RANK == 0) {
-            std::cout << " RUNNING WITH DEVICE     : " << device_info << " / "
+            std::cout << " RUNNING WITH DEVICE  : " << device_info << " / "
                       << psi::device::get_device_info(GlobalV::device_flag) << std::endl;
         }
-        GlobalV::ofs_running << "\n RUNNING WITH DEVICE     : " << device_info << " / "
-                  << psi::device::get_device_info(GlobalV::device_flag) << std::endl;
+        GlobalV::ofs_running << "\n RUNNING WITH DEVICE  : " << device_info << " / "
+                             << psi::device::get_device_info(GlobalV::device_flag) << std::endl;
         return esolver_type;
     }
 

--- a/source/module_esolver/esolver_fp.cpp
+++ b/source/module_esolver/esolver_fp.cpp
@@ -12,7 +12,7 @@ namespace ModuleESolver
 
         if (GlobalV::double_grid)
         {
-            pw_rhod = new ModulePW::PW_Basis_Sup(GlobalV::device_flag, GlobalV::precision_flag);
+            pw_rhod = new ModulePW::PW_Basis_Big(GlobalV::device_flag, GlobalV::precision_flag);
         }
         else
         {
@@ -20,7 +20,7 @@ namespace ModuleESolver
         }
 
         //temporary, it will be removed
-        pw_big = static_cast<ModulePW::PW_Basis_Big*>(pw_rho);
+        pw_big = static_cast<ModulePW::PW_Basis_Big*>(pw_rhod);
         pw_big->setbxyz(INPUT.bx, INPUT.by, INPUT.bz);
         sf.set(pw_rhod, INPUT.nbspline);
 


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### What's changed?
- Class `PW_Basis_Big` inherits from `PW_Basis_Sup` for the read and output of cube files.