### PR TITLE
Refactor: merge `K_Vectors` and `GlobalC::Parallel_Kpoints` class together

### DIFF
--- a/source/module_base/formatter_contextfmt.h
+++ b/source/module_base/formatter_contextfmt.h
@@ -69,13 +69,7 @@ namespace formatter
                     this->cache_title_ = std::to_string(value);
                 }
                 else {
-                    // it is a data
-                    if (this->known_context_) {
-                        this->p_phys_fmt_->set_context(this->phys_fmt_[this->icol_]);
-                    }
-                    else {
-                        this->p_phys_fmt_->set_context(this->default_phys_fmt_);
-                    }
+                    this->p_phys_fmt_->set_context(this->phys_fmt_[this->icol_]);
                     Table::add_col(this->cache_title_, (std::vector<std::string>){this->fmt_.format(value)});
                     this->cache_title_ = "";
                     this->fmt_.reset();

--- a/source/module_cell/klist.cpp
+++ b/source/module_cell/klist.cpp
@@ -45,15 +45,13 @@ K_Vectors::~K_Vectors()
 #endif
 }
 
-void K_Vectors::set(
-    const ModuleSymmetry::Symmetry &symm,
-    const std::string &k_file_name,
-    const int& nspin_in,
-    const ModuleBase::Matrix3 &reciprocal_vec,
-    const ModuleBase::Matrix3 &latvec)
+void K_Vectors::set(const ModuleSymmetry::Symmetry &symm,
+                    const std::string &k_file_name,
+                    const int& nspin_in,
+                    const ModuleBase::Matrix3 &reciprocal_vec,
+                    const ModuleBase::Matrix3 &latvec)
 {
     ModuleBase::TITLE("K_Vectors", "set");
-
 	GlobalV::ofs_running << "\n\n\n\n";
 	GlobalV::ofs_running << " >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>" << std::endl;
 	GlobalV::ofs_running << " |                                                                    |" << std::endl;
@@ -63,26 +61,16 @@ void K_Vectors::set(
 	GlobalV::ofs_running << " | We treat the spin as another set of k-points.                      |" << std::endl;
 	GlobalV::ofs_running << " |                                                                    |" << std::endl;
 	GlobalV::ofs_running << " <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<" << std::endl;
-	GlobalV::ofs_running << "\n\n\n\n";
+	GlobalV::ofs_running << "\n\n\n\n\n SETUP K-POINTS" << std::endl;
 
-	GlobalV::ofs_running << "\n SETUP K-POINTS" << std::endl;
-
-	// (1) set nspin, read kpoints.
-	this->nspin = nspin_in;
-	ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"nspin",nspin);
-	if(this->nspin==4)
-	{
-		this->nspin = 1;//zhengdy-soc
-	}
+	this->nspin = (this->nspin==4)? 1: nspin_in;
+	ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "nspin", nspin_in);
 
 	bool read_succesfully = this->read_kpoints(k_file_name);
 #ifdef __MPI
 	Parallel_Common::bcast_bool(read_succesfully);
 #endif
-	if(!read_succesfully)
-	{
-		ModuleBase::WARNING_QUIT("K_Vectors::set","Something wrong while reading KPOINTS.");
-	}
+	if(!read_succesfully) ModuleBase::WARNING_QUIT("K_Vectors::set","Something wrong while reading KPOINTS.");
 
     // output kpoints file
     std::string skpt1="";
@@ -137,19 +125,7 @@ void K_Vectors::set(
         ofkpt.close();
     }
 
-	int deg = 0;
-	if(GlobalV::NSPIN == 1)
-	{
-		deg = 2;
-	}
-	else if(GlobalV::NSPIN == 2||GlobalV::NSPIN==4)
-	{
-		deg = 1;
-	}
-	else
-	{
-        ModuleBase::WARNING_QUIT("K_Vectors::set", "Only available for nspin = 1 or 2 or 4");
-    }
+	int deg = (GlobalV::NSPIN == 1)? 2: 1; // GlobalV::NSPIN is not deemed to check here whether it is 1, 2, or 4 or illegal value.
 	this->normalize_wk(deg);
 
     // It's very important in parallel case,
@@ -188,6 +164,295 @@ void K_Vectors::renew(const int &kpoint_number)
     ModuleBase::Memory::record("KV::ngk",sizeof(int) * kpoint_number*3);*/
 
     return;
+}
+
+std::string K_Vectors::write_abacus_mpkmesh(const std::string& center, 
+                                            const std::vector<int>& nmp, 
+                                            const std::vector<int>& shifts)
+{
+    std::string result = "K_POINTS\n0\n";
+    if((center == "Gamma")||(center == "gamma")) result += "Gamma\n";
+    else if((center == "Monkhorst-Pack")||(center == "MP")||(center == "mp")) result += "Monkhorst-Pack\n";
+    else ModuleBase::WARNING_QUIT("K_Vectors::write_monkhorst_pack","Unknown center type.");
+    result += std::to_string(nmp[0]) + " " + std::to_string(nmp[1]) + " " + std::to_string(nmp[2]) + " ";
+    result += std::to_string(shifts[0]) + " " + std::to_string(shifts[1]) + " " + std::to_string(shifts[2]) + "\n";
+    return result;
+}
+
+std::string K_Vectors::write_abacus_kline(const std::string& scale,
+                               const std::vector<ModuleBase::Vector3<double>>& kvec, 
+                               const std::vector<int>& nks)
+{
+    std::vector<std::vector<double>> tmp(kvec.size(), std::vector<double>(3));
+    for(int i = 0; i < kvec.size(); ++i)
+    {
+        tmp[i][0] = kvec[i].x;
+        tmp[i][1] = kvec[i].y;
+        tmp[i][2] = kvec[i].z;
+    }
+    return this->write_abacus_kline(scale, tmp, nks);
+}
+
+std::string K_Vectors::write_abacus_kline(const std::string& scale,
+                               const std::vector<std::vector<double>>& kvec,
+                               const std::vector<int>& nks)
+{
+    std::string result = "K_POINTS\n";
+    result += std::to_string(kvec.size()) + "\n";
+    if(scale == "Cartesian") result += "Line_Cartesian\n";
+    else if(scale == "Direct") result += "Line_Direct\n";
+    else ModuleBase::WARNING_QUIT("K_Vectors::write_line","Unknown scale type.");
+
+    formatter::ContextFmt fmt;
+    fmt.set_context("vector3d");
+    for(int i = 0; i < kvec.size(); ++i)
+    {
+        fmt << kvec[i][0] << kvec[i][1] << kvec[i][2];
+        result += fmt.str() + " " + std::to_string(nks[i]) + "\n";
+    }
+    return result;
+}
+
+void K_Vectors::read_abacus_kpt(const std::string& fkpt)
+{
+    /*
+    there are two different kinds of KPT file
+    1. SCF mode, always need a uniformed and evenly kpoint mesh:
+        K_POINTS
+        0
+        Gamma
+        16 16 16 0.5 0.5 0.5
+    2. BAND mode, need a list of kpoints:
+        K_POINTS
+        8
+        Line
+        0.0000000000   0.0000000000   0.0000000000  20  # Γ         
+        0.5000000000  -0.5000000000   0.5000000000  20  # H                        
+        0.0000000000   0.0000000000   0.5000000000  20  # N                          
+        0.0000000000   0.0000000000   0.0000000000  20  # Γ                  
+        0.2500000000   0.2500000000   0.2500000000  20  # P                          
+        0.5000000000  -0.5000000000   0.5000000000  1   # H              
+        0.2500000000   0.2500000000   0.2500000000  20  # P              
+        0.0000000000   0.0000000000   0.5000000000  1   # N              
+    */
+    std::ifstream ifs(fkpt);
+    if(!ifs) ModuleBase::WARNING_QUIT("K_Vectors::read_abacus_kpt","Can't open file.");
+    std::string line;
+    std::getline(ifs, line);
+    #ifdef __DEBUG // ABACUS fixed format: the first line must be "K_POINTS"
+    assert (line == "K_POINTS");
+    #endif
+    // the following line may define the number of kpoints
+    std::getline(ifs, line);
+    bool kmesh = (line == "0")? true : false;
+    this->nkstot = kmesh? 0 : std::stoi(line);
+    // the following line determines which mode will kpoints be read in. Available choices
+    // currently supported are: "Gamma", "Monkhorst-Pack", "MP", "mp", along with line mode
+    // "Line_Cartesian" and "Line_Direct". A detailed mapping can be:
+    // User input                 Parse as
+    // "Gamma"/"gamma"            "Gamma", (0+, 0+, 0+) starting point
+    // "Monkhorst-Pack"/"MP"/"mp" "Monkhorst-Pack", gamma point centered mpmesh
+    // "Cartesian"/"C"            "Cartesian", read kpoint coords and weights directly
+    // "Direct"/"D"               "Direct", read kpoint coords and weights directly
+    // "Line_Cartesian"           "Line_Cartesian", read kpoints and generate line segments
+    // "Line_Direct"/"Line"       "Line_Direct", read kpoints and generate line segments
+    std::getline(ifs, line);
+    #ifdef __DEBUG // before reading kpoints, both identifier should be in the state of uninitialized
+    assert (this->kc_done == false);
+    assert (this->kd_done == false);
+    #endif
+    // next read specific kpoint coordinates, for nspin,
+    // if nspin == 2, only half will have valid value and for rest, say the rest part, 
+    // will be copied from the first half.
+    if(kmesh&&((line == "Gamma")||(line == "gamma")||(line == "MP")||(line == "mp")||(line == "Monkhorst-Pack")))
+    {
+        int ktype = (line == "Gamma" || line == "gamma")? 0 : 1;
+        this->is_mp = true; // no matter gamma or mp, it is a Monkhorst-Pack mesh
+        ifs >> this->nmp[0] >> this->nmp[1] >> this->nmp[2];
+        ifs >> this->koffset[0] >> this->koffset[1] >> this->koffset[2];
+        this->monkhorst_pack(this->nmp, this->koffset, ktype);
+    }
+    else if(!kmesh&&((line == "Cartesian")||(line == "C")||(line == "Direct")||(line == "D")))
+    {
+        for(int i = 0; i < this->nkstot; ++i)
+        {
+            // use of Vector3 should be avoided as much as possible, since it is not safe.
+            ModuleBase::Vector3<double>* kvec = (line == "Cartesian" || line == "C")? &this->kvec_c[i] : &this->kvec_d[i];
+            // a direct but actually wrong choice is to directly use >>. However, there may be comment lead by symbol #
+            // therefore, get the whole line and pick up the first three numbers with one weight.
+            std::getline(ifs, line);
+            std::istringstream iss(line);
+            iss >> kvec->x >> kvec->y >> kvec->z >> this->wk[i]; // drop the rest of the line
+        }
+        if(line == "Cartesian" || line == "C") this->kc_done = true;
+        else this->kd_done = true;
+    }
+    else if(!kmesh&&((line == "Line_Cartesian")||(line == "Line_Direct")||(line == "Line")))
+    {
+        std::vector<int> nks;
+        std::vector<std::vector<double>> knodes(this->nkstot);
+        for(int i = 0; i < this->nkstot; ++i)
+        {
+            ModuleBase::Vector3<double>* kvec = (line == "Line_Cartesian")? &this->kvec_c[i] : &this->kvec_d[i];
+            std::getline(ifs, line);
+            std::istringstream iss(line);
+            knodes[i].resize(3);
+            iss >> knodes[i][0] >> knodes[i][1] >> knodes[i][2] >> nks[i]; // drop the rest of the line
+        }
+        std::vector<ModuleBase::Vector3<double>>* kvec = (line == "Line_Cartesian")? &this->kvec_c : &this->kvec_d;
+        this->interpolate_knodes(knodes, nks, *kvec, this->kl_segids);
+        if(line == "Line_Cartesian") this->kc_done = true;
+        else this->kd_done = true;
+    }
+    else ModuleBase::WARNING_QUIT("K_Vectors::read_abacus_kpt","Unknown kpoint type.");
+}
+
+void K_Vectors::interpolate_knodes(const std::vector<std::vector<double>>& knodes,
+                                   const std::vector<int>& nks,
+                                   std::vector<ModuleBase::Vector3<double>>& kvec,
+                                   std::vector<int>& kseg_ids)
+{
+    kvec.clear();
+    kseg_ids.clear();
+    if(std::all_of(nks.begin(), nks.end(), [](int i){return i == 1;}))
+    {
+        // for some cases, the kline is defined as a list of kpoints and each with a weight of 1
+        // in this case, the kline is actually a list of kpoints
+        for(int i = 0; i < knodes.size(); ++i)
+        {
+            kvec.push_back(ModuleBase::Vector3<double>(knodes[i][0], knodes[i][1], knodes[i][2]));
+        }
+        kseg_ids.resize(kvec.size(), 0); // all kpoints are assumed to be in the same segment
+    }
+    else // a more common case would be...
+    {
+        /*
+            routinely, the kline can be defined in the following language:
+            [kx] [ky] [kz] [including the start but excluding the end, evenly interpolate a number of kpoints]
+            this will also force the last number of the last kpoint to be 1, say only itself, otherwise the
+            delta kx/ky/kz cannot be determined.
+        */
+        #ifdef __DEBUG
+        assert (knodes.size() == nks.size()); // one line must have kx, ky, kz and nk
+        assert (std::all_of(nks.begin(), nks.end(), [](int i){return i > 0;})); // nk value should be valid
+        assert (nks[nks.size()-1] == 1); // the last one should be 1 to define the end of kpath
+        #endif
+        int ikseg = 0;
+        for(int i = 0; i < knodes.size(); ++i) // loop over all defined specical kpoints
+        {
+            if(nks[i] == 1) // only itself
+            {
+                kvec.push_back(ModuleBase::Vector3<double>(knodes[i][0], knodes[i][1], knodes[i][2]));
+                kseg_ids.push_back(ikseg); // the last one is 1, so the previous one is the end of the segment
+                ++ikseg;
+            }
+            else // interpolate
+            {
+                ModuleBase::Vector3<double> start(knodes[i][0], knodes[i][1], knodes[i][2]);
+                ModuleBase::Vector3<double> end(knodes[i+1][0], knodes[i+1][1], knodes[i+1][2]);
+                ModuleBase::Vector3<double> delta = end - start;
+                for(int j = 0; j < nks[i]; ++j)
+                {
+                    kvec.emplace_back(start + delta * double(j) / double(nks[i]));
+                    kseg_ids.push_back(ikseg);
+                }
+            }
+        }
+    }
+    // refresh the value of nks_tot
+    this->nkstot = kvec.size();
+    // refresh weights of kpoints
+    this->wk.clear();
+    this->wk.resize(kvec.size());
+    std::fill(this->wk.begin(), this->wk.end(), 1.0);
+}
+
+void K_Vectors::sync_kvec_betweencd(const bool& direct,
+                                    const ModuleBase::Matrix3& t)
+{
+    if(direct)
+    {
+        for(int i = 0; i < this->nkstot; ++i)
+        {
+            this->kvec_c[i] = t * this->kvec_d[i];
+        }
+    }
+    else
+    {
+        for(int i = 0; i < this->nkstot; ++i)
+        {
+            this->kvec_d[i] = t * this->kvec_c[i];
+        }
+    }
+}
+
+void K_Vectors::sync_kvec_betweenspin(const int& nspin)
+{
+    this->renew(this->nkstot * nspin);
+    std::copy(this->kvec_c.begin(), this->kvec_c.begin() + this->nkstot, this->kvec_c.begin() + this->nkstot*(nspin - 1));
+    std::copy(this->kvec_d.begin(), this->kvec_d.begin() + this->nkstot, this->kvec_d.begin() + this->nkstot*(nspin - 1));
+}
+
+std::vector<int> K_Vectors::kspacing_tompmesh(const std::vector<std::vector<double>>& bvecs,
+                                            const double& lat0,
+                                            const std::vector<double>& kspacing)
+{
+    #ifdef __DEBUG
+    assert (std::all_of(kspacing.begin(), kspacing.end(), [](double i){return i > 0.0;}));
+    assert (lat0 > 0.0);
+    assert (bvecs.size() == 3);
+    assert (bvecs[0].size() == 3);
+    assert (bvecs[1].size() == 3);
+    assert (bvecs[2].size() == 3);
+    #endif
+    std::vector<double> bnorms(bvecs.size());
+    std::transform(bvecs.begin(), bvecs.end(), bnorms.begin(), [](const std::vector<double>& bvec)
+    {
+        return std::sqrt(std::inner_product(bvec.begin(), bvec.end(), bvec.begin(), 0.0));
+    });
+    std::vector<int> nmp(3);
+    for(int i = 0; i < 3; ++i)
+    {
+        nmp[i] = std::max(1, static_cast<int>(bnorms[i] * ModuleBase::TWO_PI / kspacing[i] / lat0 + 1));
+    }
+    return nmp;
+}
+
+std::vector<int> K_Vectors::kspacing_tompmesh(const ModuleBase::Matrix3& bmat,
+                                   const double& lat0,
+                                   const std::vector<double>& kspacing)
+{
+    std::vector<std::vector<double>> bvecs(3);
+    for(int i = 0; i < 3; ++i) bvecs[i].resize(3);
+    bvecs[0][0] = bmat.e11; bvecs[0][1] = bmat.e12; bvecs[0][2] = bmat.e13;
+    bvecs[1][0] = bmat.e21; bvecs[1][1] = bmat.e22; bvecs[1][2] = bmat.e23;
+    bvecs[2][0] = bmat.e31; bvecs[2][1] = bmat.e32; bvecs[2][2] = bmat.e33;
+    return kspacing_tompmesh(bvecs, lat0, kspacing);
+}
+
+bool K_Vectors::build_kpt(const std::string& fkpt)
+{
+    ModuleBase::TITLE("K_Vectors", "build_kpt");
+    if(GlobalV::MY_RANK != 0) return true;
+    // GlobalV variables should be imported earlier
+    std::string overwrite = "";
+    if(GlobalV::GAMMA_ONLY_LOCAL) overwrite = this->write_abacus_mpkmesh("Gamma", {1, 1, 1}, {0, 0, 0});
+    else if(GlobalV::KSPACING[0] > 0.0)
+    {
+        std::vector<double> kspacing = {GlobalV::KSPACING[0], GlobalV::KSPACING[1], GlobalV::KSPACING[2]};
+        std::vector<int> nmp = this->kspacing_tompmesh(GlobalC::ucell.G, GlobalC::ucell.lat0, kspacing);
+        overwrite = this->write_abacus_mpkmesh("MP", nmp, {0, 0, 0});
+    }
+    if(overwrite != "")
+    {
+        GlobalV::ofs_running << "KPT file overwritten due to user settings in INPUT card." << fkpt << std::endl;
+        std::ofstream ofs(fkpt);
+        ofs << overwrite;
+        ofs.close();
+    }
+    this->read_abacus_kpt(fkpt);
+    this->nkstot_full = this->nks = this->nkstot;
+    return true;
 }
 
 bool K_Vectors::read_kpoints(const std::string &fn)
@@ -309,7 +574,7 @@ bool K_Vectors::read_kpoints(const std::string &fn)
         ifk >> nmp[0] >> nmp[1] >> nmp[2];
 
         ifk >> koffset[0] >> koffset[1] >> koffset[2];
-        this->Monkhorst_Pack(nmp, koffset, k_type);
+        this->monkhorst_pack(nmp, koffset, k_type);
     }
     else if (nkstot > 0)
     {
@@ -497,7 +762,10 @@ bool K_Vectors::read_kpoints(const std::string &fn)
             assert(kl_segids.size() == nkstot); /* ISSUE#3482: to distinguish different kline segments */
 
 			std::for_each(wk.begin(), wk.end(), [](double& d){d = 1.0;});
-
+            for(int ik = 0; ik < nkstot; ik++)
+            {
+                printf("kvec_d[%d] = %f %f %f\n", ik, kvec_d[ik].x, kvec_d[ik].y, kvec_d[ik].z);
+            }
             this->kd_done = true;
 		}
 
@@ -525,7 +793,7 @@ double K_Vectors::Monkhorst_Pack_formula( const int &k_type, const double &offse
 }
 
 //add by dwan
-void K_Vectors::Monkhorst_Pack(const int *nmp_in, const double *koffset_in, const int k_type)
+void K_Vectors::monkhorst_pack(const int *nmp_in, const double *koffset_in, const int k_type)
 {
     if (GlobalV::test_kpoint) ModuleBase::TITLE("K_Vectors", "Monkhorst_Pack");
     const int mpnx = nmp_in[0];
@@ -556,10 +824,7 @@ void K_Vectors::Monkhorst_Pack(const int *nmp_in, const double *koffset_in, cons
     }
 
     const double weight = 1.0 / static_cast<double>(nkstot);
-    for (int ik=0; ik<nkstot; ik++)
-    {
-        wk[ik] = weight;
-    }
+    std::fill(wk.begin(), wk.begin() + nkstot, weight);
     this->kd_done = true;
 
     return;

--- a/source/module_cell/klist.h
+++ b/source/module_cell/klist.h
@@ -1,6 +1,56 @@
 #ifndef K_VECTORS_H
 #define K_VECTORS_H
 
+/*
+    On the refactor to remove GlobalV and GlobalC from class implementation
+    2024/03/30 Kirk0830
+
+    What IS kpoint?
+    kpoint remarks translational symmetry of a crystal wavefunction. Each kpoint represents a translational
+    symmetry that the wavefunction can only strictly recover itself after a specific translation operation.
+    A more modern understanding is the translational operator and Hamiltonian operator is commutable, thus
+    the eigenstates of the translational operator can be used to linearly combined to form the eigenstates of
+    Hamiltonian operator.
+
+    For programming, what can kpoint class have?
+    0. Basic
+    kpoint class is for storing kpoint related information, certainly it should have functionalities to read
+    and even write ABACUS KPT files. Therefore it is a class, if compactly impelemented, it should hold the
+    kpoint coordinates data, and have methods for I/O the kpoint coordinates.
+    Comparatively the old implementation let kpoint know about nspin, the number of spin channels. However
+    it is, totally unaccpectable, because the translational symmetry has nothing related to the spin symmetry.
+
+    1. Symmetry: kpoint reduction, irreducible Brillouin zone
+    More specifically, the import of kpoints from external files, should be accompied with a kpoint processing,
+    such as the reduction of kpoints by symmetry operations. 
+    Then it comes to the question "How to determine and reduce the number of kpoints according to symmetry".
+    In symmetry module, there are symmetrical operations instantiated according to the symmetry detected by
+    program. Imposing these operations on kpoints, if any two kpoints are equivalent, then they are the same,
+    and one of them should be removed.
+
+    2. Parallelization
+    At least for planewave, the parallelization on kpoints is natural. Prsent parallelization strategy is to
+    distribute kpoints by simple % and // way.
+    
+    Regulations on implementing MPI related functions:
+    1. no matter if it is really MPI environment, always keep the workflow strictly unchanged, and if it is
+    non-MPI, then some functions are left empty but they are still be called in workflow. Which means it is
+    bad to implement functions like:
+    #ifdef __MPI
+    void mpi_k()
+    {
+        // do something
+    }
+    #endif
+    , it is recommended to implement like:
+    void mpi_k()
+    {
+        #ifdef __MPI
+        // do something
+        #endif
+    }
+*/
+
 #include <vector>
 
 #include "module_base/global_function.h"
@@ -34,23 +84,104 @@ public:
     K_Vectors();
     ~K_Vectors();
 
-    void set(
-        const ModuleSymmetry::Symmetry &symm,
-        const std::string &k_file_name,
-        const int& nspin,
-        const ModuleBase::Matrix3 &reciprocal_vec,
-        const ModuleBase::Matrix3 &latvec);
+    void set(const ModuleSymmetry::Symmetry &symm,
+             const std::string &k_file_name,
+             const int& nspin,
+             const ModuleBase::Matrix3 &reciprocal_vec,
+             const ModuleBase::Matrix3 &latvec);
 
-    void ibz_kpoint(const ModuleSymmetry::Symmetry &symm, bool use_symm,std::string& skpt, const UnitCell &ucell, bool& match);
+    void ibz_kpoint(const ModuleSymmetry::Symmetry &symm, 
+                    bool use_symm,std::string& skpt, 
+                    const UnitCell& ucell, 
+                    bool& match);
     //LiuXh add 20180515
-    void set_after_vc(
-            const ModuleSymmetry::Symmetry &symm,
-            const std::string &k_file_name,
-            const int& nspin,
-            const ModuleBase::Matrix3 &reciprocal_vec,
-            const ModuleBase::Matrix3 &latvec);
+    void set_after_vc(const ModuleSymmetry::Symmetry &symm,
+                     const std::string &k_file_name,
+                     const int& nspin,
+                     const ModuleBase::Matrix3 &reciprocal_vec,
+                     const ModuleBase::Matrix3 &latvec);
     //get global index for ik
     inline int getik_global(const int& ik) const;
+
+private:
+    // newly built functions on refactor to remove GlobalC::Pkpoints and parallel_kpoints class
+    K_Vectors(const std::string& fkpt,
+              const double& lat0,
+              const std::vector<std::vector<double>>& avecs,
+              const std::vector<std::vector<double>>& bvecs,
+              const int& npools, 
+              const int& nprocs_inpool);
+
+    // partial alternative to set() function
+    bool build_kpt(const std::string& fkpt);
+
+    // I/O functions
+    // read ABACUS KPT file
+    void read_abacus_kpt(const std::string& fkpt);
+    // from special kpoints specified in KPT file, generate a kpoint-path
+    void interpolate_knodes(const std::vector<std::vector<double>>& knodes, //< [in] special kpoints direct coordinates
+                            const std::vector<int>& nks,                    //< [in] number of kpoints in each segment
+                            std::vector<ModuleBase::Vector3<double>>& kvec, //< [out] kpoints direct coordinates
+                            std::vector<int>& kseg_ids);                    //< [out] segment ids of kpoints
+    // convert kspacing to exact Monkhorst-Pack mesh dimensions
+    std::vector<int> kspacing_tompmesh(const std::vector<std::vector<double>>& bvecs,    //< [in] reciprocal lattice vectors
+                                       const double& lat0,                               //< [in] lattice_constant
+                                       const std::vector<double>& kspacing);             //< [in] kspacing
+    // overloaded version for ModuleBase::Matrix3
+    std::vector<int> kspacing_tompmesh(const ModuleBase::Matrix3& bmat,                  //< [in] reciprocal lattice matrix
+                                       const double& lat0,                               //< [in] lattice_constant
+                                       const std::vector<double>& kspacing);             //< [in] kspacing
+    // write Monkhorst-Pack kpoints to KPT file
+    std::string write_abacus_mpkmesh(const std::string& center,         //< [in] can be "Gamma" or "Monkhorst-Pack"
+                                     const std::vector<int>& nmp,       //< [in] number of Monkhorst-Pack kpoints
+                                     const std::vector<int>& shifts);   //< [in] shifts of Monkhorst-Pack kpoints
+    // write Line mode kpoints to KPT file
+    std::string write_abacus_kline(const std::string& scale,                             //< [in] can be "Direct" or "Cartesian"
+                                   const std::vector<std::vector<double>>& kvec,         //< [in] kpoints coordinates
+                                   const std::vector<int>& nks);                         //< [in] number of kpoints in each segment
+    // overloaded version for ModuleBase::Vector3, which is not safe and has partially been deprecated by new compilers like icpx
+    std::string write_abacus_kline(const std::string& scale,                             //< [in] can be "Direct" or "Cartesian"
+                                   const std::vector<ModuleBase::Vector3<double>>& kvec, //< [in] kpoints coordinates
+                                   const std::vector<int>& nks);                         //< [in] number of kpoints in each segment
+
+    // Synchronize
+    // synchronize between alpha and beta spin. Because kpoint does not distinguish spin physically, this way
+    // is just a computational implementation convention, rather than physically strict/correct way.
+    void sync_kvec_betweenspin(const int& nspin); // because in principle there is forever 1 set of kpoints,
+                                                  // the special treatment like treating different spin
+                                                  // kpoints separately is not physically correct. Thus the
+                                                  // nspin is set as one parameter instead of a member variable.
+    // synchronize between kvec_c and kvec_d
+    void sync_kvec_betweencd(const bool& direct,            //< [in] true is from kvec_d to kvec_c, false is from kvec_c to kvec_d
+                             const ModuleBase::Matrix3& t); //< [in] transformation matrix
+    // synchronize between MPI processes
+    void sync_kvec_betweenproc();
+
+    std::vector<std::vector<double>> kvec(const std::vector<int>& iks,
+                                          const bool& direct = true,
+                                          const bool& irreducible = true) const
+    {
+        std::vector<std::vector<double>> kvecs(iks.size());
+        std::transform(iks.begin(), iks.end(), kvecs.begin(), [&](const int& ik)
+        {
+            return kvec(ik, direct, irreducible);
+        });
+        return kvecs;
+    }
+    std::vector<double> kvec(const int& ik,
+                             const bool& direct = true,
+                             const bool& irreducible = true) const
+    {
+        if((direct)&&(irreducible)) return kvec_d_[ikibz2ik_[ik]];
+        if((direct)&&(!irreducible)) return kvec_d_[ik];
+        if((!direct)&&(irreducible)) return kvec_c_[ikibz2ik_[ik]];
+        if((!direct)&&(!irreducible)) return kvec_c_[ik];
+        return std::vector<double>();
+    }
+    std::vector<std::vector<double>> kvec_c_;
+    std::vector<std::vector<double>> kvec_d_;
+    std::vector<int> ik2ikibz_; // mapping from kpoint index to irreducible kpoint index
+    std::vector<int> ikibz2ik_; // mapping from irreducible kpoint index to kpoint index
 
 private:
     int nspin;
@@ -65,9 +196,13 @@ private:
 
     // step 1 : generate kpoints
     bool read_kpoints(const std::string &fn); // return 0: something wrong.
-    void Monkhorst_Pack(const int *nmp_in,const double *koffset_in,const int tipo);
-    double Monkhorst_Pack_formula( const int &k_type, const double &offset,
-                                   const int& n, const int &dim);
+    void monkhorst_pack(const int *nmp_in, 
+                        const double *koffset_in,
+                        const int tipo);
+    double Monkhorst_Pack_formula(const int &k_type, 
+                                  const double &offset,
+                                  const int& n, 
+                                  const int &dim);
 
     // step 2 : set both kvec and kved; normalize weight
     void update_use_ibz( void );

--- a/source/module_cell/klist_mpi.cpp
+++ b/source/module_cell/klist_mpi.cpp
@@ -1,0 +1,8 @@
+// on the plan of removal of GlobalC::parallel_kpoints, it is totally unreasonable to have such
+// a class.
+
+// Path: source/module_cell/parallel_kpoints.h, after refactor this class will be removed and
+// the functions will be moved to module_cell/klist_mpi.cpp
+
+// parallel_kpoints is instantiated in global.cpp, it's life span is presently unknown.
+

--- a/source/module_cell/test/klist_test.cpp
+++ b/source/module_cell/test/klist_test.cpp
@@ -227,7 +227,7 @@ TEST_F(KlistTest, MP)
 	kv->koffset[2] = 0;
 	kv->nspin = 1;
 	int k_type = 0;
-	kv->Monkhorst_Pack(kv->nmp,kv->koffset,k_type);
+	kv->monkhorst_pack(kv->nmp,kv->koffset,k_type);
 	/*
 	std::cout << " " <<std::endl;
 	for (int ik=0;ik<kv->nkstot;ik++)
@@ -244,7 +244,7 @@ TEST_F(KlistTest, MP)
 	kv1->koffset[2] = 1;
 	kv1->nspin = 1;
 	k_type = 1;
-	kv1->Monkhorst_Pack(kv1->nmp,kv1->koffset,k_type);
+	kv1->monkhorst_pack(kv1->nmp,kv1->koffset,k_type);
 	//std::cout << " " <<std::endl;
 	for (int ik=0;ik<kv1->nkstot;ik++)
 	{
@@ -773,6 +773,270 @@ TEST_F(KlistTest, IbzKpointIsMP)
 	GlobalV::ofs_running.close();
 	ClearUcell();
 	remove("tmp_klist_4");
+}
+
+TEST_F(KlistTest, KspacingTompmesh)
+{
+	std::vector<std::vector<double>> bvecs(3);
+	bvecs[0] = std::vector<double>{1.2345,2.3456,3.4567};
+	bvecs[1] = std::vector<double>{4.5678,5.6789,6.7890};
+	bvecs[2] = std::vector<double>{7.8901,8.9012,9.0123};
+	double lat0 = 1.8897261254578281;
+	std::vector<double> kspacing = {0.1,0.2,0.3};
+	std::vector<int> result = kv->kspacing_tompmesh(bvecs,lat0,kspacing);
+	EXPECT_EQ(result.size(),3);
+}
+
+TEST_F(KlistTest, WriteAbacusKline)
+{
+	std::vector<std::vector<double>> kvecs = {
+		{0.0,0.0,0.0},
+		{0.1,0.1,0.1},
+		{0.2,0.2,0.2},
+		{0.3,0.3,0.3}
+	};
+	std::vector<int> nks = {10, 1, 10, 1};
+	std::string result_d = kv->write_abacus_kline("Direct", kvecs, nks);
+	std::string result_c = kv->write_abacus_kline("Cartesian", kvecs, nks);
+	EXPECT_THAT(result_d, testing::HasSubstr("Line_Direct"));
+	EXPECT_THAT(result_d, testing::HasSubstr("    0.0000000000     0.0000000000     0.0000000000 10"));
+	EXPECT_THAT(result_d, testing::HasSubstr("    0.3000000000     0.3000000000     0.3000000000 1"));
+	EXPECT_THAT(result_c, testing::HasSubstr("Line_Cartesian"));
+	EXPECT_THAT(result_c, testing::HasSubstr("    0.0000000000     0.0000000000     0.0000000000 10"));
+	EXPECT_THAT(result_c, testing::HasSubstr("    0.3000000000     0.3000000000     0.3000000000 1"));
+}
+
+TEST_F(KlistTest, WriteAbacusMpkmesh)
+{
+	std::string result = kv->write_abacus_mpkmesh("Gamma", {10, 10, 10}, {0, 0, 0});
+	EXPECT_THAT(result, testing::HasSubstr("Gamma"));
+	EXPECT_THAT(result, testing::HasSubstr("10 10 10 0 0 0"));
+}
+
+TEST_F(KlistTest, SyncKvecBetweencd)
+{
+	kv->nspin = 1;
+	kv->nkstot = 2;
+	kv->nks = 2;
+	kv->renew(kv->nkstot);
+	kv->kvec_d[0].x = 0.0;
+	kv->kvec_d[0].y = 0.0;
+	kv->kvec_d[0].z = 0.0;
+	kv->kvec_d[1].x = 0.1;
+	kv->kvec_d[1].y = 0.1;
+	kv->kvec_d[1].z = 0.1;
+	kv->kvec_c[0].x = 1.0;
+	kv->kvec_c[0].y = 1.0;
+	kv->kvec_c[0].z = 1.0;
+	kv->kvec_c[1].x = 1.1;
+	kv->kvec_c[1].y = 1.1;
+	kv->kvec_c[1].z = 1.1;
+	ModuleBase::Matrix3 G = {1.0, 0.0, 0.0,
+							 0.0, 1.0, 0.0,
+							 0.0, 0.0, 1.0};
+	ModuleBase::Matrix3 R = {1.0, 0.0, 0.0,
+							 0.0, 1.0, 0.0,
+							 0.0, 0.0, 1.0};
+	kv->sync_kvec_betweencd(true, R);
+	EXPECT_DOUBLE_EQ(kv->kvec_c[0].x, 0.0);
+	EXPECT_DOUBLE_EQ(kv->kvec_c[0].y, 0.0);
+	EXPECT_DOUBLE_EQ(kv->kvec_c[0].z, 0.0);
+	EXPECT_DOUBLE_EQ(kv->kvec_c[1].x, 0.1);
+	EXPECT_DOUBLE_EQ(kv->kvec_c[1].y, 0.1);
+	EXPECT_DOUBLE_EQ(kv->kvec_c[1].z, 0.1);
+	kv->kvec_c[0].x = 1.0;
+	kv->kvec_c[0].y = 1.0;
+	kv->kvec_c[0].z = 1.0;
+	kv->kvec_c[1].x = 1.1;
+	kv->kvec_c[1].y = 1.1;
+	kv->kvec_c[1].z = 1.1;
+	kv->sync_kvec_betweencd(false, G);
+	EXPECT_DOUBLE_EQ(kv->kvec_d[0].x, 1.0);
+	EXPECT_DOUBLE_EQ(kv->kvec_d[0].y, 1.0);
+	EXPECT_DOUBLE_EQ(kv->kvec_d[0].z, 1.0);
+	EXPECT_DOUBLE_EQ(kv->kvec_d[1].x, 1.1);
+	EXPECT_DOUBLE_EQ(kv->kvec_d[1].y, 1.1);
+	EXPECT_DOUBLE_EQ(kv->kvec_d[1].z, 1.1);
+}
+
+TEST_F(KlistTest, SyncKvecBetweenspin)
+{
+	kv->nspin = 1;
+	kv->nkstot = 2;
+	kv->nks = 2;
+	kv->renew(kv->nkstot);
+	kv->kvec_d[0].x = 0.0;
+	kv->kvec_d[0].y = 0.0;
+	kv->kvec_d[0].z = 0.0;
+	kv->kvec_d[1].x = 0.1;
+	kv->kvec_d[1].y = 0.1;
+	kv->kvec_d[1].z = 0.1;
+	kv->kvec_c[0].x = 1.0;
+	kv->kvec_c[0].y = 1.0;
+	kv->kvec_c[0].z = 1.0;
+	kv->kvec_c[1].x = 1.1;
+	kv->kvec_c[1].y = 1.1;
+	kv->kvec_c[1].z = 1.1;
+	kv->sync_kvec_betweenspin(2);
+	EXPECT_EQ(kv->kvec_c.size(), 4);
+	EXPECT_EQ(kv->kvec_d.size(), 4);
+	for(int i=0;i<2;i++)
+	{
+		EXPECT_DOUBLE_EQ(kv->kvec_c[i].x, kv->kvec_c[i+2].x);
+		EXPECT_DOUBLE_EQ(kv->kvec_c[i].y, kv->kvec_c[i+2].y);
+		EXPECT_DOUBLE_EQ(kv->kvec_c[i].z, kv->kvec_c[i+2].z);
+		EXPECT_DOUBLE_EQ(kv->kvec_d[i].x, kv->kvec_d[i+2].x);
+		EXPECT_DOUBLE_EQ(kv->kvec_d[i].y, kv->kvec_d[i+2].y);
+		EXPECT_DOUBLE_EQ(kv->kvec_d[i].z, kv->kvec_d[i+2].z);
+	}
+}
+
+TEST_F(KlistTest, InterpolateKnodes)
+{
+	std::vector<std::vector<double>> knodes = {
+		{0.0,0.0,0.0},
+		{0.1,0.1,0.1},
+		{0.2,0.2,0.2},
+		{0.3,0.3,0.3}
+	};
+	std::vector<int> nks = {10, 1, 10, 1};
+	std::vector<ModuleBase::Vector3<double>> kvec;
+	std::vector<int> kseg_ids;
+	kv->interpolate_knodes(knodes, nks, kvec, kseg_ids);
+	EXPECT_EQ(kvec.size(), 22);
+	std::vector<ModuleBase::Vector3<double>> kvec_ref;
+	for(int i=0;i<11;i++)
+	{
+		kvec_ref.push_back({i*0.1/10, i*0.1/10, i*0.1/10});
+	}
+	for(int i=0;i<11;i++)
+	{
+		kvec_ref.push_back({i*0.1/10 + 0.2, i*0.1/10 + 0.2, i*0.1/10 + 0.2});
+	}
+	EXPECT_EQ(kseg_ids.size(), 22);
+	std::vector<int> kseg_ids_ref = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+									 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+	for(int i=0;i<22;i++)
+	{
+		EXPECT_DOUBLE_EQ(kvec[i].x, kvec_ref[i].x);
+		EXPECT_DOUBLE_EQ(kvec[i].y, kvec_ref[i].y);
+		EXPECT_DOUBLE_EQ(kvec[i].z, kvec_ref[i].z);
+		EXPECT_EQ(kseg_ids[i], kseg_ids_ref[i]);
+	}
+}
+
+TEST_F(KlistTest, ReadAbacusKpt)
+{
+	std::string k_file = "./support/KPT";
+	kv->nspin = 1;
+	kv->read_abacus_kpt(k_file);
+	EXPECT_EQ(kv->nkstot, 8*8*8);
+	EXPECT_EQ(kv->kvec_d.size(), 8*8*8);
+	EXPECT_EQ(kv->kvec_c.size(), 8*8*8); // but does not have values
+	EXPECT_TRUE(kv->kd_done);
+	EXPECT_FALSE(kv->kc_done);
+	EXPECT_TRUE(kv->is_mp);
+}
+
+TEST_F(KlistTest, ReadAbacusKpt1)
+{
+	std::string k_file = "./support/KPT1";
+	kv->nspin = 1;
+	kv->read_abacus_kpt(k_file);
+	EXPECT_EQ(kv->nkstot, 8*8*8);
+	EXPECT_EQ(kv->kvec_d.size(), 8*8*8);
+	EXPECT_EQ(kv->kvec_c.size(), 8*8*8);  // but does not have values
+	EXPECT_TRUE(kv->kd_done);
+	EXPECT_FALSE(kv->kc_done);
+	EXPECT_TRUE(kv->is_mp);
+}
+
+TEST_F(KlistTest, ReadAbacusKpt2)
+{
+	std::string k_file = "./support/KPT2";
+	kv->nspin = 1;
+	kv->read_abacus_kpt(k_file);
+	EXPECT_EQ(kv->nkstot, 122);
+	EXPECT_EQ(kv->kvec_d.size(), 122);
+	EXPECT_EQ(kv->kvec_c.size(), 0);
+	EXPECT_TRUE(kv->kd_done);
+	EXPECT_FALSE(kv->kc_done);
+	EXPECT_FALSE(kv->is_mp);
+
+	EXPECT_EQ(kv->kl_segids.size(), 122);
+	std::vector<int> kseg_ids_ref;
+	for(int i = 0; i <= 100; i++)
+	{
+		kseg_ids_ref.push_back(0);
+	}
+	for(int i = 101; i <= 121; i++)
+	{
+		kseg_ids_ref.push_back(1);
+	}
+	for(int i = 0; i < 122; i++)
+	{
+		EXPECT_EQ(kv->kl_segids[i], kseg_ids_ref[i]);
+	}
+}
+
+TEST_F(KlistTest, ReadAbacusKpt4)
+{
+	std::string k_file = "./support/KPT4";
+	kv->nspin = 1;
+	kv->read_abacus_kpt(k_file);
+	EXPECT_EQ(kv->nkstot, 5);
+	EXPECT_EQ(kv->kvec_d.size(), 0);
+	EXPECT_EQ(kv->kvec_c.size(), 5);
+	EXPECT_FALSE(kv->kd_done);
+	EXPECT_TRUE(kv->kc_done);
+	EXPECT_FALSE(kv->is_mp);
+	EXPECT_EQ(kv->kvec_c[0].x, 0.0); EXPECT_EQ(kv->kvec_c[0].y, 0.0); EXPECT_EQ(kv->kvec_c[0].z, 0.0);
+	EXPECT_EQ(kv->kvec_c[1].x, 0.0); EXPECT_EQ(kv->kvec_c[1].y, 0.0); EXPECT_EQ(kv->kvec_c[1].z, 1.0);
+	EXPECT_EQ(kv->kvec_c[2].x, 0.5); EXPECT_EQ(kv->kvec_c[2].y, 0.0); EXPECT_EQ(kv->kvec_c[2].z, 1.0);
+	EXPECT_EQ(kv->kvec_c[3].x, 0.75); EXPECT_EQ(kv->kvec_c[3].y, 0.75); EXPECT_EQ(kv->kvec_c[3].z, 0.0);
+	EXPECT_EQ(kv->kvec_c[4].x, 0.5); EXPECT_EQ(kv->kvec_c[4].y, 0.5); EXPECT_EQ(kv->kvec_c[4].z, 0.5);
+}
+
+TEST_F(KlistTest, ReadAbacusKpt5)
+{
+	std::string k_file = "./support/KPT5";
+	kv->nspin = 1;
+	kv->read_abacus_kpt(k_file);
+	EXPECT_EQ(kv->nkstot, 51);
+	EXPECT_EQ(kv->kvec_d.size(), 0);
+	EXPECT_EQ(kv->kvec_c.size(), 51);
+	EXPECT_FALSE(kv->kd_done);
+	EXPECT_TRUE(kv->kc_done);
+	EXPECT_FALSE(kv->is_mp);
+	std::vector<int> kseg_ids_ref(51, 0);
+	for(int i = 0; i < 51; i++)
+	{
+		EXPECT_EQ(kv->kl_segids[i], kseg_ids_ref[i]);
+	}
+}
+
+TEST_F(KlistTest, ReadAbacusKpt6)
+{
+	std::string k_file = "./support/KPT6";
+	kv->nspin = 1;
+	kv->read_abacus_kpt(k_file);
+	EXPECT_EQ(kv->nkstot, 6);
+	EXPECT_EQ(kv->kvec_d.size(), 6);
+	EXPECT_EQ(kv->kvec_c.size(), 0);
+	EXPECT_TRUE(kv->kd_done);
+	EXPECT_FALSE(kv->kc_done);
+	EXPECT_FALSE(kv->is_mp);
+	EXPECT_EQ(kv->kvec_d[0].x, 0.0); EXPECT_EQ(kv->kvec_d[0].y, 0.0); EXPECT_EQ(kv->kvec_d[0].z, 0.0);
+	EXPECT_EQ(kv->kvec_d[1].x, 0.0); EXPECT_EQ(kv->kvec_d[1].y, 0.0); EXPECT_EQ(kv->kvec_d[1].z, 1.0);
+	EXPECT_EQ(kv->kvec_d[2].x, 0.5); EXPECT_EQ(kv->kvec_d[2].y, 0.0); EXPECT_EQ(kv->kvec_d[2].z, 1.0);
+	EXPECT_EQ(kv->kvec_d[3].x, 0.75); EXPECT_EQ(kv->kvec_d[3].y, 0.75); EXPECT_EQ(kv->kvec_d[3].z, 0.0);
+	EXPECT_EQ(kv->kvec_d[4].x, 0.5); EXPECT_EQ(kv->kvec_d[4].y, 0.5); EXPECT_EQ(kv->kvec_d[4].z, 0.5);
+	EXPECT_EQ(kv->kvec_d[5].x, 0.0); EXPECT_EQ(kv->kvec_d[5].y, 0.0); EXPECT_EQ(kv->kvec_d[5].z, 0.0);
+}
+
+TEST_F(KlistTest, BuildKpt)
+{
+
 }
 
 #undef private

--- a/source/module_hamilt_lcao/module_deepks/test/klist.h
+++ b/source/module_hamilt_lcao/module_deepks/test/klist.h
@@ -51,7 +51,7 @@ private:
 		bool &GAMMA_ONLY_LOCAL,
 		std::ofstream &ofs_warning,
 		std::ofstream &ofs_running);
-    void Monkhorst_Pack(const int *nmp_in,const double *koffset_in,const int tipo);
+    void monkhorst_pack(const int *nmp_in,const double *koffset_in,const int tipo);
     double Monkhorst_Pack_formula( const int &k_type, const double &offset,
                                    const int& n, const int &dim);
 

--- a/source/module_hamilt_lcao/module_deepks/test/klist_1.cpp
+++ b/source/module_hamilt_lcao/module_deepks/test/klist_1.cpp
@@ -184,7 +184,7 @@ namespace Test_Deepks
 			ifk >> nmp[0] >> nmp[1] >> nmp[2];
 
 			ifk >> koffset[0] >> koffset[1] >> koffset[2];
-			this->Monkhorst_Pack(nmp, koffset, k_type);
+			this->monkhorst_pack(nmp, koffset, k_type);
 		}
 		else if (nkstot > 0)
 		{
@@ -396,7 +396,7 @@ namespace Test_Deepks
 	}
 
 	//add by dwan
-	void K_Vectors::Monkhorst_Pack(const int *nmp_in, const double *koffset_in, const int k_type)
+	void K_Vectors::monkhorst_pack(const int *nmp_in, const double *koffset_in, const int k_type)
 	{
 		const int mpnx = nmp_in[0];
 		const int mpny = nmp_in[1];

--- a/source/module_io/nscf_band.cpp
+++ b/source/module_io/nscf_band.cpp
@@ -102,6 +102,7 @@ void ModuleIO::nscf_band(
 			auto delta=kv.kvec_c[ik]-kv.kvec_c[ik-1];
 			klength[ik] = klength[ik-1];
 			klength[ik] += (kv.kl_segids[ik] == kv.kl_segids[ik-1]) ? delta.norm() : 0.0;
+			printf("klength[%d] = %f\n", ik, klength[ik]);
 		}
 		if( kv.isk[ik] == is)
 		{


### PR DESCRIPTION
### Motivation
- Removal of classes in `GlobalC` has been scheduled by ABACUS developer team, `Parallel_Kpoints` is one of them and seems will only be used in orbital generation codes now, mostly.
- The design of `K_Vectors` class is not clear. In principle, the kpoint should not have "knowledge" about the number of spin channel, the duplication of set of kpoints is in aspect of conventional implementation. Plus this class is for generating a series of kpoints, but **it is not clear why kpoints CAN BE an object**.
- The function `renew()` in `K_Vectors` breaks partially the idea of RAII, the resource acquisition is put too late after the instantiate of class.
- There are large redundance of codes of `K_Vectors`, especially the output, although has been formatted with `formatter` library.
- The used out-dated data containers like `ModuleBase::realarray`, `ModuleBase::complexarray`, `ModuleBase::Matrix3` and `ModuleBase::Vector3` will be replaced by `container::tensor` or `std::vector` up to context for memory safe reason.
- The naming of member functions in `K_Vectors` rather confusing and misleading, and there are few annotations.
- The implementation of hybrid functional on pw basis (by @Flying-dragon-boxing) and phonon calculation will need q-grids. `K_Vectors` class should change its name for code consistency, if want to reuse directly for q-grid.
- A DETAILED DESIGN NOTE WILL COME SOON

Possibily I will do following changes:
1. methods are not needed by external calling functions, such as something in ESolver, ESolver only needs the coordinates and weights of kpoints. Thus the kpoints really belongs to ESolver will be change to datatype of `std::vector<container::Tensor>` or `std::vector<std::vector<double>>`.
2. After 1, generally, there should be some places storing phonon q-grid, might outside ESolver. For pw HFX, there will be a `hfx_qvecs` storing things similar to kpoints the `kvecs`.
3. Use the concept of generator instead of an instance for Brilloun zone sampling, therefore, it will be more appropriate to name a set of method called `bz_sampl`. Might be `namespace`, might not be `class`, might be an static instance of class or singleton because in the whole program, do not need the second one.
4. will provide flexibility on k/q points distribution for parallelization.

### Reminder
- [x] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #3850 

### Unit Tests and/or Case Tests for my changes
- Not ready for test yet

### What's changed?
- Seems `Parallel_Kpoints` is an out-dated class. A redesign of `K_Vectors` class with consideration of MPI is expected to be an example for ABACUS developers participate in the next refactor plan.

### Any changes of core modules? (ignore if not applicable)
- Yes
