### PR TITLE
Fix: Bug when kpar > 1, nspin=2, and cell-relax

### DIFF
--- a/source/module_cell/klist.cpp
+++ b/source/module_cell/klist.cpp
@@ -1347,9 +1347,10 @@ void K_Vectors::set_after_vc(
     this->set_both_kvec_after_vc(reciprocal_vec, latvec);
     //this->set_both_kvec(reciprocal_vec, latvec);
 
-    this->mpi_k_after_vc();
+    //Since the number of kpoints is not changed, we do not need to do the following.
+    // this->mpi_k_after_vc(); 
 
-    this->set_kup_and_kdw_after_vc();
+    // this->set_kup_and_kdw_after_vc();
 
     this->print_klists(GlobalV::ofs_running);
 
@@ -1358,6 +1359,7 @@ void K_Vectors::set_after_vc(
 
 //LiuXh add a new function here,
 //20180515
+//Useless now, it has bugs in it.
 void K_Vectors::mpi_k_after_vc(void)
 {
 #ifdef __MPI
@@ -1395,6 +1397,7 @@ void K_Vectors::mpi_k_after_vc(void)
 
     if (GlobalV::MY_RANK == 0)
     {
+        // It is wrong! kvec_c and kvec_d are local variables.
         for (int ik = 0;ik < nkstot;ik++)
         {
             isk_aux[ik] = isk[ik];
@@ -1503,6 +1506,7 @@ void K_Vectors::set_both_kvec_after_vc(const ModuleBase::Matrix3 &G, const Modul
     return;
 }
 
+//Useless now
 void K_Vectors::set_kup_and_kdw_after_vc(void)
 {
     ModuleBase::TITLE("K_Vectors", "setup_kup_and_kdw_after_vc");
@@ -1535,7 +1539,7 @@ void K_Vectors::set_kup_and_kdw_after_vc(void)
         }
 
         this->nks *= 2;
-        //this->nkstot *= 2;
+        //this->nkstot *= 2; //This makes the code difficult to read.
 
         ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"nks(nspin=2)",nks);
         ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"nkstot(nspin=2)",nkstot);

--- a/source/module_cell/klist.h
+++ b/source/module_cell/klist.h
@@ -87,8 +87,8 @@ private:
     void print_klists(std::ofstream &fn);
     //bool read_kpoints_after_vc(const std::string &fn); //LiuXh add 20180515
     //void Monkhorst_Pack_after_vc(const int *nmp_in,const double *koffset_in,const int tipo); //LiuXh add 20180515
-    void mpi_k_after_vc(); //LiuXh add 20180515
-    void set_both_kvec_after_vc(const ModuleBase::Matrix3 &G,const ModuleBase::Matrix3 &R);
+    void mpi_k_after_vc(); //LiuXh add 20180515 //Useless now, it should be removed after several versions' testing.
+    void set_both_kvec_after_vc(const ModuleBase::Matrix3 &G,const ModuleBase::Matrix3 &R); //Useless now, it should be removed after several versions' testing.
     void set_kup_and_kdw_after_vc();
 };
 

--- a/tests/integrate/109_PW_CR/INPUT
+++ b/tests/integrate/109_PW_CR/INPUT
@@ -8,6 +8,8 @@ calculation             cell-relax
 #Parameters (Accuracy)
 ecutwfc			20
 scf_nmax			20
+kpar  2
+nspin 2
 
 basis_type		pw
 relax_nmax                   2

--- a/tests/integrate/109_PW_CR/result.ref
+++ b/tests/integrate/109_PW_CR/result.ref
@@ -1,5 +1,5 @@
-etotref -211.8220727412902988
-etotperatomref -105.9110363706
-totalforceref 0.000018
-totalstressref 348.867117
-totaltimeref +0.31629
+etotref -211.8247254821208969
+etotperatomref -105.9123627411
+totalforceref 0.000000
+totalstressref 342.188349
+totaltimeref 1.87


### PR DESCRIPTION
### Linked Issue
Fix #3932 
### What's changed?
Remove some functions which are unnecessary and wrong.

