### PR TITLE
Refactor: removal of GlobalC::UOT

### DIFF
--- a/source/module_basis/module_ao/ORB_gen_tables.cpp
+++ b/source/module_basis/module_ao/ORB_gen_tables.cpp
@@ -6,11 +6,6 @@
 #include "module_base/math_integral.h"
 #include "module_base/constants.h"
 
-namespace GlobalC
-{
-///here is a member of ORB_gen_tables class
-ORB_gen_tables UOT;
-}
 
 ORB_gen_tables::ORB_gen_tables() {}
 ORB_gen_tables::~ORB_gen_tables() {}

--- a/source/module_basis/module_ao/ORB_gen_tables.cpp
+++ b/source/module_basis/module_ao/ORB_gen_tables.cpp
@@ -15,11 +15,6 @@ ORB_gen_tables UOT;
 ORB_gen_tables::ORB_gen_tables() {}
 ORB_gen_tables::~ORB_gen_tables() {}
 
-const ORB_gen_tables& ORB_gen_tables::get_const_instance()
-{
-	return GlobalC::UOT;
-}
-
 /// call in hamilt_linear::init_before_ions.
 void ORB_gen_tables::gen_tables(
 	std::ofstream &ofs_in,

--- a/source/module_basis/module_ao/ORB_gen_tables.h
+++ b/source/module_basis/module_ao/ORB_gen_tables.h
@@ -119,11 +119,4 @@ class ORB_gen_tables
 
 };
 
-/// PLEASE try to get rid of GlobalC::UOT, which is a global variable
-/// mohan add 2021-03-30
-namespace GlobalC
-{
-extern ORB_gen_tables UOT;
-}
-
 #endif

--- a/source/module_basis/module_ao/ORB_gen_tables.h
+++ b/source/module_basis/module_ao/ORB_gen_tables.h
@@ -25,9 +25,6 @@ class ORB_gen_tables
 	ORB_gen_tables();
 	~ORB_gen_tables();
 
-	// static function to get global instance
-	static const ORB_gen_tables& get_const_instance();
-
 	void gen_tables(
 		std::ofstream &ofs_in, // mohan add 2021-05-07
 		LCAO_Orbitals &orb,

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -387,6 +387,7 @@ void ESolver_KS_LCAO<TK, TR>::cal_force(ModuleBase::matrix& force)
             this->gen_h, // mohan add 2024-04-02
             this->GG, // mohan add 2024-04-01
             this->GK, // mohan add 2024-04-01
+            uot_,
 			force,
 			this->scs,
 			this->sf,

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -84,6 +84,7 @@ ESolver_KS_LCAO<TK, TR>::~ESolver_KS_LCAO()
 #ifndef USE_NEW_TWO_CENTER
 	this->orb_con.clear_after_ions(*uot_, GlobalC::ORB, GlobalV::deepks_setorb, GlobalC::ucell.infoNL.nproj);
 #endif
+    delete uot_;
 }
 
 
@@ -567,11 +568,11 @@ void ESolver_KS_LCAO<TK, TR>::init_basis_lcao(
     // * construct the interpolation tables.
 
 
-    // NOTE: This is a temporary step in the elimination of GlobalC::UOT.
-    // Once the direct usage of UOT via GlobalC is eliminated, this step
-    // uot_ will be replaced by a shared_ptr to ORB_gen_tables, which is
-    // the only owner of the UOT object.
-    uot_ = &GlobalC::UOT;
+    // NOTE: This following raw pointer serves as a temporary step in
+    // LCAO refactoring. Eventually, it will be replaced by a shared_ptr,
+    // which is the only owner of the ORB_gen_tables object. All other
+    // usages will take a weak_ptr.
+    uot_ = new ORB_gen_tables;
     auto& two_center_bundle = uot_->two_center_bundle;
 
     two_center_bundle.reset(new TwoCenterBundle);

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -1446,6 +1446,7 @@ ModuleIO::Output_Mat_Sparse<TK> ESolver_KS_LCAO<TK, TR>::create_Output_Mat_Spars
 			this->orb_con.ParaV,
             this->gen_h, // mohan add 2024-04-06
             this->GK, // mohan add 2024-04-01
+            uot_,
 			this->LM,
             GlobalC::GridD, // mohan add 2024-04-06
 			this->kv,

--- a/source/module_esolver/esolver_ks_lcao.h
+++ b/source/module_esolver/esolver_ks_lcao.h
@@ -88,7 +88,15 @@ namespace ModuleESolver
 
         Grid_Technique GridT;
 
-        std::unique_ptr<TwoCenterBundle> two_center_bundle;
+        // The following variable is introduced in the stage-1 of LCAO
+        // refactoring. It is supposed to replace the previous GlobalC::UOT.
+        //
+        // This is the only place supposed to have the ownership; all other
+        // places should be considered as "borrowing" the object. Unfortunately,
+        // imposing shared_ptr/weak_ptr is only possible once GlobalC::UOT is
+        // completely removed from the code; we have to rely on raw pointers
+        // during the transition period.
+        ORB_gen_tables* uot_;
 
         // Temporarily store the stress to unify the interface with PW,
         // because it's hard to seperate force and stress calculation in LCAO.

--- a/source/module_esolver/esolver_ks_lcao_elec.cpp
+++ b/source/module_esolver/esolver_ks_lcao_elec.cpp
@@ -148,6 +148,7 @@ void ESolver_KS_LCAO<TK, TR>::beforesolver(const int istep)
             &(this->LOC),
             this->pelec->pot,
             this->kv,
+            uot_,
 #ifdef __EXX
             DM,
             GlobalC::exx_info.info_ri.real_number ? &this->exd->two_level_step : &this->exc->two_level_step);
@@ -449,7 +450,7 @@ void ESolver_KS_LCAO<std::complex<double>, double>::get_S(void)
 
     if (this->p_hamilt == nullptr)
     {
-        this->p_hamilt = new hamilt::HamiltLCAO<std::complex<double>, double>(&this->LM, this->kv);
+        this->p_hamilt = new hamilt::HamiltLCAO<std::complex<double>, double>(&this->LM, this->kv, uot_);
         dynamic_cast<hamilt::OperatorLCAO<std::complex<double>, double>*>(this->p_hamilt->ops)->contributeHR();
     }
 
@@ -480,7 +481,7 @@ void ESolver_KS_LCAO<std::complex<double>, std::complex<double>>::get_S(void)
     this->LM.ParaV = &this->orb_con.ParaV;
     if (this->p_hamilt == nullptr)
     {
-        this->p_hamilt = new hamilt::HamiltLCAO<std::complex<double>, std::complex<double>>(&this->LM, this->kv);
+        this->p_hamilt = new hamilt::HamiltLCAO<std::complex<double>, std::complex<double>>(&this->LM, this->kv, uot_);
         dynamic_cast<hamilt::OperatorLCAO<std::complex<double>, std::complex<double>>*>(this->p_hamilt->ops)
             ->contributeHR();
     }

--- a/source/module_esolver/esolver_ks_lcao_elec.cpp
+++ b/source/module_esolver/esolver_ks_lcao_elec.cpp
@@ -165,11 +165,11 @@ void ESolver_KS_LCAO<TK, TR>::beforesolver(const int istep)
     {
         const Parallel_Orbitals* pv = this->LM.ParaV;
         // build and save <psi(0)|alpha(R)> at beginning
-        GlobalC::ld.build_psialpha(GlobalV::CAL_FORCE, GlobalC::ucell, GlobalC::ORB, GlobalC::GridD, GlobalC::UOT);
+        GlobalC::ld.build_psialpha(GlobalV::CAL_FORCE, GlobalC::ucell, GlobalC::ORB, GlobalC::GridD, *uot_);
 
         if (GlobalV::deepks_out_unittest)
         {
-            GlobalC::ld.check_psialpha(GlobalV::CAL_FORCE, GlobalC::ucell, GlobalC::ORB, GlobalC::GridD, GlobalC::UOT);
+            GlobalC::ld.check_psialpha(GlobalV::CAL_FORCE, GlobalC::ucell, GlobalC::ORB, GlobalC::GridD, *uot_);
         }
     }
 #endif

--- a/source/module_esolver/esolver_ks_lcao_tddft.cpp
+++ b/source/module_esolver/esolver_ks_lcao_tddft.cpp
@@ -437,6 +437,7 @@ void ESolver_KS_LCAO_TDDFT::after_scf(const int istep)
                                 this->psi,
                                 pelec,
                                 kv,
+                                uot_,
                                 tmp_DM->get_paraV_pointer(),
                                 this->RA,
                                 this->LM,     // mohan add 2024-04-02

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE.h
@@ -61,6 +61,7 @@ private:
 #endif
         LCAO_gen_fixedH& gen_h, // mohan add 2024-04-02
         typename TGint<T>::type& gint,
+        const ORB_gen_tables* uot,
         const Parallel_Orbitals& pv,
         LCAO_Matrix& lm,
         const K_Vectors* kv = nullptr,
@@ -71,6 +72,7 @@ private:
     void allocate(const Parallel_Orbitals& pv,
         LCAO_Matrix& lm,
         LCAO_gen_fixedH& gen_h,
+        const ORB_gen_tables* uot,
         const int& nks = 0,
         const std::vector<ModuleBase::Vector3<double>>& kvec_d = {});
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
@@ -37,6 +37,7 @@ void Force_Stress_LCAO<T>::getForceStress(const bool isforce,
                                           LCAO_gen_fixedH &gen_h, // mohan add 2024-04-02
 										  Gint_Gamma &gint_gamma, // mohan add 2024-04-01
 										  Gint_k &gint_k, // mohan add 2024-04-01
+                                          const ORB_gen_tables* uot,
 										  ModuleBase::matrix& fcs,
                                           ModuleBase::matrix& scs,
                                           const Structure_Factor& sf,
@@ -245,6 +246,7 @@ void Force_Stress_LCAO<T>::getForceStress(const bool isforce,
 					nullptr,
 					GlobalC::ucell,
 					&GlobalC::GridD,
+                    uot,
 					&GlobalC::dftu,
 					*(lm.ParaV));
             tmp_dftu.cal_force_stress(isforce, isstress, force_dftu, stress_dftu);

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
@@ -161,6 +161,7 @@ void Force_Stress_LCAO<T>::getForceStress(const bool isforce,
         gen_h, // mohan add 2024-04-02
         gint_gamma,
         gint_k,
+        uot,
         pv,
         lm,
         kv);
@@ -749,6 +750,7 @@ void Force_Stress_LCAO<double>::integral_part(
     LCAO_gen_fixedH &gen_h, // mohan add 2024-04-02
 	Gint_Gamma &gint_gamma, // mohan add 2024-04-01
 	Gint_k &gint_k, // mohan add 2024-04-01
+    const ORB_gen_tables* uot,
     const Parallel_Orbitals& pv,
     LCAO_Matrix &lm,
     const K_Vectors& kv)
@@ -771,6 +773,7 @@ void Force_Stress_LCAO<double>::integral_part(
 #endif
         gen_h,
         gint_gamma,
+        uot,
         pv,
         lm);
     return;
@@ -799,6 +802,7 @@ void Force_Stress_LCAO<std::complex<double>>::integral_part(
     LCAO_gen_fixedH &gen_h, // mohan add 2024-04-02
 	Gint_Gamma &gint_gamma,
 	Gint_k &gint_k,
+    const ORB_gen_tables* uot,
     const Parallel_Orbitals& pv,
 	LCAO_Matrix &lm,
 	const K_Vectors& kv)
@@ -820,6 +824,7 @@ void Force_Stress_LCAO<std::complex<double>>::integral_part(
 #endif
         gen_h,
         gint_k,
+        uot,
         pv,
         lm,
         & kv,

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
@@ -93,6 +93,7 @@ class Force_Stress_LCAO
         LCAO_gen_fixedH &gen_h, // mohan add 2024-04-02
 		Gint_Gamma &gint_gamma,
 		Gint_k &gint_k,
+        const ORB_gen_tables* uot,
 	    const Parallel_Orbitals &pv,
 		LCAO_Matrix &lm,
 		const K_Vectors& kv);

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
@@ -40,6 +40,7 @@ class Force_Stress_LCAO
         LCAO_gen_fixedH &gen_h, // mohan add 2024-04-02
 		Gint_Gamma &gint_gamma, // mohan add 2024-04-01
 		Gint_k &gint_k, // mohan add 2024-04-01
+        const ORB_gen_tables* uot,
         ModuleBase::matrix& fcs,
         ModuleBase::matrix& scs,
         const Structure_Factor& sf,

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_gamma.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_gamma.cpp
@@ -15,6 +15,7 @@ template<>
 void Force_LCAO<double>::allocate(const Parallel_Orbitals& pv,
     LCAO_Matrix& lm,
     LCAO_gen_fixedH& gen_h,
+    const ORB_gen_tables* uot,
     const int& nks,
     const std::vector<ModuleBase::Vector3<double>>& kvec_d)
 {
@@ -67,7 +68,7 @@ void Force_LCAO<double>::allocate(const Parallel_Orbitals& pv,
     }
     // calculate dS in LCAO basis
     // ModuleBase::timer::tick("Force_LCAO_gamma","build_S_new");
-    gen_h.build_ST_new('S', cal_deri, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD), lm.Sloc.data());
+    gen_h.build_ST_new('S', cal_deri, GlobalC::ucell, GlobalC::ORB, *uot, &(GlobalC::GridD), lm.Sloc.data());
     // ModuleBase::timer::tick("Force_LCAO_gamma","build_S_new");
 
     // calculate dT in LCAP
@@ -84,12 +85,12 @@ void Force_LCAO<double>::allocate(const Parallel_Orbitals& pv,
     // calculate dT
     // calculate T + VNL(P1) in LCAO basis
     // ModuleBase::timer::tick("Force_LCAO_gamma","build_T_new");
-    gen_h.build_ST_new('T', cal_deri, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD), lm.Hloc_fixed.data());
+    gen_h.build_ST_new('T', cal_deri, GlobalC::ucell, GlobalC::ORB, *uot, &(GlobalC::GridD), lm.Hloc_fixed.data());
     // ModuleBase::timer::tick("Force_LCAO_gamma","build_T_new");
     // test_gamma(lm.DHloc_fixed_x, "dHloc_fixed_x T part");
 
     // ModuleBase::timer::tick("Force_LCAO_gamma","build_Nonlocal_mu");
-    gen_h.build_Nonlocal_mu_new(lm.Hloc_fixed.data(), cal_deri, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD));
+    gen_h.build_Nonlocal_mu_new(lm.Hloc_fixed.data(), cal_deri, GlobalC::ucell, GlobalC::ORB, *uot, &(GlobalC::GridD));
     // ModuleBase::timer::tick("Force_LCAO_gamma","build_Nonlocal_mu");
     // test_gamma(lm.DHloc_fixed_x, "dHloc_fixed_x Vnl part");
 
@@ -100,7 +101,7 @@ void Force_LCAO<double>::allocate(const Parallel_Orbitals& pv,
 
         lm.zeros_HSgamma('S');
 
-        gen_h.build_ST_new('S', cal_deri, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD), lm.Sloc.data(), INPUT.cal_syns, INPUT.dmax);
+        gen_h.build_ST_new('S', cal_deri, GlobalC::ucell, GlobalC::ORB, *uot, &(GlobalC::GridD), lm.Sloc.data(), INPUT.cal_syns, INPUT.dmax);
 
         bool bit = false; // LiuXh, 2017-03-21
 
@@ -202,6 +203,7 @@ void Force_LCAO<double>::ftable(const bool isforce,
 #endif
     LCAO_gen_fixedH& gen_h, // mohan add 2024-04-02
     TGint<double>::type& gint,
+    const ORB_gen_tables* uot,
     const Parallel_Orbitals& pv,
     LCAO_Matrix& lm,
     const K_Vectors* kv,
@@ -219,7 +221,7 @@ void Force_LCAO<double>::ftable(const bool isforce,
 
     // allocate DSloc_x, DSloc_y, DSloc_z
     // allocate DHloc_fixed_x, DHloc_fixed_y, DHloc_fixed_z
-    this->allocate(pv, lm, gen_h);
+    this->allocate(pv, lm, gen_h, uot);
 
     // calculate the 'energy density matrix' here.
     this->cal_foverlap(isforce, isstress, psi, pv, pelec, lm, foverlap, soverlap);
@@ -229,7 +231,7 @@ void Force_LCAO<double>::ftable(const bool isforce,
 
     this->cal_ftvnl_dphi(DM, pv, GlobalC::ucell, lm, isforce, isstress, ftvnl_dphi, stvnl_dphi);
 
-    this->cal_fvnl_dbeta(DM, pv, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, GlobalC::GridD, isforce, isstress, fvnl_dbeta, svnl_dbeta);
+    this->cal_fvnl_dbeta(DM, pv, GlobalC::ucell, GlobalC::ORB, *uot, GlobalC::GridD, isforce, isstress, fvnl_dbeta, svnl_dbeta);
 
     this->cal_fvl_dphi(isforce, isstress, pelec->pot, gint, fvl_dphi, svl_dphi);
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_k.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_k.cpp
@@ -26,6 +26,7 @@ template<>
 void Force_LCAO<std::complex<double>>::allocate(const Parallel_Orbitals& pv,
     LCAO_Matrix& lm,
     LCAO_gen_fixedH& gen_h,
+    const ORB_gen_tables* uot,
     const int& nks,
     const std::vector<ModuleBase::Vector3<double>>& kvec_d)
 {
@@ -88,7 +89,7 @@ void Force_LCAO<std::complex<double>>::allocate(const Parallel_Orbitals& pv,
     // calculate dS = <phi | dphi>
     //-----------------------------
     bool cal_deri = true;
-    gen_h.build_ST_new('S', cal_deri, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD), gen_h.LM->SlocR.data());
+    gen_h.build_ST_new('S', cal_deri, GlobalC::ucell, GlobalC::ORB, *uot, &(GlobalC::GridD), gen_h.LM->SlocR.data());
 
     //-----------------------------------------
     // (2) allocate for <phi | T + Vnl | dphi>
@@ -111,10 +112,10 @@ void Force_LCAO<std::complex<double>>::allocate(const Parallel_Orbitals& pv,
 
     // calculate dT=<phi|kin|dphi> in LCAO
     // calculate T + VNL(P1) in LCAO basis
-    gen_h.build_ST_new('T', cal_deri, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD), gen_h.LM->Hloc_fixedR.data());
+    gen_h.build_ST_new('T', cal_deri, GlobalC::ucell, GlobalC::ORB, *uot, &(GlobalC::GridD), gen_h.LM->Hloc_fixedR.data());
 
     // calculate dVnl=<phi|dVnl|dphi> in LCAO
-    gen_h.build_Nonlocal_mu_new(gen_h.LM->Hloc_fixed.data(), cal_deri, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD));
+    gen_h.build_Nonlocal_mu_new(gen_h.LM->Hloc_fixed.data(), cal_deri, GlobalC::ucell, GlobalC::ORB, *uot, &(GlobalC::GridD));
 
     // calculate asynchronous S matrix to output for Hefei-NAMD
     if (INPUT.cal_syns)
@@ -126,7 +127,7 @@ void Force_LCAO<std::complex<double>>::allocate(const Parallel_Orbitals& pv,
 				cal_deri, 
 				GlobalC::ucell,
                 GlobalC::ORB,
-                GlobalC::UOT,
+                *uot,
                 &(GlobalC::GridD),
 				lm.SlocR.data(), 
 				INPUT.cal_syns, 
@@ -289,6 +290,7 @@ void Force_LCAO<std::complex<double>>::test(
 #endif
         LCAO_gen_fixedH& gen_h,
         TGint<std::complex<double>>::type& gint,
+        const ORB_gen_tables* uot,
         const Parallel_Orbitals& pv,
         LCAO_Matrix& lm,
         const K_Vectors* kv,
@@ -304,6 +306,7 @@ void Force_LCAO<std::complex<double>>::test(
             pv,
             lm,
             gen_h,
+            uot,
             kv->get_nks(),
             kv->kvec_d);
 
@@ -347,7 +350,7 @@ void Force_LCAO<std::complex<double>>::test(
             pv,
             GlobalC::ucell,
             GlobalC::ORB,
-            GlobalC::UOT,
+            *uot,
             GlobalC::GridD,
             isforce,
             isstress,

--- a/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_gen_fixedH.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_gen_fixedH.cpp
@@ -21,37 +21,37 @@ LCAO_gen_fixedH::LCAO_gen_fixedH()
 LCAO_gen_fixedH::~LCAO_gen_fixedH()
 {}
 
-void LCAO_gen_fixedH::calculate_NL_no(double* HlocR)
-{
-    ModuleBase::TITLE("LCAO_gen_fixedH","calculate_NL_no");
-	if(GlobalV::GAMMA_ONLY_LOCAL)
-	{
-	  	//for gamma only.
-		this->build_Nonlocal_beta_new(HlocR, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD));
-	}
-	else
-	{
-		this->build_Nonlocal_mu_new(HlocR, false, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD));
-	}
-
-    return;
-}
-
-void LCAO_gen_fixedH::calculate_T_no(double* HlocR)
-{
-    ModuleBase::TITLE("LCAO_gen_fixedH","calculate_T_no");
-    this->build_ST_new('T', false, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD), HlocR);
-    return;
-}
-
-void LCAO_gen_fixedH::calculate_S_no(double* SlocR)
-{
-    ModuleBase::TITLE("LCAO_gen_fixedH", "calculate_S_no");
-    ModuleBase::timer::tick("LCAO_gen_fixedH","calculate_S_no");
-	this->build_ST_new('S', false, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD), SlocR);
-    ModuleBase::timer::tick("LCAO_gen_fixedH","calculate_S_no");
-    return;
-}
+//void LCAO_gen_fixedH::calculate_NL_no(double* HlocR)
+//{
+//    ModuleBase::TITLE("LCAO_gen_fixedH","calculate_NL_no");
+//	if(GlobalV::GAMMA_ONLY_LOCAL)
+//	{
+//	  	//for gamma only.
+//		this->build_Nonlocal_beta_new(HlocR, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD));
+//	}
+//	else
+//	{
+//		this->build_Nonlocal_mu_new(HlocR, false, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD));
+//	}
+//
+//    return;
+//}
+//
+//void LCAO_gen_fixedH::calculate_T_no(double* HlocR)
+//{
+//    ModuleBase::TITLE("LCAO_gen_fixedH","calculate_T_no");
+//    this->build_ST_new('T', false, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD), HlocR);
+//    return;
+//}
+//
+//void LCAO_gen_fixedH::calculate_S_no(double* SlocR)
+//{
+//    ModuleBase::TITLE("LCAO_gen_fixedH", "calculate_S_no");
+//    ModuleBase::timer::tick("LCAO_gen_fixedH","calculate_S_no");
+//	this->build_ST_new('S', false, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD), SlocR);
+//    ModuleBase::timer::tick("LCAO_gen_fixedH","calculate_S_no");
+//    return;
+//}
 
 
 //liaochen modify interface 2010-3-22
@@ -157,7 +157,6 @@ void LCAO_gen_fixedH::build_ST_new(const char& dtype,
 
 							if(!calc_deri)
 							{
-								// PLEASE use UOT as an input parameter of this subroutine
 								// mohan add 2021-03-30
 #ifdef USE_NEW_TWO_CENTER
                                 //=================================================================

--- a/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_gen_fixedH.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_gen_fixedH.h
@@ -20,11 +20,11 @@ class LCAO_gen_fixedH
     LCAO_gen_fixedH();
     ~LCAO_gen_fixedH();
 
-    void calculate_NL_no(double* HlocR);
+    //void calculate_NL_no(double* HlocR);
     // void calculate_NL_no(std::complex<double>* HlocR);
-    void calculate_T_no(double* HlocR);
+    //void calculate_T_no(double* HlocR);
     // void calculate_T_no(std::complex<double>* HlocR);
-    void calculate_S_no(double* SlocR);
+    //void calculate_S_no(double* SlocR);
     // void calculate_S_no(std::complex<double>* SlocR);
     void build_ST_new(const char& dtype,
                       const bool& cal_deri,

--- a/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.cpp
@@ -36,7 +36,7 @@ namespace hamilt
 {
 
 template<typename TK, typename TR>
-HamiltLCAO<TK, TR>::HamiltLCAO(LCAO_Matrix* LM_in, const K_Vectors& kv_in)
+HamiltLCAO<TK, TR>::HamiltLCAO(LCAO_Matrix* LM_in, const K_Vectors& kv_in, const ORB_gen_tables* uot)
 {
     this->classname = "HamiltLCAO";
 
@@ -55,6 +55,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(LCAO_Matrix* LM_in, const K_Vectors& kv_in)
         &(this->getSk(LM_in)),
         &GlobalC::ucell,
         &GlobalC::GridD,
+        uot,
         LM_in->ParaV
     );
 }
@@ -68,6 +69,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(
     Local_Orbital_Charge* loc_in,
     elecstate::Potential* pot_in,
     const K_Vectors& kv_in,
+    const ORB_gen_tables* uot,
     elecstate::DensityMatrix<TK, double>* DM_in,
     int* exx_two_level_step)
 {
@@ -132,6 +134,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(
             &(this->getSk(LM_in)),
             &GlobalC::ucell,
             &GlobalC::GridD,
+            uot,
             LM_in->ParaV
         );
 
@@ -147,6 +150,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(
                 &(this->getHk(LM_in)),
                 &GlobalC::ucell, 
                 &GlobalC::GridD,
+                uot,
                 LM_in->ParaV
             );
             this->getOperator()->add(ekinetic);
@@ -163,6 +167,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(
                 &(this->getHk(LM_in)),
                 &GlobalC::ucell, 
                 &GlobalC::GridD,
+                uot,
                 LM_in->ParaV
             );
             this->getOperator()->add(nonlocal);
@@ -285,6 +290,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(
             &(this->getSk(LM_in)),
             &GlobalC::ucell,
             &GlobalC::GridD,
+            uot,
             LM_in->ParaV
         );
         if(this->getOperator() == nullptr)
@@ -307,6 +313,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(
                 &(this->getHk(LM_in)),
                 &GlobalC::ucell,
                 &GlobalC::GridD,
+                uot,
                 LM_in->ParaV
             );
             this->getOperator()->add(ekinetic);
@@ -323,6 +330,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(
                 &(this->getHk(LM_in)),
                 &GlobalC::ucell,
                 &GlobalC::GridD,
+                uot,
                 LM_in->ParaV
             );
             //TDDFT velocity gague will calculate full non-local potential including the original one and the correction on its own.

--- a/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.cpp
@@ -209,6 +209,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(
                                                                         &(this->getHk(LM_in)),
                                                                         &GlobalC::ucell,
                                                                         &GlobalC::GridD,
+                                                                        uot,
                                                                         this->kv->get_nks(),
                                                                         DM_in);
             this->getOperator()->add(deepks);
@@ -238,6 +239,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(
                     &(this->getHk(LM_in)),
                     GlobalC::ucell,
                     &GlobalC::GridD,
+                    uot,
                     &GlobalC::dftu,
                     *(LM_in->ParaV)
                 );
@@ -357,6 +359,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(
                                                     &(this->getHk(LM_in)),
                                                     &GlobalC::ucell,
                                                     &GlobalC::GridD,
+                                                    uot,
                                                     this->kv->get_nks(),
                                                     DM_in);
             this->getOperator()->add(deepks);
@@ -386,6 +389,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(
                     &(this->getHk(LM_in)),
                     &GlobalC::ucell, 
                     &GlobalC::GridD,
+                    uot,
                     LM_in->ParaV
                 );
             this->getOperator()->add(td_nonlocal);
@@ -412,6 +416,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(
                     &(this->getHk(LM_in)),
                     GlobalC::ucell,
                     &GlobalC::GridD,
+                    uot,
                     &GlobalC::dftu,
                     *(LM_in->ParaV)
                 );

--- a/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h
@@ -32,12 +32,13 @@ class HamiltLCAO : public Hamilt<TK>
         Local_Orbital_Charge* loc_in,
         elecstate::Potential* pot_in,
         const K_Vectors& kv_in,
+        const ORB_gen_tables* uot,
         elecstate::DensityMatrix<TK, double>* DM_in,
         int* exx_two_level_step = nullptr);
     /**
      * @brief Constructor of vacuum Operators, only HR and SR will be initialed as empty HContainer
     */
-    HamiltLCAO(LCAO_Matrix* LM_in, const K_Vectors& kv_in);
+    HamiltLCAO(LCAO_Matrix* LM_in, const K_Vectors& kv_in, const ORB_gen_tables* uot);
 
     ~HamiltLCAO()
     {

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.cpp
@@ -21,8 +21,9 @@ DeePKS<OperatorLCAO<TK, TR>>::DeePKS(Local_Orbital_Charge* loc_in,
     std::vector<TK>* hK_in,
     const UnitCell* ucell_in,
     Grid_Driver* GridD_in,
+    const ORB_gen_tables* uot,
     const int& nks_in,
-    elecstate::DensityMatrix<TK,double>* DM_in) : loc(loc_in), nks(nks_in), ucell(ucell_in), OperatorLCAO<TK, TR>(LM_in, kvec_d_in, hR_in, hK_in), DM(DM_in)
+    elecstate::DensityMatrix<TK,double>* DM_in) : loc(loc_in), nks(nks_in), ucell(ucell_in), OperatorLCAO<TK, TR>(LM_in, kvec_d_in, hR_in, hK_in), DM(DM_in), uot_(uot)
 {
     this->cal_type = lcao_deepks;
 #ifdef __DEEPKS
@@ -266,7 +267,6 @@ void hamilt::DeePKS<hamilt::OperatorLCAO<TK, TR>>::pre_calculate_nlm(const int i
         const ModuleBase::Vector3<double>& tau1 = adjs.adjacent_tau[ad];
         const Atom* atom1 = &ucell->atoms[T1];
 
-        const ORB_gen_tables& uot = ORB_gen_tables::get_const_instance();
         auto all_indexes = paraV->get_indexes_row(iat1);
         auto col_indexes = paraV->get_indexes_col(iat1);
         // insert col_indexes into all_indexes to get universal set with no repeat elements
@@ -293,10 +293,10 @@ void hamilt::DeePKS<hamilt::OperatorLCAO<TK, TR>>::pre_calculate_nlm(const int i
             int M1 = (m1 % 2 == 0) ? -m1/2 : (m1+1)/2;
 
             ModuleBase::Vector3<double> dtau = tau0 - tau1;
-            uot.two_center_bundle->overlap_orb_alpha->snap(
+            uot_->two_center_bundle->overlap_orb_alpha->snap(
                     T1, L1, N1, M1, 0, dtau * ucell->lat0, 0 /*calc_deri*/, nlm);
 #else
-            uot.snap_psialpha_half(
+            uot_->snap_psialpha_half(
                     orb,
                     nlm, 0, tau1, T1,
                     atom1->iw2l[ iw1 ], // L1

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.h
@@ -36,6 +36,7 @@ class DeePKS<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                             std::vector<TK>* hK_in,
                             const UnitCell* ucell_in,
                             Grid_Driver* GridD_in,
+                            const ORB_gen_tables* uot,
                             const int& nks_in,
                             elecstate::DensityMatrix<TK,double>* DM_in);
     ~DeePKS();
@@ -62,6 +63,10 @@ class DeePKS<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
     const UnitCell* ucell = nullptr;
 
     HContainer<TR>* H_V_delta = nullptr;
+
+    // the following variable is introduced temporarily during LCAO refactoring
+    const ORB_gen_tables* uot_ = nullptr;
+
 #ifdef __DEEPKS
 
     /**

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/dftu_force_stress.hpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/dftu_force_stress.hpp
@@ -60,7 +60,6 @@ void DFTU<OperatorLCAO<TK, TR>>::cal_force_stress(
             const ModuleBase::Vector3<double>& tau1 = adjs.adjacent_tau[ad];
             const Atom* atom1 = &ucell->atoms[T1];
 
-            const ORB_gen_tables& uot = ORB_gen_tables::get_const_instance();
             const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
             auto all_indexes = paraV->get_indexes_row(iat1);
             auto col_indexes = paraV->get_indexes_col(iat1);
@@ -88,7 +87,7 @@ void DFTU<OperatorLCAO<TK, TR>>::cal_force_stress(
                 int M1 = (m1 % 2 == 0) ? -m1/2 : (m1+1)/2;
 
                 ModuleBase::Vector3<double> dtau = tau0 - tau1;
-                uot.two_center_bundle->overlap_orb_onsite->snap(
+                uot_->two_center_bundle->overlap_orb_onsite->snap(
                         T1, L1, N1, M1, T0, dtau * this->ucell->lat0, 1 /*cal_deri*/, nlm);
 #else
                 ModuleBase::WARNING_QUIT("DFTU", "old two center integral method not implemented");

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/dftu_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/dftu_lcao.cpp
@@ -19,9 +19,10 @@ hamilt::DFTU<hamilt::OperatorLCAO<TK, TR>>::DFTU(
     std::vector<TK>* hK_in,
     const UnitCell& ucell_in,
     Grid_Driver* GridD_in,
+    const ORB_gen_tables* uot,
     ModuleDFTU::DFTU* dftu_in,
     const Parallel_Orbitals& paraV)
-    : hamilt::OperatorLCAO<TK, TR>(LM_in, kvec_d_in, hR_in, hK_in)
+    : hamilt::OperatorLCAO<TK, TR>(LM_in, kvec_d_in, hR_in, hK_in), uot_(uot)
 {
     this->cal_type = lcao_dftu;
     this->ucell = &ucell_in;
@@ -117,7 +118,6 @@ void hamilt::DFTU<hamilt::OperatorLCAO<TK, TR>>::cal_nlm_all(const Parallel_Orbi
             const ModuleBase::Vector3<double>& tau1 = adjs.adjacent_tau[ad];
             const Atom* atom1 = &ucell->atoms[T1];
 
-            const ORB_gen_tables& uot = ORB_gen_tables::get_const_instance();
             const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
             auto all_indexes = paraV->get_indexes_row(iat1);
             auto col_indexes = paraV->get_indexes_col(iat1);
@@ -147,7 +147,7 @@ void hamilt::DFTU<hamilt::OperatorLCAO<TK, TR>>::cal_nlm_all(const Parallel_Orbi
                 const int M1 = (m1 % 2 == 0) ? -m1/2 : (m1+1)/2;
 
                 ModuleBase::Vector3<double> dtau = tau0 - tau1;
-                uot.two_center_bundle->overlap_orb_onsite->snap(
+                uot_->two_center_bundle->overlap_orb_onsite->snap(
                         T1, L1, N1, M1, T0, dtau * this->ucell->lat0, 0 /*cal_deri*/, nlm);
                 // select the elements of nlm with target_L
                 for(int iw =0;iw < this->ucell->atoms[T0].nw; iw++)
@@ -172,7 +172,7 @@ void hamilt::DFTU<hamilt::OperatorLCAO<TK, TR>>::cal_nlm_all(const Parallel_Orbi
                     {
                         for(int m = 0; m < tlp1; m++)
                         {
-                            uot.snap_psipsi(orb, // orbitals
+                            uot_->snap_psipsi(orb, // orbitals
                                 olm,
                                 0,
                                 'S', // olm, job of derivation, dtype of Operator

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/dftu_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/dftu_lcao.h
@@ -10,6 +10,7 @@
 #include "module_elecstate/module_dm/density_matrix.h"
 #include "module_hamilt_lcao/module_dftu/dftu.h"
 #include "dftu.hpp"
+#include "module_basis/module_ao/ORB_gen_tables.h"
 
 namespace hamilt
 {
@@ -31,6 +32,7 @@ class DFTU<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                                       std::vector<TK>* hK_in,
                                       const UnitCell& ucell_in,
                                       Grid_Driver* gridD_in,
+                                      const ORB_gen_tables* uot,
                                       ModuleDFTU::DFTU* dftu_in,
                                       const Parallel_Orbitals& paraV);
     ~DFTU<OperatorLCAO<TK, TR>>();
@@ -56,6 +58,8 @@ class DFTU<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
     hamilt::HContainer<TR>* HR = nullptr;
 
     TK* HK_pointer = nullptr;
+
+    const ORB_gen_tables* uot_ = nullptr;
 
     /// @brief the number of spin components, 1 for no-spin, 2 for collinear spin case and 4 for non-collinear spin case
     int nspin = 0;

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/ekinetic_new.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/ekinetic_new.cpp
@@ -16,8 +16,9 @@ hamilt::EkineticNew<hamilt::OperatorLCAO<TK, TR>>::EkineticNew(
     std::vector<TK>* hK_in,
     const UnitCell* ucell_in,
     Grid_Driver* GridD_in,
+    const ORB_gen_tables* uot,
     const Parallel_Orbitals* paraV)
-    : hamilt::OperatorLCAO<TK, TR>(LM_in, kvec_d_in, hR_in, hK_in)
+    : hamilt::OperatorLCAO<TK, TR>(LM_in, kvec_d_in, hR_in, hK_in), uot_(uot)
 {
     this->cal_type = lcao_fixed;
     this->ucell = ucell_in;
@@ -144,7 +145,6 @@ void hamilt::EkineticNew<hamilt::OperatorLCAO<TK, TR>>::cal_HR_IJR(const int& ia
                                                                    const ModuleBase::Vector3<double>& dtau,
                                                                    TR* data_pointer)
 {
-    const ORB_gen_tables& uot = ORB_gen_tables::get_const_instance();
     const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
     // ---------------------------------------------
     // get info of orbitals of atom1 and atom2 from ucell
@@ -204,10 +204,10 @@ void hamilt::EkineticNew<hamilt::OperatorLCAO<TK, TR>>::cal_HR_IJR(const int& ia
             //=================================================================
             // convert m (0,1,...2l) to M (-l, -l+1, ..., l-1, l)
             int M2 = (m2 % 2 == 0) ? -m2/2 : (m2+1)/2;
-            uot.two_center_bundle->kinetic_orb->calculate(T1, L1, N1, M1,
+            uot_->two_center_bundle->kinetic_orb->calculate(T1, L1, N1, M1,
                     T2, L2, N2, M2, dtau * this->ucell->lat0, olm);
 #else
-            uot.snap_psipsi(orb, // orbitals
+            uot_->snap_psipsi(orb, // orbitals
                             olm,
                             0,
                             'T', // olm, job of derivation, dtype of Operator

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/ekinetic_new.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/ekinetic_new.h
@@ -5,6 +5,7 @@
 #include "module_cell/unitcell.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/operator_lcao.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
+#include "module_basis/module_ao/ORB_gen_tables.h"
 
 namespace hamilt
 {
@@ -44,6 +45,7 @@ class EkineticNew<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                                       std::vector<TK>* hK_in,
                                       const UnitCell* ucell_in,
                                       Grid_Driver* GridD_in,
+                                      const ORB_gen_tables* uot,
                                       const Parallel_Orbitals* paraV);
 
     /**
@@ -63,6 +65,9 @@ class EkineticNew<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
     const UnitCell* ucell = nullptr;
 
     hamilt::HContainer<TR>* HR_fixed = nullptr;
+
+    // the following variable is introduced temporarily during LCAO refactoring
+    const ORB_gen_tables* uot_ = nullptr;
 
     bool allocated = false;
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/nonlocal_new.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/nonlocal_new.cpp
@@ -18,8 +18,9 @@ hamilt::NonlocalNew<hamilt::OperatorLCAO<TK, TR>>::NonlocalNew(
     std::vector<TK>* hK_in,
     const UnitCell* ucell_in,
     Grid_Driver* GridD_in,
+    const ORB_gen_tables* uot,
     const Parallel_Orbitals* paraV)
-    : hamilt::OperatorLCAO<TK, TR>(LM_in, kvec_d_in, hR_in, hK_in)
+    : hamilt::OperatorLCAO<TK, TR>(LM_in, kvec_d_in, hR_in, hK_in), uot_(uot)
 {
     this->cal_type = lcao_fixed;
     this->ucell = ucell_in;
@@ -147,7 +148,6 @@ void hamilt::NonlocalNew<hamilt::OperatorLCAO<TK, TR>>::calculate_HR()
             const ModuleBase::Vector3<double>& tau1 = adjs.adjacent_tau[ad];
             const Atom* atom1 = &ucell->atoms[T1];
 
-            const ORB_gen_tables& uot = ORB_gen_tables::get_const_instance();
             const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
             auto all_indexes = paraV->get_indexes_row(iat1);
 #ifdef _OPENMP
@@ -181,10 +181,10 @@ void hamilt::NonlocalNew<hamilt::OperatorLCAO<TK, TR>>::calculate_HR()
                 int M1 = (m1 % 2 == 0) ? -m1/2 : (m1+1)/2;
 
                 ModuleBase::Vector3<double> dtau = tau0 - tau1;
-                uot.two_center_bundle->overlap_orb_beta->snap(
+                uot_->two_center_bundle->overlap_orb_beta->snap(
                         T1, L1, N1, M1, T0, dtau * this->ucell->lat0, 0 /*cal_deri*/, nlm);
 #else
-                uot.snap_psibeta_half(orb,
+                uot_->snap_psibeta_half(orb,
                                       this->ucell->infoNL,
                                       nlm,
                                       tau1,

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/nonlocal_new.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/nonlocal_new.h
@@ -7,6 +7,7 @@
 #include "module_cell/unitcell.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/operator_lcao.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
+#include "module_basis/module_ao/ORB_gen_tables.h"
 
 namespace hamilt
 {
@@ -43,6 +44,7 @@ class NonlocalNew<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                                       std::vector<TK>* hK_in,
                                       const UnitCell* ucell_in,
                                       Grid_Driver* GridD_in,
+                                      const ORB_gen_tables* uot,
                                       const Parallel_Orbitals* paraV);
     ~NonlocalNew<OperatorLCAO<TK, TR>>();
 
@@ -60,6 +62,9 @@ class NonlocalNew<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
     hamilt::HContainer<TR>* HR = nullptr;
 
     hamilt::HContainer<TR>* HR_fixed = nullptr;
+
+    // the following variable is introduced temporarily during LCAO refactoring
+    const ORB_gen_tables* uot_ = nullptr;
 
     bool allocated = false;
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/overlap_new.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/overlap_new.cpp
@@ -16,8 +16,9 @@ hamilt::OverlapNew<hamilt::OperatorLCAO<TK, TR>>::OverlapNew(LCAO_Matrix* LM_in,
                                                              std::vector<TK>* SK_pointer_in,
                                                              const UnitCell* ucell_in,
                                                              Grid_Driver* GridD_in,
+                                                             const ORB_gen_tables* uot,
                                                              const Parallel_Orbitals* paraV)
-    : hamilt::OperatorLCAO<TK, TR>(LM_in, kvec_d_in, hR_in, hK_in)
+    : hamilt::OperatorLCAO<TK, TR>(LM_in, kvec_d_in, hR_in, hK_in), uot_(uot)
 {
     this->cal_type = lcao_overlap;
     this->ucell = ucell_in;
@@ -115,7 +116,6 @@ void hamilt::OverlapNew<hamilt::OperatorLCAO<TK, TR>>::cal_SR_IJR(const int& iat
                                                                   const ModuleBase::Vector3<double>& dtau,
                                                                   TR* data_pointer)
 {
-    const ORB_gen_tables& uot = ORB_gen_tables::get_const_instance();
     const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
     // ---------------------------------------------
     // get info of orbitals of atom1 and atom2 from ucell
@@ -175,10 +175,10 @@ void hamilt::OverlapNew<hamilt::OperatorLCAO<TK, TR>>::cal_SR_IJR(const int& iat
             //=================================================================
             // convert m (0,1,...2l) to M (-l, -l+1, ..., l-1, l)
             int M2 = (m2 % 2 == 0) ? -m2/2 : (m2+1)/2;
-            uot.two_center_bundle->overlap_orb->calculate(T1, L1, N1, M1,
+            uot_->two_center_bundle->overlap_orb->calculate(T1, L1, N1, M1,
                     T2, L2, N2, M2, dtau * this->ucell->lat0, olm);
 #else
-            uot.snap_psipsi(orb, // orbitals
+            uot_->snap_psipsi(orb, // orbitals
                             olm,
                             0,
                             'S', // olm, job of derivation, dtype of Operator

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/overlap_new.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/overlap_new.h
@@ -5,6 +5,7 @@
 #include "module_cell/unitcell.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/operator_lcao.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
+#include "module_basis/module_ao/ORB_gen_tables.h"
 
 namespace hamilt
 {
@@ -43,6 +44,7 @@ class OverlapNew<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                                      std::vector<TK>* SK_pointer_in,
                                      const UnitCell* ucell_in,
                                      Grid_Driver* GridD_in,
+                                     const ORB_gen_tables* uot,
                                      const Parallel_Orbitals* paraV);
 
     virtual void contributeHR() override;
@@ -57,6 +59,9 @@ class OverlapNew<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
     hamilt::HContainer<TR>* SR = nullptr;
 
     std::vector<TK>* SK_pointer = nullptr;
+
+    // the following variable is introduced temporarily during LCAO refactoring
+    const ORB_gen_tables* uot_ = nullptr;
 
     bool SR_fixed_done = false;
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_ekinetic_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_ekinetic_lcao.cpp
@@ -116,7 +116,6 @@ void TDEkinetic<OperatorLCAO<TK, TR>>::cal_HR_IJR(const int& iat1,
                                                               std::complex<double>* data_pointer,
                                                               TR* s_pointer)
 {
-    const ORB_gen_tables& uot = ORB_gen_tables::get_const_instance();
     const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
     // ---------------------------------------------
     // get info of orbitals of atom1 and atom2 from ucell

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_nonlocal_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_nonlocal_lcao.cpp
@@ -19,8 +19,9 @@ hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::TDNonlocal(
     std::vector<TK>* hK_in,
     const UnitCell* ucell_in,
     Grid_Driver* GridD_in,
+    const ORB_gen_tables* uot,
     const Parallel_Orbitals* paraV)
-    : hamilt::OperatorLCAO<TK, TR>(LM_in, kvec_d_in, hR_in, hK_in)
+    : hamilt::OperatorLCAO<TK, TR>(LM_in, kvec_d_in, hR_in, hK_in), uot_(uot)
 {
     this->cal_type = lcao_tddft_velocity;
     this->ucell = ucell_in;
@@ -162,7 +163,6 @@ void hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::calculate_HR()
             const ModuleBase::Vector3<double>& tau1 = adjs.adjacent_tau[ad];
             const Atom* atom1 = &ucell->atoms[T1];
 
-            const ORB_gen_tables& uot = ORB_gen_tables::get_const_instance();
             const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
             auto all_indexes = paraV->get_indexes_row(iat1);
 #ifdef _OPENMP
@@ -194,7 +194,7 @@ void hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::calculate_HR()
                 int M1 = (m1 % 2 == 0) ? -m1/2 : (m1+1)/2;
 
                 ModuleBase::Vector3<double> dtau = tau0 - tau1;
-                uot.snap_psibeta_half_tddft(orb,
+                uot_->snap_psibeta_half_tddft(orb,
                                             this->ucell->infoNL,
                                             nlm,
                                             tau1 * this->ucell->lat0,
@@ -207,7 +207,7 @@ void hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::calculate_HR()
                                             -cart_At/2.0,
                                             0);
 #else
-                uot.snap_psibeta_half_tddft(orb,
+                uot_->snap_psibeta_half_tddft(orb,
                                             this->ucell->infoNL,
                                             nlm,
                                             tau1 * this->ucell->lat0,

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_nonlocal_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_nonlocal_lcao.h
@@ -3,6 +3,7 @@
 #include <unordered_map>
 
 #include "module_basis/module_ao/parallel_orbitals.h"
+#include "module_basis/module_ao/ORB_gen_tables.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
 #include "module_cell/unitcell.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/operator_lcao.h"
@@ -40,6 +41,7 @@ class TDNonlocal<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                                       std::vector<TK>* hK_in,
                                       const UnitCell* ucell_in,
                                       Grid_Driver* GridD_in,
+                                      const ORB_gen_tables* uot,
                                       const Parallel_Orbitals* paraV);
     ~TDNonlocal<OperatorLCAO<TK, TR>>();
 
@@ -59,6 +61,9 @@ class TDNonlocal<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
     /// @brief Store real space hamiltonian. TD term should include imaginary part, thus it has to be complex type. Only shared between TD operators.
     HContainer<std::complex<double>>* hR_tmp = nullptr;
     Grid_Driver* Grid = nullptr;
+
+    // this variable is introduced temporarily during LCAO refactoring
+    const ORB_gen_tables* uot_;
 
     bool allocated = false;
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_T_NL_cd.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_T_NL_cd.cpp
@@ -124,6 +124,7 @@ class TNLTest : public ::testing::Test
     UnitCell ucell;
     hamilt::HContainer<std::complex<double>>* HR;
     Parallel_Orbitals *paraV;
+    ORB_gen_tables uot_;
 
     int dsize;
     int my_rank = 0;
@@ -144,6 +145,7 @@ TEST_F(TNLTest, testTVNLcd2cd)
         &hk, 
         &ucell, 
         &gd,
+        &uot_,
         paraV
     );
     hamilt::Operator<std::complex<double>> *op1 = new hamilt::NonlocalNew<hamilt::OperatorLCAO<std::complex<double>, std::complex<double>>>(
@@ -153,6 +155,7 @@ TEST_F(TNLTest, testTVNLcd2cd)
         &hk, 
         &ucell, 
         &gd,
+        &uot_,
         paraV
     );
     // merge two Operators to a chain

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_dftu.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_dftu.cpp
@@ -134,6 +134,7 @@ class DFTUTest : public ::testing::Test
     hamilt::HContainer<double>* HR;
     hamilt::HContainer<double>* DMR;
     Parallel_Orbitals *paraV;
+    ORB_gen_tables uot_;
 
     int dsize;
     int my_rank = 0;
@@ -166,6 +167,7 @@ TEST_F(DFTUTest, constructHRd2d)
         &hk, 
         ucell, 
         &gd,
+        &uot_,
         &GlobalC::dftu,
         *paraV
     );
@@ -233,6 +235,7 @@ TEST_F(DFTUTest, constructHRd2cd)
         &hk, 
         ucell, 
         &gd,
+        &uot_,
         &GlobalC::dftu,
         *paraV
     );

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_ekineticnew.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_ekineticnew.cpp
@@ -93,6 +93,7 @@ class EkineticNewTest : public ::testing::Test
     UnitCell ucell;
     hamilt::HContainer<double>* HR;
     Parallel_Orbitals *paraV;
+    ORB_gen_tables uot_;
 
     int dsize;
     int my_rank = 0;
@@ -111,6 +112,7 @@ TEST_F(EkineticNewTest, constructHRd2d)
         &hk, 
         &ucell, 
         &gd,
+        &uot_,
         paraV
     );
     op.contributeHR();
@@ -166,6 +168,7 @@ TEST_F(EkineticNewTest, constructHRd2cd)
         &hk, 
         &ucell, 
         &gd,
+        &uot_,
         paraV
     );
     op.contributeHR();

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_nonlocalnew.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_nonlocalnew.cpp
@@ -122,6 +122,7 @@ class NonlocalNewTest : public ::testing::Test
     UnitCell ucell;
     hamilt::HContainer<double>* HR;
     Parallel_Orbitals *paraV;
+    ORB_gen_tables uot_;
 
     int dsize;
     int my_rank = 0;
@@ -144,6 +145,7 @@ TEST_F(NonlocalNewTest, constructHRd2d)
         &hk, 
         &ucell, 
         &gd,
+        &uot_,
         paraV
     );
     std::chrono::high_resolution_clock::time_point end_time = std::chrono::high_resolution_clock::now();
@@ -212,6 +214,7 @@ TEST_F(NonlocalNewTest, constructHRd2cd)
         &hk, 
         &ucell, 
         &gd,
+        &uot_,
         paraV
     );
     op.contributeHR();

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_overlapnew.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_overlapnew.cpp
@@ -93,6 +93,7 @@ class OverlapNewTest : public ::testing::Test
     UnitCell ucell;
     hamilt::HContainer<double>* SR;
     Parallel_Orbitals *paraV;
+    ORB_gen_tables uot_;
 
     int dsize;
     int my_rank = 0;
@@ -113,6 +114,7 @@ TEST_F(OverlapNewTest, constructHRd2d)
         &hk, 
         &ucell, 
         &gd,
+        &uot_,
         paraV
     );
     op.contributeHR();
@@ -154,6 +156,7 @@ TEST_F(OverlapNewTest, constructHRd2cd)
         &hk, 
         &ucell, 
         &gd,
+        &uot_,
         paraV
     );
     op.contributeHR();

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_overlapnew_cd.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_overlapnew_cd.cpp
@@ -92,6 +92,7 @@ class OverlapNewTest : public ::testing::Test
     UnitCell ucell;
     hamilt::HContainer<std::complex<double>>* SR;
     Parallel_Orbitals *paraV;
+    ORB_gen_tables uot_;
 
     int dsize;
     int my_rank = 0;
@@ -113,6 +114,7 @@ TEST_F(OverlapNewTest, constructHRcd2cd)
         &hk, 
         &ucell, 
         &gd,
+        &uot_,
         paraV
     );
     op.contributeHR();

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/tmp_mocks.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/tmp_mocks.cpp
@@ -141,11 +141,6 @@ template class hamilt::OperatorLCAO<std::complex<double>, std::complex<double>>;
 
 // mock of ORB_gen_tables and LCAO_Orbitals
 #include "module_basis/module_ao/ORB_gen_tables.h"
-const ORB_gen_tables& ORB_gen_tables::get_const_instance()
-{
-    static ORB_gen_tables instance;
-    return instance;
-}
 ORB_gen_tables::ORB_gen_tables() {}
 ORB_gen_tables::~ORB_gen_tables() {}
 ORB_gaunt_table::ORB_gaunt_table() {}

--- a/source/module_hamilt_lcao/hamilt_lcaodft/spar_dh.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/spar_dh.cpp
@@ -3,6 +3,7 @@
 void sparse_format::cal_dH(
 		LCAO_Matrix &lm,
 		Grid_Driver &grid,
+        const ORB_gen_tables* uot,
 		LCAO_gen_fixedH &gen_h, 
 		const int &current_spin, 
 		const double &sparse_thr,
@@ -26,15 +27,15 @@ void sparse_format::cal_dH(
 	{
         GlobalV::CAL_STRESS = false;
 
-        gen_h.build_ST_new('T', true, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD), lm.Hloc_fixedR.data());
+        gen_h.build_ST_new('T', true, GlobalC::ucell, GlobalC::ORB, *uot, &(GlobalC::GridD), lm.Hloc_fixedR.data());
 
         GlobalV::CAL_STRESS = true;
     }
     else
     {
-        gen_h.build_ST_new('T', true, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD), lm.Hloc_fixedR.data());
+        gen_h.build_ST_new('T', true, GlobalC::ucell, GlobalC::ORB, *uot, &(GlobalC::GridD), lm.Hloc_fixedR.data());
     }
-    gen_h.build_Nonlocal_mu_new (lm.Hloc_fixed.data(), true, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD));
+    gen_h.build_Nonlocal_mu_new (lm.Hloc_fixed.data(), true, GlobalC::ucell, GlobalC::ORB, *uot, &(GlobalC::GridD));
     
     sparse_format::cal_dSTN_R(lm, grid, current_spin, sparse_thr);
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/spar_dh.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/spar_dh.h
@@ -11,6 +11,7 @@ namespace sparse_format
 	void cal_dH(
 			LCAO_Matrix &lm,
 			Grid_Driver &grid,
+            const ORB_gen_tables* uot,
 			LCAO_gen_fixedH &gen_h, 
 			const int &current_spin, 
 			const double &sparse_thr,

--- a/source/module_hamilt_lcao/hamilt_lcaodft/spar_st.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/spar_st.cpp
@@ -43,6 +43,7 @@ void sparse_format::cal_TR(
         const Parallel_Orbitals &pv,
         LCAO_Matrix &lm,
 	    Grid_Driver &grid,
+        const ORB_gen_tables* uot,
 		LCAO_gen_fixedH &gen_h,
 		const double &sparse_thr)
 {
@@ -52,7 +53,7 @@ void sparse_format::cal_TR(
     lm.Hloc_fixedR.resize(lm.ParaV->nnr);
     lm.zeros_HSR('T');
 
-    gen_h.build_ST_new('T', 0, ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD), lm.Hloc_fixedR.data());
+    gen_h.build_ST_new('T', 0, ucell, GlobalC::ORB, *uot, &(GlobalC::GridD), lm.Hloc_fixedR.data());
 
     sparse_format::set_R_range(lm.all_R_coor, grid);
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/spar_st.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/spar_st.h
@@ -22,6 +22,7 @@ namespace sparse_format
 			const Parallel_Orbitals &pv,
 			LCAO_Matrix &lm,
 			Grid_Driver &grid,
+            const ORB_gen_tables* uot,
 			LCAO_gen_fixedH &gen_h,
 			const double &sparse_thr);
 

--- a/source/module_io/output_mat_sparse.cpp
+++ b/source/module_io/output_mat_sparse.cpp
@@ -17,6 +17,7 @@ namespace ModuleIO
         const Parallel_Orbitals &pv,
         LCAO_gen_fixedH &gen_h, // mohan add 2024-04-02
         Gint_k &gint_k, // mohan add 2024-04-01
+        const ORB_gen_tables* uot,
         LCAO_Matrix &lm,
         Grid_Driver &grid, // mohan add 2024-04-06
         const K_Vectors& kv,
@@ -30,6 +31,7 @@ namespace ModuleIO
       _pv(pv),
       _gen_h(gen_h), // mohan add 2024-04-02
       _gint_k(gint_k), // mohan add 2024-04-01
+      uot_(uot),
       _lm(lm),
       _grid(grid), // mohan add 2024-04-06
       _kv(kv),
@@ -68,6 +70,7 @@ void Output_Mat_Sparse<std::complex<double>>::write(void)
                 this->_pv, 
 				this->_lm, 
 				this->_grid,
+                uot_,
 				this->_gen_h); // LiuXh add 2019-07-15
     }
 
@@ -81,6 +84,7 @@ void Output_Mat_Sparse<std::complex<double>>::write(void)
 				this->_gint_k, // mohan add 2024-04-01
 				this->_lm,
                 this->_grid, // mohan add 2024-04-06
+                uot_,
 				_kv); // LiuXh add 2019-07-15
 	}
 

--- a/source/module_io/output_mat_sparse.h
+++ b/source/module_io/output_mat_sparse.h
@@ -25,6 +25,7 @@ namespace ModuleIO
         const Parallel_Orbitals &pv,
         LCAO_gen_fixedH &gen_h, // mohan add 2024-04-02
         Gint_k &gint_k, // mohan add 2024-04-01
+        const ORB_gen_tables* uot,
         LCAO_Matrix &lm,
         Grid_Driver &grid, // mohan add 2024-04-06
         const K_Vectors &kv,
@@ -55,6 +56,9 @@ namespace ModuleIO
     LCAO_gen_fixedH& _gen_h; // mohan add 2024-04-02
 
     Gint_k& _gint_k; // mohan add 2024-04-01
+
+    // introduced temporarily for LCAO refactoring
+    const ORB_gen_tables* uot_;
 
     LCAO_Matrix& _lm;
 

--- a/source/module_io/td_current_io.cpp
+++ b/source/module_io/td_current_io.cpp
@@ -15,7 +15,8 @@
 void ModuleIO::Init_DS_tmp(
 		const Parallel_Orbitals& pv,
 		LCAO_Matrix &lm,
-		LCAO_gen_fixedH &gen_h)
+		LCAO_gen_fixedH &gen_h,
+        const ORB_gen_tables* uot)
 {    
     ModuleBase::TITLE("ModuleIO", "Init_DS_tmp");
     ModuleBase::timer::tick("ModuleIO", "Init_DS_tmp");
@@ -34,7 +35,7 @@ void ModuleIO::Init_DS_tmp(
 
     ModuleBase::OMP_PARALLEL(init_DSloc_Rxyz);
     bool cal_deri = true;
-    gen_h.build_ST_new('S', cal_deri, GlobalC::ucell, GlobalC::ORB, GlobalC::UOT, &(GlobalC::GridD), lm.SlocR.data());
+    gen_h.build_ST_new('S', cal_deri, GlobalC::ucell, GlobalC::ORB, *uot, &(GlobalC::GridD), lm.SlocR.data());
 
     ModuleBase::timer::tick("ModuleIO", "Init_DS_tmp");
     return;
@@ -141,6 +142,7 @@ void ModuleIO::write_current(const int istep,
                                 const psi::Psi<std::complex<double>>* psi,
                                 const elecstate::ElecState* pelec,
                                 const K_Vectors& kv,
+                                const ORB_gen_tables* uot,
                                 const Parallel_Orbitals* pv,
 								Record_adj& ra,
 								LCAO_Matrix &lm, // mohan add 2024-04-02
@@ -150,7 +152,7 @@ void ModuleIO::write_current(const int istep,
     ModuleBase::TITLE("ModuleIO", "write_current");
     ModuleBase::timer::tick("ModuleIO", "write_current");
     //Init_DS_tmp
-    Init_DS_tmp(*pv, lm, gen_h);
+    Init_DS_tmp(*pv, lm, gen_h, uot);
     // construct a DensityMatrix object
     elecstate::DensityMatrix<std::complex<double>, double> DM(&kv,pv,GlobalV::NSPIN);
     

--- a/source/module_io/td_current_io.h
+++ b/source/module_io/td_current_io.h
@@ -14,6 +14,7 @@ void write_current(const int istep,
                     const psi::Psi<std::complex<double>>* psi,
                     const elecstate::ElecState* pelec,
                     const K_Vectors& kv,
+                    const ORB_gen_tables* uot,
                     const Parallel_Orbitals* pv,
 					Record_adj& ra,
 					LCAO_Matrix &lm, // mohan add 2024-04-02
@@ -26,7 +27,8 @@ void cal_tmp_DM(elecstate::DensityMatrix<std::complex<double>, double>& DM, cons
 void Init_DS_tmp(
 		const Parallel_Orbitals& pv,
 		LCAO_Matrix &lm,
-		LCAO_gen_fixedH &gen_h);
+		LCAO_gen_fixedH &gen_h,
+        const ORB_gen_tables* uot);
 
 /// @brief DS_locR will be initialized again in force calculation, so it must be destoryed here.
 void destory_DS_tmp(LCAO_Matrix &lm);

--- a/source/module_io/write_HS_R.cpp
+++ b/source/module_io/write_HS_R.cpp
@@ -95,6 +95,7 @@ void ModuleIO::output_dHR(const int &istep,
                            Gint_k &gint_k,  // mohan add 2024-04-01
                            LCAO_Matrix &lm,  // mohan add 2024-04-01
                            Grid_Driver &grid, // mohan add 2024-04-06
+                           const ORB_gen_tables* uot,
                            const K_Vectors& kv,
                            const bool &binary,
                            const double &sparse_thr)
@@ -116,6 +117,7 @@ void ModuleIO::output_dHR(const int &istep,
 		sparse_format::cal_dH(
                 lm,
                 grid,
+                uot,
 				gen_h,
 				cspin, 
 				sparse_thr, 
@@ -141,6 +143,7 @@ void ModuleIO::output_dHR(const int &istep,
             sparse_format::cal_dH(
                     lm,
                     grid,
+                    uot,
                     gen_h,
                     cspin, 
                     sparse_thr, 
@@ -204,6 +207,7 @@ void ModuleIO::output_TR(
     const Parallel_Orbitals &pv,
     LCAO_Matrix &lm,
     Grid_Driver &grid,
+    const ORB_gen_tables* uot,
     LCAO_gen_fixedH &gen_h, // mohan add 2024-04-02
     const std::string &TR_filename,
     const bool &binary,
@@ -228,6 +232,7 @@ void ModuleIO::output_TR(
 			pv,
 			lm,
 			grid,
+            uot,
 			gen_h, 
 			sparse_thr);
 

--- a/source/module_io/write_HS_R.h
+++ b/source/module_io/write_HS_R.h
@@ -31,6 +31,7 @@ namespace ModuleIO
 			Gint_k& gint_k,  // mohan add 2024-04-01
 			LCAO_Matrix &lm,  // mohan add 2024-04-01
             Grid_Driver &grid, // mohan add 2024-04-06
+            const ORB_gen_tables* uot,
             const K_Vectors& kv,
             const bool& binary = false,
             const double& sparse_threshold = 1e-10);
@@ -41,6 +42,7 @@ namespace ModuleIO
             const Parallel_Orbitals &pv,
 			LCAO_Matrix &lm,
             Grid_Driver &grid,
+            const ORB_gen_tables* uot,
             LCAO_gen_fixedH &gen_h, // mohan add 2024-04-02
             const std::string& TR_filename = "data-TR-sparse_SPIN0.csr",
             const bool& binary = false,


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
https://github.com/deepmodeling/abacus-develop/issues/4079

### What's changed?
The global variable "GlobalC::UOT" (an object of class ORB_gen_tables) is removed from the code. Instead, ESolver_KS_LCAO becomes the owner of the only object of class ORB_gen_tables.

### Any changes of core modules? (ignore if not applicable)
Various functions & classes relying on GlobalC::UOT now have "const ORB_gen_tables*" as an explicit argument. 
