### PR TITLE
Refactor: Remove DiagoIterAssist dependencies in DiagoDavid

### DIFF
--- a/source/module_hsolver/diago_david.h
+++ b/source/module_hsolver/diago_david.h
@@ -25,9 +25,11 @@ class DiagoDavid : public DiagH<T, Device>
 
     virtual ~DiagoDavid() override;
 
-    virtual void diag(hamilt::Hamilt<T, Device>* phm_in,
+    int diag(hamilt::Hamilt<T, Device>* phm_in,
                       psi::Psi<T, Device>& phi,
-                      Real* eigenvalue_in) override ;
+                      Real* eigenvalue_in,
+                      const int ntry_max = 5,
+                      const int notconv_max = 5);
 
   private:
     int david_ndim = 4;
@@ -122,9 +124,13 @@ class DiagoDavid : public DiagH<T, Device>
                      Real* eigenvalue,
                      T* vcc);
 
-    void diag_mock(hamilt::Hamilt<T, Device>* phm_in,
+    int diag_mock(hamilt::Hamilt<T, Device>* phm_in,
                    psi::Psi<T, Device>& psi,
-                   Real* eigenvalue_in);
+                   Real* eigenvalue_in,
+                   const int david_diag_thr,
+                   const int david_diag_maxiter);
+    
+    bool check_block_conv(const int &ntry, const int &notconv, const int &ntry_max, const int &notconv_max);
 
     using resmem_complex_op = base_device::memory::resize_memory_op<T, Device>;
     using delmem_complex_op = base_device::memory::delete_memory_op<T, Device>;

--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -763,7 +763,14 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm, psi::P
         }
         else
         {
-            this->pdiagh->diag(hm, psi, eigenvalue);
+            // Allow 5 tries at most. If ntry > ntry_max = 5, exit diag loop.
+            int ntry_max = 5;
+            // In non-self consistent calculation, do until totally converged. Else allow 5 eigenvecs to be NOT converged.
+            int notconv_max = ("nscf" == GlobalV::CALCULATION)? 0: 5;
+            // do diag and add davidson iteration counts up to avg_iter
+            DiagoIterAssist<T, Device>::avg_iter += static_cast<double>(
+                reinterpret_cast<DiagoDavid<T, Device>*>(this->pdiagh)->diag(hm, psi, eigenvalue, ntry_max, notconv_max)
+            );
         }
         return;
     }


### PR DESCRIPTION
### Description
Remove reference to `DiagoIterAssist` constants, variables and functions in `DiagoDavid` and access them in the form of parameters, return value and internal functions instead.
Refactor convergence condition test in  `DiagoDavid` to enhance readability.

### What's changed?

- Modify `diag` and `diag_mock` to return iteration count and add parameters for maxiter and convergence threshold to replace reference to external `DiagoIterAssist` global constants.
- Change corresponding calls to `DiagoDavid::diag` in `hsolver_pw.cpp`. Now `DiagoIterAssist<T, Device>::avg_iter` is referenced in `hsolver_pw.cpp` by adding up the return values of function  `DiagoDavid::diag` to sum Davidson iteration count.
- The convergence condition test in `DiagoDavid` has been updated from `DiagoIterAssist<T, Device>::test_exit_cond(ntry, this->notconv)` to `!check_block_conv(ntry, this->notconv, ntry_max, notconv_max)`, where the `check_block_conv` function has been introduced (in class `DiagoDavid`) to encapsulate the logic of the convergence test, improving readability and making the condition easier to understand at a glance. Now convergence criterion is determined when calling `diag` according to `GlobalV::CALCULATION` type in `hsolver_pw.cpp`.

### Linked Issue
#4320
