### PR TITLE
Fix: delete threshold for weight of bands

### DIFF
--- a/source/module_elecstate/elecstate_pw.cpp
+++ b/source/module_elecstate/elecstate_pw.cpp
@@ -164,7 +164,6 @@ void ElecStatePW<T, Device>::rhoBandK(const psi::Psi<T, Device>& psi)
         current_spin = this->klist->isk[ik];
     }
     int nbands = psi.get_nbands();
-    const double threshold = ModuleBase::threshold_wg * this->wg(ik, 0);
     //  here we compute the band energy: the sum of the eigenvalues
     if (GlobalV::NSPIN == 4)
     {
@@ -175,9 +174,6 @@ void ElecStatePW<T, Device>::rhoBandK(const psi::Psi<T, Device>& psi)
             /// only occupied band should be calculated.
             /// be care of when smearing_sigma is large, wg would less than 0
             ///
-            if (std::fabs(this->wg(ik, ibnd)) < threshold) {
-                continue;
-            }
 
             this->basis->recip_to_real(this->ctx, &psi(ibnd,0), this->wfcr, ik);
 
@@ -185,8 +181,11 @@ void ElecStatePW<T, Device>::rhoBandK(const psi::Psi<T, Device>& psi)
 
             const auto w1 = static_cast<Real>(this->wg(ik, ibnd) / get_ucell_omega());
 
-            // replaced by denghui at 20221110
-            elecstate_pw_op()(this->ctx, GlobalV::DOMAG, GlobalV::DOMAG_Z, this->charge->nrxx, w1, this->rho, this->wfcr, this->wfcr_another_spin);
+            if (w1 != 0.0)
+            {
+                // replaced by denghui at 20221110
+                elecstate_pw_op()(this->ctx, GlobalV::DOMAG, GlobalV::DOMAG_Z, this->charge->nrxx, w1, this->rho, this->wfcr, this->wfcr_another_spin);
+            }
         }
     }
     else
@@ -196,9 +195,6 @@ void ElecStatePW<T, Device>::rhoBandK(const psi::Psi<T, Device>& psi)
             ///
             /// only occupied band should be calculated.
             ///
-            if (this->wg(ik, ibnd) < threshold) {
-                continue;
-            }
 
             this->basis->recip_to_real(this->ctx, &psi(ibnd,0), this->wfcr, ik);
 

--- a/source/module_hamilt_pw/hamilt_pwdft/forces.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/forces.cpp
@@ -832,8 +832,7 @@ void Forces<FPTYPE, Device>::cal_force_nl(ModuleBase::matrix& forcenl,
         /// only occupied band should be calculated.
         ///
         int nbands_occ = GlobalV::NBANDS;
-        const double threshold = ModuleBase::threshold_wg * wg(ik, 0);
-        while (std::fabs(wg(ik, nbands_occ - 1)) < threshold)
+        while (wg(ik, nbands_occ - 1) == 0.0)
         {
             nbands_occ--;
             if (nbands_occ == 0)

--- a/source/module_hamilt_pw/hamilt_pwdft/stress_func_nl.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/stress_func_nl.cpp
@@ -137,8 +137,7 @@ void Stress_Func<FPTYPE, Device>::stress_nl(ModuleBase::matrix& sigma,
         /// only occupied band should be calculated.
         ///
         int nbands_occ = GlobalV::NBANDS;
-        const double threshold = ModuleBase::threshold_wg * wg(ik, 0);
-        while (std::fabs(wg(ik, nbands_occ - 1)) < threshold)
+        while (wg(ik, nbands_occ - 1) == 0.0)
         {
             nbands_occ--;
             if (nbands_occ == 0)


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #3251 .

### What's changed?
- stress and force is sensitive with tiny weight bands, change threshold from 1e-10*weight_k to zero.

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
