### PR TITLE
Feature: change default value of smearing from fixed to gauss

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -936,7 +936,7 @@ calculations.
   - **gauss** or **gaussian**: Gaussian smearing method.
   - **mp**: methfessel-paxton smearing method; recommended for metals.
   - **fd**: Fermi-Dirac smearing method: $f=1/\{1+\exp[(E-\mu)/kT]\}$ and smearing_sigma below is the temperature $T$ (in Ry).
-- **Default**: fixed
+- **Default**: gauss
 
 ### smearing_sigma
 

--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -942,7 +942,7 @@ calculations.
 
 - **Type**: Real
 - **Description**: Energy range for smearing.
-- **Default**: 0.01
+- **Default**: 0.015
 - **Unit**: Ry
 
 ### smearing_sigma_temp

--- a/source/module_elecstate/occupy.cpp
+++ b/source/module_elecstate/occupy.cpp
@@ -141,7 +141,7 @@ void Occupy::iweights(const int nks,
     int ib_min = std::ceil(ib_mind);
     if (ib_min != int(ib_mind))
     {
-        ModuleBase::WARNING_QUIT("iweights", "It is not a semiconductor or insulator. Change 'smearing_method'.");
+        ModuleBase::WARNING_QUIT("iweights", "It is not a semiconductor or insulator. Please do not set 'smearing_method=fixed', and try other options.");
     }
     ef = -1e+10;
 

--- a/source/module_elecstate/test/elecstate_occupy_test.cpp
+++ b/source/module_elecstate/test/elecstate_occupy_test.cpp
@@ -227,7 +227,7 @@ TEST_F(OccupyTest, IweightsWarning)
   testing::internal::CaptureStdout();
   EXPECT_EXIT(occupy.iweights(1, wk, 1, 1.0, ekb, ef, wg, -1, isk);, ::testing::ExitedWithCode(0), "");
   output = testing::internal::GetCapturedStdout();
-  EXPECT_THAT(output, testing::HasSubstr("It is not a semiconductor or insulator. Change 'smearing_method'."));
+  EXPECT_THAT(output, testing::HasSubstr("It is not a semiconductor or insulator. Please do not set 'smearing_method=fixed', and try other options."));
 }
 
 TEST_F(OccupyTest, Wgauss)

--- a/source/module_io/input.cpp
+++ b/source/module_io/input.cpp
@@ -291,8 +291,8 @@ void Input::Default(void)
     //----------------------------------------------------------
     // occupation
     //----------------------------------------------------------
-    occupations = "smearing"; // pengfei 2014-10-13
-    smearing_method = "fixed";
+    occupations = "smearing"; 
+    smearing_method = "gauss";
     smearing_sigma = 0.01;
     //----------------------------------------------------------
     //  charge mixing

--- a/source/module_io/input.cpp
+++ b/source/module_io/input.cpp
@@ -292,8 +292,8 @@ void Input::Default(void)
     // occupation
     //----------------------------------------------------------
     occupations = "smearing"; 
-    smearing_method = "gauss";
-    smearing_sigma = 0.01;
+    smearing_method = "gauss"; // this setting is based on the report in Issue #2847
+    smearing_sigma = 0.015; // this setting is based on the report in Issue #2847
     //----------------------------------------------------------
     //  charge mixing
     //----------------------------------------------------------

--- a/source/module_io/test/input_test.cpp
+++ b/source/module_io/test/input_test.cpp
@@ -152,7 +152,7 @@ TEST_F(InputTest, Default)
         EXPECT_EQ(INPUT.out_stru,0);
         EXPECT_EQ(INPUT.occupations,"smearing");
         EXPECT_EQ(INPUT.smearing_method,"gauss");
-        EXPECT_DOUBLE_EQ(INPUT.smearing_sigma,0.01);
+        EXPECT_DOUBLE_EQ(INPUT.smearing_sigma,0.015);
         EXPECT_EQ(INPUT.mixing_mode,"broyden");
         EXPECT_DOUBLE_EQ(INPUT.mixing_beta,-10.0);
         EXPECT_EQ(INPUT.mixing_ndim,8);

--- a/source/module_io/test/input_test.cpp
+++ b/source/module_io/test/input_test.cpp
@@ -151,7 +151,7 @@ TEST_F(InputTest, Default)
         EXPECT_EQ(INPUT.relax_nmax,0);
         EXPECT_EQ(INPUT.out_stru,0);
         EXPECT_EQ(INPUT.occupations,"smearing");
-        EXPECT_EQ(INPUT.smearing_method,"fixed");
+        EXPECT_EQ(INPUT.smearing_method,"gauss");
         EXPECT_DOUBLE_EQ(INPUT.smearing_sigma,0.01);
         EXPECT_EQ(INPUT.mixing_mode,"broyden");
         EXPECT_DOUBLE_EQ(INPUT.mixing_beta,-10.0);

--- a/tests/integrate/107_PW_W90/INPUT
+++ b/tests/integrate/107_PW_W90/INPUT
@@ -3,6 +3,7 @@ suffix			autotest
 pseudo_dir              ../../PP_ORB
 orbital_dir             ../../PP_ORB
 ecutwfc                 50
+smearing_method         fixed
 nbands                  4
 calculation             nscf
 scf_nmax                50

--- a/tests/integrate/207_NO_KP_OS/INPUT
+++ b/tests/integrate/207_NO_KP_OS/INPUT
@@ -3,6 +3,7 @@ suffix 			autotest
 pseudo_dir 		../../PP_ORB
 orbital_dir 		../../PP_ORB
 #ecutwfc 		100 
+smearing_method  fixed
 ecutwfc 		10
 scf_thr 		1e-6 
 basis_type 		lcao


### PR DESCRIPTION
### Linked Issue
Some issues call for a more reasonable default value for smearing, f.e Issue #2847, Issue #3310, and Issue #3284.

### What's changed?
According to the report in Issue #2847 @LiuXiaohui123321,
1. change default value of `smearing_method` from `fixed` to `gauss`.
2. change default value of `smearing_sigma` from `fixed` to `0.015`.
3. change corresponding documentation.
