### PR TITLE
Refactor：Support custom HexxR to OperatorEXX

### DIFF
--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/op_exx_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/op_exx_lcao.cpp
@@ -33,7 +33,7 @@ void OperatorEXX<OperatorLCAO<double, double>>::contributeHk(int ik)
 				kv,
 				ik,
 				GlobalC::exx_info.info_global.hybrid_alpha,
-                *this->LM->Hexxd,
+                this->Hexxd == nullptr ? *this->LM->Hexxd : *this->Hexxd,
                 *this->LM->ParaV,
                 *this->hK);
 		else
@@ -41,7 +41,7 @@ void OperatorEXX<OperatorLCAO<double, double>>::contributeHk(int ik)
 				kv,
 				ik,
 				GlobalC::exx_info.info_global.hybrid_alpha,
-                *this->LM->Hexxc,
+                this->Hexxc == nullptr ? *this->LM->Hexxc : *this->Hexxc,
                 *this->LM->ParaV,
                 *this->hK);
     }

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/op_exx_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/op_exx_lcao.h
@@ -3,7 +3,8 @@
 #include "module_base/timer.h"
 #include "module_cell/klist.h"
 #include "operator_lcao.h"
-
+#ifdef __EXX
+#include <RI/global/Tensor.h>
 namespace hamilt
 {
 
@@ -20,12 +21,15 @@ class OperatorEXX : public T
 template <typename TK, typename TR>
 class OperatorEXX<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
 {
-  public:
+    using TAC = std::pair<int, std::array<int, 3>>;
+public:
     OperatorEXX<OperatorLCAO<TK, TR>>(LCAO_Matrix* LM_in,
-                                 hamilt::HContainer<TR>* hR_in,
-                                 std::vector<TK>* hK_in,
-                                 const K_Vectors& kv_in)
-        : kv(kv_in), OperatorLCAO<TK, TR>(LM_in, kv_in.kvec_d, hR_in, hK_in)
+        hamilt::HContainer<TR>* hR_in,
+        std::vector<TK>* hK_in,
+        const K_Vectors& kv_in,
+        std::vector<std::map<int, std::map<TAC, RI::Tensor<double>>>>* Hexxd_in = nullptr,
+        std::vector<std::map<int, std::map<TAC, RI::Tensor<std::complex<double>>>>>* Hexxc_in = nullptr)
+        : kv(kv_in), Hexxd(Hexxd_in), Hexxc(Hexxc_in), OperatorLCAO<TK, TR>(LM_in, kv_in.kvec_d, hR_in, hK_in)
     {
         this->cal_type = lcao_exx;
     }
@@ -36,10 +40,14 @@ class OperatorEXX<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
 
   private:
 
-    bool HR_fixed_done = false;
+      bool HR_fixed_done = false;
 
-    const K_Vectors& kv;
+      std::vector<std::map<int, std::map<TAC, RI::Tensor<double>>>>* Hexxd = nullptr;
+      std::vector<std::map<int, std::map<TAC, RI::Tensor<std::complex<double>>>>>* Hexxc = nullptr;
+
+      const K_Vectors& kv;
 };
 
 } // namespace hamilt
+#endif
 #endif


### PR DESCRIPTION
The future implementation of density matrix functional theory will use a different Hexx(R) from the one in `LM`. 

@dyzheng This PR will conflict with #3451, please merge this first and let me solve the conflict in #3451, thanks.