### PR TITLE
Add and Remove some functions in klist.h etc

### DIFF
--- a/source/module_cell/klist.cpp
+++ b/source/module_cell/klist.cpp
@@ -834,7 +834,7 @@ bool K_Vectors::check_symmetry(const ModuleSymmetry::Symmetry &symm, const UnitC
         {
             return (symm.equal(a.e11, b.e11) && symm.equal(a.e12, b.e12) && symm.equal(a.e13, b.e13) &&
             symm.equal(a.e21, b.e21) && symm.equal(a.e22, b.e22) && symm.equal(a.e23, b.e23) &&
-            symm.equal(a.e31, b.e31) && symm.equal(a.e23, b.e23) && symm.equal(a.e33, b.e33));
+            symm.equal(a.e31, b.e31) && symm.equal(a.e32, b.e32) && symm.equal(a.e33, b.e33));
         };
         for(int i=0;i<symm.nrotk;++i)
         {

--- a/source/module_cell/klist.cpp
+++ b/source/module_cell/klist.cpp
@@ -530,9 +530,18 @@ void K_Vectors::ibz_kpoint(const ModuleSymmetry::Symmetry &symm, bool use_symm,s
 
     // k-lattice: "pricell" of reciprocal space
     // CAUTION: should fit into all k-input method, not only MP  !!!
-    
+    ModuleBase::Vector3<double> gb1(ucell.G.e11, ucell.G.e12, ucell.G.e13);
+    ModuleBase::Vector3<double> gb2(ucell.G.e21, ucell.G.e22, ucell.G.e23);
+    ModuleBase::Vector3<double> gb3(ucell.G.e31, ucell.G.e32, ucell.G.e33);
+    ModuleBase::Vector3<double> gk1, gk2, gk3;
     ModuleBase::Matrix3 gk;
-    
+    if (this->is_mp)
+    {
+        gk1 = ModuleBase::Vector3<double>(gb1.x / nmp[0], gb1.y / nmp[0], gb1.z / nmp[0]);
+        gk2 = ModuleBase::Vector3<double>(gb2.x / nmp[1], gb2.y / nmp[1], gb2.z / nmp[1]);
+        gk3 = ModuleBase::Vector3<double>(gb3.x / nmp[2], gb3.y / nmp[2], gb3.z / nmp[2]);
+        gk = ModuleBase::Matrix3(gk1.x, gk1.y, gk1.z, gk2.x, gk2.y, gk2.z, gk3.x, gk3.y, gk3.z);
+    }
 
 
     //===============================================
@@ -548,8 +557,78 @@ void K_Vectors::ibz_kpoint(const ModuleSymmetry::Symmetry &symm, bool use_symm,s
     int nrotkm=0;
     if(use_symm)
     {
-        if(!check_symmetry(symm, ucell, match, gk)) {
+        // bravais type of reciprocal lattice and k-lattice
+        double b_const[6];
+        double b0_const[6];
+        double bk_const[6];
+        double bk0_const[6];
+        int bbrav=15;
+        int bkbrav=15;
+        std::string bbrav_name;
+        std::string bkbrav_name;
+        ModuleBase::Vector3<double>gk01 = gk1, gk02 = gk2, gk03 = gk3;
+
+        ModuleBase::Matrix3 b_optlat = symm.optlat.Inverse().Transpose();
+        //search optlat after using reciprocity relation
+        ModuleBase::Vector3<double> gb01(b_optlat.e11, b_optlat.e12, b_optlat.e13);
+        ModuleBase::Vector3<double> gb02(b_optlat.e21, b_optlat.e22, b_optlat.e23);
+        ModuleBase::Vector3<double> gb03(b_optlat.e31, b_optlat.e32, b_optlat.e33);
+        symm.lattice_type(gb1, gb2, gb3, gb01, gb02, gb03, b_const, b0_const, bbrav, bbrav_name, ucell.atoms, false, nullptr);
+        GlobalV::ofs_running<<"(for reciprocal lattice: )"<<std::endl;
+        ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"BRAVAIS TYPE", bbrav);
+        ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"BRAVAIS LATTICE NAME", bbrav_name);
+        ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "ibrav", bbrav);
+        
+        // the map of bravis lattice from real to reciprocal space
+        // for example, 3(fcc) in real space matches 2(bcc) in reciprocal space
+        std::vector<int> ibrav_a2b{ 1, 3, 2, 4, 5, 6, 7, 8, 10, 9, 11, 12, 13, 14 };
+        auto ibrav_match = [&](int ibrav_b) -> bool
+        {
+            const int& ibrav_a = symm.real_brav;
+            if (ibrav_a < 1 || ibrav_a > 14) return false;
+            return (ibrav_b == ibrav_a2b[ibrav_a - 1]);
+        };
+        if (!ibrav_match(bbrav))
+        {
+            GlobalV::ofs_running << "Error: Bravais lattice type of reciprocal lattice is not compatible with that of real space lattice:" << std::endl;
+            GlobalV::ofs_running << "ibrav of real space lattice: " << symm.ilattname << std::endl;
+            GlobalV::ofs_running << "ibrav of reciprocal lattice: " << bbrav_name << std::endl;
+            GlobalV::ofs_running << "(which should be " << ibrav_a2b[symm.real_brav - 1] << ")." << std::endl;
+            match = false;
             return;
+        }
+        if (this->is_mp)
+        {
+            symm.lattice_type(gk1, gk2, gk3, gk01, gk02, gk03, bk_const, bk0_const, bkbrav, bkbrav_name, ucell.atoms, false, nullptr);
+            GlobalV::ofs_running << "(for k-lattice: )" << std::endl;
+            ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "BRAVAIS TYPE", bkbrav);
+            ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "BRAVAIS LATTICE NAME", bkbrav_name);
+            ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "ibrav", bkbrav);
+        }
+        // point-group analysis of reciprocal lattice
+        ModuleBase::Matrix3 bsymop[48];
+        int bnop = 0;
+        // search again
+        symm.lattice_type(gb1, gb2, gb3, gb1, gb2, gb3, b_const, b0_const, bbrav, bbrav_name, ucell.atoms, false, nullptr);
+        ModuleBase::Matrix3 b_optlat_new(gb1.x, gb1.y, gb1.z, gb2.x, gb2.y, gb2.z, gb3.x, gb3.y, gb3.z);
+        symm.setgroup(bsymop, bnop, bbrav);
+        symm.gmatrix_convert(bsymop, bsymop, bnop, b_optlat_new, ucell.G);
+        
+        //check if all the kgmatrix are in bsymop
+        auto matequal = [&symm] (ModuleBase::Matrix3 a, ModuleBase::Matrix3 b)
+        {
+            return (symm.equal(a.e11, b.e11) && symm.equal(a.e12, b.e12) && symm.equal(a.e13, b.e13) &&
+            symm.equal(a.e21, b.e21) && symm.equal(a.e22, b.e22) && symm.equal(a.e23, b.e23) &&
+            symm.equal(a.e31, b.e31) && symm.equal(a.e32, b.e32) && symm.equal(a.e33, b.e33));
+        };
+        for(int i=0;i<symm.nrotk;++i)
+        {
+            match = false;
+            for(int j=0;j<bnop;++j) 
+            {
+                if (matequal(symm.kgmatrix[i], bsymop[j])) {match=true; break;}
+            }
+            if (!match) return;
         }
         nrotkm = symm.nrotk;// change if inv not included
         for (int i = 0; i < nrotkm; ++i)
@@ -745,7 +824,7 @@ void K_Vectors::ibz_kpoint(const ModuleSymmetry::Symmetry &symm, bool use_symm,s
     ss << table << std::endl;
     skpt = ss.str();
 	ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "nkstot_ibz", nkstot_ibz);
-
+    
     table.clear();
     table += "K-POINTS REDUCTION ACCORDING TO SYMMETRY\n";
     table += FmtCore::format("%8s%12s%12s%12s%8s%8s\n",

--- a/source/module_cell/klist.cpp
+++ b/source/module_cell/klist.cpp
@@ -343,82 +343,14 @@ bool K_Vectors::read_kpoints(const std::string &fn)
         }
 		else if (kword == "Line_Cartesian" )
 		{
-			//std::cout << " kword = " << kword << std::endl;
 			if(ModuleSymmetry::Symmetry::symm_flag == 1)
 			{
 				ModuleBase::WARNING("K_Vectors::read_kpoints","Line mode of k-points is open, please set symmetry to 0 or -1.");
 				return 0;
 			}
 
+            Linely_add_k_between(ifk, kvec_c);
 
-			// how many special points.
-			int nks_special = this->nkstot;
-			//std::cout << " nks_special = " << nks_special << std::endl;
-
-			//------------------------------------------
-			// number of points to the next k points
-			//------------------------------------------
-			std::vector<int> nkl(nks_special,0);
-
-			//------------------------------------------
-			// cartesian coordinates of special points.
-			//------------------------------------------
-			std::vector<double> ksx(nks_special);
-			std::vector<double> ksy(nks_special);
-			std::vector<double> ksz(nks_special);
-
-			//recalculate nkstot.
-			nkstot = 0;
-            /* ISSUE#3482: to distinguish different kline segments */
-            std::vector<int> kpt_segids;
-            kl_segids.clear(); kl_segids.shrink_to_fit();
-            int kpt_segid = 0;
-			for(int iks=0; iks<nks_special; iks++)
-			{
-				ifk >> ksx[iks];
-				ifk >> ksy[iks];
-				ifk >> ksz[iks];
-				ModuleBase::GlobalFunc::READ_VALUE( ifk, nkl[iks] );
-				//std::cout << " nkl[" << iks << "]=" << nkl[iks] << std::endl;
-				assert(nkl[iks] >= 0);
-				nkstot += nkl[iks];
-                /* ISSUE#3482: to distinguish different kline segments */
-                if((nkl[iks] == 1)&&(iks!=(nks_special-1))) kpt_segid++;
-                kpt_segids.push_back(kpt_segid);
-			}
-			assert( nkl[nks_special-1] == 1);
-
-			//std::cout << " nkstot = " << nkstot << std::endl;
-        	this->renew(nkstot * nspin);//mohan fix bug 2009-09-01
-
-			int count = 0;
-			for(int iks=1; iks<nks_special; iks++)
-			{
-				double dx = (ksx[iks] - ksx[iks-1]) / nkl[iks-1];
-				double dy = (ksy[iks] - ksy[iks-1]) / nkl[iks-1];
-				double dz = (ksz[iks] - ksz[iks-1]) / nkl[iks-1];
-//				GlobalV::ofs_running << " dx=" << dx << " dy=" << dy << " dz=" << dz << std::endl;
-				for(int is=0; is<nkl[iks-1]; is++)
-				{
-					kvec_c[count].x = ksx[iks-1] + is*dx;
-					kvec_c[count].y = ksy[iks-1] + is*dy;
-					kvec_c[count].z = ksz[iks-1] + is*dz;
-                    kl_segids.push_back(kpt_segids[iks-1]); /* ISSUE#3482: to distinguish different kline segments */
-					++count;
-				}
-			}
-
-			// deal with the last special k point.
-			kvec_c[count].x = ksx[nks_special-1];
-			kvec_c[count].y = ksy[nks_special-1];
-			kvec_c[count].z = ksz[nks_special-1];
-            kl_segids.push_back(kpt_segids[nks_special-1]); /* ISSUE#3482: to distinguish different kline segments */
-			++count;
-
-			//std::cout << " count = " << count << std::endl;
-			assert(count == nkstot);
-            assert(kl_segids.size() == nkstot); /* ISSUE#3482: to distinguish different kline segments */
-			
             std::for_each(wk.begin(), wk.end(), [](double& d){d = 1.0;});
 
             this->kc_done = true;
@@ -427,81 +359,13 @@ bool K_Vectors::read_kpoints(const std::string &fn)
 
 		else if (kword == "Line_Direct" || kword == "L" || kword == "Line" )
 		{
-			//std::cout << " kword = " << kword << std::endl;
 			if(ModuleSymmetry::Symmetry::symm_flag == 1)
 			{
 				ModuleBase::WARNING("K_Vectors::read_kpoints","Line mode of k-points is open, please set symmetry to 0 or -1.");
 				return 0;
 			}
 
-
-			// how many special points.
-			int nks_special = this->nkstot;
-			//std::cout << " nks_special = " << nks_special << std::endl;
-
-			//------------------------------------------
-			// number of points to the next k points
-			//------------------------------------------
-			std::vector<int> nkl(nks_special,0);
-
-			//------------------------------------------
-			// cartesian coordinates of special points.
-			//------------------------------------------
-			std::vector<double> ksx(nks_special);
-			std::vector<double> ksy(nks_special);
-			std::vector<double> ksz(nks_special);
-
-			//recalculate nkstot.
-			nkstot = 0;
-            /* ISSUE#3482: to distinguish different kline segments */
-            std::vector<int> kpt_segids;
-            kl_segids.clear(); kl_segids.shrink_to_fit();
-            int kpt_segid = 0;
-			for(int iks=0; iks<nks_special; iks++)
-			{
-				ifk >> ksx[iks];
-				ifk >> ksy[iks];
-				ifk >> ksz[iks];
-				ModuleBase::GlobalFunc::READ_VALUE( ifk, nkl[iks] ); /* so ifk is ifstream for kpoint, then nkl is number of kpoints on line */
-				//std::cout << " nkl[" << iks << "]=" << nkl[iks] << std::endl;
-				assert(nkl[iks] >= 0);
-				nkstot += nkl[iks];
-                /* ISSUE#3482: to distinguish different kline segments */
-                if((nkl[iks] == 1)&&(iks!=(nks_special-1))) kpt_segid++;
-                kpt_segids.push_back(kpt_segid);
-			}
-			assert( nkl[nks_special-1] == 1);
-
-			//std::cout << " nkstot = " << nkstot << std::endl;
-        	this->renew(nkstot * nspin);//mohan fix bug 2009-09-01
-
-			int count = 0;
-			for(int iks=1; iks<nks_special; iks++)
-			{
-				double dx = (ksx[iks] - ksx[iks-1]) / nkl[iks-1];
-				double dy = (ksy[iks] - ksy[iks-1]) / nkl[iks-1];
-				double dz = (ksz[iks] - ksz[iks-1]) / nkl[iks-1];
-//				GlobalV::ofs_running << " dx=" << dx << " dy=" << dy << " dz=" << dz << std::endl;
-				for(int is=0; is<nkl[iks-1]; is++)
-				{
-					kvec_d[count].x = ksx[iks-1] + is*dx;
-					kvec_d[count].y = ksy[iks-1] + is*dy;
-					kvec_d[count].z = ksz[iks-1] + is*dz;
-                    kl_segids.push_back(kpt_segids[iks-1]); /* ISSUE#3482: to distinguish different kline segments */
-					++count;
-				}
-			}
-
-			// deal with the last special k point.
-			kvec_d[count].x = ksx[nks_special-1];
-			kvec_d[count].y = ksy[nks_special-1];
-			kvec_d[count].z = ksz[nks_special-1];
-            kl_segids.push_back(kpt_segids[nks_special-1]); /* ISSUE#3482: to distinguish different kline segments */
-			++count;
-
-			//std::cout << " count = " << count << std::endl;
-			assert(count == nkstot );
-            assert(kl_segids.size() == nkstot); /* ISSUE#3482: to distinguish different kline segments */
+            Linely_add_k_between(ifk, kvec_d);
 
 			std::for_each(wk.begin(), wk.end(), [](double& d){d = 1.0;});
 
@@ -521,6 +385,68 @@ bool K_Vectors::read_kpoints(const std::string &fn)
     return 1;
 } // END SUBROUTINE
 
+void K_Vectors::Linely_add_k_between(std::ifstream& ifk,
+                                        std::vector<ModuleBase::Vector3<double>>& kvec) {
+    // how many special points.
+    int nks_special = this->nkstot;
+
+    // number of points to the next k points
+    std::vector<int> nkl(nks_special,0);
+
+    // coordinates of special points.
+    std::vector<ModuleBase::Vector3<double>> ks(nks_special);
+
+    //recalculate nkstot.
+    nkstot = 0;
+    /* ISSUE#3482: to distinguish different kline segments */
+    std::vector<int> kpt_segids;
+    kl_segids.clear(); kl_segids.shrink_to_fit();
+    int kpt_segid = 0;
+    for(int iks=0; iks<nks_special; iks++)
+    {
+        ifk >> ks[iks].x;
+        ifk >> ks[iks].y;
+        ifk >> ks[iks].z;
+        ModuleBase::GlobalFunc::READ_VALUE( ifk, nkl[iks] );
+
+        assert(nkl[iks] >= 0);
+        nkstot += nkl[iks];
+        /* ISSUE#3482: to distinguish different kline segments */
+        if((nkl[iks] == 1)&&(iks!=(nks_special-1))) kpt_segid++;
+        kpt_segids.push_back(kpt_segid);
+    }
+    assert( nkl[nks_special-1] == 1);
+
+    //std::cout << " nkstot = " << nkstot << std::endl;
+    this->renew(nkstot * nspin);//mohan fix bug 2009-09-01
+
+    int count = 0;
+    for(int iks=1; iks<nks_special; iks++)
+    {
+        double dxs = (ks[iks].x - ks[iks-1].x) / nkl[iks-1];
+        double dys = (ks[iks].y - ks[iks-1].y) / nkl[iks-1];
+        double dzs = (ks[iks].z - ks[iks-1].z) / nkl[iks-1];
+        for(int is=0; is<nkl[iks-1]; is++)
+        {
+            kvec[count].x = ks[iks-1].x + is*dxs;
+            kvec[count].y = ks[iks-1].y + is*dys;
+            kvec[count].z = ks[iks-1].z + is*dzs;
+            kl_segids.push_back(kpt_segids[iks-1]); /* ISSUE#3482: to distinguish different kline segments */
+            ++count;
+        }
+    }
+
+    // deal with the last special k point.
+    kvec[count].x = ks[nks_special-1].x;
+    kvec[count].y = ks[nks_special-1].y;
+    kvec[count].z = ks[nks_special-1].z;
+    kl_segids.push_back(kpt_segids[nks_special-1]); /* ISSUE#3482: to distinguish different kline segments */
+    ++count;
+
+    assert(count == nkstot);
+    assert(kl_segids.size() == nkstot); /* ISSUE#3482: to distinguish different kline segments */
+
+}
 
 double K_Vectors::Monkhorst_Pack_formula( const int &k_type, const double &offset,
                                       const int& n, const int &dim)

--- a/source/module_cell/klist.h
+++ b/source/module_cell/klist.h
@@ -63,6 +63,7 @@ private:
 
     // step 1 : generate kpoints
     bool read_kpoints(const std::string &fn); // return 0: something wrong.
+    void auto_gen_gamma_KPT(const std::string &fn, const int& nk1, const int& nk2, const int& nk3);
     void Linely_add_k_between(std::ifstream& ifk, std::vector<ModuleBase::Vector3<double>>& kvec);
     void Monkhorst_Pack(const int *nmp_in,const double *koffset_in,const int tipo);
     double Monkhorst_Pack_formula( const int &k_type, const double &offset,
@@ -70,6 +71,7 @@ private:
 
     // step 2 : set both kvec and kved; normalize weight
     void update_use_ibz( void );
+    bool check_symmetry(const ModuleSymmetry::Symmetry &symm, const UnitCell &ucell, bool& match, ModuleBase::Matrix3& gk);
     void set_both_kvec(const ModuleBase::Matrix3 &G,const ModuleBase::Matrix3 &R, std::string& skpt);
     void normalize_wk( const int &degspin );
 

--- a/source/module_cell/klist.h
+++ b/source/module_cell/klist.h
@@ -44,8 +44,6 @@ public:
     void ibz_kpoint(const ModuleSymmetry::Symmetry &symm, bool use_symm,std::string& skpt, const UnitCell &ucell, bool& match);
     //LiuXh add 20180515
     void set_after_vc(
-            const ModuleSymmetry::Symmetry &symm,
-            const std::string &k_file_name,
             const int& nspin,
             const ModuleBase::Matrix3 &reciprocal_vec,
             const ModuleBase::Matrix3 &latvec);
@@ -85,11 +83,6 @@ private:
     // step 5
     // print k lists.
     void print_klists(std::ofstream &fn);
-    //bool read_kpoints_after_vc(const std::string &fn); //LiuXh add 20180515
-    //void Monkhorst_Pack_after_vc(const int *nmp_in,const double *koffset_in,const int tipo); //LiuXh add 20180515
-    void mpi_k_after_vc(); //LiuXh add 20180515 //Useless now, it should be removed after several versions' testing.
-    void set_both_kvec_after_vc(const ModuleBase::Matrix3 &G,const ModuleBase::Matrix3 &R); //Useless now, it should be removed after several versions' testing.
-    void set_kup_and_kdw_after_vc();
 };
 
 inline int K_Vectors:: getik_global(const int& ik) const

--- a/source/module_cell/klist.h
+++ b/source/module_cell/klist.h
@@ -63,6 +63,7 @@ private:
 
     // step 1 : generate kpoints
     bool read_kpoints(const std::string &fn); // return 0: something wrong.
+    void Linely_add_k_between(std::ifstream& ifk, std::vector<ModuleBase::Vector3<double>>& kvec);
     void Monkhorst_Pack(const int *nmp_in,const double *koffset_in,const int tipo);
     double Monkhorst_Pack_formula( const int &k_type, const double &offset,
                                    const int& n, const int &dim);

--- a/source/module_cell/klist.h
+++ b/source/module_cell/klist.h
@@ -21,7 +21,7 @@ public:
 
     std::vector<int> ngk;						// ngk, number of plane waves for each k point
     std::vector<int> isk;						// distinguish spin up and down k points
-    std::vector<int> ibz2bz;					// mohan added 2009-05-18
+
 
     int nks;						// number of k points in this pool(processor, up+dw)
     int nkstot;						/// total number of k points, equal to nkstot_ibz after reducing k points
@@ -58,6 +58,8 @@ private:
     std::string k_kword; //LiuXh add 20180619
     int k_nkstot; //LiuXh add 20180619
     bool is_mp = false; //Monkhorst-Pack
+
+    std::vector<int> ibz2bz;					// mohan added 2009-05-18
     
     void renew( const int &kpoint_number );
 

--- a/source/module_cell/parallel_kpoints.h
+++ b/source/module_cell/parallel_kpoints.h
@@ -25,6 +25,7 @@ class Parallel_Kpoints
                          const ModuleBase::realArray& b,
                          const int& ik);
     void pool_collection(std::complex<double>* value, const ModuleBase::ComplexArray& w, const int& ik);
+    template <class T, class V> void pool_collection_aux(T *value, const V &w, const int& dim, const int &ik);
 #ifdef __MPI
     /**
      * @brief gather kpoints from all processors

--- a/source/module_cell/test/klist_test.cpp
+++ b/source/module_cell/test/klist_test.cpp
@@ -79,15 +79,9 @@ namespace GlobalC
  *   - set_kup_and_kdw()
  *     - SetKupKdown: set basic kpoints info: kvec_c, kvec_d, wk, isk, nks, nkstot
  *       according to different spin case
- *   - set_kup_and_kdw_after_vc()
- *     - SetKupKdownAfterVC: set basic kpoints info: kvec_c, kvec_d, wk, isk, nks, nkstot
- *       according to different spin case after variable-cell optimization
  *   - set_both_kvec()
  *     - SetBothKvec: set kvec_c (cartesian coor.) and kvec_d (direct coor.)
  *     - SetBothKvecFinalSCF: same as above, with GlobalV::FINAL_SCF=1
- *   - set_both_kvec_after_vc()
- *     - SetBothKvecAfterVC: set kvec_c (cartesian coor.) and kvec_d (direct coor.)
- *       after variable-cell relaxation
  *   - print_klists()
  *     - PrintKlists: print kpoints coordinates
  *     - PrintKlistsWarningQuit: for nkstot < nks error
@@ -549,37 +543,8 @@ TEST_F(KlistTest, SetKupKdown)
 	}
 }
 
-TEST_F(KlistTest, SetKupKdownAfterVC)
-{
-	std::string k_file = "./support/KPT4";
-	kv->nspin = 1;
-	kv->read_kpoints(k_file);
-	kv->set_kup_and_kdw_after_vc();
-	for (int ik=0;ik<5;ik++)
-	{
-		EXPECT_EQ(kv->isk[ik],0);
-	}
-	kv->nspin = 4;
-	kv->read_kpoints(k_file);
-	kv->set_kup_and_kdw_after_vc();
-	for (int ik=0;ik<5;ik++)
-	{
-		EXPECT_EQ(kv->isk[ik],0);
-		EXPECT_EQ(kv->isk[ik+5],0);
-		EXPECT_EQ(kv->isk[ik+10],0);
-		EXPECT_EQ(kv->isk[ik+15],0);
-	}
-	kv->nspin = 2;
-	kv->read_kpoints(k_file);
-	kv->set_kup_and_kdw_after_vc();
-	for (int ik=0;ik<5;ik++)
-	{
-		EXPECT_EQ(kv->isk[ik],0);
-		EXPECT_EQ(kv->isk[ik+5],1);
-	}
-}
 
-TEST_F(KlistTest, SetBothKvecAfterVC)
+TEST_F(KlistTest, SetAfterVC)
 {
 	kv->nspin = 1;
 	kv->nkstot = 1;
@@ -588,7 +553,7 @@ TEST_F(KlistTest, SetBothKvecAfterVC)
 	kv->kvec_c[0].x = 0;
 	kv->kvec_c[0].y = 0;
 	kv->kvec_c[0].z = 0;
-	kv->set_both_kvec_after_vc(GlobalC::ucell.G,GlobalC::ucell.latvec);
+	kv->set_after_vc(GlobalV::NSPIN, GlobalC::ucell.G,GlobalC::ucell.latvec);
 	EXPECT_TRUE(kv->kd_done);
 	EXPECT_TRUE(kv->kc_done);
 	EXPECT_DOUBLE_EQ(kv->kvec_d[0].x,0);
@@ -608,7 +573,7 @@ TEST_F(KlistTest, PrintKlists)
 	kv->kvec_c[0].x = 0;
 	kv->kvec_c[0].y = 0;
 	kv->kvec_c[0].z = 0;
-	kv->set_both_kvec_after_vc(GlobalC::ucell.G,GlobalC::ucell.latvec);
+	kv->set_after_vc(GlobalV::NSPIN, GlobalC::ucell.G,GlobalC::ucell.latvec);
 	EXPECT_TRUE(kv->kd_done);
 	kv->print_klists(GlobalV::ofs_running);
 	GlobalV::ofs_running.close();

--- a/source/module_cell/test/klist_test_para.cpp
+++ b/source/module_cell/test/klist_test_para.cpp
@@ -232,7 +232,7 @@ TEST_F(KlistParaTest,SetAfterVC)
 	}
 	//call set_after_vc here
 	kv->kc_done = 0;
-	kv->set_after_vc(symm,k_file,kv->nspin,GlobalC::ucell.G,GlobalC::ucell.latvec);
+	kv->set_after_vc(kv->nspin,GlobalC::ucell.G,GlobalC::ucell.latvec);
 	EXPECT_TRUE(kv->kc_done);
 	EXPECT_TRUE(kv->kd_done);
 	//clear

--- a/source/module_esolver/esolver_fp.cpp
+++ b/source/module_esolver/esolver_fp.cpp
@@ -166,7 +166,7 @@ void ESolver_FP::init_after_vc(Input& inp, UnitCell& cell)
 		ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running, "SYMMETRY");
 	}
 
-	kv.set_after_vc(cell.symm, GlobalV::global_kpoint_card, GlobalV::NSPIN, cell.G, cell.latvec);
+	kv.set_after_vc(GlobalV::NSPIN, cell.G, cell.latvec);
 	ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running, "INIT K-POINTS");
 
     return;


### PR DESCRIPTION
It's part of the final class project.

### What's changed?

1. Remove func `set_both_kvec_after_vc` for it do the same as `set_after_vc`
2. Remove two useless  parameters in func `set_after_vc`
3. Remove func `K_Vectors::mpi_k_after_vc` for it do the same as `mpi_k`
4. Remove func `set_kup_and_kdw_after_vc` for it's useless now
5. Add a function `Linely_add_k_between` to make the func `read_kpoints` more readable
6. Add a func `pool_collection_aux` to deal with the repeat of `pool_collection`
7. add `auto_gen_KPT` and `check symmetry` to make code readable
8. fix a small miswritten of `e32` in `auto matequal`
9. change `ibz2bz` to private