### PR TITLE
Test: supplementary use of Memory::record to record memory

### DIFF
--- a/source/module_base/clebsch_gordan_coeff.cpp
+++ b/source/module_base/clebsch_gordan_coeff.cpp
@@ -30,6 +30,7 @@ void Clebsch_Gordan::clebsch_gordan(const int& lli,
     ModuleBase::matrix ylm(llx, llx);
     ModuleBase::matrix mly(llx, llx);
 
+    ModuleBase::Memory::record("Clebsch_Gordan::matrix",sizeof(double)*llx*llx*2+sizeof(ModuleBase::Vector3<double>)*llx);
     // generate an array of random vectors (uniform deviate on unitary sphere)
     gen_rndm_r(llx, r);
 

--- a/source/module_base/module_container/ATen/core/tensor_buffer.cpp
+++ b/source/module_base/module_container/ATen/core/tensor_buffer.cpp
@@ -2,6 +2,7 @@
 
 #include <base/core/cpu_allocator.h>
 #include <base/macros/macros.h>
+#include "module_base/memory.h"
 
 #if defined(__CUDA) || defined(__ROCM)
 #include <base/core/gpu_allocator.h>
@@ -22,6 +23,7 @@ TensorBuffer::TensorBuffer(base::core::Allocator* alloc, size_t size) {
     alloc_ = alloc; 
     if (size > 0) {
         data_ = alloc_->allocate(size);
+        ModuleBase::Memory::record("TensorBuffer::data_",sizeof(size_t)*size);
         owns_memory_ = true;
         allocated_bytes_ = size;
     }

--- a/source/module_base/module_container/ATen/core/tensor_buffer.h
+++ b/source/module_base/module_container/ATen/core/tensor_buffer.h
@@ -4,6 +4,7 @@
 #include <base/core/refcount.h>
 #include <base/core/allocator.h>
 #include <ATen/core/tensor_types.h>
+#include "module_base/memory.h"
 
 namespace container {
 

--- a/source/module_base/module_mixing/broyden_mixing.cpp
+++ b/source/module_base/module_mixing/broyden_mixing.cpp
@@ -45,6 +45,7 @@ void Broyden_Mixing::tem_push_data(Mixing_Data& mdata,
 
     // container::Tensor data = data_in + mixing_beta * F;
     std::vector<FPTYPE> data(length);
+    ModuleBase::Memory::record("Broyden_Mixing::F_tmp&data",sizeof(FPTYPE)*length*2);
     mix(data.data(), data_in, F_tmp.data());
 
     mdata.push(data.data());
@@ -70,6 +71,7 @@ void Broyden_Mixing::tem_push_data(Mixing_Data& mdata,
         if (dF != nullptr)
             free(dF);
         dF = malloc(sizeof(FPTYPE) * length * mixing_ndim);
+        ModuleBase::Memory::record("Broyden_Mixing::F&DF",sizeof(FPTYPE)*length*(mixing_ndim+1));
         FP_dF = static_cast<FPTYPE*>(dF);
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static, 4096 / sizeof(FPTYPE))

--- a/source/module_base/module_mixing/broyden_mixing.h
+++ b/source/module_base/module_mixing/broyden_mixing.h
@@ -2,6 +2,7 @@
 #define BROYDEN_MIXING_H_
 #include "mixing.h"
 #include "module_base/matrix.h"
+#include "module_base/memory.h"
 
 namespace Base_Mixing
 {

--- a/source/module_cell/module_symmetry/symmetry.cpp
+++ b/source/module_cell/module_symmetry/symmetry.cpp
@@ -1,3 +1,4 @@
+#include <complex>
 #include <memory>
 #include <array>
 #include "symmetry.h"
@@ -5,6 +6,7 @@
 #include "module_base/mathzone.h"
 #include "module_base/constants.h"
 #include "module_base/timer.h"
+#include "module_base/memory.h"
 
 namespace ModuleSymmetry
 {
@@ -51,6 +53,7 @@ void Symmetry::analy_sys(const Lattice& lat, const Statistics& st, Atom* atoms, 
     rotpos = new double[3*nat];
 	ModuleBase::GlobalFunc::ZEROS(newpos, 3*nat);
     ModuleBase::GlobalFunc::ZEROS(rotpos, 3*nat);
+    ModuleBase::Memory::record("Symmetry::analy_sys",sizeof(int)*(ntype*2+nat+2)+sizeof(double)*(nat*6));
 
     this->a1 = lat.a1;
     this->a2 = lat.a2;
@@ -300,6 +303,7 @@ int Symmetry::standard_lat(
     ModuleBase::Vector3<double> &c,
     double *cel_const) const
 {
+    // ModuleBase::TITLE("Symmetry", "standard_lat");
     static bool first = true;
     // there are only 14 types of Bravais lattice.
     int type = 15;
@@ -921,6 +925,7 @@ void Symmetry::checksym(ModuleBase::Matrix3 &s, ModuleBase::Vector3<double> &gtr
 	// is a valid symmetry operation on a supercell
 	//----------------------------------------------
     // the start atom index.
+    ModuleBase::TITLE("Symmetry", "checksym");
     bool no_diff = 0;
     ModuleBase::Vector3<double> trans(2.0, 2.0, 2.0);
     s_flag = 0;
@@ -1094,6 +1099,7 @@ void Symmetry::checksym(ModuleBase::Matrix3 &s, ModuleBase::Vector3<double> &gtr
 
 void Symmetry::pricell(double* pos, const Atom* atoms)
 {
+    ModuleBase::TITLE("Symmetry", "pricell");
     bool no_diff = 0;
     s_flag = 0;
     ptrans.clear();
@@ -1209,6 +1215,7 @@ void Symmetry::pricell(double* pos, const Atom* atoms)
 
     //sort ptrans:
     double* ptrans_array = new double[ntrans*3];
+    ModuleBase::Memory::record("Symmetry::ptrans_array",sizeof(double)*ntrans*3);
     for(int i=0;i<ntrans;++i)
     {
         ptrans_array[i*3]=ptrans[i].x;
@@ -1402,11 +1409,13 @@ void Symmetry::pricell(double* pos, const Atom* atoms)
 void Symmetry::rho_symmetry( double *rho,
                              const int &nr1, const int &nr2, const int &nr3)
 {
+    ModuleBase::TITLE("Symmetry", "rho_symmetry");
 //  if (GlobalV::test_symmetry)ModuleBase::TITLE("Symmetry","rho_symmetry");
     ModuleBase::timer::tick("Symmetry","rho_symmetry");
 
 	// allocate flag for each FFT grid.
     bool* symflag = new bool[nr1 * nr2 * nr3];
+    ModuleBase::Memory::record("Symmetry::symflag",sizeof(bool) *nr1*nr2*nr3);
     for (int i=0; i<nr1*nr2*nr3; i++)
     {
         symflag[i] = false;
@@ -1460,6 +1469,7 @@ void Symmetry::rhog_symmetry(std::complex<double> *rhogtot,
     int* ixyz2ipw, const int &nx, const int &ny, const int &nz, 
     const int &fftnx, const int &fftny, const int &fftnz)
 {
+    ModuleBase::TITLE("Symmetry", "rhog_symmetry");
 //  if (GlobalV::test_symmetry)ModuleBase::TITLE("Symmetry","rho_symmetry");
     ModuleBase::timer::tick("Symmetry","rhog_symmetry");
 // ----------------------------------------------------------------------
@@ -1472,6 +1482,12 @@ void Symmetry::rhog_symmetry(std::complex<double> *rhogtot,
     int(*isymflag)[48] = new int[fftnx*fftny*fftnz][48];//which rotration operation the grid corresponds to
     int(*table_xyz)[48] = new int[fftnx * fftny * fftnz][48];// group information
     int* count_xyz = new int[fftnx * fftny * fftnz];// how many symmetry operations has been covered
+    // ModuleBase::Memory::record("Symmetry::rhog_symmetry",sizeof(int) *fftnx*fftny*fftnz*98);
+    ModuleBase::Memory::record("Symmetry::symflag",sizeof(int) *fftnx*fftny*fftnz);
+    ModuleBase::Memory::record("Symmetry::isymflag",sizeof(int) *fftnx*fftny*fftnz*48);
+    ModuleBase::Memory::record("Symmetry::table_xyz",sizeof(int) *fftnx*fftny*fftnz*48);
+    ModuleBase::Memory::record("Symmetry::count_xyz",sizeof(int) *fftnx*fftny*fftnz);
+    // ModuleBase::TITLE("Symmetry", "rhog_symmetry2");
     for (int i = 0; i < fftnx * fftny * fftnz; i++)
     {
         symflag[i] = -1;
@@ -1483,6 +1499,7 @@ void Symmetry::rhog_symmetry(std::complex<double> *rhogtot,
 
     //map the gmatrix to inv
     int* invmap = new int[nrotk];
+    ModuleBase::Memory::record("Symmetry::invmap",sizeof(int)*nrotk);
     this->gmatrix_invmap(kgmatrix, nrotk, invmap);
 
 // ---------------------------------------------------
@@ -1601,6 +1618,7 @@ for (int g_index = 0; g_index < group_index; g_index++)
     int *ipw_record = new int[nrotk];
     int *ixyz_record = new int[nrotk];
     std::complex<double>* gphase_record = new std::complex<double> [nrotk];
+    ModuleBase::Memory::record("Symmetry::*_record",sizeof(int) *nrotk*2 + sizeof(std::complex<double>)*nrotk);
     std::complex<double> sum(0, 0);
     int rot_count=0;
 
@@ -1740,6 +1758,7 @@ void Symmetry::symmetrize_vec3_nat(double* v)const   // pengfei 2016-12-20
     vtot = new double[nat * 3]; ModuleBase::GlobalFunc::ZEROS(vtot, nat * 3);
     n = new int[nat]; ModuleBase::GlobalFunc::ZEROS(n, nat);
 
+    ModuleBase::Memory::record("Symmetry::vtot&n",sizeof(int)*nat + sizeof(double)*nat*3);
     for (int j = 0;j < nat; ++j)
     {
         const int jx = j * 3; const int jy = j * 3 + 1; const int jz = j * 3 + 2;
@@ -1766,6 +1785,7 @@ void Symmetry::symmetrize_vec3_nat(double* v)const   // pengfei 2016-12-20
 
 void Symmetry::symmetrize_mat3(ModuleBase::matrix& sigma, const Lattice& lat)const   //zhengdy added 2017
 {
+    ModuleBase::TITLE("Symmetry", "symmetrize_mat3");
     ModuleBase::matrix A = lat.latvec.to_matrix();
     ModuleBase::matrix AT = lat.latvec.Transpose().to_matrix();
     ModuleBase::matrix invA = lat.GT.to_matrix();
@@ -1781,6 +1801,7 @@ void Symmetry::symmetrize_mat3(ModuleBase::matrix& sigma, const Lattice& lat)con
 void Symmetry::gmatrix_convert_int(const ModuleBase::Matrix3* sa, ModuleBase::Matrix3* sb, 
         const int n, const ModuleBase::Matrix3 &a, const ModuleBase::Matrix3 &b) const
 {
+    ModuleBase::TITLE("Symmetry", "gmatrix_convert_int");
     auto round = [](double x){return (x>0.0)?floor(x+0.5):ceil(x-0.5);};
     ModuleBase::Matrix3 ai = a.Inverse();
     ModuleBase::Matrix3 bi = b.Inverse();
@@ -1802,6 +1823,7 @@ void Symmetry::gmatrix_convert_int(const ModuleBase::Matrix3* sa, ModuleBase::Ma
 void Symmetry::gmatrix_convert(const ModuleBase::Matrix3* sa, ModuleBase::Matrix3* sb, 
         const int n, const ModuleBase::Matrix3 &a, const ModuleBase::Matrix3 &b)const
 {
+    ModuleBase::TITLE("Symmetry", "gmatrix_convert");
     ModuleBase::Matrix3 ai = a.Inverse();
     ModuleBase::Matrix3 bi = b.Inverse();
     for (int i=0;i<n;++i)
@@ -1820,6 +1842,7 @@ void Symmetry::gtrans_convert(const ModuleBase::Vector3<double>* va, ModuleBase:
 }
 void Symmetry::gmatrix_invmap(const ModuleBase::Matrix3* s, const int n, int* invmap)
 {
+    ModuleBase::TITLE("Symmetry", "gmatrix_invmap");
     ModuleBase::Matrix3 eig(1, 0, 0, 0, 1, 0, 0, 0, 1);
     ModuleBase::Matrix3 tmp;
     for (int i=0;i<n;++i)
@@ -1842,6 +1865,7 @@ void Symmetry::gmatrix_invmap(const ModuleBase::Matrix3* s, const int n, int* in
 void Symmetry::get_shortest_latvec(ModuleBase::Vector3<double> &a1, 
         ModuleBase::Vector3<double> &a2, ModuleBase::Vector3<double> &a3) const
 {
+    ModuleBase::TITLE("Symmetry", "get_shortest_latvec");
     double len1=a1.norm();
     double len2=a2.norm();
     double len3=a3.norm();
@@ -1891,6 +1915,7 @@ void Symmetry::get_optlat(ModuleBase::Vector3<double> &v1, ModuleBase::Vector3<d
         ModuleBase::Vector3<double> &w2, ModuleBase::Vector3<double> &w3, 
         int& real_brav, double* cel_const, double* tmp_const) const
 {
+    ModuleBase::TITLE("Symmetry", "get_optlat");
     ModuleBase::Vector3<double> r1, r2, r3;
     double cos1 = 1;
     double cos2 = 1;
@@ -2152,6 +2177,7 @@ bool Symmetry::magmom_same_check(const Atom* atoms)const
 
 bool Symmetry::is_all_movable(const Atom* atoms, const Statistics& st)const
 {
+    ModuleBase::TITLE("Symmetry", "is_all_movable");
     bool all_mbl = true;
     for (int iat = 0;iat < st.nat;++iat)
     {

--- a/source/module_cell/module_symmetry/symmetry_basic.cpp
+++ b/source/module_cell/module_symmetry/symmetry_basic.cpp
@@ -4,6 +4,7 @@
 //==========================================================
 #include "symmetry.h"
 #include "module_base/mymath.h"
+#include "module_base/memory.h"
 bool ModuleSymmetry::test_brav = 0;
 
 namespace ModuleSymmetry
@@ -1111,6 +1112,7 @@ void Symmetry_Basic::atom_ordering_new(double *posi, const int natom, int *subin
 
 	double*  weighted_func = new double[natom];
 	
+	ModuleBase::Memory::record("Symmetry_Basic::tmp*",sizeof(double)*natom*4);
 	//the first time: f(x, y, z)
 	for(int i=0; i<natom; i++)
 	{

--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -8,6 +8,7 @@
 #include "module_base/parallel_reduce.h"
 #include "module_base/timer.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
+#include "module_base/memory.h"
 
 Charge_Mixing::Charge_Mixing()
 {
@@ -343,6 +344,7 @@ void Charge_Mixing::mix_rho_recip(Charge* chr)
         // allocate rhog_mag[is*ngmc] and rhog_mag_save[is*ngmc]
         rhog_mag = new std::complex<double>[npw * GlobalV::NSPIN];
         rhog_mag_save = new std::complex<double>[npw * GlobalV::NSPIN];
+        ModuleBase::Memory::record("Charge_Mixing::rhog_mag*",sizeof(std::complex<double>)*npw * GlobalV::NSPIN*2);
         ModuleBase::GlobalFunc::ZEROS(rhog_mag, npw * GlobalV::NSPIN);
         ModuleBase::GlobalFunc::ZEROS(rhog_mag_save, npw * GlobalV::NSPIN);
         // get rhog_mag[is*ngmc] and rhog_mag_save[is*ngmc]
@@ -447,6 +449,7 @@ void Charge_Mixing::mix_rho_recip(Charge* chr)
         const int nrxx = this->rhopw->nrxx;
         double* rho_magabs = new double[nrxx];
         double* rho_magabs_save = new double[nrxx];
+        ModuleBase::Memory::record("Charge_Mixing::rho_magabs*",sizeof(double)*nrxx*2);
         ModuleBase::GlobalFunc::ZEROS(rho_magabs, nrxx);
         ModuleBase::GlobalFunc::ZEROS(rho_magabs_save, nrxx);
         // calculate rho_magabs and rho_magabs_save
@@ -461,6 +464,7 @@ void Charge_Mixing::mix_rho_recip(Charge* chr)
         const int npw = this->rhopw->npw;
         std::complex<double>* rhog_magabs = new std::complex<double>[npw * 2];
         std::complex<double>* rhog_magabs_save = new std::complex<double>[npw * 2];
+        ModuleBase::Memory::record("Charge_Mixing::rhog_magabs_2*",sizeof(std::complex<double>)*npw*4);
         ModuleBase::GlobalFunc::ZEROS(rhog_magabs, npw * 2);
         ModuleBase::GlobalFunc::ZEROS(rhog_magabs_save, npw * 2);
         // calculate rhog_magabs and rhog_magabs_save
@@ -632,6 +636,7 @@ void Charge_Mixing::mix_rho_real(Charge* chr)
         // allocate rho_mag[is*nnrx] and rho_mag_save[is*nnrx]
         rho_mag = new double[nrxx * GlobalV::NSPIN];
         rho_mag_save = new double[nrxx * GlobalV::NSPIN];
+        ModuleBase::Memory::record("Charge_Mixing::rho_mag_2*",sizeof(double)*nrxx * GlobalV::NSPIN*2);
         ModuleBase::GlobalFunc::ZEROS(rho_mag, nrxx * GlobalV::NSPIN);
         ModuleBase::GlobalFunc::ZEROS(rho_mag_save, nrxx * GlobalV::NSPIN);
         // get rho_mag[is*nnrx] and rho_mag_save[is*nnrx]
@@ -726,6 +731,7 @@ void Charge_Mixing::mix_rho_real(Charge* chr)
         // allocate memory for rho_magabs and rho_magabs_save
         double* rho_magabs = new double[nrxx * 2];
         double* rho_magabs_save = new double[nrxx * 2];
+        ModuleBase::Memory::record("Charge_Mixing::rho_magabs_real*",sizeof(double)*nrxx*4);
         ModuleBase::GlobalFunc::ZEROS(rho_magabs, nrxx * 2);
         ModuleBase::GlobalFunc::ZEROS(rho_magabs_save, nrxx * 2);
         // calculate rho_magabs and rho_magabs_save
@@ -822,6 +828,7 @@ void Charge_Mixing::mix_dmr(elecstate::DensityMatrix<double, double>* DM)
         // allocate dmr_mag[is*nnrx] and dmr_mag_save[is*nnrx]
         dmr_mag = new double[nnr * GlobalV::NSPIN];
         dmr_mag_save = new double[nnr * GlobalV::NSPIN];
+        ModuleBase::Memory::record("Charge_Mixing::dmr_mag*",sizeof(double)*nnr*GlobalV::NSPIN*2);
         ModuleBase::GlobalFunc::ZEROS(dmr_mag, nnr * GlobalV::NSPIN);
         ModuleBase::GlobalFunc::ZEROS(dmr_mag_save, nnr * GlobalV::NSPIN);
         double* dmr_up;
@@ -921,6 +928,7 @@ void Charge_Mixing::mix_dmr(elecstate::DensityMatrix<std::complex<double>, doubl
         // allocate dmr_mag[is*nnrx] and dmr_mag_save[is*nnrx]
         dmr_mag = new double[nnr * GlobalV::NSPIN];
         dmr_mag_save = new double[nnr * GlobalV::NSPIN];
+        ModuleBase::Memory::record("Charge_Mixing::dmr_mag_2*",sizeof(double)*nnr*GlobalV::NSPIN*2);
         ModuleBase::GlobalFunc::ZEROS(dmr_mag, nnr * GlobalV::NSPIN);
         ModuleBase::GlobalFunc::ZEROS(dmr_mag_save, nnr * GlobalV::NSPIN);
         double* dmr_up;
@@ -1015,6 +1023,7 @@ void Charge_Mixing::mix_rho(Charge* chr)
     // the charge before mixing.
     const int nrxx = chr->rhopw->nrxx;
     std::vector<double> rho123(GlobalV::NSPIN * nrxx);
+    ModuleBase::Memory::record("Charge_Mixing::rho123",sizeof(double)*GlobalV::NSPIN * nrxx);
     for (int is = 0; is < GlobalV::NSPIN; ++is)
     {
         if (is == 0 || is == 3 || !GlobalV::DOMAG_Z)
@@ -1262,6 +1271,7 @@ double Charge_Mixing::inner_product_recip_rho(std::complex<double>* rho1, std::c
 
     std::complex<double>** rhog1 = new std::complex<double>*[GlobalV::NSPIN];
     std::complex<double>** rhog2 = new std::complex<double>*[GlobalV::NSPIN];
+    ModuleBase::Memory::record("Charge_Mixing::rhog1&2",sizeof(std::complex<double>)*GlobalV::NSPIN*2);
     for (int is = 0; is < GlobalV::NSPIN; is++)
     {
         rhog1[is] = rho1 + is * this->rhopw->npw;
@@ -1623,10 +1633,13 @@ void Charge_Mixing::divide_data(std::complex<double>* data_d,
         const int ndims = this->rhopw->npw;
         const int ndimhf = ndimd - ndims;
         data_s = new std::complex<double>[GlobalV::NSPIN * ndims];
+        ModuleBase::Memory::record("Charge_Mixing::data_s",sizeof(std::complex<double>)*GlobalV::NSPIN * ndims);
         data_hf = nullptr;
         if (ndimhf > 0)
         {
             data_hf = new std::complex<double>[GlobalV::NSPIN * ndimhf];
+            
+            ModuleBase::Memory::record("Charge_Mixing::data_hf",sizeof(std::complex<double>)*GlobalV::NSPIN * ndimhf);
         }
         for (int is = 0; is < GlobalV::NSPIN; ++is)
         {

--- a/source/module_elecstate/potentials/H_Hartree_pw.cpp
+++ b/source/module_elecstate/potentials/H_Hartree_pw.cpp
@@ -3,6 +3,7 @@
 #include "module_base/constants.h"
 #include "module_base/timer.h"
 #include "module_base/parallel_reduce.h"
+#include "module_base/memory.h"
 
 namespace elecstate
 {
@@ -22,6 +23,7 @@ ModuleBase::matrix H_Hartree_pw::v_hartree(const UnitCell &cell,
 
     //  Hartree potential VH(r) from n(r)
     std::vector<std::complex<double>> Porter(rho_basis->nmaxgr);
+    ModuleBase::Memory::record("H_Hartree_pw::Porter",sizeof(std::complex<double>)*rho_basis->nmaxgr);
     const int nspin0 = (nspin == 2) ? 2 : 1;
     for (int is = 0; is < nspin0; is++)
     {
@@ -43,6 +45,7 @@ ModuleBase::matrix H_Hartree_pw::v_hartree(const UnitCell &cell,
     double ehart = 0.0;
 
     std::vector<std::complex<double>> vh_g(rho_basis->npw);
+    ModuleBase::Memory::record("H_Hartree_pw::vh_g",sizeof(std::complex<double>)*rho_basis->npw);
 #ifdef _OPENMP
 #pragma omp parallel for reduction(+:ehart)
 #endif
@@ -114,6 +117,7 @@ void PotHartree::cal_v_eff(const Charge* chg, const UnitCell* ucell, ModuleBase:
                 rho_tmp[is][ir] = chg->rho[is][ir] + chg->nhat[is][ir];
             }
         }
+        ModuleBase::Memory::record("PotHartree::rho_tmp",sizeof(double)*chg->nspin*rho_basis_->nrxx);
         v_eff += H_Hartree_pw::v_hartree(*ucell, const_cast<ModulePW::PW_Basis*>(this->rho_basis_), v_eff.nr, rho_tmp);
 
         for(int is = 0; is < chg->nspin; is++)

--- a/source/module_hamilt_general/module_xc/xc_functional_vxc.cpp
+++ b/source/module_hamilt_general/module_xc/xc_functional_vxc.cpp
@@ -8,6 +8,8 @@
 #include "module_base/parallel_reduce.h"
 #include "module_base/timer.h"
 
+#include "module_base/memory.h"
+
 // [etxc, vtxc, v] = XC_Functional::v_xc(...)
 std::tuple<double,double,ModuleBase::matrix> XC_Functional::v_xc(
 	const int &nrxx, // number of real-space grid
@@ -31,6 +33,7 @@ std::tuple<double,double,ModuleBase::matrix> XC_Functional::v_xc(
     double vtxc = 0.0;
     ModuleBase::matrix v(GlobalV::NSPIN, nrxx);
 
+    ModuleBase::Memory::record("xc_functional_vxc::matrix",sizeof(double)*GlobalV::NSPIN*nrxx);
     // the square of the e charge
     // in Rydeberg unit, so * 2.0.
     double e2 = 2.0;

--- a/source/module_hamilt_pw/hamilt_pwdft/VNL_in_pw.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/VNL_in_pw.cpp
@@ -443,6 +443,7 @@ void pseudopot_cell_vnl::getvnl(Device* ctx, const int& ik, std::complex<FPTYPE>
     resmem_var_op()(ctx, vkb1, nhm * npw, "VNL::vkb1");
 
     ModuleBase::Vector3<double>* _gk = new ModuleBase::Vector3<double>[npw];
+    ModuleBase::Memory::record("pseudopot_cell_vnl::getvnl",sizeof(ModuleBase::Vector3<double>)*npw+sizeof(int)*GlobalC::ucell.ntype*3);
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static, 4096 / sizeof(FPTYPE))
 #endif
@@ -569,6 +570,7 @@ void pseudopot_cell_vnl::init_vnl(UnitCell& cell, const ModulePW::PW_Basis* rho_
     this->dvan_so.zero_out(); // added by zhengdy-soc
     delete[] indv_ijkb0;
     this->indv_ijkb0 = new int[GlobalC::ucell.nat];
+    ModuleBase::Memory::record("pseudopot_cell_vnl::indv_ijkb0",sizeof(int)*GlobalC::ucell.nat);
     int ijkb0 = 0;
     for (int it = 0; it < cell.ntype; it++)
     {
@@ -820,6 +822,7 @@ void pseudopot_cell_vnl::init_vnl(UnitCell& cell, const ModulePW::PW_Basis* rho_
 
         double* jl = new double[kkbeta];
         double* aux = new double[kkbeta];
+        ModuleBase::Memory::record("pseudopot_cell_vnl::jl&aux",sizeof(double)*kkbeta*2);
 
         for (int ib = 0; ib < nbeta; ib++)
         {
@@ -897,6 +900,7 @@ void pseudopot_cell_vnl::compute_qrad(UnitCell& cell)
             double* aux = new double[kkbeta];
             double* besr = new double[kkbeta];
 
+            ModuleBase::Memory::record("pseudopot_cell_vnl::besr&aux",sizeof(double)*kkbeta*2);
             for (int l = 0; l < upf->nqlc; l++)
             {
                 for (int iq = 0; iq < GlobalV::NQXQ; iq++)
@@ -1311,6 +1315,7 @@ void pseudopot_cell_vnl::init_vnl_alpha(void)          // pengfei Li 2018-3-23
 		double *jl = new double[kkbeta];
 		double *aux  = new double[kkbeta];
 
+        ModuleBase::Memory::record("pseudopot_cell_vnl::jl&aux_2",sizeof(double)*kkbeta*2);
 		for (int ib = 0;ib < nbeta;ib++)
 		{
 			for (int L = 0; L <= lmaxkb+1; L++)
@@ -1512,6 +1517,7 @@ void pseudopot_cell_vnl::newq(const ModuleBase::matrix& veff, const ModulePW::PW
     ModuleBase::YlmReal::Ylm_Real(lmaxq * lmaxq, npw, rho_basis->gcar, ylmk0);
 
     double* qnorm = new double[npw];
+    ModuleBase::Memory::record("pseudopot_cell_vnl::qnorm",sizeof(double)*npw);
     for (int ig = 0; ig < npw; ig++)
     {
         qnorm[ig] = rho_basis->gcar[ig].norm() * cell.tpiba;

--- a/source/module_hamilt_pw/hamilt_pwdft/forces.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/forces.cpp
@@ -15,6 +15,8 @@
 #include "module_hamilt_general/module_surchem/surchem.h"
 #include "module_hamilt_general/module_vdw/vdw.h"
 #include "module_psi/kernels/device.h"
+#include "module_base/memory.h"
+
 #ifdef _OPENMP
 #include <omp.h>
 #endif
@@ -46,6 +48,7 @@ void Forces<FPTYPE, Device>::cal_force(ModuleBase::matrix& force,
     ModuleBase::matrix forcescc(nat, 3);
     ModuleBase::matrix forcepaw(nat,3);
 
+    ModuleBase::Memory::record("Forces::matrix",sizeof(double)*nat*3*6);
     // Force due to local ionic potential
     // For PAW, calculated together in paw_cell.calculate_force
     if(!GlobalV::use_paw)

--- a/source/module_hamilt_pw/hamilt_pwdft/wavefunc.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/wavefunc.cpp
@@ -168,6 +168,7 @@ void diago_PAO_in_pw_k2(const int &ik,
     if (p_wf->init_wfc == "file")
     {
         ModuleBase::ComplexMatrix wfcatom(nbands, nbasis);
+        ModuleBase::Memory::record("wavefunc::wfcatom_3",nbands * nbasis * sizeof(std::complex<double>));
         std::stringstream filename;
         filename << GlobalV::global_readin_dir << "WAVEFUNC" << ik + 1 << ".dat";
         bool result = ModuleIO::read_wfc_pw(filename.str(), wfc_basis, ik, p_wf->nkstot, wfcatom);
@@ -175,6 +176,7 @@ void diago_PAO_in_pw_k2(const int &ik,
         if (result)
         {
             std::vector<std::complex<float>> s_wfcatom(nbands * nbasis);
+            ModuleBase::Memory::record("wavefunc::vector1",nbands * nbasis * sizeof(std::complex<float>));=
             castmem_z2c_h2h_op()(cpu_ctx, cpu_ctx, s_wfcatom.data(), wfcatom.c, nbands * nbasis);
 
             if (GlobalV::KS_SOLVER == "cg")
@@ -255,6 +257,7 @@ void diago_PAO_in_pw_k2(const int &ik,
 	else if(p_wf->init_wfc.substr(0,6)=="atomic")
 	{
 		ModuleBase::ComplexMatrix wfcatom(starting_nw, nbasis);//added by zhengdy-soc
+        ModuleBase::Memory::record("wavefunc::ComplexMatrix",starting_nw * nbasis * sizeof(std::complex<double>));
 		if(GlobalV::test_wf)ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "starting_nw", starting_nw);
 
 		p_wf->atomic_wfc(ik, current_nbasis, GlobalC::ucell.lmax_ppwf, wfc_basis, wfcatom, GlobalC::ppcell.tab_at, GlobalV::NQX, GlobalV::DQ);
@@ -271,6 +274,7 @@ void diago_PAO_in_pw_k2(const int &ik,
 
 		// (7) Diago with cg method.
 		std::vector<std::complex<float>> s_wfcatom(starting_nw * nbasis);
+        ModuleBase::Memory::record("wavefunc::vector2",starting_nw  * nbasis * sizeof(std::complex<float>));
 		castmem_z2c_h2h_op()(cpu_ctx, cpu_ctx, s_wfcatom.data(), wfcatom.c, starting_nw * nbasis);
 		//if(GlobalV::DIAGO_TYPE == "cg") xiaohui modify 2013-09-02
 		if(GlobalV::KS_SOLVER=="cg") //xiaohui add 2013-09-02
@@ -323,6 +327,7 @@ void diago_PAO_in_pw_k2(const int &ik,
     if (p_wf->init_wfc == "file")
     {
         ModuleBase::ComplexMatrix wfcatom(nbands, nbasis);
+        ModuleBase::Memory::record("wavefunc::wfcatom_2",nbands * nbasis * sizeof(std::complex<double>));
         std::stringstream filename;
         filename << GlobalV::global_readin_dir << "WAVEFUNC" << ik + 1 << ".dat";
         bool result = ModuleIO::read_wfc_pw(filename.str(), wfc_basis, ik, p_wf->nkstot, wfcatom);
@@ -406,6 +411,7 @@ void diago_PAO_in_pw_k2(const int &ik,
     else if (p_wf->init_wfc.substr(0, 6) == "atomic")
     {
         ModuleBase::ComplexMatrix wfcatom(starting_nw, nbasis); // added by zhengdy-soc
+        ModuleBase::Memory::record("wavefunc::wfcatom_3",starting_nw * nbasis * sizeof(std::complex<double>));
         if (GlobalV::test_wf)
             ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "starting_nw", starting_nw);
 


### PR DESCRIPTION
In response to issue #3657,
The peak memory application recorded using `ModuleBase::Memory::record` is quite different from that recorded using `ModuleBase::TITLE`. Therefore, after preliminary statistical analysis of memory application during program running, supplement the key functions of missing records in `ModuleBase::Memory::record` method.