### PR TITLE
Refactor: split `Charge_Mixing::set_mixing` into `set_mixing` and `init_mixing`

### DIFF
--- a/source/module_elecstate/module_charge/charge_mixing.h
+++ b/source/module_elecstate/module_charge/charge_mixing.h
@@ -25,24 +25,6 @@ class Charge_Mixing
     ~Charge_Mixing();
 
     /**
-     * @brief reset mixing
-     */
-    void mix_reset();
-
-    /**
-     * @brief charge mixing
-     * @param chr pointer of Charge object
-     */
-    void mix_rho(Charge* chr);
-
-    /**
-     * @brief density matrix mixing, only for LCAO
-     * @param DM pointer of DensityMatrix object
-     */
-    void mix_dmr(elecstate::DensityMatrix<double, double>* DM);
-    void mix_dmr(elecstate::DensityMatrix<std::complex<double>, double>* DM);
-
-    /**
      * @brief Set all private mixing paramters
      * @param mixing_mode_in mixing mode: "plain", "broyden", "pulay"
      * @param mixing_beta_in mixing beta
@@ -79,10 +61,28 @@ class Charge_Mixing
     void allocate_mixing_dmr(int nnr);
 
     /**
+     * @brief charge mixing
+     * @param chr pointer of Charge object
+     */
+    void mix_rho(Charge* chr);
+
+    /**
+     * @brief density matrix mixing, only for LCAO
+     * @param DM pointer of DensityMatrix object
+     */
+    void mix_dmr(elecstate::DensityMatrix<double, double>* DM);
+    void mix_dmr(elecstate::DensityMatrix<std::complex<double>, double>* DM);
+    
+    /**
      * @brief Get the drho
      *
      */
     double get_drho(Charge* chr, const double nelec);
+
+    /**
+     * @brief reset mixing, actually we only call init_mixing() to reset mixing instead of this function 
+     */
+    void mix_reset();
     
     /**
      * @brief Set the smooth and dense grids

--- a/source/module_elecstate/module_charge/charge_mixing.h
+++ b/source/module_elecstate/module_charge/charge_mixing.h
@@ -67,6 +67,12 @@ class Charge_Mixing
                     const bool& mixing_dmr_in);
 
     /**
+     * @brief initialize mixing, including constructing mixing and allocating memory for mixing data
+     * @brief this function should be called at eachiterinit()
+     */
+    void init_mixing();
+
+    /**
      * @brief allocate memory of dmr_mdata
      * @param nnr size of real-space density matrix
      */

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -493,28 +493,15 @@ namespace ModuleESolver
 {
     if (iter == 1 || iter == GlobalV::MIXING_RESTART)
     {
-        if (iter == GlobalV::MIXING_RESTART) // delete mixing and re-construct it to restart 
+        this->p_chgmix->init_mixing();
+        if (iter == GlobalV::MIXING_RESTART && GlobalV::MIXING_DMR) // for mixing_dmr 
         {
-            this->p_chgmix->set_mixing(GlobalV::MIXING_MODE,
-                                GlobalV::MIXING_BETA,
-                                GlobalV::MIXING_NDIM,
-                                GlobalV::MIXING_GG0,
-                                GlobalV::MIXING_TAU,
-                                GlobalV::MIXING_BETA_MAG,
-                                GlobalV::MIXING_GG0_MAG,
-                                GlobalV::MIXING_GG0_MIN,
-                                GlobalV::MIXING_ANGLE,
-                                GlobalV::MIXING_DMR);
             // allocate memory for dmr_mdata
-            if (GlobalV::MIXING_DMR)
-            {
-                const elecstate::DensityMatrix<TK, double>* dm
-                    = dynamic_cast<const elecstate::ElecStateLCAO<TK>*>(this->pelec)->get_DM();
-                int nnr_tmp = dm->get_DMR_pointer(1)->get_nnr();
-                this->p_chgmix->allocate_mixing_dmr(nnr_tmp);
-            }
+            const elecstate::DensityMatrix<TK, double>* dm
+                = dynamic_cast<const elecstate::ElecStateLCAO<TK>*>(this->pelec)->get_DM();
+            int nnr_tmp = dm->get_DMR_pointer(1)->get_nnr();
+            this->p_chgmix->allocate_mixing_dmr(nnr_tmp);
         }
-        this->p_chgmix->mix_reset();
     }
 
     // mohan update 2012-06-05

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -599,14 +599,14 @@ namespace ModuleESolver
     void ESolver_KS_LCAO<TK, TR>::hamilt2density(int istep, int iter, double ethr)
 {
     // save input rho
-        this->pelec->charge->save_rho_before_sum_band();
-        // save density matrix for mixing
-        if (GlobalV::MIXING_RESTART > 0 && GlobalV::MIXING_DMR && iter >= GlobalV::MIXING_RESTART)
-        {
-            elecstate::DensityMatrix<TK, double>* dm
-                = dynamic_cast<elecstate::ElecStateLCAO<TK>*>(this->pelec)->get_DM();
-            dm->save_DMR();
-        }
+    this->pelec->charge->save_rho_before_sum_band();
+    // save density matrix for mixing
+    if (GlobalV::MIXING_RESTART > 0 && GlobalV::MIXING_DMR && iter >= GlobalV::MIXING_RESTART)
+    {
+        elecstate::DensityMatrix<TK, double>* dm
+            = dynamic_cast<elecstate::ElecStateLCAO<TK>*>(this->pelec)->get_DM();
+        dm->save_DMR();
+    }
 
         // using HSolverLCAO<TK>::solve()
     if (this->phsol != nullptr)

--- a/source/module_esolver/esolver_ks_pw.cpp
+++ b/source/module_esolver/esolver_ks_pw.cpp
@@ -494,20 +494,7 @@ void ESolver_KS_PW<T, Device>::eachiterinit(const int istep, const int iter)
 {
     if (iter == 1 || iter == GlobalV::MIXING_RESTART)
     {
-        if (iter == GlobalV::MIXING_RESTART) // delete mixing and re-construct it to restart 
-        {
-            this->p_chgmix->set_mixing(GlobalV::MIXING_MODE,
-                                GlobalV::MIXING_BETA,
-                                GlobalV::MIXING_NDIM,
-                                GlobalV::MIXING_GG0,
-                                GlobalV::MIXING_TAU,
-                                GlobalV::MIXING_BETA_MAG,
-                                GlobalV::MIXING_GG0_MAG,
-                                GlobalV::MIXING_GG0_MIN,
-                                GlobalV::MIXING_ANGLE,
-                                GlobalV::MIXING_DMR);
-        }
-        this->p_chgmix->mix_reset();
+        this->p_chgmix->init_mixing();
     }
     // mohan move harris functional to here, 2012-06-05
     // use 'rho(in)' and 'v_h and v_xc'(in)


### PR DESCRIPTION
Fix #3599.

### List of Changes:
1. split `Charge_Mixing::set_mixing` into `set_mixing` and `init_mixing`.
2. delete chgmix->reset() in esolver_ks.
3. polish charge_mixing_test.