### PR TITLE
Build: Improving CMake performance for finding LibXC and ELPA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -508,11 +508,12 @@ if(DEFINED Libxc_DIR)
   set(ENABLE_LIBXC ON)
 endif()
 if(ENABLE_LIBXC)
-  find_package(Libxc REQUIRED HINTS
-    ${Libxc_DIR}/share/cmake/Libxc
-    ${Libxc_DIR}/lib/cmake/Libxc
-    ${Libxc_DIR}/lib64/cmake/Libxc
-  )
+#  find_package(Libxc REQUIRED HINTS
+#    ${Libxc_DIR}/share/cmake/Libxc
+#    ${Libxc_DIR}/lib/cmake/Libxc
+#    ${Libxc_DIR}/lib64/cmake/Libxc
+#  )
+  find_package(Libxc REQUIRED)
   message(STATUS "Found Libxc: version " ${Libxc_VERSION})
   if(${Libxc_VERSION} VERSION_LESS 5.1.7)
     message(FATAL_ERROR "LibXC >= 5.1.7 is required.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -508,11 +508,7 @@ if(DEFINED Libxc_DIR)
   set(ENABLE_LIBXC ON)
 endif()
 if(ENABLE_LIBXC)
-#  find_package(Libxc REQUIRED HINTS
-#    ${Libxc_DIR}/share/cmake/Libxc
-#    ${Libxc_DIR}/lib/cmake/Libxc
-#    ${Libxc_DIR}/lib64/cmake/Libxc
-#  )
+  # use `cmake/FindLibxc.cmake` to detect Libxc installation with `pkg-config`
   find_package(Libxc REQUIRED)
   message(STATUS "Found Libxc: version " ${Libxc_VERSION})
   if(${Libxc_VERSION} VERSION_LESS 5.1.7)

--- a/cmake/FindELPA.cmake
+++ b/cmake/FindELPA.cmake
@@ -7,25 +7,6 @@
 #  ELPA_INCLUDE_DIR - Where to find ELPA headers.
 #
 
-find_path(ELPA_INCLUDE_DIR
-    elpa/elpa.h
-    HINTS ${ELPA_DIR}
-    PATH_SUFFIXES "include" "include/elpa"
-    )
-if(USE_OPENMP)
-    find_library(ELPA_LIBRARY
-        NAMES elpa_openmp elpa
-        HINTS ${ELPA_DIR}
-        PATH_SUFFIXES "lib"
-        )
-else()
-    find_library(ELPA_LIBRARY
-        NAMES elpa
-        HINTS ${ELPA_DIR}
-        PATH_SUFFIXES "lib"
-        )
-endif()
-
 find_package(PkgConfig)
 
 if(PKG_CONFIG_FOUND)
@@ -41,17 +22,17 @@ else()
     PATH_SUFFIXES "include" "include/elpa"
     )
   if(USE_OPENMP)
-	  find_library(ELPA_LINK_LIBRARIES
-        NAMES elpa_openmp elpa
-        HINTS ${ELPA_DIR}
-        PATH_SUFFIXES "lib"
-        )
+    find_library(ELPA_LINK_LIBRARIES
+      NAMES elpa_openmp elpa
+      HINTS ${ELPA_DIR}
+      PATH_SUFFIXES "lib"
+      )
   else()
-	  find_library(ELPA_LINK_LIBRARIES
-        NAMES elpa
-        HINTS ${ELPA_DIR}
-        PATH_SUFFIXES "lib"
-        )
+    find_library(ELPA_LINK_LIBRARIES
+      NAMES elpa
+      HINTS ${ELPA_DIR}
+      PATH_SUFFIXES "lib"
+      )
   endif()
   #message(
   #  "ELPA : We need pkg-config to get all information about the elpa library")

--- a/cmake/FindELPA.cmake
+++ b/cmake/FindELPA.cmake
@@ -10,6 +10,9 @@
 find_package(PkgConfig)
 
 if(PKG_CONFIG_FOUND)
+  if(DEFINED ELPA_DIR)
+    string(APPEND CMAKE_PREFIX_PATH ";${ELPA_DIR}")
+  endif()
   if(USE_OPENMP)
     pkg_search_module(ELPA REQUIRED IMPORTED_TARGET GLOBAL elpa_openmp)
   else()

--- a/cmake/FindELPA.cmake
+++ b/cmake/FindELPA.cmake
@@ -7,23 +7,37 @@
 #  ELPA_INCLUDE_DIR - Where to find ELPA headers.
 #
 
-find_path(ELPA_INCLUDE_DIR
-    elpa/elpa.h
-    HINTS ${ELPA_DIR}
-    PATH_SUFFIXES "include" "include/elpa"
-    )
-if(USE_OPENMP)
-    find_library(ELPA_LIBRARY
-        NAMES elpa_openmp elpa
-        HINTS ${ELPA_DIR}
-        PATH_SUFFIXES "lib"
-        )
+# Legacy Routine
+#find_path(ELPA_INCLUDE_DIR
+#    elpa/elpa.h
+#    HINTS ${ELPA_DIR}
+#    PATH_SUFFIXES "include" "include/elpa"
+#    )
+#if(USE_OPENMP)
+#    find_library(ELPA_LIBRARY
+#        NAMES elpa_openmp elpa
+#        HINTS ${ELPA_DIR}
+#        PATH_SUFFIXES "lib"
+#        )
+#else()
+#    find_library(ELPA_LIBRARY
+#        NAMES elpa
+#        HINTS ${ELPA_DIR}
+#        PATH_SUFFIXES "lib"
+#        )
+#endif()
+
+find_package(PkgConfig)
+
+if(PKG_CONFIG_FOUND)
+        if(USE_OPENMP)
+    pkg_search_module(ELPA REQUIRED IMPORTED_TARGET GLOBAL elpa_openmp)
+  else()
+    pkg_search_module(ELPA REQUIRED IMPORTED_TARGET GLOBAL elpa)
+  endif()
 else()
-    find_library(ELPA_LIBRARY
-        NAMES elpa
-        HINTS ${ELPA_DIR}
-        PATH_SUFFIXES "lib"
-        )
+  message(
+    "ELPA : We need pkg-config to get all information about the elpa library")
 endif()
 
 # Handle the QUIET and REQUIRED arguments and
@@ -33,8 +47,8 @@ find_package_handle_standard_args(ELPA DEFAULT_MSG ELPA_LIBRARY ELPA_INCLUDE_DIR
 
 # Copy the results to the output variables and target.
 if(ELPA_FOUND)
-    set(ELPA_LIBRARIES ${ELPA_LIBRARY})
-    set(ELPA_INCLUDE_DIR ${ELPA_INCLUDE_DIR})
+    set(ELPA_LIBRARY ${ELPA_LIBRARIES})
+    set(ELPA_INCLUDE_DIR ${ELPA_INCLUDE_DIRS})
 
     if(NOT TARGET ELPA::ELPA)
         add_library(ELPA::ELPA UNKNOWN IMPORTED)

--- a/cmake/FindELPA.cmake
+++ b/cmake/FindELPA.cmake
@@ -10,7 +10,7 @@
 find_package(PkgConfig)
 
 if(PKG_CONFIG_FOUND)
-        if(USE_OPENMP)
+  if(USE_OPENMP)
     pkg_search_module(ELPA REQUIRED IMPORTED_TARGET GLOBAL elpa_openmp)
   else()
     pkg_search_module(ELPA REQUIRED IMPORTED_TARGET GLOBAL elpa)

--- a/cmake/FindELPA.cmake
+++ b/cmake/FindELPA.cmake
@@ -7,25 +7,24 @@
 #  ELPA_INCLUDE_DIR - Where to find ELPA headers.
 #
 
-# Legacy Routine
-#find_path(ELPA_INCLUDE_DIR
-#    elpa/elpa.h
-#    HINTS ${ELPA_DIR}
-#    PATH_SUFFIXES "include" "include/elpa"
-#    )
-#if(USE_OPENMP)
-#    find_library(ELPA_LIBRARY
-#        NAMES elpa_openmp elpa
-#        HINTS ${ELPA_DIR}
-#        PATH_SUFFIXES "lib"
-#        )
-#else()
-#    find_library(ELPA_LIBRARY
-#        NAMES elpa
-#        HINTS ${ELPA_DIR}
-#        PATH_SUFFIXES "lib"
-#        )
-#endif()
+find_path(ELPA_INCLUDE_DIR
+    elpa/elpa.h
+    HINTS ${ELPA_DIR}
+    PATH_SUFFIXES "include" "include/elpa"
+    )
+if(USE_OPENMP)
+    find_library(ELPA_LIBRARY
+        NAMES elpa_openmp elpa
+        HINTS ${ELPA_DIR}
+        PATH_SUFFIXES "lib"
+        )
+else()
+    find_library(ELPA_LIBRARY
+        NAMES elpa
+        HINTS ${ELPA_DIR}
+        PATH_SUFFIXES "lib"
+        )
+endif()
 
 find_package(PkgConfig)
 
@@ -36,18 +35,36 @@ if(PKG_CONFIG_FOUND)
     pkg_search_module(ELPA REQUIRED IMPORTED_TARGET GLOBAL elpa)
   endif()
 else()
-  message(
-    "ELPA : We need pkg-config to get all information about the elpa library")
+  find_path(ELPA_INCLUDE_DIRS
+    elpa/elpa.h
+    HINTS ${ELPA_DIR}
+    PATH_SUFFIXES "include" "include/elpa"
+    )
+  if(USE_OPENMP)
+	  find_library(ELPA_LINK_LIBRARIES
+        NAMES elpa_openmp elpa
+        HINTS ${ELPA_DIR}
+        PATH_SUFFIXES "lib"
+        )
+  else()
+	  find_library(ELPA_LINK_LIBRARIES
+        NAMES elpa
+        HINTS ${ELPA_DIR}
+        PATH_SUFFIXES "lib"
+        )
+  endif()
+  #message(
+  #  "ELPA : We need pkg-config to get all information about the elpa library")
 endif()
 
 # Handle the QUIET and REQUIRED arguments and
 # set ELPA_FOUND to TRUE if all variables are non-zero.
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(ELPA DEFAULT_MSG ELPA_LIBRARY ELPA_INCLUDE_DIR)
+find_package_handle_standard_args(ELPA DEFAULT_MSG ELPA_LINK_LIBRARIES ELPA_INCLUDE_DIRS)
 
 # Copy the results to the output variables and target.
 if(ELPA_FOUND)
-    set(ELPA_LIBRARY ${ELPA_LIBRARIES})
+    set(ELPA_LIBRARY ${ELPA_LINK_LIBRARIES})
     set(ELPA_INCLUDE_DIR ${ELPA_INCLUDE_DIRS})
 
     if(NOT TARGET ELPA::ELPA)

--- a/cmake/FindLibxc.cmake
+++ b/cmake/FindLibxc.cmake
@@ -17,6 +17,9 @@ include(FindPackageHandleStandardArgs)
 
 find_package(PkgConfig)
 
+if(DEFINED Libxc_DIR)
+  string(APPEND CMAKE_PREFIX_PATH ";${Libxc_DIR}")
+endif()
 # Using CMake interface as default.
 # NO REQUIRED here, otherwhile it would throw error
 # with no LibXC found.
@@ -28,6 +31,9 @@ find_package(Libxc HINTS
 if(NOT Libxc_FOUND AND PKG_CONFIG_FOUND)
   pkg_search_module(Libxc REQUIRED IMPORTED_TARGET GLOBAL libxc)
   find_package_handle_standard_args(Libxc DEFAULT_MSG Libxc_LINK_LIBRARIES Libxc_INCLUDE_DIRS)
+elseif(NOT PKG_CONFIG_FOUND)
+  message(FATAL_ERROR
+          "LibXC : We need pkg-config to get all information about the libxc library")
 endif()
 
 # Copy the results to the output variables and target.
@@ -41,9 +47,6 @@ if(Libxc_FOUND AND NOT TARGET Libxc::xc)
 	set_target_properties(Libxc::xc PROPERTIES
 		IMPORTED_LOCATION "${Libxc_LIBRARY}"
 		INTERFACE_INCLUDE_DIRECTORIES "${Libxc_INCLUDE_DIR}")
-elseif(NOT Libxc_FOUND)
-  message(FATAL_ERROR
-          "LibXC : We need pkg-config to get all information about the libxc library")
 endif()
 
 set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${Libxc_INCLUDE_DIR})

--- a/cmake/FindLibxc.cmake
+++ b/cmake/FindLibxc.cmake
@@ -31,7 +31,7 @@ find_package(Libxc HINTS
 if(NOT TARGET Libxc::xc AND PKG_CONFIG_FOUND)
   pkg_search_module(Libxc REQUIRED IMPORTED_TARGET GLOBAL libxc)
   find_package_handle_standard_args(Libxc DEFAULT_MSG Libxc_LINK_LIBRARIES Libxc_INCLUDE_DIRS)
-elseif(NOT PKG_CONFIG_FOUND)
+elseif(NOT TARGET Libxc::xc NOT PKG_CONFIG_FOUND)
   message(FATAL_ERROR
           "LibXC : We need pkg-config to get all information about the libxc library")
 endif()

--- a/cmake/FindLibxc.cmake
+++ b/cmake/FindLibxc.cmake
@@ -31,7 +31,7 @@ find_package(Libxc HINTS
 if(NOT TARGET Libxc::xc AND PKG_CONFIG_FOUND)
   pkg_search_module(Libxc REQUIRED IMPORTED_TARGET GLOBAL libxc)
   find_package_handle_standard_args(Libxc DEFAULT_MSG Libxc_LINK_LIBRARIES Libxc_INCLUDE_DIRS)
-elseif(NOT TARGET Libxc::xc NOT PKG_CONFIG_FOUND)
+elseif(NOT TARGET Libxc::xc AND NOT PKG_CONFIG_FOUND)
   message(FATAL_ERROR
           "LibXC : We need pkg-config to get all information about the libxc library")
 endif()

--- a/cmake/FindLibxc.cmake
+++ b/cmake/FindLibxc.cmake
@@ -1,0 +1,43 @@
+###############################################################################
+# - Find ELPA
+# Find the native ELPA headers and libraries.
+#
+#  ELPA_FOUND        - True if libelpa is found.
+#  ELPA_LIBRARIES    - List of libraries when using libyaml
+#  ELPA_INCLUDE_DIR - Where to find ELPA headers.
+#
+
+#find_path(ELPA_INCLUDE_DIR
+#    elpa/elpa.h
+#    HINTS ${ELPA_DIR}
+#    PATH_SUFFIXES "include" "include/elpa"
+#    )
+
+find_package(PkgConfig)
+
+if(PKG_CONFIG_FOUND)
+	pkg_search_module(Libxc REQUIRED IMPORTED_TARGET GLOBAL libxc)
+else()
+  message(
+	  "LibXC : We need pkg-config to get all information about the libxc library")
+endif()
+
+# Handle the QUIET and REQUIRED arguments and
+# set ELPA_FOUND to TRUE if all variables are non-zero.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Libxc DEFAULT_MSG Libxc_LINK_LIBRARIES Libxc_INCLUDE_DIRS)
+
+# Copy the results to the output variables and target.
+if(Libxc_FOUND AND NOT TARGET Libxc::xc)
+	set(Libxc_LIBRARY ${Libxc_LINK_LIBRARIES})
+	set(Libxc_LIBRARIES ${Libxc_LIBRARY})
+	set(Libxc_INCLUDE_DIR ${Libxc_INCLUDE_DIRS})
+	add_library(Libxc::xc UNKNOWN IMPORTED)
+	set_target_properties(Libxc::xc PROPERTIES
+		IMPORTED_LOCATION "${Libxc_LIBRARY}"
+		INTERFACE_INCLUDE_DIRECTORIES "${Libxc_INCLUDE_DIR}")
+endif()
+
+set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${Libxc_INCLUDE_DIR})
+
+mark_as_advanced(Libxc_INCLUDE_DIR Libxc_LIBRARY)

--- a/cmake/FindLibxc.cmake
+++ b/cmake/FindLibxc.cmake
@@ -1,21 +1,4 @@
-###############################################################################
-# - Find ELPA
-# Find the native ELPA headers and libraries.
-#
-#  ELPA_FOUND        - True if libelpa is found.
-#  ELPA_LIBRARIES    - List of libraries when using libyaml
-#  ELPA_INCLUDE_DIR - Where to find ELPA headers.
-#
-
-#find_path(ELPA_INCLUDE_DIR
-#    elpa/elpa.h
-#    HINTS ${ELPA_DIR}
-#    PATH_SUFFIXES "include" "include/elpa"
-#    )
-
 include(FindPackageHandleStandardArgs)
-
-find_package(PkgConfig)
 
 if(DEFINED Libxc_DIR)
   string(APPEND CMAKE_PREFIX_PATH ";${Libxc_DIR}")
@@ -28,13 +11,12 @@ find_package(Libxc HINTS
     ${Libxc_DIR}/lib/cmake/Libxc
     ${Libxc_DIR}/lib64/cmake/Libxc
   )
-if(NOT TARGET Libxc::xc AND PKG_CONFIG_FOUND)
+if(NOT TARGET Libxc::xc)
+  find_package(PkgConfig REQUIRED)
   pkg_search_module(Libxc REQUIRED IMPORTED_TARGET GLOBAL libxc)
-  find_package_handle_standard_args(Libxc DEFAULT_MSG Libxc_LINK_LIBRARIES Libxc_INCLUDE_DIRS)
-elseif(NOT TARGET Libxc::xc AND NOT PKG_CONFIG_FOUND)
-  message(FATAL_ERROR
-          "LibXC : We need pkg-config to get all information about the libxc library")
 endif()
+
+find_package_handle_standard_args(Libxc DEFAULT_MSG Libxc_LINK_LIBRARIES Libxc_INCLUDE_DIRS)
 
 # Copy the results to the output variables and target.
 # if find_package() above works, Libxc::xc would be present and

--- a/cmake/FindLibxc.cmake
+++ b/cmake/FindLibxc.cmake
@@ -28,7 +28,7 @@ find_package(Libxc HINTS
     ${Libxc_DIR}/lib/cmake/Libxc
     ${Libxc_DIR}/lib64/cmake/Libxc
   )
-if(NOT Libxc_FOUND AND PKG_CONFIG_FOUND)
+if(NOT TARGET Libxc::xc AND PKG_CONFIG_FOUND)
   pkg_search_module(Libxc REQUIRED IMPORTED_TARGET GLOBAL libxc)
   find_package_handle_standard_args(Libxc DEFAULT_MSG Libxc_LINK_LIBRARIES Libxc_INCLUDE_DIRS)
 elseif(NOT PKG_CONFIG_FOUND)

--- a/cmake/FindLibxc.cmake
+++ b/cmake/FindLibxc.cmake
@@ -13,19 +13,22 @@
 #    PATH_SUFFIXES "include" "include/elpa"
 #    )
 
+include(FindPackageHandleStandardArgs)
+
 find_package(PkgConfig)
 
 if(PKG_CONFIG_FOUND)
-	pkg_search_module(Libxc REQUIRED IMPORTED_TARGET GLOBAL libxc)
+  pkg_search_module(Libxc REQUIRED IMPORTED_TARGET GLOBAL libxc)
+  find_package_handle_standard_args(Libxc DEFAULT_MSG Libxc_LINK_LIBRARIES Libxc_INCLUDE_DIRS)
 else()
-  message(
-	  "LibXC : We need pkg-config to get all information about the libxc library")
+  find_package(Libxc REQUIRED HINTS
+    ${Libxc_DIR}/share/cmake/Libxc
+    ${Libxc_DIR}/lib/cmake/Libxc
+    ${Libxc_DIR}/lib64/cmake/Libxc
+  )
+  #message(
+  #	  "LibXC : We need pkg-config to get all information about the libxc library")
 endif()
-
-# Handle the QUIET and REQUIRED arguments and
-# set ELPA_FOUND to TRUE if all variables are non-zero.
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Libxc DEFAULT_MSG Libxc_LINK_LIBRARIES Libxc_INCLUDE_DIRS)
 
 # Copy the results to the output variables and target.
 if(Libxc_FOUND AND NOT TARGET Libxc::xc)

--- a/cmake/FindLibxc.cmake
+++ b/cmake/FindLibxc.cmake
@@ -14,9 +14,9 @@ find_package(Libxc HINTS
 if(NOT TARGET Libxc::xc)
   find_package(PkgConfig REQUIRED)
   pkg_search_module(Libxc REQUIRED IMPORTED_TARGET GLOBAL libxc)
+  find_package_handle_standard_args(Libxc DEFAULT_MSG Libxc_LINK_LIBRARIES Libxc_INCLUDE_DIRS)
 endif()
 
-find_package_handle_standard_args(Libxc DEFAULT_MSG Libxc_LINK_LIBRARIES Libxc_INCLUDE_DIRS)
 
 # Copy the results to the output variables and target.
 # if find_package() above works, Libxc::xc would be present and

--- a/docs/quick_start/easy_install.md
+++ b/docs/quick_start/easy_install.md
@@ -116,7 +116,7 @@ Here, 'build' is the path for building ABACUS; and '-D' is used for setting up s
   - `FFTW3_DIR`: Path to FFTW3.
   - `CEREAL_INCLUDE_DIR`: Path to the parent folder of `cereal/cereal.hpp`. Will download from GitHub if absent.
   - `Libxc_DIR`: (Optional) Path to Libxc.
-  > Note: Building Libxc from source with Makefile does NOT support using it in CMake here. Please compile Libxc with CMake instead.
+  > Note: In ABACUS v3.5.1 or earlier, Libxc built from source with Makefile is NOT supported; please compile Libxc with CMake instead.
   - `LIBRI_DIR`: (Optional) Path to LibRI.
   - `LIBCOMM_DIR`: (Optional) Path to LibComm.
 

--- a/docs/quick_start/easy_install.md
+++ b/docs/quick_start/easy_install.md
@@ -111,7 +111,7 @@ Here, 'build' is the path for building ABACUS; and '-D' is used for setting up s
   - `LAPACK_DIR`: Path to OpenBLAS library `libopenblas.so`(including BLAS and LAPACK)
   - `SCALAPACK_DIR`: Path to ScaLAPACK library `libscalapack.so`
   - `ELPA_DIR`: Path to ELPA install directory; should be the folder containing 'include' and 'lib'.
-  > Note: If you install ELPA from source, please add a symlink to avoid the additional include file folder with version name: `ln -s elpa/include/elpa-2021.05.002/elpa elpa/include/elpa`. This is a known behavior of ELPA.
+  > Note: If you install ELPA from source and have no `pkg-config` installed, please add a symlink to avoid the additional include file folder with version name: `ln -s elpa/include/elpa-2021.05.002/elpa elpa/include/elpa` to help the build system find ELPA headers.
 
   - `FFTW3_DIR`: Path to FFTW3.
   - `CEREAL_INCLUDE_DIR`: Path to the parent folder of `cereal/cereal.hpp`. Will download from GitHub if absent.

--- a/docs/quick_start/easy_install.md
+++ b/docs/quick_start/easy_install.md
@@ -28,7 +28,7 @@ These requirements support the calculation of plane-wave basis in ABACUS. For LC
 Some of these packages can be installed with popular package management system, such as `apt` and `yum`:
 
 ```bash
-sudo apt update && sudo apt install -y libopenblas-openmp-dev liblapack-dev libscalapack-mpi-dev libelpa-dev libfftw3-dev libcereal-dev libxc-dev g++ make cmake bc git
+sudo apt update && sudo apt install -y libopenblas-openmp-dev liblapack-dev libscalapack-mpi-dev libelpa-dev libfftw3-dev libcereal-dev libxc-dev g++ make cmake bc git pkgconf
 ```
 
 > Installing ELPA by apt only matches requirements on Ubuntu 22.04. For earlier linux distributions, you should build ELPA from source.

--- a/docs/quick_start/easy_install.md
+++ b/docs/quick_start/easy_install.md
@@ -111,7 +111,7 @@ Here, 'build' is the path for building ABACUS; and '-D' is used for setting up s
   - `LAPACK_DIR`: Path to OpenBLAS library `libopenblas.so`(including BLAS and LAPACK)
   - `SCALAPACK_DIR`: Path to ScaLAPACK library `libscalapack.so`
   - `ELPA_DIR`: Path to ELPA install directory; should be the folder containing 'include' and 'lib'.
-  > Note: If you install ELPA from source and have no `pkg-config` installed, please add a symlink to avoid the additional include file folder with version name: `ln -s elpa/include/elpa-2021.05.002/elpa elpa/include/elpa` to help the build system find ELPA headers.
+  > Note: In ABACUS v3.5.1 or earlier, if you install ELPA from source , please add a symlink to avoid the additional include file folder with version name: `ln -s elpa/include/elpa-2021.05.002/elpa elpa/include/elpa` to help the build system find ELPA headers.
 
   - `FFTW3_DIR`: Path to FFTW3.
   - `CEREAL_INCLUDE_DIR`: Path to the parent folder of `cereal/cereal.hpp`. Will download from GitHub if absent.


### PR DESCRIPTION
### Reminder
- [X] Have you linked an issue with this pull request?
- [X] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Implementation of #3252

### What's changed?
- Changed ELPA detection from CMake findlibrary() driven to pkg-config driven, making unrenamed ELPA include dir supported; 
- Added pkg-config driven LibXC detection to support a wider range of LibXC installation, e. g. installed via gnu autotools. 

### Any changes of core modules? (ignore if not applicable)
- No.
