### PR TITLE
Refactor: Remove direct references to GlobalV related to function read_cube.

### DIFF
--- a/source/module_elecstate/module_charge/charge_extra.cpp
+++ b/source/module_elecstate/module_charge/charge_extra.cpp
@@ -429,7 +429,11 @@ void Charge_Extra::read_files(
 #ifdef __MPI
             Pgrid,
 #endif
+            GlobalV::MY_RANK,
+            GlobalV::ESOLVER_TYPE,
+            GlobalV::RANK_IN_STOGROUP,
             is,
+            GlobalV::ofs_running,
             GlobalV::NSPIN,
             filename,
             data[is],

--- a/source/module_elecstate/module_charge/charge_init.cpp
+++ b/source/module_elecstate/module_charge/charge_init.cpp
@@ -52,7 +52,11 @@ void Charge::init_rho(elecstate::efermi& eferm_iout, const ModuleBase::ComplexMa
 #ifdef __MPI
                         &(GlobalC::Pgrid),
 #endif
+                        GlobalV::MY_RANK,
+                        GlobalV::ESOLVER_TYPE,
+                        GlobalV::RANK_IN_STOGROUP,
                         is,
+                        GlobalV::ofs_running,
                         GlobalV::NSPIN,
                         ssc.str(),
                         this->rho[is],
@@ -123,7 +127,11 @@ void Charge::init_rho(elecstate::efermi& eferm_iout, const ModuleBase::ComplexMa
 #ifdef __MPI
                             &(GlobalC::Pgrid),
 #endif
+                            GlobalV::MY_RANK,
+                            GlobalV::ESOLVER_TYPE,
+                            GlobalV::RANK_IN_STOGROUP,
                             is,
+                            GlobalV::ofs_running,
                             GlobalV::NSPIN,
                             ssc.str(),
                             this->kin_r[is],

--- a/source/module_io/cube_io.h
+++ b/source/module_io/cube_io.h
@@ -12,7 +12,11 @@ bool read_cube(
 #ifdef __MPI
     Parallel_Grid* Pgrid,
 #endif
+    int my_rank,
+    std::string esolver_type,
+    int rank_in_stogroup,
     const int& is,
+    std::ofstream& ofs_running,
     const int& nspin,
     const std::string& fn,
     double* data,

--- a/source/module_io/read_rho.cpp
+++ b/source/module_io/read_rho.cpp
@@ -4,9 +4,13 @@
 
 bool ModuleIO::read_rho(
 #ifdef __MPI
-		Parallel_Grid* Pgrid,
+    	Parallel_Grid* Pgrid,
 #endif
-		const int &is,
+		int my_rank,
+		std::string esolver_type,
+		int rank_in_stogroup,
+		const int& is,
+		std::ofstream& ofs_running,
 		const int &nspin,
 		const std::string &fn,
 		double* rho,
@@ -21,7 +25,11 @@ bool ModuleIO::read_rho(
 #ifdef __MPI
 		Pgrid,
 #endif
+		my_rank,
+		esolver_type,
+		rank_in_stogroup,
 		is,
+		ofs_running,
 		nspin,
 		fn,
 		rho,

--- a/source/module_io/rho_io.h
+++ b/source/module_io/rho_io.h
@@ -10,9 +10,13 @@ namespace ModuleIO
 {
 	bool read_rho(
 #ifdef __MPI
-		Parallel_Grid* Pgrid,
+    	Parallel_Grid* Pgrid,
 #endif
-		const int &is,
+		int my_rank,
+		std::string esolver_type,
+		int rank_in_stogroup,
+		const int& is,
+		std::ofstream& ofs_running,
 		const int &nspin,
 		const std::string &fn,
 		double* rho,

--- a/source/module_io/test_serial/rho_io_test.cpp
+++ b/source/module_io/test_serial/rho_io_test.cpp
@@ -56,6 +56,12 @@ class RhoIOTest : public ::testing::Test
     int prenspin = 1;
     double** rho;
     UnitCell* ucell;
+
+    int my_rank = 0;
+    std::string esolver_type = "ksdft";
+    int rank_in_stogroup = 0;
+    std::ofstream ofs_running = std::ofstream("unittest.log");
+
     void SetUp()
     {
         rho = new double*[nspin];
@@ -86,7 +92,7 @@ TEST_F(RhoIOTest, Read)
     double ef;
     UcellTestPrepare utp = UcellTestLib["Si"];
     ucell = utp.SetUcellInfo();
-    ModuleIO::read_rho(is, nspin, fn, rho[is], nx, ny, nz, ef, ucell, prenspin);
+    ModuleIO::read_rho(my_rank, esolver_type, rank_in_stogroup, is, ofs_running, nspin, fn, rho[is], nx, ny, nz, ef, ucell, prenspin);
     EXPECT_DOUBLE_EQ(ef, 0.461002);
     EXPECT_DOUBLE_EQ(rho[0][0], 1.27020863940e-03);
     EXPECT_DOUBLE_EQ(rho[0][46655], 1.33581335706e-02);
@@ -103,7 +109,7 @@ TEST_F(RhoIOTest, Write)
     UcellTestPrepare utp = UcellTestLib["Si"];
     ucell = utp.SetUcellInfo();
     // first read
-    ModuleIO::read_rho(is, nspin, fn, rho[is], nx, ny, nz, ef, ucell, prenspin);
+    ModuleIO::read_rho(my_rank, esolver_type, rank_in_stogroup, is, ofs_running, nspin, fn, rho[is], nx, ny, nz, ef, ucell, prenspin);
     EXPECT_DOUBLE_EQ(ef, 0.461002);
     EXPECT_DOUBLE_EQ(rho[0][0], 1.27020863940e-03);
     EXPECT_DOUBLE_EQ(rho[0][46655], 1.33581335706e-02);


### PR DESCRIPTION
### What's changed?
Remove direct references to GlobalV variables (defined in module_base/global_variable.h) in the `read_cube` and `read_rho`(which depends on `read_cube`) functions and instead pass the required variables as parameters. This change improves code modularity and reduces global state dependency.

Affected functions:
- read_cube
- read_rho

GlobalV removed:
- GlobalV::MY_RANK
- GlobalV::ESOLVER_TYPE
- GlobalV::RANK_IN_STOGROUP

Unit Test Modified:
- module_io/test_serial/rho_io_test.cpp

### Linked Issue
#3806

