### PR TITLE
Fix: report error when fr-uspp used in linear calculations

### DIFF
--- a/source/module_cell/read_pp.cpp
+++ b/source/module_cell/read_pp.cpp
@@ -145,8 +145,7 @@ int Pseudopot_upf::average_p(const double& lambda)
 {
     int error = 0;
     double lambda_ = lambda;
-    if (!GlobalV::LSPINORB)
-        lambda_ = 0.0;
+    if(!GlobalV::LSPINORB) { lambda_ = 0.0; }
     if (this->has_so && this->tvanp)
     {
         error++;

--- a/source/module_cell/read_pp.cpp
+++ b/source/module_cell/read_pp.cpp
@@ -143,23 +143,32 @@ std::string Pseudopot_upf::trimend(std::string &in_str)
 
 int Pseudopot_upf::average_p(const double& lambda)
 {
-	int error = 0;
-	double lambda_ = lambda;
-	if(!GlobalV::LSPINORB) lambda_ = 0.0;
-	if(!this->has_so && GlobalV::LSPINORB) 
-	{
-		error++; 
-		std::cout<<"warning_quit! no soc upf used for lspinorb calculation, error!"<<std::endl; 
-		return error;
-	}
-	//ModuleBase::WARNING_QUIT("average_p", "no soc upf used for lspinorb calculation, error!");
+    int error = 0;
+    double lambda_ = lambda;
+    if (!GlobalV::LSPINORB)
+        lambda_ = 0.0;
+    if (this->has_so && this->tvanp)
+    {
+        error++;
+        std::cout << "------------------------------------------------------" << std::endl;
+        std::cout << " FR-USPP please use lspinorb=.true." << std::endl;
+        std::cout << "------------------------------------------------------" << std::endl;
+        return error;
+    }
+    if (!this->has_so && GlobalV::LSPINORB)
+    {
+        error++;
+        std::cout << "warning_quit! no soc upf used for lspinorb calculation, error!" << std::endl;
+        return error;
+    }
+    // ModuleBase::WARNING_QUIT("average_p", "no soc upf used for lspinorb calculation, error!");
 
-	if(!this->has_so || (GlobalV::LSPINORB && std::abs(lambda_ - 1.0) < 1.0e-8) )
-	{
-		return error; 
-	}
+    if (!this->has_so || (GlobalV::LSPINORB && std::abs(lambda_ - 1.0) < 1.0e-8))
+    {
+        return error;
+    }
 
-	//if(std::abs(lambda_)<1.0e-8)
+    //if(std::abs(lambda_)<1.0e-8)
 	if(!GlobalV::LSPINORB)
 	{
 		int new_nbeta = 0; //calculate the new nbeta

--- a/source/module_cell/test/read_pp_test.cpp
+++ b/source/module_cell/test/read_pp_test.cpp
@@ -746,6 +746,10 @@ TEST_F(ReadPPTest, AverageSimpleReturns)
 	upf->has_so = 1;
 	ierr = upf->average_p(lambda);
 	EXPECT_EQ(ierr,0);
+    upf->has_so = 1;
+    upf->tvanp = 1;
+    ierr = upf->average_p(lambda);
+    EXPECT_EQ(ierr, 1);
 }
 
 TEST_F(ReadPPTest, AverageErrReturns)

--- a/source/module_hamilt_pw/hamilt_pwdft/hamilt_pw.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/hamilt_pw.cpp
@@ -362,8 +362,6 @@ void HamiltPW<T, Device>::sPsi(const T* psi_in, // psi
         delmem_complex_op()(this->ctx, ps);
         delmem_complex_op()(this->ctx, becp);
     }
-
-    ModuleBase::TITLE("HamiltPW", "sPsi");
 }
 
 template class HamiltPW<std::complex<float>, base_device::DEVICE_CPU>;


### PR DESCRIPTION
### Linked Issue
Fix #4342 

### Unit Tests and/or Case Tests for my changes
- A unit test is updated.

### What's changed?
- add an error report in function `Pseudopot_upf::average_p(const double& lambda).

