### PR TITLE
Memory: reduce memory allocation for hpsi and spsi in diagH_subspace_init func

### DIFF
--- a/source/module_hsolver/diago_iter_assist.cpp
+++ b/source/module_hsolver/diago_iter_assist.cpp
@@ -52,57 +52,43 @@ void DiagoIterAssist<T, Device>::diagH_subspace(
     // qianrui improve this part 2021-3-14
     const T* ppsi = psi.get_pointer();
 
-    // hphi and sphi share the temp space
-    T* temp = nullptr;
-    resmem_complex_op()(ctx, temp, psi.get_nbasis(), "DiagSub::hpsi");
-    setmem_complex_op()(ctx, temp, 0, psi.get_nbasis());
+    // allocated hpsi
+    // std::vector<T> hpsi(psi.get_nbands() * psi.get_nbasis());
+    T* hphi = nullptr;
+    resmem_complex_op()(ctx, hphi, psi.get_nbands() * psi.get_nbasis(), "DiagSub::hpsi");
+    setmem_complex_op()(ctx, hphi, 0, psi.get_nbands() * psi.get_nbasis());
+    // do hPsi for all bands
+    psi::Range all_bands_range(1, psi.get_current_k(), 0, psi.get_nbands()-1);
+    hpsi_info hpsi_in(&psi, all_bands_range, hphi);
+    pHamilt->ops->hPsi(hpsi_in);
 
-    T* hphi = temp;
-    // do hPsi band by band
-    for (int i = 0; i < psi.get_nbands(); i++)
-    {
-        psi::Range band_by_band_range(1, psi.get_current_k(), i, i);
-        hpsi_info hpsi_in(&psi, band_by_band_range, hphi);
-        pHamilt->ops->hPsi(hpsi_in);
+    gemm_op<T, Device>()(
+        ctx,
+        'C',
+        'N',
+        nstart,
+        nstart,
+        dmin,
+        &one,
+        ppsi,
+        dmax,
+        hphi,
+        dmax,
+        &zero,
+        hcc,
+        nstart
+    );
+    delmem_complex_op()(ctx, hphi);
 
-        gemv_op<T, Device>()(
-            ctx,
-            'C',
-            dmax,
-            nstart,
-            &one,
-            ppsi,
-            dmax,
-            hphi,
-            1,
-            &zero,
-            hcc + i * nstart,
-            1
-        );
-    }
+    // allocated spsi
+    T* sphi = nullptr;
+    resmem_complex_op()(ctx, sphi, nstart * dmax, "DiagSub::spsi");
+    setmem_complex_op()(ctx, sphi, 0, nstart * dmax);
+    // do sPsi for all bands
+    pHamilt->sPsi(ppsi, sphi, dmax, dmin, nstart);
 
-    T* sphi = temp;
-    // do sPsi band by band
-    for(int i = 0; i < nstart; i++)
-    {
-        pHamilt->sPsi(ppsi+i*dmax, sphi, dmax, dmin, 1);
-        
-        gemv_op<T, Device>()(
-              ctx,
-              'C',
-              dmax,  
-              nstart,  
-              &one,
-              ppsi,
-              dmax,  // nbasis
-              sphi,
-              1,
-              &zero,
-              scc + i*nstart,
-              1
-            );
-    }
-    delmem_complex_op()(ctx, temp);
+    gemm_op<T, Device>()(ctx, 'C', 'N', nstart, nstart, dmin, &one, ppsi, dmax, sphi, dmax, &zero, scc, nstart);
+    delmem_complex_op()(ctx, sphi);
 
     if (GlobalV::NPROC_IN_POOL > 1)
     {

--- a/source/module_hsolver/diago_iter_assist.cpp
+++ b/source/module_hsolver/diago_iter_assist.cpp
@@ -52,43 +52,57 @@ void DiagoIterAssist<T, Device>::diagH_subspace(
     // qianrui improve this part 2021-3-14
     const T* ppsi = psi.get_pointer();
 
-    // allocated hpsi
-    // std::vector<T> hpsi(psi.get_nbands() * psi.get_nbasis());
-    T* hphi = nullptr;
-    resmem_complex_op()(ctx, hphi, psi.get_nbands() * psi.get_nbasis(), "DiagSub::hpsi");
-    setmem_complex_op()(ctx, hphi, 0, psi.get_nbands() * psi.get_nbasis());
-    // do hPsi for all bands
-    psi::Range all_bands_range(1, psi.get_current_k(), 0, psi.get_nbands()-1);
-    hpsi_info hpsi_in(&psi, all_bands_range, hphi);
-    pHamilt->ops->hPsi(hpsi_in);
+    // hphi and sphi share the temp space
+    T* temp = nullptr;
+    resmem_complex_op()(ctx, temp, psi.get_nbasis(), "DiagSub::hpsi");
+    setmem_complex_op()(ctx, temp, 0, psi.get_nbasis());
 
-    gemm_op<T, Device>()(
-        ctx,
-        'C',
-        'N',
-        nstart,
-        nstart,
-        dmin,
-        &one,
-        ppsi,
-        dmax,
-        hphi,
-        dmax,
-        &zero,
-        hcc,
-        nstart
-    );
-    delmem_complex_op()(ctx, hphi);
+    T* hphi = temp;
+    // do hPsi band by band
+    for (int i = 0; i < psi.get_nbands(); i++)
+    {
+        psi::Range band_by_band_range(1, psi.get_current_k(), i, i);
+        hpsi_info hpsi_in(&psi, band_by_band_range, hphi);
+        pHamilt->ops->hPsi(hpsi_in);
 
-    // allocated spsi
-    T* sphi = nullptr;
-    resmem_complex_op()(ctx, sphi, nstart * dmax, "DiagSub::spsi");
-    setmem_complex_op()(ctx, sphi, 0, nstart * dmax);
-    // do sPsi for all bands
-    pHamilt->sPsi(ppsi, sphi, dmax, dmin, nstart);
+        gemv_op<T, Device>()(
+            ctx,
+            'C',
+            dmax,
+            nstart,
+            &one,
+            ppsi,
+            dmax,
+            hphi,
+            1,
+            &zero,
+            hcc + i * nstart,
+            1
+        );
+    }
 
-    gemm_op<T, Device>()(ctx, 'C', 'N', nstart, nstart, dmin, &one, ppsi, dmax, sphi, dmax, &zero, scc, nstart);
-    delmem_complex_op()(ctx, sphi);
+    T* sphi = temp;
+    // do sPsi band by band
+    for(int i = 0; i < nstart; i++)
+    {
+        pHamilt->sPsi(ppsi+i*dmax, sphi, dmax, dmin, 1);
+        
+        gemv_op<T, Device>()(
+              ctx,
+              'C',
+              dmax,  
+              nstart,  
+              &one,
+              ppsi,
+              dmax,  // nbasis
+              sphi,
+              1,
+              &zero,
+              scc + i*nstart,
+              1
+            );
+    }
+    delmem_complex_op()(ctx, temp);
 
     if (GlobalV::NPROC_IN_POOL > 1)
     {
@@ -232,25 +246,24 @@ void DiagoIterAssist<T, Device>::diagH_subspace_init(
 
     const T *ppsi = psi_temp.get_pointer();
 
-    // allocated hpsi
-    T* hpsi = nullptr;
-    resmem_complex_op()(ctx, hpsi, psi_temp.get_nbands() * psi_temp.get_nbasis(), "DiagSub::hpsi");
-    setmem_complex_op()(ctx, hpsi, 0, psi_temp.get_nbands() * psi_temp.get_nbasis());
-    // ================================================
-    // std::vector<T> hpsi(psi_temp.get_nbands() * psi_temp.get_nbasis());
+    // hpsi and spsi share the temp space
+    T* temp = nullptr;
+    resmem_complex_op()(ctx, temp, psi_temp.get_nbasis(), "DiagSub::hpsi");
+    setmem_complex_op()(ctx, temp, 0,  psi_temp.get_nbasis());
 
-    // do hPsi for all bands
+    T* hpsi = temp;
+    // do hPsi for band by band
     if (base_device::get_device_type(ctx) == base_device::GpuDevice)
     {
         for (int i = 0; i < psi_temp.get_nbands(); i++)
         {
             psi::Range band_by_band_range(1, psi_temp.get_current_k(), i, i);
-            hpsi_info hpsi_in(&psi_temp, band_by_band_range, hpsi + i * psi_temp.get_nbasis());
+            hpsi_info hpsi_in(&psi_temp, band_by_band_range, hpsi);
             if(pHamilt->ops == nullptr)
             {
                 ModuleBase::WARNING("DiagoIterAssist::diagH_subspace_init",
                 "Severe warning: Operators in Hamilt are not allocated yet, will return value of psi to evc directly\n");
-                for(int iband = 0; iband < evc.get_nbands(); iband++)
+                for (int iband = 0; iband < evc.get_nbands(); iband++)
                 {
                     for(int ig = 0; ig < evc.get_nbasis(); ig++)
                     {
@@ -261,56 +274,84 @@ void DiagoIterAssist<T, Device>::diagH_subspace_init(
                 return;
             }
             pHamilt->ops->hPsi(hpsi_in);
+
+            gemv_op<T, Device>()(
+                ctx,
+                'C',
+                dmax,  
+                nstart,  
+                &one,
+                ppsi,
+                dmax,  
+                hpsi,
+                1,
+                &zero,
+                hcc + i*nstart,
+                1
+            );
         }
     }
     else if (base_device::get_device_type(ctx) == base_device::CpuDevice)
     {
-        psi::Range all_bands_range(1, psi_temp.get_current_k(), 0, psi_temp.get_nbands()-1);
-        hpsi_info hpsi_in(&psi_temp, all_bands_range, hpsi);
-        if(pHamilt->ops == nullptr)
+        for (int i = 0; i < psi_temp.get_nbands(); i++)
         {
-            ModuleBase::WARNING("DiagoIterAssist::diagH_subspace_init",
-            "Severe warning: Operators in Hamilt are not allocated yet, will return value of psi to evc directly\n");
-            for(int iband = 0; iband < evc.get_nbands(); iband++)
+            psi::Range band_by_band_range(1, psi_temp.get_current_k(), i, i);
+            hpsi_info hpsi_in(&psi_temp, band_by_band_range, hpsi);
+            if (pHamilt->ops == nullptr)
             {
-                for(int ig = 0; ig < evc.get_nbasis(); ig++)
+                ModuleBase::WARNING("DiagoIterAssist::diagH_subspace_init",
+                "Severe warning: Operators in Hamilt are not allocated yet, will return value of psi to evc directly\n");
+                for (int iband = 0; iband < evc.get_nbands(); iband++)
                 {
-                    evc(iband, ig) = psi[iband * evc.get_nbasis() + ig];
+                    for (int ig = 0; ig < evc.get_nbasis(); ig++)
+                    {
+                        evc(iband, ig) = psi[iband * evc.get_nbasis() + ig];
+                    }
+                    en[iband] = 0.0;
                 }
-                en[iband] = 0.0;
+                return;
             }
-            return;
+            pHamilt->ops->hPsi(hpsi_in);
+
+            gemv_op<T, Device>()(
+                ctx,
+                'C',
+                dmax,  
+                nstart,  
+                &one,
+                ppsi,
+                dmax,  
+                hpsi,
+                1,
+                &zero,
+                hcc + i*nstart,
+                1
+            );
         }
-        pHamilt->ops->hPsi(hpsi_in);
     }
 
-    gemm_op<T, Device>()(
-        ctx,
-        'C',
-        'N',
-        nstart,
-        nstart,
-        dmin,
-        &one,
-        ppsi,
-        dmax,
-        hpsi,
-        dmax,
-        &zero,
-        hcc,
-        nstart
-    );
-    delmem_complex_op()(ctx, hpsi);
+    T* spsi = temp;
+    // do sPsi band for band
+    for(int i = 0; i < psi_temp.get_nbands(); i++){
+        pHamilt->sPsi(ppsi+i*psi_temp.get_nbasis(), spsi, psi_temp.get_nbasis(), psi_temp.get_current_nbas(), 1);
+        
+        gemv_op<T, Device>()(
+                ctx,
+                'C',
+                dmax,  
+                nstart,  
+                &one,
+                ppsi,
+                dmax,  // nbasis
+                spsi,
+                1,
+                &zero,
+                scc + i*nstart,
+                1
+            );
+    }
 
-    // allocated spsi
-    T* spsi = nullptr;
-    resmem_complex_op()(ctx, spsi, psi_temp.get_nbands() * psi_temp.get_nbasis(), "DiagSub::spsi");
-    setmem_complex_op()(ctx, spsi, 0, psi_temp.get_nbands() * psi_temp.get_nbasis());
-    // do sPsi for all bands
-    pHamilt->sPsi(ppsi, spsi, psi_temp.get_nbasis(), psi_temp.get_current_nbas(), psi_temp.get_nbands());
-
-    gemm_op<T, Device>()(ctx, 'C', 'N', nstart, nstart, dmin, &one, ppsi, dmax, spsi, dmax, &zero, scc, nstart);
-    delmem_complex_op()(ctx, spsi);
+    delmem_complex_op()(ctx, temp);
 
     if (GlobalV::NPROC_IN_POOL > 1)
     {

--- a/source/module_hsolver/diago_iter_assist.cpp
+++ b/source/module_hsolver/diago_iter_assist.cpp
@@ -52,94 +52,57 @@ void DiagoIterAssist<T, Device>::diagH_subspace(
     // qianrui improve this part 2021-3-14
     const T* ppsi = psi.get_pointer();
 
-    // // hphi and sphi share the temp space
-    // T* temp = nullptr;
-    // resmem_complex_op()(ctx, temp, psi.get_nbasis(), "DiagSub::hpsi");
-    // setmem_complex_op()(ctx, temp, 0, psi.get_nbasis());
+    // hphi and sphi share the temp space
+    T* temp = nullptr;
+    resmem_complex_op()(ctx, temp, psi.get_nbasis(), "DiagSub::temp");
+    setmem_complex_op()(ctx, temp, 0, psi.get_nbasis());
 
-    // T* hphi = temp;
-    // // do hPsi band by band
-    // for (int i = 0; i < psi.get_nbands(); i++)
-    // {
-    //     psi::Range band_by_band_range(1, psi.get_current_k(), i, i);
-    //     hpsi_info hpsi_in(&psi, band_by_band_range, hphi);
-    //     pHamilt->ops->hPsi(hpsi_in);
+    T* hphi = temp;
+    // do hPsi band by band
+    for (int i = 0; i < psi.get_nbands(); i++)
+    {
+        psi::Range band_by_band_range(1, psi.get_current_k(), i, i);
+        hpsi_info hpsi_in(&psi, band_by_band_range, hphi);
+        pHamilt->ops->hPsi(hpsi_in);
 
-    //     gemv_op<T, Device>()(
-    //         ctx,
-    //         'C',
-    //         dmax,
-    //         nstart,
-    //         &one,
-    //         ppsi,
-    //         dmax,
-    //         hphi,
-    //         1,
-    //         &zero,
-    //         hcc + i * nstart,
-    //         1
-    //     );
-    // }
+        gemv_op<T, Device>()(
+            ctx,
+            'C',
+            dmax,
+            nstart,
+            &one,
+            ppsi,
+            dmax,
+            hphi,
+            1,
+            &zero,
+            hcc + i * nstart,
+            1
+        );
+    }
 
-    // T* sphi = temp;
-    // // do sPsi band by band
-    // for(int i = 0; i < nstart; i++)
-    // {
-    //     pHamilt->sPsi(ppsi+i*dmax, sphi, dmax, dmin, 1);
+    T* sphi = temp;
+    // do sPsi band by band
+    for(int i = 0; i < nstart; i++)
+    {
+        pHamilt->sPsi(ppsi+i*dmax, sphi, dmax, dmin, 1);
         
-    //     gemv_op<T, Device>()(
-    //           ctx,
-    //           'C',
-    //           dmax,  
-    //           nstart,  
-    //           &one,
-    //           ppsi,
-    //           dmax,  // nbasis
-    //           sphi,
-    //           1,
-    //           &zero,
-    //           scc + i*nstart,
-    //           1
-    //         );
-    // }
-    // delmem_complex_op()(ctx, temp);
-    // allocated hpsi
-    // std::vector<T> hpsi(psi.get_nbands() * psi.get_nbasis());
-    T* hphi = nullptr;
-    resmem_complex_op()(ctx, hphi, psi.get_nbands() * psi.get_nbasis(), "DiagSub::hpsi");
-    setmem_complex_op()(ctx, hphi, 0, psi.get_nbands() * psi.get_nbasis());
-    // do hPsi for all bands
-    psi::Range all_bands_range(1, psi.get_current_k(), 0, psi.get_nbands()-1);
-    hpsi_info hpsi_in(&psi, all_bands_range, hphi);
-    pHamilt->ops->hPsi(hpsi_in);
-
-    gemm_op<T, Device>()(
-        ctx,
-        'C',
-        'N',
-        nstart,
-        nstart,
-        dmin,
-        &one,
-        ppsi,
-        dmax,
-        hphi,
-        dmax,
-        &zero,
-        hcc,
-        nstart
-    );
-    delmem_complex_op()(ctx, hphi);
-
-    // allocated spsi
-    T* sphi = nullptr;
-    resmem_complex_op()(ctx, sphi, nstart * dmax, "DiagSub::spsi");
-    setmem_complex_op()(ctx, sphi, 0, nstart * dmax);
-    // do sPsi for all bands
-    pHamilt->sPsi(ppsi, sphi, dmax, dmin, nstart);
-
-    gemm_op<T, Device>()(ctx, 'C', 'N', nstart, nstart, dmin, &one, ppsi, dmax, sphi, dmax, &zero, scc, nstart);
-    delmem_complex_op()(ctx, sphi);
+        gemv_op<T, Device>()(
+              ctx,
+              'C',
+              dmax,  
+              nstart,  
+              &one,
+              ppsi,
+              dmax,  // nbasis
+              sphi,
+              1,
+              &zero,
+              scc + i*nstart,
+              1
+            );
+    }
+    delmem_complex_op()(ctx, temp);
 
     if (GlobalV::NPROC_IN_POOL > 1)
     {
@@ -283,24 +246,22 @@ void DiagoIterAssist<T, Device>::diagH_subspace_init(
 
     const T *ppsi = psi_temp.get_pointer();
 
-    // allocated hpsi
-    T* hpsi = nullptr;
-    resmem_complex_op()(ctx, hpsi, psi_temp.get_nbands() * psi_temp.get_nbasis(), "DiagSub::hpsi");
-    setmem_complex_op()(ctx, hpsi, 0, psi_temp.get_nbands() * psi_temp.get_nbasis());
-    // ================================================
-    // std::vector<T> hpsi(psi_temp.get_nbands() * psi_temp.get_nbasis());
+    // hpsi and spsi share the temp space
+    T* temp = nullptr;
+    resmem_complex_op()(ctx, temp, psi_temp.get_nbasis(), "DiagSub_init::temp");
+    setmem_complex_op()(ctx, temp, 0,  psi_temp.get_nbasis());
 
+    T* hpsi = temp;
     // do hPsi for band by band
-  
     for (int i = 0; i < psi_temp.get_nbands(); i++)
     {
         psi::Range band_by_band_range(1, psi_temp.get_current_k(), i, i);
-        hpsi_info hpsi_in(&psi_temp, band_by_band_range, hpsi + i * psi_temp.get_nbasis());
+        hpsi_info hpsi_in(&psi_temp, band_by_band_range, hpsi);
         if(pHamilt->ops == nullptr)
         {
             ModuleBase::WARNING("DiagoIterAssist::diagH_subspace_init",
             "Severe warning: Operators in Hamilt are not allocated yet, will return value of psi to evc directly\n");
-            for(int iband = 0; iband < evc.get_nbands(); iband++)
+            for (int iband = 0; iband < evc.get_nbands(); iband++)
             {
                 for(int ig = 0; ig < evc.get_nbasis(); ig++)
                 {
@@ -311,101 +272,45 @@ void DiagoIterAssist<T, Device>::diagH_subspace_init(
             return;
         }
         pHamilt->ops->hPsi(hpsi_in);
+
+        gemv_op<T, Device>()(
+            ctx,
+            'C',
+            dmax,  
+            nstart,  
+            &one,
+            ppsi,
+            dmax,  
+            hpsi,
+            1,
+            &zero,
+            hcc + i*nstart,
+            1
+        );
     }
 
-    gemm_op<T, Device>()(
-        ctx,
-        'C',
-        'N',
-        nstart,
-        nstart,
-        dmin,
-        &one,
-        ppsi,
-        dmax,
-        hpsi,
-        dmax,
-        &zero,
-        hcc,
-        nstart
-    );
-    delmem_complex_op()(ctx, hpsi);
-
-    // allocated spsi
-    T* spsi = nullptr;
-    resmem_complex_op()(ctx, spsi, psi_temp.get_nbands() * psi_temp.get_nbasis(), "DiagSub::spsi");
-    setmem_complex_op()(ctx, spsi, 0, psi_temp.get_nbands() * psi_temp.get_nbasis());
-    // do sPsi for all bands
-    pHamilt->sPsi(ppsi, spsi, psi_temp.get_nbasis(), psi_temp.get_current_nbas(), psi_temp.get_nbands());
-
-    gemm_op<T, Device>()(ctx, 'C', 'N', nstart, nstart, dmin, &one, ppsi, dmax, spsi, dmax, &zero, scc, nstart);
-    delmem_complex_op()(ctx, spsi);
-
-    // hpsi and spsi share the temp space
-    // T* temp = nullptr;
-    // resmem_complex_op()(ctx, temp, psi_temp.get_nbasis(), "DiagSub::hpsi");
-    // setmem_complex_op()(ctx, temp, 0,  psi_temp.get_nbasis());
-
-    // T* hpsi = temp;
-    // // do hPsi for band by band
-    // for (int i = 0; i < psi_temp.get_nbands(); i++)
-    // {
-    //     psi::Range band_by_band_range(1, psi_temp.get_current_k(), i, i);
-    //     hpsi_info hpsi_in(&psi_temp, band_by_band_range, hpsi);
-    //     if(pHamilt->ops == nullptr)
-    //     {
-    //         ModuleBase::WARNING("DiagoIterAssist::diagH_subspace_init",
-    //         "Severe warning: Operators in Hamilt are not allocated yet, will return value of psi to evc directly\n");
-    //         for (int iband = 0; iband < evc.get_nbands(); iband++)
-    //         {
-    //             for(int ig = 0; ig < evc.get_nbasis(); ig++)
-    //             {
-    //                 evc(iband, ig) = psi[iband * evc.get_nbasis() + ig];
-    //             }
-    //             en[iband] = 0.0;
-    //         }
-    //         return;
-    //     }
-    //     pHamilt->ops->hPsi(hpsi_in);
-
-    //     gemv_op<T, Device>()(
-    //         ctx,
-    //         'C',
-    //         dmax,  
-    //         nstart,  
-    //         &one,
-    //         ppsi,
-    //         dmax,  
-    //         hpsi,
-    //         1,
-    //         &zero,
-    //         hcc + i*nstart,
-    //         1
-    //     );
-    // }
-
-    // T* spsi = temp;
-    // // do sPsi band for band
-    // for(int i = 0; i < psi_temp.get_nbands(); i++){
-    //     pHamilt->sPsi(ppsi+i*psi_temp.get_nbasis(), spsi, psi_temp.get_nbasis(), psi_temp.get_current_nbas(), 1);
+    T* spsi = temp;
+    // do sPsi band for band
+    for(int i = 0; i < psi_temp.get_nbands(); i++){
+        pHamilt->sPsi(ppsi+i*psi_temp.get_nbasis(), spsi, psi_temp.get_nbasis(), psi_temp.get_current_nbas(), 1);
         
-    //     gemv_op<T, Device>()(
-    //             ctx,
-    //             'C',
-    //             dmax,  
-    //             nstart,  
-    //             &one,
-    //             ppsi,
-    //             dmax,  // nbasis
-    //             spsi,
-    //             1,
-    //             &zero,
-    //             scc + i*nstart,
-    //             1
-    //         );
-    // }
+        gemv_op<T, Device>()(
+                ctx,
+                'C',
+                dmax,  
+                nstart,  
+                &one,
+                ppsi,
+                dmax,  // nbasis
+                spsi,
+                1,
+                &zero,
+                scc + i*nstart,
+                1
+            );
+    }
 
-    // delmem_complex_op()(ctx, temp);
+    delmem_complex_op()(ctx, temp);
 
     if (GlobalV::NPROC_IN_POOL > 1)
     {


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #4161 

### What's changed?
-  `diagH_subspace_init` func

    - In the original code, the memory size requested by `hpsi` and `spsi` is `psi_temp.get_nbands() * psi_temp.get_nbasis()` , and `nbasis * nbands` is processed at once (do hPsi for all bands).
    - The band by band mode can be used to reduce memory application ( using the idea of ​​matrix block division ) , only one band's data is calculated each time (do hPsi bang by band). In this way,`hpsi` and `spsi` both only needs to allocate `psi_temp.get_nbasis()`.
    - In addition, `hpsi` and `spsi` can share the same memory area (`temp`).

- `diagH_subspace` func

    - The idea adopted is consistent with `diagH_subspace_init` func. 

- `hpsi` and `spsi` originally totaled `psi_temp.get_nbands() * psi_temp.get_nbasis() * 2` , but after modification only `psi_temp.get_nbasis()` is needed
