### PR TITLE
Remove redundant function and modify comments in the PW module

### DIFF
--- a/source/module_basis/module_pw/pw_basis.h
+++ b/source/module_basis/module_pw/pw_basis.h
@@ -15,9 +15,9 @@ namespace ModulePW
 {
 
 /**
- * @brief A class which can convert a function of "r" to the corresponding linear 
+ * @brief A class which can convert a function of "r" to the corresponding linear
  * superposition of plane waves (real space to reciprocal space)
- * or convert a linear superposition of plane waves to the function 
+ * or convert a linear superposition of plane waves to the function
  * of "r" (reciprocal to real).
  * @author qianrui, Sunliang on 2021-10-15
  * @details
@@ -25,13 +25,13 @@ namespace ModulePW
  * plane waves: <r|g>=1/sqrt(V) * exp(igr)
  * f(r) = 1/sqrt(V) * \sum_g{c(g)*exp(igr)}
  * c(g) = \int f(r)*exp(-igr) dr
- * USAGE: 
+ * USAGE:
  * ModulePW::PW_Basis pwtest;
  * 0. init mpi for PW_Basis
  * pwtest.inimpi(nproc_in_pool,rank_in_pool,POOL_WORLD);
  * 1. setup FFT grids for PW_Basis
  * pwtest.initgrids(lat0,latvec,gridecut);
- * pwtest.initgrids(lat0,latvec,N1,N2,N3); 
+ * pwtest.initgrids(lat0,latvec,N1,N2,N3);
  * //double lat0: unit length, (unit: bohr)
  * //ModuleBase::Matrix3 latvec: lattice vector, (unit: lat0), e.g. ModuleBase::Matrix3 latvec(1, 1, 0, 0, 2, 0, 0, 0, 2);
  * //double gridecut: cutoff energy to generate FFT grids, (unit: Ry)
@@ -42,13 +42,13 @@ namespace ModulePW
  * //double ggecut: cutoff kinetic energy for planewaves,(unit in Ry) G^2 < ggecut
  * //int dividemthd: method to divide planewaves to different cores
  * 3. Setup transforms from real space to reciprocal space or from reciprocal space to real space.
- * pwtest.setuptransform(); 
+ * pwtest.setuptransform();
  * pwtest.recip2real(rhog,rhor); //rhog to rhor
  * pwtest.real2recip(rhor,rhog); //rhor to rhog
  * 4. Generate the wave vector for planewaves
- * pwtest.collect_local_pw(); 
+ * pwtest.collect_local_pw();
  * //then we can use pwtest.gg, pwtest.gdirect, pwtest.gcar, (unit in lat0^-1 or lat0^-2)
- * 
+ *
  */
 class PW_Basis
 {
@@ -70,7 +70,7 @@ public:
     //Init the grids for FFT
     virtual void initgrids(
         const double lat0_in, //unit length (unit in bohr)
-        const ModuleBase::Matrix3 latvec_in, // Unitcell lattice vectors (unit in lat0) 
+        const ModuleBase::Matrix3 latvec_in, // Unitcell lattice vectors (unit in lat0)
         const double gridecut //unit in Ry, ecut to set up grids
     );
     //Init the grids for FFT
@@ -100,7 +100,7 @@ public:
 #ifdef __MPI
     MPI_Comm pool_world;
 #endif
-    
+
     int *ig2isz=nullptr; // map ig to (is, iz).
     int *istot2ixy=nullptr; // istot2ixy[is]: iy + ix * ny of is^th stick among all sticks.
     int *is2fftixy=nullptr, * d_is2fftixy = nullptr; // is2fftixy[is]: iy + ix * ny of is^th stick among sticks on current proc.
@@ -115,9 +115,9 @@ public:
 
     //real space
     int nrxx=0; //num. of real space grids
-    int *startz=nullptr; //startz[ip]: starting z plane in the ip-th proc. in current POOL_WORLD 
+    int *startz=nullptr; //startz[ip]: starting z plane in the ip-th proc. in current POOL_WORLD
 	int *numz=nullptr; //numz[ip]: num. of z planes in the ip-th proc. in current POOL_WORLD
-    int *numg=nullptr; //numg[ip] :  nst_per[poolrank] * numz[ip] 
+    int *numg=nullptr; //numg[ip] :  nst_per[poolrank] * numz[ip]
     int *numr=nullptr; //numr[ip] :  numz[poolrank] * nst_per[ip]
     int *startg=nullptr;  // startg[ip] = numg[ip-1] + startg[ip-1]
     int *startr=nullptr;  // startr[ip] = numr[ip-1] + startr[ip-1]
@@ -157,7 +157,7 @@ public:
     double *gg_uniq=nullptr; //[ngg] modulus (G^2) of G vectors of igg, each gg of igg is unique.
     //collect gg_uniq
     void collect_uniqgg();
-   
+
 
 public:
   bool gamma_only = false; ///< only half g are used.
@@ -182,7 +182,7 @@ public:
 protected:
     //distribute plane waves to different processors
     //method 1: first consider number of plane waves
-    void distribution_method1(); 
+    void distribution_method1();
     // Distribute sticks to cores in method 1.
     void divide_sticks_1(
         int* st_i,          // x or x + fftnx (if x < 0) of stick.
@@ -194,7 +194,7 @@ protected:
     void distribution_method2();
     // Distribute sticks to cores in method 2.
     void divide_sticks_2();
-   
+
     //Count the total number of planewaves (tot_npw) and sticks (this->nstot) (in distributeg method1 and method2)
     void count_pw_st(
         int* st_length2D, // the number of planewaves that belong to the stick located on (x, y).

--- a/source/module_basis/module_pw/pw_distributeg.cpp
+++ b/source/module_basis/module_pw/pw_distributeg.cpp
@@ -5,11 +5,11 @@
 
 namespace ModulePW
 {
-/// 
-/// distribute plane waves to different cores
-/// Known: G, GT, GGT, fftnx, fftny, nz, poolnproc, poolrank, ggecut
-/// output: ig2isz[ig], istot2ixy[is], is2fftixy[is], fftixy2ip[ixy], gg[ig], gcar[ig], gdirect[ig], nst, nstot
-/// 
+/**
+ * @brief distribute plane waves to different cores
+ * @param in: G, GT, GGT, fftnx, fftny, nz, poolnproc, poolrank, ggecut
+ * @param out: ig2isz[ig], istot2ixy[is], is2fftixy[is], fftixy2ip[ixy], gg[ig], gcar[ig], gdirect[ig], nst, nstot
+ */
 void PW_Basis::distribute_g()
 {
     ModuleBase::timer::tick(this->classname, "distributeg");
@@ -30,13 +30,16 @@ void PW_Basis::distribute_g()
     return;
 }
 
-///
-/// (1) We count the total number of planewaves (tot_npw) and sticks (this->nstot) here.
-/// Meanwhile, we record the number of planewaves on (x, y) in st_length2D, and store the smallest z-coordinate of each stick in st_bottom2D,
-/// so that we can scan a much smaller area in step(2).
-/// known: fftnx, fftny, nz, ggecut, GGT
-/// output: tot_npw, this->nstot, st_length2D, st_bottom2D, this->riy, this->liy
-///
+/**
+ * @brief (1) We count the total number of planewaves (tot_npw) and sticks (this->nstot) here.
+ *
+ *  Meanwhile, we record the number of planewaves on (x, y) in st_length2D, and store the smallest z-coordinate of each stick in st_bottom2D,
+ *  so that we can scan a much smaller area in step(2).
+ *
+ * @param in: fftnx, fftny, nz, ggecut, GGT
+ * @param out: tot_npw, this->nstot, st_length2D, st_bottom2D, this->riy, this->liy
+ */
+
 void PW_Basis::count_pw_st(
         int* st_length2D, // the number of planewaves that belong to the stick located on (x, y).
         int* st_bottom2D  // the z-coordinate of the bottom of stick on (x, y).
@@ -48,10 +51,10 @@ void PW_Basis::count_pw_st(
 
     // determine the scaning area along x-direct, if gamma-only && xprime, only positive axis is used.
     int ix_end = int(this->nx / 2) + 1;
-    int ix_start = -ix_end; 
+    int ix_start = -ix_end;
     // determine the scaning area along y-direct, if gamma-only && !xprime, only positive axis is used.
     int iy_end = int(this->ny / 2) + 1;
-    int iy_start = -iy_end; 
+    int iy_start = -iy_end;
 
     int iz_end = int(this->nz / 2) + 1;
     int iz_start = -iz_end;
@@ -59,10 +62,10 @@ void PW_Basis::count_pw_st(
     if (this->full_pw)
     {
         ix_end = int(this->nx / 2);
-        ix_start = ix_end - this->nx + 1; 
+        ix_start = ix_end - this->nx + 1;
 
         iy_end = int(this->ny / 2);
-        iy_start = iy_end - this->ny + 1; 
+        iy_start = iy_end - this->ny + 1;
 
         iz_end = int(this->nz / 2);
         iz_start = iz_end - this->nz + 1;
@@ -131,14 +134,17 @@ void PW_Basis::count_pw_st(
     return;
 }
 
-///
-/// (5) Construct ig2isz, and is2fftixy.
-/// is2fftixy contains the x-coordinate and y-coordinate of sticks on current core.
-/// ig2isz contains the z-coordinate of planewaves on current core.
-/// We will scan all the sticks and find the planewaves on them, then store the information into ig2isz and is2fftixy.
-/// known: this->nstot, st_bottom2D, st_length2D
-/// output: ig2isz, is2fftixy
-/// 
+/**
+ * @brief (5) Construct ig2isz, and is2fftixy.
+ *
+ *  is2fftixy contains the x-coordinate and y-coordinate of sticks on current core.
+ *  ig2isz contains the z-coordinate of planewaves on current core.
+ *  We will scan all the sticks and find the planewaves on them, then store the information into ig2isz and is2fftixy.
+ *
+ * @param in: this->nstot, st_bottom2D, st_length2D
+ * @param out: ig2isz, is2fftixy
+ */
+
 void PW_Basis::get_ig2isz_is2fftixy(
     int* st_bottom2D,     // minimum z of stick, stored in 1d array with this->nstot elements.
     int* st_length2D     // the stick on (x, y) consists of st_length[x*fftny+y] planewaves.
@@ -160,7 +166,7 @@ void PW_Basis::get_ig2isz_is2fftixy(
     delete[] this->ig2isz; this->ig2isz = new int[this->npw]; // map ig to the z coordinate of this planewave.
     ModuleBase::GlobalFunc::ZEROS(this->ig2isz, this->npw);
     delete[] this->is2fftixy; this->is2fftixy = new int[this->nst]; // map is (index of sticks) to ixy (iy + ix * fftny).
-    for (int is = 0; is < this->nst; ++is) 
+    for (int is = 0; is < this->nst; ++is)
     {
         this->is2fftixy[is] = -1;
     }

--- a/source/module_basis/module_pw/pw_distributer.cpp
+++ b/source/module_basis/module_pw/pw_distributer.cpp
@@ -3,11 +3,11 @@
 
 namespace ModulePW
 {
-/// 
-/// distribute real-space grids to different processors
-/// Known: nx, ny, nz, poolnproc, poolrank
-/// output: nrxx, startz, numz
-/// 
+/**
+ * @brief distribute real-space grids to different processors
+ * @param in: nx, ny, nz, poolnproc, poolrank
+ * @param out: nrxx, startz, numz
+ */
 void PW_Basis::distribute_r()
 {
     delete[] this->numz; this->numz = new int[this->poolnproc];
@@ -23,7 +23,7 @@ void PW_Basis::distribute_r()
         this->numz[ip] = npz;
         if(ip < modz)   this->numz[ip]++;
         if(ip < this->poolnproc - 1)   this->startz[ip+1] = this->startz[ip] + numz[ip];
-        if(ip == this->poolrank) 
+        if(ip == this->poolrank)
         {
             this->nplane = numz[ip];
             this->startz_current = startz[ip];


### PR DESCRIPTION
1.We remove redunant function.

The class “big” is temporary and ensures that the dimensions of the FFT can be evenly divided by bx, by, and bz. This is a requirement due to the current lattice integrals. In reality, lattice integrals can be done without this requirement, and in that case, this temporary class can be directly removed.

_________________________________________________________________________
2.We modify the comment to doxygen format