### PR TITLE
Update ORB_atomic.cpp

### DIFF
--- a/source/module_basis/module_ao/ORB_atomic.cpp
+++ b/source/module_basis/module_ao/ORB_atomic.cpp
@@ -8,6 +8,9 @@ Numerical_Orbital::Numerical_Orbital()
 	//question remains
 	this->nchi = nullptr;
 	this->phiLN = new Numerical_Orbital_Lm[1];
+	this->rcut = 0.0;
+	this->max_nchi = 0;
+	this->type = 0;
 }
 
 Numerical_Orbital::~Numerical_Orbital()


### PR DESCRIPTION
I noticed that in ORB_atomic.cpp, some member variables of the Numerical_Orbital class are not initialized in the constructor, so I set their initial values.