### PR TITLE
Add rapidjson support in toolchain

### DIFF
--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -60,7 +60,7 @@ Notice: These packages will be downloaded by `wget` from `github.com`, which is 
 
 Instead of github.com, we offer other package station, you can use it by:
 ```shell
-wget https://bohrium-api.dp.tech/ds-dl/abacus-deps-93wi-v2 -O abacus-deps-v1.zip
+wget https://bohrium-api.dp.tech/ds-dl/abacus-deps-93wi-v2 -O abacus-deps.zip
 ```
 `unzip` it ,and you can do offline installation of these packages above after rename. The above station will be updated handly but one should notice that the version will always lower than github repo.
 
@@ -91,6 +91,7 @@ The needed dependencies version default:
 - `LibXC` 6.2.2
 - `ELPA` 2023.05.001
 - `CEREAL` 1.3.2
+- `RapidJSON` 1.1.0
 And Intel-oneAPI need user or server manager to manually install from Intel.
 [Intel-oneAPI](https://www.intel.cn/content/www/cn/zh/developer/tools/oneapi/toolkits.html)
 
@@ -102,12 +103,12 @@ Dependencies below are optional， which is NOT installed by default:
 Users can install them by using `--with-*=install` in toolchain*.sh, which is `no` in default.
 > Notice: LibRI, LibComm and Libnpy is on actively development, you should check-out the package version when using this toolchain. Also, LibRI and LibComm can be installed by github submodule, which is also work for libnpy, which is more recommended.
 
-Notice: for `CEREAL`, `Libnpy`, `LibRI` and `LibComm`, 
+Notice: for `CEREAL`,`RapidJSON`, `Libnpy`, `LibRI` and `LibComm`, 
 you need to download them from github.com, 
 rename it as formatted, and put them in `build` directory at the same time
 e.g.:
 ```shell
-# packages downloaded from github.com
+# packages downloaded from github.com, RapidJSON is not supported now
 mv v1.3.2.tar.gz build/cereal-1.3.2.tar.gz
 ```
 
@@ -175,7 +176,7 @@ cmake -B $BUILD_DIR -DCMAKE_INSTALL_PREFIX=$PREFIX \
         -DCMAKE_CUDA_COMPILER=${path to cuda toolkit}/bin/nvcc \
         ......
 ```
-Notice: You CANNOT use `icpx` compiler for GPU version of ABACUS
+Notice: You CANNOT use `icpx` compiler for GPU version of ABACUS for now
 
 ### shell problem
 If you encounter problem like:
@@ -206,6 +207,8 @@ The default compiler for Intel-oneAPI is `icpx` and `icx`, which will cause prob
 
 The best way is to change `icpx` to `icpc`, `icx` to `icc`. user can manually change it in toolchain*.sh via `--with-intel-classic=yes`
 
+Notice: `icc` and `icpc` from Intel Classic Compiler of Intel-oneAPI is not supported for 2024.0 and newer version.
+
 
 ### LibRI and LibComm problem
 (There is some problem sometimes when compling with LibRI and LibComm, detailed information is needed)
@@ -215,6 +218,9 @@ The best way is to change `icpx` to `icpc`, `icx` to `icc`. user can manually ch
 Sometimes Intel-oneAPI have problem to link `mpirun`, 
 which will always show in 2023.2.0 version of MPI in Intel-oneAPI. 
 Try `source /path/to/setvars.sh` or install another version of IntelMPI may help.
+
+which is fixed in 2024.0.0 version of Intel-oneAPI, 
+And will not occur in Intel-MPI before 2021.10.0 (Intel-oneAPI before 2023.2.0)
 
 More problem and possible solution can be accessed via [#2928](https://github.com/deepmodeling/abacus-develop/issues/2928)
 
@@ -230,9 +236,6 @@ from ABACUS repo, make dependencies package more independent and flexible.
 2. Users can manually change `pkg_install_dir` variable 
 in `scripts/stage*/install*` to change the installation directory 
 of each packages, which may let the installation more fiexible.
-3. Users can manually change `INSTALL` variable in `scripts/common_vars.sh`
-to change the installation directory of all packages, which may let the
-installation more fiexible.
 
 
 ## More

--- a/toolchain/install_abacus_toolchain.sh
+++ b/toolchain/install_abacus_toolchain.sh
@@ -182,10 +182,12 @@ The --with-PKG options follow the rules:
   --with-scalapack        Parallel linear algebra library, needed for parallel
                           calculations.
                           Default = install
+  --with-elpa             Eigenvalue SoLvers for Petaflop-Applications library.
+                          Fast library for large parallel jobs， Especially for ABACUS LCAO
+                          Default = install
   --with-cereal           Enable cereal for ABACUS LCAO
                           Default = install
-  --with-elpa             Eigenvalue SoLvers for Petaflop-Applications library.
-                          Fast library for large parallel jobs.
+  --with-rapidjson        Enable rapidjson for ABACUS to read/write json files
                           Default = install
   --with-libtorch         Enable libtorch the machine learning framework needed for DeePKS
                           Default = no
@@ -230,7 +232,7 @@ EOF
 tool_list="gcc intel cmake"
 mpi_list="mpich openmpi intelmpi"
 math_list="mkl acml openblas"
-lib_list="fftw libxc scalapack elpa cereal libtorch libnpy libri libcomm"
+lib_list="fftw libxc scalapack elpa cereal rapidjson libtorch libnpy libri libcomm"
 package_list="${tool_list} ${mpi_list} ${math_list} ${lib_list}"
 # ------------------------------------------------------------------------
 
@@ -264,7 +266,8 @@ with_acml="__SYSTEM__"
 with_openblas="__INSTALL__"
 with_elpa="__INSTALL__"
 with_cereal="__INSTALL__"
-# with_libtorch="__DONTUSE__"
+with_rapidjson="__INSTALL__"
+# with_libtorch="__DONTUSE__" # default
 # with_libnpy="__DONTUSE__"
 # with_libri="__DONTUSE__"
 # with_libcomm="__DONTUSE__"
@@ -548,6 +551,9 @@ while [ $# -ge 1 ]; do
       ;;
     --with-cereal*)
       with_cereal=$(read_with "${1}")
+      ;;
+    --with-rapidjson*)
+      with_rapidjson=$(read_with "${1}")
       ;;
     --with-libnpy*)
       with_libnpy=$(read_with "${1}")

--- a/toolchain/scripts/common_vars.sh
+++ b/toolchain/scripts/common_vars.sh
@@ -7,8 +7,7 @@
 # directories and files used by the installer
 ROOTDIR=${ROOTDIR:-"$(pwd -P)"}
 SCRIPTDIR=${SCRIPTDIR:-"${ROOTDIR}/scripts"}
-INSTALLDIR=${INSTALLDIR:-"${ROOTDIR}/install"}
-#INSTALLDIR=${INSTALLDIR:-"${HOME}/abacus_deps"} # advanced installation
+INSTALLDIR=${INSTALLDIR:-"${ROOTDIR}/install"} # should not be changed
 BUILDDIR=${BUILDDIR:-"${ROOTDIR}/build"}
 SETUPFILE=${SETUPFILE:-"${INSTALLDIR}/setup"}
 ARCH_FILE_TEMPLATE=${ARCH_FILE_TEMPLATE:-"${SCRIPTDIR}/arch_base.tmpl"}

--- a/toolchain/scripts/stage4/install_cereal.sh
+++ b/toolchain/scripts/stage4/install_cereal.sh
@@ -76,9 +76,7 @@ if [ "$with_cereal" != "__DONTUSE__" ]; then
     # LibRI deps should find cereal include in CPATH
         cat << EOF > "${BUILDDIR}/setup_cereal"
 prepend_path CPATH "$pkg_install_dir/include"
-prepend_path CPATH "$pkg_install_dir/include/cereal"
 export CPATH="${pkg_install_dir}/include:"${CPATH}
-export CPATH="${pkg_install_dir}/include/cereal:"${CPATH}
 EOF
         cat "${BUILDDIR}/setup_cereal" >> $SETUPFILE
     fi

--- a/toolchain/scripts/stage4/install_rapidjson.sh
+++ b/toolchain/scripts/stage4/install_rapidjson.sh
@@ -76,9 +76,7 @@ if [ "$with_rapidjson" != "__DONTUSE__" ]; then
     # LibRI deps should find rapidjson include in CPATH
         cat << EOF > "${BUILDDIR}/setup_rapidjson"
 prepend_path CPATH "$pkg_install_dir/include"
-prepend_path CPATH "${pkg_install_dir}/include/rapidjson"
 export CPATH="${pkg_install_dir}/include:"${CPATH}
-export CPATH="${pkg_install_dir}/include/rapidjson:"${CPATH}
 EOF
         cat "${BUILDDIR}/setup_rapidjson" >> $SETUPFILE
     fi

--- a/toolchain/scripts/stage4/install_rapidjson.sh
+++ b/toolchain/scripts/stage4/install_rapidjson.sh
@@ -2,35 +2,35 @@
 
 # TODO: Review and if possible fix shellcheck errors.
 # shellcheck disable=all
-# CEREAL is not need any complex setting
+# RAPIDJSON is not need any complex setting
 # Only problem is the installation from github.com
 
 [ "${BASH_SOURCE[0]}" ] && SCRIPT_NAME="${BASH_SOURCE[0]}" || SCRIPT_NAME=$0
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")/.." && pwd -P)"
 
-cereal_ver="1.3.2"
-cereal_sha256="16a7ad9b31ba5880dac55d62b5d6f243c3ebc8d46a3514149e56b5e7ea81f85f"
+rapidjson_ver="1.1.0"
+rapidjson_sha256="bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e"
 source "${SCRIPT_DIR}"/common_vars.sh
 source "${SCRIPT_DIR}"/tool_kit.sh
 source "${SCRIPT_DIR}"/signal_trap.sh
 source "${INSTALLDIR}"/toolchain.conf
 source "${INSTALLDIR}"/toolchain.env
 
-[ -f "${BUILDDIR}/setup_cereal" ] && rm "${BUILDDIR}/setup_cereal"
+[ -f "${BUILDDIR}/setup_rapidjson" ] && rm "${BUILDDIR}/setup_rapidjson"
 
-CEREAL_CFLAGS=""
+RAPIDJSON_CFLAGS=""
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
-case "$with_cereal" in
+case "$with_rapidjson" in
   __INSTALL__)
-    echo "==================== Installing CEREAL ===================="
-    dirname="cereal-${cereal_ver}"
+    echo "==================== Installing RAPIDJSON ===================="
+    dirname="rapidjson-${rapidjson_ver}"
     pkg_install_dir="${INSTALLDIR}/$dirname"
-    #pkg_install_dir="${HOME}/lib/cereal/${cereal_ver}"
+    #pkg_install_dir="${HOME}/lib/rapidjson/${rapidjson_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
-    url="https://github.com/USCiLab/cereal/archive/refs/tags/v${cereal_ver}.tar.gz"
-    filename="cereal-${cereal_ver}.tar.gz"
+    url="https://github.com/Tencent/rapidjson/archive/refs/tags/v${rapidjson_ver}.tar.gz"
+    filename="rapidjson-${rapidjson_ver}.tar.gz"
     if verify_checksums "${install_lock_file}"; then
         echo "$dirname is already installed, skipping it."
     else
@@ -44,7 +44,7 @@ case "$with_cereal" in
             recommend_offline_installation $filename $url
             fi
         # checksum
-        checksum "$filename" "$cereal_sha256"
+        checksum "$filename" "$rapidjson_sha256"
         fi
         echo "Installing from scratch into ${pkg_install_dir}"
         [ -d $dirname ] && rm -rf $dirname
@@ -55,9 +55,9 @@ case "$with_cereal" in
     fi
         ;;
     __SYSTEM__)
-        echo "==================== CANNOT Finding CEREAL from system paths NOW ===================="
+        echo "==================== CANNOT Finding RAPIDJSON from system paths NOW ===================="
         recommend_offline_installation $filename $url
-        # How to do it in cereal? -- Zhaoqing in 2023/08/23
+        # How to do it in rapidjson? -- Zhaoqing in 2023/08/23
         # check_lib -lxcf03 "libxc"
         # check_lib -lxc "libxc"
         # add_include_from_paths LIBXC_CFLAGS "xc.h" $INCLUDE_PATHS
@@ -66,30 +66,30 @@ case "$with_cereal" in
     __DONTUSE__) ;;
     
     *)
-    echo "==================== Linking CEREAL to user paths ===================="
+    echo "==================== Linking RAPIDJSON to user paths ===================="
     check_dir "${pkg_install_dir}"
-    CEREAL_CFLAGS="-I'${pkg_install_dir}'"
+    RAPIDJSON_CFLAGS="-I'${pkg_install_dir}'"
     ;;
 esac
-if [ "$with_cereal" != "__DONTUSE__" ]; then
-    if [ "$with_cereal" != "__SYSTEM__" ]; then
-    # LibRI deps should find cereal include in CPATH
-        cat << EOF > "${BUILDDIR}/setup_cereal"
+if [ "$with_rapidjson" != "__DONTUSE__" ]; then
+    if [ "$with_rapidjson" != "__SYSTEM__" ]; then
+    # LibRI deps should find rapidjson include in CPATH
+        cat << EOF > "${BUILDDIR}/setup_rapidjson"
 prepend_path CPATH "$pkg_install_dir/include"
-prepend_path CPATH "$pkg_install_dir/include/cereal"
+prepend_path CPATH "${pkg_install_dir}/include/rapidjson"
 export CPATH="${pkg_install_dir}/include:"${CPATH}
-export CPATH="${pkg_install_dir}/include/cereal:"${CPATH}
+export CPATH="${pkg_install_dir}/include/rapidjson:"${CPATH}
 EOF
-        cat "${BUILDDIR}/setup_cereal" >> $SETUPFILE
+        cat "${BUILDDIR}/setup_rapidjson" >> $SETUPFILE
     fi
-    cat << EOF >> "${BUILDDIR}/setup_cereal"
-export CEREAL_CFLAGS="${CEREAL_CFLAGS}"
-export CEREAL_ROOT="$pkg_install_dir"
+    cat << EOF >> "${BUILDDIR}/setup_rapidjson"
+export RAPIDJSON_CFLAGS="${RAPIDJSON_CFLAGS}"
+export RAPIDJSON_ROOT="$pkg_install_dir"
 EOF
 fi
 
-load "${BUILDDIR}/setup_cereal"
+load "${BUILDDIR}/setup_rapidjson"
 write_toolchain_env "${INSTALLDIR}"
 
 cd "${ROOTDIR}"
-report_timing "cereal"
+report_timing "rapidjson"

--- a/toolchain/scripts/stage4/install_stage4.sh
+++ b/toolchain/scripts/stage4/install_stage4.sh
@@ -4,6 +4,7 @@
 # shellcheck disable=all
 
 ./scripts/stage4/install_cereal.sh
+./scripts/stage4/install_rapidjson.sh
 ./scripts/stage4/install_libtorch.sh
 ./scripts/stage4/install_libnpy.sh
 ./scripts/stage4/install_libri.sh

--- a/toolchain/scripts/tool_kit.sh
+++ b/toolchain/scripts/tool_kit.sh
@@ -54,9 +54,12 @@ By download $__filename from $__url,
 Rename it as $__filename and put it into ${BUILDDIR},
 And re-run toolchain installation script.
 
-Instead of github.com. you can manually install requirements packages via:
-1. Download from www.cp2k.org/static/downloads
-2. wget https://bohrium-api.dp.tech/ds-dl/abacus-deps-93wi-v1 -O abacus-deps-v1.zip
+You can manually install requirements packages via:
+1. Download from www.cp2k.org/static/downloads (for OpenBLAS, OpenMPI and Others)
+2. Download from github.com (for CEREAL, RapidJSON, libnpy, LibRI and others stage4 packages)
+3. Use git submodule update --init --recursive (for LibRI)
+4. wget https://bohrium-api.dp.tech/ds-dl/abacus-deps-93wi-v2 -O abacus-deps.zip
+5. for Intel-oneAPI, please contact your server manager our visit Intel official website
 EOF
 }
 

--- a/toolchain/toolchain_gnu.sh
+++ b/toolchain/toolchain_gnu.sh
@@ -18,6 +18,7 @@
 --with-fftw=install \
 --with-elpa=install \
 --with-cereal=install \
+--with-rapidjson=install \
 --with-libtorch=no \
 --with-libnpy=no \
 --with-libri=no \

--- a/toolchain/toolchain_intel-mpich.sh
+++ b/toolchain/toolchain_intel-mpich.sh
@@ -21,6 +21,7 @@
 --with-fftw=no \
 --with-elpa=install \
 --with-cereal=install \
+--with-rapidjson=install \
 --with-libtorch=no \
 --with-libnpy=no \
 --with-libri=no \

--- a/toolchain/toolchain_intel.sh
+++ b/toolchain/toolchain_intel.sh
@@ -22,6 +22,7 @@
 --with-fftw=no \
 --with-elpa=install \
 --with-cereal=install \
+--with-rapidjson=install \
 --with-libtorch=no \
 --with-libnpy=no \
 --with-libri=no \


### PR DESCRIPTION
- add install_rapidjson.sh for rapidjson support
- modified relating part
- minor notice message fixed
- update linking for cereal and rapidjson

### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix rapidjson installation and linking in toolchain


