### PR TITLE
Feature: output times for lambda inner loop

### DIFF
--- a/source/module_hamilt_lcao/module_deltaspin/lambda_loop_helper.cpp
+++ b/source/module_hamilt_lcao/module_deltaspin/lambda_loop_helper.cpp
@@ -11,19 +11,21 @@ void SpinConstrain<std::complex<double>, psi::DEVICE_CPU>::print_termination()
 }
 
 template <>
-bool SpinConstrain<std::complex<double>, psi::DEVICE_CPU>::check_rms_stop(int outer_step, int i_step, double rms_error)
+bool SpinConstrain<std::complex<double>, psi::DEVICE_CPU>::check_rms_stop(int outer_step, int i_step, double rms_error, double duration, double total_duration)
 {
     std::cout << "Step (Outer -- Inner) =  " << outer_step << " -- " << std::left << std::setw(5) << i_step + 1
-              << "       RMS = " << rms_error << std::endl;
+              << "       RMS = " << rms_error << "     TIME(s) = " << std::setw(11) << duration << std::endl;
     if (rms_error < this->sc_thr_ || i_step == this->nsc_ - 1)
     {
         if (rms_error < this->sc_thr_)
         {
-            std::cout << "Meet convergence criterion ( < " << this->sc_thr_ << " ), exit." << std::endl;
+            std::cout << "Meet convergence criterion ( < " << this->sc_thr_ << " ), exit.";
+            std::cout << "       Total TIME(s) = " << total_duration << std::endl;
         }
         else if (i_step == this->nsc_ - 1)
         {
-            std::cout << "Reach maximum number of steps ( " << this->nsc_ << " ), exit." << std::endl;
+            std::cout << "Reach maximum number of steps ( " << this->nsc_ << " ), exit.";
+            std::cout << "              Total TIME(s) = " << total_duration << std::endl;
         }
         this->print_termination();
         return true;

--- a/source/module_hamilt_lcao/module_deltaspin/spin_constrain.h
+++ b/source/module_hamilt_lcao/module_deltaspin/spin_constrain.h
@@ -61,7 +61,7 @@ public:
   void run_lambda_loop(int outer_step);
 
   /// lambda loop helper functions
-  bool check_rms_stop(int outer_step, int i_step, double rms_error);
+  bool check_rms_stop(int outer_step, int i_step, double rms_error, double duration, double total_duration);
 
   /// apply restriction
   void check_restriction(const std::vector<ModuleBase::Vector3<double>>& search, double& alpha_trial);

--- a/source/module_hamilt_lcao/module_deltaspin/template_helpers.cpp
+++ b/source/module_hamilt_lcao/module_deltaspin/template_helpers.cpp
@@ -45,7 +45,7 @@ void SpinConstrain<double, psi::DEVICE_CPU>::run_lambda_loop(int outer_step)
 }
 
 template <>
-bool SpinConstrain<double, psi::DEVICE_CPU>::check_rms_stop(int outer_step, int i_step, double rms_error)
+bool SpinConstrain<double, psi::DEVICE_CPU>::check_rms_stop(int outer_step, int i_step, double rms_error, double duration, double total_duration)
 {
     return false;
 }

--- a/source/module_hamilt_lcao/module_deltaspin/test/lambda_loop_helper_test.cpp
+++ b/source/module_hamilt_lcao/module_deltaspin/test/lambda_loop_helper_test.cpp
@@ -54,12 +54,14 @@ TEST_F(SpinConstrainTest, CheckRmsStop)
     double alpha_trial = 0.01;
     double sccut = 3.0;
     bool decay_grad_switch = 1;
+    double duration = 10;
+    double total_duration = 10;
     this->sc.set_input_parameters(sc_thr, nsc, nsc_min, alpha_trial, sccut, decay_grad_switch);
     testing::internal::CaptureStdout();
-    EXPECT_FALSE(sc.check_rms_stop(0, 0, 1e-5));
-    EXPECT_FALSE(sc.check_rms_stop(0, 11, 1e-5));
-    EXPECT_TRUE(sc.check_rms_stop(0, 12, 1e-7));
-    EXPECT_TRUE(sc.check_rms_stop(0, 99, 1e-5));
+    EXPECT_FALSE(sc.check_rms_stop(0, 0, 1e-5, duration, total_duration));
+    EXPECT_FALSE(sc.check_rms_stop(0, 11, 1e-5, duration, total_duration));
+    EXPECT_TRUE(sc.check_rms_stop(0, 12, 1e-7, duration, total_duration));
+    EXPECT_TRUE(sc.check_rms_stop(0, 99, 1e-5, duration, total_duration));
     std::string output = testing::internal::GetCapturedStdout();
     EXPECT_THAT(output, testing::HasSubstr("Step (Outer -- Inner) =  0 -- 1           RMS = 1e-05"));
     EXPECT_THAT(output, testing::HasSubstr("Step (Outer -- Inner) =  0 -- 12          RMS = 1e-05"));

--- a/source/module_hamilt_lcao/module_deltaspin/test/template_helpers_test.cpp
+++ b/source/module_hamilt_lcao/module_deltaspin/test/template_helpers_test.cpp
@@ -45,7 +45,7 @@ TEST_F(SpinConstrainTest, TemplatHelpers)
     ModuleBase::ComplexMatrix mud;
     ModuleBase::matrix MecMulP;
     EXPECT_NO_THROW(sc.collect_MW(MecMulP, mud, 0, 0));
-    EXPECT_FALSE(sc.check_rms_stop(0, 0, 0.0));
+    EXPECT_FALSE(sc.check_rms_stop(0, 0, 0.0, 0.0, 0.0));
     EXPECT_NO_THROW(sc.print_termination());
     EXPECT_NO_THROW(sc.print_header());
     std::vector<ModuleBase::Vector3<double>> new_spin, old_spin, new_delta_lambda, old_delta_lambda;


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?
- [x] Have you added adequate unit tests and/or case tests for your pull request?

### Linked Issue
Fix #3979 

### Unit Tests and/or Case Tests for my changes
- Related unit tests have been updated.

### What's changed?
The time consumed by each iteration of the lambda loop and the total time of inner lambda loop are printed out, like:
```
Step (Outer -- Inner) =  4 -- 1           RMS = 5.899e-02     TIME(s) = 7.851e-05  
Step (Outer -- Inner) =  4 -- 2           RMS = 2.432e-01     TIME(s) = 6.337e+00  
Step (Outer -- Inner) =  4 -- 3           RMS = 1.507e-02     TIME(s) = 2.697e+00  
Reach maximum number of steps ( 3 ), exit.              Total TIME(s) = 9.034e+00
```
and
```
Step (Outer -- Inner) =  2 -- 1           RMS = 5.063e-01     TIME(s) = 6.589e-05  
Step (Outer -- Inner) =  2 -- 2           RMS = 6.916e-02     TIME(s) = 6.105e+00  
Step (Outer -- Inner) =  2 -- 3           RMS = 1.781e-03     TIME(s) = 2.465e+00  
Step (Outer -- Inner) =  2 -- 4           RMS = 1.040e-06     TIME(s) = 2.473e+00  
Step (Outer -- Inner) =  2 -- 5           RMS = 4.556e-11     TIME(s) = 2.470e+00  
Meet convergence criterion ( < 1.000e-10 ), exit.       Total TIME(s) = 1.351e+01
```

