### PR TITLE
Fix: update the default two-center integration algorithm for Makefile build

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -10,6 +10,12 @@ LIBS = -lm -lpthread
 OPTS = -std=c++14 -pedantic -m64 ${INCLUDES}
 HONG = -D__LCAO
 HONG += -D__ELPA
+
+# An FFT-based spherical Bessel transform algorithm has become
+# the default since v3.3.4. Comment out the following line to use
+# the original Simpson-based spherical Bessel transform.
+HONG += -DUSE_NEW_TWO_CENTER
+
 ifeq ($(OPENMP), ON)
     ELPA_NAME = elpa_openmp
 else
@@ -45,7 +51,8 @@ ifeq ($(DEBUG), ON)
     endif
     OPTS += -O0 -fsanitize=address -fno-omit-frame-pointer -Wall -g #It can check segmental defaults
 else
-    HONG += -Ofast -march=native -DNDEBUG
+    # FIXME -Ofast is not compatible with the new two-center integration algorithm
+    HONG += -O3 -march=native -DNDEBUG
 endif
 
 ifeq ($(INTEL), ON)


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [x] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #3763 

### What's changed?
The macro "USE_NEW_TWO_CENTER" is added to Makefile in order to activate the FFT-based spherical Bessel transform algorithm as the default two-center integration method.

PS: I also have to downgrade the optimization level from -Ofast to -O3 in order to get reasonable calculation results. Although O3 is the level used in CMakeLists.txt so this change actually aligns the two builds, such behavior is unexpected and might deserve more investigation, if necessary.

### Any changes of core modules? (ignore if not applicable)
No.
