### PR TITLE
Refactor: add sc_scf_nmin to control min scf steps before spin constraining

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -360,6 +360,7 @@
     - [sc\_thr](#sc_thr)
     - [nsc](#nsc)
     - [nsc\_min](#nsc_min)
+    - [sc\_scf\_nmin](#sc_scf_nmin)
     - [alpha\_trial](#alpha_trial)
     - [sccut](#sccut)
     - [sc\_file](#sc_file)
@@ -3312,6 +3313,12 @@ These variables are used to control the usage of deltaspin functionality.
 
 - **Type**: Integer
 - **Description**: the minimum number of steps in the inner lambda loop
+- **Default**: 2
+
+### sc_scf_nmin
+
+- **Type**: Integer
+- **Description**: the minimum number of outer scf loop before initializing lambda loop
 - **Default**: 2
 
 ### alpha_trial

--- a/source/module_base/global_variable.cpp
+++ b/source/module_base/global_variable.cpp
@@ -283,6 +283,7 @@ bool decay_grad_switch = 0;
 double sc_thr = 1.0e-6;
 int nsc = 100;
 int nsc_min = 2;
+int sc_scf_nmin = 2;
 double alpha_trial = 0.01; // eV/uB^2
 double sccut = 3;          // eV/uB
 std::string sc_file = "none";

--- a/source/module_base/global_variable.h
+++ b/source/module_base/global_variable.h
@@ -312,6 +312,7 @@ extern bool decay_grad_switch; // 0: decay grad will be set to zero; 1: with dec
 extern double sc_thr;
 extern int nsc;
 extern int nsc_min;
+extern int sc_scf_nmin;
 extern double alpha_trial;
 extern double sccut;
 extern std::string sc_file;

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -563,7 +563,7 @@ namespace ModuleESolver
     }
 
     // run the inner lambda loop to contrain atomic moments with the DeltaSpin method
-    if (GlobalV::sc_mag_switch && iter > 1)
+    if (GlobalV::sc_mag_switch && iter > GlobalV::sc_scf_nmin)
     {
         SpinConstrain<TK, psi::DEVICE_CPU>& sc = SpinConstrain<TK, psi::DEVICE_CPU>::getScInstance();
         sc.run_lambda_loop(iter-1);

--- a/source/module_io/input.cpp
+++ b/source/module_io/input.cpp
@@ -613,6 +613,7 @@ void Input::Default(void)
     sc_thr = 1e-6;
     nsc = 100;
     nsc_min = 2;
+    sc_scf_nmin = 2;
     alpha_trial = 0.01;
     sccut = 3.0;
     sc_file = "none";
@@ -2221,6 +2222,9 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("nsc_min", word) == 0){
             read_value(ifs, nsc_min);
         }
+        else if (strcmp("sc_scf_nmin", word) == 0){
+            read_value(ifs, sc_scf_nmin);
+        }
         else if (strcmp("alpha_trial", word) == 0){
             read_value(ifs, alpha_trial);
         }
@@ -3458,6 +3462,7 @@ void Input::Bcast()
     Parallel_Common::bcast_double(sc_thr);
     Parallel_Common::bcast_int(nsc);
     Parallel_Common::bcast_int(nsc_min);
+    Parallel_Common::bcast_int(sc_scf_nmin);
     Parallel_Common::bcast_string(sc_file);
     Parallel_Common::bcast_double(alpha_trial);
     Parallel_Common::bcast_double(sccut);
@@ -3975,6 +3980,10 @@ void Input::Check(void)
         if (nsc_min <= 0)
         {
             ModuleBase::WARNING_QUIT("INPUT", "nsc_min must > 0");
+        }
+        if (sc_scf_nmin < 2)
+        {
+            ModuleBase::WARNING_QUIT("INPUT", "sc_scf_nmin must >= 2");
         }
         if (alpha_trial <= 0)
         {

--- a/source/module_io/input.h
+++ b/source/module_io/input.h
@@ -575,6 +575,7 @@ class Input
     double sc_thr; // threshold for spin-constrained DFT in uB
     int nsc; // maximum number of inner lambda loop
     int nsc_min; // minimum number of inner lambda loop
+    int sc_scf_nmin; // minimum number of outer scf loop before initial lambda loop
     double alpha_trial; // initial trial step size for lambda in eV/uB^2
     double sccut; // restriction of step size in eV/uB
     std::string sc_file; // file name for Deltaspin (json format)

--- a/source/module_io/input_conv.cpp
+++ b/source/module_io/input_conv.cpp
@@ -732,6 +732,7 @@ void Input_Conv::Convert(void)
     GlobalV::sc_thr = INPUT.sc_thr;
     GlobalV::nsc = INPUT.nsc;
     GlobalV::nsc_min = INPUT.nsc_min;
+    GlobalV::sc_scf_nmin = INPUT.sc_scf_nmin;
     GlobalV::alpha_trial = INPUT.alpha_trial;
     GlobalV::sccut = INPUT.sccut;
     GlobalV::sc_file = INPUT.sc_file;

--- a/source/module_io/test/input_test.cpp
+++ b/source/module_io/test/input_test.cpp
@@ -375,6 +375,7 @@ TEST_F(InputTest, Default)
     EXPECT_DOUBLE_EQ(INPUT.sc_thr, 1e-6);
     EXPECT_EQ(INPUT.nsc, 100);
     EXPECT_EQ(INPUT.nsc_min, 2);
+	EXPECT_EQ(INPUT.sc_scf_nmin, 2);
     EXPECT_DOUBLE_EQ(INPUT.alpha_trial, 0.01);
     EXPECT_DOUBLE_EQ(INPUT.sccut, 3.0);
     EXPECT_EQ(INPUT.sc_file, "none");
@@ -737,6 +738,7 @@ TEST_F(InputTest, Read)
     EXPECT_DOUBLE_EQ(INPUT.sc_thr, 1e-4);
     EXPECT_EQ(INPUT.nsc, 50);
 	EXPECT_EQ(INPUT.nsc_min, 4);
+	EXPECT_EQ(INPUT.sc_scf_nmin, 4);
     EXPECT_DOUBLE_EQ(INPUT.alpha_trial, 0.02);
 	EXPECT_DOUBLE_EQ(INPUT.sccut, 4.0);
     EXPECT_EQ(INPUT.sc_file, "sc.json");
@@ -1615,6 +1617,13 @@ TEST_F(InputTest, Check)
 	output = testing::internal::GetCapturedStdout();
 	EXPECT_THAT(output,testing::HasSubstr("sccut must > 0"));
 	INPUT.sccut = 3.0;
+	// warning 10 of Deltaspin
+	INPUT.sc_scf_nmin = -1;
+	testing::internal::CaptureStdout();
+	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
+	output = testing::internal::GetCapturedStdout();
+	EXPECT_THAT(output,testing::HasSubstr("sc_scf_nmin must >= 2"));
+	INPUT.sc_scf_nmin = 2;
     // restore to default values
     INPUT.nspin = 1;
 	INPUT.sc_file = "none";

--- a/source/module_io/test/support/INPUT
+++ b/source/module_io/test/support/INPUT
@@ -377,6 +377,7 @@ decay_grad_switch              1 #
 sc_thr                         1e-04 #Convergence criterion of spin-constrained iteration (RMS) in uB
 nsc                            50 #Maximal number of spin-constrained iteration
 nsc_min                        4 #Minimum number of spin-constrained iteration
+sc_scf_nmin                    4 #Minimum number of outer scf loop before initializing lambda loop
 alpha_trial                    0.02 #Initial trial step size for lambda in eV/uB^2
 sccut                          4 #Maximal step size for lambda in eV/uB
 sc_file                        sc.json #file name for parameters used in non-collinear spin-constrained DFT (json format)

--- a/source/module_io/test/write_input_test.cpp
+++ b/source/module_io/test/write_input_test.cpp
@@ -906,6 +906,8 @@ TEST_F(write_input, Deltaspin22)
     EXPECT_THAT(output,
                 testing::HasSubstr("nsc_min                        2 #Minimum number of spin-constrained iteration"));
     EXPECT_THAT(output,
+                testing::HasSubstr("sc_scf_nmin                    2 #Minimum number of outer scf loop before initializing lambda loop"));
+    EXPECT_THAT(output,
                 testing::HasSubstr("sc_file                        none #file name for parameters used in "
                                    "non-collinear spin-constrained DFT (json format)"));
     EXPECT_THAT(output, testing::HasSubstr("alpha_trial                    0.01 #Initial trial step size for lambda"));

--- a/source/module_io/write_input.cpp
+++ b/source/module_io/write_input.cpp
@@ -478,6 +478,7 @@ ModuleBase::GlobalFunc::OUTP(ofs, "out_bandgap", out_bandgap, "if true, print ou
    ModuleBase::GlobalFunc::OUTP(ofs, "sc_thr", sc_thr, "Convergence criterion of spin-constrained iteration (RMS) in uB");
    ModuleBase::GlobalFunc::OUTP(ofs, "nsc", nsc, "Maximal number of spin-constrained iteration");
    ModuleBase::GlobalFunc::OUTP(ofs, "nsc_min", nsc_min, "Minimum number of spin-constrained iteration");
+    ModuleBase::GlobalFunc::OUTP(ofs, "sc_scf_nmin", sc_scf_nmin, "Minimum number of outer scf loop before initializing lambda loop");
    ModuleBase::GlobalFunc::OUTP(ofs, "alpha_trial", alpha_trial, "Initial trial step size for lambda in eV/uB^2");
    ModuleBase::GlobalFunc::OUTP(ofs, "sccut", sccut, "Maximal step size for lambda in eV/uB");
    ModuleBase::GlobalFunc::OUTP(ofs, "sc_file", sc_file, "file name for parameters used in non-collinear spin-constrained DFT (json format)");


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?

### Linked Issue
Fix #3271 

### What's changed?
- `sc_scf_nmin` can be set in `INPUT` to control minimum steps of scf before initialize deltaspin calculation.