### PR TITLE
Fix: No warning is given if KPT is ill set

### DIFF
--- a/source/module_cell/klist.cpp
+++ b/source/module_cell/klist.cpp
@@ -308,7 +308,12 @@ bool K_Vectors::read_kpoints(const std::string &fn)
 
         ifk >> nmp[0] >> nmp[1] >> nmp[2];
 
-        ifk >> koffset[0] >> koffset[1] >> koffset[2];
+	if (!(ifk >> koffset[0] >> koffset[1] >> koffset[2]))
+        {
+            ModuleBase::WARNING("K_Vectors::read_kpoints", "Missing k-point offsets in the k-points file.");
+	return 0;
+        }
+
         this->Monkhorst_Pack(nmp, koffset, k_type);
     }
     else if (nkstot > 0)

--- a/source/module_cell/klist.cpp
+++ b/source/module_cell/klist.cpp
@@ -307,11 +307,13 @@ bool K_Vectors::read_kpoints(const std::string &fn)
         }
 
         ifk >> nmp[0] >> nmp[1] >> nmp[2];
-
-	if (!(ifk >> koffset[0] >> koffset[1] >> koffset[2]))
+        
+        koffset[0] = 0;
+        koffset[1] = 0;
+        koffset[2] = 0;
+        if (!(ifk >> koffset[0] >> koffset[1] >> koffset[2]))
         {
             ModuleBase::WARNING("K_Vectors::read_kpoints", "Missing k-point offsets in the k-points file.");
-	return 0;
         }
 
         this->Monkhorst_Pack(nmp, koffset, k_type);


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix [#4070](https://github.com/deepmodeling/abacus-develop/issues/4070)

### Unit Tests and/or Case Tests for my changes
Test has been performed on /abacus-develop/examples/scf/lcao_Si2.
When the KPT is well set, no warning occurs.
When the shift of K-mesh is missing, the calculation will continue with warning throwed in warning.log:
 AUTO_SET NBANDS to 0
 K_Vectors::read_kpoints  warning : Missing k-point offsets in the k-points file.

### What's changed?
throw warning when kpoints is ill set
