### PR TITLE
Fix FindLibxc.cmake to use /usr/include as include directory

### DIFF
--- a/cmake/FindLibxc.cmake
+++ b/cmake/FindLibxc.cmake
@@ -11,7 +11,7 @@ endif()
 find_package(PkgConfig)
 if(PKG_CONFIG_FOUND)
   pkg_search_module(Libxc IMPORTED_TARGET GLOBAL libxc)
-  find_package_handle_standard_args(Libxc DEFAULT_MSG Libxc_LINK_LIBRARIES Libxc_INCLUDE_DIRS)
+  find_package_handle_standard_args(Libxc DEFAULT_MSG Libxc_LINK_LIBRARIES Libxc_FOUND)
 endif()
 if(NOT Libxc_FOUND)
   find_package(Libxc REQUIRED HINTS


### PR DESCRIPTION
pkg-config would ignore flags like `-I/usr/include` in cflags; as `${prefix}_INCLUDE_DIR`S is initialized from `pkg-config --cflags-only-I ${pkgname}`, it would be empty as only `-I/usr/include` in cflags. However, under this situation, cmake would still mark `${prefix}_FOUND` as true, and without these global-visible includes no compilation issues arise; thus, this commit turns off detect of Libxc_INCLUDE_DIRS, and use Libxc_found instead.

### Reminder
- [x] Have you linked an issue with this pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #3761 

### What's changed?
- Changed filter condition of `find_package_handle_standard_args` in `cmake/FindLibxc.cmake`.

### Any changes of core modules? (ignore if not applicable)
No.