### PR TITLE
Refactor: modify arguments of gemm and gemv

### DIFF
--- a/source/module_hamilt_pw/hamilt_pwdft/forces.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/forces.cpp
@@ -1055,20 +1055,21 @@ void Forces<FPTYPE, Device>::cal_force_nl(ModuleBase::matrix& forcenl,
             }
         }
         int npm = GlobalV::NPOL * nbands_occ;
-        gemm_op()(this->ctx,
-                  transa,
-                  transb,
-                  nkb,
-                  npm,
-                  nbasis,
-                  &ModuleBase::ONE,
-                  vkb,
-                  this->npwx,
-                  psi_in[0].get_pointer(),
-                  this->npwx,
-                  &ModuleBase::ZERO,
-                  becp,
-                  nkb);
+        gemm_op()({
+            .d = this->ctx,
+            .transa = transa,
+            .transb = transb,
+            .m = nkb,
+            .n = npm,
+            .k = nbasis,
+            .alpha = &ModuleBase::ONE,
+            .a = vkb,
+            .lda = this->npwx,
+            .b = psi_in[0].get_pointer(),
+            .ldb = this->npwx,
+            .beta = &ModuleBase::ZERO,
+            .c = becp,
+            .ldc = nkb});
         if (this->device == base_device::GpuDevice)
         {
             std::complex<FPTYPE>* h_becp = nullptr;
@@ -1101,20 +1102,21 @@ void Forces<FPTYPE, Device>::cal_force_nl(ModuleBase::matrix& forcenl,
                              gcar,
                              vkb1);
             std::complex<double>* pdbecp = dbecp + ipol * GlobalV::NBANDS * nkb;
-            gemm_op()(this->ctx,
-                      transa,
-                      transb,
-                      nkb,
-                      npm,
-                      nbasis,
-                      &ModuleBase::ONE,
-                      vkb1,
-                      this->npwx,
-                      psi_in[0].get_pointer(),
-                      this->npwx,
-                      &ModuleBase::ZERO,
-                      pdbecp,
-                      nkb);
+            gemm_op()({
+                .d = this->ctx,
+                .transa = transa,
+                .transb = transb,
+                .m = nkb,
+                .n = npm,
+                .k = nbasis,
+                .alpha = &ModuleBase::ONE,
+                .a = vkb1,
+                .lda = this->npwx,
+                .b = psi_in[0].get_pointer(),
+                .ldb = this->npwx,
+                .beta = &ModuleBase::ZERO,
+                .c = pdbecp,
+                .ldc = nkb});
         } // end ipol
 
         //		don't need to reduce here, keep dbecp different in each processor,

--- a/source/module_hamilt_pw/hamilt_pwdft/hamilt_pw.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/hamilt_pw.cpp
@@ -237,35 +237,37 @@ void HamiltPW<T, Device>::sPsi(const T* psi_in, // psi
             if (nbands == 1)
             {
                 int inc = 1;
-                gemv_op()(this->ctx,
-                          transa,
-                          npw,
-                          this->ppcell->nkb,
-                          &one,
-                          this->vkb,
-                          this->ppcell->vkb.nc,
-                          psi_in,
-                          inc,
-                          &zero,
-                          becp,
-                          inc);
+                gemv_op()({
+                    .d = this->ctx,
+                    .trans = transa,
+                    .m = npw,
+                    .n = this->ppcell->nkb,
+                    .alpha = &one,
+                    .A = this->vkb,
+                    .lda = this->ppcell->vkb.nc,
+                    .X = psi_in,
+                    .incx = inc,
+                    .beta = &zero,
+                    .Y = becp,
+                    .incy = inc});
             }
             else
             {
-                gemm_op()(this->ctx,
-                          transa,
-                          transb,
-                          this->ppcell->nkb,
-                          nbands,
-                          npw,
-                          &one,
-                          this->vkb,
-                          this->ppcell->vkb.nc,
-                          psi_in,
-                          nrow,
-                          &zero,
-                          becp,
-                          this->ppcell->nkb);
+                gemm_op()({
+                    .d = this->ctx,
+                    .transa = transa,
+                    .transb = transb,
+                    .m = this->ppcell->nkb,
+                    .n = nbands,
+                    .k = npw,
+                    .alpha = &one,
+                    .a = this->vkb,
+                    .lda = this->ppcell->vkb.nc,
+                    .b = psi_in,
+                    .ldb = nrow,
+                    .beta = &zero,
+                    .c = becp,
+                    .ldc = this->ppcell->nkb});
             }
 
             Parallel_Reduce::reduce_pool(becp, this->ppcell->nkb * nbands);
@@ -306,20 +308,21 @@ void HamiltPW<T, Device>::sPsi(const T* psi_in, // psi
                     for (int ia = 0; ia < atoms->na; ia++)
                     {
                         const int iat = GlobalC::ucell.itia2iat(it, ia);
-                        gemm_op()(this->ctx,
-                                  transa,
-                                  transb,
-                                  nh,
-                                  nbands,
-                                  nh,
-                                  &one,
-                                  qqc,
-                                  nh,
-                                  &becp[this->ppcell->indv_ijkb0[iat]],
-                                  this->ppcell->nkb,
-                                  &zero,
-                                  &ps[this->ppcell->indv_ijkb0[iat]],
-                                  this->ppcell->nkb);
+                        gemm_op()({
+                            .d = this->ctx,
+                            .transa = transa,
+                            .transb = transb,
+                            .m = nh,
+                            .n = nbands,
+                            .k = nh,
+                            .alpha = &one,
+                            .a = qqc,
+                            .lda = nh,
+                            .b = &becp[this->ppcell->indv_ijkb0[iat]],
+                            .ldb = this->ppcell->nkb,
+                            .beta = &zero,
+                            .c = &ps[this->ppcell->indv_ijkb0[iat]],
+                            .ldc = this->ppcell->nkb});
                     }
                     delmem_complex_op()(ctx, qqc);
                 }
@@ -328,35 +331,38 @@ void HamiltPW<T, Device>::sPsi(const T* psi_in, // psi
             if (nbands == 1)
             {
                 const int inc = 1;
-                gemv_op()(this->ctx,
-                          transa,
-                          npw,
-                          this->ppcell->nkb,
-                          &one,
-                          this->vkb,
-                          this->ppcell->vkb.nc,
-                          ps,
-                          inc,
-                          &one,
-                          spsi,
-                          inc);
+                gemv_op()({
+                    .d = this->ctx,
+                    .trans = transa,
+                    .m = npw,
+                    .n = this->ppcell->nkb,
+                    .alpha = &one,
+                    .A = this->vkb,
+                    .lda = this->ppcell->vkb.nc,
+                    .X = ps,
+                    .incx = inc,
+                    .beta = &one,
+                    .Y = spsi,
+                    .incy = inc});
+                
             }
             else
             {
-                gemm_op()(this->ctx,
-                          transa,
-                          transb,
-                          npw,
-                          nbands,
-                          this->ppcell->nkb,
-                          &one,
-                          this->vkb,
-                          this->ppcell->vkb.nc,
-                          ps,
-                          this->ppcell->nkb,
-                          &one,
-                          spsi,
-                          nrow);
+                gemm_op()({
+                    .d = this->ctx,
+                    .transa = transa,
+                    .transb = transb,
+                    .m = npw,
+                    .n = nbands,
+                    .k = this->ppcell->nkb,
+                    .alpha = &one,
+                    .a = this->vkb,
+                    .lda = this->ppcell->vkb.nc,
+                    .b = ps,
+                    .ldb = this->ppcell->nkb,
+                    .beta = &one,
+                    .c = spsi,
+                    .ldc = nrow});
             }
         }
         delmem_complex_op()(this->ctx, ps);

--- a/source/module_hamilt_pw/hamilt_pwdft/operator_pw/nonlocal_pw.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/operator_pw/nonlocal_pw.cpp
@@ -167,41 +167,40 @@ void Nonlocal<OperatorPW<T, Device>>::add_nonlocal_pp(T *hpsi_in, const T *becp,
         int inc = 1;
         // denghui replace 2022-10-20
         // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-        gemv_op()(
-            this->ctx,
-            transa,
-            this->npw,
-            this->ppcell->nkb,
-            &this->one,
-            this->vkb,
-            this->ppcell->vkb.nc,
-            this->ps,
-            inc,
-            &this->one,
-            hpsi_in,
-            inc);
+        gemv_op()({
+            .d = this->ctx,
+            .trans = transa,
+            .m = npw,
+            .n = this->ppcell->nkb,
+            .alpha = &this->one,
+            .A = this->vkb,
+            .lda = this->ppcell->vkb.nc,
+            .X = ps,
+            .incx = inc,
+            .beta = &this->one,
+            .Y = hpsi_in,
+            .incy = inc});
     }
     else
     {
         int npm = m;
         //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
         // denghui replace 2022-10-20
-        gemm_op()(
-            this->ctx,
-            transa,
-            transb,
-            this->npw,
-            npm,
-            this->ppcell->nkb,
-            &this->one,
-            this->vkb,
-            this->ppcell->vkb.nc,
-            this->ps,
-            npm,
-            &this->one,
-            hpsi_in,
-            this->max_npw
-        );
+        gemm_op()({
+            .d = this->ctx,
+            .transa = transa,
+            .transb = transb,
+            .m = this->npw,
+            .n = npm,
+            .k = this->ppcell->nkb,
+            .alpha = &this->one,
+            .a = this->vkb,
+            .lda = this->ppcell->vkb.nc,
+            .b = this->ps,
+            .ldb = npm,
+            .beta = &this->one,
+            .c = hpsi_in,
+            .ldc = this->max_npw});
     }
     ModuleBase::timer::tick("Nonlocal", "add_nonlocal_pp");
 }
@@ -238,41 +237,40 @@ void Nonlocal<OperatorPW<T, Device>>::act(
                 int inc = 1;
                 // denghui replace 2022-10-20
                 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                gemv_op()(
-                    this->ctx,
-                    transa,
-                    this->npw,
-                    nkb,
-                    &this->one,
-                    this->vkb,
-                    this->ppcell->vkb.nc,
-                    tmpsi_in,
-                    inc,
-                    &this->zero,
-                    this->becp,
-                    inc);
+                gemv_op()({
+                    .d = this->ctx,
+                    .trans = transa,
+                    .m = this->npw,
+                    .n = nkb,
+                    .alpha = &this->one,
+                    .A = this->vkb,
+                    .lda = this->ppcell->vkb.nc,
+                    .X = tmpsi_in,
+                    .incx = inc,
+                    .beta = &this->zero,
+                    .Y = this->becp,
+                    .incy = inc});
             }
             else
             {
                 int npm = nbands;
                 //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                 // denghui replace 2022-10-20
-                gemm_op()(
-                    this->ctx,
-                    transa,
-                    transb,
-                    nkb,
-                    npm,
-                    this->npw,
-                    &this->one,
-                    this->vkb,
-                    this->ppcell->vkb.nc,
-                    tmpsi_in,
-                    max_npw,
-                    &this->zero,
-                    this->becp,
-                    nkb
-                );
+                gemm_op()({
+                    .d = this->ctx,
+                    .transa = transa,
+                    .transb = transb,
+                    .m = nkb,
+                    .n = npm,
+                    .k = this->npw,
+                    .alpha = &this->one,
+                    .a = this->vkb,
+                    .lda = this->ppcell->vkb.nc,
+                    .b = tmpsi_in,
+                    .ldb = max_npw,
+                    .beta = &this->zero,
+                    .c = this->becp,
+                    .ldc = nkb});
             }
 
             Parallel_Reduce::reduce_pool(becp, nkb * nbands);

--- a/source/module_hamilt_pw/hamilt_pwdft/stress_func_nl.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/stress_func_nl.cpp
@@ -146,20 +146,21 @@ void Stress_Func<FPTYPE, Device>::stress_nl(ModuleBase::matrix& sigma,
             }
         }
         int npm = GlobalV::NPOL * nbands_occ;
-        gemm_op()(this->ctx,
-                  transa,
-                  transb,
-                  nkb,
-                  npm,
-                  npw,
-                  &ModuleBase::ONE,
-                  vkb,
-                  npwx,
-                  ppsi,
-                  npwx,
-                  &ModuleBase::ZERO,
-                  becp,
-                  nkb);
+        gemm_op()({
+            .d = this->ctx,
+            .transa = transa,
+            .transb = transb,
+            .m = nkb,
+            .n = npm,
+            .k = npw,
+            .alpha = &ModuleBase::ONE,
+            .a = vkb,
+            .lda = npwx,
+            .b = ppsi,
+            .ldb = npwx,
+            .beta = &ModuleBase::ZERO,
+            .c = becp,
+            .ldc = nkb});
         // becp calculate is over , now we should broadcast this data.
         if (this->device == base_device::GpuDevice)
         {
@@ -214,20 +215,21 @@ void Stress_Func<FPTYPE, Device>::stress_nl(ModuleBase::matrix& sigma,
                                         vkb1,
                                         pvkb2,
                                         dbecp_noevc);
-                gemm_op()(this->ctx,
-                          transa,
-                          transb,
-                          nkb,
-                          npm,
-                          npw,
-                          &ModuleBase::ONE,
-                          dbecp_noevc,
-                          npwx,
-                          ppsi,
-                          npwx,
-                          &ModuleBase::ZERO,
-                          dbecp,
-                          nkb);
+                gemm_op()({
+                    .d = this->ctx,
+                    .transa = transa,
+                    .transb = transb,
+                    .m = nkb,
+                    .n = npm,
+                    .k = npw,
+                    .alpha = &ModuleBase::ONE,
+                    .a = dbecp_noevc,
+                    .lda = npwx,
+                    .b = ppsi,
+                    .ldb = npwx,
+                    .beta = &ModuleBase::ZERO,
+                    .c = dbecp,
+                    .ldc = nkb});
                 //              don't need to reduce here, keep
 				//              dbecp different in each
 				//              processor, and at last sum up

--- a/source/module_hsolver/diago_cg.cpp
+++ b/source/module_hsolver/diago_cg.cpp
@@ -247,52 +247,52 @@ void DiagoCG<T, Device>::orth_grad(
     ct::Tensor& lagrange)
 {
     this->spsi_func_(grad, scg); // scg = S|grad>
-    gemv_op<T, Device>()(
-        ctx_,
-        'C',
-        this->n_basis_,
-        m,
-        this->one_,
-        psi.data<T>(),
-        this->n_basis_,
-        scg.data<T>(),
-        1,
-        this->zero_,
-        lagrange.data<T>(),
-        1);
+    gemv_op<T, Device>()({
+        .d = ctx_,
+        .trans = 'C',
+        .m = this->n_basis_,
+        .n = m,
+        .alpha = this->one_,
+        .A = psi.data<T>(),
+        .lda = this->n_basis_,
+        .X = scg.data<T>(),
+        .incx = 1,
+        .beta = this->zero_,
+        .Y = lagrange.data<T>(),
+        .incy = 1});
 
     Parallel_Reduce::reduce_pool(lagrange.data<T>(), m);
 
     // (3) orthogonal |g> and |scg> to all states (0~m-1)
     //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
     // haozhihan replace 2022-10-07
-    gemv_op<T, Device>()(
-        ctx_,
-        'N',
-        this->n_basis_,
-        m,
-        this->neg_one_,
-        psi.data<T>(),
-        this->n_basis_,
-        lagrange.data<T>(),
-        1,
-        this->one_,
-        grad.data<T>(),
-        1);
+    gemv_op<T, Device>()({
+        .d = ctx_,
+        .trans = 'N',
+        .m = this->n_basis_,
+        .n = m,
+        .alpha = this->neg_one_,
+        .A = psi.data<T>(),
+        .lda = this->n_basis_,
+        .X = lagrange.data<T>(),
+        .incx = 1,
+        .beta = this->one_,
+        .Y = grad.data<T>(),
+        .incy = 1});
 
-    gemv_op<T, Device>()(
-        ctx_,
-        'N',
-        this->n_basis_,
-        m,
-        this->neg_one_,
-        psi.data<T>(),
-        this->n_basis_,
-        lagrange.data<T>(),
-        1,
-        this->one_,
-        scg.data<T>(),
-        1);
+    gemv_op<T, Device>()({
+        .d = ctx_,
+        .trans = 'N',
+        .m = this->n_basis_,
+        .n = m,
+        .alpha = this->neg_one_,
+        .A = psi.data<T>(),
+        .lda = this->n_basis_,
+        .X = lagrange.data<T>(),
+        .incx = 1,
+        .beta = this->one_,
+        .Y = scg.data<T>(),
+        .incy = 1});
 }
 
 template<typename T, typename Device>
@@ -465,38 +465,38 @@ void DiagoCG<T, Device>::schmit_orth(
     //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
     // haozhihan replace 2022-10-6
     int inc = 1;
-    gemv_op<T, Device>()(
-        ctx_,
-        'C',
-        this->n_basis_,
-        m + 1,
-        this->one_,
-        psi.data<T>(),
-        this->n_basis_,
-        sphi.data<T>(),
-        inc,
-        this->zero_,
-        lagrange_so.data<T>(),
-        inc);
+    gemv_op<T, Device>()({
+        .d = ctx_,
+        .trans = 'C',
+        .m = this->n_basis_,
+        .n = m + 1,
+        .alpha = this->one_,
+        .A = psi.data<T>(),
+        .lda = this->n_basis_,
+        .X = sphi.data<T>(),
+        .incx = inc,
+        .beta = this->zero_,
+        .Y = lagrange_so.data<T>(),
+        .incy = inc});
 
     // be careful , here reduce m+1
     Parallel_Reduce::reduce_pool(lagrange_so.data<T>(), m + 1);
 
     //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
     // haozhihan replace 2022-10-6
-    gemv_op<T, Device>()(
-        ctx_,
-        'N',
-        this->n_basis_,
-        m,
-        this->neg_one_,
-        psi.data<T>(),
-        this->n_basis_,
-        lagrange_so.data<T>(),
-        inc,
-        this->one_,
-        phi_m.data<T>(),
-        inc);
+    gemv_op<T, Device>()({
+        .d = ctx_,
+        .trans = 'N',
+        .m = this->n_basis_,
+        .n = m,
+        .alpha = this->neg_one_,
+        .A = psi.data<T>(),
+        .lda = this->n_basis_,
+        .X = lagrange_so.data<T>(),
+        .incx = inc,
+        .beta = this->one_,
+        .Y = phi_m.data<T>(),
+        .incy = inc});
 
     //======================================================================
     /*for (int j = 0; j < m; j++)

--- a/source/module_hsolver/diago_iter_assist.cpp
+++ b/source/module_hsolver/diago_iter_assist.cpp
@@ -62,22 +62,21 @@ void DiagoIterAssist<T, Device>::diagH_subspace(
     hpsi_info hpsi_in(&psi, all_bands_range, hphi);
     pHamilt->ops->hPsi(hpsi_in);
 
-    gemm_op<T, Device>()(
-        ctx,
-        'C',
-        'N',
-        nstart,
-        nstart,
-        dmin,
-        &one,
-        ppsi,
-        dmax,
-        hphi,
-        dmax,
-        &zero,
-        hcc,
-        nstart
-    );
+    gemm_op<T, Device>()({
+        .d = ctx,
+        .transa = 'C',
+        .transb = 'N',
+        .m = nstart,
+        .n = nstart,
+        .k = dmin,
+        .alpha = &one,
+        .a = ppsi,
+        .lda = dmax, 
+        .b = hphi,
+        .ldb = dmax, 
+        .beta = &zero,
+        .c = hcc,
+        .ldc = nstart}); 
     delmem_complex_op()(ctx, hphi);
 
     // allocated spsi
@@ -87,7 +86,21 @@ void DiagoIterAssist<T, Device>::diagH_subspace(
     // do sPsi for all bands
     pHamilt->sPsi(ppsi, sphi, dmax, dmin, nstart);
 
-    gemm_op<T, Device>()(ctx, 'C', 'N', nstart, nstart, dmin, &one, ppsi, dmax, sphi, dmax, &zero, scc, nstart);
+    gemm_op<T, Device>()({
+        .d = ctx,
+        .transa = 'C',
+        .transb = 'N',
+        .m = nstart,
+        .n = nstart,
+        .k = dmin,
+        .alpha = &one,
+        .a = ppsi,
+        .lda = dmax, 
+        .b = sphi,
+        .ldb = dmax, 
+        .beta = &zero,
+        .c = scc,
+        .ldc = nstart}); 
     delmem_complex_op()(ctx, sphi);
 
     if (GlobalV::NPROC_IN_POOL > 1)
@@ -127,22 +140,21 @@ void DiagoIterAssist<T, Device>::diagH_subspace(
         // because psi and evc are different here,
         // I think if psi and evc are the same,
         // there may be problems, mohan 2011-01-01
-        gemm_op<T, Device>()(
-            ctx,
-            'N',
-            'N',
-            dmax,
-            n_band,
-            nstart,
-            &one,
-            ppsi, // dmax * nstart
-            dmax,
-            vcc,  // nstart * n_band
-            nstart,
-            &zero,
-            evc.get_pointer(),
-            dmax
-        );
+        gemm_op<T, Device>()({
+            .d = ctx,
+            .transa = 'N',
+            .transb = 'N',
+            .m = dmax,
+            .n = n_band,
+            .k = nstart,
+            .alpha = &one,
+            .a = ppsi,
+            .lda = dmax, 
+            .b = vcc,
+            .ldb = nstart, 
+            .beta = &zero,
+            .c = evc.get_pointer(),
+            .ldc = dmax}); 
     }
     else
     {
@@ -152,23 +164,21 @@ void DiagoIterAssist<T, Device>::diagH_subspace(
         T* evctemp = nullptr;
         resmem_complex_op()(ctx, evctemp, n_band * dmin, "DiagSub::evctemp");
         setmem_complex_op()(ctx, evctemp, 0, n_band * dmin);
-
-        gemm_op<T, Device>()(
-            ctx,
-            'N',
-            'N',
-            dmin,
-            n_band,
-            nstart,
-            &one,
-            ppsi, // dmin * nstart
-            dmax,
-            vcc,  // nstart * n_band
-            nstart,
-            &zero,
-            evctemp,
-            dmin
-        );
+        gemm_op<T, Device>()({
+            .d = ctx,
+            .transa = 'N',
+            .transb = 'N',
+            .m = dmin,
+            .n = n_band,
+            .k = nstart,
+            .alpha = &one,
+            .a = ppsi,
+            .lda = dmax, 
+            .b = vcc,
+            .ldb = nstart, 
+            .beta = &zero,
+            .c = evctemp,
+            .ldc = dmin}); 
 
         matrixSetToAnother<T, Device>()(ctx, n_band, evctemp, dmin, evc.get_pointer(), dmax);
         // for (int ib = 0; ib < n_band; ib++)
@@ -284,22 +294,22 @@ void DiagoIterAssist<T, Device>::diagH_subspace_init(
         pHamilt->ops->hPsi(hpsi_in);
     }
 
-    gemm_op<T, Device>()(
-        ctx,
-        'C',
-        'N',
-        nstart,
-        nstart,
-        dmin,
-        &one,
-        ppsi,
-        dmax,
-        hpsi,
-        dmax,
-        &zero,
-        hcc,
-        nstart
-    );
+    gemm_op<T, Device>()({
+        .d = ctx,
+        .transa = 'C',
+        .transb = 'N',
+        .m = nstart,
+        .n = nstart,
+        .k = dmin,
+        .alpha = &one,
+        .a = ppsi,
+        .lda = dmax, 
+        .b = hpsi,
+        .ldb = dmax, 
+        .beta = &zero,
+        .c = hcc,
+        .ldc = nstart}); 
+
     delmem_complex_op()(ctx, hpsi);
 
     // allocated spsi
@@ -309,7 +319,21 @@ void DiagoIterAssist<T, Device>::diagH_subspace_init(
     // do sPsi for all bands
     pHamilt->sPsi(ppsi, spsi, psi_temp.get_nbasis(), psi_temp.get_current_nbas(), psi_temp.get_nbands());
 
-    gemm_op<T, Device>()(ctx, 'C', 'N', nstart, nstart, dmin, &one, ppsi, dmax, spsi, dmax, &zero, scc, nstart);
+    gemm_op<T, Device>()({
+        .d = ctx,
+        .transa = 'C',
+        .transb = 'N',
+        .m = nstart,
+        .n = nstart,
+        .k = dmin,
+        .alpha = &one,
+        .a = ppsi,
+        .lda = dmax, 
+        .b = spsi,
+        .ldb = dmax, 
+        .beta = &zero,
+        .c = scc,
+        .ldc = nstart}); 
     delmem_complex_op()(ctx, spsi);
 
     if (GlobalV::NPROC_IN_POOL > 1)
@@ -357,22 +381,21 @@ void DiagoIterAssist<T, Device>::diagH_subspace_init(
         // because psi and evc are different here,
         // I think if psi and evc are the same,
         // there may be problems, mohan 2011-01-01
-        gemm_op<T, Device>()(
-            ctx,
-            'N',
-            'N',
-            dmax,
-            n_band,
-            nstart,
-            &one,
-            ppsi, // dmax * nstart
-            dmax,
-            vcc,  // nstart * n_band
-            nstart,
-            &zero,
-            evc.get_pointer(),
-            dmax
-        );
+        gemm_op<T, Device>()({
+            .d = ctx,
+            .transa = 'N',
+            .transb = 'N',
+            .m = dmax,
+            .n = n_band,
+            .k = nstart,
+            .alpha = &one,
+            .a = ppsi,
+            .lda = dmax, 
+            .b = vcc,
+            .ldb = nstart, 
+            .beta = &zero,
+            .c = evc.get_pointer(),
+            .ldc = dmax}); 
     }
     else
     {
@@ -383,22 +406,21 @@ void DiagoIterAssist<T, Device>::diagH_subspace_init(
         resmem_complex_op()(ctx, evctemp, n_band * dmin, "DiagSub::evctemp");
         setmem_complex_op()(ctx, evctemp, 0, n_band * dmin);
 
-        gemm_op<T, Device>()(
-            ctx,
-            'N',
-            'N',
-            dmin,
-            n_band,
-            nstart,
-            &one,
-            ppsi, // dmin * nstart
-            dmax,
-            vcc,  // nstart * n_band
-            nstart,
-            &zero,
-            evctemp,
-            dmin
-        );
+        gemm_op<T, Device>()({
+            .d = ctx,
+            .transa = 'N',
+            .transb = 'N',
+            .m = dmin,
+            .n = n_band,
+            .k = nstart,
+            .alpha = &one,
+            .a = ppsi,
+            .lda = dmax, 
+            .b = vcc,
+            .ldb = nstart, 
+            .beta = &zero,
+            .c = evctemp,
+            .ldc = dmin}); 
 
         matrixSetToAnother<T, Device>()(ctx, n_band, evctemp, dmin, evc.get_pointer(), dmax);
 

--- a/source/module_hsolver/hsolver_lcao.cpp
+++ b/source/module_hsolver/hsolver_lcao.cpp
@@ -293,19 +293,19 @@ void HSolverLCAO<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T>* hm, psi::Psi<T>&
 
             Device * ctx = {};
 
-            gemv_op<T, Device>()(
-                ctx,
-                'N',
-                h_mat.row,
-                h_mat.col,
-                one_,
-                h_mat.p,
-                h_mat.row,
-                psi_in.data<T>(),
-                1,
-                zero_,
-                hpsi_out.data<T>(),
-                1);
+            gemv_op<T, Device>()({
+                .d = ctx,
+                .trans = 'N',
+                .m =  h_mat.row,
+                .n = h_mat.col,
+                .alpha = one_,
+                .A = h_mat.p,
+                .lda = h_mat.row,
+                .X = psi_in.data<T>(),
+                .incx = 1,
+                .beta = zero_,
+                .Y = hpsi_out.data<T>(),
+                .incy = 1});
 
             ModuleBase::timer::tick("DiagoCG_New", "hpsi_func");
         };
@@ -319,19 +319,19 @@ void HSolverLCAO<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T>* hm, psi::Psi<T>&
 
             Device * ctx = {};
             
-            gemv_op<T, Device>()(
-                ctx,
-                'N',
-                s_mat.row,
-                s_mat.col,
-                one_,
-                s_mat.p,
-                s_mat.row,
-                psi_in.data<T>(),
-                1,
-                zero_,
-                spsi_out.data<T>(),
-                1);
+            gemv_op<T, Device>()({
+                .d = ctx,
+                .trans = 'N',
+                .m = s_mat.row,
+                .n = s_mat.col,
+                .alpha = one_,
+                .A = s_mat.p,
+                .lda = s_mat.row,
+                .X = psi_in.data<T>(),
+                .incx = 1,
+                .beta = zero_,
+                .Y = spsi_out.data<T>(),
+                .incy = 1});
             
             ModuleBase::timer::tick("DiagoCG_New", "spsi_func");
         };

--- a/source/module_hsolver/kernels/cuda/math_kernel_op.cu
+++ b/source/module_hsolver/kernels/cuda/math_kernel_op.cu
@@ -5,6 +5,7 @@
 #include "module_base/tool_quit.h"
 
 #include <base/macros/macros.h>
+#include <complex>
 #include <cuda_runtime.h>
 #include <thrust/complex.h>
 #include <thrust/execution_policy.h>
@@ -650,90 +651,90 @@ void axpy_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const ba
 }
 
 template <>
-void gemv_op<double, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* d,
-                                                          const char& trans,
-                                                          const int& m,
-                                                          const int& n,
-                                                          const double* alpha,
-                                                          const double* A,
-                                                          const int& lda,
-                                                          const double* X,
-                                                          const int& incx,
-                                                          const double* beta,
-                                                          double* Y,
-                                                          const int& incy)
+void gemv_op<double, base_device::DEVICE_GPU>::operator()(gemv_op_args<double, base_device::DEVICE_GPU> args)
 {
     cublasOperation_t cutrans = {};
-    if (trans == 'N') {
+    if (args.trans == 'N') {
         cutrans = CUBLAS_OP_N;
     }
-    else if (trans == 'T') {
+    else if (args.trans == 'T') {
         cutrans = CUBLAS_OP_T;
     }
     else {
-        ModuleBase::WARNING_QUIT("gemv_op", std::string("Unknown trans type ") + trans + std::string(" !"));
+        ModuleBase::WARNING_QUIT("gemv_op", std::string("Unknown trans type ") + args.trans + std::string(" !"));
     }
-    cublasErrcheck(cublasDgemv(cublas_handle, cutrans, m, n, alpha, A, lda, X, incx, beta, Y, incx));
+    cublasErrcheck(cublasDgemv(cublas_handle, 
+                               cutrans, 
+                               args.m, 
+                               args.n, 
+                               args.alpha, 
+                               args.A, 
+                               args.lda, 
+                               args.X, 
+                               args.incx, 
+                               args.beta, 
+                               args.Y, 
+                               args.incx));
 }
 
 template <>
-void gemv_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* d,
-                                                                       const char& trans,
-                                                                       const int& m,
-                                                                       const int& n,
-                                                                       const std::complex<float>* alpha,
-                                                                       const std::complex<float>* A,
-                                                                       const int& lda,
-                                                                       const std::complex<float>* X,
-                                                                       const int& incx,
-                                                                       const std::complex<float>* beta,
-                                                                       std::complex<float>* Y,
-                                                                       const int& incy)
+void gemv_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(gemv_op_args<std::complex<float>, base_device::DEVICE_GPU> args)
 {
     cublasOperation_t cutrans = {};
-    if (trans == 'N'){
+    if (args.trans == 'N'){
         cutrans = CUBLAS_OP_N;
     } 
-    else if (trans == 'T'){
+    else if (args.trans == 'T'){
         cutrans = CUBLAS_OP_T;
     } 
-    else if (trans == 'C'){
+    else if (args.trans == 'C'){
         cutrans = CUBLAS_OP_C;
     }
     else {
-        ModuleBase::WARNING_QUIT("gemv_op", std::string("Unknown trans type ") + trans + std::string(" !"));
+        ModuleBase::WARNING_QUIT("gemv_op", std::string("Unknown trans type ") + args.trans + std::string(" !"));
     }
-    cublasErrcheck(cublasCgemv(cublas_handle, cutrans, m, n, (float2*)alpha, (float2*)A, lda, (float2*)X, incx, (float2*)beta, (float2*)Y, incx));
+    cublasErrcheck(cublasCgemv(cublas_handle, 
+                               cutrans, 
+                               args.m, 
+                               args.n, 
+                               (float2*)args.alpha, 
+                               (float2*)args.A, 
+                               args.lda, 
+                               (float2*)args.X, 
+                               args.incx, 
+                               (float2*)args.beta, 
+                               (float2*)args.Y, 
+                               args.incx));
 }
 
 template <>
-void gemv_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* d,
-                                                                        const char& trans,
-                                                                        const int& m,
-                                                                        const int& n,
-                                                                        const std::complex<double>* alpha,
-                                                                        const std::complex<double>* A,
-                                                                        const int& lda,
-                                                                        const std::complex<double>* X,
-                                                                        const int& incx,
-                                                                        const std::complex<double>* beta,
-                                                                        std::complex<double>* Y,
-                                                                        const int& incy)
+void gemv_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(gemv_op_args<std::complex<double>, base_device::DEVICE_GPU> args)
 {
     cublasOperation_t cutrans = {};
-    if (trans == 'N'){
+    if (args.trans == 'N'){
         cutrans = CUBLAS_OP_N;
     } 
-    else if (trans == 'T'){
+    else if (args.trans == 'T'){
         cutrans = CUBLAS_OP_T;
     } 
-    else if (trans == 'C'){
+    else if (args.trans == 'C'){
         cutrans = CUBLAS_OP_C;
     }
     else {
-        ModuleBase::WARNING_QUIT("gemv_op", std::string("Unknown trans type ") + trans + std::string(" !"));
+        ModuleBase::WARNING_QUIT("gemv_op", std::string("Unknown trans type ") + args.trans + std::string(" !"));
     }
-    cublasErrcheck(cublasZgemv(cublas_handle, cutrans, m, n, (double2*)alpha, (double2*)A, lda, (double2*)X, incx, (double2*)beta, (double2*)Y, incx));
+    cublasErrcheck(cublasZgemv(cublas_handle, 
+                               cutrans, 
+                               args.m, 
+                               args.n, 
+                               (double2*)args.alpha, 
+                               (double2*)args.A, 
+                               args.lda, 
+                               (double2*)args.X, 
+                               args.incx, 
+                               (double2*)args.beta, 
+                               (double2*)args.Y, 
+                               args.incx));
 }
 
 template <>
@@ -757,137 +758,137 @@ void scal_op<double, base_device::DEVICE_GPU>::operator()(const base_device::DEV
 }
 
 template <>
-void gemm_op<double, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* d,
-                                                          const char& transa,
-                                                          const char& transb,
-                                                          const int& m,
-                                                          const int& n,
-                                                          const int& k,
-                                                          const double* alpha,
-                                                          const double* a,
-                                                          const int& lda,
-                                                          const double* b,
-                                                          const int& ldb,
-                                                          const double* beta,
-                                                          double* c,
-                                                          const int& ldc)
+void gemm_op<double, base_device::DEVICE_GPU>::operator()(gemm_op_args<double, base_device::DEVICE_GPU> args)
 {
     cublasOperation_t cutransA;
     cublasOperation_t cutransB;
     // cutransA
-    if (transa == 'N') {
+    if (args.transa == 'N') {
         cutransA = CUBLAS_OP_N;
     }
-    else if (transa == 'T') {
+    else if (args.transa == 'T') {
         cutransA = CUBLAS_OP_T;
     }
     else {
-        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transa type ") + transa + std::string(" !"));
+        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transa type ") + args.transa + std::string(" !"));
     }
     // cutransB
-    if (transb == 'N') {
+    if (args.transb == 'N') {
         cutransB = CUBLAS_OP_N;
     }
-    else if (transb == 'T') {
+    else if (args.transb == 'T') {
         cutransB = CUBLAS_OP_T;
     }
     else {
-        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transb type ") + transb + std::string(" !"));
+        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transb type ") + args.transb + std::string(" !"));
     }
-    cublasErrcheck(cublasDgemm(cublas_handle, cutransA, cutransB, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc));
+    cublasErrcheck(cublasDgemm(cublas_handle, 
+                               cutransA, 
+                               cutransB, 
+                               args.m, 
+                               args.n, 
+                               args.k, 
+                               args.alpha, 
+                               args.a, 
+                               args.lda, 
+                               args.b, 
+                               args.ldb, 
+                               args.beta, 
+                               args.c, 
+                               args.ldc));
 }
 template <>
-void gemm_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* d,
-                                                                       const char& transa,
-                                                                       const char& transb,
-                                                                       const int& m,
-                                                                       const int& n,
-                                                                       const int& k,
-                                                                       const std::complex<float>* alpha,
-                                                                       const std::complex<float>* a,
-                                                                       const int& lda,
-                                                                       const std::complex<float>* b,
-                                                                       const int& ldb,
-                                                                       const std::complex<float>* beta,
-                                                                       std::complex<float>* c,
-                                                                       const int& ldc)
+void gemm_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(gemm_op_args<std::complex<float>, base_device::DEVICE_GPU> args)
 {
     cublasOperation_t cutransA = {};
     cublasOperation_t cutransB = {};
     // cutransA
-    if (transa == 'N'){
+    if (args.transa == 'N'){
         cutransA = CUBLAS_OP_N;
     } 
-    else if (transa == 'T'){
+    else if (args.transa == 'T'){
         cutransA = CUBLAS_OP_T;
     } 
-    else if (transa == 'C'){
+    else if (args.transa == 'C'){
         cutransA = CUBLAS_OP_C;
     } 
     else {
-        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transa type ") + transa + std::string(" !"));
+        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transa type ") + args.transa + std::string(" !"));
     }
     // cutransB
-    if (transb == 'N'){
+    if (args.transb == 'N'){
         cutransB = CUBLAS_OP_N;
     } 
-    else if (transb == 'T'){
+    else if (args.transb == 'T'){
         cutransB = CUBLAS_OP_T;
     } 
-    else if (transb == 'C'){
+    else if (args.transb == 'C'){
         cutransB = CUBLAS_OP_C;
     }
     else {
-        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transb type ") + transb + std::string(" !"));
+        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transb type ") + args.transb + std::string(" !"));
     }
-    cublasErrcheck(cublasCgemm(cublas_handle, cutransA, cutransB, m, n ,k, (float2*)alpha, (float2*)a , lda, (float2*)b, ldb, (float2*)beta, (float2*)c, ldc));
+    cublasErrcheck(cublasCgemm(cublas_handle, 
+                               cutransA, 
+                               cutransB, 
+                               args.m, 
+                               args.n,
+                               args.k, 
+                               (float2*)args.alpha, 
+                               (float2*)args.a, 
+                               args.lda, 
+                               (float2*)args.b, 
+                               args.ldb, 
+                               (float2*)args.beta, 
+                               (float2*)args.c, 
+                               args.ldc));
 }
 
 template <>
-void gemm_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* d,
-                                                                        const char& transa,
-                                                                        const char& transb,
-                                                                        const int& m,
-                                                                        const int& n,
-                                                                        const int& k,
-                                                                        const std::complex<double>* alpha,
-                                                                        const std::complex<double>* a,
-                                                                        const int& lda,
-                                                                        const std::complex<double>* b,
-                                                                        const int& ldb,
-                                                                        const std::complex<double>* beta,
-                                                                        std::complex<double>* c,
-                                                                        const int& ldc)
+void gemm_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(gemm_op_args<std::complex<double>, base_device::DEVICE_GPU> args)
 {
-    cublasOperation_t cutransA;
-    cublasOperation_t cutransB;
+    cublasOperation_t cutransA = {};
+    cublasOperation_t cutransB = {};
     // cutransA
-    if (transa == 'N'){
+    if (args.transa == 'N'){
         cutransA = CUBLAS_OP_N;
     } 
-    else if (transa == 'T'){
+    else if (args.transa == 'T'){
         cutransA = CUBLAS_OP_T;
     } 
-    else if (transa == 'C'){
+    else if (args.transa == 'C'){
         cutransA = CUBLAS_OP_C;
     } 
     else {
-        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transa type ") + transa + std::string(" !"));
+        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transa type ") + args.transa + std::string(" !"));
     }
     // cutransB
-    if (transb == 'N'){
+    if (args.transb == 'N'){
         cutransB = CUBLAS_OP_N;
     } 
-    else if (transb == 'T'){
+    else if (args.transb == 'T'){
         cutransB = CUBLAS_OP_T;
     } 
-    else if (transb == 'C'){
+    else if (args.transb == 'C'){
         cutransB = CUBLAS_OP_C;
     }
     else {
-        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transb type ") + transb + std::string(" !"));
+        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transb type ") + args.transb + std::string(" !"));
     }
-    cublasErrcheck(cublasZgemm(cublas_handle, cutransA, cutransB, m, n ,k, (double2*)alpha, (double2*)a , lda, (double2*)b, ldb, (double2*)beta, (double2*)c, ldc));
+    cublasErrcheck(cublasZgemm(cublas_handle, 
+                               cutransA, 
+                               cutransB, 
+                               args.m, 
+                               args.n,
+                               args.k, 
+                               (double2*)args.alpha, 
+                               (double2*)args.a, 
+                               args.lda, 
+                               (double2*)args.b, 
+                               args.ldb, 
+                               (double2*)args.beta, 
+                               (double2*)args.c, 
+                               args.ldc));
 }
 
 template <>

--- a/source/module_hsolver/kernels/math_kernel_op.cpp
+++ b/source/module_hsolver/kernels/math_kernel_op.cpp
@@ -1,4 +1,5 @@
 #include "module_hsolver/kernels/math_kernel_op.h"
+#include "math_kernel_op.h"
 
 #include <iomanip>
 #include <iostream>
@@ -227,20 +228,19 @@ struct scal_op<FPTYPE, base_device::DEVICE_CPU>
 template <typename T>
 struct gemv_op<T, base_device::DEVICE_CPU>
 {
-    void operator()(const base_device::DEVICE_CPU* d,
-                    const char& trans,
-                    const int& m,
-                    const int& n,
-                    const T* alpha,
-                    const T* A,
-                    const int& lda,
-                    const T* X,
-                    const int& incx,
-                    const T* beta,
-                    T* Y,
-                    const int& incy)
+    void operator()(gemv_op_args<T, base_device::DEVICE_CPU> args)
     {
-        BlasConnector::gemv(trans, m, n, *alpha, A, lda, X, incx, *beta, Y, incy);
+        BlasConnector::gemv(args.trans, 
+                            args.m, 
+                            args.n, 
+                            *(args.alpha), 
+                            args.A, 
+                            args.lda, 
+                            args.X, 
+                            args.incx, 
+                            *(args.beta), 
+                            args.Y, 
+                            args.incy);
     }
 };
 
@@ -262,22 +262,21 @@ struct axpy_op<T, base_device::DEVICE_CPU>
 template <typename T>
 struct gemm_op<T, base_device::DEVICE_CPU>
 {
-    void operator()(const base_device::DEVICE_CPU* /*ctx*/,
-                    const char& transa,
-                    const char& transb,
-                    const int& m,
-                    const int& n,
-                    const int& k,
-                    const T* alpha,
-                    const T* a,
-                    const int& lda,
-                    const T* b,
-                    const int& ldb,
-                    const T* beta,
-                    T* c,
-                    const int& ldc)
+    void operator()(gemm_op_args<T, base_device::DEVICE_CPU> args)
     {
-        BlasConnector::gemm(transb, transa, n, m, k, *alpha, b, ldb, a, lda, *beta, c, ldc);
+        BlasConnector::gemm(args.transb, 
+                            args.transa, 
+                            args.n, 
+                            args.m, 
+                            args.k, 
+                            *(args.alpha), 
+                            args.b, 
+                            args.ldb, 
+                            args.a, 
+                            args.lda, 
+                            *(args.beta), 
+                            args.c, 
+                            args.ldc);
     }
 };
 

--- a/source/module_hsolver/kernels/math_kernel_op.h
+++ b/source/module_hsolver/kernels/math_kernel_op.h
@@ -271,40 +271,58 @@ struct axpy_op
     void operator()(const Device* d, const int& N, const T* alpha, const T* X, const int& incX, T* Y, const int& incY);
 };
 
+// Edit: For function calls with numerous arguments(typically > 10), it is suggested
+// that we use a struct to pass the arguments.
+// It has been tested that this method may result in loading data from memory,
+// but as the data is most likely to be stored in L1 cache, the performance impact is negligible.
+
+/// This struct describes the arguments for the gemv_op function.
+template <typename T, typename Device>
+struct gemv_op_args
+{
+    const Device* d; /// the type of computing device
+    const char& trans; /// whether to transpose A
+    const int& m; /// first dimension of matrix
+    const int& n; /// second dimension of matrix
+    const T* alpha; /// input constant alpha
+    const T* A; /// input matrix A
+    const int& lda; /// leading dimension of A
+    const T* X; /// input array X
+    const int& incx; /// computing strip of X
+    const T* beta; /// input constant beta
+    T* Y; /// input/output array Y
+    const int& incy; /// computing strip of Y
+};
+
 // compute y = alpha * op(A) * x + beta * y
 template <typename T, typename Device>
 struct gemv_op
 {
     /// @brief y = alpha * op(A) * x + beta * y
     ///
-    /// Input Parameters
-    /// \param d : the type of computing device
-    /// \param trans : whether to transpose A
-    /// \param m : first dimension of matrix
-    /// \param n : second dimension of matrix
-    /// \param alpha : input constant alpha
-    /// \param A : input matrix A
-    /// \param lda : leading dimention of A
-    /// \param X : input array X
-    /// \param incx : computing strip of X
-    /// \param beta : input constant beta
-    /// \param Y : input array Y
-    /// \param incy : computing strip of Y
-    ///
-    /// Output Parameters
-    /// \param Y : output array Y
-    void operator()(const Device* d,
-                    const char& trans,
-                    const int& m,
-                    const int& n,
-                    const T* alpha,
-                    const T* A,
-                    const int& lda,
-                    const T* X,
-                    const int& incx,
-                    const T* beta,
-                    T* Y,
-                    const int& incy);
+    /// Parameters
+    /// \param args: the arguments for the gemv_op function
+
+    void operator()(gemv_op_args<T, Device> args);
+};
+
+template <typename T, typename Device>
+struct gemm_op_args
+{
+    const Device* d; /// the type of computing device
+    const char& transa; /// whether to transpose matrix A
+    const char& transb; /// whether to transpose matrix B
+    const int& m; /// first dimension of matrix mulplication
+    const int& n; /// second dimension of matrix mulplication
+    const int& k; /// third dimension of matrix mulplication
+    const T* alpha; /// input constant alpha
+    const T* a; /// input matrix A
+    const int& lda; /// leading dimention of A
+    const T* b; /// input matrix B
+    const int& ldb; /// leading dimention of B
+    const T* beta; /// input constant beta
+    T* c; /// input/output matrix C
+    const int& ldc; /// leading dimention of C
 };
 
 // compute C = alpha * op(A) * op(B) + beta * C
@@ -313,38 +331,9 @@ struct gemm_op
 {
     /// @brief C = alpha * op(A) * op(B) + beta * C
     ///
-    /// Input Parameters
-    /// \param d : the type of computing device
-    /// \param transa : whether to transpose matrix A
-    /// \param transb : whether to transpose matrix B
-    /// \param m : first dimension of matrix mulplication
-    /// \param n : second dimension of matrix mulplication
-    /// \param k : third dimension of matrix mulplication
-    /// \param alpha : input constant alpha
-    /// \param a : input matrix A
-    /// \param lda : leading dimention of A
-    /// \param b : input matrix B
-    /// \param ldb : leading dimention of A
-    /// \param beta : input constant beta
-    /// \param c : input matrix C
-    /// \param ldc : leading dimention of C
-    ///
-    /// Output Parameters
-    /// \param c : output matrix C
-    void operator()(const Device* d,
-                    const char& transa,
-                    const char& transb,
-                    const int& m,
-                    const int& n,
-                    const int& k,
-                    const T* alpha,
-                    const T* a,
-                    const int& lda,
-                    const T* b,
-                    const int& ldb,
-                    const T* beta,
-                    T* c,
-                    const int& ldc);
+    /// Parameters
+    /// \param args: the arguments for the gemm_op function
+    void operator()(gemm_op_args<T, Device> args);
 };
 
 template <typename T, typename Device>

--- a/source/module_hsolver/kernels/rocm/math_kernel_op.hip.cu
+++ b/source/module_hsolver/kernels/rocm/math_kernel_op.hip.cu
@@ -5,6 +5,7 @@
 #include "module_base/tool_quit.h"
 
 #include <base/macros/macros.h>
+#include <complex>
 #include <hip/hip_runtime.h>
 #include <hipblas/hipblas.h>
 #include <thrust/complex.h>
@@ -654,93 +655,93 @@ void axpy_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const ba
 }
 
 template <>
-void gemv_op<double, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* d,
-                                                          const char& trans,
-                                                          const int& m,
-                                                          const int& n,
-                                                          const double* alpha,
-                                                          const double* A,
-                                                          const int& lda,
-                                                          const double* X,
-                                                          const int& incx,
-                                                          const double* beta,
-                                                          double* Y,
-                                                          const int& incy)
+void gemv_op<double, base_device::DEVICE_GPU>::operator()(gemv_op_args<double, base_device::DEVICE_GPU> args)
 {
     hipblasOperation_t cutrans = {};
-    if (trans == 'N') {
+    if (args.trans == 'N') {
         cutrans = HIPBLAS_OP_N;
     }
-    else if (trans == 'T') {
+    else if (args.trans == 'T') {
         cutrans = HIPBLAS_OP_T;
     }
-    else if (trans == 'C') {
+    else if (args.trans == 'C') {
         cutrans = HIPBLAS_OP_C;
     }
     else {
-        ModuleBase::WARNING_QUIT("gemv_op", std::string("Unknown trans type ") + trans + std::string(" !"));
+        ModuleBase::WARNING_QUIT("gemv_op", std::string("Unknown trans type ") + args.trans + std::string(" !"));
     }
-    hipblasErrcheck(hipblasDgemv(cublas_handle, cutrans, m, n, alpha, A, lda, X, incx, beta, Y, incx));
+    hipblasErrcheck(hipblasDgemv(cublas_handle, 
+                                 cutrans, 
+                                 args.m, 
+                                 args.n, 
+                                 args.alpha, 
+                                 args.A, 
+                                 args.lda, 
+                                 args.X, 
+                                 args.incx, 
+                                 args.beta, 
+                                 args.Y, 
+                                 args.incx));
 }
 
 template <>
-void gemv_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* d,
-                                                                       const char& trans,
-                                                                       const int& m,
-                                                                       const int& n,
-                                                                       const std::complex<float>* alpha,
-                                                                       const std::complex<float>* A,
-                                                                       const int& lda,
-                                                                       const std::complex<float>* X,
-                                                                       const int& incx,
-                                                                       const std::complex<float>* beta,
-                                                                       std::complex<float>* Y,
-                                                                       const int& incy)
+void gemv_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(gemv_op_args<std::complex<float>, base_device::DEVICE_GPU> args)
 {
     hipblasOperation_t cutrans = {};
-    if (trans == 'N') {
+    if (args.trans == 'N') {
         cutrans = HIPBLAS_OP_N;
-    } 
-    else if (trans == 'T') {
+    }
+    else if (args.trans == 'T') {
         cutrans = HIPBLAS_OP_T;
-    } 
-    else if (trans == 'C') {
+    }
+    else if (args.trans == 'C') {
         cutrans = HIPBLAS_OP_C;
     }
     else {
-        ModuleBase::WARNING_QUIT("gemv_op", std::string("Unknown trans type ") + trans + std::string(" !"));
+        ModuleBase::WARNING_QUIT("gemv_op", std::string("Unknown trans type ") + args.trans + std::string(" !"));
     }
-    hipblasErrcheck(hipblasCgemv(cublas_handle, cutrans, m, n, (hipblasComplex*)alpha, (hipblasComplex*)A, lda, (hipblasComplex*)X, incx, (hipblasComplex*)beta, (hipblasComplex*)Y, incx));
+    hipblasErrcheck(hipblasCgemv(cublas_handle, 
+                                 cutrans, 
+                                 args.m, 
+                                 args.n, 
+                                 (hipblasComplex*)args.alpha, 
+                                 (hipblasComplex*)args.A, 
+                                 args.lda, 
+                                 (hipblasComplex*)args.X, 
+                                 args.incx, 
+                                 (hipblasComplex*)args.beta, 
+                                 (hipblasComplex*)args.Y, 
+                                 args.incx));
 }
 
 template <>
-void gemv_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* d,
-                                                                        const char& trans,
-                                                                        const int& m,
-                                                                        const int& n,
-                                                                        const std::complex<double>* alpha,
-                                                                        const std::complex<double>* A,
-                                                                        const int& lda,
-                                                                        const std::complex<double>* X,
-                                                                        const int& incx,
-                                                                        const std::complex<double>* beta,
-                                                                        std::complex<double>* Y,
-                                                                        const int& incy)
+void gemv_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(gemv_op_args<std::complex<double>, base_device::DEVICE_GPU> args)
 {
     hipblasOperation_t cutrans = {};
-    if (trans == 'N'){
+    if (args.trans == 'N') {
         cutrans = HIPBLAS_OP_N;
-    } 
-    else if (trans == 'T'){
+    }
+    else if (args.trans == 'T') {
         cutrans = HIPBLAS_OP_T;
-    } 
-    else if (trans == 'C'){
+    }
+    else if (args.trans == 'C') {
         cutrans = HIPBLAS_OP_C;
     }
     else {
-        ModuleBase::WARNING_QUIT("gemv_op", std::string("Unknown trans type ") + trans + std::string(" !"));
+        ModuleBase::WARNING_QUIT("gemv_op", std::string("Unknown trans type ") + args.trans + std::string(" !"));
     }
-    hipblasErrcheck(hipblasZgemv(cublas_handle, cutrans, m, n, (hipblasDoubleComplex*)alpha, (hipblasDoubleComplex*)A, lda, (hipblasDoubleComplex*)X, incx, (hipblasDoubleComplex*)beta, (hipblasDoubleComplex*)Y, incx));
+    hipblasErrcheck(hipblasZgemv(cublas_handle, 
+                                 cutrans, 
+                                 args.m, 
+                                 args.n, 
+                                 (hipblasDoubleComplex*)args.alpha, 
+                                 (hipblasDoubleComplex*)args.A, 
+                                 args.lda, 
+                                 (hipblasDoubleComplex*)args.X, 
+                                 args.incx, 
+                                 (hipblasDoubleComplex*)args.beta, 
+                                 (hipblasDoubleComplex*)args.Y, 
+                                 args.incx));
 }
 
 template <>
@@ -764,138 +765,138 @@ void scal_op<double, base_device::DEVICE_GPU>::operator()(const base_device::DEV
 }
 
 template <>
-void gemm_op<double, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* d,
-                                                          const char& transa,
-                                                          const char& transb,
-                                                          const int& m,
-                                                          const int& n,
-                                                          const int& k,
-                                                          const double* alpha,
-                                                          const double* a,
-                                                          const int& lda,
-                                                          const double* b,
-                                                          const int& ldb,
-                                                          const double* beta,
-                                                          double* c,
-                                                          const int& ldc)
+void gemm_op<double, base_device::DEVICE_GPU>::operator()(gemm_op_args<double, base_device::DEVICE_GPU> args)
 {
     hipblasOperation_t cutransA;
     hipblasOperation_t cutransB;
     // cutransA
-    if (transa == 'N') {
+    if (args.transa == 'N') {
         cutransA = HIPBLAS_OP_N;
     }
-    else if (transa == 'T') {
+    else if (args.transa == 'T') {
         cutransA = HIPBLAS_OP_T;
     }
     else {
-        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transa type ") + transa + std::string(" !"));
+        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transa type ") + args.transa + std::string(" !"));
     }
     // cutransB
-    if (transb == 'N') {
+    if (args.transb == 'N') {
         cutransB = HIPBLAS_OP_N;
     }
-    else if (transb == 'T') {
+    else if (args.transb == 'T') {
         cutransB = HIPBLAS_OP_T;
     }
     else {
-        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transb type ") + transb + std::string(" !"));
+        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transb type ") + args.transb + std::string(" !"));
     }
-    hipblasErrcheck(hipblasDgemm(cublas_handle, cutransA, cutransB, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc));
+    hipblasErrcheck(hipblasDgemm(cublas_handle, 
+                                 cutransA, 
+                                 cutransB, 
+                                 args.m, 
+                                 args.n, 
+                                 args.k, 
+                                 args.alpha, 
+                                 args.a, 
+                                 args.lda, 
+                                 args.b, 
+                                 args.ldb, 
+                                 args.beta, 
+                                 args.c, 
+                                 args.ldc));
 }
 
 template <>
-void gemm_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* d,
-                                                                       const char& transa,
-                                                                       const char& transb,
-                                                                       const int& m,
-                                                                       const int& n,
-                                                                       const int& k,
-                                                                       const std::complex<float>* alpha,
-                                                                       const std::complex<float>* a,
-                                                                       const int& lda,
-                                                                       const std::complex<float>* b,
-                                                                       const int& ldb,
-                                                                       const std::complex<float>* beta,
-                                                                       std::complex<float>* c,
-                                                                       const int& ldc)
+void gemm_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(gemm_op_args<double, base_device::DEVICE_GPU> args)
 {
     hipblasOperation_t cutransA = {};
     hipblasOperation_t cutransB = {};
     // cutransA
-    if (transa == 'N'){
+    if (args.transa == 'N'){
         cutransA = HIPBLAS_OP_N;
     } 
-    else if (transa == 'T'){
+    else if (args.transa == 'T'){
         cutransA = HIPBLAS_OP_T;
     } 
-    else if (transa == 'C'){
+    else if (args.transa == 'C'){
         cutransA = HIPBLAS_OP_C;
     }
     else {
-        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transa type ") + transa + std::string(" !"));
+        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transa type ") + args.transa + std::string(" !"));
     } 
     // cutransB
-    if (transb == 'N'){
+    if (args.transb == 'N'){
         cutransB = HIPBLAS_OP_N;
     } 
-    else if (transb == 'T'){
+    else if (args.transb == 'T'){
         cutransB = HIPBLAS_OP_T;
     } 
-    else if (transb == 'C'){
+    else if (args.transb == 'C'){
         cutransB = HIPBLAS_OP_C;
     }
     else {
-        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transb type ") + transb + std::string(" !"));
+        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transb type ") + args.transb + std::string(" !"));
     }
-    hipblasErrcheck(hipblasCgemm(cublas_handle, cutransA, cutransB, m, n ,k, (hipblasComplex*)alpha, (hipblasComplex*)a , lda, (hipblasComplex*)b, ldb, (hipblasComplex*)beta, (hipblasComplex*)c, ldc));
+    hipblasErrcheck(hipblasCgemm(cublas_handle, 
+                                 cutransA, 
+                                 cutransB, 
+                                 args.m, 
+                                 args.n, 
+                                 args.k, 
+                                 (hipblasComplex*)args.alpha, 
+                                 (hipblasComplex*)args.a, 
+                                 args.lda, 
+                                 (hipblasComplex*)args.b, 
+                                 args.ldb, 
+                                 (hipblasComplex*)args.beta, 
+                                 (hipblasComplex*)args.c, 
+                                 args.ldc));
 }
 
 template <>
-void gemm_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* d,
-                                                                        const char& transa,
-                                                                        const char& transb,
-                                                                        const int& m,
-                                                                        const int& n,
-                                                                        const int& k,
-                                                                        const std::complex<double>* alpha,
-                                                                        const std::complex<double>* a,
-                                                                        const int& lda,
-                                                                        const std::complex<double>* b,
-                                                                        const int& ldb,
-                                                                        const std::complex<double>* beta,
-                                                                        std::complex<double>* c,
-                                                                        const int& ldc)
+void gemm_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(gemm_op_args<double, base_device::DEVICE_GPU> args)
 {
     hipblasOperation_t cutransA;
     hipblasOperation_t cutransB;
     // cutransA
-    if (transa == 'N'){
+    if (args.transa == 'N'){
         cutransA = HIPBLAS_OP_N;
     } 
-    else if (transa == 'T'){
+    else if (args.transa == 'T'){
         cutransA = HIPBLAS_OP_T;
     } 
-    else if (transa == 'C'){
+    else if (args.transa == 'C'){
         cutransA = HIPBLAS_OP_C;
     }
     else {
-        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transa type ") + transa + std::string(" !"));
+        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transa type ") + args.transa + std::string(" !"));
     } 
     // cutransB
-    if (transb == 'N'){
+    if (args.transb == 'N'){
         cutransB = HIPBLAS_OP_N;
     } 
-    else if (transb == 'T'){
+    else if (args.transb == 'T'){
         cutransB = HIPBLAS_OP_T;
     } 
-    else if (transb == 'C'){
+    else if (args.transb == 'C'){
         cutransB = HIPBLAS_OP_C;
     }
     else {
-        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transb type ") + transb + std::string(" !"));
+        ModuleBase::WARNING_QUIT("gemm_op", std::string("Unknown transb type ") + args.transb + std::string(" !"));
     }
-    hipblasErrcheck(hipblasZgemm(cublas_handle, cutransA, cutransB, m, n ,k, (hipblasDoubleComplex*)alpha, (hipblasDoubleComplex*)a , lda, (hipblasDoubleComplex*)b, ldb, (hipblasDoubleComplex*)beta, (hipblasDoubleComplex*)c, ldc));
+    hipblasErrcheck(hipblasZgemm(cublas_handle, 
+                                 cutransA, 
+                                 cutransB, 
+                                 args.m, 
+                                 args.n, 
+                                 args.k, 
+                                 (hipblasDoubleComplex*)args.alpha, 
+                                 (hipblasDoubleComplex*)args.a, 
+                                 args.lda, 
+                                 (hipblasDoubleComplex*)args.b, 
+                                 args.ldb, 
+                                 (hipblasDoubleComplex*)args.beta, 
+                                 (hipblasDoubleComplex*)args.c, 
+                                 args.ldc));
 }
 
 template <>

--- a/source/module_hsolver/kernels/test/math_kernel_test.cpp
+++ b/source/module_hsolver/kernels/test/math_kernel_test.cpp
@@ -334,18 +334,19 @@ TEST_F(TestModuleHsolverMathKernel, scal_op_cpu)
 
 TEST_F(TestModuleHsolverMathKernel, gemv_op_cpu)
 {
-    gemv_op_cpu()(cpu_ctx,
-                  'C',
-                  2,
-                  3,
-                  &ModuleBase::ONE,
-                  A_gemv.data(),
-                  2,
-                  X_gemv.data(),
-                  1,
-                  &ModuleBase::ONE,
-                  Y_gemv.data(),
-                  1);
+    gemv_op_cpu()({
+        .d = cpu_ctx,
+        .trans = 'C',
+        .m = 2,
+        .n = 3,
+        .alpha = &ModuleBase::ONE,
+        .A = A_gemv.data(),
+        .lda = 2,
+        .X = X_gemv.data(),
+        .incx = 1,
+        .beta = &ModuleBase::ONE,
+        .Y = Y_gemv.data(),
+        .incy = 1});
     char trans = 'C';
     int inc = 1;
     int row = 2;
@@ -601,7 +602,19 @@ TEST_F(TestModuleHsolverMathKernel, gemv_op_gpu)
 
     // run
     hsolver::createGpuBlasHandle();
-    gemv_op_gpu()(gpu_ctx, 'C', 2, 3, &ModuleBase::ONE, A_gemv_dev, 2, X_gemv_dev, 1, &ModuleBase::ONE, Y_gemv_dev, 1);
+    gemv_op_gpu()({
+        .d = gpu_ctx, 
+        .trans = 'C', 
+        .m = 2, 
+        .n = 3, 
+        .alpha = &ModuleBase::ONE, 
+        .A = A_gemv_dev, 
+        .lda = 2, 
+        .X = X_gemv_dev, 
+        .incx = 1, 
+        .beta = &ModuleBase::ONE, 
+        .Y = Y_gemv_dev, 
+        .incy = 1});
     hsolver::destoryBLAShandle();
     // syn the output data in GPU to CPU
     synchronize_memory_op_gpu()(cpu_ctx, gpu_ctx, Y_gemv.data(), Y_gemv_dev, Y_gemv.size());


### PR DESCRIPTION
Some function calls(especially those calling LAPACK functions) have extremely long list of arguments, impairing readability and improves the risk of writing the wrong code. Therefore, structs are used to pass arguments for better readability.