### PR TITLE
Feature: Pythonization of math_integral in Module Base

### DIFF
--- a/python/pyabacus/CMakeLists.txt
+++ b/python/pyabacus/CMakeLists.txt
@@ -8,7 +8,6 @@ project(
 find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
 find_package(pybind11 CONFIG REQUIRED)
 
-set(BASE_PATH "${PROJECT_SOURCE_DIR}/../../source/module_base")
 set(ABACUS_SOURCE_DIR "${PROJECT_SOURCE_DIR}/../../source")
 include_directories(${BASE_PATH} ${ABACUS_SOURCE_DIR})
 list(APPEND _sources
@@ -17,6 +16,8 @@ list(APPEND _sources
     ${ABACUS_SOURCE_DIR}/module_base/constants.h
     ${ABACUS_SOURCE_DIR}/module_base/math_sphbes.h
     ${ABACUS_SOURCE_DIR}/module_base/math_sphbes.cpp
+    ${ABACUS_SOURCE_DIR}/module_base/math_integral.h
+    ${ABACUS_SOURCE_DIR}/module_base/math_integral.cpp
     ${PROJECT_SOURCE_DIR}/src/py_abacus.cpp
     #${PROJECT_SOURCE_DIR}/src/py_numerical_radial.cpp
     ${PROJECT_SOURCE_DIR}/src/py_math_base.cpp)

--- a/python/pyabacus/pyproject.toml
+++ b/python/pyabacus/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest"]
+test = ["pytest", "numpy"]
 
 
 [tool.scikit-build]

--- a/python/pyabacus/src/py_math_base.cpp
+++ b/python/pyabacus/src/py_math_base.cpp
@@ -2,6 +2,7 @@
 #include <pybind11/pybind11.h>
 
 #include "module_base/math_sphbes.h"
+#include "module_base/math_integral.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;
@@ -12,6 +13,7 @@ void bind_math_base(py::module& m)
 {
     py::module module_base = m.def_submodule("ModuleBase");
 
+    // python binding for class Sphbes
     py::class_<ModuleBase::Sphbes>(module_base, "Sphbes")
         .def(py::init<>())
         .def_static("sphbesj", overload_cast_<const int, const double>()(&ModuleBase::Sphbes::sphbesj), "l"_a, "x"_a)
@@ -59,5 +61,162 @@ void bind_math_base(py::module& m)
                 throw std::runtime_error("zeros array must be 1-dimensional");
             }
             ModuleBase::Sphbes::sphbes_zeros(l, n, static_cast<double* const>(zeros_info.ptr));
+        });
+
+    // python binding for class Integral
+    py::class_<ModuleBase::Integral>(module_base, "Integral")
+        .def(py::init<>())
+        .def_static("Simpson_Integral", [](const int mesh, py::array_t<double> func, py::array_t<double> rab, double asum) {
+            py::buffer_info func_info = func.request();
+            if (func_info.ndim != 1)
+            {
+                throw std::runtime_error("func array must be 1-dimensional");
+            }
+            py::buffer_info rab_info = rab.request();
+            if (rab.ndim() != 1)
+            {
+                throw std::runtime_error("rab array must be 1-dimensional");
+            }
+
+            double isum = asum;
+            ModuleBase::Integral::Simpson_Integral(mesh,
+                                                    static_cast<const double* const>(func_info.ptr),
+                                                    static_cast<const double* const>(rab_info.ptr),
+                                                    isum);
+            return isum;
+        })
+        .def_static("Simpson_Integral", [](const int mesh, py::array_t<double> func, const double dr, double asum){
+            py::buffer_info func_info = func.request();
+            if (func_info.ndim != 1)
+            {
+                throw std::runtime_error("func array must be 1-dimensional");
+            }
+                
+                double isum = asum;
+                ModuleBase::Integral::Simpson_Integral(mesh,
+                                                        static_cast<const double* const>(func_info.ptr),
+                                                        dr,
+                                                        isum);
+                return isum;
+        })
+        .def_static("Simpson_Integral_0toall", [](const int mesh, py::array_t<double> func, py::array_t<double> rab, py::array_t<double> asum){
+            py::buffer_info func_info = func.request();
+            if (func_info.ndim != 1)
+            {
+                throw std::runtime_error("func array must be 1-dimensional");
+            }
+            py::buffer_info rab_info = rab.request();
+            if (rab.ndim() != 1)
+            {
+                throw std::runtime_error("rab array must be 1-dimensional");
+            }
+            py::buffer_info asum_info = asum.request();
+            if (asum.ndim() != 1)
+            {
+                throw std::runtime_error("asum array must be 1-dimensional");
+            }
+            ModuleBase::Integral::Simpson_Integral_0toall(mesh,
+                                                            static_cast<const double* const>(func_info.ptr),
+                                                            static_cast<const double* const>(rab_info.ptr),
+                                                            static_cast<double* const>(asum_info.ptr));
+        })
+        .def_static("Simpson_Integral_alltoinf", [](const int mesh, py::array_t<double> func, py::array_t<double> rab, py::array_t<double> asum){
+            py::buffer_info func_info = func.request();
+            if (func_info.ndim != 1)
+            {
+                throw std::runtime_error("func array must be 1-dimensional");
+            }
+            py::buffer_info rab_info = rab.request();
+            if (rab.ndim() != 1)
+            {
+                throw std::runtime_error("rab array must be 1-dimensional");
+            }
+            py::buffer_info asum_info = asum.request();
+            if (asum.ndim() != 1)
+            {
+                throw std::runtime_error("asum array must be 1-dimensional");
+            }
+            ModuleBase::Integral::Simpson_Integral_alltoinf(mesh,
+                                                            static_cast<const double* const>(func_info.ptr),
+                                                            static_cast<const double* const>(rab_info.ptr),
+                                                            static_cast<double* const>(asum_info.ptr));
+        })
+        .def_static("Simpson_Integral_alltoinf", [](const int mesh, py::array_t<double> func, py::array_t<double> rab, py::array_t<double> asum){
+            py::buffer_info func_info = func.request();
+            if (func_info.ndim != 1)
+            {
+                throw std::runtime_error("func array must be 1-dimensional");
+            }
+            py::buffer_info rab_info = rab.request();
+            if (rab.ndim() != 1)
+            {
+                throw std::runtime_error("rab array must be 1-dimensional");
+            }
+            py::buffer_info asum_info = asum.request();
+            if (asum.ndim() != 1)
+            {
+                throw std::runtime_error("asum array must be 1-dimensional");
+            }
+            ModuleBase::Integral::Simpson_Integral_alltoinf(mesh,
+                                                            static_cast<const double* const>(func_info.ptr),
+                                                            static_cast<const double* const>(rab_info.ptr),
+                                                            static_cast<double* const>(asum_info.ptr));
+        })
+        .def_static("simpson", [](const int n, py::array_t<double> f, const double dx){
+            py::buffer_info f_info = f.request();
+            if (f_info.ndim != 1)
+            {
+                throw std::runtime_error("f array must be 1-dimensional");
+            }
+            return ModuleBase::Integral::simpson(n,
+                                                    static_cast<const double* const>(f_info.ptr),
+                                                    dx);
+        })
+        .def_static("simpson", [](const int n, py::array_t<double> f, py::array_t<double> h){
+            py::buffer_info f_info = f.request();
+            if (f_info.ndim != 1)
+            {
+                throw std::runtime_error("f array must be 1-dimensional");
+            }
+            py::buffer_info h_info = h.request();
+            if (h.ndim() != 1)
+            {
+                throw std::runtime_error("h array must be 1-dimensional");
+            }
+            return ModuleBase::Integral::simpson(n,
+                                                    static_cast<const double* const>(f_info.ptr),
+                                                    static_cast<const double* const>(h_info.ptr));
+        })
+        .def_static("Gauss_Legendre_grid_and_weight", [](const int n, py::array_t<double> x, py::array_t<double> w){
+            py::buffer_info x_info = x.request();
+            if (x_info.ndim != 1)
+            {
+                throw std::runtime_error("x array must be 1-dimensional");
+            }
+            py::buffer_info w_info = w.request();
+            if (w.ndim() != 1)
+            {
+                throw std::runtime_error("w array must be 1-dimensional");
+            }
+            ModuleBase::Integral::Gauss_Legendre_grid_and_weight(n,
+                                                                    static_cast<double*>(x_info.ptr),
+                                                                    static_cast<double*>(w_info.ptr));
+        })
+        .def_static("Gauss_Legendre_grid_and_weight", [](const double xmin, const double xmax, const int n, py::array_t<double> x, py::array_t<double> w){
+            py::buffer_info x_info = x.request();
+            if (x_info.ndim != 1)
+            {
+                throw std::runtime_error("x array must be 1-dimensional");
+            }
+            py::buffer_info w_info = w.request();
+            if (w.ndim() != 1)
+            {
+                throw std::runtime_error("w array must be 1-dimensional");
+            }
+            ModuleBase::Integral::Gauss_Legendre_grid_and_weight(xmin,
+                                                                    xmax,
+                                                                    n,
+                                                                    static_cast<double*>(x_info.ptr),
+                                                                    static_cast<double*>(w_info.ptr));
         });
 }

--- a/python/pyabacus/tests/test_base_math.py
+++ b/python/pyabacus/tests/test_base_math.py
@@ -1,15 +1,29 @@
 from __future__ import annotations
 
+import pytest
 import pyabacus as m
 import numpy as np
 
 
-def test_version():
-    assert m.__version__ == "0.0.1"
 
 def test_sphbes():
     s = m.ModuleBase.Sphbes()
     # test for sphbesj
     assert s.sphbesj(1, 0.0) == 0.0
     assert s.sphbesj(0, 0.0) == 1.0
+
+@pytest.fixture
+def simpson_setup():
+    n = 1000
+    x = np.linspace(0, 2*np.pi, n)
+    func = np.sin(x)
+    dx = 2 * np.pi / (n - 1)
+    return n, func, dx
+
+def test_simpson(simpson_setup):
+    n, func, dx= simpson_setup
+    s = m.ModuleBase.Integral()
+    assert s.simpson(n, func, dx) == pytest.approx(0, abs=1e-10)
+    
+
 


### PR DESCRIPTION
As mentioned in #3207, add python wrapper for [math_integral](https://github.com/deepmodeling/abacus-develop/blob/develop/source/module_base/math_integral.h) and add pytest support.