### PR TITLE
Modify the average electrostatic potential script （Useful Information：How to plot electrostatic potential）

### DIFF
--- a/tools/average_pot/README
+++ b/tools/average_pot/README
@@ -1,6 +1,11 @@
 Requriements:
+    os
+    sys
+    scipy
     numpy
+    matplotlib
 
-This Python script can be used to calculate the average electrostatic potential stored in an ElecStaticPot.cube file. 
-Simply enter the path containing ElecStaticPot.cube, and run the script using 'python path-to-tools/aveElecStatPot.py'. 
-The output file, ElecStaticPot_AVE, will be generated in the same directory.
+This Python script can be used to calculate and plot the average electrostatic potential stored in an ElecStaticPot.cube file.
+Simply navigate to the directory containing ElecStaticPot.cube, and run the script using 'python path-to-tools/aveElecStatPot.py'.
+The output files, ElecStaticPot_AVE and ElecStaticPot-vs-Z.png, will be generated in the same directory.
+One can check the details in ElecStaticPot_AVE, where the data is already converted to eV units.

--- a/tools/average_pot/aveElecStatPot.py
+++ b/tools/average_pot/aveElecStatPot.py
@@ -1,21 +1,50 @@
+import os
+import sys
 import numpy as np
+import matplotlib.pyplot as plt
+from scipy.interpolate import interp1d
 
-input_file = "ElecStaticPot.cube"
-output_file = "ElecStaticPot_AVE"
+current_dir = os.getcwd()
 
+if os.path.exists(os.path.join(current_dir, "ElecStaticPot.cube")):
+    input_file = os.path.join(current_dir, "ElecStaticPot.cube")
+    output_file = os.path.join(current_dir, "ElecStaticPot_AVE")
+    output_png = os.path.join(current_dir, "ElecStaticPot-vs-Z.png")
+else:
+    for dir_name in os.listdir(current_dir):
+        dir_path = os.path.join(current_dir, dir_name)
+
+        if os.path.isdir(dir_path) and dir_name.startswith("OUT."):
+            input_file = os.path.join(dir_path, "ElecStaticPot.cube")
+            output_file = os.path.join(dir_path, "ElecStaticPot_AVE")
+            output_png = os.path.join(dir_path, "ElecStaticPot-vs-Z.png") 
+            if os.path.exists(input_file):
+                print(f"Processeding: {input_file}")
+                break
+            else:
+                print(f"File does not exist: {input_file}")
+                sys.exit()
+                        
 with open(input_file, 'r') as inpt:
     temp = inpt.readlines()
+
+Ry_to_eV = 13.605698066819
+bohr_to_Ang = 1.8897259885789
 
 natom = int(temp[2].split()[0])
 nx = int(temp[3].split()[0])
 ny = int(temp[4].split()[0])
 nz = int(temp[5].split()[0])
+step_z_bohr = float(temp[5].split()[3])
+step_z = step_z_bohr / bohr_to_Ang
+z_Ang = np.arange(nz) * step_z
 
 nrow = nz // 6
 if nz % 6 != 0: nrow += 1
 
 data_start = 6 + natom
 average = np.zeros(nz)
+average_eV = np.zeros(nz)
 
 nxy = nx * ny
 for ixy in range(nxy):
@@ -26,11 +55,30 @@ for ixy in range(nxy):
 
 average /= nxy
 
+average_eV = average * Ry_to_eV
+
 with open(output_file, 'w') as output:
     output.write("Average electrostatic potential along z axis\n")
     for i in range(1, data_start):
         output.write(temp[i])
     
-    output.write("iz\t\taverage\n")
+    output.write("iz\t\t Average(Ry)\t\t z(Angstrom)\t\t Average(eV)\n")
     for iz in range(nz):
-        output.write("{0}\t\t{1:.9e}\n".format(iz, average[iz]))
+        output.write("{:<7d}\t{:>16.9e}\t{:>16.9e}\t{:>16.9e}\n".format(iz, z_Ang[iz], average[iz], average_eV[iz]))
+
+
+z_values = z_Ang
+interpolation_func = interp1d(z_values, average_eV, kind='cubic')
+
+z_interpolated = np.linspace(z_values.min(), z_values.max(), nz * 5)
+average_interpolated = interpolation_func(z_interpolated)
+
+plt.figure(figsize=(4.5, 8)) 
+plt.plot(average_interpolated, z_interpolated)
+plt.xlabel('Average Electrostatic Potential (eV)')
+plt.ylabel('Z axis (Angstrom)')
+plt.title('Average Electrostatic Potential along Z')
+plt.grid(True)
+
+plt.savefig(output_png, dpi=300)
+plt.show()


### PR DESCRIPTION
Convert the unit of the average electrostatic potential to eV and also save the formatted results both in Ry and eV, and modify the script for calculating and plotting the average electrostatic potential to automatically plot the figure which is saved as ElecStaticPot-vs-Z.png.

![284ed31c5ee804f2ab2d27931e86777](https://github.com/deepmodeling/abacus-develop/assets/55775434/fdb28cca-d645-438a-9e7d-da19f20f39d6)

![image](https://github.com/deepmodeling/abacus-develop/assets/55775434/a8c98da8-3d6a-485f-939a-27f92b8ced0c)


### Reminder
- [x] Have you linked an issue with this pull request?
- [x] Have you added adequate unit tests and/or case tests for your pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [x] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fixes #4349

### Unit Tests and/or Case Tests for my changes
- None.

### What's changed?
- tools/average_pot/aveElecStatPot.py
- tools/average_pot/README

### Any changes of core modules? (ignore if not applicable)
- None.
