### PR TITLE
Fix test-warnings related to symmetry

### DIFF
--- a/source/module_relax/relax_new/relax.cpp
+++ b/source/module_relax/relax_new/relax.cpp
@@ -476,7 +476,7 @@ void Relax::move_cell_ions(const bool is_new_dir)
             };
         cp_mat_to_mat3();
 
-        if (ModuleSymmetry::Symmetry::symm_flag)
+        if (ModuleSymmetry::Symmetry::symm_flag && GlobalC::ucell.symm.nrotk > 0)
         {
             search_dr_cell = sr_dr_cell.Transpose().to_matrix();
             GlobalC::ucell.symm.symmetrize_mat3(search_dr_cell, GlobalC::ucell.lat);
@@ -558,7 +558,8 @@ void Relax::move_cell_ions(const bool is_new_dir)
         }
     }
 
-    if (ModuleSymmetry::Symmetry::symm_flag && GlobalC::ucell.symm.all_mbl)GlobalC::ucell.symm.symmetrize_vec3_nat(move_ion);
+    if (ModuleSymmetry::Symmetry::symm_flag && GlobalC::ucell.symm.all_mbl && GlobalC::ucell.symm.nrotk > 0)
+        GlobalC::ucell.symm.symmetrize_vec3_nat(move_ion);
 
 	GlobalC::ucell.update_pos_taud(move_ion);
 

--- a/source/module_relax/relax_old/ions_move_basic.cpp
+++ b/source/module_relax/relax_old/ions_move_basic.cpp
@@ -93,7 +93,8 @@ void Ions_Move_Basic::move_atoms(UnitCell &ucell, double *move, double *pos)
     const double move_threshold = 1.0e-10;
     const int total_freedom = ucell.nat * 3;
 
-    if (ModuleSymmetry::Symmetry::symm_flag && ucell.symm.all_mbl)ucell.symm.symmetrize_vec3_nat(move);
+    if (ModuleSymmetry::Symmetry::symm_flag && ucell.symm.all_mbl && ucell.symm.nrotk > 0)
+        ucell.symm.symmetrize_vec3_nat(move);
 
     for (int i = 0; i < total_freedom; i++)
     {

--- a/source/module_relax/relax_old/lattice_change_basic.cpp
+++ b/source/module_relax/relax_old/lattice_change_basic.cpp
@@ -82,7 +82,7 @@ void Lattice_Change_Basic::change_lattice(UnitCell &ucell, double *move, double 
        "<<std::setprecision(12)<<ucell.latvec.e31<<"   "<<ucell.latvec.e32<<"
        "<<ucell.latvec.e33<<std::endl;
     */
-    if (ModuleSymmetry::Symmetry::symm_flag)
+    if (ModuleSymmetry::Symmetry::symm_flag && ucell.symm.nrotk > 0)
     {
         ModuleBase::matrix move_mat_t(3, 3);
         for (int i = 0;i < 3;++i)for (int j = 0;j < 3;++j)move_mat_t(j, i) = move[i * 3 + j] / ucell.lat0;    //transpose

--- a/tests/integrate/207_NO_KP_OHS_SPIN4/result.ref
+++ b/tests/integrate/207_NO_KP_OHS_SPIN4/result.ref
@@ -1,5 +1,5 @@
-etotref -145.7968134044029
-etotperatomref -145.7968134044
+etotref -145.7915076086667
+etotperatomref -145.7915076087
 CompareH_pass 0
 CompareS_pass 0
 CompareSR_pass 0

--- a/tests/integrate/207_NO_KP_OTdH/result.ref
+++ b/tests/integrate/207_NO_KP_OTdH/result.ref
@@ -1,5 +1,5 @@
-etotref -145.7968108686881
-etotperatomref -145.7968108687
+etotref -145.7948404672053
+etotperatomref -145.7948404672
 ComparerTR_pass 0
 ComparerdHRx_pass 0
 ComparerdHRy_pass 0

--- a/tests/integrate/213_NO_mulliken/result.ref
+++ b/tests/integrate/213_NO_mulliken/result.ref
@@ -1,6 +1,6 @@
-etotref -31.5775931558278344
-etotperatomref -15.7887965779
-totalforceref 4.526686
-totalstressref 16.672975
+etotref -31.57750366324151
+etotperatomref -15.7887518316
+totalforceref 4.525602
+totalstressref 16.666119
 Compare_mulliken_pass 0
 totaltimeref +0.25620


### PR DESCRIPTION
1. Fix a call of structure symmetrization when symmetry is not analyzed
In #3242 @Zhuxuegang2022 mentioned the warning of case `704_LJ_CR` introduced in #3247, it is because in `ESolver_LJ` the symmetry does not be analyzed even if symmetry=1 is set in the  INPUT file. 
So I changed the condition to call structure symmetrization only when there exist some symmetry operations, i.e. `nrotk>0`. 

2. Change the reference value of some cases: the difference is just because the symmetrization is changed from real space into reciprocal space in #3081. The old values can be reproduced using real-space symmetrization in my local test.