### PR TITLE
Feature: autoset efield related parameters

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -1976,15 +1976,15 @@ These variables are relevant to electric field and dipole correction
 
 - **Type**: Real
 - **Availability**: with efield_flag = True.
-- **Description**: Position of the maximum of the saw-like potential along crystal axis efield_dir, within the  unit cell, 0 < efield_pos_max < 1.
-- **Default**: 0.5
+- **Description**: Position of the maximum of the saw-like potential along crystal axis efield_dir, within the  unit cell, 0 <= efield_pos_max < 1.
+- **Default**: Autoset to `center of vacuum - width of vacuum / 20`
 
 ### efield_pos_dec
 
 - **Type**: Real
 - **Availability**: with efield_flag = True.
 - **Description**: Zone in the unit cell where the saw-like potential decreases, 0 < efield_pos_dec < 1.
-- **Default**: 0.1
+- **Default**: Autoset to `width of vacuum / 10`
 
 ### efield_amp
 

--- a/source/module_elecstate/potentials/efield.cpp
+++ b/source/module_elecstate/potentials/efield.cpp
@@ -38,6 +38,9 @@ ModuleBase::matrix Efield::add_efield(const UnitCell& cell,
     ModuleBase::TITLE("Efield", "add_efield");
     ModuleBase::timer::tick("Efield", "add_efield");
 
+    // set the parameters
+    autoset(cell);
+
     double latvec; // latvec along the efield direction
     double area; // surface area along the efield direction
     prepare(cell, latvec, area);
@@ -301,6 +304,59 @@ void Efield::prepare(const UnitCell &cell, double &latvec, double &area)
         ModuleBase::WARNING_QUIT("Efield::prepare", "direction is wrong!");
     }
     bmod = sqrt(pow(bvec[0], 2) + pow(bvec[1], 2) + pow(bvec[2], 2));
+}
+
+void Efield::autoset(const UnitCell& cell)
+{
+    if (efield_pos_max == -1 || efield_pos_dec == -1)
+    {
+        // obtain the position of atoms along the efield direction
+        std::vector<double> pos;
+        for (int it = 0; it < cell.ntype; ++it)
+        {
+            for (int ia = 0; ia < cell.atoms[it].na; ++ia)
+            {
+                pos.push_back(cell.atoms[it].taud[ia][efield_dir]);
+            }
+        }
+
+        // determine the vacuum region
+        std::sort(pos.begin(), pos.end());
+        double vacuum = 0.0;
+        double center = 0.0;
+        for (int i = 1; i < pos.size(); i++)
+        {
+            double diff = pos[i] - pos[i - 1];
+            if (diff > vacuum)
+            {
+                vacuum = diff;
+                center = (pos[i] + pos[i - 1]) / 2;
+            }
+        }
+
+        // consider the periodic boundary condition
+        double diff = pos[0] + 1 - pos[pos.size() - 1];
+        if (diff > vacuum)
+        {
+            vacuum = diff;
+            center = (pos[0] + pos[pos.size() - 1] + 1) / 2;
+        }
+
+        // set the parameters
+        efield_pos_max = center - vacuum / 20;
+        efield_pos_dec = vacuum / 10;
+        while (efield_pos_max >= 1)
+        {
+            efield_pos_max -= 1;
+        }
+        while (efield_pos_max < 0)
+        {
+            efield_pos_max += 1;
+        }
+
+        ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "Autoset efield_pos_max", efield_pos_max);
+        ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "Autoset efield_pos_dec", efield_pos_dec);
+    }
 }
 
 } // namespace elecstate

--- a/source/module_elecstate/potentials/efield.h
+++ b/source/module_elecstate/potentials/efield.h
@@ -38,6 +38,8 @@ class Efield
 
     static void prepare(const UnitCell &cell, double &latvec, double &area);
 
+    static void autoset(const UnitCell& cell);
+
     static double etotefield; // dipole energy
     static double tot_dipole; // total dipole
     static int efield_dir; // 0, 1, 2 denotes x, y, z direction for dipole correction

--- a/source/module_elecstate/potentials/efield.h
+++ b/source/module_elecstate/potentials/efield.h
@@ -38,7 +38,7 @@ class Efield
 
     static void prepare(const UnitCell &cell, double &latvec, double &area);
 
-    static void autoset(const UnitCell& cell);
+    static void autoset(std::vector<double>& pos);
 
     static double etotefield; // dipole energy
     static double tot_dipole; // total dipole

--- a/source/module_io/DEFAULT_VALUE.conf
+++ b/source/module_io/DEFAULT_VALUE.conf
@@ -176,8 +176,8 @@
     efield_flag  false
     dip_cor_flag  false
     efield_dir  2
-    efield_pos_max  0.5
-    efield_pos_dec  0.1
+    efield_pos_max  -1.0
+    efield_pos_dec  -1.0
     efield_amp  0.0
     gate_flag  false
     zgate  0.5

--- a/source/module_io/input.cpp
+++ b/source/module_io/input.cpp
@@ -366,8 +366,8 @@ void Input::Default(void)
     efield_flag = false;
     dip_cor_flag = false;
     efield_dir = 2;
-    efield_pos_max = 0.5;
-    efield_pos_dec = 0.1;
+    efield_pos_max = -1.0;
+    efield_pos_dec = -1.0;
     efield_amp = 0.0;
     //----------------------------------------------------------
     // gatefield                        Yu Liu add 2022-09-13

--- a/source/module_io/test/input_test.cpp
+++ b/source/module_io/test/input_test.cpp
@@ -210,8 +210,8 @@ TEST_F(InputTest, Default)
         EXPECT_FALSE(INPUT.efield_flag);
         EXPECT_FALSE(INPUT.dip_cor_flag);
         EXPECT_EQ(INPUT.efield_dir,2);
-        EXPECT_DOUBLE_EQ(INPUT.efield_pos_max,0.5);
-        EXPECT_DOUBLE_EQ(INPUT.efield_pos_dec,0.1);
+        EXPECT_DOUBLE_EQ(INPUT.efield_pos_max, -1.0);
+        EXPECT_DOUBLE_EQ(INPUT.efield_pos_dec, -1.0);
         EXPECT_DOUBLE_EQ(INPUT.efield_amp ,0.0);
         EXPECT_FALSE(INPUT.gate_flag);
         EXPECT_DOUBLE_EQ(INPUT.zgate,0.5);

--- a/source/module_io/test/input_test_para.cpp
+++ b/source/module_io/test/input_test_para.cpp
@@ -214,8 +214,8 @@ TEST_F(InputParaTest, Bcast)
     EXPECT_FALSE(INPUT.efield_flag);
     EXPECT_FALSE(INPUT.dip_cor_flag);
     EXPECT_EQ(INPUT.efield_dir, 2);
-    EXPECT_DOUBLE_EQ(INPUT.efield_pos_max, 0.5);
-    EXPECT_DOUBLE_EQ(INPUT.efield_pos_dec, 0.1);
+    EXPECT_DOUBLE_EQ(INPUT.efield_pos_max, -1.0);
+    EXPECT_DOUBLE_EQ(INPUT.efield_pos_dec, -1.0);
     EXPECT_DOUBLE_EQ(INPUT.efield_amp, 0.0);
     EXPECT_FALSE(INPUT.gate_flag);
     EXPECT_DOUBLE_EQ(INPUT.zgate, 0.5);

--- a/tests/integrate/112_PW_dipole/INPUT
+++ b/tests/integrate/112_PW_dipole/INPUT
@@ -24,6 +24,8 @@ mixing_beta		    0.7
 
 efield_flag         1
 dip_cor_flag        1
+efield_pos_max      0.5
+efield_pos_dec      0.1
 efield_amp          0.01
 cal_force           1
 cal_stress          1

--- a/tests/integrate/112_PW_efield/result.ref
+++ b/tests/integrate/112_PW_efield/result.ref
@@ -1,5 +1,5 @@
-etotref -441.7143153067928552
-etotperatomref -147.2381051023
-totalforceref 7.548332
-totalstressref 2052.331678
-totaltimeref 0.62
+etotref -441.7143144800801906
+etotperatomref -147.2381048267
+totalforceref 7.548339
+totalstressref 2052.324249
+totaltimeref 0.30

--- a/tests/integrate/113_PW_gatefield/INPUT
+++ b/tests/integrate/113_PW_gatefield/INPUT
@@ -25,6 +25,8 @@ mixing_beta		    0.7
 
 efield_flag         1
 dip_cor_flag        1
+efield_pos_max      0.5
+efield_pos_dec      0.1
 cal_force           1
 cal_stress          1
 


### PR DESCRIPTION
### Linked Issue
Fix #3386 

### What's changed?
- Autoset `efield_pos_max` and `efield_pos_dec` according to the vacuum region. Specifically, `efield_pos_dec` is auto-set to one-tenth of the vacuum width, `efield_pos_max` is auto-set to the center of the vacuum region minus one-twenty of the vacuum width

