### PR TITLE
fix: bug in Autotest.sh when result.ref has no totaltimeref

### DIFF
--- a/tests/integrate/Autotest.sh
+++ b/tests/integrate/Autotest.sh
@@ -74,6 +74,11 @@ check_out(){
     # check every 'key' word
     #------------------------------------------------------
     for key in $properties; do
+    
+        if [ $key == "totaltimeref" ]; then
+            # echo "time=$cal ref=$ref"
+            break
+        fi
 
         #--------------------------------------------------
         # calculated value
@@ -90,11 +95,6 @@ check_out(){
         # and reference value
         #--------------------------------------------------
         deviation=`awk 'BEGIN {x='$ref';y='$cal';printf "%.'$ca'f\n",x-y}'`
-
-        if [ $key == "totaltimeref" ]; then
-            # echo "time=$cal ref=$ref"
-            break
-        fi
 
 
         #--------------------------------------------------


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #3522 

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
