### PR TITLE
Refactor `istate_charge.cpp` to reduce dependence on other modules

### DIFF
--- a/source/module_elecstate/fp_energy.cpp
+++ b/source/module_elecstate/fp_energy.cpp
@@ -1,36 +1,38 @@
 #include "fp_energy.h"
+
 #include "module_base/global_variable.h"
 #ifdef USE_PAW
 #include "module_cell/module_paw/paw_cell.h"
 #endif
 
+#include "module_base/tool_quit.h"
+
 #include <iomanip>
 #include <iostream>
 
-#include "module_base/tool_quit.h"
 namespace elecstate
 {
 
 /// @brief calculate etot
 double fenergy::calculate_etot()
 {
-    if(GlobalV::use_paw)
+    if (GlobalV::use_paw)
     {
-        etot = eband + deband + etxc + ewald_energy - hartree_energy + demet + descf + exx + efield + gatefield
-               + evdw + esol_el + esol_cav + edftu + edeepks_scf;
+        etot = eband + deband + etxc + ewald_energy - hartree_energy + demet + descf + exx + efield + gatefield + evdw
+               + esol_el + esol_cav + edftu + edeepks_scf;
     }
     else
     {
-        etot = eband + deband + (etxc - etxcc) + ewald_energy + hartree_energy + demet + descf + exx + efield + gatefield
-               + evdw + esol_el + esol_cav + edftu + edeepks_scf + escon;
+        etot = eband + deband + (etxc - etxcc) + ewald_energy + hartree_energy + demet + descf + exx + efield
+               + gatefield + evdw + esol_el + esol_cav + edftu + edeepks_scf + escon;
     }
 
 #ifdef USE_PAW
-    if(GlobalV::use_paw)
+    if (GlobalV::use_paw)
     {
         double ecore = GlobalC::paw_cell.calculate_ecore();
         double epawdc = GlobalC::paw_cell.get_epawdc();
-        etot += ( ecore + epawdc );
+        etot += (ecore + epawdc);
     }
 #endif
     return etot;
@@ -39,22 +41,22 @@ double fenergy::calculate_etot()
 /// @brief calculate etot_harris
 double fenergy::calculate_harris()
 {
-    if(GlobalV::use_paw)
+    if (GlobalV::use_paw)
     {
         etot_harris = eband + deband_harris + etxc + ewald_energy - hartree_energy + demet + descf + exx + efield
-                  + gatefield + evdw + esol_el + esol_cav + edftu + edeepks_scf;
+                      + gatefield + evdw + esol_el + esol_cav + edftu + edeepks_scf;
     }
     else
     {
-        etot_harris = eband + deband_harris + (etxc - etxcc) + ewald_energy + hartree_energy + demet + descf + exx + efield
-                  + gatefield + evdw + esol_el + esol_cav + edftu + edeepks_scf + escon;
+        etot_harris = eband + deband_harris + (etxc - etxcc) + ewald_energy + hartree_energy + demet + descf + exx
+                      + efield + gatefield + evdw + esol_el + esol_cav + edftu + edeepks_scf + escon;
     }
 #ifdef USE_PAW
-    if(GlobalV::use_paw)
+    if (GlobalV::use_paw)
     {
         double ecore = GlobalC::paw_cell.calculate_ecore();
         double epawdc = GlobalC::paw_cell.get_epawdc();
-        etot_harris += ( ecore + epawdc );
+        etot_harris += (ecore + epawdc);
     }
 #endif
     return etot_harris;
@@ -64,7 +66,8 @@ double fenergy::calculate_harris()
 void fenergy::clear_all()
 {
     etot = etot_old = eband = deband = etxc = etxcc = vtxc = ewald_energy = hartree_energy = demet = descf = exx
-        = efield = gatefield = evdw = etot_harris = deband_harris = esol_el = esol_cav = edftu = edeepks_scf = escon = 0.0;
+        = efield = gatefield = evdw = etot_harris = deband_harris = esol_el = esol_cav = edftu = edeepks_scf = escon
+        = 0.0;
 }
 
 /// @brief print all energies
@@ -137,6 +140,20 @@ double efermi::get_efval(const int& is) const
     {
         ModuleBase::WARNING_QUIT("energy", "Please check NSPIN when TWO_EFERMI is true");
         __builtin_unreachable();
+    }
+}
+
+/// @brief get all fermi energies for all spins
+/// @return all fermi energies for all spins
+std::vector<double> efermi::get_all_ef() const
+{
+    if (two_efermi)
+    {
+        return {ef_up, ef_dw};
+    }
+    else
+    {
+        return {ef, ef}; // For NSPIN=1, ef_up=ef_dw=ef
     }
 }
 

--- a/source/module_elecstate/fp_energy.h
+++ b/source/module_elecstate/fp_energy.h
@@ -1,3 +1,5 @@
+#include <vector>
+
 /**
  * @file fp_energy.h
  * @brief This file contains all energies about first-principle calculations
@@ -12,8 +14,8 @@ namespace elecstate
  */
 struct fenergy
 {
-    double etot = 0.0;     ///< the total free energy
-    double etot_old = 0.0; ///< old total free energy
+    double etot = 0.0;       ///< the total free energy
+    double etot_old = 0.0;   ///< old total free energy
     double etot_delta = 0.0; // the difference of total energy between two steps = etot - etot_old
 
     double eband = 0.0;          ///< the band energy
@@ -42,8 +44,8 @@ struct fenergy
 
     double escon = 0.0; ///< spin constraint energy
 
-    double ekinetic = 0.0;      /// kinetic energy, used in OFDFT
-    double eion_elec = 0.0;     /// ion-electron interaction energy, used in OFDFT
+    double ekinetic = 0.0;  /// kinetic energy, used in OFDFT
+    double eion_elec = 0.0; /// ion-electron interaction energy, used in OFDFT
 
     double calculate_etot();
     double calculate_harris();
@@ -63,6 +65,7 @@ struct efermi
     bool two_efermi = false; ///<
     double& get_ef(const int& is);
     double get_efval(const int& is) const;
+    std::vector<double> get_all_ef() const;
 };
 
 } // namespace elecstate

--- a/source/module_esolver/esolver_ks_lcao_elec.cpp
+++ b/source/module_esolver/esolver_ks_lcao_elec.cpp
@@ -19,11 +19,10 @@
 #include "module_elecstate/elecstate_lcao.h"
 #include "module_hamilt_general/module_ewald/H_Ewald_pw.h"
 #include "module_hamilt_general/module_vdw/vdw.h"
-#include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/op_exx_lcao.h"
-#include "module_io/dm_io.h"
-
-#include "module_hamilt_lcao/module_deltaspin/spin_constrain.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/LCAO_domain.h"
+#include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/op_exx_lcao.h"
+#include "module_hamilt_lcao/module_deltaspin/spin_constrain.h"
+#include "module_io/dm_io.h"
 
 namespace ModuleESolver
 {
@@ -102,8 +101,8 @@ void ESolver_KS_LCAO<TK, TR>::beforesolver(const int istep)
     // init psi
     if (this->psi == nullptr)
     {
-        int nsk=0;
-        int ncol=0;
+        int nsk = 0;
+        int ncol = 0;
         if (GlobalV::GAMMA_ONLY_LOCAL)
         {
             nsk = GlobalV::NSPIN;
@@ -127,12 +126,7 @@ void ESolver_KS_LCAO<TK, TR>::beforesolver(const int istep)
     }
 
     // prepare grid in Gint
-	LCAO_domain::grid_prepare(
-			this->GridT, 
-			this->GG,
-			this->GK,
-			*this->pw_rho, 
-			*this->pw_big);
+    LCAO_domain::grid_prepare(this->GridT, this->GG, this->GK, *this->pw_rho, *this->pw_big);
 
     // init Hamiltonian
     if (this->p_hamilt != nullptr)
@@ -143,7 +137,8 @@ void ESolver_KS_LCAO<TK, TR>::beforesolver(const int istep)
     if (this->p_hamilt == nullptr)
     {
         elecstate::DensityMatrix<TK, double>* DM = dynamic_cast<elecstate::ElecStateLCAO<TK>*>(this->pelec)->get_DM();
-        this->p_hamilt = new hamilt::HamiltLCAO<TK, TR>(GlobalV::GAMMA_ONLY_LOCAL ? &(this->GG) : nullptr,
+        this->p_hamilt = new hamilt::HamiltLCAO<TK, TR>(
+            GlobalV::GAMMA_ONLY_LOCAL ? &(this->GG) : nullptr,
             GlobalV::GAMMA_ONLY_LOCAL ? nullptr : &(this->GK),
             &(this->gen_h),
             &(this->LM),
@@ -270,12 +265,12 @@ void ESolver_KS_LCAO<TK, TR>::beforesolver(const int istep)
     //=========================================================
     // cal_ux should be called before init_scf because
     // the direction of ux is used in noncoline_rho
-	//=========================================================
-	if(GlobalV::NSPIN == 4 && GlobalV::DOMAG) 
-	{
-		GlobalC::ucell.cal_ux();
-	}
-	ModuleBase::timer::tick("ESolver_KS_LCAO", "beforesolver");
+    //=========================================================
+    if (GlobalV::NSPIN == 4 && GlobalV::DOMAG)
+    {
+        GlobalC::ucell.cal_ux();
+    }
+    ModuleBase::timer::tick("ESolver_KS_LCAO", "beforesolver");
 }
 
 template <typename TK, typename TR>
@@ -311,15 +306,15 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(int istep)
 
     this->beforesolver(istep);
     // Peize Lin add 2016-12-03
-#ifdef __EXX    // set xc type before the first cal of xc in pelec->init_scf
-	if (GlobalC::exx_info.info_ri.real_number)
-	{
-		this->exd->exx_beforescf(this->kv, *this->p_chgmix);
-	}
-	else
-	{
-		this->exc->exx_beforescf(this->kv, *this->p_chgmix);
-	}
+#ifdef __EXX // set xc type before the first cal of xc in pelec->init_scf
+    if (GlobalC::exx_info.info_ri.real_number)
+    {
+        this->exd->exx_beforescf(this->kv, *this->p_chgmix);
+    }
+    else
+    {
+        this->exc->exx_beforescf(this->kv, *this->p_chgmix);
+    }
 #endif // __EXX
 
     this->pelec->init_scf(istep, this->sf.strucFac);
@@ -329,22 +324,22 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(int istep)
         ->get_DM()
         ->init_DMR(*(dynamic_cast<hamilt::HamiltLCAO<TK, TR>*>(this->p_hamilt)->getHR()));
 
-    if(GlobalV::dm_to_rho)
+    if (GlobalV::dm_to_rho)
     {
         std::string zipname = "output_DM0.npz";
         elecstate::DensityMatrix<TK, double>* dm
             = dynamic_cast<const elecstate::ElecStateLCAO<TK>*>(this->pelec)->get_DM();
-        this->read_mat_npz(zipname,*(dm->get_DMR_pointer(1)));
-        if(GlobalV::NSPIN == 2)
+        this->read_mat_npz(zipname, *(dm->get_DMR_pointer(1)));
+        if (GlobalV::NSPIN == 2)
         {
             zipname = "output_DM1.npz";
-            this->read_mat_npz(zipname,*(dm->get_DMR_pointer(2)));
+            this->read_mat_npz(zipname, *(dm->get_DMR_pointer(2)));
         }
 
         this->pelec->psiToRho(*this->psi);
 
         this->create_Output_Rho(0, istep).write();
-        if(GlobalV::NSPIN == 2)
+        if (GlobalV::NSPIN == 2)
         {
             this->create_Output_Rho(1, istep).write();
         }
@@ -358,7 +353,7 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(int istep)
     for (int is = 0; is < GlobalV::NSPIN; is++)
     {
         srho.begin(is, *(this->pelec->charge), this->pw_rho, GlobalC::Pgrid, GlobalC::ucell.symm);
-    } 
+    }
 
     // 1. calculate ewald energy.
     // mohan update 2021-02-25
@@ -423,11 +418,20 @@ void ESolver_KS_LCAO<TK, TR>::others(const int istep)
     {
         IState_Charge ISC(this->psi, this->LOC);
         ISC.begin(this->GG,
-                  this->pelec,
-                  this->pw_rho,
-                  this->pw_big,
+                  this->pelec->charge->rho,
+                  this->pelec->wg,
+                  this->pelec->eferm.get_all_ef(),
+                  this->pw_rho->nrxx,
+                  this->pw_rho->nplane,
+                  this->pw_rho->startz_current,
+                  this->pw_rho->nx,
+                  this->pw_rho->ny,
+                  this->pw_rho->nz,
+                  this->pw_big->bz,
+                  this->pw_big->nbz,
                   GlobalV::GAMMA_ONLY_LOCAL,
                   GlobalV::NBANDS_ISTATE,
+                  INPUT.get_out_band_kb(),
                   GlobalV::NBANDS,
                   GlobalV::nelec,
                   GlobalV::NSPIN,
@@ -481,14 +485,12 @@ void ESolver_KS_LCAO<TK, TR>::others(const int istep)
     return;
 }
 
-
 template <>
 void ESolver_KS_LCAO<double, double>::get_S(void)
 {
     ModuleBase::TITLE("ESolver_KS_LCAO", "get_S");
     ModuleBase::WARNING_QUIT("ESolver_KS_LCAO<double,double>::get_S", "not implemented for");
 }
-
 
 template <>
 void ESolver_KS_LCAO<std::complex<double>, double>::get_S(void)
@@ -523,7 +525,6 @@ void ESolver_KS_LCAO<std::complex<double>, double>::get_S(void)
     return;
 }
 
-
 template <>
 void ESolver_KS_LCAO<std::complex<double>, std::complex<double>>::get_S(void)
 {
@@ -546,8 +547,7 @@ void ESolver_KS_LCAO<std::complex<double>, std::complex<double>>::get_S(void)
     this->LM.ParaV = &this->orb_con.ParaV;
     if (this->p_hamilt == nullptr)
     {
-        this->p_hamilt
-            = new hamilt::HamiltLCAO<std::complex<double>, std::complex<double>>(&this->LM, this->kv);
+        this->p_hamilt = new hamilt::HamiltLCAO<std::complex<double>, std::complex<double>>(&this->LM, this->kv);
         dynamic_cast<hamilt::OperatorLCAO<std::complex<double>, std::complex<double>>*>(this->p_hamilt->ops)
             ->contributeHR();
     }
@@ -556,7 +556,6 @@ void ESolver_KS_LCAO<std::complex<double>, std::complex<double>>::get_S(void)
 
     return;
 }
-
 
 template <typename TK, typename TR>
 void ESolver_KS_LCAO<TK, TR>::nscf(void)
@@ -661,36 +660,31 @@ void ESolver_KS_LCAO<TK, TR>::nscf(void)
 #ifdef __LCAO
         if (INPUT.wannier_method == 1)
         {
-            toWannier90_LCAO_IN_PW myWannier(
-                INPUT.out_wannier_mmn,
-                INPUT.out_wannier_amn,
-                INPUT.out_wannier_unk, 
-                INPUT.out_wannier_eig,
-                INPUT.out_wannier_wvfn_formatted,
-                INPUT.nnkpfile,
-                INPUT.wannier_spin
-            );
+            toWannier90_LCAO_IN_PW myWannier(INPUT.out_wannier_mmn,
+                                             INPUT.out_wannier_amn,
+                                             INPUT.out_wannier_unk,
+                                             INPUT.out_wannier_eig,
+                                             INPUT.out_wannier_wvfn_formatted,
+                                             INPUT.nnkpfile,
+                                             INPUT.wannier_spin);
 
-            myWannier.calculate(
-              this->pelec->ekb, 
-              this->pw_wfc, 
-              this->pw_big, 
-              this->sf, 
-              this->kv, 
-              this->psi, 
-              this->LOWF.ParaV);
+            myWannier.calculate(this->pelec->ekb,
+                                this->pw_wfc,
+                                this->pw_big,
+                                this->sf,
+                                this->kv,
+                                this->psi,
+                                this->LOWF.ParaV);
         }
         else if (INPUT.wannier_method == 2)
         {
-            toWannier90_LCAO myWannier(
-                INPUT.out_wannier_mmn,
-                INPUT.out_wannier_amn,
-                INPUT.out_wannier_unk, 
-                INPUT.out_wannier_eig,
-                INPUT.out_wannier_wvfn_formatted,
-                INPUT.nnkpfile,
-                INPUT.wannier_spin
-            );
+            toWannier90_LCAO myWannier(INPUT.out_wannier_mmn,
+                                       INPUT.out_wannier_amn,
+                                       INPUT.out_wannier_unk,
+                                       INPUT.out_wannier_eig,
+                                       INPUT.out_wannier_wvfn_formatted,
+                                       INPUT.nnkpfile,
+                                       INPUT.wannier_spin);
 
             myWannier.calculate(this->pelec->ekb, this->kv, *(this->psi), this->LOWF.ParaV);
         }

--- a/source/module_io/input.h
+++ b/source/module_io/input.h
@@ -9,6 +9,7 @@
 
 #include "module_base/vector3.h"
 #include "module_md/md_para.h"
+#include "input_conv.h"
 
 class Input
 {
@@ -704,9 +705,17 @@ class Input
     void read_bool(std::ifstream &ifs, bool &var);
 
     // Return the const string pointer of private member bands_to_print_
+    // Not recommended to use this function directly, use get_out_band_kb() instead
     const std::string* get_bands_to_print() const
     {
         return &bands_to_print_;
+    }
+    // Return parsed bands_to_print_ as a vector of integers
+    std::vector<int> get_out_band_kb() const
+    {
+        std::vector<int> out_band_kb;
+        Input_Conv::parse_expression(bands_to_print_, out_band_kb);
+        return out_band_kb;
     }
 };
 

--- a/source/module_io/istate_charge.h
+++ b/source/module_io/istate_charge.h
@@ -1,15 +1,14 @@
 #ifndef ISTATE_CHARGE_H
 #define ISTATE_CHARGE_H
-#include <module_base/complexmatrix.h>
-#include <module_base/matrix.h>
-
-#include <stdexcept>
-#include <vector>
-
 #include "module_basis/module_pw/pw_basis.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/local_orbital_charge.h"
 #include "module_hamilt_lcao/module_gint/gint_gamma.h"
 #include "module_psi/psi.h"
+
+#include <module_base/complexmatrix.h>
+#include <module_base/matrix.h>
+#include <stdexcept>
+#include <vector>
 
 /**
  * @brief Manages the computation of the charge density for different bands.
@@ -31,11 +30,20 @@ class IState_Charge
     ~IState_Charge();
 
     void begin(Gint_Gamma& gg,
-               elecstate::ElecState* pelec,
-               const ModulePW::PW_Basis* rhopw,
-               const ModulePW::PW_Basis_Big* bigpw,
+               double** rho,
+               const ModuleBase::matrix& wg,
+               const std::vector<double>& ef_all_spin,
+               const int rhopw_nrxx,
+               const int rhopw_nplane,
+               const int rhopw_startz_current,
+               const int rhopw_nx,
+               const int rhopw_ny,
+               const int rhopw_nz,
+               const int bigpw_bz,
+               const int bigpw_nbz,
                const bool gamma_only_local,
                const int nbands_istate,
+               const std::vector<int>& out_band_kb,
                const int nbands,
                const double nelec,
                const int nspin,
@@ -50,8 +58,18 @@ class IState_Charge
 #ifdef __MPI
     /**
      * @brief Calculates the density matrix for a given band and spin.
+     *
+     * This method calculates the density matrix for a given band and spin using the wave function coefficients.
+     * It adjusts the coefficients based on the Fermi energy and performs a matrix multiplication to produce the density
+     * matrix.
+     *
+     * @param ib Band index.
+     * @param nspin Number of spin channels.
+     * @param nelec Total number of electrons.
+     * @param nlocal Number of local orbitals.
+     * @param wg Weight matrix for bands and spins.
      */
-    void idmatrix(const int& ib, elecstate::ElecState* pelec, const int nspin, const double nelec, const int nlocal);
+    void idmatrix(const int& ib, const int nspin, const double nelec, const int nlocal, const ModuleBase::matrix& wg);
 #endif
     psi::Psi<double>* psi_gamma;
     Local_Orbital_Charge* loc;


### PR DESCRIPTION
### Linked Issue
Fix #4085.

### What's changed?
This pull request introduces a series of refactoring and improvements aimed at enhancing code readability, performance, and modularity. Here are the major changes made:

1. **Used `parse_expression` Template Function**:
   - Overloaded the `parse_expression` template function to support direct parsing to `int` types. This update eliminates the need for explicit type conversions previously present, reducing potential type conversion errors.

2. **Isolation of `bands_to_print` to `out_band_kb` Conversion**:
   - Extracted the conversion from `bands_to_print` to `out_band_kb` into a separate function. This change ensures that the process of obtaining `out_band_kb` is handled internally within the `INPUT` class, making the intermediate transformation process invisible and inaccessible from outside.

3. **Reduced Dependency on `pelec`**:
   - Modified the system to allow passing `wg` directly into functions where `pelec` was previously required. This reduction in dependency decreases coupling across the codebase.

4. **Extended Functionality in `efermi` Struct**:
   - Added a new member function, `get_all_ef`, to the `efermi` struct, which returns a vector of Fermi energies for all spins. This enhancement provides a more flexible and straightforward way to access all Fermi energy values across different spins.

5. **Expansion of `rhopw` Parameters**:
   - Decomposed the `rhopw` parameter into six distinct input parameters.

6. **Expanded `bigpw` Parameters**:
   - Expanded the `bigpw` parameter into two separate input parameters.

**Reminder**
- The decision to maintain the dependency on `Local Orbital Charge` (LOC) is due to the extensive use of its numerous member functions, which are currently tightly integrated into various parts of the codebase. Detaching this dependency now would be inefficient and could potentially destabilize critical functionalities.

**Future Plans for Refactoring `idmatrix`**:
- See #3572.
