### PR TITLE
Fix: gamma_only label calculating error for DeePKS

### DIFF
--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks_pdm.cpp
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks_pdm.cpp
@@ -110,6 +110,11 @@ void LCAO_Deepks::cal_projected_DM(const elecstate::DensityMatrix<double, double
 				const Atom* atom1 = &ucell.atoms[T1];
 				const int nw1_tot = atom1->nw*GlobalV::NPOL;
 				const double Rcut_AO1 = orb.Phi[T1].getRcut(); 
+                const double dist1 = (tau1-tau0).norm() * ucell.lat0;
+                if (dist1 > Rcut_Alpha + Rcut_AO1)
+				{
+					continue;
+				}
 
                 auto row_indexes = pv->get_indexes_row(ibt1);
                 const int row_size = row_indexes.size();
@@ -138,11 +143,9 @@ void LCAO_Deepks::cal_projected_DM(const elecstate::DensityMatrix<double, double
 					const int nw2_tot = atom2->nw*GlobalV::NPOL;
 					
 					const double Rcut_AO2 = orb.Phi[T2].getRcut();
-                	const double dist1 = (tau1-tau0).norm() * ucell.lat0;
                 	const double dist2 = (tau2-tau0).norm() * ucell.lat0;
 
-					if (dist1 > Rcut_Alpha + Rcut_AO1
-							|| dist2 > Rcut_Alpha + Rcut_AO2)
+					if (dist2 > Rcut_Alpha + Rcut_AO2)
 					{
 						continue;
 					}


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #3374 

### What's changed?
- Judge the neighbor before use the two-center integral table

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
