### PR TITLE
Refactor DiagoDavid: Remove Dependency on External DiagoIterAssist Class

### DIFF
--- a/source/module_hsolver/diago_david.h
+++ b/source/module_hsolver/diago_david.h
@@ -20,6 +20,9 @@ class DiagoDavid : public DiagH<T, Device>
 
     DiagoDavid(const Real* precondition_in, 
                const int david_ndim_in,
+               const double david_diag_thr_in,
+               const int david_maxiter_in,
+               const bool david_scf_type,
                const bool use_paw_in,
                const diag_comm_info& diag_comm_in);
 
@@ -31,6 +34,9 @@ class DiagoDavid : public DiagH<T, Device>
 
   private:
     int david_ndim = 4;
+    const double david_diag_thr;
+    const int david_maxiter;
+    const bool scf_type;
     bool use_paw = false;
     int test_david = 0;
 
@@ -125,6 +131,8 @@ class DiagoDavid : public DiagH<T, Device>
     void diag_mock(hamilt::Hamilt<T, Device>* phm_in,
                    psi::Psi<T, Device>& psi,
                    Real* eigenvalue_in);
+    
+    bool test_exit_cond(const int& ntry, const int& notconv, const bool& scf) const;
 
     using resmem_complex_op = base_device::memory::resize_memory_op<T, Device>;
     using delmem_complex_op = base_device::memory::delete_memory_op<T, Device>;

--- a/source/module_hsolver/diago_david.h
+++ b/source/module_hsolver/diago_david.h
@@ -31,6 +31,8 @@ class DiagoDavid : public DiagH<T, Device>
     virtual void diag(hamilt::Hamilt<T, Device>* phm_in,
                       psi::Psi<T, Device>& phi,
                       Real* eigenvalue_in) override ;
+    
+    int get_sum_iter() const;
 
   private:
     int david_ndim = 4;
@@ -39,6 +41,8 @@ class DiagoDavid : public DiagH<T, Device>
     const bool scf_type;
     bool use_paw = false;
     int test_david = 0;
+
+    int sum_iter = 0; // for adding up to external DiagoIterAssist<T, Device>::avg_iter
 
     diag_comm_info diag_comm;
 
@@ -128,7 +132,7 @@ class DiagoDavid : public DiagH<T, Device>
                      Real* eigenvalue,
                      T* vcc);
 
-    void diag_mock(hamilt::Hamilt<T, Device>* phm_in,
+    int diag_mock(hamilt::Hamilt<T, Device>* phm_in,
                    psi::Psi<T, Device>& psi,
                    Real* eigenvalue_in);
     

--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -96,9 +96,14 @@ void HSolverPW<T, Device>::initDiagh(const psi::Psi<T, Device>& psi)
             {
                 delete (DiagoDavid<T, Device>*)this->pdiagh;
 
+                bool scf_type = (GlobalV::CALCULATION == "nscf") ? false : true;
+
                 this->pdiagh = new DiagoDavid<T, Device>(
                                 precondition.data(),
                                 GlobalV::PW_DIAG_NDIM,
+                                DiagoIterAssist<T, Device>::PW_DIAG_THR,
+                                DiagoIterAssist<T, Device>::PW_DIAG_NMAX,
+                                scf_type,
                                 GlobalV::use_paw,
                                 comm_info
                                 );
@@ -108,9 +113,13 @@ void HSolverPW<T, Device>::initDiagh(const psi::Psi<T, Device>& psi)
         }
         else
         {
+            bool scf_type = (GlobalV::CALCULATION == "nscf") ? false : true;
             this->pdiagh = new DiagoDavid<T, Device>(
                                 precondition.data(),
                                 GlobalV::PW_DIAG_NDIM,
+                                DiagoIterAssist<T, Device>::PW_DIAG_THR,
+                                DiagoIterAssist<T, Device>::PW_DIAG_NMAX,
+                                scf_type,
                                 GlobalV::use_paw,
                                 comm_info
                                 );

--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -724,7 +724,9 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm, psi::P
         }
         else
         {
-            this->pdiagh->diag(hm, psi, eigenvalue);
+            reinterpret_cast<DiagoDavid<T, Device>*>(this->pdiagh)->diag(hm, psi, eigenvalue);
+            DiagoIterAssist<T, Device>::avg_iter
+                += static_cast<double>(reinterpret_cast<DiagoDavid<T, Device>*>(this->pdiagh)->get_sum_iter());
         }
         return;
     }


### PR DESCRIPTION
### Linked Issue
#4320 

### Description
This pull request refactors the `DiagoDavid` class to eliminate its dependency on the external `DiagoIterAssist` class. Previously, `DiagoDavid` relied on constants such as `PW_DIAG_THR, PW_DIAG_NMAX` which were defined in `DiagoIterAssist`(`diago_iter_assist.h`). This change promotes modularity, reduces coupling, and enhances the maintainability of the codebase.

### What's changed?
- Remove the References to external `DiagoIterAssist` constants and variables in `DiagoDavid` code `diago_david.h` and `diago_david.cpp`.
- Update the `DiagoDavid` constructor to manage its dependencies through parameters.
- Modify all instances in `hsolver_pw.cpp` where the `DiagoDavid` constructor was called, ensuring they adapt to the new changes.
- Move function `DiagoIterAssist::test_exit_cond` to `DiagoDavid` class.
- Add a new public method `get_sum_iter()` to the DiagoDavid class, providing read-only access to the iteration summary.
- Modify `DiagoDavid` to no longer directly reference `DiagoIterAssist<T, Device>::avg_iter`. Now `avg_iter` is referenced in `hsolver_pw.cpp`, utilizing the newly introduced `get_sum_iter()` method for getting Davidson iteration count.
