### PR TITLE
Memory: reduce memory allocation for hpsi and spsi in diagH_subspace_init func (GPU)

### DIFF
--- a/source/module_hsolver/diago_iter_assist.cpp
+++ b/source/module_hsolver/diago_iter_assist.cpp
@@ -56,7 +56,6 @@ void DiagoIterAssist<T, Device>::diagH_subspace(
 
     if (base_device::get_device_type(ctx) == base_device::GpuDevice)
     {
-        std::cout << "11111 " << std::endl;
         // hphi and sphi share the temp space
         T* temp = nullptr;
         resmem_complex_op()(ctx, temp, psi.get_nbasis(), "DiagSub::temp");


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #4161

### What's changed?
- `diagH_subspace_init` func
    - In the original code, the memory size requested by `hpsi` and `spsi` is `psi_temp.get_nbands() * psi_temp.get_nbasis()` 
    - In the computing part of the GPU, `hPsi()` only calculates the data of one band at a time (do hPsi band by band). We can also change the calculation of `sPsi()` to band by band mode, and change the matrix multiplication to block calculation using `gemv` method.
    - Therefore, both `hpsi` and `spsi` only need to be allocated `psi_temp.get_nbasis()`.
    - In addition, `hpsi` and `spsi` can share the same memory area (`temp`).
- `diagH_subspace` func

    -   The idea adopted is consistent with `diagH_subspace_init` func.


- `hpsi` and `spsi` originally totaled `psi_temp.get_nbands() * psi_temp.get_nbasis() * 2` , but after modification only `psi_temp.get_nbasis()` is needed. (GPU)
