### PR TITLE
Refactor & Feature: Better zero-finding algorithms for spherical Bessel functions

### DIFF
--- a/source/module_base/math_sphbes.h
+++ b/source/module_base/math_sphbes.h
@@ -1,6 +1,8 @@
 #ifndef MATH_SPHBES_H
 #define MATH_SPHBES_H
 
+#include <functional>
+
 //========================================================
 // Spherical Bessel functions, mohan 2021-05-06
 //========================================================
@@ -118,6 +120,21 @@ class Sphbes
                         double* const djl      //!< [out] results
     );
 
+    /** 
+     * @brief Zeros of spherical Bessel functions.
+     *
+     * This function computes the first n positive zeros of the l-th order
+     * spherical Bessel function of the first kind. 
+     *
+     * @param[in]   l       order of the spherical Bessel function
+     * @param[in]   n       number of zeros to be computed
+     * @param[out]  zeros   on exit, contains the first n positive zeros in ascending order
+     */
+    static void sphbes_zeros(const int l,
+                             const int n,
+                             double* const zeros
+    );
+
 private:
 
     static double Spherical_Bessel_7(const int n, const double &x);
@@ -134,6 +151,13 @@ private:
     // utility functions for sphbesj
     static double _sphbesj_ascending_recurrence(int l, double x);
     static double _sphbesj_series(int l, double x);
+
+    // Regula falsi with Illinois anti-stalling variation
+    static double illinois(std::function<double(double)> func,
+                           double x0,
+                           double x1,
+                           const double tol = 1e-12,
+                           const int max_iter = 50);
 };
 
 }

--- a/source/module_base/test/math_sphbes_test.cpp
+++ b/source/module_base/test/math_sphbes_test.cpp
@@ -26,6 +26,7 @@
  *      - Spherical_Bessel_Roots
  *      - overloading of Spherical_Bessel. This funnction sets sjp[i] to 1.0 when i < msh.
  *      - sphbesj
+ *      - sphbes_zeros
  */
 
 double mean(const double* vect, const int totN)
@@ -331,6 +332,23 @@ TEST_F(Sphbes, SphericalBesselPrecisionNearZero)
     }
     delete[] x;
     delete[] Y;
+}
+
+TEST_F(Sphbes, Zeros)
+{
+    // This test checks whether sphbes_zeros properly computes the zeros of sphbesj.
+
+    int lmax = 20;
+    int nzeros = 500;
+    double* zeros = new double[nzeros];
+    for (int l = 0; l <= lmax; ++l)
+    {
+        ModuleBase::Sphbes::sphbes_zeros(l, nzeros, zeros);
+        for (int i = 0; i < nzeros; ++i)
+        {
+            EXPECT_LT(std::abs(ModuleBase::Sphbes::sphbesj(l, zeros[i])), 1e-14);
+        }
+    }
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
This PR improves a function that will be crucial for implementing https://github.com/deepmodeling/abacus-develop/issues/3267

### Reminder
- [x] Have you linked an issue with this pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [x] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
This is a necessary step towards https://github.com/deepmodeling/abacus-develop/issues/3267


### What's changed?
A more robust & efficient algorithm is implemented for finding the zeros of spherical Bessel functions. This is used to determine the wave numbers of spherical Bessel components in numerical atomic orbitals.

### Any changes of core modules? (ignore if not applicable)
No.