### PR TITLE
Fix: wrong override in veff_lcao, and some error annotations

### DIFF
--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.h
@@ -16,7 +16,7 @@ namespace hamilt
 /// The DeePKS class template inherits from class T
 /// it is used to calculate the Deep Potential Kohn-Sham correction from DeePKS method
 /// Template parameters:
-/// - T: base class, it would be OperatorLCAO<TK> or OperatorPW<TK>
+/// - T: base class, it would be OperatorLCAO<TK>
 /// - TR: data type of real space Hamiltonian, it would be double or std::complex<double>
 template <class T>
 class DeePKS : public T
@@ -40,8 +40,17 @@ class DeePKS<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                             elecstate::DensityMatrix<TK,double>* DM_in);
     ~DeePKS();
 
+    /**
+     * @brief contribute the DeePKS correction to real space Hamiltonian
+     * this function is used for update hR and H_V_delta
+    */
     virtual void contributeHR() override;
 #ifdef __DEEPKS
+    /**
+     * @brief contribute the DeePKS correction for each k-point to ld.H_V_delta or ld.H_V_delta_k
+     * this function is not used for update hK, but for DeePKS module
+     * @param ik: the index of k-point
+    */
     virtual void contributeHk(int ik) override;
 #endif
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/veff_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/veff_lcao.cpp
@@ -158,10 +158,4 @@ void Veff<OperatorLCAO<double, double>>::contributeHR()
     this->new_e_iteration = false;
 }
 
-template<typename TK, typename TR>
-void Veff<OperatorLCAO<TK, TR>>::contributeHk(int ik)
-{
-    ModuleBase::TITLE("Veff", "contributeHk");
-}
-
 }

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/veff_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/veff_lcao.h
@@ -22,10 +22,19 @@ class Veff : public T
 
 #endif
 
+/// @brief Effective potential class, used for calculating Hamiltonian with grid integration tools
+/// If user want to separate the contribution of V_{eff} into V_{H} and V_{XC} and V_{local pseudopotential} and so on,
+/// the user can separate the Potential class into different parts, and construct different Veff class for each part.
+/// @tparam TK 
+/// @tparam TR 
 template <typename TK, typename TR>
 class Veff<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
 {
   public:
+    /**
+     * @brief Construct a new Veff object for multi-kpoint calculation
+     * @param GK_in: the pointer of Gint_k object, used for grid integration
+    */
     Veff<OperatorLCAO<TK, TR>>(Gint_k* GK_in,
                           Local_Orbital_Charge* loc_in,
                           LCAO_Matrix* LM_in,
@@ -46,6 +55,10 @@ class Veff<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
         this->initialize_HR(ucell_in, GridD_in, paraV);
         GK_in->initialize_pvpR(*ucell_in, GridD_in);
     }
+    /**
+     * @brief Construct a new Veff object for Gamma-only calculation
+     * @param GG_in: the pointer of Gint_Gamma object, used for grid integration
+    */
     Veff<OperatorLCAO<TK, TR>>(Gint_Gamma* GG_in,
                           Local_Orbital_Charge* loc_in,
                           LCAO_Matrix* LM_in,
@@ -69,9 +82,13 @@ class Veff<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
 
     ~Veff<OperatorLCAO<TK, TR>>(){};
 
+    /**
+     * @brief contributeHR() is used to calculate the HR matrix
+     * <phi_{\mu, 0}|V_{eff}|phi_{\nu, R}>
+     * the contribution of V_{eff} is calculated by the contribution of V_{H} and V_{XC} and V_{local pseudopotential} and so on.
+     * grid integration is used to calculate the contribution Hamiltonian of effective potential
+     */
     virtual void contributeHR() override;
-
-    virtual void contributeHk(int ik) override;
 
   private:
     // used for k-dependent grid integration.

--- a/source/module_hamilt_lcao/module_hcontainer/hcontainer.h
+++ b/source/module_hamilt_lcao/module_hcontainer/hcontainer.h
@@ -14,7 +14,7 @@ namespace hamilt
  * class HContainer
  * used to store a matrix for atom-pair local Hamiltonian with specific R-index
  * ----------------------------------------
- *   <Psi_{mu_I,R}|H|Psi_{nu_J,0}>
+ *   <Psi_{mu_I,0}|H|Psi_{nu_J,R}>
  * ----------------------------------------
  * template T can be double or complex<double>
  * 
@@ -25,23 +25,17 @@ namespace hamilt
  *       // ucell is a UnitCell object
  *       // in this method, all empty atom-pairs will be initialized in HR
  *       // atom-pairs are sorted by matrix of (i, j)
- *       HContainer<double> HR(ucell);
+ *       HContainer<double> HR(ucell, nullptr); // serial case
+ *       HContainer<double> HR(ucell, paraV); // 2d-block-recycle parallel case
  *     ```
  *    b. use insert_pair() to insert atom-pair
  *     ```
- *       // HR is a HContainer object, from simple constructor
  *       HContainer<double> HR;
- *       // there are many methods to init AtomPair, this case is step by step method
- *       AtomPair<double> atom_ij(0, 1);
- *       // set size of AtomPair by set_size() 
- *       atom_ij.set_size(2, 2);
- *       // allocate local matrix memory with R-index in AtomPair
- *       auto local_matrix = atom_ij.get_HR_values(0, 0, 0);
- *       // save array to local_matrix
- *       std::vector<double> local_matrix_ij = ...;
- *       local_matrix.add_array(local_matrix_ij.data());
- *       // insert atom_ij into HR
+ *       AtomPair<double> atom_ij...
  *       HR.insert_pair(atom_ij);
+ *       // allocate is nessasary if atom-pairs are inserted
+ *       HR.allocate(nullptr, 0); // arrange memory by HContainer
+ *       HR.allocate(data_array, 0); // use data_array as memory pool
  *     ```
  *   c. use Parallel_Orbital to initialize atom_pairs and HContainer
  *     ```
@@ -49,15 +43,6 @@ namespace hamilt
  *       HCotainer<double> HR(paraV);
  *       // initialize a new AtomPair with atom paraV
  *       AtomPair<double> atom_ij(0, 1, paraV);
- *       // insert atom_ij into HR
- *       HR.insert_pair(atom_ij);
- *     ```
- *   d. use data_pointer of existed matrix to initialize HContainer, which means HContainer is a wrapper
- *     ```
- *       // data_pointer is a pointer of existed matrix
- *       HContainer<double> HR(paraV, data_pointer);
- *       // initialize a new AtomPair with data_pointer
- *       AtomPair<double> atom_ij(0, 1, paraV, data_pointer);
  *       // insert atom_ij into HR
  *       HR.insert_pair(atom_ij);
  *     ```
@@ -77,11 +62,6 @@ namespace hamilt
  *       // HR is a HContainer object
  *       AtomPair<double>& atom_ij_1 = HR.get_atom_pair(0, 1);
  *       AtomPair<double>& atom_ij_2 = HR.get_atom_pair(1);//suppose 0,1 is the second atom-pair in atom_pairs
- *       // check if atom_ij_1 and atom_ij_2 are the same
- *       if(atom_ij_1.identify(atom_ij_2)) 
- *       {
- *           std::cout<<"atom_ij_1 and atom_ij_2 are the same"<<std::endl;
- *       }
  *     ```
  * 3. get data pointer of target local matrix <Psi_{mu_I,R}|H|Psi_{nu_J,0}>
  *    a. use interface data() with atom_i and atom_j and R index


### PR DESCRIPTION
### What's changed?
- Fix the wrong function Veff<OperatorLCAO<TK, TR>>::contributeHK(), the correct function for this derivative class is OperatorLCAO<TK, TR>::contributeHK() after this PR.
- Fix incorrect annotations for HContainer since last feature changes.

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
