### PR TITLE
Feature: add a linear fit function by least square method

### DIFF
--- a/source/Makefile.Objects
+++ b/source/Makefile.Objects
@@ -129,6 +129,7 @@ OBJS_BASE=abfs-vector3_order.o\
     math_bspline.o\
     math_chebyshev.o\
     math_op.o\
+    math_tools.o\
     mathzone_add1.o\
     matrix.o\
     matrix3.o\

--- a/source/module_base/CMakeLists.txt
+++ b/source/module_base/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(
     math_bspline.cpp
     math_chebyshev.cpp
     mathzone_add1.cpp
+    math_tools.cpp
     matrix.cpp
     matrix3.cpp
     memory.cpp

--- a/source/module_base/math_tools.cpp
+++ b/source/module_base/math_tools.cpp
@@ -1,0 +1,34 @@
+#include "module_base/math_tools.h"
+#include <cassert>
+
+namespace ModuleBase
+{
+
+std::pair<double, double> linear_fit(const std::vector<double>& x, const std::vector<double>& y)
+{
+    assert(x.size() == y.size()); // the size of x and y should be the same
+    assert(x.size() > 0); // the size of x should be larger than 0
+    // get the size
+    const int n = x.size();
+
+  // calculate the sum of x, y, xy, xx
+    double x_sum = 0.0, y_sum = 0.0, x2_sum = 0.0, xy_sum = 0.0;
+    for(int i = 0; i < n; i++) 
+    {
+        x_sum += x[i];
+        y_sum += y[i];
+        x2_sum += x[i] * x[i];
+        xy_sum += x[i] * y[i];
+    }
+
+    double x_mean = x_sum / n;
+    double y_mean = y_sum / n;
+
+    //
+    double slope = (n * xy_sum - x_sum * y_sum) / (n * x2_sum - x_sum * x_sum);
+    double b = y_mean - slope * x_mean;
+
+    return {slope, b};
+}
+
+} // namespace ModuleBase

--- a/source/module_base/math_tools.h
+++ b/source/module_base/math_tools.h
@@ -1,0 +1,21 @@
+#ifndef MATH_TOOLS_H
+#define MATH_TOOLS_H
+
+#include <vector>
+
+//========================================================
+// some fundamental math tools
+//========================================================
+namespace ModuleBase
+{
+    /**
+     * @brief linear fit by using least square method
+     * 
+     * @param x [in] x data
+     * @param y [in] y data
+     * @return std::pair<double, double> slope and intercept
+     */
+    std::pair<double, double> linear_fit(const std::vector<double>& x, const std::vector<double>& y);
+}
+
+#endif

--- a/source/module_base/test/CMakeLists.txt
+++ b/source/module_base/test/CMakeLists.txt
@@ -106,6 +106,11 @@ AddTest(
   SOURCES math_polyint_test.cpp ../math_polyint.cpp ../realarray.cpp ../timer.cpp 
 )
 AddTest(
+  TARGET base_math_tools
+  LIBS formatter
+  SOURCES math_tools_test.cpp ../math_tools.cpp ../timer.cpp
+)
+AddTest(
   TARGET base_gram_schmidt_orth
   LIBS ${math_libs}
   SOURCES gram_schmidt_orth_test.cpp ../gram_schmidt_orth.h ../gram_schmidt_orth-inl.h ../global_function.h ../math_integral.cpp

--- a/source/module_base/test/math_tools_test.cpp
+++ b/source/module_base/test/math_tools_test.cpp
@@ -1,0 +1,22 @@
+#include "../math_tools.h"
+#include "gtest/gtest.h"
+
+/************************************************
+ *  unit test of math tools
+ ***********************************************/
+
+TEST(Tools,LinearFit)
+{
+    std::vector<double> x;
+    std::vector<double> y;
+    x = {1, 2, 3, 4, 5, 6, 7, 8};
+    y = {2, 4, 6, 8, 10, 12, 14, 16}; // y = 2x
+    std::pair<double, double> result = ModuleBase::linear_fit(x, y);
+    EXPECT_DOUBLE_EQ(result.first, 2.0); // slope = 2.0
+    EXPECT_DOUBLE_EQ(result.second, 0.0); // b = 0.0
+
+    y = {1.8, 3.9, 6.1, 8.2, 9.8, 12.3, 13.9, 16.1};
+    result = ModuleBase::linear_fit(x, y);
+    EXPECT_NEAR(result.first, 2.0, 0.1); // slope ~ 2.0
+    EXPECT_NEAR(result.second, 0.0, 0.12); // b ~ 0.0
+}


### PR DESCRIPTION
Fix #3815.

Add a linear fit function by least square method.

### The List of Changes
1. add `math_tools.h` and `math_tools.cpp` in `Base` class to store fundamental mathematical function.
2. add `ModuleBase::linear_fit()` to perform linear fit by least square method.
3. add correspond UnitTests to protect it.