### PR TITLE
use vector to replace new and delete

### DIFF
--- a/source/module_base/mathzone_add1.cpp
+++ b/source/module_base/mathzone_add1.cpp
@@ -277,8 +277,8 @@ void Mathzone_Add1::Uni_Deriv_Phi
 
     std::vector<fftw_complex> fft_phir(FFT_NR);
 	std::vector<fftw_complex> fft_phik(FFT_NR);
-	std::vector<fftw_complex> fft_ndphik(FFT_NR);
-	std::vector<fftw_complex> fft_ndphir(FFT_NR);
+	fftw_complex *fft_ndphik = new fftw_complex[FFT_NR];
+    fftw_complex *fft_ndphir = new fftw_complex[FFT_NR];
 	fftw_plan p1;
 	fftw_plan p2;
 
@@ -403,6 +403,9 @@ void Mathzone_Add1::Uni_Deriv_Phi
 	
 	fftw_destroy_plan (p1);
 	fftw_destroy_plan (p2);
+
+	delete [] fft_ndphik;
+    delete [] fft_ndphir;
 	
 	ModuleBase::timer::tick("Mathzone_Add1", "Uni_Deriv_Phi");
 }

--- a/source/module_base/mathzone_add1.cpp
+++ b/source/module_base/mathzone_add1.cpp
@@ -275,10 +275,10 @@ void Mathzone_Add1::Uni_Deriv_Phi
 	// std::cout << "\n mesh=" << mesh << ", radf[8010]=" << radf[8010] <<  ", radf[8009]=" << radf[8009] ;
 	// mesh=8010, radf[8010]=4.396478951532926e-01, radf[8009]=0.000000000000000e+00
 
-    fftw_complex *fft_phir = new fftw_complex[FFT_NR];
-    fftw_complex *fft_phik = new fftw_complex[FFT_NR];
-    fftw_complex *fft_ndphik = new fftw_complex[FFT_NR];
-    fftw_complex *fft_ndphir = new fftw_complex[FFT_NR];
+    std::vector<fftw_complex> fft_phir(FFT_NR);
+	std::vector<fftw_complex> fft_phik(FFT_NR);
+	std::vector<fftw_complex> fft_ndphik(FFT_NR);
+	std::vector<fftw_complex> fft_ndphir(FFT_NR);
 	fftw_plan p1;
 	fftw_plan p2;
 
@@ -403,11 +403,6 @@ void Mathzone_Add1::Uni_Deriv_Phi
 	
 	fftw_destroy_plan (p1);
 	fftw_destroy_plan (p2);
-
-    delete [] fft_phir;
-    delete [] fft_phik;
-    delete [] fft_ndphik;
-    delete [] fft_ndphir;
 	
 	ModuleBase::timer::tick("Mathzone_Add1", "Uni_Deriv_Phi");
 }

--- a/source/module_base/memory.cpp
+++ b/source/module_base/memory.cpp
@@ -245,7 +245,7 @@ void Memory::print_all(std::ofstream &ofs)
     
     assert(n_memory>0);
 
-	bool *print_flag = new bool[n_memory];
+	std::vector<bool> print_flag(n_memory, false);
 
 	for(int i=0; i<n_memory; i++) 
 	{
@@ -307,7 +307,6 @@ void Memory::print_all(std::ofstream &ofs)
 	ofs<<" -------------   < 1.0 MB has been ignored ----------------"<<std::endl;
     ofs<<" ----------------------------------------------------------"<<std::endl;
 
-	delete[] print_flag; //mohan fix by valgrind at 2012-04-02
 	return;
 }
 

--- a/source/module_base/parallel_global.cpp
+++ b/source/module_base/parallel_global.cpp
@@ -56,8 +56,7 @@ void Parallel_Global::split_diag_world(const int &diag_np)
 #ifdef __MPI
 	assert(diag_np>0);
 	// number of processors in each 'grid group'.
-	int* group_grid_np = new int[diag_np];
-	ModuleBase::GlobalFunc::ZEROS(group_grid_np, diag_np);
+	std::vector<int> group_grid_np(diag_np, 0);
 	// average processors in each 'grid group'
 	int ave = GlobalV::NPROC/diag_np;
 	// remain processors.
@@ -94,8 +93,6 @@ void Parallel_Global::split_diag_world(const int &diag_np)
 	MPI_Comm_size(DIAG_WORLD, &GlobalV::DSIZE);
 	GlobalV::DCOLOR=color;
 
-
-	delete[] group_grid_np;
 #else
 	GlobalV::DCOLOR=0; //mohan fix bug 2012-02-04
 	GlobalV::DRANK=0;
@@ -111,8 +108,7 @@ void Parallel_Global::split_grid_world(const int &diag_np)
 #ifdef __MPI
 	assert(diag_np>0);
 	// number of processors in each 'grid group'.
-	int* group_grid_np = new int[diag_np];
-	ModuleBase::GlobalFunc::ZEROS(group_grid_np, diag_np);
+	std::vector<int> group_grid_np(diag_np, 0);
 	// average processors in each 'grid group'
 	int ave = GlobalV::NPROC/diag_np;
 	// remain processors.
@@ -148,7 +144,6 @@ void Parallel_Global::split_grid_world(const int &diag_np)
 	MPI_Comm_rank(GRID_WORLD, &GlobalV::GRANK);
 	MPI_Comm_size(GRID_WORLD, &GlobalV::GSIZE);
 
-	delete[] group_grid_np;
 #else
 	GlobalV::GRANK=0;  //mohan fix bug 2012-02-04
 	GlobalV::GSIZE=1;

--- a/source/module_io/cal_dos.cpp
+++ b/source/module_io/cal_dos.cpp
@@ -69,9 +69,6 @@ bool ModuleIO::calculate_dos
 	ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"min state energy (eV)",emin_ev);
 	ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"max state energy (eV)",emax_ev);
 	ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"delta energy interval (eV)",  de_ev);
-	
-	double *e_mod = new double[npoints];
-	ModuleBase::GlobalFunc::ZEROS(e_mod, npoints);
 
 	double sum   = 0.0;
 	double e_new = emin_ev;
@@ -157,7 +154,6 @@ bool ModuleIO::calculate_dos
 	}
 	ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"number of bands",nbands);
 	ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"sum up the states", sum);
-	delete[] e_mod;
 
 	return 1;
 }


### PR DESCRIPTION
I have utilized the `vector` type from the standard library to replace some variables that were previously managed with `new` and `delete` for memory management.