### PR TITLE
Feature: extended support on arbitrary atom symbols defined in STRU to calculate QO_OVLP data

### DIFF
--- a/source/module_io/to_qo_tools.cpp
+++ b/source/module_io/to_qo_tools.cpp
@@ -6,7 +6,7 @@ void toQO::unwrap_unitcell(UnitCell* p_ucell)
     p_ucell_ = p_ucell;
     ntype_ = p_ucell->ntype;
     std::for_each(p_ucell->atoms, p_ucell->atoms + p_ucell->ntype, [this](Atom& atom){
-        symbols_.push_back(atom.label);
+        symbols_.push_back(atom.ncpp.psd);
         na_.push_back(atom.na);
     });
     nmax_.resize(ntype_);


### PR DESCRIPTION
### Motivation
Note that currently deltaspin and dft+u are under development, numerical basis's behavior now is a key point to check, and physical meaning should be got as easy as possible. I find QO can meet this demand easily, therefore to make it more flexible, I change a little bit the way to generate data, but mostly it is user-insensitive, except the case the atom symbol in STRU is changed to some arbitrary values.
This PR fix this exception, now QO will directly read symbol from pseudopotential and construct hydrogen-like orbitals, perform two-center-integral.
Looking forward to help more developers.

### Reminder
- [x] Have you linked an issue with this pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [x] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #3632 

### What's changed?
before
```C++
    std::for_each(p_ucell->atoms, p_ucell->atoms + p_ucell->ntype, [this](Atom& atom){
        symbols_.push_back(atom.label);
        na_.push_back(atom.na);
    });
```
after
```C++
    std::for_each(p_ucell->atoms, p_ucell->atoms + p_ucell->ntype, [this](Atom& atom){
        symbols_.push_back(atom.ncpp.psd);
        na_.push_back(atom.na);
    });
```

### Any changes of core modules? (ignore if not applicable)
No
