### PR TITLE
Refactor: remove some global variables in read_dm and read_wfc_nao

### DIFF
--- a/source/module_esolver/esolver_ks_lcao_elec.cpp
+++ b/source/module_esolver/esolver_ks_lcao_elec.cpp
@@ -179,6 +179,9 @@ void ESolver_KS_LCAO<TK, TR>::beforesolver(const int istep)
                 this->GridT.nnrg,
                 this->GridT.trace_lo,
 #endif
+                GlobalV::GAMMA_ONLY_LOCAL,
+                GlobalV::NLOCAL,
+                GlobalV::NSPIN,
                 is,
                 ssd.str(),
                 this->LOC.DM,

--- a/source/module_hamilt_lcao/hamilt_lcaodft/local_orbital_wfc.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/local_orbital_wfc.cpp
@@ -60,7 +60,8 @@ void Local_Orbital_wfc::gamma_file(psi::Psi<double>* psid, elecstate::ElecState*
 
     for (int is = 0; is < GlobalV::NSPIN; ++is)
     {
-        this->error = ModuleIO::read_wfc_nao(ctot, is, this->ParaV, psid, pelec);
+        this->error = ModuleIO::read_wfc_nao(ctot, is, GlobalV::GAMMA_ONLY_LOCAL, GlobalV::NB2D, GlobalV::NBANDS, 
+                                             GlobalV::NLOCAL, GlobalV::global_readin_dir, this->ParaV, psid, pelec);
 #ifdef __MPI
         Parallel_Common::bcast_int(this->error);
 #endif
@@ -164,7 +165,8 @@ void Local_Orbital_wfc::allocate_k(const int& lgd,
         for (int ik = 0; ik < nkstot; ++ik)
         {
             std::complex<double>** ctot;
-            this->error = ModuleIO::read_wfc_nao_complex(ctot, ik, kvec_c[ik], this->ParaV, psi, pelec);
+            this->error = ModuleIO::read_wfc_nao_complex(ctot, ik, GlobalV::NB2D, GlobalV::NBANDS, GlobalV::NLOCAL, 
+                                    GlobalV::global_readin_dir, kvec_c[ik], this->ParaV, psi, pelec);
 #ifdef __MPI
             Parallel_Common::bcast_int(this->error);
 #endif

--- a/source/module_io/dm_io.h
+++ b/source/module_io/dm_io.h
@@ -12,6 +12,9 @@ void read_dm(
 	const int nnrg,
 	const int* trace_lo,
 #endif
+	const bool gamma_only_local,
+	const int nlocal,
+	const int nspin,
 	const int &is,
 	const std::string &fn,
 	double*** DM,

--- a/source/module_io/read_dm.cpp
+++ b/source/module_io/read_dm.cpp
@@ -8,6 +8,9 @@ void ModuleIO::read_dm(
 	const int nnrg,
 	const int* trace_lo,
 #endif
+    const bool gamma_only_local,
+    const int nlocal,
+    const int nspin,
 	const int &is,
 	const std::string &fn,
 	double*** DM,
@@ -77,10 +80,10 @@ void ModuleIO::read_dm(
                 }
             }
 
-            ModuleBase::CHECK_INT(ifs, GlobalV::NSPIN);
+            ModuleBase::CHECK_INT(ifs, nspin);
             ModuleBase::GlobalFunc::READ_VALUE(ifs, ef);
-            ModuleBase::CHECK_INT(ifs, GlobalV::NLOCAL);
-            ModuleBase::CHECK_INT(ifs, GlobalV::NLOCAL);
+            ModuleBase::CHECK_INT(ifs, nlocal);
+            ModuleBase::CHECK_INT(ifs, nlocal);
         }// If file exist, read in data.
     } // Finish reading the first part of density matrix.
 
@@ -88,11 +91,11 @@ void ModuleIO::read_dm(
 #ifndef __MPI
     GlobalV::ofs_running << " Read SPIN = " << is+1 << " density matrix now." << std::endl;
 
-    if(GlobalV::GAMMA_ONLY_LOCAL)
+    if(gamma_only_local)
     {
-        for(int i=0; i<GlobalV::NLOCAL; ++i)
+        for(int i=0; i<nlocal; ++i)
         {
-            for(int j=0; j<GlobalV::NLOCAL; ++j)
+            for(int j=0; j<nlocal; ++j)
             {
                 ifs >> DM[is][i][j];
             }
@@ -125,27 +128,27 @@ void ModuleIO::read_dm(
 
     Parallel_Common::bcast_double(ef);
 
-    if(GlobalV::GAMMA_ONLY_LOCAL)
+    if(gamma_only_local)
     {
 
-        double *tmp = new double[GlobalV::NLOCAL];
-        for(int i=0; i<GlobalV::NLOCAL; ++i)
+        double *tmp = new double[nlocal];
+        for(int i=0; i<nlocal; ++i)
         {
             //GlobalV::ofs_running << " i=" << i << std::endl;
-            ModuleBase::GlobalFunc::ZEROS(tmp, GlobalV::NLOCAL);
+            ModuleBase::GlobalFunc::ZEROS(tmp, nlocal);
             if(GlobalV::MY_RANK==0)
             {
-                for(int j=0; j<GlobalV::NLOCAL; ++j)
+                for(int j=0; j<nlocal; ++j)
                 {
                     ifs >> tmp[j];
                 }
             }
-            Parallel_Common::bcast_double(tmp, GlobalV::NLOCAL);
+            Parallel_Common::bcast_double(tmp, nlocal);
 
             const int mu = trace_lo[i];
             if(mu >= 0)
             {   
-                for(int j=0; j<GlobalV::NLOCAL; ++j)
+                for(int j=0; j<nlocal; ++j)
                 {
                     const int nu = trace_lo[j];
                     if(nu >= 0)

--- a/source/module_io/read_wfc_nao.cpp
+++ b/source/module_io/read_wfc_nao.cpp
@@ -10,13 +10,14 @@ inline int CTOT2q(
 	int dim1,
 	int iprow,
 	int ipcol,
+    const int nbands,
 	double* work,
 	double** CTOT)
 {
     for(int j=0; j<naroc[1]; ++j)
     {
         int igcol=Local_Orbital_wfc::globalIndex(j, nb, dim1, ipcol);
-        if(igcol>=GlobalV::NBANDS) continue;
+        if(igcol>=nbands) continue;
         for(int i=0; i<naroc[0]; ++i)
         {
             int igrow=Local_Orbital_wfc::globalIndex(i, nb, dim0, iprow);
@@ -35,13 +36,14 @@ inline int CTOT2q_c(
 	int dim1,
 	int iprow,
 	int ipcol,
+    const int nbands,
 	std::complex<double>* work,
 	std::complex<double>** CTOT)
 {
     for(int j=0; j<naroc[1]; ++j)
     {
         int igcol=Local_Orbital_wfc::globalIndex(j, nb, dim1, ipcol);
-        if(igcol>=GlobalV::NBANDS) continue;
+        if(igcol>=nbands) continue;
         for(int i=0; i<naroc[0]; ++i)
         {
             int igrow=Local_Orbital_wfc::globalIndex(i, nb, dim0, iprow);
@@ -56,6 +58,10 @@ inline int CTOT2q_c(
 int ModuleIO::read_wfc_nao_complex(
     std::complex<double>** ctot, 
     const int& ik,
+    const int& nb2d,
+    const int& nbands_g,
+    const int& nlocal_g,
+    const std::string& global_readin_dir,
     const ModuleBase::Vector3<double> kvec_c,
     const Parallel_Orbitals* ParaV, 
     psi::Psi<std::complex<double>>* psi, 
@@ -66,7 +72,7 @@ int ModuleIO::read_wfc_nao_complex(
 
     std::stringstream ss;
 	// read wave functions
-    ss << GlobalV::global_readin_dir << "LOWF_K_" << ik+1 <<".txt";
+    ss << global_readin_dir << "LOWF_K_" << ik+1 <<".txt";
 //	std::cout << " name is = " << ss.str() << std::endl;
 
     std::ifstream ifs;
@@ -119,26 +125,26 @@ int ModuleIO::read_wfc_nao_complex(
 			 << " kz=" << kvec_c.z << std::endl;
 			 error = 4; 
 		}
-        else if (nbands!=GlobalV::NBANDS)
+        else if (nbands!=nbands_g)
         {
             GlobalV::ofs_warning << " read in nbands=" << nbands;
-            GlobalV::ofs_warning << " NBANDS=" << GlobalV::NBANDS << std::endl;
+            GlobalV::ofs_warning << " NBANDS=" << nbands_g << std::endl;
             error = 2;
         }
-        else if (nlocal != GlobalV::NLOCAL)
+        else if (nlocal != nlocal_g)
         {
             GlobalV::ofs_warning << " read in nlocal=" << nlocal;
-            GlobalV::ofs_warning << " NLOCAL=" << GlobalV::NLOCAL << std::endl;
+            GlobalV::ofs_warning << " NLOCAL=" << nlocal_g << std::endl;
             error = 3;
         }
 
-        ctot = new std::complex<double>*[GlobalV::NBANDS];
-        for (int i=0; i<GlobalV::NBANDS; i++)
+        ctot = new std::complex<double>*[nbands_g];
+        for (int i=0; i<nbands_g; i++)
         {
-            ctot[i] = new std::complex<double>[GlobalV::NLOCAL];
+            ctot[i] = new std::complex<double>[nlocal_g];
         }
 
-        for (int i=0; i<GlobalV::NBANDS; ++i)
+        for (int i=0; i<nbands_g; ++i)
         {
             int ib;
             ModuleBase::GlobalFunc::READ_VALUE(ifs, ib);
@@ -151,7 +157,7 @@ int ModuleIO::read_wfc_nao_complex(
 			ModuleBase::GlobalFunc::READ_VALUE(ifs, pelec->wg(ik,ib));
             assert( i==ib );
 			double a, b;
-            for (int j=0; j<GlobalV::NLOCAL; ++j)
+            for (int j=0; j<nlocal_g; ++j)
             {
                 ifs >> a >> b;
 				ctot[i][j]=std::complex<double>(a,b);
@@ -168,7 +174,7 @@ int ModuleIO::read_wfc_nao_complex(
 	if(error==3) return 3;
 	if(error==4) return 4;
 	
-	ModuleIO::distri_wfc_nao_complex(ctot, ik, ParaV, psi);
+	ModuleIO::distri_wfc_nao_complex(ctot, ik, nb2d, nbands_g, ParaV, psi);
 	
 	// mohan add 2012-02-15,
 	// still have bugs, but can solve it later.
@@ -177,7 +183,7 @@ int ModuleIO::read_wfc_nao_complex(
     if (GlobalV::DRANK==0)
     {
         // delte the ctot
-        for (int i=0; i<GlobalV::NBANDS; i++)
+        for (int i=0; i<nbands_g; i++)
         {
             delete[] ctot[i];
         }
@@ -188,10 +194,10 @@ int ModuleIO::read_wfc_nao_complex(
 	// TEST
 	//---------
 	/*
-	for(int i=0; i<GlobalV::NBANDS; ++i)
+	for(int i=0; i<nbands_g; ++i)
 	{
 		std::cout << " c band i=" << i+1 << std::endl;
-		for(int j=0; j<GlobalV::NLOCAL; ++j)
+		for(int j=0; j<nlocal_g; ++j)
 		{
 			std::cout << " " << c[i][j];
 		}
@@ -207,6 +213,11 @@ int ModuleIO::read_wfc_nao_complex(
 int ModuleIO::read_wfc_nao(
     double** ctot, 
     const int& is,
+    const bool& gamma_only_local,
+    const int& nb2d,
+    const int& nbands_g,
+    const int& nlocal_g,
+    const std::string& global_readin_dir,
     const Parallel_Orbitals* ParaV, 
     psi::Psi<double>* psid, 
     elecstate::ElecState* pelec)
@@ -218,12 +229,12 @@ int ModuleIO::read_wfc_nao(
 	if(GlobalV::GAMMA_ONLY_LOCAL)
 	{
 		// read wave functions
-    	ss << GlobalV::global_readin_dir << "LOWF_GAMMA_S" << is+1 <<".txt";
+    	ss << global_readin_dir << "LOWF_GAMMA_S" << is+1 <<".txt";
 		std::cout << " name is = " << ss.str() << std::endl;
 	}
 	else
 	{
-		ss << GlobalV::global_readin_dir << "LOWF_K.txt";
+		ss << global_readin_dir << "LOWF_K.txt";
 	}
 
     std::ifstream ifs;
@@ -254,27 +265,27 @@ int ModuleIO::read_wfc_nao(
         ModuleBase::GlobalFunc::READ_VALUE(ifs, nbands);
         ModuleBase::GlobalFunc::READ_VALUE(ifs, nlocal);
 
-        if (nbands!=GlobalV::NBANDS)
+        if (nbands!=nbands_g)
         {
             GlobalV::ofs_warning << " read in nbands=" << nbands;
-            GlobalV::ofs_warning << " NBANDS=" << GlobalV::NBANDS << std::endl;
+            GlobalV::ofs_warning << " NBANDS=" << nbands_g << std::endl;
             error = 2;
         }
-        else if (nlocal != GlobalV::NLOCAL)
+        else if (nlocal != nlocal_g)
         {
             GlobalV::ofs_warning << " read in nlocal=" << nlocal;
-            GlobalV::ofs_warning << " NLOCAL=" << GlobalV::NLOCAL << std::endl;
+            GlobalV::ofs_warning << " NLOCAL=" << nlocal_g << std::endl;
             error = 3;
         }
 
-        ctot = new double*[GlobalV::NBANDS];
-        for (int i=0; i<GlobalV::NBANDS; i++)
+        ctot = new double*[nbands_g];
+        for (int i=0; i<nbands_g; i++)
         {
-            ctot[i] = new double[GlobalV::NLOCAL];
+            ctot[i] = new double[nlocal_g];
         }
 
-		//std::cout << "nbands" << GlobalV::NBANDS << std::endl;
-        for (int i=0; i<GlobalV::NBANDS; i++)
+		//std::cout << "nbands" << nbands_g << std::endl;
+        for (int i=0; i<nbands_g; i++)
         {
             int ib;
             ModuleBase::GlobalFunc::READ_VALUE(ifs, ib);
@@ -282,7 +293,7 @@ int ModuleIO::read_wfc_nao(
             ModuleBase::GlobalFunc::READ_VALUE(ifs, pelec->wg(is, i));
             assert( (i+1)==ib);
 			//std::cout << " ib=" << ib << std::endl;
-            for (int j=0; j<GlobalV::NLOCAL; j++)
+            for (int j=0; j<nlocal_g; j++)
             {
                 ifs >> ctot[i][j];
 				//std::cout << ctot[i][j] << " ";
@@ -294,13 +305,13 @@ int ModuleIO::read_wfc_nao(
 
 #ifdef __MPI
     Parallel_Common::bcast_int(error);
-	Parallel_Common::bcast_double( &(pelec->ekb(is, 0)), GlobalV::NBANDS);
-	Parallel_Common::bcast_double( &(pelec->wg(is, 0)), GlobalV::NBANDS);
+	Parallel_Common::bcast_double( &(pelec->ekb(is, 0)), nbands_g);
+	Parallel_Common::bcast_double( &(pelec->wg(is, 0)), nbands_g);
 #endif
 	if(error==2) return 2;
 	if(error==3) return 3;
 
-	ModuleIO::distri_wfc_nao(ctot, is, ParaV, psid);
+	ModuleIO::distri_wfc_nao(ctot, is, nb2d, nbands_g, ParaV, psid);
 	
 	// mohan add 2012-02-15,
 	// still have bugs, but can solve it later.
@@ -310,7 +321,7 @@ int ModuleIO::read_wfc_nao(
     if (GlobalV::MY_RANK==0)
     {
         // delte the ctot
-        for (int i=0; i<GlobalV::NBANDS; i++)
+        for (int i=0; i<nbands_g; i++)
         {
             delete[] ctot[i];
         }
@@ -321,8 +332,8 @@ int ModuleIO::read_wfc_nao(
     return 0;
 }
 
-void ModuleIO::distri_wfc_nao(double** ctot, const int& is,
-    const Parallel_Orbitals* ParaV, psi::Psi<double>* psid)
+void ModuleIO::distri_wfc_nao(double** ctot, const int& is, const int& nb2d, const int& nbands_g,
+                              const Parallel_Orbitals* ParaV, psi::Psi<double>* psid)
 {
     ModuleBase::TITLE("ModuleIO","distri_wfc_nao");
 #ifdef __MPI
@@ -340,9 +351,9 @@ void ModuleIO::distri_wfc_nao(double** ctot, const int& is,
 
 	double *work=new double[maxnloc]; // work/buffer matrix
 #ifdef __DEBUG
-assert(GlobalV::NB2D > 0);
+assert(nb2d > 0);
 #endif	
-	int nb = GlobalV::NB2D;
+	int nb = nb2d;
 	int info;
 	int naroc[2]; // maximum number of row or column
 	
@@ -363,7 +374,7 @@ assert(GlobalV::NB2D > 0);
 			info=MPI_Bcast(naroc, 2, MPI_INT, src_rank, ParaV->comm_2D);
 
 //2.2 copy from ctot to work, then bcast work
-			info=CTOT2q(myid, naroc, nb, ParaV->dim0, ParaV->dim1, iprow, ipcol, work, ctot);
+			info=CTOT2q(myid, naroc, nb, ParaV->dim0, ParaV->dim1, iprow, ipcol, nbands_g, work, ctot);
 			info=MPI_Bcast(work, maxnloc, MPI_DOUBLE, 0, ParaV->comm_2D);
 			//GlobalV::ofs_running << "iprow, ipcow : " << iprow << ipcol << std::endl;
 			//for (int i=0; i<maxnloc; ++i)
@@ -382,9 +393,9 @@ assert(GlobalV::NB2D > 0);
 
 	delete[] work;
 #else
-        for (int i=0; i<GlobalV::NBANDS; i++)
+        for (int i=0; i<nbands_g; i++)
         {
-            for (int j=0; j<GlobalV::NLOCAL; j++)
+            for (int j=0; j<nlocal_g; j++)
             {
                psid[0](is, i, j) = ctot[i][j];
             }
@@ -393,8 +404,8 @@ assert(GlobalV::NB2D > 0);
     return;
 }
 
-void ModuleIO::distri_wfc_nao_complex(std::complex<double>** ctot, const int& ik,
-    const Parallel_Orbitals* ParaV, psi::Psi<std::complex<double>>* psi)
+void ModuleIO::distri_wfc_nao_complex(std::complex<double>** ctot, const int& ik, const int& nb2d,
+         const int& nbands_g, const Parallel_Orbitals* ParaV, psi::Psi<std::complex<double>>* psi)
 {
     ModuleBase::TITLE("ModuleIO","distri_wfc_nao_complex");
 #ifdef __MPI
@@ -412,9 +423,9 @@ void ModuleIO::distri_wfc_nao_complex(std::complex<double>** ctot, const int& ik
 
 	std::complex<double> *work=new std::complex<double>[maxnloc]; // work/buffer matrix
 #ifdef __DEBUG
-assert(GlobalV::NB2D > 0);
+assert(nb2d > 0);
 #endif	
-	int nb = GlobalV::NB2D;
+	int nb = nb2d;
 	int info;
 	int naroc[2]; // maximum number of row or column
 	
@@ -435,7 +446,7 @@ assert(GlobalV::NB2D > 0);
 			info=MPI_Bcast(naroc, 2, MPI_INT, src_rank, ParaV->comm_2D);
 
 //2.2 copy from ctot to work, then bcast work
-			info=CTOT2q_c(myid, naroc, nb, ParaV->dim0, ParaV->dim1, iprow, ipcol, work, ctot);
+			info=CTOT2q_c(myid, naroc, nb, ParaV->dim0, ParaV->dim1, iprow, ipcol, nbands_g, work, ctot);
 			info=MPI_Bcast(work, maxnloc, MPI_DOUBLE_COMPLEX, 0, ParaV->comm_2D);
 			//ofs_running << "iprow, ipcow : " << iprow << ipcol << std::endl;
 			//for (int i=0; i<maxnloc; ++i)

--- a/source/module_io/read_wfc_nao.cpp
+++ b/source/module_io/read_wfc_nao.cpp
@@ -311,7 +311,7 @@ int ModuleIO::read_wfc_nao(
 	if(error==2) return 2;
 	if(error==3) return 3;
 
-	ModuleIO::distri_wfc_nao(ctot, is, nb2d, nbands_g, ParaV, psid);
+	ModuleIO::distri_wfc_nao(ctot, is, nb2d, nbands_g, nlocal_g,ParaV, psid);
 	
 	// mohan add 2012-02-15,
 	// still have bugs, but can solve it later.
@@ -333,7 +333,7 @@ int ModuleIO::read_wfc_nao(
 }
 
 void ModuleIO::distri_wfc_nao(double** ctot, const int& is, const int& nb2d, const int& nbands_g,
-                              const Parallel_Orbitals* ParaV, psi::Psi<double>* psid)
+                              const int& nlocal_g, const Parallel_Orbitals* ParaV, psi::Psi<double>* psid)
 {
     ModuleBase::TITLE("ModuleIO","distri_wfc_nao");
 #ifdef __MPI

--- a/source/module_io/read_wfc_nao.h
+++ b/source/module_io/read_wfc_nao.h
@@ -11,14 +11,19 @@
 // mohan add 2010-09-09
 namespace ModuleIO
 {
-    void distri_wfc_nao(double** ctot, const int& is,
-        const Parallel_Orbitals* ParaV, psi::Psi<double>* psid);
-    void distri_wfc_nao_complex(std::complex<double>** ctot, const int& ik,
-        const Parallel_Orbitals* ParaV, psi::Psi<std::complex<double>>* psi);
+    void distri_wfc_nao(double** ctot, const int& is, const int& nb2d,const int& nbands_g,
+                        const Parallel_Orbitals* ParaV, psi::Psi<double>* psid);
+    void distri_wfc_nao_complex(std::complex<double>** ctot, const int& ik,const int& nb2d, const int& nbands_g,
+                                const Parallel_Orbitals* ParaV, psi::Psi<std::complex<double>>* psi);
 
     int read_wfc_nao(
         double** ctot, 
         const int& is,
+        const bool& gamma_only_local,
+        const int& nb2d,
+        const int& nbands_g,
+        const int& nlocal_g,
+        const std::string& global_readin_dir,
         const Parallel_Orbitals* ParaV, 
         psi::Psi<double>* psid,
         elecstate::ElecState* pelec);
@@ -26,6 +31,10 @@ namespace ModuleIO
     int read_wfc_nao_complex(
         std::complex<double>** ctot, 
         const int& ik,
+        const int& nb2d,
+        const int& nbands_g,
+        const int& nlocal_g,
+        const std::string& global_readin_dir,
         const ModuleBase::Vector3<double> kvec_c,
         const Parallel_Orbitals* ParaV, 
         psi::Psi<std::complex<double>>* psi,

--- a/source/module_io/read_wfc_nao.h
+++ b/source/module_io/read_wfc_nao.h
@@ -12,7 +12,7 @@
 namespace ModuleIO
 {
     void distri_wfc_nao(double** ctot, const int& is, const int& nb2d,const int& nbands_g,
-                        const Parallel_Orbitals* ParaV, psi::Psi<double>* psid);
+                        const int& nlocal_g, const Parallel_Orbitals* ParaV, psi::Psi<double>* psid);
     void distri_wfc_nao_complex(std::complex<double>** ctot, const int& ik,const int& nb2d, const int& nbands_g,
                                 const Parallel_Orbitals* ParaV, psi::Psi<std::complex<double>>* psi);
 

--- a/source/module_io/test_serial/dm_io_test.cpp
+++ b/source/module_io/test_serial/dm_io_test.cpp
@@ -86,7 +86,8 @@ TEST_F(DMIOTest,Read)
 	double ef;
 	UcellTestPrepare utp = UcellTestLib["Si"];
 	ucell = utp.SetUcellInfo();
-	ModuleIO::read_dm(is,fn,DM,DM_R,ef,ucell);
+	ModuleIO::read_dm(GlobalV::GAMMA_ONLY_LOCAL, GlobalV::NLOCAL,
+					  GlobalV::NSPIN,is,fn,DM,DM_R,ef,ucell);
 	EXPECT_DOUBLE_EQ(ef,0.570336288802337);
 	EXPECT_NEAR(DM[0][0][0],3.904e-01,1e-6);
 	EXPECT_NEAR(DM[0][25][25],3.445e-02,1e-6);
@@ -103,7 +104,8 @@ TEST_F(DMIOTest,Write)
 	double ef;
 	UcellTestPrepare utp = UcellTestLib["Si"];
 	ucell = utp.SetUcellInfo();
-	ModuleIO::read_dm(is,fn,DM,DM_R,ef,ucell);
+	ModuleIO::read_dm(GlobalV::GAMMA_ONLY_LOCAL, GlobalV::NLOCAL,
+					  GlobalV::NSPIN,is,fn,DM,DM_R,ef,ucell);
 	EXPECT_DOUBLE_EQ(ef,0.570336288802337);
 	EXPECT_NEAR(DM[0][0][0],3.904e-01,1e-6);
 	EXPECT_NEAR(DM[0][25][25],3.445e-02,1e-6);

--- a/source/module_io/test_serial/read_wfc_nao_test.cpp
+++ b/source/module_io/test_serial/read_wfc_nao_test.cpp
@@ -55,7 +55,7 @@ TEST_F(ReadWfcNaoTest,DistriWfcNao)
       Parallel_Orbitals* ParaV = new Parallel_Orbitals;
       psi::Psi<double>* psid = new psi::Psi<double>(nks, nband, nlocal, &ngk[0]);
       // Act
-      ModuleIO::distri_wfc_nao(ctot, is, GlobalV::NB2D, GlobalV::NBANDS, ParaV, psid);
+      ModuleIO::distri_wfc_nao(ctot, is, GlobalV::NB2D, GlobalV::NBANDS, GlobalV::NLOCAL, ParaV, psid);
       // Assert
       for (int i=0; i<nband; i++)
       {

--- a/source/module_io/test_serial/read_wfc_nao_test.cpp
+++ b/source/module_io/test_serial/read_wfc_nao_test.cpp
@@ -55,7 +55,7 @@ TEST_F(ReadWfcNaoTest,DistriWfcNao)
       Parallel_Orbitals* ParaV = new Parallel_Orbitals;
       psi::Psi<double>* psid = new psi::Psi<double>(nks, nband, nlocal, &ngk[0]);
       // Act
-      ModuleIO::distri_wfc_nao(ctot, is, ParaV, psid);
+      ModuleIO::distri_wfc_nao(ctot, is, GlobalV::NB2D, GlobalV::NBANDS, ParaV, psid);
       // Assert
       for (int i=0; i<nband; i++)
       {
@@ -97,7 +97,8 @@ TEST_F(ReadWfcNaoTest,ReadWfcNao)
       pelec->ekb.create(nks,nband);
       pelec->wg.create(nks,nband);
       // Act
-      ModuleIO::read_wfc_nao(ctot, is, ParaV, psid, pelec);
+      ModuleIO::read_wfc_nao(ctot, is, GlobalV::GAMMA_ONLY_LOCAL, GlobalV::NB2D, GlobalV::NBANDS,
+                             GlobalV::NLOCAL, GlobalV::global_readin_dir, ParaV, psid, pelec);
       // Assert
       EXPECT_NEAR(pelec->ekb(0,1),0.314822,1e-5);
       EXPECT_NEAR(pelec->wg(0,1),0.0,1e-5);


### PR DESCRIPTION
### What's changed?
- remove `GlobalV::GAMMA_ONLY_LOCAL`, `GlobalV::NSPIN`, `GlobalV::NLOCAL` , `GlobalV::NBANDS` and `GlobalV::global_readin_dir` in read_dm and read_wfc_nao.