### PR TITLE
Test: install ccache to reduce compilation time of GPU version ABACUS on testing machine

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -16,12 +16,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Install Ccache
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ccache
+
       - name: Build
         run: |
           nvidia-smi
           cmake -B build -DUSE_CUDA=ON -DBUILD_TESTING=ON
           cmake --build build -j4
           cmake --install build
+
       - name: Test
         run: |
           cd tests/integrate


### PR DESCRIPTION
### What's changed?
- add ccache installation step to cuda.yml

