### PR TITLE
Fix: uspp bug caused by kpar>1

### DIFF
--- a/source/module_hamilt_pw/hamilt_pwdft/VNL_in_pw.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/VNL_in_pw.cpp
@@ -774,8 +774,8 @@ void pseudopot_cell_vnl::init_vnl(UnitCell& cell, const ModulePW::PW_Basis* rho_
     }
 
 #ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, this->qq_nt.ptr, this->qq_nt.getSize(), MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
-    MPI_Allreduce(MPI_IN_PLACE, this->qq_so.ptr, this->qq_so.getSize(), MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, this->qq_nt.ptr, this->qq_nt.getSize(), MPI_DOUBLE, MPI_SUM, POOL_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, this->qq_so.ptr, this->qq_so.getSize(), MPI_DOUBLE_COMPLEX, MPI_SUM, POOL_WORLD);
 #endif
 
     // set the atomic specific qq_at matrices
@@ -1605,7 +1605,7 @@ void pseudopot_cell_vnl::newq(const ModuleBase::matrix& veff, const ModulePW::PW
     }
 
 #ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, deeq.ptr, deeq.getSize(), MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, deeq.ptr, deeq.getSize(), MPI_DOUBLE, MPI_SUM, POOL_WORLD);
 #endif
 
     delete[] qnorm;

--- a/tests/integrate/101_PW_upf201_uspp_Fe/INPUT
+++ b/tests/integrate/101_PW_upf201_uspp_Fe/INPUT
@@ -30,3 +30,5 @@ pseudo_rcut            10
 
 cal_force              1
 cal_stress             1
+
+kpar                   3

--- a/tests/integrate/101_PW_upf201_uspp_Fe/result.ref
+++ b/tests/integrate/101_PW_upf201_uspp_Fe/result.ref
@@ -1,5 +1,5 @@
-etotref -673.8349343156786517
-etotperatomref -673.8349343157
+etotref -673.8349337888099626
+etotperatomref -673.8349337888
 totalforceref 0.000000
-totalstressref 66620.579350
-totaltimeref 0.87
+totalstressref 66620.402512
+totaltimeref 0.75

--- a/tests/integrate/101_PW_upf201_uspp_NaCl/result.ref
+++ b/tests/integrate/101_PW_upf201_uspp_NaCl/result.ref
@@ -1,8 +1,8 @@
-etotref -1675.0621002950274487
-etotperatomref -837.5310501475
-totalforceref 9.447764
-totalstressref 1647.357767
+etotref -1675.0621003362039119
+etotperatomref -837.5310501681
+totalforceref 9.446120
+totalstressref 1646.116655
 pointgroupref C_2v
 spacegroupref C_2v
 nksibzref 5
-totaltimeref 1.61
+totaltimeref 1.36


### PR DESCRIPTION
### Linked Issue
Fix #3339 

### What's changed?
- fix a bug caused by `kpar` > 1
