### PR TITLE
Refactor: add values to `hK` rather than `LM.Hloc` in `OperatorEXX::contribute_Hk`

### DIFF
--- a/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h
@@ -189,7 +189,8 @@ private:
     double* DHloc_fixed_23;
     double* DHloc_fixed_33;
 
-
+    template <typename T>
+    static void set_mat2d(const int& global_ir, const int& global_ic, const T& v, const Parallel_Orbitals& pv, T* mat);
     void set_HSgamma(const int& iw1_all, const int& iw2_all, const double& v, double* HSloc);
     void set_HSk(const int &iw1_all, const int &iw2_all, const std::complex<double> &v, const char &dtype, const int spin = 0);
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/op_exx_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/op_exx_lcao.cpp
@@ -33,15 +33,17 @@ void OperatorEXX<OperatorLCAO<double, double>>::contributeHk(int ik)
 				kv,
 				ik,
 				GlobalC::exx_info.info_global.hybrid_alpha,
-				*this->LM->Hexxd,
-				*this->LM);
+                *this->LM->Hexxd,
+                *this->LM->ParaV,
+                *this->hK);
 		else
 			RI_2D_Comm::add_Hexx(
 				kv,
 				ik,
 				GlobalC::exx_info.info_global.hybrid_alpha,
-				*this->LM->Hexxc,
-				*this->LM);
+                *this->LM->Hexxc,
+                *this->LM->ParaV,
+                *this->hK);
     }
 }
 
@@ -57,14 +59,16 @@ void OperatorEXX<OperatorLCAO<std::complex<double>, double>>::contributeHk(int i
                 ik,
 				GlobalC::exx_info.info_global.hybrid_alpha,
 				*this->LM->Hexxd,
-				*this->LM);
+                *this->LM->ParaV,
+                *this->hK);
 		else
             RI_2D_Comm::add_Hexx(
                 kv,
                 ik,
 				GlobalC::exx_info.info_global.hybrid_alpha,
 				*this->LM->Hexxc,
-				*this->LM);
+                *this->LM->ParaV,
+                *this->hK);
     }
 }
 
@@ -80,14 +84,16 @@ void OperatorEXX<OperatorLCAO<std::complex<double>, std::complex<double>>>::cont
                 ik,
 				GlobalC::exx_info.info_global.hybrid_alpha,
 				*this->LM->Hexxd,
-				*this->LM);
+                *this->LM->ParaV,
+                *this->hK);
 		else
             RI_2D_Comm::add_Hexx(
                 kv,
                 ik,
 				GlobalC::exx_info.info_global.hybrid_alpha,
 				*this->LM->Hexxc,
-				*this->LM);
+                *this->LM->ParaV,
+                *this->hK);
     }
 }
 

--- a/source/module_ri/RI_2D_Comm.h
+++ b/source/module_ri/RI_2D_Comm.h
@@ -36,13 +36,14 @@ namespace RI_2D_Comm
 	extern std::vector<std::tuple<std::set<TA>, std::set<TA>>>
 	get_2D_judge(const Parallel_Orbitals &pv);
 
-	template<typename Tdata>
-	extern void add_Hexx(
-		const K_Vectors &kv,
-		const int ik,
-		const double alpha,
-		const std::vector<std::map<TA,std::map<TAC,RI::Tensor<Tdata>>>> &Hs,
-		LCAO_Matrix &lm);
+    template<typename Tdata, typename TK>
+    extern void add_Hexx(
+        const K_Vectors& kv,
+        const int ik,
+        const double alpha,
+        const std::vector<std::map<TA, std::map<TAC, RI::Tensor<Tdata>>>>& Hs,
+        const Parallel_Orbitals& pv,
+        std::vector<TK>& Hloc);
 
 	template<typename Tdata>
 	extern std::vector<std::vector<Tdata>> Hexxs_to_Hk(

--- a/source/module_ri/RI_2D_Comm.hpp
+++ b/source/module_ri/RI_2D_Comm.hpp
@@ -94,18 +94,17 @@ auto RI_2D_Comm::split_m2D_ktoR(const K_Vectors &kv, const std::vector<const Tma
 }
 
 
-template<typename Tdata>
+template<typename Tdata, typename TK>
 void RI_2D_Comm::add_Hexx(
 	const K_Vectors &kv,
 	const int ik,
 	const double alpha,
 	const std::vector<std::map<TA,std::map<TAC,RI::Tensor<Tdata>>>> &Hs,
-	LCAO_Matrix &lm)
+    const Parallel_Orbitals& pv,
+    std::vector<TK>& Hloc)
 {
 	ModuleBase::TITLE("RI_2D_Comm","add_Hexx");
 	ModuleBase::timer::tick("RI_2D_Comm", "add_Hexx");
-  
-    const Parallel_Orbitals& pv = *lm.ParaV;
 
 	const std::map<int, std::vector<int>> is_list = {{1,{0}}, {2,{kv.isk[ik]}}, {4,{0,1,2,3}}};
 	for(const int is_b : is_list.at(GlobalV::NSPIN))
@@ -130,15 +129,7 @@ void RI_2D_Comm::add_Hexx(
 					{
 						const int iwt1 = RI_2D_Comm::get_iwt(iat1, iw1_b, is1_b);
                         if (pv.global2local_col(iwt1) < 0)	continue;
-
-						if(GlobalV::GAMMA_ONLY_LOCAL)
-							lm.set_HSgamma(iwt0, iwt1,
-								RI::Global_Func::convert<double>(H(iw0_b, iw1_b)) * RI::Global_Func::convert<double>(frac),
-                                lm.Hloc.data());
-						else
-							lm.set_HSk(iwt0, iwt1,
-								RI::Global_Func::convert<std::complex<double>>(H(iw0_b, iw1_b)) * frac,
-								'L', -1);
+                        LCAO_Matrix::set_mat2d(iwt0, iwt1, RI::Global_Func::convert<TK>(H(iw0_b, iw1_b)) * RI::Global_Func::convert<TK>(frac), pv, Hloc.data());
 					}
 				}
 			}


### PR DESCRIPTION
Some algorithms will need a custom hK passed into `OperatorEXX`, which should not be fixed to `LM.Hloc(2)`.