### PR TITLE
Refactor: let `Charge_Mixing::inner_product_recip_hartree` supports all cases

### DIFF
--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -1260,7 +1260,7 @@ double Charge_Mixing::inner_product_recip(std::complex<double>* rho1, std::compl
 }
 
 // a simple inner product
-double Charge_Mixing::inner_product_recip_new1(std::complex<double>* rho1, std::complex<double>* rho2)
+double Charge_Mixing::inner_product_recip_simple(std::complex<double>* rho1, std::complex<double>* rho2)
 {
     double rnorm = 0.0;
     // consider a resize for mixing_angle

--- a/source/module_elecstate/module_charge/charge_mixing.h
+++ b/source/module_elecstate/module_charge/charge_mixing.h
@@ -159,7 +159,7 @@ class Charge_Mixing
      */
     double inner_product_recip(std::complex<double>* rho1, std::complex<double>* rho2);
     double inner_product_recip_simple(std::complex<double>* rho1, std::complex<double>* rho2);
-    double inner_product_recip_new2(std::complex<double>* rho1, std::complex<double>* rho2);
+    double inner_product_recip_hartree(std::complex<double>* rho1, std::complex<double>* rho2);
 
     /**
      * @brief Inner product of two double vectors

--- a/source/module_elecstate/module_charge/charge_mixing.h
+++ b/source/module_elecstate/module_charge/charge_mixing.h
@@ -158,7 +158,7 @@ class Charge_Mixing
      * 
      */
     double inner_product_recip(std::complex<double>* rho1, std::complex<double>* rho2);
-    double inner_product_recip_new1(std::complex<double>* rho1, std::complex<double>* rho2);
+    double inner_product_recip_simple(std::complex<double>* rho1, std::complex<double>* rho2);
     double inner_product_recip_new2(std::complex<double>* rho1, std::complex<double>* rho2);
 
     /**

--- a/source/module_elecstate/module_charge/charge_mixing.h
+++ b/source/module_elecstate/module_charge/charge_mixing.h
@@ -155,9 +155,12 @@ class Charge_Mixing
 
     /**
      * @brief Inner product of two complex vectors
-     * 
+     * @brief inner_product_recip_rho is used for charge, like get_drho()
+     * @brief inner_product_recip_hartree and inner_product_recip_simple are used for charge mixing
+     * @brief inner_product_recip_simple is used for test
+     * @brief Actually, I am not sure if the definition of inner product for NSPIN=4 is correct, need to be checked.
      */
-    double inner_product_recip(std::complex<double>* rho1, std::complex<double>* rho2);
+    double inner_product_recip_rho(std::complex<double>* rho1, std::complex<double>* rho2);
     double inner_product_recip_simple(std::complex<double>* rho1, std::complex<double>* rho2);
     double inner_product_recip_hartree(std::complex<double>* rho1, std::complex<double>* rho2);
 
@@ -166,9 +169,6 @@ class Charge_Mixing
      *
      */
     double inner_product_real(double* rho1, double* rho2);
-
-    double rhog_dot_product(const std::complex<double>* const* const rhog1,
-                            const std::complex<double>* const* const rhog2) const;
 
     /**
      * @brief divide rho/tau to smooth and high frequency parts

--- a/source/module_elecstate/test/charge_mixing_test.cpp
+++ b/source/module_elecstate/test/charge_mixing_test.cpp
@@ -491,10 +491,10 @@ TEST_F(ChargeMixingTest, InnerDotNewTest)
         drhog2_mag[i+pw_basis.npw] = drhog2[i] - drhog2[i+pw_basis.npw];
     }
     GlobalV::GAMMA_ONLY_PW = false;
-    inner = CMtest.inner_product_recip_new2(drhog1_mag.data(), drhog2_mag.data());
+    inner = CMtest.inner_product_recip_hartree(drhog1_mag.data(), drhog2_mag.data());
     EXPECT_NEAR(inner, 236763.82650318215, 1e-8);
     GlobalV::GAMMA_ONLY_PW = true;
-    inner = CMtest.inner_product_recip_new2(drhog1_mag.data(), drhog2_mag.data());
+    inner = CMtest.inner_product_recip_hartree(drhog1_mag.data(), drhog2_mag.data());
     EXPECT_NEAR(inner, 236763.82650318215 * 2, 1e-8);
 }
 

--- a/source/module_elecstate/test/charge_mixing_test.cpp
+++ b/source/module_elecstate/test/charge_mixing_test.cpp
@@ -460,7 +460,7 @@ TEST_F(ChargeMixingTest, InnerDotNewTest)
     CMtest.set_rhopw(&pw_basis, &pw_basis);
     GlobalV::NSPIN = 1;
 
-    // inner_product_recip_new1
+    // a simple sum for inner product
     std::vector<std::complex<double>> drhog1(pw_basis.npw);
     std::vector<std::complex<double>> drhog2(pw_basis.npw);
     for (int i = 0; i < pw_basis.npw; ++i)
@@ -468,7 +468,7 @@ TEST_F(ChargeMixingTest, InnerDotNewTest)
         drhog1[i] = 1.0;
         drhog2[i] = double(i);
     }
-    double inner = CMtest.inner_product_recip_new1(drhog1.data(), drhog2.data());
+    double inner = CMtest.inner_product_recip_simple(drhog1.data(), drhog2.data());
     EXPECT_NEAR(inner, 0.5 * pw_basis.npw * (pw_basis.npw - 1), 1e-8);
 
     // inner_product_recip_new2

--- a/source/module_elecstate/test/charge_mixing_test.cpp
+++ b/source/module_elecstate/test/charge_mixing_test.cpp
@@ -51,7 +51,7 @@ UnitCell ucell;
 /**
  * - Tested Functions:
  *   - SetMixingTest:
- * Charge_Mixing::set_mixing(mixing_mode_in,mixing_beta_in,mixing_ndim_in,mixing_gg0_in,mixing_tau_in)
+ * Charge_Mixing::set_mixing()
  *                    Charge_Mixing::init_mixing()
  *                    Charge_Mixing::set_rhopw(rhopw_in)
  *                    Charge_Mixing::get_mixing_mode()
@@ -62,8 +62,9 @@ UnitCell ucell;
  *   - KerkerScreenTest: Charge_Mixing::Kerker_screen_recip(drhog)
  *                       Charge_Mixing::Kerker_screen_real(drhog)
  *      - screen drho with Kerker method
- *   - InnerDotTest: Charge_Mixing::inner_product_recip(rhog1, rhog2)
- *                   Charge_Mixing::rhog_dot_product(rhog1, rhog2)
+ *   - InnerDotTest: Charge_Mixing::inner_product_recip_hartree(rhog1, rhog2)
+ *                   Charge_Mixing::inner_product_recip_rho(rhog1, rhog2)
+ *                   Charge_Mixing::inner_product_recip_simple(rhog1, rhog2)
  *                   Charge_Mixing::inner_product_real(rho1, rho2)
  *      - calculate the inner product of two vectors
  *   - MixRhoTest: Charge_Mixing::mix_rho(chr)
@@ -462,6 +463,75 @@ TEST_F(ChargeMixingTest, InnerDotRecipHartreeTest)
     EXPECT_NEAR(inner, 44776.555369916401, 1e-8);
 }
 
+TEST_F(ChargeMixingTest, InnerDotRecipRhoTest)
+{
+    // REAL
+    Charge_Mixing CMtest;
+    CMtest.set_rhopw(&pw_basis, &pw_basis);
+    GlobalV::NSPIN = 1;
+    std::vector<double> drhor1(pw_basis.nrxx);
+    std::vector<double> drhor2(pw_basis.nrxx);
+    for (int i = 0; i < pw_basis.nrxx; ++i)
+    {
+        drhor1[i] = 1.0;
+        drhor2[i] = double(i);
+    }
+    double inner = CMtest.inner_product_real(drhor1.data(), drhor2.data());
+    EXPECT_NEAR(inner, 0.5 * pw_basis.nrxx * (pw_basis.nrxx - 1), 1e-8);
+
+    // RECIPROCAL
+    GlobalC::ucell.tpiba2 = 1.0;
+    GlobalC::ucell.omega = 2.0;
+
+    GlobalV::NSPIN = 1;
+    std::vector<std::complex<double>> drhog1(pw_basis.npw);
+    std::vector<std::complex<double>> drhog2(pw_basis.npw);
+    for (int i = 0; i < pw_basis.nrxx; ++i)
+    {
+        drhor1[i] = 0.0;
+    }
+    drhor1[2] = 1.0;
+    pw_basis.real2recip(drhor1.data(), drhog1.data());
+    pw_basis.real2recip(drhor2.data(), drhog2.data());
+
+    inner = CMtest.inner_product_recip_rho(drhog1.data(), drhog2.data());
+    EXPECT_NEAR(inner, -0.3 * ModuleBase::e2 * ModuleBase::FOUR_PI, 1e-8);
+
+    GlobalV::NSPIN = 2;
+    drhog1.resize(pw_basis.npw * GlobalV::NSPIN);
+    drhog2.resize(pw_basis.npw * GlobalV::NSPIN);
+    for (int i = 0; i < pw_basis.npw * GlobalV::NSPIN; ++i)
+    {
+        drhog1[i] = std::complex<double>(1.0, double(i));
+        drhog2[i] = std::complex<double>(1.0, 1.0);
+    }
+    GlobalV::GAMMA_ONLY_PW = false;
+    inner = CMtest.inner_product_recip_rho(drhog1.data(), drhog2.data());
+    EXPECT_NEAR(inner, 236763.82650318215, 1e-8);
+    GlobalV::GAMMA_ONLY_PW = true;
+    inner = CMtest.inner_product_recip_rho(drhog1.data(), drhog2.data());
+    EXPECT_NEAR(inner, 236763.82650318215 * 2, 1e-8);
+
+    GlobalV::NSPIN = 4;
+    drhog1.resize(pw_basis.npw * GlobalV::NSPIN);
+    drhog2.resize(pw_basis.npw * GlobalV::NSPIN);
+    for (int i = 0; i < pw_basis.npw * GlobalV::NSPIN; ++i)
+    {
+        drhog1[i] = std::complex<double>(1.0, double(i));
+        drhog2[i] = std::complex<double>(1.0, 1.0);
+    }
+
+    GlobalV::DOMAG = false;
+    GlobalV::DOMAG_Z = false;
+    inner = CMtest.inner_product_recip_rho(drhog1.data(), drhog2.data());
+    EXPECT_NEAR(inner, 28260.091995611871, 1e-8);
+    GlobalV::GAMMA_ONLY_PW = true;
+    GlobalV::DOMAG = true;
+    GlobalV::DOMAG_Z = true;
+    inner = CMtest.inner_product_recip_rho(drhog1.data(), drhog2.data());
+    EXPECT_NEAR(inner, 110668.61166927818, 1e-8);
+}
+
 TEST_F(ChargeMixingTest, KerkerScreenRecipTest)
 {
     Charge_Mixing CMtest;
@@ -576,119 +646,6 @@ TEST_F(ChargeMixingTest, KerkerScreenRecipNewTest)
     delete[] drhog_old;
     delete[] drhor;
     delete[] drhor_ref;
-}
-
-TEST_F(ChargeMixingTest, InnerDotTest)
-{
-    // REAL
-    Charge_Mixing CMtest;
-    CMtest.set_rhopw(&pw_basis, &pw_basis);
-    GlobalV::NSPIN = 1;
-    std::vector<double> drhor1(pw_basis.nrxx);
-    std::vector<double> drhor2(pw_basis.nrxx);
-    for (int i = 0; i < pw_basis.nrxx; ++i)
-    {
-        drhor1[i] = 1.0;
-        drhor2[i] = double(i);
-    }
-    double inner = CMtest.inner_product_real(drhor1.data(), drhor2.data());
-    EXPECT_NEAR(inner, 0.5 * pw_basis.nrxx * (pw_basis.nrxx - 1), 1e-8);
-
-    // RECIPROCAL
-    GlobalC::ucell.tpiba2 = 1.0;
-    GlobalC::ucell.omega = 2.0;
-
-    GlobalV::NSPIN = 1;
-    std::vector<std::complex<double>> drhog1(pw_basis.npw);
-    std::vector<std::complex<double>> drhog2(pw_basis.npw);
-    for (int i = 0; i < pw_basis.nrxx; ++i)
-    {
-        drhor1[i] = 0.0;
-    }
-    drhor1[2] = 1.0;
-    pw_basis.real2recip(drhor1.data(), drhog1.data());
-    pw_basis.real2recip(drhor2.data(), drhog2.data());
-
-    inner = CMtest.inner_product_recip(drhog1.data(), drhog2.data());
-    EXPECT_NEAR(inner, -0.3 * ModuleBase::e2 * ModuleBase::FOUR_PI, 1e-8);
-
-    GlobalV::NSPIN = 2;
-    drhog1.resize(pw_basis.npw * GlobalV::NSPIN);
-    drhog2.resize(pw_basis.npw * GlobalV::NSPIN);
-    for (int i = 0; i < pw_basis.npw * GlobalV::NSPIN; ++i)
-    {
-        drhog1[i] = std::complex<double>(1.0, double(i));
-        drhog2[i] = std::complex<double>(1.0, 1.0);
-    }
-    GlobalV::GAMMA_ONLY_PW = false;
-    inner = CMtest.inner_product_recip(drhog1.data(), drhog2.data());
-    EXPECT_NEAR(inner, 236763.82650318215, 1e-8);
-    GlobalV::GAMMA_ONLY_PW = true;
-    inner = CMtest.inner_product_recip(drhog1.data(), drhog2.data());
-    EXPECT_NEAR(inner, 236763.82650318215 * 2, 1e-8);
-
-    GlobalV::NSPIN = 4;
-    drhog1.resize(pw_basis.npw * GlobalV::NSPIN);
-    drhog2.resize(pw_basis.npw * GlobalV::NSPIN);
-    for (int i = 0; i < pw_basis.npw * GlobalV::NSPIN; ++i)
-    {
-        drhog1[i] = std::complex<double>(1.0, double(i));
-        drhog2[i] = std::complex<double>(1.0, 1.0);
-    }
-
-    GlobalV::DOMAG = false;
-    GlobalV::DOMAG_Z = false;
-    inner = CMtest.inner_product_recip(drhog1.data(), drhog2.data());
-    EXPECT_NEAR(inner, 28260.091995611871, 1e-8);
-    GlobalV::GAMMA_ONLY_PW = true;
-    GlobalV::DOMAG = true;
-    GlobalV::DOMAG_Z = true;
-    inner = CMtest.inner_product_recip(drhog1.data(), drhog2.data());
-    EXPECT_NEAR(inner, 110668.61166927818, 1e-8);
-}
-
-TEST_F(ChargeMixingTest, InnerDotNewTest)
-{
-    Charge_Mixing CMtest;
-    CMtest.set_rhopw(&pw_basis, &pw_basis);
-    GlobalV::NSPIN = 1;
-
-    // a simple sum for inner product
-    std::vector<std::complex<double>> drhog1(pw_basis.npw);
-    std::vector<std::complex<double>> drhog2(pw_basis.npw);
-    for (int i = 0; i < pw_basis.npw; ++i)
-    {
-        drhog1[i] = 1.0;
-        drhog2[i] = double(i);
-    }
-    double inner = CMtest.inner_product_recip_simple(drhog1.data(), drhog2.data());
-    EXPECT_NEAR(inner, 0.5 * pw_basis.npw * (pw_basis.npw - 1), 1e-8);
-
-    // inner_product_recip_new2
-    GlobalV::NSPIN = 2;
-    drhog1.resize(pw_basis.npw * GlobalV::NSPIN);
-    drhog2.resize(pw_basis.npw * GlobalV::NSPIN);
-    std::vector<std::complex<double>> drhog1_mag(pw_basis.npw * GlobalV::NSPIN);
-    std::vector<std::complex<double>> drhog2_mag(pw_basis.npw * GlobalV::NSPIN);
-    for (int i = 0; i < pw_basis.npw * GlobalV::NSPIN; ++i)
-    {
-        drhog1[i] = std::complex<double>(1.0, double(i));
-        drhog2[i] = std::complex<double>(1.0, 1.0);
-    }
-    // set mag
-    for (int i = 0; i < pw_basis.npw; ++i)
-    {
-        drhog1_mag[i] = drhog1[i] + drhog1[i+pw_basis.npw];
-        drhog1_mag[i+pw_basis.npw] = drhog1[i] - drhog1[i+pw_basis.npw];
-        drhog2_mag[i] = drhog2[i] + drhog2[i+pw_basis.npw];
-        drhog2_mag[i+pw_basis.npw] = drhog2[i] - drhog2[i+pw_basis.npw];
-    }
-    GlobalV::GAMMA_ONLY_PW = false;
-    inner = CMtest.inner_product_recip_hartree(drhog1_mag.data(), drhog2_mag.data());
-    EXPECT_NEAR(inner, 236763.82650318215, 1e-8);
-    GlobalV::GAMMA_ONLY_PW = true;
-    inner = CMtest.inner_product_recip_hartree(drhog1_mag.data(), drhog2_mag.data());
-    EXPECT_NEAR(inner, 236763.82650318215 * 2, 1e-8);
 }
 
 TEST_F(ChargeMixingTest, MixRhoTest)

--- a/source/module_elecstate/test/charge_mixing_test.cpp
+++ b/source/module_elecstate/test/charge_mixing_test.cpp
@@ -269,6 +269,78 @@ TEST_F(ChargeMixingTest, InitMixingTest)
     EXPECT_EQ(CMtest.rho_mdata.length, 2 * pw_basis.nrxx);
 }
 
+TEST_F(ChargeMixingTest, InnerDotRealTest)
+{
+    Charge_Mixing CMtest;
+    // non mixing angle case
+    CMtest.set_mixing(GlobalV::MIXING_MODE,
+                    GlobalV::MIXING_BETA,
+                    GlobalV::MIXING_NDIM,
+                    GlobalV::MIXING_GG0,
+                    GlobalV::MIXING_TAU,
+                    GlobalV::MIXING_BETA_MAG,
+                    GlobalV::MIXING_GG0_MAG,
+                    GlobalV::MIXING_GG0_MIN,
+                    GlobalV::MIXING_ANGLE,
+                    GlobalV::MIXING_DMR);
+    CMtest.set_rhopw(&pw_basis, &pw_basis);
+    GlobalV::NSPIN = 4;
+
+    // a simple sum for inner product
+    std::vector<double> drho1(pw_basis.nrxx * GlobalV::NSPIN);
+    std::vector<double> drho2(pw_basis.nrxx * GlobalV::NSPIN);
+    for (int i = 0; i < pw_basis.nrxx * GlobalV::NSPIN; ++i)
+    {
+        drho1[i] = 1.0;
+        drho2[i] = double(i);
+    }
+    double inner = CMtest.inner_product_real(drho1.data(), drho2.data());
+    EXPECT_NEAR(inner, 0.5 * pw_basis.nrxx * GlobalV::NSPIN  * (pw_basis.nrxx * GlobalV::NSPIN - 1), 1e-8);
+
+    // mixing angle case
+    GlobalV::MIXING_ANGLE = 1.0;
+    CMtest.set_mixing(GlobalV::MIXING_MODE,
+                    GlobalV::MIXING_BETA,
+                    GlobalV::MIXING_NDIM,
+                    GlobalV::MIXING_GG0,
+                    GlobalV::MIXING_TAU,
+                    GlobalV::MIXING_BETA_MAG,
+                    GlobalV::MIXING_GG0_MAG,
+                    GlobalV::MIXING_GG0_MIN,
+                    GlobalV::MIXING_ANGLE,
+                    GlobalV::MIXING_DMR);
+    GlobalV::NSPIN = 4;
+
+    // a simple sum for inner product
+    drho1.resize(pw_basis.nrxx * 2);
+    drho2.resize(pw_basis.nrxx * 2);
+    for (int i = 0; i < pw_basis.nrxx * 2; ++i)
+    {
+        drho1[i] = 1.0;
+        drho2[i] = double(i);
+    }
+    inner = CMtest.inner_product_real(drho1.data(), drho2.data());
+    EXPECT_NEAR(inner, 0.5 * pw_basis.nrxx * 2  * (pw_basis.nrxx * 2 - 1), 1e-8);
+}
+
+TEST_F(ChargeMixingTest, InnerDotRecipSimpleTest)
+{
+    Charge_Mixing CMtest;
+    CMtest.set_rhopw(&pw_basis, &pw_basis);
+    GlobalV::NSPIN = 1;
+
+    // a simple sum for inner product
+    std::vector<std::complex<double>> drhog1(pw_basis.npw);
+    std::vector<std::complex<double>> drhog2(pw_basis.npw);
+    for (int i = 0; i < pw_basis.npw; ++i)
+    {
+        drhog1[i] = 1.0;
+        drhog2[i] = double(i);
+    }
+    double inner = CMtest.inner_product_recip_simple(drhog1.data(), drhog2.data());
+    EXPECT_NEAR(inner, 0.5 * pw_basis.npw * (pw_basis.npw - 1), 1e-8);
+}
+
 TEST_F(ChargeMixingTest, KerkerScreenRecipTest)
 {
     Charge_Mixing CMtest;


### PR DESCRIPTION
Fix #3603.

### List of Changes:
1. rename `inner_product_recip_new1()` as `inner_product_recip_simple()`
2. rename `inner_product_recip_new2()` as `inner_product_recip_hartree()`
3. combine `inner_product_recip()` and `rhog_dot_product()`, and rename it as `inner_product_recip_rho()`
4. let `inner_product_recip_hartree()` supports all cases in `mix_rho_recip_new()`
5. polish UnitTests to protect above functions.
