### PR TITLE
Style: update `clang-tidy` config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,6 @@
 Language: Cpp
 BasedOnStyle: Microsoft
 
-AlignArrayOfStructures: Right
 AlwaysBreakTemplateDeclarations: Yes
 
 AllowAllArgumentsOnNextLine: false
@@ -18,23 +17,6 @@ FixNamespaceComments: true
 
 # About include
 IncludeBlocks: Regroup
-IncludeCategories:
-  - Regex: '^<ext/.*\.h>'
-    Priority: 2
-    SortPriority: 0
-    CaseSensitive: false
-  - Regex: '^<.*\.h>'
-    Priority: 1
-    SortPriority: 0
-    CaseSensitive: false
-  - Regex: '^<.*'
-    Priority: 2
-    SortPriority: 0
-    CaseSensitive: false
-  - Regex: '.*'
-    Priority: 3
-    SortPriority: 0
-    CaseSensitive: false
 IncludeIsMainRegex: '([-_](test|unittest))?$'
 IncludeIsMainSourceRegex: ''
 
@@ -44,8 +26,6 @@ IndentWrappedFunctionNames: true
 # About Point
 DerivePointerAlignment: false
 PointerAlignment: Left
-
-PackConstructorInitializers: NextLine
 
 ReflowComments: true
 SortIncludes: true

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,35 @@
 ---
-Checks: '-*,clang-diagnostic-*,clang-analyzer-*,google-*,llvm-header-guard,cppcoreguidelines-avoid-non-const-global-variables,cppcoreguidelines-init-variables,cppcoreguidelines-pro-type-member-init,fuchsia-multiple-inheritance,misc-non-private-member-variables-in-classes,readability-make-member-function-const,readability-function-size,misc-unused-parameters,readability-non-const-parameter,cppcoreguidelines-macro-usage,modernize-use-nullptr,modernize-deprecated-headers'
-FormatStyle: none
-CheckOptions:
+Checks: '
+    -*,
+    bugprone-*,
+    clang-analyzer-*,
+    clang-diagnostic-*,
+    cppcoreguidelines-avoid-non-const-global-variables,
+    cppcoreguidelines-macro-usage,
+    cppcoreguidelines-pro-type-member-init,
+    fuchsia-multiple-inheritance,
+    google-*,
+    -google-runtime-references,
+    llvm-header-guard,
+    misc-*,
+    modernize-deprecated-headers,
+    modernize-redundant-void-arg,
+    modernize-use-nullptr,
+    modernize-use-bool-literals,
+    modernize-use-auto,
+    modernize-use-std-numbers,
+    modernize-pass-by-value,
+    modernize-shrink-to-fit,
+    mpi-*,
+    performance-*,
+    -performance-avoid-endl,
+    readability-*,
+    -readability-magic-numbers,
+    -readability-isolate-declaration,
+    -readability-braces-around-statements,
+    -readability-implicit-bool-conversion,
+    -google-readability-braces-around-statements,
+    -misc-unused-parameters,
+'
+FormatStyle: file
 ...


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
#3915
### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
`clang-tidy` is an autonomous code static analysis tool. This PR reviewed the config file used for clang-tidy.
I've choose some checks that balances existed coding style and code robustness. Full list of checks can be found [here](https://clang.llvm.org/extra/clang-tidy/checks/list.html).
Feel free to add or remove rules.


