### PR TITLE
Perf: Improve the performence of dav-subspace method in pw basis

### DIFF
--- a/source/module_hsolver/diago_dav_subspace.h
+++ b/source/module_hsolver/diago_dav_subspace.h
@@ -81,8 +81,7 @@ class Diago_DavSubspace : public DiagH<T, Device>
                   const psi::Psi<T, Device>& basis,
                   const T* hphi,
                   T* hcc,
-                  T* scc,
-                  bool init);
+                  T* scc);
 
     void refresh(const int& dim,
                  const int& nband,


### PR DESCRIPTION
By swapping the order of two matrices during matrix multiplication to avoid matrix transposition in cal_elem func in davidson method for pw basis, the computational efficiency of multi-core computing can be improved.

### Reminder
- [x] Have you linked an issue with this pull request?
- [x] Have you added adequate unit tests and/or case tests for your pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [x] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #3922 
