### PR TITLE
Refactor: remove paw code in module_hsolver

### DIFF
--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -13,9 +13,7 @@
 #include "module_hamilt_pw/hamilt_pwdft/hamilt_pw.h"
 #include "module_hamilt_pw/hamilt_pwdft/wavefunc.h"
 #include "module_hsolver/diago_iter_assist.h"
-#ifdef USE_PAW
-#include "module_cell/module_paw/paw_cell.h"
-#endif
+
 namespace hsolver
 {
 
@@ -192,71 +190,11 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
         /// update H(k) for each k point
         pHamilt->updateHk(ik);
 
-#ifdef USE_PAW
-        if (GlobalV::use_paw)
-        {
-            const int npw = this->wfc_basis->npwk[ik];
-            ModuleBase::Vector3<double>* _gk = new ModuleBase::Vector3<double>[npw];
-            for (int ig = 0; ig < npw; ig++)
-            {
-                _gk[ig] = this->wfc_basis->getgpluskcar(ik, ig);
-            }
-
-            std::vector<double> kpt(3,0);
-            kpt[0] = this->wfc_basis->kvec_c[ik].x;
-            kpt[1] = this->wfc_basis->kvec_c[ik].y;
-            kpt[2] = this->wfc_basis->kvec_c[ik].z;
-
-            double** kpg;
-            double** gcar;
-            kpg = new double*[npw];
-            gcar = new double*[npw];
-            for (int ipw = 0; ipw < npw; ipw++)
-            {
-                kpg[ipw] = new double[3];
-                kpg[ipw][0] = _gk[ipw].x;
-                kpg[ipw][1] = _gk[ipw].y;
-                kpg[ipw][2] = _gk[ipw].z;
-
-                gcar[ipw] = new double[3];
-                gcar[ipw][0] = this->wfc_basis->getgcar(ik, ipw).x;
-                gcar[ipw][1] = this->wfc_basis->getgcar(ik, ipw).y;
-                gcar[ipw][2] = this->wfc_basis->getgcar(ik, ipw).z;
-            }
-
-            GlobalC::paw_cell.set_paw_k(npw,
-                                        wfc_basis->npwk_max,
-                                        kpt.data(),
-                                        this->wfc_basis->get_ig2ix(ik).data(),
-                                        this->wfc_basis->get_ig2iy(ik).data(),
-                                        this->wfc_basis->get_ig2iz(ik).data(),
-                                        (const double**)kpg,
-                                        GlobalC::ucell.tpiba,
-                                        (const double**)gcar);
-
-            std::vector<double>().swap(kpt);
-            for (int ipw = 0; ipw < npw; ipw++)
-            {
-                delete[] kpg[ipw];
-                delete[] gcar[ipw];
-            }
-            delete[] kpg;
-            delete[] gcar;
-
-            GlobalC::paw_cell.get_vkb();
-
-            GlobalC::paw_cell.set_currentk(ik);
-        }
-#endif
 
         this->updatePsiK(pHamilt, psi, ik);
 
         // template add precondition calculating here
         update_precondition(precondition, ik, this->wfc_basis->npwk[ik]);
-
-#ifdef USE_PAW
-        GlobalC::paw_cell.set_currentk(ik);
-#endif
 
         /// solve eigenvector and eigenvalue for H(k)
         this->hamiltSolvePsiK(pHamilt, psi, eigenvalues.data() + ik * pes->ekb.nc);
@@ -284,112 +222,6 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
     }
     reinterpret_cast<elecstate::ElecStatePW<T, Device>*>(pes)->psiToRho(psi);
 
-#ifdef USE_PAW
-    if (GlobalV::use_paw)
-    {
-        if (typeid(Real) != typeid(double))
-        {
-            ModuleBase::WARNING_QUIT("HSolverPW::solve", "PAW is only supported for double precision!");
-        }
-
-        GlobalC::paw_cell.reset_rhoij();
-        for (int ik = 0; ik < this->wfc_basis->nks; ++ik)
-        {
-            const int npw = this->wfc_basis->npwk[ik];
-            ModuleBase::Vector3<double>* _gk = new ModuleBase::Vector3<double>[npw];
-            for (int ig = 0; ig < npw; ig++)
-            {
-                _gk[ig] = this->wfc_basis->getgpluskcar(ik, ig);
-            }
-
-            std::vector<double> kpt(3,0);
-            kpt[0] = this->wfc_basis->kvec_c[ik].x;
-            kpt[1] = this->wfc_basis->kvec_c[ik].y;
-            kpt[2] = this->wfc_basis->kvec_c[ik].z;
-
-            double** kpg;
-            double** gcar;
-            kpg = new double*[npw];
-            gcar = new double*[npw];
-            for (int ipw = 0; ipw < npw; ipw++)
-            {
-                kpg[ipw] = new double[3];
-                kpg[ipw][0] = _gk[ipw].x;
-                kpg[ipw][1] = _gk[ipw].y;
-                kpg[ipw][2] = _gk[ipw].z;
-
-                gcar[ipw] = new double[3];
-                gcar[ipw][0] = this->wfc_basis->getgcar(ik, ipw).x;
-                gcar[ipw][1] = this->wfc_basis->getgcar(ik, ipw).y;
-                gcar[ipw][2] = this->wfc_basis->getgcar(ik, ipw).z;
-            }
-
-            GlobalC::paw_cell.set_paw_k(npw,
-                                        wfc_basis->npwk_max,
-                                        kpt.data(),
-                                        this->wfc_basis->get_ig2ix(ik).data(),
-                                        this->wfc_basis->get_ig2iy(ik).data(),
-                                        this->wfc_basis->get_ig2iz(ik).data(),
-                                        (const double**)kpg,
-                                        GlobalC::ucell.tpiba,
-                                        (const double**)gcar);
-
-            std::vector<double>().swap(kpt);
-            for (int ipw = 0; ipw < npw; ipw++)
-            {
-                delete[] kpg[ipw];
-                delete[] gcar[ipw];
-            }
-            delete[] kpg;
-            delete[] gcar;
-
-            GlobalC::paw_cell.get_vkb();
-
-            psi.fix_k(ik);
-            GlobalC::paw_cell.set_currentk(ik);
-            int nbands = psi.get_nbands();
-            for (int ib = 0; ib < nbands; ib++)
-            {
-                GlobalC::paw_cell.accumulate_rhoij(reinterpret_cast<std::complex<double>*>(psi.get_pointer(ib)),
-                                                   pes->wg(ik, ib));
-            }
-        }
-
-        std::vector<std::vector<double>> rhoijp;
-        std::vector<std::vector<int>> rhoijselect;
-        std::vector<int> nrhoijsel;
-
-#ifdef __MPI
-        if (GlobalV::RANK_IN_POOL == 0)
-        {
-            GlobalC::paw_cell.get_rhoijp(rhoijp, rhoijselect, nrhoijsel);
-
-            for (int iat = 0; iat < GlobalC::ucell.nat; iat++)
-            {
-                GlobalC::paw_cell.set_rhoij(iat,
-                                            nrhoijsel[iat],
-                                            rhoijselect[iat].size(),
-                                            rhoijselect[iat].data(),
-                                            rhoijp[iat].data());
-            }
-        }
-#else
-        GlobalC::paw_cell.get_rhoijp(rhoijp, rhoijselect, nrhoijsel);
-
-        for (int iat = 0; iat < GlobalC::ucell.nat; iat++)
-        {
-            GlobalC::paw_cell.set_rhoij(iat,
-                                        nrhoijsel[iat],
-                                        rhoijselect[iat].size(),
-                                        rhoijselect[iat].data(),
-                                        rhoijp[iat].data());
-        }
-
-#endif
-        double* nhatgr;
-        GlobalC::paw_cell.get_nhat(pes->charge->nhat, nhatgr);
-    }
-#endif
     ModuleBase::timer::tick("HSolverPW", "solve");
     return;
 }
@@ -411,62 +243,7 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt, // ESolver_
     {
         /// update H(k) for each k point
         pHamilt->updateHk(ik);
-#ifdef USE_PAW
-        if (GlobalV::use_paw)
-        {
-            const int npw = this->wfc_basis->npwk[ik];
-            ModuleBase::Vector3<double>* _gk = new ModuleBase::Vector3<double>[npw];
-            for (int ig = 0; ig < npw; ig++)
-            {
-                _gk[ig] = this->wfc_basis->getgpluskcar(ik, ig);
-            }
 
-            std::vector<double> kpt(3,0);
-            kpt[0] = this->wfc_basis->kvec_c[ik].x;
-            kpt[1] = this->wfc_basis->kvec_c[ik].y;
-            kpt[2] = this->wfc_basis->kvec_c[ik].z;
-
-            double** kpg;
-            double** gcar;
-            kpg = new double*[npw];
-            gcar = new double*[npw];
-            for (int ipw = 0; ipw < npw; ipw++)
-            {
-                kpg[ipw] = new double[3];
-                kpg[ipw][0] = _gk[ipw].x;
-                kpg[ipw][1] = _gk[ipw].y;
-                kpg[ipw][2] = _gk[ipw].z;
-
-                gcar[ipw] = new double[3];
-                gcar[ipw][0] = this->wfc_basis->getgcar(ik, ipw).x;
-                gcar[ipw][1] = this->wfc_basis->getgcar(ik, ipw).y;
-                gcar[ipw][2] = this->wfc_basis->getgcar(ik, ipw).z;
-            }
-
-            GlobalC::paw_cell.set_paw_k(npw,
-                                        wfc_basis->npwk_max,
-                                        kpt.data(),
-                                        this->wfc_basis->get_ig2ix(ik).data(),
-                                        this->wfc_basis->get_ig2iy(ik).data(),
-                                        this->wfc_basis->get_ig2iz(ik).data(),
-                                        (const double**)kpg,
-                                        GlobalC::ucell.tpiba,
-                                        (const double**)gcar);
-
-            std::vector<double>().swap(kpt);
-            for (int ipw = 0; ipw < npw; ipw++)
-            {
-                delete[] kpg[ipw];
-                delete[] gcar[ipw];
-            }
-            delete[] kpg;
-            delete[] gcar;
-
-            GlobalC::paw_cell.get_vkb();
-
-            GlobalC::paw_cell.set_currentk(ik);
-        }
-#endif
         psi.fix_k(ik);
         transform.fix_k(ik);
         /// solve eigenvector and eigenvalue for H(k)
@@ -507,112 +284,6 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt, // ESolver_
     }
     reinterpret_cast<elecstate::ElecStatePW<T, Device>*>(pes)->psiToRho(psi);
 
-#ifdef USE_PAW
-    if (GlobalV::use_paw)
-    {
-        if (typeid(Real) != typeid(double))
-        {
-            ModuleBase::WARNING_QUIT("HSolverPW::solve", "PAW is only supported for double precision!");
-        }
-
-        GlobalC::paw_cell.reset_rhoij();
-        for (int ik = 0; ik < this->wfc_basis->nks; ++ik)
-        {
-            const int npw = this->wfc_basis->npwk[ik];
-            ModuleBase::Vector3<double>* _gk = new ModuleBase::Vector3<double>[npw];
-            for (int ig = 0; ig < npw; ig++)
-            {
-                _gk[ig] = this->wfc_basis->getgpluskcar(ik, ig);
-            }
-
-            std::vector<double> kpt(3,0);
-            kpt[0] = this->wfc_basis->kvec_c[ik].x;
-            kpt[1] = this->wfc_basis->kvec_c[ik].y;
-            kpt[2] = this->wfc_basis->kvec_c[ik].z;
-
-            double** kpg;
-            double** gcar;
-            kpg = new double*[npw];
-            gcar = new double*[npw];
-            for (int ipw = 0; ipw < npw; ipw++)
-            {
-                kpg[ipw] = new double[3];
-                kpg[ipw][0] = _gk[ipw].x;
-                kpg[ipw][1] = _gk[ipw].y;
-                kpg[ipw][2] = _gk[ipw].z;
-
-                gcar[ipw] = new double[3];
-                gcar[ipw][0] = this->wfc_basis->getgcar(ik, ipw).x;
-                gcar[ipw][1] = this->wfc_basis->getgcar(ik, ipw).y;
-                gcar[ipw][2] = this->wfc_basis->getgcar(ik, ipw).z;
-            }
-
-            GlobalC::paw_cell.set_paw_k(npw,
-                                        wfc_basis->npwk_max,
-                                        kpt.data(),
-                                        this->wfc_basis->get_ig2ix(ik).data(),
-                                        this->wfc_basis->get_ig2iy(ik).data(),
-                                        this->wfc_basis->get_ig2iz(ik).data(),
-                                        (const double**)kpg,
-                                        GlobalC::ucell.tpiba,
-                                        (const double**)gcar);
-
-            std::vector<double>().swap(kpt);
-            for (int ipw = 0; ipw < npw; ipw++)
-            {
-                delete[] kpg[ipw];
-                delete[] gcar[ipw];
-            }
-            delete[] kpg;
-            delete[] gcar;
-
-            GlobalC::paw_cell.get_vkb();
-
-            psi.fix_k(ik);
-            GlobalC::paw_cell.set_currentk(ik);
-            int nbands = psi.get_nbands();
-            for (int ib = 0; ib < nbands; ib++)
-            {
-                GlobalC::paw_cell.accumulate_rhoij(reinterpret_cast<std::complex<double>*>(psi.get_pointer(ib)),
-                                                   pes->wg(ik, ib));
-            }
-        }
-
-        std::vector<std::vector<double>> rhoijp;
-        std::vector<std::vector<int>> rhoijselect;
-        std::vector<int> nrhoijsel;
-
-#ifdef __MPI
-        if (GlobalV::RANK_IN_POOL == 0)
-        {
-            GlobalC::paw_cell.get_rhoijp(rhoijp, rhoijselect, nrhoijsel);
-
-            for (int iat = 0; iat < GlobalC::ucell.nat; iat++)
-            {
-                GlobalC::paw_cell.set_rhoij(iat,
-                                            nrhoijsel[iat],
-                                            rhoijselect[iat].size(),
-                                            rhoijselect[iat].data(),
-                                            rhoijp[iat].data());
-            }
-        }
-#else
-        GlobalC::paw_cell.get_rhoijp(rhoijp, rhoijselect, nrhoijsel);
-
-        for (int iat = 0; iat < GlobalC::ucell.nat; iat++)
-        {
-            GlobalC::paw_cell.set_rhoij(iat,
-                                        nrhoijsel[iat],
-                                        rhoijselect[iat].size(),
-                                        rhoijselect[iat].data(),
-                                        rhoijp[iat].data());
-        }
-
-#endif
-        double* nhatgr;
-        GlobalC::paw_cell.get_nhat(pes->charge->nhat, nhatgr);
-    }
-#endif
     ModuleBase::timer::tick("HSolverPW", "solve");
     return;
 }


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?

### Linked Issue
Fix https://github.com/deepmodeling/abacus-develop/issues/4180

### Details

The abacus develop team is executing @mohanchen's Absolute Zero plan to refactor the code of different modules.

Currently, I am responsible for the refactoring of module_hsolver.

As far as I know, currently there are no users using the paw-related functions in abacus. Therefore, @mohanchen recommends deleting the paw-related code when refactoring and creating [a new paw_code branch](https://github.com/deepmodeling/abacus-develop/tree/paw_code) to save the current paw-related code.

After waiting for the refactoring plan to go well, consider adding the paw code.

I have created [a new paw_code branch](https://github.com/deepmodeling/abacus-develop/tree/paw_code), and I submit this PR to delete the paw-related code in module_hsolver.
