### PR TITLE
Refactor: Removed GlobalVs related to function ModuleIO::write_dm

### DIFF
--- a/source/module_io/dm_io.h
+++ b/source/module_io/dm_io.h
@@ -30,7 +30,10 @@ void write_dm(
 	int out_dm,
 	double*** DM,
 	const double& ef,
-	const UnitCell* ucell);
+	const UnitCell* ucell,
+    const int my_rank,
+    const int nspin,
+    const int nlocal);
 
 }
 

--- a/source/module_io/output_dm.cpp
+++ b/source/module_io/output_dm.cpp
@@ -47,6 +47,9 @@ void Output_DM::write()
         _out_dm,
         _DM,
         _ef,
-        _ucell);
+        _ucell,
+        GlobalV::MY_RANK,
+        GlobalV::NSPIN,
+        GlobalV::NLOCAL);
 }
 } // namespace ModuleIO

--- a/source/module_io/test_serial/dm_io_test.cpp
+++ b/source/module_io/test_serial/dm_io_test.cpp
@@ -111,7 +111,7 @@ TEST_F(DMIOTest,Write)
 	std::string ssd = "SPIN1_DM";
 	int precision = 3;
 	int out_dm = 1;
-	ModuleIO::write_dm(is,0,ssd,precision,out_dm,DM,ef,ucell);
+	ModuleIO::write_dm(is,0,ssd,precision,out_dm,DM,ef,ucell,GlobalV::MY_RANK,GlobalV::NSPIN,GlobalV::NLOCAL);
 	std::ifstream ifs;
 	ifs.open("SPIN1_DM");
 	std::string str((std::istreambuf_iterator<char>(ifs)),std::istreambuf_iterator<char>());

--- a/source/module_io/write_dm.cpp
+++ b/source/module_io/write_dm.cpp
@@ -46,7 +46,10 @@ void ModuleIO::write_dm(
 	int out_dm,
 	double*** DM,
 	const double& ef,
-	const UnitCell* ucell)
+	const UnitCell* ucell,
+    const int my_rank,
+    const int nspin,
+    const int nlocal)
 {
     ModuleBase::TITLE("ModuleIO","write_dm");
 
@@ -60,7 +63,7 @@ void ModuleIO::write_dm(
 	time_t start, end;
 	std::ofstream ofs;
 
-	if(GlobalV::MY_RANK==0)
+	if(my_rank==0)
 	{
 		start = time(NULL);
 
@@ -101,10 +104,10 @@ void ModuleIO::write_dm(
 			}
 		}
 
-		ofs << "\n " << GlobalV::NSPIN;
+		ofs << "\n " << nspin;
 		ofs << "\n " << ef << " (fermi energy)";
 
-		ofs << "\n  " << GlobalV::NLOCAL << " " << GlobalV::NLOCAL << std::endl;
+		ofs << "\n  " << nlocal << " " << nlocal << std::endl;
 
 		ofs << std::setprecision(precision);
 		ofs << std::scientific;
@@ -114,9 +117,9 @@ void ModuleIO::write_dm(
     //ofs << "\n " << GlobalV::GAMMA_ONLY_LOCAL << " (GAMMA ONLY LOCAL)" << std::endl;
 #ifndef __MPI
 
-    for(int i=0; i<GlobalV::NLOCAL; ++i)
+    for(int i=0; i<nlocal; ++i)
     {
-        for(int j=0; j<GlobalV::NLOCAL; ++j)
+        for(int j=0; j<nlocal; ++j)
         {
             if(j%8==0) ofs << "\n";
             ofs << " " << DM[is][i][j];
@@ -126,16 +129,16 @@ void ModuleIO::write_dm(
 #else
     //xiaohui modify 2014-06-18
     
-    double* tmp = new double[GlobalV::NLOCAL];
-    int* count = new int[GlobalV::NLOCAL];
-    for (int i=0; i<GlobalV::NLOCAL; ++i)
+    double* tmp = new double[nlocal];
+    int* count = new int[nlocal];
+    for (int i=0; i<nlocal; ++i)
     {
         // when reduce, there may be 'redundance', we need to count them.
-        ModuleBase::GlobalFunc::ZEROS(count, GlobalV::NLOCAL);
+        ModuleBase::GlobalFunc::ZEROS(count, nlocal);
         const int mu = trace_lo[i];
         if (mu >= 0)
         {
-            for (int j=0; j<GlobalV::NLOCAL; ++j)
+            for (int j=0; j<nlocal; ++j)
             {
                 const int nu = trace_lo[j];
                 if (nu >= 0)
@@ -144,13 +147,13 @@ void ModuleIO::write_dm(
                 }
             }
         }
-        Parallel_Reduce::reduce_all(count, GlobalV::NLOCAL);
+        Parallel_Reduce::reduce_all(count, nlocal);
 
         // reduce the density matrix for 'i' line.
-        ModuleBase::GlobalFunc::ZEROS(tmp, GlobalV::NLOCAL);
+        ModuleBase::GlobalFunc::ZEROS(tmp, nlocal);
         if (mu >= 0)
         {
-            for (int j=0; j<GlobalV::NLOCAL; j++)
+            for (int j=0; j<nlocal; j++)
             {
                 const int nu = trace_lo[j];
                 if (nu >=0)
@@ -160,11 +163,11 @@ void ModuleIO::write_dm(
                 }
             }
         }
-        Parallel_Reduce::reduce_all(tmp, GlobalV::NLOCAL);
+        Parallel_Reduce::reduce_all(tmp, nlocal);
 
-        if(GlobalV::MY_RANK==0)
+        if(my_rank==0)
         {
-            for (int j=0; j<GlobalV::NLOCAL; j++)
+            for (int j=0; j<nlocal; j++)
             {
                 if(j%8==0) ofs << "\n";
                 if(count[j]>0)
@@ -181,7 +184,7 @@ void ModuleIO::write_dm(
     delete[] tmp;
     delete[] count;
 #endif
-	if(GlobalV::MY_RANK==0)
+	if(my_rank==0)
 	{
 		end = time(NULL);
 		ModuleBase::GlobalFunc::OUT_TIME("write_dm",start,end);


### PR DESCRIPTION
### What's changed?
Following GlobalVs are removed from function ModuleIO::write_dm:
- GlobalV::MY_RANK
- GlobalV::NSPIN
- GlobalV::NLOCAL

Related to Issue #3806.