### PR TITLE
Refactor: delete tmp files in md/relax

### DIFF
--- a/source/module_base/global_file.cpp
+++ b/source/module_base/global_file.cpp
@@ -8,6 +8,8 @@
 #include <mpi.h>
 #endif
 
+#include <unistd.h>
+
 #include "global_function.h"
 #include "global_variable.h"
 #include "module_base/parallel_common.h"
@@ -283,5 +285,31 @@ void ModuleBase::Global_File::close_all_log(const int rank, const bool out_alllo
     close_log(GlobalV::ofs_info, "math_info");
 #endif
     return;
+}
+
+void ModuleBase::Global_File::delete_tmp_files()
+{
+    if (GlobalV::MY_RANK == 0)
+    {
+        for (int is = 0; is < GlobalV::NSPIN; ++is)
+        {
+            std::string tmp_chg_1 = GlobalV::global_out_dir + "NOW_SPIN" + std::to_string(is + 1) + "_CHG.cube";
+            std::string tmp_chg_2 = GlobalV::global_out_dir + "OLD1_SPIN" + std::to_string(is + 1) + "_CHG.cube";
+            std::string tmp_chg_3 = GlobalV::global_out_dir + "OLD2_SPIN" + std::to_string(is + 1) + "_CHG.cube";
+
+            if (access(tmp_chg_1.c_str(), 0) == 0)
+            {
+                std::remove(tmp_chg_1.c_str());
+            }
+            if (access(tmp_chg_2.c_str(), 0) == 0)
+            {
+                std::remove(tmp_chg_2.c_str());
+            }
+            if (access(tmp_chg_3.c_str(), 0) == 0)
+            {
+                std::remove(tmp_chg_3.c_str());
+            }
+        }
+    }
 }
 }

--- a/source/module_base/global_file.h
+++ b/source/module_base/global_file.h
@@ -32,6 +32,12 @@ namespace Global_File
 	void open_log ( std::ofstream &ofs, const std::string &fn, const std::string &calculation, const bool &restart);
 	void close_log( std::ofstream &ofs, const std::string &fn);
 	void close_all_log(const int rank, const bool out_alllog = false);
+
+    /**
+     * @brief delete tmperary files
+     *
+     */
+    void delete_tmp_files();
 }
 }
 #endif

--- a/source/module_base/test/global_file_test.cpp
+++ b/source/module_base/test/global_file_test.cpp
@@ -155,3 +155,25 @@ TEST_F(GlobalFile,closealllog)
 		remove("running.log");
 		remove("warning.log");
 }
+
+TEST_F(GlobalFile, DeleteTmpFiles)
+{
+
+    std::string tmp_chg_1 = GlobalV::global_out_dir + "NOW_SPIN1_CHG.cube";
+    std::string tmp_chg_2 = GlobalV::global_out_dir + "OLD1_SPIN1_CHG.cube";
+    std::string tmp_chg_3 = GlobalV::global_out_dir + "OLD2_SPIN1_CHG.cube";
+    std::ofstream ofs1(tmp_chg_1.c_str());
+    std::ofstream ofs2(tmp_chg_2.c_str());
+    std::ofstream ofs3(tmp_chg_3.c_str());
+    ofs1.close();
+    ofs2.close();
+    ofs3.close();
+    EXPECT_TRUE(access(tmp_chg_1.c_str(), 0) == 0);
+    EXPECT_TRUE(access(tmp_chg_2.c_str(), 0) == 0);
+    EXPECT_TRUE(access(tmp_chg_3.c_str(), 0) == 0);
+
+    ModuleBase::Global_File::delete_tmp_files();
+    EXPECT_TRUE(access(tmp_chg_1.c_str(), 0) == -1);
+    EXPECT_TRUE(access(tmp_chg_2.c_str(), 0) == -1);
+    EXPECT_TRUE(access(tmp_chg_3.c_str(), 0) == -1);
+}

--- a/source/module_md/run_md.cpp
+++ b/source/module_md/run_md.cpp
@@ -3,6 +3,7 @@
 #include "fire.h"
 #include "langevin.h"
 #include "md_func.h"
+#include "module_base/global_file.h"
 #include "module_base/timer.h"
 #include "module_io/print_info.h"
 #include "msst.h"
@@ -104,6 +105,8 @@ void md_line(UnitCell& unit_in, ModuleESolver::ESolver* p_esolver, MD_para& md_p
 
         mdrun->step_++;
     }
+
+    ModuleBase::Global_File::delete_tmp_files();
 
     delete mdrun;
     ModuleBase::timer::tick("Run_MD", "md_line");

--- a/source/module_relax/relax_driver.cpp
+++ b/source/module_relax/relax_driver.cpp
@@ -1,5 +1,6 @@
 #include "relax_driver.h"
 
+#include "module_base/global_file.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h" // use chr.
 #include "module_io/print_info.h"
 #include "module_io/write_wfc_r.h"
@@ -123,6 +124,11 @@ void Relax_Driver<FPTYPE, Device>::relax_driver(ModuleESolver::ESolver *p_esolve
     if (GlobalV::OUT_LEVEL == "i")
     {
         std::cout << " ION DYNAMICS FINISHED :)" << std::endl;
+    }
+
+    if (GlobalV::CALCULATION == "relax" || GlobalV::CALCULATION == "cell-relax")
+    {
+        ModuleBase::Global_File::delete_tmp_files();
     }
 
     ModuleBase::timer::tick("Ions", "opt_ions");


### PR DESCRIPTION
### Linked Issue
Fix #3333 

### What's changed?
- delete *_SPIN*_CHG.cube tempary files in md/relax.

