### PR TITLE
Fix: Fix the hexadecimal output in MD with OFDFT

### DIFF
--- a/source/module_esolver/esolver_of_tool.cpp
+++ b/source/module_esolver/esolver_of_tool.cpp
@@ -400,7 +400,7 @@ void ESolver_OF::print_info()
     //     if (this->pdEdphi_[0][i] < minPot) minPot = this->pdEdphi_[0][i];
     //     if (this->pdEdphi_[0][i] > maxPot) maxPot = this->pdEdphi_[0][i];
     // }
-    std::cout << std::setw(6) << this->iter_ << std::setw(22) << std::setiosflags(std::ios::scientific)
+    std::cout << std::setw(6) << this->iter_ << std::setw(22) << std::scientific
               << std::setprecision(12) << this->energy_current_ / 2. << std::setw(12) << std::setprecision(3)
               << this->mu_[0] / 2. << std::setw(12) << this->theta_[0] << std::setw(12) << this->normdLdphi_
               << std::setw(12) << (this->energy_current_ - this->energy_last_) / 2. << std::endl;


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #3895 

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
