### PR TITLE
using STL std::vector replace new[] and delete[].

### DIFF
--- a/source/module_base/test/global_function_test.cpp
+++ b/source/module_base/test/global_function_test.cpp
@@ -84,13 +84,13 @@ inline void EXPECT_COMPLEX_DOUBLE_EQ(const std::complex<double>& a, const std::c
 template<typename T>
 inline void CHECK_ZEROS(T &size)
 {
-    std::vector<bool>* pt_b[size];
-    std::vector<int>* pt_i[size];
-    std::vector<float>* pt_f[size];
-    std::vector<double>* pt_d[size];
-    std::vector<std::complex<float>>* pt_cf(size);
-    std::vector<std::complex<double>>* pt_cd(size);
-    std::vector<ModuleBase::Vector3<double>>* pt_v3(size);
+    std::vector<bool> pt_b(size);
+    std::vector<int> pt_i(size);
+    std::vector<float> pt_f(size);
+    std::vector<double> pt_d(size);
+    std::vector<std::complex<float>> pt_cf(size);
+    std::vector<std::complex<double>> pt_cd(size);
+    std::vector<ModuleBase::Vector3<double>> pt_v3(size);
     // long long size
     long long size_ll = 100;
     bool value_b = true;
@@ -608,8 +608,10 @@ TEST_F(GlobalFunctionTest, VectorToPointer)
 TEST_F(GlobalFunctionTest, COPYARRAY)
 {
     long size = 100;
-    std::vector<std::complex<double>>* aa(size);
-    std::vector<std::complex<double>>* bb(size);
+    std::complex<double>* aa = nullptr;
+    std::complex<double>* bb = nullptr;
+    aa = new std::complex<double>[size];
+    bb = new std::complex<double>[size];
     std::complex<double> value{1.1, 2.2};
     std::fill(&aa[0], &aa[size], value);
     ModuleBase::GlobalFunc::COPYARRAY(aa,bb,size);
@@ -617,16 +619,21 @@ TEST_F(GlobalFunctionTest, COPYARRAY)
     {
         EXPECT_COMPLEX_DOUBLE_EQ(bb[i], value);
     }
-    std::vector<double>* daa(size);
-    std::vector<double>* dbb(size);
+    double* daa = nullptr;
+    double* dbb = nullptr;
+    daa = new double[size];
+    dbb = new double[size];
     std::fill(&daa[0],&daa[size],3.3);
     ModuleBase::GlobalFunc::COPYARRAY(daa,dbb,size);
     for (int i = 0; i < size; ++i)
     {
         EXPECT_DOUBLE_EQ(dbb[i], 3.3);
     }
+    delete[] aa;
+    delete[] bb;
+    delete[] daa;
+    delete[] dbb;
 }
-
 TEST_F(GlobalFunctionTest,IsColumnMajor)
 {
 	GlobalV::KS_SOLVER = "genelpa";

--- a/source/module_base/test/global_function_test.cpp
+++ b/source/module_base/test/global_function_test.cpp
@@ -84,9 +84,6 @@ inline void EXPECT_COMPLEX_DOUBLE_EQ(const std::complex<double>& a, const std::c
 template<typename T>
 inline void CHECK_ZEROS(T &size)
 {
-    std::complex<float>* pt_cf = nullptr;
-    std::complex<double>* pt_cd = nullptr;
-    ModuleBase::Vector3<double>* pt_v3 = nullptr;
     std::vector<bool> pt_b[size];
     std::vector<int> pt_i[size];
     std::vector<float> pt_f[size];

--- a/source/module_base/test/global_function_test.cpp
+++ b/source/module_base/test/global_function_test.cpp
@@ -84,13 +84,13 @@ inline void EXPECT_COMPLEX_DOUBLE_EQ(const std::complex<double>& a, const std::c
 template<typename T>
 inline void CHECK_ZEROS(T &size)
 {
-    std::vector<bool> pt_b[size];
-    std::vector<int> pt_i[size];
-    std::vector<float> pt_f[size];
-    std::vector<double> pt_d[size];
-    std::vector<std::complex<float>> pt_cf(size);
-    std::vector<std::complex<double>> pt_cd(size);
-    std::vector<ModuleBase::Vector3<double>> pt_v3(size);
+    std::vector<bool>* pt_b[size];
+    std::vector<int>* pt_i[size];
+    std::vector<float>* pt_f[size];
+    std::vector<double>* pt_d[size];
+    std::vector<std::complex<float>>* pt_cf(size);
+    std::vector<std::complex<double>>* pt_cd(size);
+    std::vector<ModuleBase::Vector3<double>>* pt_v3(size);
     // long long size
     long long size_ll = 100;
     bool value_b = true;
@@ -608,8 +608,8 @@ TEST_F(GlobalFunctionTest, VectorToPointer)
 TEST_F(GlobalFunctionTest, COPYARRAY)
 {
     long size = 100;
-    std::vector<std::complex<double>> aa(size);
-    std::vector<std::complex<double>> bb(size);
+    std::vector<std::complex<double>>* aa(size);
+    std::vector<std::complex<double>>* bb(size);
     std::complex<double> value{1.1, 2.2};
     std::fill(&aa[0], &aa[size], value);
     ModuleBase::GlobalFunc::COPYARRAY(aa,bb,size);
@@ -617,8 +617,8 @@ TEST_F(GlobalFunctionTest, COPYARRAY)
     {
         EXPECT_COMPLEX_DOUBLE_EQ(bb[i], value);
     }
-    std::vector<double> daa(size);
-    std::vector<double> dbb(size);
+    std::vector<double>* daa(size);
+    std::vector<double>* dbb(size);
     std::fill(&daa[0],&daa[size],3.3);
     ModuleBase::GlobalFunc::COPYARRAY(daa,dbb,size);
     for (int i = 0; i < size; ++i)
@@ -636,7 +636,7 @@ TEST_F(GlobalFunctionTest,IsColumnMajor)
 TEST_F(GlobalFunctionTest,Vector2Ptr)
 {
     int size = 100;
-    std::vector<std::complex<double>> aa(size, std::complex<double>(1.0, 2.0));
+    std::vector<std::complex<double>>* aa(size, std::complex<double>(1.0, 2.0));
     std::complex<double>* ptr_d = nullptr;
     ptr_d=ModuleBase::GlobalFunc::VECTOR_TO_PTR(aa);
     for (int i = 0; i < size; ++i)

--- a/source/module_base/test/global_function_test.cpp
+++ b/source/module_base/test/global_function_test.cpp
@@ -84,20 +84,16 @@ inline void EXPECT_COMPLEX_DOUBLE_EQ(const std::complex<double>& a, const std::c
 template<typename T>
 inline void CHECK_ZEROS(T &size)
 {
-    bool* pt_b = nullptr;
-    int* pt_i = nullptr;
-    float* pt_f = nullptr;
-    double* pt_d = nullptr;
     std::complex<float>* pt_cf = nullptr;
     std::complex<double>* pt_cd = nullptr;
     ModuleBase::Vector3<double>* pt_v3 = nullptr;
-    pt_b = new bool[size];
-    pt_i = new int[size];
-    pt_f = new float[size];
-    pt_d = new double[size];
-    pt_cf = new std::complex<float>[size];
-    pt_cd = new std::complex<double>[size];
-    pt_v3 = new ModuleBase::Vector3<double>[size];
+    std::vector<bool> pt_b[size];
+    std::vector<int> pt_i[size];
+    std::vector<float> pt_f[size];
+    std::vector<double> pt_d[size];
+    std::vector<std::complex<float>> pt_cf(size);
+    std::vector<std::complex<double>> pt_cd(size);
+    std::vector<ModuleBase::Vector3<double>> pt_v3(size);
     // long long size
     long long size_ll = 100;
     bool value_b = true;
@@ -140,13 +136,6 @@ inline void CHECK_ZEROS(T &size)
         EXPECT_DOUBLE_EQ(pt_v3[i].y,zero_d);
         EXPECT_DOUBLE_EQ(pt_v3[i].z,zero_d);
     }
-    delete[] pt_b;
-    delete[] pt_i;
-    delete[] pt_f;
-    delete[] pt_d;
-    delete[] pt_cf;
-    delete[] pt_cd;
-    delete[] pt_v3;
 }
 
 class GlobalFunctionTest : public testing::Test
@@ -622,10 +611,8 @@ TEST_F(GlobalFunctionTest, VectorToPointer)
 TEST_F(GlobalFunctionTest, COPYARRAY)
 {
     long size = 100;
-    std::complex<double>* aa = nullptr;
-    std::complex<double>* bb = nullptr;
-    aa = new std::complex<double>[size];
-    bb = new std::complex<double>[size];
+    std::vector<std::complex<double>> aa(size);
+    std::vector<std::complex<double>> bb(size);
     std::complex<double> value{1.1, 2.2};
     std::fill(&aa[0], &aa[size], value);
     ModuleBase::GlobalFunc::COPYARRAY(aa,bb,size);
@@ -633,20 +620,14 @@ TEST_F(GlobalFunctionTest, COPYARRAY)
     {
         EXPECT_COMPLEX_DOUBLE_EQ(bb[i], value);
     }
-    double* daa = nullptr;
-    double* dbb = nullptr;
-    daa = new double[size];
-    dbb = new double[size];
+    std::vector<double> daa(size);
+    std::vector<double> dbb(size);
     std::fill(&daa[0],&daa[size],3.3);
     ModuleBase::GlobalFunc::COPYARRAY(daa,dbb,size);
     for (int i = 0; i < size; ++i)
     {
         EXPECT_DOUBLE_EQ(dbb[i], 3.3);
     }
-    delete[] aa;
-    delete[] bb;
-    delete[] daa;
-    delete[] dbb;
 }
 
 TEST_F(GlobalFunctionTest,IsColumnMajor)


### PR DESCRIPTION


using STL std::vector  to replace new[] and delete[] in global_function_test.cpp.

