### PR TITLE
Bug: Fix Intel compile warnings

### DIFF
--- a/python/pyabacus/examples/vis_nao.py
+++ b/python/pyabacus/examples/vis_nao.py
@@ -21,11 +21,8 @@ def cart2sph(x, y, z):
     azimuth = np.arctan2(y, x)
     return r, polar, azimuth
 
-def orbital_plot(m, l, zeta, file_list):
-    nfile = len(file_list)
-    orb = nao.RadialCollection()
-    orb.build(nfile, file_list, 'o')
-    chi = orb(m, l, zeta)
+def orbital_plot(orb, itype, l, zeta, m):
+    chi = orb(itype, l, zeta)
 
     # 3d mesh grid
     w = 3
@@ -59,10 +56,18 @@ def orbital_plot(m, l, zeta, file_list):
     fig.show()
 
 if __name__ == '__main__':
-    l = 1
-    zeta = 0
-    m = 0
+
     orb_dir = '../../../tests/PP_ORB/'
     file_list = ['H_gga_8au_100Ry_2s1p.orb', 'O_gga_10au_100Ry_2s2p1d.orb']
     file_list = [orb_dir + orbfile for orbfile in file_list ]
-    orbital_plot(m, l, zeta, file_list)
+    nfile = len(file_list)
+
+    # set parameters
+    l = 1
+    zeta = 0
+    m = 0
+    itype = 0
+    orb = nao.RadialCollection()
+    orb.build(nfile, file_list, 'o')
+
+    orbital_plot(orb, itype, l, zeta, m)

--- a/python/pyabacus/src/py_m_nao.cpp
+++ b/python/pyabacus/src/py_m_nao.cpp
@@ -162,15 +162,15 @@ void bind_m_nao(py::module& m)
                     grad_out = new double[3];
                 }
                 self.calculate(itype1, l1, izeta1, m1, itype2, l2, izeta2, m2, vR, out, grad_out);
-                py::array_t<double> out_array({1}, out);
+                py::array_t<double> out_array(1, out);
                 if (cal_grad)
                 {
-                    py::array_t<double> grad_out_array({3}, grad_out);
+                    py::array_t<double> grad_out_array(3, grad_out);
                     return py::make_tuple(out_array, grad_out_array);
                 }
                 else
                 {
-                    py::array_t<double> grad_out_array({0});
+                    py::array_t<double> grad_out_array(0);
                     return py::make_tuple(out_array, grad_out_array);
                 }
             },
@@ -475,22 +475,22 @@ void bind_m_nao(py::module& m)
         .def_property_readonly("rgrid",
                                [](NumericalRadial& self) {
                                    const double* rgrid = self.rgrid();
-                                   return py::array_t<double>({self.nr()}, rgrid);
+                                   return py::array_t<double>(self.nr(), rgrid);
                                })
         .def_property_readonly("kgrid",
                                [](NumericalRadial& self) {
                                    const double* kgrid = self.kgrid();
-                                   return py::array_t<double>({self.nk()}, kgrid);
+                                   return py::array_t<double>(self.nk(), kgrid);
                                })
         .def_property_readonly("rvalue",
                                [](NumericalRadial& self) {
                                    const double* rvalue = self.rvalue();
-                                   return py::array_t<double>({self.nr()}, rvalue);
+                                   return py::array_t<double>(self.nr(), rvalue);
                                })
         .def_property_readonly("kvalue",
                                [](NumericalRadial& self) {
                                    const double* kvalue = self.kvalue();
-                                   return py::array_t<double>({self.nk()}, kvalue);
+                                   return py::array_t<double>(self.nk(), kvalue);
                                })
         .def_property_readonly("is_fft_compliant", overload_cast_<>()(&NumericalRadial::is_fft_compliant, py::const_));
 }


### PR DESCRIPTION
Fix Intel compile warnings when building pyabacus

```shell
/abacus-develop/python/pyabacus/src/py_m_nao.cpp:165:47: warning: braces around scalar initializer [-Wbraced-scalar-init]
    165 |                 py::array_t<double> out_array({1}, out);
        |                                               ^~~
  /abacus-develop/python/pyabacus/src/py_m_nao.cpp:168:56: warning: braces around scalar initializer [-Wbraced-scalar-init]
    168 |                     py::array_t<double> grad_out_array({3}, grad_out);
        |                                                        ^~~
  /abacus-develop/python/pyabacus/src/py_m_nao.cpp:173:56: warning: braces around scalar initializer [-Wbraced-scalar-init]
    173 |                     py::array_t<double> grad_out_array({0});
        |                                                        ^~~
  /abacus-develop/python/pyabacus/src/py_m_nao.cpp:478:63: warning: braces around scalar initializer [-Wbraced-scalar-init]
    478 |                                    return py::array_t<double>({self.nr()}, rgrid);
        |                                                               ^~~~~~~~~~~
  /abacus-develop/python/pyabacus/src/py_m_nao.cpp:483:63: warning: braces around scalar initializer [-Wbraced-scalar-init]
    483 |                                    return py::array_t<double>({self.nk()}, kgrid);
        |                                                               ^~~~~~~~~~~
  /abacus-develop/python/pyabacus/src/py_m_nao.cpp:488:63: warning: braces around scalar initializer [-Wbraced-scalar-init]
    488 |                                    return py::array_t<double>({self.nr()}, rvalue);
        |                                                               ^~~~~~~~~~~
  /abacus-develop/python/pyabacus/src/py_m_nao.cpp:493:63: warning: braces around scalar initializer [-Wbraced-scalar-init]
    493 |                                    return py::array_t<double>({self.nk()}, kvalue);
        |                                                               ^~~~~~~~~~~
  7 warnings generated.
```
I fixed the warnings since when the shape of array is one-dim, there is no need to use braces.