### PR TITLE
Refactor: interface between new & old NAO (1/3): NumericalRadial & Numerical_Orbital_Lm

### DIFF
--- a/source/module_basis/module_nao/numerical_radial.h
+++ b/source/module_basis/module_nao/numerical_radial.h
@@ -6,6 +6,7 @@
 #include <memory>
 
 #include "module_base/spherical_bessel_transformer.h"
+#include "module_basis/module_ao/ORB_atomic_lm.h"
 
 /**
  * @brief A class that represents a numerical radial function.
@@ -99,6 +100,13 @@ public:
                const int itype = 0,
                const bool init_sbt = true
     );
+
+    /**
+     * @brief Overwrites the content of a Numerical_Orbital_Lm object with the current object.
+     *
+     * This function provides an interface to the corresponding object in the old module_ao.
+     */
+    void to_numerical_orbital_lm(Numerical_Orbital_Lm& orbital_lm);
 
     /** 
      * @brief Sets a SphericalBesselTransformer.
@@ -345,6 +353,9 @@ private:
      * backward: k to r
      */
     void transform(const bool forward);
+
+    /// Checks whether a grid is uniform.
+    bool is_uniform(const int n, const double* const grid, const double tol) const;
 
     /**
      * @brief Checks whether the given two grids are FFT-compliant.

--- a/source/module_basis/module_nao/test/CMakeLists.txt
+++ b/source/module_basis/module_nao/test/CMakeLists.txt
@@ -3,6 +3,7 @@ AddTest(
   SOURCES
     numerical_radial_test.cpp
     ../numerical_radial.cpp
+    ../../module_ao/ORB_atomic_lm.cpp
   LIBS ${math_libs} device base
 )
 
@@ -13,6 +14,7 @@ AddTest(
     ../atomic_radials.cpp
     ../radial_set.cpp
     ../numerical_radial.cpp
+    ../../module_ao/ORB_atomic_lm.cpp
   LIBS ${math_libs} device base
 )
 
@@ -23,17 +25,19 @@ AddTest(
     ../beta_radials.cpp
     ../radial_set.cpp
     ../numerical_radial.cpp
+    ../../module_ao/ORB_atomic_lm.cpp
   LIBS ${math_libs} device base
 )
 
 AddTest(
-    TARGET sphbes_radials
-    SOURCES
-        sphbes_radials_test.cpp
-        ../sphbes_radials.cpp
-        ../radial_set.cpp
-        ../numerical_radial.cpp
-    LIBS ${math_libs} device base
+  TARGET sphbes_radials
+  SOURCES
+  sphbes_radials_test.cpp
+    ../sphbes_radials.cpp
+    ../radial_set.cpp
+    ../numerical_radial.cpp
+    ../../module_ao/ORB_atomic_lm.cpp
+ LIBS ${math_libs} device base
 )
 
 AddTest(
@@ -43,8 +47,10 @@ AddTest(
     ../radial_collection.cpp
     ../atomic_radials.cpp
     ../beta_radials.cpp
+    ../sphbes_radials.cpp
     ../radial_set.cpp
     ../numerical_radial.cpp
+    ../../module_ao/ORB_atomic_lm.cpp
   LIBS ${math_libs} device base
 )
 
@@ -56,6 +62,7 @@ AddTest(
     ../radial_collection.cpp
     ../atomic_radials.cpp
     ../beta_radials.cpp
+    ../sphbes_radials.cpp
     ../radial_set.cpp
     ../numerical_radial.cpp
     ../two_center_bundle.cpp
@@ -83,6 +90,7 @@ AddTest(
     ../radial_collection.cpp
     ../atomic_radials.cpp
     ../beta_radials.cpp
+    ../sphbes_radials.cpp
     ../radial_set.cpp
     ../numerical_radial.cpp
     ../two_center_bundle.cpp
@@ -100,6 +108,7 @@ AddTest(
     ../radial_collection.cpp
     ../atomic_radials.cpp
     ../beta_radials.cpp
+    ../sphbes_radials.cpp
     ../radial_set.cpp
     ../numerical_radial.cpp
   LIBS ${math_libs} device base container orb

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/CMakeLists.txt
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/CMakeLists.txt
@@ -7,6 +7,7 @@ AddTest(
   SOURCES test_overlapnew.cpp ../overlap_new.cpp ../../../module_hcontainer/func_folding.cpp 
   ../../../module_hcontainer/base_matrix.cpp ../../../module_hcontainer/hcontainer.cpp ../../../module_hcontainer/atom_pair.cpp  
   ../../../../module_basis/module_ao/parallel_2d.cpp ../../../../module_basis/module_ao/parallel_orbitals.cpp 
+  ../../../../module_basis/module_ao/ORB_atomic_lm.cpp
   tmp_mocks.cpp ../../../../module_hamilt_general/operator.cpp
 )
 
@@ -16,6 +17,7 @@ AddTest(
   SOURCES test_overlapnew_cd.cpp ../overlap_new.cpp ../../../module_hcontainer/func_folding.cpp 
   ../../../module_hcontainer/base_matrix.cpp ../../../module_hcontainer/hcontainer.cpp ../../../module_hcontainer/atom_pair.cpp  
   ../../../../module_basis/module_ao/parallel_2d.cpp ../../../../module_basis/module_ao/parallel_orbitals.cpp 
+  ../../../../module_basis/module_ao/ORB_atomic_lm.cpp
   tmp_mocks.cpp ../../../../module_hamilt_general/operator.cpp
 )
 
@@ -25,6 +27,7 @@ AddTest(
   SOURCES test_ekineticnew.cpp ../ekinetic_new.cpp ../../../module_hcontainer/func_folding.cpp 
   ../../../module_hcontainer/base_matrix.cpp ../../../module_hcontainer/hcontainer.cpp ../../../module_hcontainer/atom_pair.cpp  
   ../../../../module_basis/module_ao/parallel_2d.cpp ../../../../module_basis/module_ao/parallel_orbitals.cpp 
+  ../../../../module_basis/module_ao/ORB_atomic_lm.cpp
   tmp_mocks.cpp ../../../../module_hamilt_general/operator.cpp
 )
 
@@ -34,6 +37,7 @@ AddTest(
   SOURCES test_nonlocalnew.cpp ../nonlocal_new.cpp ../../../module_hcontainer/func_folding.cpp 
   ../../../module_hcontainer/base_matrix.cpp ../../../module_hcontainer/hcontainer.cpp ../../../module_hcontainer/atom_pair.cpp  
   ../../../../module_basis/module_ao/parallel_2d.cpp ../../../../module_basis/module_ao/parallel_orbitals.cpp 
+  ../../../../module_basis/module_ao/ORB_atomic_lm.cpp
   tmp_mocks.cpp ../../../../module_hamilt_general/operator.cpp
 )
 
@@ -43,6 +47,7 @@ AddTest(
   SOURCES test_T_NL_cd.cpp ../nonlocal_new.cpp ../ekinetic_new.cpp ../../../module_hcontainer/func_folding.cpp 
   ../../../module_hcontainer/base_matrix.cpp ../../../module_hcontainer/hcontainer.cpp ../../../module_hcontainer/atom_pair.cpp  
   ../../../../module_basis/module_ao/parallel_2d.cpp ../../../../module_basis/module_ao/parallel_orbitals.cpp 
+  ../../../../module_basis/module_ao/ORB_atomic_lm.cpp
   tmp_mocks.cpp ../../../../module_hamilt_general/operator.cpp
 )
 


### PR DESCRIPTION
In order to support using spherical Bessel coefficients as an alternative to numerical atomic orbital files, we need some mechanism to initialize GlobalC::ORB from those spherical Bessel coefficients. Given that module_ao shall remain unaltered, the only feasible way is to support building module_ao objects from module_nao objects.

This PR adds an interface between NumericalRadial & Numerical_Orbital_Lm to support the construction of the latter from the former.

### Reminder
- [x] Have you linked an issue with this pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [x] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
https://github.com/deepmodeling/abacus-develop/issues/3315 https://github.com/deepmodeling/abacus-develop/issues/3267

### What's changed?
An interface between NumericalRadial & Numerical_Orbital_Lm is add to support the construction of the latter from the former.

### Any changes of core modules? (ignore if not applicable)
No