### PR TITLE
change `namespace A::B{}` to `namespace A{namespace B{}}`

### DIFF
--- a/source/module_ri/ABFs_Construct-PCA.cpp
+++ b/source/module_ri/ABFs_Construct-PCA.cpp
@@ -11,7 +11,9 @@
 #include <cassert>
 #include <limits>
 
-namespace ABFs_Construct::PCA
+namespace ABFs_Construct
+{
+namespace PCA
 {
 	void tensor_dsyev(const char jobz, const char uplo, RI::Tensor<double> & a, double*const w, int & info)
 	{
@@ -151,3 +153,4 @@ namespace ABFs_Construct::PCA
 	}
 
 }	// namespace ABFs_Construct::PCA
+}	// namespace ABFs_Construct

--- a/source/module_ri/ABFs_Construct-PCA.h
+++ b/source/module_ri/ABFs_Construct-PCA.h
@@ -10,12 +10,15 @@
 //	new basis:     to be constructed
 //	( all lcaos and abfs on same atom )
 
-namespace ABFs_Construct::PCA
+namespace ABFs_Construct
+{
+namespace PCA
 {
 	extern std::vector<std::vector<std::pair<std::vector<double>,RI::Tensor<double>>>> cal_PCA( 
 		const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &lcaos, 
 		const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &abfs,		// abfs must be orthonormal
 		const double kmesh_times );
+}
 }
 
 #endif	// ABFS_CONSTRUCT_PCA_H


### PR DESCRIPTION
Change `namespace A::B{}` to `namespace A{namespace B{}}`, since `namespace A::B{}` is a C++17 feature.