### PR TITLE
Modify the input file of examples/interface_wannier90 to run the Wannier90 interface correctly.

### DIFF
--- a/examples/interface_wannier90/ABACUS_towannier90_lcao/INPUT-nscf
+++ b/examples/interface_wannier90/ABACUS_towannier90_lcao/INPUT-nscf
@@ -8,9 +8,11 @@ nbands                  12
 calculation             nscf
 scf_nmax                50
 pw_diag_thr             1.0e-12
-scf_thr                 1.0e-15
+scf_thr                 1.0e-13
 init_chg                file
 symmetry                0
 towannier90             1
 nnkpfile                diamond.nnkp
-basis_type		lcao
+basis_type		        lcao
+wannier_method          2
+out_wannier_unk         0

--- a/examples/interface_wannier90/ABACUS_towannier90_lcao/INPUT-scf
+++ b/examples/interface_wannier90/ABACUS_towannier90_lcao/INPUT-scf
@@ -7,4 +7,4 @@ ecutwfc                 50
 calculation             scf
 scf_thr                 1e-13
 out_chg                 1
-basis_type		lcao
+basis_type              lcao

--- a/examples/interface_wannier90/ABACUS_towannier90_lcao/diamond.win
+++ b/examples/interface_wannier90/ABACUS_towannier90_lcao/diamond.win
@@ -1,15 +1,17 @@
 num_bands         =   12
 num_wann          =   8 
 
-Begin Projections
+dis_win_min       =  -7.2
+dis_win_max       =  45
+dis_froz_min      =  -7.2
+dis_froz_max      =  20
+dis_num_iter      =  200
+
+begin projections
 C:s;px;py;pz
-End Projections  
+end projections 
 
-dis_num_iter      = 5000
-num_iter          = 5000
-num_print_cycles  = 50 
-
-wannier_plot=.true.
+wannier_plot=.false.
 wannier_plot_supercell = 3
 wvfn_formatted = .true.
 
@@ -25,6 +27,14 @@ begin unit_cell_cart
  0.000000   1.613990   1.613990
 -1.613990   1.613990   0.000000
 end unit_cell_cart
+
+bands_plot = true
+
+begin kpoint_path
+G 0.0000000000  0.0000000000    0.0000000000     L 0.5000000000 0.5000000000    0.5000000000
+L 0.5000000000  0.5000000000    0.5000000000     W 0.5000000000 0.2500000000    0.7500000000
+W 0.5000000000  0.2500000000    0.7500000000     X 0.5000000000 0.0000000000    0.5000000000
+end kpoint_path
 
 mp_grid : 4 4 4
 

--- a/examples/interface_wannier90/ABACUS_towannier90_lcao_in_pw/INPUT-nscf
+++ b/examples/interface_wannier90/ABACUS_towannier90_lcao_in_pw/INPUT-nscf
@@ -8,11 +8,12 @@ nbands                  12
 calculation             nscf
 scf_nmax                50
 pw_diag_thr             1.0e-12
-scf_thr                 1.0e-15
+scf_thr                 1.0e-13
 init_chg                file
 symmetry                0
 towannier90             1
-wannier_method 1
 nnkpfile                diamond.nnkp
-basis_type		lcao
+basis_type              lcao
+wannier_method          1
+out_wannier_unk         0
 

--- a/examples/interface_wannier90/ABACUS_towannier90_lcao_in_pw/INPUT-scf
+++ b/examples/interface_wannier90/ABACUS_towannier90_lcao_in_pw/INPUT-scf
@@ -7,5 +7,5 @@ ecutwfc                 50
 calculation             scf
 scf_thr                 1e-13
 out_chg                 1
-basis_type		lcao_in_pw
+basis_type              lcao_in_pw
 ks_solver               lapack

--- a/examples/interface_wannier90/ABACUS_towannier90_lcao_in_pw/diamond.win
+++ b/examples/interface_wannier90/ABACUS_towannier90_lcao_in_pw/diamond.win
@@ -1,15 +1,17 @@
 num_bands         =   12
 num_wann          =   8 
 
-Begin Projections
+dis_win_min       =  -7.2
+dis_win_max       =  45
+dis_froz_min      =  -7.2
+dis_froz_max      =  20
+dis_num_iter      =  200
+
+begin projections
 C:s;px;py;pz
-End Projections  
+end projections 
 
-dis_num_iter      = 5000
-num_iter          = 5000
-num_print_cycles  = 50 
-
-wannier_plot=.true.
+wannier_plot=.false.
 wannier_plot_supercell = 3
 wvfn_formatted = .true.
 
@@ -25,6 +27,14 @@ begin unit_cell_cart
  0.000000   1.613990   1.613990
 -1.613990   1.613990   0.000000
 end unit_cell_cart
+
+bands_plot = true
+
+begin kpoint_path
+G 0.0000000000  0.0000000000    0.0000000000     L 0.5000000000 0.5000000000    0.5000000000
+L 0.5000000000  0.5000000000    0.5000000000     W 0.5000000000 0.2500000000    0.7500000000
+W 0.5000000000  0.2500000000    0.7500000000     X 0.5000000000 0.0000000000    0.5000000000
+end kpoint_path
 
 mp_grid : 4 4 4
 

--- a/examples/interface_wannier90/ABACUS_towannier90_pw/INPUT-nscf
+++ b/examples/interface_wannier90/ABACUS_towannier90_pw/INPUT-nscf
@@ -5,11 +5,14 @@ orbital_dir             ../../../tests/PP_ORB
 ntype                   1
 ecutwfc                 50
 nbands                  4
+smearing_method         fixed
 calculation             nscf
 scf_nmax                50
 pw_diag_thr             1.0e-12
-scf_thr                 1.0e-15
+scf_thr                 1.0e-13
 init_chg                file
 symmetry                0
 towannier90             1
 nnkpfile                diamond.nnkp
+basis_type		        pw
+out_wannier_unk         0

--- a/examples/interface_wannier90/ABACUS_towannier90_pw/diamond.win
+++ b/examples/interface_wannier90/ABACUS_towannier90_pw/diamond.win
@@ -1,7 +1,7 @@
 num_wann        =  4 
 num_iter        = 20
 
-wannier_plot=.true.
+wannier_plot=.false.
 wannier_plot_supercell = 3
 wvfn_formatted = .true.
 


### PR DESCRIPTION
Modify the input file of examples/interface_wannier90 to run the Wannier90 interface correctly.

### Reminder
- [x] Have you linked an issue with this pull request?
- [x] Have you added adequate unit tests and/or case tests for your pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [x] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #3418 

