### PR TITLE
fix #2608: change the result.ref in 810_PW_LT_fco

### DIFF
--- a/tests/integrate/810_PW_LT_fco/result.ref
+++ b/tests/integrate/810_PW_LT_fco/result.ref
@@ -1,5 +1,5 @@
-etotref -30.4494090165072109
+etotref -30.4494090165948208
 etotperatomref -15.2247045083
-totalforceref 6.839970
-totalstressref 51.247689
+totalforceref 6.839894
+totalstressref 51.246633
 totaltimeref 


### PR DESCRIPTION
fix #2608 
In #3081 we use reciprocal-space symmetrization for all cases, so the pure-point-group cases' reference value should be changed. 
 #3081 changed the `result.ref` file of 824_NO_LT_fco but forgot to change the one in 810_PW_LT_fco.
Now I change it in this PR. 