### PR TITLE
Improve output of H and S matrices: output matrices when the self-con…

### DIFF
--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -819,7 +819,7 @@ void ESolver_KS_LCAO<TK, TR>::update_pot(const int istep, const int iter)
     ModuleBase::TITLE("ESolver_KS_LCAO", "update_pot");
 
     // print Hamiltonian and Overlap matrix
-    if (this->conv_elec)
+    if (this->conv_elec || iter == GlobalV::SCF_NMAX)
     {
         if (!GlobalV::GAMMA_ONLY_LOCAL && hsolver::HSolverLCAO<TK>::out_mat_hs[0])
         {


### PR DESCRIPTION
…sistent iteration steps reach scf_nmax, even if the charge density doesn't converge.

### Reminder
- [x] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #4093 

On top of the current code framework, I just simply add the output H and S matrices when the self-consistent iteration steps reach scf_nmax. However, I'm not quite sure if this will have an impact on the rest of the update_pot() function, which contains both the function to output the H and S matrices and a few other functions as well. Also, I think the function update_pot() is a bit unclear in its functionality.

