### PR TITLE
Fix: remove parameter_pool.cpp in CMakeLists.txt

### DIFF
--- a/source/module_io/CMakeLists.txt
+++ b/source/module_io/CMakeLists.txt
@@ -28,7 +28,7 @@ list(APPEND objects
     output_log.cpp
     output_rho.cpp
     output_potential.cpp
-    parameter_pool.cpp
+    #parameter_pool.cpp
     para_json.cpp
 )
 


### PR DESCRIPTION
Fix #3209.