### PR TITLE
Fix: recover formatter in write_HS

### DIFF
--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -694,8 +694,8 @@ namespace ModuleESolver
                 this->p_hamilt->matrix(h_mat, s_mat);
                 if (hsolver::HSolverLCAO<TK>::out_mat_hs)
                 {
-                    ModuleIO::save_mat(istep, h_mat.p, GlobalV::NLOCAL, bit, 1, GlobalV::out_app_flag, "H", "data-" + std::to_string(ik), *this->LOWF.ParaV, GlobalV::DRANK);
-                    ModuleIO::save_mat(istep, s_mat.p, GlobalV::NLOCAL, bit, 1, GlobalV::out_app_flag, "S", "data-" + std::to_string(ik), *this->LOWF.ParaV, GlobalV::DRANK);
+                    ModuleIO::save_mat(istep, h_mat.p, GlobalV::NLOCAL, bit, 1, GlobalV::out_app_flag, "H", "data-" + std::to_string(ik), *this->LOWF.ParaV, GlobalV::DRANK, GlobalV::out_ndigits);
+                    ModuleIO::save_mat(istep, s_mat.p, GlobalV::NLOCAL, bit, 1, GlobalV::out_app_flag, "S", "data-" + std::to_string(ik), *this->LOWF.ParaV, GlobalV::DRANK, GlobalV::out_ndigits);
                 }
             }
         }

--- a/source/module_esolver/esolver_ks_lcao_tddft.cpp
+++ b/source/module_esolver/esolver_ks_lcao_tddft.cpp
@@ -260,8 +260,8 @@ void ESolver_KS_LCAO_TDDFT::updatepot(const int istep, const int iter)
                 this->p_hamilt->matrix(h_mat, s_mat);
                 if (hsolver::HSolverLCAO<std::complex<double>>::out_mat_hs)
                 {
-                    ModuleIO::save_mat(istep, h_mat.p, GlobalV::NLOCAL, bit, 1, GlobalV::out_app_flag, "H", "data-" + std::to_string(ik), *this->LOWF.ParaV, GlobalV::DRANK);
-                    ModuleIO::save_mat(istep, h_mat.p, GlobalV::NLOCAL, bit, 1, GlobalV::out_app_flag, "S", "data-" + std::to_string(ik), *this->LOWF.ParaV, GlobalV::DRANK);
+                    ModuleIO::save_mat(istep, h_mat.p, GlobalV::NLOCAL, bit, 1, GlobalV::out_app_flag, "H", "data-" + std::to_string(ik), *this->LOWF.ParaV, GlobalV::DRANK, GlobalV::out_ndigits);
+                    ModuleIO::save_mat(istep, h_mat.p, GlobalV::NLOCAL, bit, 1, GlobalV::out_app_flag, "S", "data-" + std::to_string(ik), *this->LOWF.ParaV, GlobalV::DRANK, GlobalV::out_ndigits);
                 }
             }
         }

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_gamma.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_gamma.cpp
@@ -210,8 +210,8 @@ void Force_LCAO_gamma::allocate_gamma(const Parallel_Orbitals& pv)
         this->UHM->genH
             .build_ST_new('S', cal_deri, GlobalC::ucell, this->UHM->genH.LM->Sloc.data(), INPUT.cal_syns, INPUT.dmax);
         bool bit = false; // LiuXh, 2017-03-21
-        ModuleIO::save_mat(0, this->UHM->genH.LM->Hloc.data(), GlobalV::NLOCAL, bit, 0, GlobalV::out_app_flag, "H", "data-" + std::to_string(0), *this->ParaV, GlobalV::DRANK);
-        ModuleIO::save_mat(0, this->UHM->genH.LM->Sloc.data(), GlobalV::NLOCAL, bit, 0, GlobalV::out_app_flag, "S", "data-" + std::to_string(0), *this->ParaV, GlobalV::DRANK);
+        ModuleIO::save_mat(0, this->UHM->genH.LM->Hloc.data(), GlobalV::NLOCAL, bit, 0, GlobalV::out_app_flag, "H", "data-" + std::to_string(0), *this->ParaV, GlobalV::DRANK, GlobalV::out_ndigits);
+        ModuleIO::save_mat(0, this->UHM->genH.LM->Sloc.data(), GlobalV::NLOCAL, bit, 0, GlobalV::out_app_flag, "S", "data-" + std::to_string(0), *this->ParaV, GlobalV::DRANK, GlobalV::out_ndigits);
     }
 
     ModuleBase::timer::tick("Force_LCAO_gamma", "allocate_gamma");

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_k.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_k.cpp
@@ -243,8 +243,8 @@ void Force_LCAO_k::allocate_k(const Parallel_Orbitals& pv,
             this->UHM->genH.LM->zeros_HSk('S');
             this->UHM->genH.LM->folding_fixedH(ik, kvec_d, 1);
             bool bit = false; // LiuXh, 2017-03-21
-            ModuleIO::save_mat(0, this->UHM->genH.LM->Hloc2.data(), GlobalV::NLOCAL, bit, 0, GlobalV::out_app_flag, "H", "data-" + std::to_string(ik), *this->ParaV, GlobalV::DRANK);
-            ModuleIO::save_mat(0, this->UHM->genH.LM->Sloc2.data(), GlobalV::NLOCAL, bit, 0, GlobalV::out_app_flag, "S", "data-" + std::to_string(ik), *this->ParaV, GlobalV::DRANK);
+            ModuleIO::save_mat(0, this->UHM->genH.LM->Hloc2.data(), GlobalV::NLOCAL, bit, 0, GlobalV::out_app_flag, "H", "data-" + std::to_string(ik), *this->ParaV, GlobalV::DRANK, GlobalV::out_ndigits);
+            ModuleIO::save_mat(0, this->UHM->genH.LM->Sloc2.data(), GlobalV::NLOCAL, bit, 0, GlobalV::out_app_flag, "S", "data-" + std::to_string(ik), *this->ParaV, GlobalV::DRANK, GlobalV::out_ndigits);
         }
     }
 

--- a/source/module_io/write_HS.h
+++ b/source/module_io/write_HS.h
@@ -30,7 +30,8 @@ namespace ModuleIO
         const std::string label,
         const std::string& file_name,
         const Parallel_2D& pv,
-        const int drank);
+        const int drank,
+        const int ndigits);
 
     // comment out this function for not used
     // void save_HSR_tr(const int current_spin, LCAO_Matrix& lm); // LiuXh add 2019-07-15

--- a/source/module_io/write_HS.hpp
+++ b/source/module_io/write_HS.hpp
@@ -1,5 +1,5 @@
 #include "write_HS.h"
-
+#include "module_base/formatter_contextfmt.h"
 #include "module_base/parallel_reduce.h"
 #include "module_base/timer.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
@@ -94,11 +94,15 @@ void ModuleIO::save_mat(const int istep,
     const std::string label,
     const std::string& file_name,
     const Parallel_2D& pv,
-    const int drank)
+    const int drank,
+    const int ndigits)
 {
     ModuleBase::TITLE("ModuleIO", "save_mat");
     ModuleBase::timer::tick("ModuleIO", "save_mat");
     ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "Dimension of " + label + " : ", dim);
+
+    formatter::PhysicalFmt physfmt;
+    physfmt.adjust_formatter_flexible(ndigits, -1, true);
 
     std::stringstream ss;
 

--- a/source/module_io/write_Vxc.hpp
+++ b/source/module_io/write_Vxc.hpp
@@ -190,7 +190,7 @@ namespace ModuleIO
             // write
             ModuleIO::save_mat(-1, vxc_k_mo.data(), nbands,
                 false/*binary*/, true/*triangle*/, false/*append*/,
-                "Vxc", "k-" + std::to_string(ik), p2d, drank);
+                "Vxc", "k-" + std::to_string(ik), p2d, drank, GlobalV::out_ndigits);
             // ======test=======
             // total_energy += all_band_energy(ik, vxc_k_mo, p2d, wg);
             // ======test=======


### PR DESCRIPTION
The precision control using `GlobalV::out_ndigits` in the matrix writing function is deleted by mistake in #3441, now recover it.