### PR TITLE
Fix: move template LCAO_Matrix::set_mat2d() from LCAO_matrix.cpp to LCAO_matrix.hpp

### DIFF
--- a/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.cpp
@@ -134,54 +134,6 @@ void LCAO_Matrix::allocate_HS_R(const int &nnR)
     return;
 }
 
-//------------------------------------------------------
-// DESCRIPTION:
-// set 'dtype' matrix element (iw1_all, iw2_all) with 
-// an input value 'v'
-//------------------------------------------------------
-template<typename T>
-void LCAO_Matrix::set_mat2d(
-    const int& global_ir, // index i for atomic orbital (row)
-    const int& global_ic, // index j for atomic orbital (column)
-    const T& v, // value for matrix element (i,j) 
-    const Parallel_Orbitals& pv,
-    T* HSloc)  //input pointer for store the matrix
-{
-    // use iw1_all and iw2_all to set Hloc
-    // becareful! The ir and ic may be < 0 !!!
-    const int ir = pv.global2local_row(global_ir);
-    const int ic = pv.global2local_col(global_ic);
-
-    //const int index = ir * ParaO.ncol + ic;
-    long index=0;
-
-    // save the matrix as column major format
-    if (ModuleBase::GlobalFunc::IS_COLUMN_MAJOR_KS_SOLVER())
-    {
-        index = ic * pv.nrow + ir;
-    }
-    else
-    {
-        index = ir * pv.ncol + ic;
-    }
-   
-    if (index >= pv.nloc)
-    {
-        std::cout << " iw1_all = " << global_ir << std::endl;
-        std::cout << " iw2_all = " << global_ic << std::endl;
-        std::cout << " ir = " << ir << std::endl;
-        std::cout << " ic = " << ic << std::endl;
-        std::cout << " index = " << index << std::endl;
-        std::cout << " ParaV->nloc = " << pv.nloc << std::endl;
-        ModuleBase::WARNING_QUIT("LCAO_Matrix", "set_mat2d");
-    }	 
-
-    //using input pointer HSloc
-    HSloc[index] += v;
-
-    return;
-}
-
 void LCAO_Matrix::set_HSgamma(const int& iw1_all, const int& iw2_all, const double& v, double* HSloc)
 {
     LCAO_Matrix::set_mat2d<double>(iw1_all, iw2_all, v, *this->ParaV, HSloc);

--- a/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h
@@ -228,4 +228,6 @@ private:
 
 };
 
+#include "LCAO_matrix.hpp"
+
 #endif

--- a/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.hpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.hpp
@@ -1,0 +1,44 @@
+#ifndef LCAO_MATRIX_HPP
+#define LCAO_MATRIX_HPP
+
+#include "LCAO_matrix.h"
+
+//------------------------------------------------------
+// DESCRIPTION:
+// set 'dtype' matrix element (iw1_all, iw2_all) with 
+// an input value 'v'
+//------------------------------------------------------
+template<typename T>
+void LCAO_Matrix::set_mat2d(
+    const int& global_ir, // index i for atomic orbital (row)
+    const int& global_ic, // index j for atomic orbital (column)
+    const T& v, // value for matrix element (i,j) 
+    const Parallel_Orbitals& pv,
+    T* HSloc)  //input pointer for store the matrix
+{
+    // use iw1_all and iw2_all to set Hloc
+    // becareful! The ir and ic may be < 0 !!!
+    const int ir = pv.global2local_row(global_ir);
+    const int ic = pv.global2local_col(global_ic);
+
+    const long index =
+        ModuleBase::GlobalFunc::IS_COLUMN_MAJOR_KS_SOLVER()
+        ? ic * static_cast<long>(pv.nrow) + ir
+        : ir * static_cast<long>(pv.ncol) + ic;
+
+    if (index >= pv.nloc)
+    {
+        std::cout << " iw1_all = " << global_ir << std::endl;
+        std::cout << " iw2_all = " << global_ic << std::endl;
+        std::cout << " ir = " << ir << std::endl;
+        std::cout << " ic = " << ic << std::endl;
+        std::cout << " index = " << index << std::endl;
+        std::cout << " ParaV->nloc = " << pv.nloc << std::endl;
+        ModuleBase::WARNING_QUIT("LCAO_Matrix", "set_mat2d");
+    }	 
+
+    //using input pointer HSloc
+    HSloc[index] += v;
+}
+
+#endif


### PR DESCRIPTION
The template must be written in the header file, otherwise there will be compilation errors.