### PR TITLE
Refactor: charge_mixing::set_mixing()

### DIFF
--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -42,6 +42,17 @@ void Charge_Mixing::set_mixing(const std::string& mixing_mode_in,
     this->mixing_angle = mixing_angle_in;
     this->mixing_dmr = mixing_dmr_in;
 
+    // check the paramters
+    if (GlobalV::MIXING_BETA > 1.0 || GlobalV::MIXING_BETA < 0.0)
+    {
+        ModuleBase::WARNING_QUIT("Charge_Mixing", "You'd better set mixing_beta to [0.0, 1.0]!");
+    }
+    if (GlobalV::MIXING_BETA_MAG < 0.0)
+    {
+        ModuleBase::WARNING_QUIT("Charge_Mixing", "You'd better set mixing_beta_mag >= 0.0!");
+    }
+
+    // print into running.log
     GlobalV::ofs_running<<"\n----------- Double Check Mixing Parameters Begin ------------"<<std::endl;
     GlobalV::ofs_running<<"mixing_type: "<< this->mixing_mode <<std::endl;
     GlobalV::ofs_running<<"mixing_beta: "<< this->mixing_beta <<std::endl;

--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -43,11 +43,11 @@ void Charge_Mixing::set_mixing(const std::string& mixing_mode_in,
     this->mixing_dmr = mixing_dmr_in;
 
     // check the paramters
-    if (GlobalV::MIXING_BETA > 1.0 || GlobalV::MIXING_BETA < 0.0)
+    if (this->mixing_beta > 1.0 || this->mixing_beta < 0.0)
     {
         ModuleBase::WARNING_QUIT("Charge_Mixing", "You'd better set mixing_beta to [0.0, 1.0]!");
     }
-    if (GlobalV::MIXING_BETA_MAG < 0.0)
+    if (GlobalV::NSPIN >= 2 && this->mixing_beta_mag < 0.0)
     {
         ModuleBase::WARNING_QUIT("Charge_Mixing", "You'd better set mixing_beta_mag >= 0.0!");
     }

--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -24,14 +24,23 @@ void Charge_Mixing::set_mixing(const std::string& mixing_mode_in,
                                const int& mixing_ndim_in,
                                const double& mixing_gg0_in,
                                const bool& mixing_tau_in,
-                               const double& mixing_beta_mag_in)
+                               const double& mixing_beta_mag_in,
+                               const double& mixing_gg0_mag_in,
+                               const double& mixing_gg0_min_in,
+                               const double& mixing_angle_in,
+                               const bool& mixing_dmr_in)
 {
+    // get private mixing parameters
     this->mixing_mode = mixing_mode_in;
     this->mixing_beta = mixing_beta_in;
     this->mixing_beta_mag = mixing_beta_mag_in;
     this->mixing_ndim = mixing_ndim_in;
     this->mixing_gg0 = mixing_gg0_in;
     this->mixing_tau = mixing_tau_in;
+    this->mixing_gg0_mag = mixing_gg0_mag_in;
+    this->mixing_gg0_min = mixing_gg0_min_in;
+    this->mixing_angle = mixing_angle_in;
+    this->mixing_dmr = mixing_dmr_in;
 
     GlobalV::ofs_running<<"\n----------- Double Check Mixing Parameters Begin ------------"<<std::endl;
     GlobalV::ofs_running<<"mixing_type: "<< this->mixing_mode <<std::endl;

--- a/source/module_elecstate/module_charge/charge_mixing.h
+++ b/source/module_elecstate/module_charge/charge_mixing.h
@@ -46,33 +46,6 @@ class Charge_Mixing
     void mix_rho_real(Charge* chr);
 
     /**
-     * @brief Kerker screen method for reciprocal space
-     *
-     */
-    void Kerker_screen_recip(std::complex<double>* rhog);
-    void Kerker_screen_recip_new(std::complex<double>* rhog);
-
-    /**
-     * @brief Kerker screen method for real space
-     *
-     */
-    void Kerker_screen_real(double* rho);
-
-    /**
-     * @brief Inner product of two complex vectors
-     *
-     */
-    double inner_product_recip(std::complex<double>* rho1, std::complex<double>* rho2);
-    double inner_product_recip_new1(std::complex<double>* rho1, std::complex<double>* rho2);
-    double inner_product_recip_new2(std::complex<double>* rho1, std::complex<double>* rho2);
-
-    /**
-     * @brief Inner product of two double vectors
-     *
-     */
-    double inner_product_real(double* rho1, double* rho2);
-
-    /**
      * @brief Set the mixing object
      *
      * @param mixing_mode_in mixing mode: "plain", "broyden", "pulay"
@@ -100,8 +73,6 @@ class Charge_Mixing
      *
      */
     double get_drho(Charge* chr, const double nelec);
-
-    // init pwrho and rhodpw
     
     /**
      * @brief Set the smooth and dense grids
@@ -111,10 +82,8 @@ class Charge_Mixing
      */
     void set_rhopw(ModulePW::PW_Basis* rhopw_in, ModulePW::PW_Basis* rhodpw_in);
 
-    // extracting parameters
-    // normally these parameters will not be used
-    // outside charge mixing, but Exx is using them
-    // as well as some other places
+    // extracting parameters normally these parameters will not be used outside charge mixing
+    // while Exx is using them as well as some other places
     const std::string& get_mixing_mode() const
     {
         return mixing_mode;
@@ -156,7 +125,33 @@ class Charge_Mixing
 
     ModulePW::PW_Basis* rhopw = nullptr;  ///< smooth grid
     ModulePW::PW_Basis* rhodpw = nullptr; ///< dense grid, same as rhopw for ncpp.
-    // bool autoset = false;
+
+    /**
+     * @brief Kerker screen method for reciprocal space
+     *
+     */
+    void Kerker_screen_recip(std::complex<double>* rhog);
+    void Kerker_screen_recip_new(std::complex<double>* rhog);
+
+    /**
+     * @brief Kerker screen method for real space
+     *
+     */
+    void Kerker_screen_real(double* rho);
+
+    /**
+     * @brief Inner product of two complex vectors
+     *
+     */
+    double inner_product_recip(std::complex<double>* rho1, std::complex<double>* rho2);
+    double inner_product_recip_new1(std::complex<double>* rho1, std::complex<double>* rho2);
+    double inner_product_recip_new2(std::complex<double>* rho1, std::complex<double>* rho2);
+
+    /**
+     * @brief Inner product of two double vectors
+     *
+     */
+    double inner_product_real(double* rho1, double* rho2);
 
     double rhog_dot_product(const std::complex<double>* const* const rhog1,
                             const std::complex<double>* const* const rhog2) const;

--- a/source/module_elecstate/module_charge/charge_mixing.h
+++ b/source/module_elecstate/module_charge/charge_mixing.h
@@ -73,6 +73,7 @@ class Charge_Mixing
     double get_mixing_beta() const {return mixing_beta;}
     int get_mixing_ndim() const {return mixing_ndim;}
     double get_mixing_gg0() const {return mixing_gg0;}
+    Base_Mixing::Mixing* get_mixing() const {return mixing;}
 
   private:
   

--- a/source/module_elecstate/module_charge/charge_mixing.h
+++ b/source/module_elecstate/module_charge/charge_mixing.h
@@ -16,26 +16,24 @@ class Charge_Mixing
 
     /**
      * @brief reset mixing
-     *
      */
     void mix_reset();
 
     /**
      * @brief charge mixing
-     *
+     * @param chr pointer of Charge object
      */
     void mix_rho(Charge* chr);
 
     /**
      * @brief density matrix mixing, only for LCAO
-     *
+     * @param DM pointer of DensityMatrix object
      */
     void mix_dmr(elecstate::DensityMatrix<double, double>* DM);
     void mix_dmr(elecstate::DensityMatrix<std::complex<double>, double>* DM);
 
     /**
      * @brief Set the mixing object
-     *
      * @param mixing_mode_in mixing mode: "plain", "broyden", "pulay"
      * @param mixing_beta_in mixing beta
      * @param mixing_ndim_in mixing ndim
@@ -52,7 +50,7 @@ class Charge_Mixing
 
     /**
      * @brief allocate memory of dmr_mdata
-     *
+     * @param nnr size of real-space density matrix
      */
     void allocate_mixing_dmr(int nnr);
 
@@ -64,7 +62,6 @@ class Charge_Mixing
     
     /**
      * @brief Set the smooth and dense grids
-     * 
      * @param rhopw_in smooth grid
      * @param rhodpw_in dense grid when double grid is used, otherwise same as rhopw
      */
@@ -72,22 +69,10 @@ class Charge_Mixing
 
     // extracting parameters normally these parameters will not be used outside charge mixing
     // while Exx is using them as well as some other places
-    const std::string& get_mixing_mode() const
-    {
-        return mixing_mode;
-    }
-    double get_mixing_beta() const
-    {
-        return mixing_beta;
-    }
-    int get_mixing_ndim() const
-    {
-        return mixing_ndim;
-    }
-    double get_mixing_gg0() const
-    {
-        return mixing_gg0;
-    }
+    const std::string& get_mixing_mode() const {return mixing_mode;}
+    double get_mixing_beta() const {return mixing_beta;}
+    int get_mixing_ndim() const {return mixing_ndim;}
+    double get_mixing_gg0() const {return mixing_gg0;}
 
   private:
   
@@ -116,32 +101,32 @@ class Charge_Mixing
 
     /**
      * @brief charge mixing for reciprocal space
-     *
+     * @param chr pointer of Charge object
      */
     void mix_rho_recip_new(Charge* chr);
 
     /**
      * @brief charge mixing for real space
-     *
+     * @param chr pointer of Charge object
      */
     void mix_rho_real(Charge* chr);
-    
+
     /**
      * @brief Kerker screen method for reciprocal space
-     *
+     * @param rhog charge density in reciprocal space
      */
     void Kerker_screen_recip(std::complex<double>* rhog);
     void Kerker_screen_recip_new(std::complex<double>* rhog);
 
     /**
      * @brief Kerker screen method for real space
-     *
+     * @param rho charge density in real space
      */
     void Kerker_screen_real(double* rho);
 
     /**
      * @brief Inner product of two complex vectors
-     *
+     * 
      */
     double inner_product_recip(std::complex<double>* rho1, std::complex<double>* rho2);
     double inner_product_recip_new1(std::complex<double>* rho1, std::complex<double>* rho2);

--- a/source/module_elecstate/module_charge/charge_mixing.h
+++ b/source/module_elecstate/module_charge/charge_mixing.h
@@ -10,6 +10,16 @@
 #include "module_cell/unitcell.h"
 class Charge_Mixing
 {
+  /// Charge_Mixing class
+  /// This class is used to mix charge density, kinetic energy density and real-space density matrix
+  /// This Charge_Mixing class offers the following interfaces:
+  /// 1. set_mixing() to set all private mixing parameters
+  /// 2. init_mixing() to initialize mixing, including allocating memory for mixing data and reset mixing
+  /// 3. mix_rho() to mix charge density
+  /// 4. mix_dmr() to mix real-space density matrix
+  /// how to use it:
+  /// you can (re)start a mixing by calling set_mixing() and init_mixing() before calling mix_rho() or mix_dmr()
+
   public:
     Charge_Mixing();
     ~Charge_Mixing();
@@ -40,13 +50,21 @@ class Charge_Mixing
      * @param mixing_gg0_in mixing gg0 for Kerker screen
      * @param mixing_tau_in whether to use tau mixing
      * @param mixing_beta_mag_in mixing beta for magnetism
+     * @param mixing_gg0_mag_in mixing gg0 for Kerker screen for magnetism
+     * @param mixing_gg0_min_in minimum kerker coefficient
+     * @param mixing_angle_in mixing angle for nspin=4
+     * @param mixing_dmr_in whether to mixing real space density matrix
      */
     void set_mixing(const std::string& mixing_mode_in,
                     const double& mixing_beta_in,
                     const int& mixing_ndim_in,
                     const double& mixing_gg0_in,
                     const bool& mixing_tau_in,
-                    const double& mixing_beta_mag_in);
+                    const double& mixing_beta_mag_in,
+                    const double& mixing_gg0_mag_in,
+                    const double& mixing_gg0_min_in,
+                    const double& mixing_angle_in,
+                    const bool& mixing_dmr_in);
 
     /**
      * @brief allocate memory of dmr_mdata

--- a/source/module_elecstate/module_charge/charge_mixing.h
+++ b/source/module_elecstate/module_charge/charge_mixing.h
@@ -13,13 +13,6 @@ class Charge_Mixing
   public:
     Charge_Mixing();
     ~Charge_Mixing();
-    Base_Mixing::Mixing* mixing = nullptr; ///< Mixing object to mix charge density, kinetic energy density and compensation density
-    Base_Mixing::Mixing_Data rho_mdata;    ///< Mixing data for charge density
-    Base_Mixing::Mixing_Data tau_mdata;    ///< Mixing data for kinetic energy density
-    Base_Mixing::Mixing_Data nhat_mdata;   ///< Mixing data for compensation density
-    Base_Mixing::Mixing_Data dmr_mdata;    ///< Mixing data for real space density matrix
-
-    Base_Mixing::Plain_Mixing* mixing_highf = nullptr; ///< The high_frequency part is mixed by plain mixing method.
 
     /**
      * @brief reset mixing
@@ -140,6 +133,15 @@ class Charge_Mixing
     }
 
   private:
+  
+    // mixing_data
+    Base_Mixing::Mixing* mixing = nullptr; ///< Mixing object to mix charge density, kinetic energy density and compensation density
+    Base_Mixing::Mixing_Data rho_mdata;    ///< Mixing data for charge density
+    Base_Mixing::Mixing_Data tau_mdata;    ///< Mixing data for kinetic energy density
+    Base_Mixing::Mixing_Data nhat_mdata;   ///< Mixing data for compensation density
+    Base_Mixing::Mixing_Data dmr_mdata;    ///< Mixing data for real space density matrix
+    Base_Mixing::Plain_Mixing* mixing_highf = nullptr; ///< The high_frequency part is mixed by plain mixing method.
+
     //======================================
     // General parameters
     //======================================
@@ -156,7 +158,6 @@ class Charge_Mixing
     ModulePW::PW_Basis* rhodpw = nullptr; ///< dense grid, same as rhopw for ncpp.
     // bool autoset = false;
 
-  private:
     double rhog_dot_product(const std::complex<double>* const* const rhog1,
                             const std::complex<double>* const* const rhog2) const;
 

--- a/source/module_elecstate/module_charge/charge_mixing.h
+++ b/source/module_elecstate/module_charge/charge_mixing.h
@@ -33,7 +33,7 @@ class Charge_Mixing
     void mix_dmr(elecstate::DensityMatrix<std::complex<double>, double>* DM);
 
     /**
-     * @brief Set the mixing object
+     * @brief Set all private mixing paramters
      * @param mixing_mode_in mixing mode: "plain", "broyden", "pulay"
      * @param mixing_beta_in mixing beta
      * @param mixing_ndim_in mixing ndim
@@ -85,7 +85,7 @@ class Charge_Mixing
     Base_Mixing::Plain_Mixing* mixing_highf = nullptr; ///< The high_frequency part is mixed by plain mixing method.
 
     //======================================
-    // General parameters
+    // private mixing parameters
     //======================================
     std::string mixing_mode = "broyden"; ///< mixing mode: "plain", "broyden", "pulay"
     double mixing_beta = 0.8;            ///< mixing beta for density
@@ -93,6 +93,10 @@ class Charge_Mixing
     int mixing_ndim = 8;                 ///< mixing ndim for broyden and pulay
     double mixing_gg0 = 0.0;             ///< mixing gg0 for Kerker screen
     bool mixing_tau = false;             ///< whether to use tau mixing
+    double mixing_gg0_mag = 0.0;         ///< mixing gg0 for Kerker screen for magnetism
+    double mixing_gg0_min = 0.1;         ///< minimum kerker coefficient
+    double mixing_angle = 0.0;           ///< mixing angle for nspin=4
+    bool mixing_dmr = false;             ///< whether to mixing real space density matrix
 
     bool new_e_iteration = true;
 

--- a/source/module_elecstate/module_charge/charge_mixing.h
+++ b/source/module_elecstate/module_charge/charge_mixing.h
@@ -34,18 +34,6 @@ class Charge_Mixing
     void mix_dmr(elecstate::DensityMatrix<std::complex<double>, double>* DM);
 
     /**
-     * @brief charge mixing for reciprocal space
-     *
-     */
-    void mix_rho_recip_new(Charge* chr);
-
-    /**
-     * @brief charge mixing for real space
-     *
-     */
-    void mix_rho_real(Charge* chr);
-
-    /**
      * @brief Set the mixing object
      *
      * @param mixing_mode_in mixing mode: "plain", "broyden", "pulay"
@@ -126,6 +114,18 @@ class Charge_Mixing
     ModulePW::PW_Basis* rhopw = nullptr;  ///< smooth grid
     ModulePW::PW_Basis* rhodpw = nullptr; ///< dense grid, same as rhopw for ncpp.
 
+    /**
+     * @brief charge mixing for reciprocal space
+     *
+     */
+    void mix_rho_recip_new(Charge* chr);
+
+    /**
+     * @brief charge mixing for real space
+     *
+     */
+    void mix_rho_real(Charge* chr);
+    
     /**
      * @brief Kerker screen method for reciprocal space
      *

--- a/source/module_elecstate/test/charge_mixing_test.cpp
+++ b/source/module_elecstate/test/charge_mixing_test.cpp
@@ -93,10 +93,21 @@ class ChargeMixingTest : public ::testing::Test
         pw_dbasis.initparameters(false, 40);
         pw_dbasis.setuptransform(&pw_basis);
         pw_dbasis.collect_local_pw();
+        // mixing parameters
+        GlobalV::MIXING_MODE = "broyden";
+        GlobalV::MIXING_BETA = 0.8;
+        GlobalV::MIXING_NDIM = 8;
+        GlobalV::MIXING_GG0  = 1.0;
+        GlobalV::MIXING_TAU  = false;
+        GlobalV::MIXING_BETA_MAG = 1.6;
+        GlobalV::MIXING_GG0_MAG = 0.0;
+        GlobalV::MIXING_GG0_MIN = 0.1;
+        GlobalV::MIXING_ANGLE = -10.0;
+        GlobalV::MIXING_DMR = false;
     }
     ModulePW::PW_Basis pw_basis;
     ModulePW::PW_Basis_Sup pw_dbasis;
-    Charge charge;
+    Charge charge;    
 };
 
 TEST_F(ChargeMixingTest, SetMixingTest)
@@ -105,20 +116,35 @@ TEST_F(ChargeMixingTest, SetMixingTest)
     GlobalV::NSPIN = 1;
     Charge_Mixing CMtest;
     CMtest.set_rhopw(&pw_basis, &pw_basis);
-    double beta = 1.0;
-    int dim = 1;
-    double gg0 = 1;
+    GlobalV::MIXING_BETA = 1.0;
+    GlobalV::MIXING_NDIM = 1;
+    GlobalV::MIXING_GG0 = 1.0;
 
     FUNC_TYPE = 1;
-    bool mixingtau = false;
     GlobalV::SCF_THR_TYPE = 1;
-    std::string mode = "broyden";
-    CMtest.set_mixing(mode, beta, dim, gg0, mixingtau, 1.6);
+    CMtest.set_mixing(GlobalV::MIXING_MODE,
+                    GlobalV::MIXING_BETA,
+                    GlobalV::MIXING_NDIM,
+                    GlobalV::MIXING_GG0,
+                    GlobalV::MIXING_TAU,
+                    GlobalV::MIXING_BETA_MAG,
+                    GlobalV::MIXING_GG0_MAG,
+                    GlobalV::MIXING_GG0_MIN,
+                    GlobalV::MIXING_ANGLE,
+                    GlobalV::MIXING_DMR);
     EXPECT_EQ(CMtest.rho_mdata.length, pw_basis.npw);
 
     GlobalV::SCF_THR_TYPE = 2;
-    mode = "broyden";
-    CMtest.set_mixing(mode, beta, dim, gg0, mixingtau, 1.6);
+    CMtest.set_mixing(GlobalV::MIXING_MODE,
+                    GlobalV::MIXING_BETA,
+                    GlobalV::MIXING_NDIM,
+                    GlobalV::MIXING_GG0,
+                    GlobalV::MIXING_TAU,
+                    GlobalV::MIXING_BETA_MAG,
+                    GlobalV::MIXING_GG0_MAG,
+                    GlobalV::MIXING_GG0_MIN,
+                    GlobalV::MIXING_ANGLE,
+                    GlobalV::MIXING_DMR);
     EXPECT_EQ(CMtest.rho_mdata.length, pw_basis.nrxx);
     EXPECT_EQ(CMtest.get_mixing_mode(), "broyden");
     EXPECT_EQ(CMtest.get_mixing_beta(), 1.0);
@@ -126,22 +152,49 @@ TEST_F(ChargeMixingTest, SetMixingTest)
     EXPECT_EQ(CMtest.get_mixing_gg0(), 1.0);
 
     FUNC_TYPE = 3;
-    mixingtau = true;
-    mode = "plain";
+    GlobalV::MIXING_TAU = true;
+    GlobalV::MIXING_MODE = "plain";
     GlobalV::SCF_THR_TYPE = 1;
-    CMtest.set_mixing(mode, beta, dim, gg0, mixingtau, 1.6);
+    CMtest.set_mixing(GlobalV::MIXING_MODE,
+                    GlobalV::MIXING_BETA,
+                    GlobalV::MIXING_NDIM,
+                    GlobalV::MIXING_GG0,
+                    GlobalV::MIXING_TAU,
+                    GlobalV::MIXING_BETA_MAG,
+                    GlobalV::MIXING_GG0_MAG,
+                    GlobalV::MIXING_GG0_MIN,
+                    GlobalV::MIXING_ANGLE,
+                    GlobalV::MIXING_DMR);
     CMtest.mix_reset();
     EXPECT_EQ(CMtest.tau_mdata.length, pw_basis.npw);
 
     GlobalV::SCF_THR_TYPE = 2;
-    CMtest.set_mixing(mode, beta, dim, gg0, mixingtau, 1.6);
+    CMtest.set_mixing(GlobalV::MIXING_MODE,
+                    GlobalV::MIXING_BETA,
+                    GlobalV::MIXING_NDIM,
+                    GlobalV::MIXING_GG0,
+                    GlobalV::MIXING_TAU,
+                    GlobalV::MIXING_BETA_MAG,
+                    GlobalV::MIXING_GG0_MAG,
+                    GlobalV::MIXING_GG0_MIN,
+                    GlobalV::MIXING_ANGLE,
+                    GlobalV::MIXING_DMR);
     CMtest.mix_reset();
     EXPECT_EQ(CMtest.tau_mdata.length, pw_basis.nrxx);
 
-    mode = "nothing";
+    GlobalV::MIXING_MODE = "nothing";
     std::string output;
     testing::internal::CaptureStdout();
-    EXPECT_EXIT(CMtest.set_mixing(mode, beta, dim, gg0, mixingtau, 1.6);, ::testing::ExitedWithCode(0), "");
+    EXPECT_EXIT(CMtest.set_mixing(GlobalV::MIXING_MODE,
+                                GlobalV::MIXING_BETA,
+                                GlobalV::MIXING_NDIM,
+                                GlobalV::MIXING_GG0,
+                                GlobalV::MIXING_TAU,
+                                GlobalV::MIXING_BETA_MAG,
+                                GlobalV::MIXING_GG0_MAG,
+                                GlobalV::MIXING_GG0_MIN,
+                                GlobalV::MIXING_ANGLE,
+                                GlobalV::MIXING_DMR);, ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
     EXPECT_THAT(output, testing::HasSubstr("This Mixing mode is not implemended yet,coming soon."));
 }
@@ -382,11 +435,11 @@ TEST_F(ChargeMixingTest, MixRhoTest)
     const int nspin = GlobalV::NSPIN = 1;
     GlobalV::DOMAG_Z = false;
     FUNC_TYPE = 3;
-    double beta = 0.7;
-    int dim = 1;
-    double gg0 = 0.0;
-    bool mixingtau = true;
-    std::string mode = "plain";
+    GlobalV::MIXING_BETA = 0.7;
+    GlobalV::MIXING_NDIM = 1;
+    GlobalV::MIXING_GG0 = 0.0;
+    GlobalV::MIXING_TAU = true;
+    GlobalV::MIXING_MODE = "plain";
     const int nrxx = pw_basis.nrxx;
     const int npw = pw_basis.npw;
     charge._space_rho = new double[nspin * nrxx];
@@ -429,7 +482,16 @@ TEST_F(ChargeMixingTest, MixRhoTest)
     Charge_Mixing CMtest_recip;
     CMtest_recip.set_rhopw(&pw_basis, &pw_basis);
     GlobalV::SCF_THR_TYPE = 1;
-    CMtest_recip.set_mixing(mode, beta, dim, gg0, mixingtau, 1.6);
+    CMtest_recip.set_mixing(GlobalV::MIXING_MODE,
+                            GlobalV::MIXING_BETA,
+                            GlobalV::MIXING_NDIM,
+                            GlobalV::MIXING_GG0,
+                            GlobalV::MIXING_TAU,
+                            GlobalV::MIXING_BETA_MAG,
+                            GlobalV::MIXING_GG0_MAG,
+                            GlobalV::MIXING_GG0_MIN,
+                            GlobalV::MIXING_ANGLE,
+                            GlobalV::MIXING_DMR);
     CMtest_recip.mix_reset();
     for(int i = 0 ; i < nspin * npw; ++i)
     {
@@ -459,7 +521,16 @@ TEST_F(ChargeMixingTest, MixRhoTest)
     Charge_Mixing CMtest_real;
     GlobalV::SCF_THR_TYPE = 2;
     CMtest_real.set_rhopw(&pw_basis, &pw_basis);
-    CMtest_real.set_mixing(mode, beta, dim, gg0, mixingtau, 1.6);
+    CMtest_real.set_mixing(GlobalV::MIXING_MODE,
+                        GlobalV::MIXING_BETA,
+                        GlobalV::MIXING_NDIM,
+                        GlobalV::MIXING_GG0,
+                        GlobalV::MIXING_TAU,
+                        GlobalV::MIXING_BETA_MAG,
+                        GlobalV::MIXING_GG0_MAG,
+                        GlobalV::MIXING_GG0_MIN,
+                        GlobalV::MIXING_ANGLE,
+                        GlobalV::MIXING_DMR);
     CMtest_real.mix_reset();
     for(int i = 0 ; i < nspin * nrxx; ++i)
     {
@@ -498,11 +569,11 @@ TEST_F(ChargeMixingTest, MixDoubleGridRhoTest)
     const int nspin = GlobalV::NSPIN = 1;
     GlobalV::DOMAG_Z = false;
     FUNC_TYPE = 3;
-    double beta = 0.7;
-    int dim = 1;
-    double gg0 = 0.0;
-    bool mixingtau = true;
-    std::string mode = "plain";
+    GlobalV::MIXING_BETA = 0.7;
+    GlobalV::MIXING_NDIM = 1;
+    GlobalV::MIXING_GG0 = 0.0;
+    GlobalV::MIXING_TAU = true;
+    GlobalV::MIXING_MODE = "plain";
     const int nrxx = pw_dbasis.nrxx;
     const int npw = pw_dbasis.npw;
     charge._space_rho = new double[nspin * nrxx];
@@ -545,7 +616,16 @@ TEST_F(ChargeMixingTest, MixDoubleGridRhoTest)
     Charge_Mixing CMtest_recip;
     CMtest_recip.set_rhopw(&pw_basis, &pw_dbasis);
     GlobalV::SCF_THR_TYPE = 1;
-    CMtest_recip.set_mixing(mode, beta, dim, gg0, mixingtau, 1.6);
+    CMtest_recip.set_mixing(GlobalV::MIXING_MODE,
+                            GlobalV::MIXING_BETA,
+                            GlobalV::MIXING_NDIM,
+                            GlobalV::MIXING_GG0,
+                            GlobalV::MIXING_TAU,
+                            GlobalV::MIXING_BETA_MAG,
+                            GlobalV::MIXING_GG0_MAG,
+                            GlobalV::MIXING_GG0_MIN,
+                            GlobalV::MIXING_ANGLE,
+                            GlobalV::MIXING_DMR);
     CMtest_recip.mix_reset();
     for (int i = 0; i < nspin * npw; ++i)
     {

--- a/source/module_elecstate/test/charge_mixing_test.cpp
+++ b/source/module_elecstate/test/charge_mixing_test.cpp
@@ -208,6 +208,7 @@ TEST_F(ChargeMixingTest, SetMixingTest)
 
     GlobalV::MIXING_BETA = 0.7;
     GlobalV::MIXING_BETA_MAG = -0.1;
+    GlobalV::NSPIN = 2;
     testing::internal::CaptureStdout();
     EXPECT_EXIT(CMtest.set_mixing(GlobalV::MIXING_MODE,
                                 GlobalV::MIXING_BETA,
@@ -222,6 +223,7 @@ TEST_F(ChargeMixingTest, SetMixingTest)
     output = testing::internal::GetCapturedStdout();
     EXPECT_THAT(output, testing::HasSubstr("You'd better set mixing_beta_mag >= 0.0!"));
 
+    GlobalV::NSPIN = 1;
     GlobalV::MIXING_BETA = 0.7;
     GlobalV::MIXING_BETA_MAG = 1.6;
     GlobalV::MIXING_MODE = "nothing";

--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -84,20 +84,6 @@ namespace ModuleESolver
                              GlobalV::MIXING_GG0_MIN,
                              GlobalV::MIXING_ANGLE,
                              GlobalV::MIXING_DMR);
-        // I use default value to replace autoset                     
-        // using bandgap to auto set mixing_beta
-        // if (std::abs(GlobalV::MIXING_BETA + 10.0) < 1e-6)
-        //{
-        //    p_chgmix->need_auto_set();
-        //}
-        if (GlobalV::MIXING_BETA > 1.0 || GlobalV::MIXING_BETA < 0.0)
-        {
-            ModuleBase::WARNING("INPUT", "You'd better set mixing_beta to [0.0, 1.0]!");
-        }
-        if (GlobalV::MIXING_BETA_MAG < 0.0)
-        {
-            ModuleBase::WARNING("INPUT", "You'd better set mixing_beta_mag >= 0.0!");
-        }
         
 #ifdef USE_PAW
         if(GlobalV::use_paw)

--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -79,7 +79,11 @@ namespace ModuleESolver
                              GlobalV::MIXING_NDIM,
                              GlobalV::MIXING_GG0,
                              GlobalV::MIXING_TAU,
-                             GlobalV::MIXING_BETA_MAG);
+                             GlobalV::MIXING_BETA_MAG,
+                             GlobalV::MIXING_GG0_MAG,
+                             GlobalV::MIXING_GG0_MIN,
+                             GlobalV::MIXING_ANGLE,
+                             GlobalV::MIXING_DMR);
         // I use default value to replace autoset                     
         // using bandgap to auto set mixing_beta
         // if (std::abs(GlobalV::MIXING_BETA + 10.0) < 1e-6)

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -500,7 +500,11 @@ namespace ModuleESolver
                                 GlobalV::MIXING_NDIM,
                                 GlobalV::MIXING_GG0,
                                 GlobalV::MIXING_TAU,
-                                GlobalV::MIXING_BETA_MAG);
+                                GlobalV::MIXING_BETA_MAG,
+                                GlobalV::MIXING_GG0_MAG,
+                                GlobalV::MIXING_GG0_MIN,
+                                GlobalV::MIXING_ANGLE,
+                                GlobalV::MIXING_DMR);
             // allocate memory for dmr_mdata
             if (GlobalV::MIXING_DMR)
             {

--- a/source/module_esolver/esolver_ks_pw.cpp
+++ b/source/module_esolver/esolver_ks_pw.cpp
@@ -501,7 +501,11 @@ void ESolver_KS_PW<T, Device>::eachiterinit(const int istep, const int iter)
                                 GlobalV::MIXING_NDIM,
                                 GlobalV::MIXING_GG0,
                                 GlobalV::MIXING_TAU,
-                                GlobalV::MIXING_BETA_MAG);
+                                GlobalV::MIXING_BETA_MAG,
+                                GlobalV::MIXING_GG0_MAG,
+                                GlobalV::MIXING_GG0_MIN,
+                                GlobalV::MIXING_ANGLE,
+                                GlobalV::MIXING_DMR);
         }
         this->p_chgmix->mix_reset();
     }

--- a/source/module_io/test/for_testing_input_conv.h
+++ b/source/module_io/test/for_testing_input_conv.h
@@ -265,20 +265,6 @@ Magnetism::Magnetism()
 Magnetism::~Magnetism()
 {
 }
-
-void Charge_Mixing::set_mixing(const std::string& mixing_mode_in,
-                               const double& mixing_beta_in,
-                               const int& mixing_ndim_in,
-                               const double& mixing_gg0_in,
-                               const bool& mixing_tau_in,
-                               const double& mixing_beta_mag_in)
-{
-    return;
-}
-// void Charge_Mixing::need_auto_set()
-// {
-//     this->autoset = true;
-// }
 void Occupy::decision(const std::string& name, const std::string& smearing_method, const double& smearing_sigma)
 {
     return;

--- a/source/module_ri/Exx_LRI_interface.hpp
+++ b/source/module_ri/Exx_LRI_interface.hpp
@@ -60,7 +60,7 @@ void Exx_LRI_Interface<T, Tdata>::exx_beforescf(const K_Vectors& kv, const Charg
 			if(GlobalC::exx_info.info_global.separate_loop)
                 this->mix_DMk_2D.set_mixing(nullptr);
 			else
-				this->mix_DMk_2D.set_mixing(chgmix.mixing);
+				this->mix_DMk_2D.set_mixing(chgmix.get_mixing());
         }
         // for exx two_level scf
         this->two_level_step = 0;


### PR DESCRIPTION
Fix #3597. 

### List of Changes:
1. only keep some interfaces like `set_mixing()`/`reset()`/`mix_rho`/`mix_dmr` as pubilc in `charge_mixing.h`, and set other members as private.
2. polish `set_mixing()`, and make sure all mixing parameters can be got by this interface.
3. polish corresponding UnitTests.