### PR TITLE
CI: fix the incorrect argument order in Autotest.sh

### DIFF
--- a/tests/integrate/Autotest.sh
+++ b/tests/integrate/Autotest.sh
@@ -17,7 +17,7 @@ case='^[^#].*_.*$'
 # enable AddressSanitizer
 sanitize=false
 
-while getopts a:n:t:c:s:r:g:f flag
+while getopts a:n:t:c:s:r:f:g flag
 do
     case "${flag}" in
         a) abacus=${OPTARG};;
@@ -26,8 +26,8 @@ do
         c) ca=${OPTARG};;
         s) sanitize=${OPTARG};;
         r) case=${OPTARG};;
-        g) g=true;; #generate test reference
         f) cases_file=${OPTARG};;
+        g) g=true;; #generate test reference
     esac
 done
 


### PR DESCRIPTION
### Linked Issue
Fix an error introduced by #4083: The argument order of the newly added argument ‘-f’ is incorrect, which caused the integrated tests for the GPU to fail to run properly.

### What's changed?
- changed the order of newly added argument '-f'
