### PR TITLE
modify the reference of 184_PW_BNDKPAR_SDFT_MALL/ALL

### DIFF
--- a/tests/integrate/184_PW_BNDKPAR_SDFT_ALL/result.ref
+++ b/tests/integrate/184_PW_BNDKPAR_SDFT_ALL/result.ref
@@ -1,5 +1,5 @@
-etotref -103.9857283719017573
-etotperatomref -51.9928641860
-totalforceref 197.980360
-totalstressref 257668.731244
-totaltimeref +1.39407
+etotref -103.9857325301833697
+etotperatomref -51.9928662651
+totalforceref 197.980562
+totalstressref 257668.732196
+totaltimeref 16.20

--- a/tests/integrate/184_PW_BNDKPAR_SDFT_MALL/result.ref
+++ b/tests/integrate/184_PW_BNDKPAR_SDFT_MALL/result.ref
@@ -1,5 +1,5 @@
-etotref -103.9857257248261391
-etotperatomref -51.9928628624
-totalforceref 197.980106
-totalstressref 257668.861146
-totaltimeref +5.34573
+etotref -103.9857316470281745
+etotperatomref -51.9928658235
+totalforceref 197.981112
+totalstressref 257669.179265
+totaltimeref 31.18


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

Since #3175 modify the symmetry_prec from 1e-5 to 1e-6, 184_PW_BNDKPAR_SDFT_ALL/184_PW_BNDKPAR_SDFT_MALL will suffer warning.
Modify the reference to the value produced by latest codes.

### Linked Issue
Fix #3242

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
