### PR TITLE
Docs: #3867 An issue about the Abacus Document Easy Installation part

### DIFF
--- a/docs/quick_start/easy_install.md
+++ b/docs/quick_start/easy_install.md
@@ -152,6 +152,7 @@ You can change the number after `-j` on your need: set to the number of CPU core
 ## Run
 
 If ABACUS is installed into a custom directory using `CMAKE_INSTALL_PREFIX`, please add it to your environment variable `PATH` to locate the correct executable.
+*(Note: `my-install-dir` should be changed to the location of your installed abacus:`/home/your-path/abacus/bin/`.)*
 
 ```bash
 export PATH=/my-install-dir/:$PATH


### PR DESCRIPTION
### Reminder
- [Y] Have you linked an issue with this pull request?
- [N] Have you added adequate unit tests and/or case tests for your pull request?
- [Y] Have you noticed possible changes of behavior below or in the linked issue?
- [N] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #3867

### What's changed?
- My change is to give a notification of the path during the installation.
- One sentence added: "*(Note: `my-install-dir` should be changed to the location of your installed abacus:`/home/your-path/abacus/bin/`.)*"
