### PR TITLE
Fix: no cal_nlm_tot in cal_force_stress  and onsite_radius > rcut_NAOs

### DIFF
--- a/source/module_basis/module_nao/atomic_radials.cpp
+++ b/source/module_basis/module_nao/atomic_radials.cpp
@@ -85,13 +85,21 @@ void AtomicRadials::build(RadialSet* const other, const int itype, const double 
         const double* rgrid = other->cbegin()[ichi].rgrid();
         const double* rvalue = other->cbegin()[ichi].rvalue();
         const int izeta = other->cbegin()[ichi].izeta();
-        // call projgen to modify the orbitals
-        std::vector<double> rvalue_new;
-        smoothgen(ngrid, rgrid, rvalue, rcut, rvalue_new);
-        ngrid = rvalue_new.size();
-        //projgen(l, ngrid, rgrid, rvalue, rcut, 20, rvalue_new);
-        //build the new on-site orbitals
-        this->chi_[ichi].build(l, true, ngrid, rgrid, rvalue_new.data(), 0, izeta, symbol_, itype, false);
+        // if the cutoff radius is larger than the original one, just copy the orbitals
+        if(rcut >= other->cbegin()[ichi].rcut())
+        {
+            this->chi_[ichi].build(l, true, ngrid, rgrid, rvalue, 0, izeta, symbol_, itype, false);
+        }
+        else
+        {
+            // call smoothgen to modify the orbitals to the local projections
+            std::vector<double> rvalue_new;
+            smoothgen(ngrid, rgrid, rvalue, rcut, rvalue_new);
+            ngrid = rvalue_new.size();
+            //projgen(l, ngrid, rgrid, rvalue, rcut, 20, rvalue_new);
+            //build the new on-site orbitals
+            this->chi_[ichi].build(l, true, ngrid, rgrid, rvalue_new.data(), 0, izeta, symbol_, itype, false);
+        }
     }
 }
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/dftu_new.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/dftu_new.h
@@ -87,6 +87,12 @@ class DFTUNew<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
      */
     void initialize_HR(Grid_Driver* GridD_in, const Parallel_Orbitals* paraV);
 
+    /**
+     * @brief calculate the <phi|alpha^I> overlap values and save them in this->nlm_tot
+     * it will be reused in the calculation of calculate_HR()
+    */
+    void cal_nlm_all(const Parallel_Orbitals* paraV);
+
     void cal_occupations(const int& iat1,
                         const int& iat2,
                         const int& T0,
@@ -157,6 +163,7 @@ class DFTUNew<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                         double* stress);
 
     std::vector<AdjacentAtomInfo> adjs_all;
+    bool precal_nlm_done = false;
     std::vector<std::vector<std::unordered_map<int, std::vector<double>>>> nlm_tot;
 };
 


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #3676 

### What's changed?
- no calculation of nlm_tot when only force_stress are calculated by DFTUNew
- use NAOs rather than modulated projections when onsite_radius > rcut_NAO

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
