### PR TITLE
Feature: support double_grid in `mix_rho_recip_new()`

### DIFF
--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -417,6 +417,15 @@ void Charge_Mixing::mix_rho_recip_new(Charge* chr)
         // delete
         delete[] rhog_mag;
         delete[] rhog_mag_save;
+        // get rhogs_out for combine_data()
+        if (GlobalV::double_grid)
+        {
+            for (int ig = 0; ig < npw; ig++)
+            {
+                rhogs_out[ig] = chr->rhog[0][ig];
+                rhogs_out[ig + npw] = chr->rhog[1][ig];
+            }
+        }
     }
     else if (GlobalV::NSPIN == 4 && GlobalV::MIXING_ANGLE <= 0)
     {

--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -316,12 +316,6 @@ void Charge_Mixing::mix_rho_recip(Charge* chr)
 
 void Charge_Mixing::mix_rho_recip_new(Charge* chr)
 {
-    // old support see mix_rho_recip()
-    if (GlobalV::double_grid)
-    {
-        ModuleBase::WARNING_QUIT("Charge_Mixing", "double_grid is not supported for new mixing method yet.");
-    }
-
     std::complex<double>* rhog_in = nullptr;
     std::complex<double>* rhog_out = nullptr;
     // for smooth part
@@ -430,8 +424,8 @@ void Charge_Mixing::mix_rho_recip_new(Charge* chr)
     else if (GlobalV::NSPIN == 4 && GlobalV::MIXING_ANGLE <= 0)
     {
         // normal broyden mixing for {rho, mx, my, mz}
-        rhog_in = chr->rhog_save[0];
-        rhog_out = chr->rhog[0];
+        rhog_in = rhogs_in;
+        rhog_out = rhogs_out;
         const int npw = this->rhopw->npw;
         auto screen = std::bind(&Charge_Mixing::Kerker_screen_recip_new, this, std::placeholders::_1); // use old one
         auto twobeta_mix
@@ -460,6 +454,11 @@ void Charge_Mixing::mix_rho_recip_new(Charge* chr)
     {
         // special broyden mixing for {rho, |m|} proposed by J. Phys. Soc. Jpn. 82 (2013) 114706
         // here only consider the case of mixing_angle = 1, which mean only change |m| and keep angle fixed
+        // old support see mix_rho_recip()
+        if (GlobalV::double_grid)
+        {
+            ModuleBase::WARNING_QUIT("Charge_Mixing", "double_grid is not supported for new mixing method yet.");
+        }
         // allocate memory for rho_magabs and rho_magabs_save
         const int nrxx = this->rhopw->nrxx;
         double* rho_magabs = new double[nrxx];

--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -535,6 +535,17 @@ void Charge_Mixing::mix_rho_recip_new(Charge* chr)
         delete[] rho_magabs_save;
     }
 
+    if (GlobalV::double_grid)
+    {
+        // plain mixing for high_frequencies
+        const int ndimhf = (this->rhodpw->npw - this->rhopw->npw) * GlobalV::NSPIN;
+        this->mixing_highf->plain_mix(rhoghf_out, rhoghf_in, rhoghf_out, ndimhf, nullptr);
+
+        // combine smooth part and high_frequency part
+        combine_data(chr->rhog[0], rhogs_out, rhoghf_out);
+        clean_data(rhogs_in, rhoghf_in);
+    }
+
     // rhog to rho
     if (GlobalV::NSPIN == 4 && GlobalV::MIXING_ANGLE > 0)
     {

--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -549,13 +549,17 @@ void Charge_Mixing::mix_rho_recip_new(Charge* chr)
     // rhog to rho
     if (GlobalV::NSPIN == 4 && GlobalV::MIXING_ANGLE > 0)
     {
+        // only tranfer rhog[0]
+        // do not support double_grid, use rhopw directly
         chr->rhopw->recip2real(chr->rhog[0], chr->rho[0]);
     }
     else
     {
         for (int is = 0; is < GlobalV::NSPIN; is++)
         {
-            chr->rhopw->recip2real(chr->rhog[is], chr->rho[is]);
+            // use rhodpw for double_grid
+            // rhodpw is the same as rhopw for !GlobalV::double_grid
+            this->rhodpw->recip2real(chr->rhog[is], chr->rho[is]);
         }
     }
 

--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -609,6 +609,20 @@ void Charge_Mixing::mix_rho_recip_new(Charge* chr)
         }
     }
 
+#ifdef USE_PAW
+    if(GlobalV::use_paw)
+    {
+        double *nhat_out, *nhat_in;
+        nhat_in = chr->nhat_save[0];
+        nhat_out = chr->nhat[0];
+        // Note: there is no kerker modification for tau because I'm not sure
+        // if we should have it. If necessary we can try it in the future.
+        this->mixing->push_data(this->nhat_mdata, nhat_in, nhat_out, nullptr, false);
+
+        this->mixing->mix_data(this->nhat_mdata, nhat_out);
+    }
+#endif
+
     return;
 }
 

--- a/source/module_elecstate/module_charge/charge_mixing.h
+++ b/source/module_elecstate/module_charge/charge_mixing.h
@@ -44,7 +44,6 @@ class Charge_Mixing
      * @brief charge mixing for reciprocal space
      *
      */
-    void mix_rho_recip(Charge* chr);
     void mix_rho_recip_new(Charge* chr);
 
     /**

--- a/tests/integrate/101_PW_upf201_uspp_Fe/INPUT
+++ b/tests/integrate/101_PW_upf201_uspp_Fe/INPUT
@@ -24,6 +24,9 @@ smearing_sigma         0.02
 #parameters (5.Mixing)
 mixing_type            pulay
 mixing_beta            0.4
+mixing_beta_mag        0.4
+mixing_gg0             1.0
+mixing_gg0_mag         1.0
 
 pseudo_mesh            1
 pseudo_rcut            10


### PR DESCRIPTION
Fix #3520.

1. Based on `mix_rho_recip()`, support `Global::double_grid` and `PAW` in `mix_rho_recip_new()` as well.
2. Only perform DIIS mixing for `rhogs`, while make plain mixing for `rhoghf`.
3. delete `mix_rho_recip()`.