### PR TITLE
Refactor: rename `Kerker_screen_recip()` and add more UnitTests to protect `Charge_Mixing`

### DIFF
--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -1097,7 +1097,7 @@ void Charge_Mixing::Kerker_screen_recip(std::complex<double>* drhog)
 
     // consider a resize for mixing_angle
     int resize_tmp = 1;
-    if (GlobalV::NSPIN == 4 && GlobalV::MIXING_ANGLE > 0) resize_tmp = 2;
+    if (GlobalV::NSPIN == 4 && this->mixing_angle > 0) resize_tmp = 2;
 
     // implement Kerker for density and magnetization separately
     for (int is = 0; is < GlobalV::NSPIN / resize_tmp; ++is)
@@ -1105,7 +1105,7 @@ void Charge_Mixing::Kerker_screen_recip(std::complex<double>* drhog)
         // new mixing method only support nspin=2 not nspin=4
         if (is >= 1)
         {
-            if (GlobalV::MIXING_GG0_MAG <= 0.0001 || GlobalV::MIXING_BETA_MAG <= 0.1)
+            if (this->mixing_gg0_mag <= 0.0001 || this->mixing_beta_mag <= 0.1)
             {
 #ifdef __DEBUG
                 assert(is == 1); // make sure break works
@@ -1117,8 +1117,8 @@ void Charge_Mixing::Kerker_screen_recip(std::complex<double>* drhog)
                 //}
                 break;
             }
-            fac = GlobalV::MIXING_GG0_MAG;
-            amin = GlobalV::MIXING_BETA_MAG;
+            fac = this->mixing_gg0_mag;
+            amin = this->mixing_beta_mag;
         }
         else
         {
@@ -1133,7 +1133,7 @@ void Charge_Mixing::Kerker_screen_recip(std::complex<double>* drhog)
         for (int ig = 0; ig < this->rhopw->npw; ++ig)
         {
             double gg = this->rhopw->gg[ig];
-            double filter_g = std::max(gg / (gg + gg0), GlobalV::MIXING_GG0_MIN / amin);
+            double filter_g = std::max(gg / (gg + gg0), this->mixing_gg0_min / amin);
             drhog[is * this->rhopw->npw + ig] *= filter_g;
         }
     }

--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -1366,7 +1366,7 @@ double Charge_Mixing::inner_product_recip_simple(std::complex<double>* rho1, std
     double rnorm = 0.0;
     // consider a resize for mixing_angle
     int resize_tmp = 1;
-    if (GlobalV::NSPIN == 4 && GlobalV::MIXING_ANGLE > 0) resize_tmp = 2;
+    if (GlobalV::NSPIN == 4 && this->mixing_angle > 0) resize_tmp = 2;
 #ifdef _OPENMP
 #pragma omp parallel for reduction(+ : rnorm)
 #endif
@@ -1554,7 +1554,7 @@ double Charge_Mixing::inner_product_real(double* rho1, double* rho2)
     double rnorm = 0.0;
     // consider a resize for mixing_angle
     int resize_tmp = 1;
-    if (GlobalV::NSPIN == 4 && GlobalV::MIXING_ANGLE > 0) resize_tmp = 2;
+    if (GlobalV::NSPIN == 4 && this->mixing_angle > 0) resize_tmp = 2;
 
 #ifdef _OPENMP
 #pragma omp parallel for reduction(+ : rnorm)

--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -1146,7 +1146,7 @@ void Charge_Mixing::Kerker_screen_real(double* drhor)
         return;
     // consider a resize for mixing_angle
     int resize_tmp = 1;
-    if (GlobalV::NSPIN == 4 && GlobalV::MIXING_ANGLE > 0) resize_tmp = 2;
+    if (GlobalV::NSPIN == 4 && this->mixing_angle > 0) resize_tmp = 2;
     //
     std::vector<std::complex<double>> drhog(this->rhopw->npw * GlobalV::NSPIN / resize_tmp);
     std::vector<double> drhor_filter(this->rhopw->nrxx * GlobalV::NSPIN / resize_tmp);
@@ -1163,21 +1163,21 @@ void Charge_Mixing::Kerker_screen_real(double* drhor)
 
         if (is >= 1)
         {
-            if (GlobalV::MIXING_GG0_MAG <= 0.0001 || GlobalV::MIXING_BETA_MAG <= 0.1)
+            if (this->mixing_gg0_mag <= 0.0001 || this->mixing_beta_mag <= 0.1)
             {
 #ifdef __DEBUG
                 assert(is == 1); // make sure break works
 #endif
                 double is_mag = GlobalV::NSPIN - 1;
-                if (GlobalV::NSPIN == 4 && GlobalV::MIXING_ANGLE > 0) is_mag = 1;
+                if (GlobalV::NSPIN == 4 && this->mixing_angle > 0) is_mag = 1;
                 for (int ig = 0; ig < this->rhopw->npw * is_mag; ig++)
                 {
                     drhog[is * this->rhopw->npw + ig] = 0;
                 }
                 break;
             }
-            fac = GlobalV::MIXING_GG0_MAG;
-            amin = GlobalV::MIXING_BETA_MAG;
+            fac = this->mixing_gg0_mag;
+            amin = this->mixing_beta_mag;
         }
         else
         {
@@ -1198,7 +1198,7 @@ void Charge_Mixing::Kerker_screen_real(double* drhor)
             //    drhog[is * this->rhopw->npw + ig] *= 0;
             //    continue;
             //}
-            double filter_g = std::max(gg / (gg + gg0), GlobalV::MIXING_GG0_MIN / amin);
+            double filter_g = std::max(gg / (gg + gg0), this->mixing_gg0_min / amin);
             drhog[is * this->rhopw->npw + ig] *= (1 - filter_g);
         }
     }

--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -291,7 +291,7 @@ void Charge_Mixing::mix_rho_recip(Charge* chr)
     {
         rhog_in = rhogs_in;
         rhog_out = rhogs_out;
-        auto screen = std::bind(&Charge_Mixing::Kerker_screen_recip_new, this, std::placeholders::_1);
+        auto screen = std::bind(&Charge_Mixing::Kerker_screen_recip, this, std::placeholders::_1);
         this->mixing->push_data(this->rho_mdata, rhog_in, rhog_out, screen, true);
         this->mixing->cal_coef(this->rho_mdata, inner_product);
         this->mixing->mix_data(this->rho_mdata, rhog_out);
@@ -322,7 +322,7 @@ void Charge_Mixing::mix_rho_recip(Charge* chr)
         rhog_in = rhog_mag_save;
         rhog_out = rhog_mag;
         //
-        auto screen = std::bind(&Charge_Mixing::Kerker_screen_recip_new, this, std::placeholders::_1);
+        auto screen = std::bind(&Charge_Mixing::Kerker_screen_recip, this, std::placeholders::_1);
         auto twobeta_mix
             = [this, npw](std::complex<double>* out, const std::complex<double>* in, const std::complex<double>* sres) {
 #ifdef _OPENMP
@@ -373,7 +373,7 @@ void Charge_Mixing::mix_rho_recip(Charge* chr)
         rhog_in = rhogs_in;
         rhog_out = rhogs_out;
         const int npw = this->rhopw->npw;
-        auto screen = std::bind(&Charge_Mixing::Kerker_screen_recip_new, this, std::placeholders::_1); // use old one
+        auto screen = std::bind(&Charge_Mixing::Kerker_screen_recip, this, std::placeholders::_1); // use old one
         auto twobeta_mix
             = [this, npw](std::complex<double>* out, const std::complex<double>* in, const std::complex<double>* sres) {
 #ifdef _OPENMP
@@ -437,7 +437,7 @@ void Charge_Mixing::mix_rho_recip(Charge* chr)
         //
         rhog_in = rhog_magabs_save;
         rhog_out = rhog_magabs;
-        auto screen = std::bind(&Charge_Mixing::Kerker_screen_recip_new, this, std::placeholders::_1); // use old one
+        auto screen = std::bind(&Charge_Mixing::Kerker_screen_recip, this, std::placeholders::_1); // use old one
         auto twobeta_mix
             = [this, npw](std::complex<double>* out, const std::complex<double>* in, const std::complex<double>* sres) {
 #ifdef _OPENMP
@@ -1089,7 +1089,7 @@ void Charge_Mixing::mix_rho(Charge* chr)
     return;
 }
 
-void Charge_Mixing::Kerker_screen_recip_new(std::complex<double>* drhog)
+void Charge_Mixing::Kerker_screen_recip(std::complex<double>* drhog)
 {
     if (this->mixing_gg0 <= 0.0 || this->mixing_beta <= 0.1)
         return;

--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -1089,27 +1089,6 @@ void Charge_Mixing::mix_rho(Charge* chr)
     return;
 }
 
-void Charge_Mixing::Kerker_screen_recip(std::complex<double>* drhog)
-{
-    if (this->mixing_gg0 <= 0.0 || this->mixing_beta <= 0.1)
-        return;
-    const double fac = this->mixing_gg0;
-    const double gg0 = std::pow(fac * 0.529177 / GlobalC::ucell.tpiba, 2);
-#ifdef _OPENMP
-#pragma omp parallel for collapse(2) schedule(static, 512)
-#endif
-    for (int is = 0; is < GlobalV::NSPIN; ++is)
-    {
-        for (int ig = 0; ig < this->rhopw->npw; ++ig)
-        {
-            double gg = this->rhopw->gg[ig];
-            double filter_g = std::max(gg / (gg + gg0), GlobalV::MIXING_GG0_MIN / this->mixing_beta);
-            drhog[is * this->rhopw->npw + ig] *= filter_g;
-        }
-    }
-    return;
-}
-
 void Charge_Mixing::Kerker_screen_recip_new(std::complex<double>* drhog)
 {
     if (this->mixing_gg0 <= 0.0 || this->mixing_beta <= 0.1)

--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -264,7 +264,7 @@ double Charge_Mixing::get_drho(Charge* chr, const double nelec)
     return drho;
 }
 
-void Charge_Mixing::mix_rho_recip_new(Charge* chr)
+void Charge_Mixing::mix_rho_recip(Charge* chr)
 {
     std::complex<double>* rhog_in = nullptr;
     std::complex<double>* rhog_out = nullptr;
@@ -1027,7 +1027,7 @@ void Charge_Mixing::mix_rho(Charge* chr)
     // --------------------Mixing Body--------------------
     if (GlobalV::SCF_THR_TYPE == 1)
     {
-        mix_rho_recip_new(chr);
+        mix_rho_recip(chr);
     }
     else if (GlobalV::SCF_THR_TYPE == 2)
     {

--- a/source/module_elecstate/module_charge/charge_mixing.h
+++ b/source/module_elecstate/module_charge/charge_mixing.h
@@ -144,7 +144,6 @@ class Charge_Mixing
      * @brief Kerker screen method for reciprocal space
      * @param rhog charge density in reciprocal space
      */
-    void Kerker_screen_recip(std::complex<double>* rhog);
     void Kerker_screen_recip_new(std::complex<double>* rhog);
 
     /**
@@ -157,7 +156,7 @@ class Charge_Mixing
      * @brief Inner product of two complex vectors
      * @brief inner_product_recip_rho is used for charge, like get_drho()
      * @brief inner_product_recip_hartree and inner_product_recip_simple are used for charge mixing
-     * @brief inner_product_recip_simple is used for test
+     * @brief inner_product_recip_simple is only used for test
      * @brief Actually, I am not sure if the definition of inner product for NSPIN=4 is correct, need to be checked.
      */
     double inner_product_recip_rho(std::complex<double>* rho1, std::complex<double>* rho2);

--- a/source/module_elecstate/module_charge/charge_mixing.h
+++ b/source/module_elecstate/module_charge/charge_mixing.h
@@ -132,7 +132,7 @@ class Charge_Mixing
      * @brief charge mixing for reciprocal space
      * @param chr pointer of Charge object
      */
-    void mix_rho_recip_new(Charge* chr);
+    void mix_rho_recip(Charge* chr);
 
     /**
      * @brief charge mixing for real space

--- a/source/module_elecstate/module_charge/charge_mixing.h
+++ b/source/module_elecstate/module_charge/charge_mixing.h
@@ -144,7 +144,7 @@ class Charge_Mixing
      * @brief Kerker screen method for reciprocal space
      * @param rhog charge density in reciprocal space
      */
-    void Kerker_screen_recip_new(std::complex<double>* rhog);
+    void Kerker_screen_recip(std::complex<double>* rhog);
 
     /**
      * @brief Kerker screen method for real space

--- a/source/module_elecstate/test/charge_mixing_test.cpp
+++ b/source/module_elecstate/test/charge_mixing_test.cpp
@@ -550,7 +550,7 @@ TEST_F(ChargeMixingTest, KerkerScreenRecipNewTest)
     {
         drhog_old[i] = drhog[i] = std::complex<double>(1.0, 1.0);
     }
-    CMtest.Kerker_screen_recip_new(drhog);
+    CMtest.Kerker_screen_recip(drhog);
     for (int i = 0; i < GlobalV::NSPIN*pw_basis.npw; ++i)
     {
         EXPECT_EQ(drhog[i], drhog_old[i]);
@@ -559,7 +559,7 @@ TEST_F(ChargeMixingTest, KerkerScreenRecipNewTest)
     // RECIPROCAL
     CMtest.mixing_gg0 = 1.0;
     GlobalV::MIXING_GG0_MAG = 0.0;
-    CMtest.Kerker_screen_recip_new(drhog);
+    CMtest.Kerker_screen_recip(drhog);
     const double gg0 = std::pow(0.529177, 2);
     for (int i = 0; i < pw_basis.npw; ++i)
     {

--- a/source/module_elecstate/test/charge_mixing_test.cpp
+++ b/source/module_elecstate/test/charge_mixing_test.cpp
@@ -532,62 +532,6 @@ TEST_F(ChargeMixingTest, InnerDotRecipRhoTest)
     EXPECT_NEAR(inner, 110668.61166927818, 1e-8);
 }
 
-TEST_F(ChargeMixingTest, KerkerScreenRecipTest)
-{
-    Charge_Mixing CMtest;
-    CMtest.set_rhopw(&pw_basis, &pw_basis);
-    GlobalV::NSPIN = 1;
-    GlobalC::ucell.tpiba = 1.0;
-
-    CMtest.mixing_gg0 = 0.0;
-    std::complex<double>* drhog = new std::complex<double>[pw_basis.npw];
-    std::complex<double>* drhog_old = new std::complex<double>[pw_basis.npw];
-    double* drhor = new double[pw_basis.nrxx];
-    double* drhor_ref = new double[pw_basis.nrxx];
-    for (int i = 0; i < pw_basis.npw; ++i)
-    {
-        drhog_old[i] = drhog[i] = std::complex<double>(1.0, 1.0);
-    }
-    CMtest.Kerker_screen_recip(drhog);
-    for (int i = 0; i < pw_basis.npw; ++i)
-    {
-        EXPECT_EQ(drhog[i], drhog_old[i]);
-    }
-
-    // RECIPROCAL
-    CMtest.mixing_gg0 = 1.0;
-    CMtest.Kerker_screen_recip(drhog);
-    const double gg0 = std::pow(0.529177, 2);
-    for (int i = 0; i < pw_basis.npw; ++i)
-    {
-        std::complex<double> ration = drhog[i] / drhog_old[i];
-        double gg = this->pw_basis.gg[i];
-        double ration_ref = std::max(gg / (gg + gg0), 0.1 / CMtest.mixing_beta);
-        EXPECT_NEAR(ration.real(), ration_ref, 1e-10);
-        EXPECT_NEAR(ration.imag(), 0, 1e-10);
-    }
-
-    // REAL
-    pw_basis.recip2real(drhog, drhor_ref);
-    pw_basis.recip2real(drhog_old, drhor);
-
-    CMtest.mixing_gg0 = 0.0;
-    // nothing happens
-    CMtest.Kerker_screen_real(drhor);
-
-    CMtest.mixing_gg0 = 1.0;
-    CMtest.Kerker_screen_real(drhor);
-    for (int i = 0; i < pw_basis.nrxx; ++i)
-    {
-        EXPECT_NEAR(drhor[i], drhor_ref[i], 1e-8);
-    }
-
-    delete[] drhog;
-    delete[] drhog_old;
-    delete[] drhor;
-    delete[] drhor_ref;
-}
-
 TEST_F(ChargeMixingTest, KerkerScreenRecipNewTest)
 {
     Charge_Mixing CMtest;


### PR DESCRIPTION
Fix #3608.

### List of Changes
1. delete old `kerker_screen_recip()`, which was not used anywhere.
2. rename `kerker_screen_recip_new()` as `kerker_screen_recip()`.
3. rename `mix_rho_recip_new()` as `mix_rho_recip()`.
4. Polish corresponding UnitTests.