### PR TITLE
Fix: mulliken_charge error for magnetism_atom_y

### DIFF
--- a/source/module_hamilt_lcao/module_deltaspin/cal_mw_helper.cpp
+++ b/source/module_hamilt_lcao/module_deltaspin/cal_mw_helper.cpp
@@ -141,14 +141,16 @@ void SpinConstrain<std::complex<double>, psi::DEVICE_CPU>::collect_MW(ModuleBase
                     const int ic = this->ParaV->global2local_col(k2);
                     // note that mud is column major
                     MecMulP(1, j) += mud(ic, ir).real();
-                    MecMulP(2, j) += mud(ic, ir).imag();
+                    // M_y = i(M_{up,down} - M_{down,up}) = -(M_{up,down} - M_{down,up}).imag()
+                    MecMulP(2, j) -= mud(ic, ir).imag();
                 }
                 if (this->ParaV->in_this_processor(k2, k1))
                 {
                     const int ir = this->ParaV->global2local_row(k2);
                     const int ic = this->ParaV->global2local_col(k1);
                     MecMulP(1, j) += mud(ic, ir).real();
-                    MecMulP(2, j) -= mud(ic, ir).imag();
+                    // M_y = i(M_{up,down} - M_{down,up}) = -(M_{up,down} - M_{down,up}).imag()
+                    MecMulP(2, j) += mud(ic, ir).imag();
                 }
                 if (this->ParaV->in_this_processor(k2, k2))
                 {

--- a/source/module_hamilt_lcao/module_deltaspin/test/cal_mw_helper_test.cpp
+++ b/source/module_hamilt_lcao/module_deltaspin/test/cal_mw_helper_test.cpp
@@ -94,7 +94,7 @@ TEST_F(SpinConstrainTest, CollectMW)
     ModuleBase::matrix expected_MecMulP(4, 1);
     expected_MecMulP(0, 0) = 7.0;
     expected_MecMulP(1, 0) = 7.0;
-    expected_MecMulP(2, 0) = -1.0;
+    expected_MecMulP(2, 0) = 1.0;
     expected_MecMulP(3, 0) = -3.0;
     // Compare the matrices
     for (size_t i = 0; i < expected_MecMulP.nr; ++i)

--- a/source/module_io/mulliken_charge.cpp
+++ b/source/module_io/mulliken_charge.cpp
@@ -208,14 +208,16 @@ ModuleBase::matrix ModuleIO::cal_mulliken(const std::vector<std::vector<std::com
                         const int ir = LM->ParaV->global2local_row(k1);
                         const int ic = LM->ParaV->global2local_col(k2);
                         MecMulP(1, j) += mud(ic, ir).real();
-                        MecMulP(2, j) += mud(ic, ir).imag();
+                        // M_y = i(M_{up,down} - M_{down,up}) = -(M_{up,down} - M_{down,up}).imag()
+                        MecMulP(2, j) -= mud(ic, ir).imag(); 
                     }
                     if(LM->ParaV->in_this_processor(k2, k1))
                     {
                         const int ir = LM->ParaV->global2local_row(k2);
                         const int ic = LM->ParaV->global2local_col(k1);
                         MecMulP(1, j) += mud(ic, ir).real();
-                        MecMulP(2, j) -= mud(ic, ir).imag();
+                        // M_y = i(M_{up,down} - M_{down,up}) = -(M_{up,down} - M_{down,up}).imag()
+                        MecMulP(2, j) += mud(ic, ir).imag();
                     }
                     if(LM->ParaV->in_this_processor(k2, k2))
                     {


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #3629 

### What's changed?
- Reviewer can read bug reason in annotations

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
