### PR TITLE
Fix: elpa memory leak

### DIFF
--- a/source/module_basis/module_nao/numerical_radial.cpp
+++ b/source/module_basis/module_nao/numerical_radial.cpp
@@ -158,9 +158,9 @@ void NumericalRadial::build(const int l,
 void NumericalRadial::to_numerical_orbital_lm(Numerical_Orbital_Lm& orbital_lm, const int nk_legacy, const double lcao_dk) const
 {
 #ifdef __DEBUG
-    assert(rgrid_ && kgrid_);
-    assert(rgrid_[0] == 0.0 && kgrid_[0] == 0.0);
-    assert(is_uniform(nr_, rgrid_, 1e-14) && is_uniform(nk_, kgrid_, 1e-14));
+    assert(rgrid_);
+    assert(rgrid_[0] == 0.0);
+    assert(is_uniform(nr_, rgrid_, 1e-14));
 
     // Numerical_Orbital_Lm does not support extra exponent in the real space value
     assert(pr_ == 0);
@@ -329,7 +329,7 @@ void NumericalRadial::wipe(const bool r_space, const bool k_space)
         pr_ = 0;
         ircut_ = 0;
     }
-    
+
     if (k_space)
     {
         delete[] kgrid_;

--- a/source/module_hamilt_pw/hamilt_pwdft/hamilt_pw.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/hamilt_pw.cpp
@@ -214,9 +214,6 @@ void HamiltPW<T, Device>::sPsi(const T* psi_in, // psi
     if(GlobalV::use_paw)
     {
 #ifdef USE_PAW
-#ifdef __DEBUG
-        assert(psi.get_k_first());
-#endif
         for(int m = 0; m < nbands; m ++)
         {
             GlobalC::paw_cell.paw_nl_psi(1, reinterpret_cast<const std::complex<double>*> (&psi_in[m * npw]),

--- a/source/module_hsolver/genelpa/elpa_new.cpp
+++ b/source/module_hsolver/genelpa/elpa_new.cpp
@@ -206,6 +206,7 @@ void ELPA_Solver::exit()
         logfile.close();
     int error;
     elpa_deallocate(NEW_ELPA_HANDLE_POOL[handle_id], &error);
+    elpa_uninit(&error);
 }
 
 int ELPA_Solver::read_cpuflag()


### PR DESCRIPTION
### Linked Issue

Fix #3259 

### What's changed

Following the [ELPA docs](https://gitlab.mpcdf.mpg.de/elpa/elpa/-/blob/master/documentation/USERS_GUIDE.md#i-general-concept-of-the-elpa-api), I carefully reviewed the calling process of GenELPA in ABACUS, and found that `elpa_init` did not follow an `elpa_uninit` call. This might causing the memory leak.

@hongriTianqi verified that this patch can mitigate the memory growth when calculating. (Thanks!)

However, please note that the calling convention of GenELPA is malformed. For every SCF step, ELPA and its handle is initialized and released. In my humble opinion, these operations should be done only once. @pplab @dyzheng 
