### PR TITLE
Fix: support cross-boundary structures in orbital generation

### DIFF
--- a/source/module_io/numerical_basis.cpp
+++ b/source/module_io/numerical_basis.cpp
@@ -17,7 +17,6 @@
 Numerical_Basis::Numerical_Basis() {}
 Numerical_Basis::~Numerical_Basis() {}
 
-#define __LCAO
 //============================================================
 // MEMBER FUNCTION :
 // NAME : init

--- a/source/module_io/numerical_basis.cpp
+++ b/source/module_io/numerical_basis.cpp
@@ -17,6 +17,7 @@
 Numerical_Basis::Numerical_Basis() {}
 Numerical_Basis::~Numerical_Basis() {}
 
+#define __LCAO
 //============================================================
 // MEMBER FUNCTION :
 // NAME : init
@@ -157,6 +158,7 @@ void Numerical_Basis::output_overlap(const psi::Psi<std::complex<double>>& psi, 
                                                    this->bessel_basis.get_ecut_number(),
                                                    INPUT.bessel_nao_rcut,
                                                    tau_cart,
+                                                   ucell.lat0 * ucell.latvec,
                                                    NumericalBasis::indexgen(natom, lmax));
 #endif
                 ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running,"cal_overlap_Sq");

--- a/source/module_io/numerical_basis.cpp
+++ b/source/module_io/numerical_basis.cpp
@@ -1,21 +1,27 @@
 #include "numerical_basis.h"
+
 #include "module_base/constants.h"
 #include "module_base/global_variable.h"
 #include "module_base/intarray.h"
-#include "module_base/vector3.h"
-#include "module_hamilt_pw/hamilt_pwdft/global.h"
-#include "module_cell/module_symmetry/symmetry.h"
-#include "winput.h"
 #include "module_base/math_ylmreal.h"
 #include "module_base/parallel_reduce.h"
+#include "module_base/timer.h"
+#include "module_base/vector3.h"
+#include "module_cell/module_symmetry/symmetry.h"
+#include "module_hamilt_pw/hamilt_pwdft/global.h"
+#include "module_io/numerical_basis_jyjy.h"
+#include "winput.h"
+
+#include <algorithm>
 #include <cstring>
 #include <functional>
-#include <algorithm>
 #include <vector>
-#include "module_base/timer.h"
-#include "module_io/numerical_basis_jyjy.h"
-Numerical_Basis::Numerical_Basis() {}
-Numerical_Basis::~Numerical_Basis() {}
+Numerical_Basis::Numerical_Basis()
+{
+}
+Numerical_Basis::~Numerical_Basis()
+{
+}
 
 //============================================================
 // MEMBER FUNCTION :
@@ -33,24 +39,17 @@ Numerical_Basis::~Numerical_Basis() {}
 // to generate TableOne
 // Secondly output overlap, use psi(evc) and jlq3d.
 //============================================================
-void Numerical_Basis::start_from_file_k(const int& ik, ModuleBase::ComplexMatrix& psi, const Structure_Factor& sf, const ModulePW::PW_Basis_K* wfcpw, const UnitCell& ucell)
+void Numerical_Basis::start_from_file_k(const int& ik, ModuleBase::ComplexMatrix& psi, const Structure_Factor& sf,
+                                        const ModulePW::PW_Basis_K* wfcpw, const UnitCell& ucell)
 {
-    ModuleBase::TITLE("Numerical_Basis","start_from_file_k");
+    ModuleBase::TITLE("Numerical_Basis", "start_from_file_k");
 
     if (!this->init_label)
     {
         // true stands for : start_from_file
-        this->bessel_basis.init(
-			true,
-			std::stod(INPUT.bessel_nao_ecut),
-			ucell.ntype,
-			ucell.lmax,
-			INPUT.bessel_nao_smooth,
-			INPUT.bessel_nao_sigma,
-			INPUT.bessel_nao_rcut,
-			INPUT.bessel_nao_tolerence,
-            ucell
-            );
+        this->bessel_basis.init(true, std::stod(INPUT.bessel_nao_ecut), ucell.ntype, ucell.lmax,
+                                INPUT.bessel_nao_smooth, INPUT.bessel_nao_sigma, INPUT.bessel_nao_rcut,
+                                INPUT.bessel_nao_tolerence, ucell);
         this->mu_index = this->init_mu_index(ucell);
         this->init_label = true;
     }
@@ -58,45 +57,47 @@ void Numerical_Basis::start_from_file_k(const int& ik, ModuleBase::ComplexMatrix
 }
 
 // The function is called in run_fp.cpp.
-void Numerical_Basis::output_overlap(const psi::Psi<std::complex<double>>& psi, const Structure_Factor& sf, const K_Vectors& kv, const ModulePW::PW_Basis_K* wfcpw, const UnitCell& ucell)
+void Numerical_Basis::output_overlap(const psi::Psi<std::complex<double>>& psi, const Structure_Factor& sf,
+                                     const K_Vectors& kv, const ModulePW::PW_Basis_K* wfcpw, const UnitCell& ucell)
 {
-    ModuleBase::TITLE("Numerical_Basis","output_overlap");
+    ModuleBase::TITLE("Numerical_Basis", "output_overlap");
     ModuleBase::GlobalFunc::NEW_PART("Overlap Data For Spillage Minimization");
 
-	//---------------------------------------------------------
-	// if the numerical_basis hasn't been initialized yet,
+    //---------------------------------------------------------
+    // if the numerical_basis hasn't been initialized yet,
     // then we initial here.
-	//---------------------------------------------------------
+    //---------------------------------------------------------
     if (!this->init_label)
     {
         // false stands for : 'Faln' is not used.
-        this->bessel_basis.init(
-			false,
-			std::stod(INPUT.bessel_nao_ecut),
-			ucell.ntype,
-			ucell.lmax,
-			INPUT.bessel_nao_smooth,
-			INPUT.bessel_nao_sigma,
-			INPUT.bessel_nao_rcut,
-			INPUT.bessel_nao_tolerence,
-            ucell
-            );
+        this->bessel_basis.init(false, std::stod(INPUT.bessel_nao_ecut), ucell.ntype, ucell.lmax,
+                                INPUT.bessel_nao_smooth, INPUT.bessel_nao_sigma, INPUT.bessel_nao_rcut,
+                                INPUT.bessel_nao_tolerence, ucell);
         this->mu_index = this->init_mu_index(ucell);
         this->init_label = true;
     }
     ModuleBase::GlobalFunc::MAKE_DIR(winput::spillage_outdir);
-	for(int derivative_order=0; derivative_order<=1; ++derivative_order)            // Peize Lin add 2020.04.23
-	{
+    for (int derivative_order = 0; derivative_order <= 1; ++derivative_order) // Peize Lin add 2020.04.23
+    {
         std::ofstream ofs;
         std::stringstream ss;
         // the parameter 'winput::spillage_outdir' is read from INPUTw.
         ss << winput::spillage_outdir << "/";
-        
-        if(INPUT.bessel_nao_rcuts.size() > 1) { ss << "orb_matrix_rcut" << INPUT.bessel_nao_rcut << "deriv"; }
-        else { ss << "orb_matrix."; } // to make it compatible with old version of orbital generation
+
+        if (INPUT.bessel_nao_rcuts.size() > 1)
+        {
+            ss << "orb_matrix_rcut" << INPUT.bessel_nao_rcut << "deriv";
+        }
+        else
+        {
+            ss << "orb_matrix.";
+        } // to make it compatible with old version of orbital generation
         ss << derivative_order << ".dat";
-        
-        if (GlobalV::MY_RANK==0) { ofs.open(ss.str().c_str()); }
+
+        if (GlobalV::MY_RANK == 0)
+        {
+            ofs.open(ss.str().c_str());
+        }
 
         // ALLOCATE MEMORY FOR THE OVERLAP MATRIX
         // OVERLAP : < J_mu | Psi >
@@ -105,10 +106,11 @@ void Numerical_Basis::output_overlap(const psi::Psi<std::complex<double>>& psi, 
         std::vector<ModuleBase::ComplexArray> overlap_Sq(kv.get_nks());
 
         ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "number of k points", kv.get_nks());
-        ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"number of bands", GlobalV::NBANDS);
-        ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"number of local orbitals", GlobalV::NLOCAL);
-        ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,"number of eigenvalues of Jl(x)", this->bessel_basis.get_ecut_number());
-        
+        ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "number of bands", GlobalV::NBANDS);
+        ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "number of local orbitals", GlobalV::NLOCAL);
+        ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "number of eigenvalues of Jl(x)",
+                                    this->bessel_basis.get_ecut_number());
+
         // CALCULATE THE OVERLAP MATRIX
         // nks now is the reduced k-points.
         for (int ik = 0; ik < kv.get_nks(); ik++)
@@ -117,21 +119,20 @@ void Numerical_Basis::output_overlap(const psi::Psi<std::complex<double>>& psi, 
             GlobalV::ofs_running << " --------------------------------------------------------" << std::endl;
             GlobalV::ofs_running << " Print the overlap matrixs Q and S for this kpoint" << std::endl;
             GlobalV::ofs_running << std::setw(8) << "ik" << std::setw(8) << "npw" << std::endl;
-            GlobalV::ofs_running << std::setw(8) << ik+1 << std::setw(8) << npw << std::endl;
+            GlobalV::ofs_running << std::setw(8) << ik + 1 << std::setw(8) << npw << std::endl;
             GlobalV::ofs_running << " --------------------------------------------------------" << std::endl;
 
             // search for all k-points.
             psi.fix_k(ik);
-            overlap_Q[ik]
-                = this->cal_overlap_Q(ik, npw, wfcpw, psi, static_cast<double>(derivative_order), sf, ucell);
-            ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running,"cal_overlap_Q");
+            overlap_Q[ik] = this->cal_overlap_Q(ik, npw, wfcpw, psi, static_cast<double>(derivative_order), sf, ucell);
+            ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running, "cal_overlap_Q");
 
             // (2) generate Sq matrix if necessary.
             if (winput::out_spillage == 2)
             {
 #ifndef __LCAO
                 // compute <jY|jY> in plane-wave basis
-                overlap_Sq[ik] = this->cal_overlap_Sq( ik, npw, static_cast<double>(derivative_order), sf, wfcpw, ucell);
+                overlap_Sq[ik] = this->cal_overlap_Sq(ik, npw, static_cast<double>(derivative_order), sf, wfcpw, ucell);
 #else
                 // compute <jY|jY> with two-center integration
                 assert(derivative_order == 0 || derivative_order == 1);
@@ -151,77 +152,78 @@ void Numerical_Basis::output_overlap(const psi::Psi<std::complex<double>>& psi, 
                     }
                 }
 
-                overlap_Sq[ik] = 
-                    NumericalBasis::cal_overlap_Sq(type,
-                                                   ucell.lmaxmax,
-                                                   this->bessel_basis.get_ecut_number(),
-                                                   INPUT.bessel_nao_rcut,
-                                                   tau_cart,
-                                                   ucell.lat0 * ucell.latvec,
-                                                   NumericalBasis::indexgen(natom, lmax));
+                overlap_Sq[ik] = NumericalBasis::cal_overlap_Sq(
+                    type, ucell.lmaxmax, this->bessel_basis.get_ecut_number(), INPUT.bessel_nao_rcut, tau_cart,
+                    ucell.lat0 * ucell.latvec, NumericalBasis::indexgen(natom, lmax));
 #endif
-                ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running,"cal_overlap_Sq");
+                ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running, "cal_overlap_Sq");
             }
         }
 
-        const ModuleBase::matrix overlap_V = this->cal_overlap_V(wfcpw,
-                                                                 psi,
-                                                                 static_cast<double>(derivative_order),
-                                                                 kv,
-                                                                 ucell.tpiba);
+        const ModuleBase::matrix overlap_V
+            = this->cal_overlap_V(wfcpw, psi, static_cast<double>(derivative_order), kv, ucell.tpiba);
 
         // ALTHOUGH THIS FUNCTION NAMES output_overlap, IT ACTUALLY OUTPUTS THE OVERLAP MATRIX HERE
 #ifdef __MPI
         for (int ik = 0; ik < kv.get_nks(); ik++)
         {
             Parallel_Reduce::reduce_pool(overlap_Q[ik].ptr, overlap_Q[ik].getSize());
-            //Parallel_Reduce::reduce_pool(overlap_Sq[ik].ptr, overlap_Sq[ik].getSize());
+            // Parallel_Reduce::reduce_pool(overlap_Sq[ik].ptr, overlap_Sq[ik].getSize());
         }
-        Parallel_Reduce::reduce_pool(overlap_V.c, overlap_V.nr * overlap_V.nc);		// Peize Lin add 2020.04.23
-    #endif
+        Parallel_Reduce::reduce_pool(overlap_V.c, overlap_V.nr * overlap_V.nc); // Peize Lin add 2020.04.23
+#endif
         // exception handling following, for FileNotOpenFailure
-        if(ofs.good()) this->output_info(ofs, bessel_basis, kv, ucell); // header of orb_matrix* file
-        else ModuleBase::WARNING_QUIT("Numerical_Basis","Failed to open file for writing the overlap matrix.");
+        if (ofs.good())
+            this->output_info(ofs, bessel_basis, kv, ucell); // header of orb_matrix* file
+        else
+            ModuleBase::WARNING_QUIT("Numerical_Basis", "Failed to open file for writing the overlap matrix.");
         // because one stage of file io complete, re-check the file status.
-        if(ofs.good()) this->output_k(ofs, kv); // <WEIGHTS_OF_KPOINTS>...</WEIGHTS_OF_KPOINTS>
-        else ModuleBase::WARNING_QUIT("Numerical_Basis","Failed to write k-points to file.");
+        if (ofs.good())
+            this->output_k(ofs, kv); // <WEIGHTS_OF_KPOINTS>...</WEIGHTS_OF_KPOINTS>
+        else
+            ModuleBase::WARNING_QUIT("Numerical_Basis", "Failed to write k-points to file.");
         // because one stage of file io complete, re-check the file status.
-        if(ofs.good()) this->output_overlap_Q(ofs, overlap_Q, kv); // <OVERLAP_Q>...</OVERLAP_Q>
-        else ModuleBase::WARNING_QUIT("Numerical_Basis","Failed to write overlap Q to file.");
+        if (ofs.good())
+            this->output_overlap_Q(ofs, overlap_Q, kv); // <OVERLAP_Q>...</OVERLAP_Q>
+        else
+            ModuleBase::WARNING_QUIT("Numerical_Basis", "Failed to write overlap Q to file.");
         // because one stage of file io complete, re-check the file status.
-        if(winput::out_spillage == 2)
+        if (winput::out_spillage == 2)
         {
             // caution: this is the largest matrix to be output, always flush
-            if(ofs.good()) this->output_overlap_Sq(ss.str(), ofs, overlap_Sq, kv); // <OVERLAP_Sq>...</OVERLAP_Sq>
-            else ModuleBase::WARNING_QUIT("Numerical_Basis","Failed to write overlap S to file.");
+            if (ofs.good())
+                this->output_overlap_Sq(ss.str(), ofs, overlap_Sq, kv); // <OVERLAP_Sq>...</OVERLAP_Sq>
+            else
+                ModuleBase::WARNING_QUIT("Numerical_Basis", "Failed to write overlap S to file.");
         }
         // because one stage of file io complete, re-check the file status.
-        if(ofs.good()) this->output_overlap_V(ofs, overlap_V); // <OVERLAP_V>...</OVERLAP_V>
-                                                               // Peize Lin add 2020.04.23
-        else ModuleBase::WARNING_QUIT("Numerical_Basis","Failed to write overlap V to file.");
-        if (GlobalV::MY_RANK==0) ofs.close();
+        if (ofs.good())
+            this->output_overlap_V(ofs, overlap_V); // <OVERLAP_V>...</OVERLAP_V>
+                                                    // Peize Lin add 2020.04.23
+        else
+            ModuleBase::WARNING_QUIT("Numerical_Basis", "Failed to write overlap V to file.");
+        if (GlobalV::MY_RANK == 0)
+            ofs.close();
     }
     return;
 }
 
-ModuleBase::ComplexArray Numerical_Basis::cal_overlap_Q(const int& ik,
-                                                        const int& np,
-                                                        const ModulePW::PW_Basis_K* wfcpw,
+ModuleBase::ComplexArray Numerical_Basis::cal_overlap_Q(const int& ik, const int& np, const ModulePW::PW_Basis_K* wfcpw,
                                                         const psi::Psi<std::complex<double>>& psi,
-                                                        const double derivative_order,
-                                                        const Structure_Factor& sf,
+                                                        const double derivative_order, const Structure_Factor& sf,
                                                         const UnitCell& ucell) const
 {
-    ModuleBase::TITLE("Numerical_Basis","cal_overlap_Q");
-    ModuleBase::timer::tick("Numerical_Basis","cal_overlap_Q");
+    ModuleBase::TITLE("Numerical_Basis", "cal_overlap_Q");
+    ModuleBase::timer::tick("Numerical_Basis", "cal_overlap_Q");
 
-	GlobalV::ofs_running << " OUTPUT THE OVERLAP BETWEEN SPHERICAL BESSEL FUNCTIONS AND BLOCH WAVE FUNCTIONS" << std::endl;
-	GlobalV::ofs_running << " Q = < J_mu, q | Psi_n, k > " << std::endl;
+    GlobalV::ofs_running << " OUTPUT THE OVERLAP BETWEEN SPHERICAL BESSEL FUNCTIONS AND BLOCH WAVE FUNCTIONS"
+                         << std::endl;
+    GlobalV::ofs_running << " Q = < J_mu, q | Psi_n, k > " << std::endl;
 
-    ModuleBase::ComplexArray overlap_Q(GlobalV::NBANDS, GlobalV::NLOCAL, this->bessel_basis.get_ecut_number() );
+    ModuleBase::ComplexArray overlap_Q(GlobalV::NBANDS, GlobalV::NLOCAL, this->bessel_basis.get_ecut_number());
     overlap_Q.zero_out();
 
-	const double normalization = (4 * ModuleBase::PI) / sqrt(ucell.omega);			// Peize Lin add normalization 2015-12-29
+    const double normalization = (4 * ModuleBase::PI) / sqrt(ucell.omega); // Peize Lin add normalization 2015-12-29
 
     std::vector<ModuleBase::Vector3<double>> gk(np);
     for (int ig = 0; ig < np; ig++)
@@ -231,79 +233,75 @@ ModuleBase::ComplexArray Numerical_Basis::cal_overlap_Q(const int& ik,
 
     const std::vector<double> gpow = Numerical_Basis::cal_gpow(gk, derivative_order);
 
-	const ModuleBase::realArray flq = this->cal_flq(gk, ucell.lmax);
+    const ModuleBase::realArray flq = this->cal_flq(gk, ucell.lmax);
 
     const ModuleBase::matrix ylm = Numerical_Basis::cal_ylm(gk, ucell.lmax);
 
-    GlobalV::ofs_running << "\n " << std::setw(5)
-        << "ik" << std::setw(8)
-        << "Type1" << std::setw(8)
-        << "Atom1" << std::setw(8)
-        << "L" << std::endl;
+    GlobalV::ofs_running << "\n " << std::setw(5) << "ik" << std::setw(8) << "Type1" << std::setw(8) << "Atom1"
+                         << std::setw(8) << "L" << std::endl;
 
     for (int T = 0; T < ucell.ntype; T++)
     {
-        //OUT("T",T);
+        // OUT("T",T);
         for (int I = 0; I < ucell.atoms[T].na; I++)
         {
-            //OUT("I",I);
+            // OUT("I",I);
             std::complex<double>* sk = sf.get_sk(ik, T, I, wfcpw);
-            for (int L=0; L< ucell.atoms[T].nwl+1; L++)
+            for (int L = 0; L < ucell.atoms[T].nwl + 1; L++)
             {
-                GlobalV::ofs_running << " " << std::setw(5) << ik+1
-                            << std::setw(8) << ucell.atoms[T].label
-                            << std::setw(8) << I+1
-							<< std::setw(8) << L
-							<< std::endl;
-                //OUT("l",l);
-                std::complex<double> lphase = normalization * pow(ModuleBase::IMAG_UNIT, -L);			// Peize Lin add normalization 2015-12-29
-                for (int ie=0; ie < this->bessel_basis.get_ecut_number(); ie++)
+                GlobalV::ofs_running << " " << std::setw(5) << ik + 1 << std::setw(8) << ucell.atoms[T].label
+                                     << std::setw(8) << I + 1 << std::setw(8) << L << std::endl;
+                // OUT("l",l);
+                std::complex<double> lphase
+                    = normalization * pow(ModuleBase::IMAG_UNIT, -L); // Peize Lin add normalization 2015-12-29
+                for (int ie = 0; ie < this->bessel_basis.get_ecut_number(); ie++)
                 {
                     const int N = 0;
-                    assert( ucell.nmax == 1);
-                    for (int m=0; m<2*L+1; m++)
+                    assert(ucell.nmax == 1);
+                    for (int m = 0; m < 2 * L + 1; m++)
                     {
-                        const int lm = L*L+m;
-                        for (int ib=0; ib<GlobalV::NBANDS; ib++)
+                        const int lm = L * L + m;
+                        for (int ib = 0; ib < GlobalV::NBANDS; ib++)
                         {
                             std::complex<double> overlap_tmp = ModuleBase::ZERO;
-                            for (int ig=0; ig<np; ig++)
+                            for (int ig = 0; ig < np; ig++)
                             {
-//                              const std::complex<double> local_tmp = lphase * sk[ig] * ylm(lm, ig) * flq[ig];
-                                const std::complex<double> local_tmp = lphase * sk[ig] * ylm(lm, ig) * flq(L,ie,ig) * gpow[ig];		// Peize Lin add for dpsi 2020.04.23
-                                overlap_tmp += conj( local_tmp ) * psi(ib, ig); // psi is bloch orbitals
+                                //                              const std::complex<double> local_tmp = lphase * sk[ig] *
+                                //                              ylm(lm, ig) * flq[ig];
+                                const std::complex<double> local_tmp = lphase * sk[ig] * ylm(lm, ig) * flq(L, ie, ig)
+                                                                       * gpow[ig]; // Peize Lin add for dpsi 2020.04.23
+                                overlap_tmp += conj(local_tmp) * psi(ib, ig);      // psi is bloch orbitals
                             }
                             overlap_Q(ib, this->mu_index[T](I, L, N, m), ie) = overlap_tmp;
                         }
                     }
-                }//end ie
-            }//end l
-            delete[] sk;    sk=nullptr;
+                } // end ie
+            }     // end l
+            delete[] sk;
+            sk = nullptr;
         }
     }
 
-    ModuleBase::timer::tick("Numerical_Basis","cal_overlap_Q");
+    ModuleBase::timer::tick("Numerical_Basis", "cal_overlap_Q");
     return overlap_Q;
 }
 
-ModuleBase::ComplexArray Numerical_Basis::cal_overlap_Sq(const int& ik,
-                                                         const int& np,
-                                                         const double derivative_order,
-                                                         const Structure_Factor& sf,
-                                                         const ModulePW::PW_Basis_K* wfcpw,
+ModuleBase::ComplexArray Numerical_Basis::cal_overlap_Sq(const int& ik, const int& np, const double derivative_order,
+                                                         const Structure_Factor& sf, const ModulePW::PW_Basis_K* wfcpw,
                                                          const UnitCell& ucell) const
 {
-    ModuleBase::TITLE("Numerical_Basis","cal_overlap_Sq");
-    ModuleBase::timer::tick("Numerical_Basis","cal_overlap_Sq");
+    ModuleBase::TITLE("Numerical_Basis", "cal_overlap_Sq");
+    ModuleBase::timer::tick("Numerical_Basis", "cal_overlap_Sq");
 
-	GlobalV::ofs_running << " OUTPUT THE OVERLAP BETWEEN SPHERICAL BESSEL FUNCTIONS"  << std::endl;
-	GlobalV::ofs_running << " S = < J_mu,q1 | J_nu,q2 >" << std::endl;
+    GlobalV::ofs_running << " OUTPUT THE OVERLAP BETWEEN SPHERICAL BESSEL FUNCTIONS" << std::endl;
+    GlobalV::ofs_running << " S = < J_mu,q1 | J_nu,q2 >" << std::endl;
 
     const int enumber = this->bessel_basis.get_ecut_number();
-    ModuleBase::ComplexArray overlap_Sq( GlobalV::NLOCAL, GlobalV::NLOCAL, enumber, enumber );
+    ModuleBase::ComplexArray overlap_Sq(GlobalV::NLOCAL, GlobalV::NLOCAL, enumber, enumber);
     overlap_Sq.zero_out();
 
-	const double normalization = (4 * ModuleBase::PI) * (4 * ModuleBase::PI) / ucell.omega;			// Peize Lin add normalization 2015-12-29
+    const double normalization
+        = (4 * ModuleBase::PI) * (4 * ModuleBase::PI) / ucell.omega; // Peize Lin add normalization 2015-12-29
 
     std::vector<ModuleBase::Vector3<double>> gk(np);
     for (int ig = 0; ig < np; ig++)
@@ -311,64 +309,58 @@ ModuleBase::ComplexArray Numerical_Basis::cal_overlap_Sq(const int& ik,
 
     const std::vector<double> gpow = Numerical_Basis::cal_gpow(gk, derivative_order);
 
-	const ModuleBase::realArray flq = this->cal_flq(gk, ucell.lmax);
+    const ModuleBase::realArray flq = this->cal_flq(gk, ucell.lmax);
 
     const ModuleBase::matrix ylm = Numerical_Basis::cal_ylm(gk, ucell.lmax);
 
-    GlobalV::ofs_running << "\n " << std::setw(5)
-        << "ik" << std::setw(8)
-        << "Type1" << std::setw(8)
-        << "Atom1" << std::setw(8)
-        << "L1" << std::setw(8)
-        << "Type2" << std::setw(8)
-        << "Atom2" << std::setw(8)
-        << "L2" << std::endl;
+    GlobalV::ofs_running << "\n " << std::setw(5) << "ik" << std::setw(8) << "Type1" << std::setw(8) << "Atom1"
+                         << std::setw(8) << "L1" << std::setw(8) << "Type2" << std::setw(8) << "Atom2" << std::setw(8)
+                         << "L2" << std::endl;
 
     for (int T1 = 0; T1 < ucell.ntype; T1++) // 1.1
     {
         for (int I1 = 0; I1 < ucell.atoms[T1].na; I1++) // 1.2
         {
             std::complex<double>* sk1 = sf.get_sk(ik, T1, I1, wfcpw);
-            for (int T2=0; T2<ucell.ntype; T2++) // 2.1
+            for (int T2 = 0; T2 < ucell.ntype; T2++) // 2.1
             {
-                for (int I2=0; I2<ucell.atoms[T2].na; I2++) // 2.2
+                for (int I2 = 0; I2 < ucell.atoms[T2].na; I2++) // 2.2
                 {
                     std::complex<double>* sk2 = sf.get_sk(ik, T2, I2, wfcpw);
-                    for (int l1 = 0; l1 < ucell.atoms[T1].nwl+1; l1++) // 1.3
+                    for (int l1 = 0; l1 < ucell.atoms[T1].nwl + 1; l1++) // 1.3
                     {
-                        const std::complex<double> lphase1 = normalization * pow(ModuleBase::IMAG_UNIT, l1);			// Peize Lin add normalization 2015-12-29
-                        for (int l2 = 0; l2 < ucell.atoms[T2].nwl+1; l2++) // 2.3
+                        const std::complex<double> lphase1
+                            = normalization * pow(ModuleBase::IMAG_UNIT, l1); // Peize Lin add normalization 2015-12-29
+                        for (int l2 = 0; l2 < ucell.atoms[T2].nwl + 1; l2++)  // 2.3
                         {
-                            GlobalV::ofs_running << " " << std::setw(5)
-                                << ik+1 << std::setw(8)
-                                << ucell.atoms[T1].label << std::setw(8)
-                                << I1+1 << std::setw(8)
-                                << l1 << std::setw(8)
-                                << ucell.atoms[T2].label << std::setw(8)
-                                << I2+1 << std::setw(8)
-                                << l2 << std::setw(8) << std::endl;
+                            GlobalV::ofs_running << " " << std::setw(5) << ik + 1 << std::setw(8)
+                                                 << ucell.atoms[T1].label << std::setw(8) << I1 + 1 << std::setw(8)
+                                                 << l1 << std::setw(8) << ucell.atoms[T2].label << std::setw(8)
+                                                 << I2 + 1 << std::setw(8) << l2 << std::setw(8) << std::endl;
 
                             const std::complex<double> lphase2 = pow(ModuleBase::IMAG_UNIT, l2);
-                            for (int ic1=0; ic1 < ucell.nmax; ic1++) // 1.5
+                            for (int ic1 = 0; ic1 < ucell.nmax; ic1++) // 1.5
                             {
-                                for (int ic2=0; ic2 < ucell.nmax; ic2++) // 2.5
+                                for (int ic2 = 0; ic2 < ucell.nmax; ic2++) // 2.5
                                 {
-                                    for (int m1=0; m1<2*l1+1; m1++) // 1.6
+                                    for (int m1 = 0; m1 < 2 * l1 + 1; m1++) // 1.6
                                     {
-                                        const int lm1 = l1*l1+m1;
-                                        const int iwt1 = this->mu_index[T1](I1,l1,ic1,m1);
+                                        const int lm1 = l1 * l1 + m1;
+                                        const int iwt1 = this->mu_index[T1](I1, l1, ic1, m1);
 
-                                        std::vector<std::complex<double>> about_ig1(np, std::complex<double>(0.0,0.0));
-                                        for (int ig=0; ig<np; ig++)
-                                            about_ig1[ig] = conj( lphase1 * sk1[ig] * ylm(lm1, ig) ) * gpow[ig];		// Peize Lin add for dpsi 2020.04.23
+                                        std::vector<std::complex<double>> about_ig1(np, std::complex<double>(0.0, 0.0));
+                                        for (int ig = 0; ig < np; ig++)
+                                            about_ig1[ig] = conj(lphase1 * sk1[ig] * ylm(lm1, ig))
+                                                            * gpow[ig]; // Peize Lin add for dpsi 2020.04.23
 
-                                        for (int m2=0; m2<2*l2+1; m2++) // 2.6
+                                        for (int m2 = 0; m2 < 2 * l2 + 1; m2++) // 2.6
                                         {
-                                            const int lm2 = l2*l2+m2;
-                                            const int iwt2 = this->mu_index[T2](I2,l2,ic2,m2);
+                                            const int lm2 = l2 * l2 + m2;
+                                            const int iwt2 = this->mu_index[T2](I2, l2, ic2, m2);
 
-                                            std::vector<std::complex<double>> about_ig2(np, std::complex<double>(0.0,0.0));
-                                            for (int ig=0; ig<np; ++ig)
+                                            std::vector<std::complex<double>> about_ig2(np,
+                                                                                        std::complex<double>(0.0, 0.0));
+                                            for (int ig = 0; ig < np; ++ig)
                                                 about_ig2[ig] = lphase2 * sk2[ig] * ylm(lm2, ig) * about_ig1[ig];
 
                                             /* same as:
@@ -379,94 +371,96 @@ ModuleBase::ComplexArray Numerical_Basis::cal_overlap_Sq(const int& ik,
                                                             about_ig2[ig] * flq(l1,ie1,ig) * flq(l2,ie2,ig);
                                             */
 
-                                            ModuleBase::ComplexMatrix about_ig3_1(enumber,np);
-                                            std::copy( &flq(l1,0,0), &flq(l1,0,0)+enumber*np, about_ig3_1.c );
+                                            ModuleBase::ComplexMatrix about_ig3_1(enumber, np);
+                                            std::copy(&flq(l1, 0, 0), &flq(l1, 0, 0) + enumber * np, about_ig3_1.c);
 
-                                            ModuleBase::ComplexMatrix about_ig3_2(enumber,np);
-                                            for(int ie2=0; ie2<enumber; ++ie2)
-                                                std::transform( &flq(l2,ie2,0), &flq(l2,ie2,0)+np, about_ig2.data(), about_ig3_2.c+ie2*np, std::multiplies<std::complex<double>>() );
+                                            ModuleBase::ComplexMatrix about_ig3_2(enumber, np);
+                                            for (int ie2 = 0; ie2 < enumber; ++ie2)
+                                                std::transform(&flq(l2, ie2, 0), &flq(l2, ie2, 0) + np,
+                                                               about_ig2.data(), about_ig3_2.c + ie2 * np,
+                                                               std::multiplies<std::complex<double>>());
 
-                                            BlasConnector::gemm('N', 'T', enumber, enumber, np,
-                                                1.0, about_ig3_1.c, np, about_ig3_2.c, np,
-                                                1.0, &overlap_Sq(iwt1,iwt2,0,0), enumber);
+                                            BlasConnector::gemm('N', 'T', enumber, enumber, np, 1.0, about_ig3_1.c, np,
+                                                                about_ig3_2.c, np, 1.0, &overlap_Sq(iwt1, iwt2, 0, 0),
+                                                                enumber);
                                         }
                                     }
                                 }
                             }
                         }
                     }
-                    delete[] sk2;   sk2=nullptr;
+                    delete[] sk2;
+                    sk2 = nullptr;
                 }
             }
-            delete[] sk1;   sk1=nullptr;
+            delete[] sk1;
+            sk1 = nullptr;
         }
     }
 
-    ModuleBase::timer::tick("Numerical_Basis","cal_overlap_Sq");
+    ModuleBase::timer::tick("Numerical_Basis", "cal_overlap_Sq");
     return overlap_Sq;
 }
-
-
-
 
 // Peize Lin add for dpsi 2020.04.23
 ModuleBase::matrix Numerical_Basis::cal_overlap_V(const ModulePW::PW_Basis_K* wfcpw,
                                                   const psi::Psi<std::complex<double>>& psi,
-                                                  const double derivative_order,
-                                                  const K_Vectors& kv,
+                                                  const double derivative_order, const K_Vectors& kv,
                                                   const double tpiba)
 {
     ModuleBase::matrix overlap_V(kv.get_nks(), GlobalV::NBANDS);
     for (int ik = 0; ik < kv.get_nks(); ++ik)
     {
         std::vector<ModuleBase::Vector3<double>> gk(kv.ngk[ik]);
-        for (int ig=0; ig<gk.size(); ig++)
-            gk[ig] = wfcpw->getgpluskcar(ik,ig) * tpiba;
+        for (int ig = 0; ig < gk.size(); ig++)
+            gk[ig] = wfcpw->getgpluskcar(ik, ig) * tpiba;
 
         const std::vector<double> gpow = Numerical_Basis::cal_gpow(gk, derivative_order);
 
-		for(int ib=0; ib<GlobalV::NBANDS; ++ib)
+        for (int ib = 0; ib < GlobalV::NBANDS; ++ib)
             for (int ig = 0; ig < kv.ngk[ik]; ++ig)
-                overlap_V(ik,ib)+= norm(psi(ik,ib,ig)) * gpow[ig];
-	}
-	return overlap_V;
+                overlap_V(ik, ib) += norm(psi(ik, ib, ig)) * gpow[ig];
+    }
+    return overlap_V;
 }
 
-ModuleBase::realArray Numerical_Basis::cal_flq(const std::vector<ModuleBase::Vector3<double>> &gk, const int ucell_lmax) const
+ModuleBase::realArray Numerical_Basis::cal_flq(const std::vector<ModuleBase::Vector3<double>>& gk,
+                                               const int ucell_lmax) const
 {
-	const int np = gk.size();
-	const int enumber = this->bessel_basis.get_ecut_number();
+    const int np = gk.size();
+    const int enumber = this->bessel_basis.get_ecut_number();
 
     // get flq(G) = \int f(r)jl(G*r) from interpolation table.
-    ModuleBase::realArray flq(ucell_lmax+1, enumber, np);
-    for (int il=0; il<ucell_lmax+1; il++)
+    ModuleBase::realArray flq(ucell_lmax + 1, enumber, np);
+    for (int il = 0; il < ucell_lmax + 1; il++)
     {
-        for (int ie=0; ie<enumber; ie++)
+        for (int ie = 0; ie < enumber; ie++)
         {
-            for (int ig=0; ig<np; ig++)
+            for (int ig = 0; ig < np; ig++)
             {
-                flq(il,ie,ig) = this->bessel_basis.Polynomial_Interpolation2(il, ie, gk[ig].norm());
+                flq(il, ie, ig) = this->bessel_basis.Polynomial_Interpolation2(il, ie, gk[ig].norm());
             }
         }
     }
-	return flq;
+    return flq;
 }
 
-ModuleBase::matrix Numerical_Basis::cal_ylm(const std::vector<ModuleBase::Vector3<double>> &gk, const int ucell_lmax)
+ModuleBase::matrix Numerical_Basis::cal_ylm(const std::vector<ModuleBase::Vector3<double>>& gk, const int ucell_lmax)
 {
-    const int total_lm = ( ucell_lmax + 1) * ( ucell_lmax + 1);
+    const int total_lm = (ucell_lmax + 1) * (ucell_lmax + 1);
     ModuleBase::matrix ylm(total_lm, gk.size());
     ModuleBase::YlmReal::Ylm_Real(total_lm, gk.size(), gk.data(), ylm);
     return ylm;
 }
 
-std::vector<double> Numerical_Basis::cal_gpow (const std::vector<ModuleBase::Vector3<double>> &gk, const double derivative_order)
+std::vector<double> Numerical_Basis::cal_gpow(const std::vector<ModuleBase::Vector3<double>>& gk,
+                                              const double derivative_order)
 {
     constexpr double thr = 1E-12;
     std::vector<double> gpow(gk.size(), 0.0);
-    for (int ig=0; ig<gpow.size(); ++ig)
+    for (int ig = 0; ig < gpow.size(); ++ig)
     {
-        if (derivative_order>=0)
+        if (derivative_order >= 0)
         {
             gpow[ig] = std::pow(gk[ig].norm2(), derivative_order);
         }
@@ -481,36 +475,31 @@ std::vector<double> Numerical_Basis::cal_gpow (const std::vector<ModuleBase::Vec
 
 std::vector<ModuleBase::IntArray> Numerical_Basis::init_mu_index(const UnitCell& ucell)
 {
-	GlobalV::ofs_running << " Initialize the mu index" << std::endl;
+    GlobalV::ofs_running << " Initialize the mu index" << std::endl;
     std::vector<ModuleBase::IntArray> mu_index_(ucell.ntype);
 
     int mu = 0;
-    for (int it=0; it<ucell.ntype; it++)
+    for (int it = 0; it < ucell.ntype; it++)
     {
-        mu_index_[it].create(
-            ucell.atoms[it].na,
-            ucell.atoms[it].nwl+1,
-            ucell.nmax,
-            2*(ucell.atoms[it].nwl+1)+1); // m ==> 2*l+1
+        mu_index_[it].create(ucell.atoms[it].na, ucell.atoms[it].nwl + 1, ucell.nmax,
+                             2 * (ucell.atoms[it].nwl + 1) + 1); // m ==> 2*l+1
 
         mu_index_[it].zero_out();
 
-		// mohan added 2021-01-03
-		GlobalV::ofs_running << "Type " << it+1
-            << " number_of_atoms " << ucell.atoms[it].na
-            << " number_of_L " << ucell.atoms[it].nwl+1
-            << " number_of_n " << ucell.nmax
-            << " number_of_m " << 2*(ucell.atoms[it].nwl+1)+1 << std::endl;
+        // mohan added 2021-01-03
+        GlobalV::ofs_running << "Type " << it + 1 << " number_of_atoms " << ucell.atoms[it].na << " number_of_L "
+                             << ucell.atoms[it].nwl + 1 << " number_of_n " << ucell.nmax << " number_of_m "
+                             << 2 * (ucell.atoms[it].nwl + 1) + 1 << std::endl;
 
-        for (int ia=0; ia<ucell.atoms[it].na; ia++)
+        for (int ia = 0; ia < ucell.atoms[it].na; ia++)
         {
-            for (int l=0; l< ucell.atoms[it].nwl+1; l++)
+            for (int l = 0; l < ucell.atoms[it].nwl + 1; l++)
             {
-                for (int n=0; n< ucell.atoms[it].l_nchi[l]; n++)
+                for (int n = 0; n < ucell.atoms[it].l_nchi[l]; n++)
                 {
-                    for (int m=0; m<2*l+1; m++)
+                    for (int m = 0; m < 2 * l + 1; m++)
                     {
-                        mu_index_[it](ia,l,n,m) = mu;
+                        mu_index_[it](ia, l, n, m) = mu;
                         mu++;
                     }
                 }
@@ -520,10 +509,8 @@ std::vector<ModuleBase::IntArray> Numerical_Basis::init_mu_index(const UnitCell&
     return mu_index_;
 }
 
-void Numerical_Basis::numerical_atomic_wfc(const int& ik,
-                                           const ModulePW::PW_Basis_K* wfcpw,
-                                           ModuleBase::ComplexMatrix& psi,
-                                           const Structure_Factor& sf,
+void Numerical_Basis::numerical_atomic_wfc(const int& ik, const ModulePW::PW_Basis_K* wfcpw,
+                                           ModuleBase::ComplexMatrix& psi, const Structure_Factor& sf,
                                            const UnitCell& ucell)
 {
     ModuleBase::TITLE("Numerical_Basis", "numerical_atomic_wfc");
@@ -532,52 +519,52 @@ void Numerical_Basis::numerical_atomic_wfc(const int& ik,
     for (int ig = 0; ig < np; ig++)
         gk[ig] = wfcpw->getgpluskcar(ik, ig);
 
-    const int total_lm = ( ucell.lmax + 1) * ( ucell.lmax + 1);
+    const int total_lm = (ucell.lmax + 1) * (ucell.lmax + 1);
     ModuleBase::matrix ylm(total_lm, np);
     ModuleBase::YlmReal::Ylm_Real(total_lm, np, gk.data(), ylm);
 
     std::vector<double> flq(np);
     for (int it = 0; it < ucell.ntype; it++)
     {
-        //OUT("it",it);
+        // OUT("it",it);
         for (int ia = 0; ia < ucell.atoms[it].na; ia++)
         {
-            //OUT("ia",ia);
+            // OUT("ia",ia);
             std::complex<double>* sk = sf.get_sk(ik, it, ia, wfcpw);
-            for (int l = 0; l < ucell.atoms[it].nwl+1; l++)
+            for (int l = 0; l < ucell.atoms[it].nwl + 1; l++)
             {
-                //OUT("l",l);
+                // OUT("l",l);
                 std::complex<double> lphase = pow(ModuleBase::IMAG_UNIT, l);
-                for (int ic=0; ic < ucell.atoms[it].l_nchi[l]; ic++)
+                for (int ic = 0; ic < ucell.atoms[it].l_nchi[l]; ic++)
                 {
-                    //OUT("ic",ic);
-                    for (int ig=0; ig<np; ig++)
+                    // OUT("ic",ic);
+                    for (int ig = 0; ig < np; ig++)
                     {
-                        flq[ig] = this->bessel_basis.
-                                  Polynomial_Interpolation(it, l, ic, gk[ig].norm() * ucell.tpiba );
+                        flq[ig] = this->bessel_basis.Polynomial_Interpolation(it, l, ic, gk[ig].norm() * ucell.tpiba);
                     }
 
-                    for (int m=0; m<2*l+1; m++)
+                    for (int m = 0; m < 2 * l + 1; m++)
                     {
-                        //OUT("m",m);
-                        const int lm = l*l+m;
-                        for (int ig=0; ig<np; ig++)
+                        // OUT("m",m);
+                        const int lm = l * l + m;
+                        for (int ig = 0; ig < np; ig++)
                         {
-                            psi( this->mu_index[it](ia,l,ic,m), ig) =
-                                lphase * sk[ig] * ylm(lm, ig) * flq[ig];
+                            psi(this->mu_index[it](ia, l, ic, m), ig) = lphase * sk[ig] * ylm(lm, ig) * flq[ig];
                         }
                     }
                 }
             }
-            delete[] sk;    sk=nullptr;
+            delete[] sk;
+            sk = nullptr;
         }
     }
 }
 
-void Numerical_Basis::output_info(std::ofstream& ofs, const Bessel_Basis& bessel_basis, const K_Vectors& kv, const UnitCell& ucell)
+void Numerical_Basis::output_info(std::ofstream& ofs, const Bessel_Basis& bessel_basis, const K_Vectors& kv,
+                                  const UnitCell& ucell)
 {
     // only print out to the information by the first processor
-    if (GlobalV::MY_RANK==0)
+    if (GlobalV::MY_RANK == 0)
     {
         ofs.precision(10);
         ofs << ucell.lat0 << std::endl;
@@ -587,22 +574,21 @@ void Numerical_Basis::output_info(std::ofstream& ofs, const Bessel_Basis& bessel
         ofs << ucell.latvec.e31 << " " << ucell.latvec.e32 << " " << ucell.latvec.e33 << std::endl;
 
         ofs << ucell.ntype << " ntype" << std::endl;
-        for (int it=0; it<ucell.ntype; it++)
+        for (int it = 0; it < ucell.ntype; it++)
         {
             ofs << ucell.atoms[it].label << " label" << std::endl; // mohan add 2009-07-23
             ofs << ucell.atoms[it].na << " na" << std::endl;
-            for (int ia=0; ia<ucell.atoms[it].na; ia++)
+            for (int ia = 0; ia < ucell.atoms[it].na; ia++)
             {
-                ofs << ucell.atoms[it].tau[ia].x << " "
-                    << ucell.atoms[it].tau[ia].y << " "
-                    << ucell.atoms[it].tau[ia].z << std::endl;
+                ofs << ucell.atoms[it].tau[ia].x << " " << ucell.atoms[it].tau[ia].y << " " << ucell.atoms[it].tau[ia].z
+                    << std::endl;
             }
         }
         // ecutwfc_jlq determine the jlq corresponding to plane wave calculation.
         ofs << INPUT.ecutwfc << " ecutwfc" << std::endl; // mohan add 2009-09-08
 
         // this parameter determine the total number of jlq.
-        ofs << bessel_basis.get_ecut() << " ecutwfc_jlq" << std::endl;//mohan modify 2009-09-08
+        ofs << bessel_basis.get_ecut() << " ecutwfc_jlq" << std::endl; // mohan modify 2009-09-08
         ofs << bessel_basis.get_rcut() << " rcut_Jlq" << std::endl;
 
         // mohan add 'smooth' and 'sigma' 2009-08-28
@@ -619,7 +605,7 @@ void Numerical_Basis::output_info(std::ofstream& ofs, const Bessel_Basis& bessel
     ofs << std::setprecision(8);
     // NOTICE: ofs_warning << "\n The precison may affect the optimize result.";
 
-    if (GlobalV::MY_RANK==0)
+    if (GlobalV::MY_RANK == 0)
     {
         ofs << kv.get_nkstot() << " nks" << std::endl;
         ofs << GlobalV::NBANDS << " nbands" << std::endl;
@@ -631,7 +617,7 @@ void Numerical_Basis::output_info(std::ofstream& ofs, const Bessel_Basis& bessel
 void Numerical_Basis::output_k(std::ofstream& ofs, const K_Vectors& kv)
 {
     // (1)
-    if (GlobalV::MY_RANK==0)
+    if (GlobalV::MY_RANK == 0)
     {
         ofs << "<WEIGHT_OF_KPOINTS>";
     }
@@ -640,19 +626,20 @@ void Numerical_Basis::output_k(std::ofstream& ofs, const K_Vectors& kv)
     int nkstot = kv.get_nkstot();
 
     // (2)
-    for (int ik=0; ik<nkstot; ik++)
+    for (int ik = 0; ik < nkstot; ik++)
     {
         double kx, ky, kz, wknow;
 #ifdef __MPI
-        //temprary restrict kpar=1 for NSPIN=2 case for generating_orbitals
+        // temprary restrict kpar=1 for NSPIN=2 case for generating_orbitals
         int pool = 0;
-        if(GlobalV::NSPIN !=2 ) pool = GlobalC::Pkpoints.whichpool[ik];
+        if (GlobalV::NSPIN != 2)
+            pool = GlobalC::Pkpoints.whichpool[ik];
         const int iknow = ik - GlobalC::Pkpoints.startk_pool[GlobalV::MY_POOL];
-        if (GlobalV::RANK_IN_POOL==0)
+        if (GlobalV::RANK_IN_POOL == 0)
         {
-            if (GlobalV::MY_POOL==0)
+            if (GlobalV::MY_POOL == 0)
             {
-                if (pool==0)
+                if (pool == 0)
                 {
                     kx = kv.kvec_c[ik].x;
                     ky = kv.kvec_c[ik].y;
@@ -661,12 +648,12 @@ void Numerical_Basis::output_k(std::ofstream& ofs, const K_Vectors& kv)
                 }
                 else
                 {
-                    int startpro_pool=GlobalC::Pkpoints.get_startpro_pool(pool);
+                    int startpro_pool = GlobalC::Pkpoints.get_startpro_pool(pool);
                     MPI_Status ierror;
-                    MPI_Recv(&kx, 1, MPI_DOUBLE, startpro_pool, ik*4, MPI_COMM_WORLD,&ierror);
-                    MPI_Recv(&ky, 1, MPI_DOUBLE, startpro_pool, ik*4+1, MPI_COMM_WORLD,&ierror);
-                    MPI_Recv(&kz, 1, MPI_DOUBLE, startpro_pool, ik*4+2, MPI_COMM_WORLD,&ierror);
-                    MPI_Recv(&wknow, 1, MPI_DOUBLE, startpro_pool, ik*4+3, MPI_COMM_WORLD,&ierror);
+                    MPI_Recv(&kx, 1, MPI_DOUBLE, startpro_pool, ik * 4, MPI_COMM_WORLD, &ierror);
+                    MPI_Recv(&ky, 1, MPI_DOUBLE, startpro_pool, ik * 4 + 1, MPI_COMM_WORLD, &ierror);
+                    MPI_Recv(&kz, 1, MPI_DOUBLE, startpro_pool, ik * 4 + 2, MPI_COMM_WORLD, &ierror);
+                    MPI_Recv(&wknow, 1, MPI_DOUBLE, startpro_pool, ik * 4 + 3, MPI_COMM_WORLD, &ierror);
                 }
             }
             else
@@ -683,7 +670,7 @@ void Numerical_Basis::output_k(std::ofstream& ofs, const K_Vectors& kv)
         // this barrier is very important
         MPI_Barrier(MPI_COMM_WORLD);
 #else
-        if (GlobalV::MY_RANK==0)
+        if (GlobalV::MY_RANK == 0)
         {
             kx = kv.kvec_c[ik].x;
             ky = kv.kvec_c[ik].y;
@@ -692,25 +679,24 @@ void Numerical_Basis::output_k(std::ofstream& ofs, const K_Vectors& kv)
         }
 #endif
 
-        if (GlobalV::MY_RANK==0)
+        if (GlobalV::MY_RANK == 0)
         {
             ofs << "\n" << kx << " " << ky << " " << kz;
             ofs << " " << wknow * 0.5;
         }
     }
 
-    if (GlobalV::MY_RANK==0)
+    if (GlobalV::MY_RANK == 0)
     {
         ofs << "\n</WEIGHT_OF_KPOINTS>" << std::endl;
     }
 }
 
-void Numerical_Basis::output_overlap_Q(std::ofstream& ofs,
-                                       const std::vector<ModuleBase::ComplexArray>& overlap_Q,
+void Numerical_Basis::output_overlap_Q(std::ofstream& ofs, const std::vector<ModuleBase::ComplexArray>& overlap_Q,
                                        const K_Vectors& kv)
 {
     // (3)
-    if (GlobalV::MY_RANK==0)
+    if (GlobalV::MY_RANK == 0)
     {
         ofs << "\n<OVERLAP_Q>";
     }
@@ -731,34 +717,31 @@ void Numerical_Basis::output_overlap_Q(std::ofstream& ofs,
     // It's better to refactor to Pkpoints.pool_collection(overlap_Q) in the future.
     // Peize Lin comments 2021.07.25
     assert(kv.get_nks() > 0);
-    ModuleBase::ComplexArray overlap_Q_k(kv.get_nks(),
-                                         overlap_Q[0].getBound1(),
-                                         overlap_Q[0].getBound2(),
+    ModuleBase::ComplexArray overlap_Q_k(kv.get_nks(), overlap_Q[0].getBound1(), overlap_Q[0].getBound2(),
                                          overlap_Q[0].getBound3());
     for (int ik = 0; ik < kv.get_nks(); ++ik)
     {
-        std::memcpy(
-            overlap_Q_k.ptr + ik*overlap_Q[ik].getSize(),
-            overlap_Q[ik].ptr,
-            overlap_Q[ik].getSize() * sizeof(std::complex<double>));
+        std::memcpy(overlap_Q_k.ptr + ik * overlap_Q[ik].getSize(), overlap_Q[ik].ptr,
+                    overlap_Q[ik].getSize() * sizeof(std::complex<double>));
     }
 
     // only half of nkstot should be output in "NSPIN == 2" case, k_up and k_down has same k infomation
     int nkstot = kv.get_nkstot();
     int count = 0;
-    for (int ik=0; ik<nkstot; ik++)
+    for (int ik = 0; ik < nkstot; ik++)
     {
         ModuleBase::ComplexArray Qtmp(overlap_Q[ik].getBound1(), overlap_Q[ik].getBound2(), overlap_Q[ik].getBound3());
         Qtmp.zero_out();
         GlobalC::Pkpoints.pool_collection(Qtmp.ptr, overlap_Q_k, ik);
-        if (GlobalV::MY_RANK==0)
+        if (GlobalV::MY_RANK == 0)
         {
-    //        ofs << "\n ik=" << ik;
+            //        ofs << "\n ik=" << ik;
             // begin data writing.
             const int dim = Qtmp.getSize();
-            for (int i=0; i<dim; i++)
+            for (int i = 0; i < dim; i++)
             {
-                if ( count%4==0 ) ofs << std::endl;
+                if (count % 4 == 0)
+                    ofs << std::endl;
                 ofs << " " << Qtmp.ptr[i].real() << " " << Qtmp.ptr[i].imag();
                 ++count;
             }
@@ -770,18 +753,16 @@ void Numerical_Basis::output_overlap_Q(std::ofstream& ofs,
     }
 
     // (5)
-    if (GlobalV::MY_RANK==0)
+    if (GlobalV::MY_RANK == 0)
     {
         ofs << "\n</OVERLAP_Q>" << std::endl;
     }
 }
 
-void Numerical_Basis::output_overlap_Sq(const std::string& name,
-                                        std::ofstream& ofs,
-                                        const std::vector<ModuleBase::ComplexArray>& overlap_Sq,
-                                        const K_Vectors& kv)
+void Numerical_Basis::output_overlap_Sq(const std::string& name, std::ofstream& ofs,
+                                        const std::vector<ModuleBase::ComplexArray>& overlap_Sq, const K_Vectors& kv)
 {
-    if (GlobalV::MY_RANK==0)
+    if (GlobalV::MY_RANK == 0)
     {
         ofs << "\n<OVERLAP_Sq>";
         ofs.close();
@@ -789,39 +770,41 @@ void Numerical_Basis::output_overlap_Sq(const std::string& name,
 
     // only half of nkstot should be output in "NSPIN == 2" case, k_up and k_down has same k infomation
     int ispin = 1;
-    if(GlobalV::NSPIN == 2) ispin = 2;
+    if (GlobalV::NSPIN == 2)
+        ispin = 2;
     int nkstot = kv.get_nkstot() / ispin;
     int count = 0;
-    for(int is = 0; is<ispin; is++)
+    for (int is = 0; is < ispin; is++)
     {
-        for (int ik=0; ik<nkstot; ik++)
+        for (int ik = 0; ik < nkstot; ik++)
         {
-            if ( GlobalV::MY_POOL == GlobalC::Pkpoints.whichpool[ik] )
+            if (GlobalV::MY_POOL == GlobalC::Pkpoints.whichpool[ik])
             {
-                if ( GlobalV::RANK_IN_POOL == 0)
+                if (GlobalV::RANK_IN_POOL == 0)
                 {
                     ofs.open(name.c_str(), std::ios::app);
                     const int ik_now = ik - GlobalC::Pkpoints.startk_pool[GlobalV::MY_POOL] + is * nkstot;
 
                     const int size = overlap_Sq[ik_now].getSize();
-                    for (int i=0; i<size; i++)
+                    for (int i = 0; i < size; i++)
                     {
-                        if (count%2==0) ofs << std::endl;
+                        if (count % 2 == 0)
+                            ofs << std::endl;
                         ofs << " " << overlap_Sq[ik_now].ptr[i].real() << " " << overlap_Sq[ik_now].ptr[i].imag();
                         ++count;
                     }
                     ofs.flush();
                     ofs.close();
                 }
-    #ifdef __MPI
+#ifdef __MPI
                 MPI_Barrier(MPI_COMM_WORLD);
-    #endif
+#endif
             }
             else
             {
-    #ifdef __MPI
+#ifdef __MPI
                 MPI_Barrier(MPI_COMM_WORLD);
-    #endif
+#endif
             }
 
             /*
@@ -832,10 +815,9 @@ void Numerical_Basis::output_overlap_Sq(const std::string& name,
                 ofs << " " << Sq_real[ik].ptr[i] << " " << Sq_imag[ik].ptr[i];
             }
             */
-
         }
     }
-    if (GlobalV::MY_RANK==0)
+    if (GlobalV::MY_RANK == 0)
     {
         ofs.open(name.c_str(), std::ios::app);
         ofs << "\n</OVERLAP_Sq>" << std::endl;
@@ -843,14 +825,13 @@ void Numerical_Basis::output_overlap_Sq(const std::string& name,
 }
 
 // Peize Lin add 2020.04.23
-void Numerical_Basis::output_overlap_V(
-    std::ofstream &ofs,
-	const ModuleBase::matrix &overlap_V)
+void Numerical_Basis::output_overlap_V(std::ofstream& ofs, const ModuleBase::matrix& overlap_V)
 {
-	if (GlobalV::MY_RANK==0)
+    if (GlobalV::MY_RANK == 0)
     {
-        ofs << "\n<OVERLAP_V>" <<std::endl;;
-		overlap_V.print(ofs);
-		ofs << "</OVERLAP_V>" <<std::endl;
-	}
+        ofs << "\n<OVERLAP_V>" << std::endl;
+        ;
+        overlap_V.print(ofs);
+        ofs << "</OVERLAP_V>" << std::endl;
+    }
 }

--- a/source/module_io/numerical_basis_jyjy.cpp
+++ b/source/module_io/numerical_basis_jyjy.cpp
@@ -3,8 +3,6 @@
 #include "module_base/vector3.h"
 #include "module_basis/module_nao/two_center_integrator.h"
 
-#define __LCAO
-
 namespace NumericalBasis
 {
 #ifdef __LCAO

--- a/source/module_io/numerical_basis_jyjy.cpp
+++ b/source/module_io/numerical_basis_jyjy.cpp
@@ -1,4 +1,5 @@
 #include "module_io/numerical_basis_jyjy.h"
+
 #include "module_base/matrix3.h"
 #include "module_base/vector3.h"
 #include "module_basis/module_nao/two_center_integrator.h"
@@ -11,8 +12,7 @@ using Vec3 = ModuleBase::Vector3<double>;
 using ModuleBase::cross;
 using ModuleBase::dot;
 
-std::vector<index_t> indexgen(const std::vector<int>& natom,
-                              const std::vector<int>& lmax)
+std::vector<index_t> indexgen(const std::vector<int>& natom, const std::vector<int>& lmax)
 {
 #ifdef __DEBUG
     assert(natom.size() == lmax.size());
@@ -24,10 +24,10 @@ std::vector<index_t> indexgen(const std::vector<int>& natom,
         {
             for (int l = 0; l <= lmax[itype]; ++l)
             {
-                for (int M = 0; M < 2*l+1; ++M)
+                for (int M = 0; M < 2 * l + 1; ++M)
                 {
                     // convert the "abacus M" to the conventional m
-                    const int m = (M % 2 == 0) ? -M/2 : (M+1)/2;
+                    const int m = (M % 2 == 0) ? -M / 2 : (M + 1) / 2;
                     index.emplace_back(itype, iatom, l, m);
                 }
             }
@@ -36,16 +36,9 @@ std::vector<index_t> indexgen(const std::vector<int>& natom,
     return index;
 }
 
-
-ModuleBase::ComplexArray cal_overlap_Sq(
-    const char type,
-    const int lmax,
-    const int nbes,
-    const double rcut,
-    const std::vector<std::vector<Vec3>>& R,
-    const ModuleBase::Matrix3& latvec,
-    const std::vector<index_t>& mu_index
-)
+ModuleBase::ComplexArray cal_overlap_Sq(const char type, const int lmax, const int nbes, const double rcut,
+                                        const std::vector<std::vector<Vec3>>& R, const ModuleBase::Matrix3& latvec,
+                                        const std::vector<index_t>& mu_index)
 {
     // allocate output array
     const int nlocal = mu_index.size();
@@ -62,7 +55,7 @@ ModuleBase::ComplexArray cal_overlap_Sq(
 
     const double rmax = orb.rcut_max() * 2.0;
     const int nr = static_cast<int>(rmax / dr) + 1;
-    
+
     orb.set_uniform_grid(true, nr, rmax, 'i', true);
 
     // build the two-center integrator
@@ -73,28 +66,22 @@ ModuleBase::ComplexArray cal_overlap_Sq(
     int t1 = 0, a1 = 0, l1 = 0, m1 = 0;
     int t2 = 0, a2 = 0, l2 = 0, m2 = 0;
 
-
     for (auto it1 = mu_index.cbegin(); it1 != mu_index.cend(); ++it1)
     {
         std::tie(t1, a1, l1, m1) = *it1;
         for (auto it2 = mu_index.cbegin(); it2 != mu_index.cend(); ++it2)
         {
             std::tie(t2, a2, l2, m2) = *it2;
-            std::vector<Vec3> dR_all =
-                neighbor_vec(R[t2][a2] - R[t1][a1], latvec, 2 * rcut);
-            for (auto& dR : dR_all)
+            std::vector<Vec3> dR_all = neighbor_vec(R[t2][a2] - R[t1][a1], latvec, 2 * rcut);
+            for (auto& dR: dR_all)
             {
                 for (int zeta1 = 0; zeta1 < nbes; ++zeta1)
                 {
                     for (int zeta2 = 0; zeta2 < nbes; ++zeta2)
                     {
                         double elem = 0.0;
-                        intor.calculate(t1, l1, zeta1, m1,
-                                        t2, l2, zeta2, m2,
-                                        dR, &elem);
-                        overlap_Sq(it1 - mu_index.cbegin(),
-                                   it2 - mu_index.cbegin(),
-                                   zeta1, zeta2) += elem;
+                        intor.calculate(t1, l1, zeta1, m1, t2, l2, zeta2, m2, dR, &elem);
+                        overlap_Sq(it1 - mu_index.cbegin(), it2 - mu_index.cbegin(), zeta1, zeta2) += elem;
                     }
                 }
             }
@@ -104,24 +91,19 @@ ModuleBase::ComplexArray cal_overlap_Sq(
     return overlap_Sq;
 }
 
-std::vector<Vec3> neighbor_vec(
-    const Vec3& d0,
-    const ModuleBase::Matrix3& latvec,
-    const double r
-) {
+std::vector<Vec3> neighbor_vec(const Vec3& d0, const ModuleBase::Matrix3& latvec, const double r)
+{
     // convert the format of lattice vectors from Matrix3 to a vector of
     // Vector3<double> before searching for neighboring periodic images
-    std::vector<Vec3> a{
-        {latvec.e11, latvec.e12, latvec.e13},
-        {latvec.e21, latvec.e22, latvec.e23},
-        {latvec.e31, latvec.e32, latvec.e33}
-    };
+    std::vector<Vec3> a{{latvec.e11, latvec.e12, latvec.e13},
+                        {latvec.e21, latvec.e22, latvec.e23},
+                        {latvec.e31, latvec.e32, latvec.e33}};
 
     // unit vectors normal to the three faces of the parallelepiped
     std::vector<Vec3> u(3);
     for (int i = 0; i < 3; ++i)
     {
-        u[i] = cross(a[(i+1)%3], a[(i+2)%3]);
+        u[i] = cross(a[(i + 1) % 3], a[(i + 2) % 3]);
         u[i] = u[i] / u[i].norm();
     }
 
@@ -141,7 +123,7 @@ std::vector<Vec3> neighbor_vec(
     for (int i = 0; i < 3; ++i)
     {
         double n_min_tmp = (-r - dot(d0, u[i])) / dot(a[i], u[i]);
-        double n_max_tmp = ( r - dot(d0, u[i])) / dot(a[i], u[i]);
+        double n_max_tmp = (r - dot(d0, u[i])) / dot(a[i], u[i]);
         if (n_min_tmp > n_max_tmp) // in case dot(a[i], u[i]) < 0
         {
             std::swap(n_min_tmp, n_max_tmp);
@@ -160,10 +142,8 @@ std::vector<Vec3> neighbor_vec(
         {
             for (int n2 = n_min[2]; n2 <= n_max[2]; ++n2)
             {
-                Vec3 d_tmp = d0
-                    + static_cast<double>(n0) * a[0]
-                    + static_cast<double>(n1) * a[1]
-                    + static_cast<double>(n2) * a[2];
+                Vec3 d_tmp = d0 + static_cast<double>(n0) * a[0] + static_cast<double>(n1) * a[1]
+                             + static_cast<double>(n2) * a[2];
 
                 if (d_tmp.norm() < r)
                 {

--- a/source/module_io/numerical_basis_jyjy.cpp
+++ b/source/module_io/numerical_basis_jyjy.cpp
@@ -1,10 +1,17 @@
 #include "module_io/numerical_basis_jyjy.h"
+#include "module_base/matrix3.h"
+#include "module_base/vector3.h"
 #include "module_basis/module_nao/two_center_integrator.h"
+
+#define __LCAO
 
 namespace NumericalBasis
 {
 #ifdef __LCAO
 using index_t = std::tuple<int, int, int, int>;
+using Vec3 = ModuleBase::Vector3<double>;
+using ModuleBase::cross;
+using ModuleBase::dot;
 
 std::vector<index_t> indexgen(const std::vector<int>& natom,
                               const std::vector<int>& lmax)
@@ -37,7 +44,8 @@ ModuleBase::ComplexArray cal_overlap_Sq(
     const int lmax,
     const int nbes,
     const double rcut,
-    const std::vector<std::vector<ModuleBase::Vector3<double>>>& R,
+    const std::vector<std::vector<Vec3>>& R,
+    const ModuleBase::Matrix3& latvec,
     const std::vector<index_t>& mu_index
 )
 {
@@ -66,24 +74,30 @@ ModuleBase::ComplexArray cal_overlap_Sq(
     // traverse the vector of composite index (itype, iatom, l, m)
     int t1 = 0, a1 = 0, l1 = 0, m1 = 0;
     int t2 = 0, a2 = 0, l2 = 0, m2 = 0;
+
+
     for (auto it1 = mu_index.cbegin(); it1 != mu_index.cend(); ++it1)
     {
         std::tie(t1, a1, l1, m1) = *it1;
         for (auto it2 = mu_index.cbegin(); it2 != mu_index.cend(); ++it2)
         {
             std::tie(t2, a2, l2, m2) = *it2;
-            ModuleBase::Vector3<double> dR = R[t2][a2] - R[t1][a1];
-            for (int zeta1 = 0; zeta1 < nbes; ++zeta1)
+            std::vector<Vec3> dR_all =
+                neighbor_vec(R[t2][a2] - R[t1][a1], latvec, 2 * rcut);
+            for (auto& dR : dR_all)
             {
-                for (int zeta2 = 0; zeta2 < nbes; ++zeta2)
+                for (int zeta1 = 0; zeta1 < nbes; ++zeta1)
                 {
-                    double elem = 0.0;
-                    intor.calculate(t1, l1, zeta1, m1,
-                                    t2, l2, zeta2, m2,
-                                    dR, &elem);
-                    overlap_Sq(it1 - mu_index.begin(),
-                               it2 - mu_index.begin(),
-                               zeta1, zeta2) = elem;
+                    for (int zeta2 = 0; zeta2 < nbes; ++zeta2)
+                    {
+                        double elem = 0.0;
+                        intor.calculate(t1, l1, zeta1, m1,
+                                        t2, l2, zeta2, m2,
+                                        dR, &elem);
+                        overlap_Sq(it1 - mu_index.cbegin(),
+                                   it2 - mu_index.cbegin(),
+                                   zeta1, zeta2) += elem;
+                    }
                 }
             }
         }
@@ -91,6 +105,79 @@ ModuleBase::ComplexArray cal_overlap_Sq(
 
     return overlap_Sq;
 }
+
+std::vector<Vec3> neighbor_vec(
+    const Vec3& d0,
+    const ModuleBase::Matrix3& latvec,
+    const double r
+) {
+    // convert the format of lattice vectors from Matrix3 to a vector of
+    // Vector3<double> before searching for neighboring periodic images
+    std::vector<Vec3> a{
+        {latvec.e11, latvec.e12, latvec.e13},
+        {latvec.e21, latvec.e22, latvec.e23},
+        {latvec.e31, latvec.e32, latvec.e33}
+    };
+
+    // unit vectors normal to the three faces of the parallelepiped
+    std::vector<Vec3> u(3);
+    for (int i = 0; i < 3; ++i)
+    {
+        u[i] = cross(a[(i+1)%3], a[(i+2)%3]);
+        u[i] = u[i] / u[i].norm();
+    }
+
+    // range of supercell coordinates
+    //
+    // Suppose n0, n1, n2 can take any real numbers (rather than just integers),
+    // given any n0, one can always find n1 & n2 such that
+    //
+    //          d0 + n0*a0 + n1*a1 + n2*a2
+    //
+    // is perpendicular to the plane spanned by a1 and a2. Therefore, the
+    // min/max values of n0 should satisfy
+    //
+    //          dot(d0 + n0*a0, u0) = r
+    //
+    std::vector<int> n_min(3), n_max(3);
+    for (int i = 0; i < 3; ++i)
+    {
+        double n_min_tmp = (-r - dot(d0, u[i])) / dot(a[i], u[i]);
+        double n_max_tmp = ( r - dot(d0, u[i])) / dot(a[i], u[i]);
+        if (n_min_tmp > n_max_tmp) // in case dot(a[i], u[i]) < 0
+        {
+            std::swap(n_min_tmp, n_max_tmp);
+        }
+        // cast to int truncates towards 0
+        // slightly widens the range for floating point precision error
+        n_min[i] = static_cast<int>(n_min_tmp - 1e-6);
+        n_max[i] = static_cast<int>(n_max_tmp + 1e-6);
+    }
+
+    // loop over the neighboring supercells
+    std::vector<Vec3> d;
+    for (int n0 = n_min[0]; n0 <= n_max[0]; ++n0)
+    {
+        for (int n1 = n_min[1]; n1 <= n_max[1]; ++n1)
+        {
+            for (int n2 = n_min[2]; n2 <= n_max[2]; ++n2)
+            {
+                Vec3 d_tmp = d0
+                    + static_cast<double>(n0) * a[0]
+                    + static_cast<double>(n1) * a[1]
+                    + static_cast<double>(n2) * a[2];
+
+                if (d_tmp.norm() < r)
+                {
+                    d.push_back(d_tmp);
+                }
+            }
+        }
+    }
+
+    return d;
+}
+
 #endif
 
 } // end of namespace NumericalBasis

--- a/source/module_io/numerical_basis_jyjy.h
+++ b/source/module_io/numerical_basis_jyjy.h
@@ -1,16 +1,16 @@
 #ifndef NUMERICAL_BASIS_JYJY_H
 #define NUMERICAL_BASIS_JYJY_H
 
-#include <tuple>
-#include <vector>
+#include "module_base/complexarray.h"
 #include "module_base/matrix3.h"
 #include "module_base/vector3.h"
-#include "module_base/complexarray.h"
+
+#include <tuple>
+#include <vector>
 
 namespace NumericalBasis
 {
-std::vector<std::tuple<int, int, int, int>> indexgen(const std::vector<int>& natom,
-                                                     const std::vector<int>& lmax);
+std::vector<std::tuple<int, int, int, int>> indexgen(const std::vector<int>& natom, const std::vector<int>& lmax);
 
 /**
  * @brief <jy|op|jy> overlap matrix (two-center integration)
@@ -25,15 +25,11 @@ std::vector<std::tuple<int, int, int, int>> indexgen(const std::vector<int>& nat
  * @param[in]   mu_index            composite index
  *
  */
-ModuleBase::ComplexArray cal_overlap_Sq(
-    const char type, // 'S' or 'T'
-    const int lmax,
-    const int nbes,
-    const double rcut,
-    const std::vector<std::vector<ModuleBase::Vector3<double>>>& tau_cart,
-    const ModuleBase::Matrix3& latvec,
-    const std::vector<std::tuple<int, int, int, int>>& mu_index
-);
+ModuleBase::ComplexArray cal_overlap_Sq(const char type, // 'S' or 'T'
+                                        const int lmax, const int nbes, const double rcut,
+                                        const std::vector<std::vector<ModuleBase::Vector3<double>>>& tau_cart,
+                                        const ModuleBase::Matrix3& latvec,
+                                        const std::vector<std::tuple<int, int, int, int>>& mu_index);
 
 /**
  * @brief Searching for all relative position vectors for periodic images
@@ -47,12 +43,9 @@ ModuleBase::ComplexArray cal_overlap_Sq(
  * where n0, n1, n2 are integers and a0, a1, a2 are the lattice vectors.
  *
  */
-std::vector<ModuleBase::Vector3<double>> neighbor_vec(
-    const ModuleBase::Vector3<double>& d0,
-    const ModuleBase::Matrix3& latvec,
-    const double r
-);
+std::vector<ModuleBase::Vector3<double>> neighbor_vec(const ModuleBase::Vector3<double>& d0,
+                                                      const ModuleBase::Matrix3& latvec, const double r);
 
-}
+} // namespace NumericalBasis
 
 #endif

--- a/source/module_io/numerical_basis_jyjy.h
+++ b/source/module_io/numerical_basis_jyjy.h
@@ -3,6 +3,7 @@
 
 #include <tuple>
 #include <vector>
+#include "module_base/matrix3.h"
 #include "module_base/vector3.h"
 #include "module_base/complexarray.h"
 
@@ -19,8 +20,8 @@ std::vector<std::tuple<int, int, int, int>> indexgen(const std::vector<int>& nat
  * @param[in]   lmax                maximum angular momentum
  * @param[in]   nbes                number of Bessel functions
  * @param[in]   rcut                cutoff radius
- * @param[in]   sigma               smoothing parameter
  * @param[in]   tau_cart            atomic positions (in Bohr)
+ * @param[in]   latvec              lattice vectors (in Bohr)
  * @param[in]   mu_index            composite index
  *
  */
@@ -30,7 +31,26 @@ ModuleBase::ComplexArray cal_overlap_Sq(
     const int nbes,
     const double rcut,
     const std::vector<std::vector<ModuleBase::Vector3<double>>>& tau_cart,
+    const ModuleBase::Matrix3& latvec,
     const std::vector<std::tuple<int, int, int, int>>& mu_index
+);
+
+/**
+ * @brief Searching for all relative position vectors for periodic images
+ * within a cutoff radius.
+ *
+ * Given an initial relative position vector d0 and a searching radius r,
+ * this function returns all d such that
+ *
+ *      d = d0 + n0*a0 + n1*a1 + n2*a2   and |d| < r
+ *
+ * where n0, n1, n2 are integers and a0, a1, a2 are the lattice vectors.
+ *
+ */
+std::vector<ModuleBase::Vector3<double>> neighbor_vec(
+    const ModuleBase::Vector3<double>& d0,
+    const ModuleBase::Matrix3& latvec,
+    const double r
 );
 
 }

--- a/source/module_io/test/numerical_basis_test.cpp
+++ b/source/module_io/test/numerical_basis_test.cpp
@@ -1,8 +1,9 @@
-#include "gtest/gtest.h"
+#include "module_base/math_sphbes.h"
 #include "module_base/matrix3.h"
 #include "module_base/vector3.h"
 #include "module_io/numerical_basis_jyjy.h"
-#include "module_base/math_sphbes.h"
+
+#include "gtest/gtest.h"
 
 using namespace NumericalBasis;
 using ModuleBase::Sphbes;
@@ -23,10 +24,9 @@ using ModuleBase::Sphbes;
  */
 class NumericalBasisTest : public ::testing::Test
 {
-protected:
+  protected:
     void SetUp();
     void TearDown();
-
 };
 
 void NumericalBasisTest::SetUp()
@@ -51,10 +51,10 @@ TEST_F(NumericalBasisTest, indexgen)
         {
             for (int l = 0; l <= lmax[it]; ++l)
             {
-                for (int M = 0; M < 2*l+1; ++M)
+                for (int M = 0; M < 2 * l + 1; ++M)
                 {
                     // convert the "abacus M" to the conventional m
-                    const int m = (M % 2 == 0) ? -M/2 : (M+1)/2;
+                    const int m = (M % 2 == 0) ? -M / 2 : (M + 1) / 2;
                     EXPECT_EQ(index[idx], std::make_tuple(int(it), ia, l, m));
                     ++idx;
                 }
@@ -69,16 +69,14 @@ TEST_F(NumericalBasisTest, cal_overlap_Sq)
     const int nbes = 7;
     const double rcut = 7.0;
 
-    const ModuleBase::Matrix3 latvec(30.0,  0.0,  0.0,
-                                      0.0, 30.0,  0.0,
-                                      0.0,  0.0, 30.0);
+    const ModuleBase::Matrix3 latvec(30.0, 0.0, 0.0, 0.0, 30.0, 0.0, 0.0, 0.0, 30.0);
 
     // atom-0 and 1 have overlap with each other, but neither of them
     // has overlap with atom-2
     std::vector<std::vector<ModuleBase::Vector3<double>>> tau_cart;
     tau_cart.emplace_back();
-    tau_cart[0].emplace_back(0.0, 0.0,  0.0);
-    tau_cart[0].emplace_back(1.0, 1.0,  1.0);
+    tau_cart[0].emplace_back(0.0, 0.0, 0.0);
+    tau_cart[0].emplace_back(1.0, 1.0, 1.0);
     tau_cart[0].emplace_back(0.0, 0.0, 15.0);
 
     const std::vector<int> natom = {int(tau_cart[0].size())};
@@ -86,9 +84,8 @@ TEST_F(NumericalBasisTest, cal_overlap_Sq)
     const auto index = indexgen(natom, lmax_v);
     const int nao = index.size();
 
-
     // zeros of sperical Bessel functions
-    std::vector<double> zeros(nbes*(lmax+1));
+    std::vector<double> zeros(nbes * (lmax + 1));
     ModuleBase::Sphbes::sphbes_zeros(lmax, nbes, zeros.data(), true);
 
     // <jy|jy> and <jy|-\nabla^2|jy>
@@ -112,14 +109,14 @@ TEST_F(NumericalBasisTest, cal_overlap_Sq)
                         if (q1 == q2)
                         {
                             // diagonal elements have analytical results
-                            double S_ref = std::pow(rcut, 3) * 0.5 *
-                                           std::pow(Sphbes::sphbesj(l1+1, zeros[l1*nbes+q1]),
-                                                    2);
+                            double S_ref
+                                = std::pow(rcut, 3) * 0.5 * std::pow(Sphbes::sphbesj(l1 + 1, zeros[l1 * nbes + q1]), 2);
                             EXPECT_NEAR(S(i, i, q1, q1).real(), S_ref, S_thr);
                             EXPECT_EQ(S(i, i, q1, q1).imag(), 0);
 
-                            double T_ref = 0.5 * rcut * std::pow(zeros[l1*nbes+q1] * 
-                                           Sphbes::sphbesj(l1+1, zeros[l1*nbes+q1]), 2);
+                            double T_ref
+                                = 0.5 * rcut
+                                  * std::pow(zeros[l1 * nbes + q1] * Sphbes::sphbesj(l1 + 1, zeros[l1 * nbes + q1]), 2);
                             EXPECT_NEAR(T(i, i, q1, q1).real(), T_ref, T_thr);
                             EXPECT_EQ(T(i, i, q1, q1).imag(), 0);
                         }
@@ -154,7 +151,6 @@ TEST_F(NumericalBasisTest, cal_overlap_Sq)
                         EXPECT_EQ(T(i, j, q1, q2).imag(), 0);
                     }
                 }
-
             }
         }
     }
@@ -186,9 +182,7 @@ TEST_F(NumericalBasisTest, cal_overlap_Sq)
 TEST_F(NumericalBasisTest, neighbor_vec)
 {
     const ModuleBase::Vector3<double> d0(2.5, 0.0, 0.0);
-    const ModuleBase::Matrix3 latvec(3.0, 0.0, 0.0,
-                                     0.0, 4.0, 0.0,
-                                     0.0, 0.0, 5.0);
+    const ModuleBase::Matrix3 latvec(3.0, 0.0, 0.0, 0.0, 4.0, 0.0, 0.0, 0.0, 5.0);
 
     const double r1 = 2.0;
     auto d1 = neighbor_vec(d0, latvec, r1);
@@ -200,15 +194,14 @@ TEST_F(NumericalBasisTest, neighbor_vec)
     EXPECT_EQ(d2.size(), 3);
     EXPECT_EQ(d2[0], ModuleBase::Vector3<double>(-3.5, 0.0, 0.0));
     EXPECT_EQ(d2[1], ModuleBase::Vector3<double>(-0.5, 0.0, 0.0));
-    EXPECT_EQ(d2[2], ModuleBase::Vector3<double>( 2.5, 0.0, 0.0));
+    EXPECT_EQ(d2[2], ModuleBase::Vector3<double>(2.5, 0.0, 0.0));
 
     const double r3 = 4.1;
     auto d3 = neighbor_vec(d0, latvec, r3);
     EXPECT_EQ(d3.size(), 5);
-    EXPECT_EQ(d3[0], ModuleBase::Vector3<double>(-3.5,  0.0, 0.0));
+    EXPECT_EQ(d3[0], ModuleBase::Vector3<double>(-3.5, 0.0, 0.0));
     EXPECT_EQ(d3[1], ModuleBase::Vector3<double>(-0.5, -4.0, 0.0));
-    EXPECT_EQ(d3[2], ModuleBase::Vector3<double>(-0.5,  0.0, 0.0));
-    EXPECT_EQ(d3[3], ModuleBase::Vector3<double>(-0.5,  4.0, 0.0));
-    EXPECT_EQ(d3[4], ModuleBase::Vector3<double>( 2.5,  0.0, 0.0));
+    EXPECT_EQ(d3[2], ModuleBase::Vector3<double>(-0.5, 0.0, 0.0));
+    EXPECT_EQ(d3[3], ModuleBase::Vector3<double>(-0.5, 4.0, 0.0));
+    EXPECT_EQ(d3[4], ModuleBase::Vector3<double>(2.5, 0.0, 0.0));
 }
-

--- a/source/module_io/test/numerical_basis_test.cpp
+++ b/source/module_io/test/numerical_basis_test.cpp
@@ -1,4 +1,6 @@
 #include "gtest/gtest.h"
+#include "module_base/matrix3.h"
+#include "module_base/vector3.h"
 #include "module_io/numerical_basis_jyjy.h"
 #include "module_base/math_sphbes.h"
 
@@ -67,13 +69,17 @@ TEST_F(NumericalBasisTest, cal_overlap_Sq)
     const int nbes = 7;
     const double rcut = 7.0;
 
+    const ModuleBase::Matrix3 latvec(30.0,  0.0,  0.0,
+                                      0.0, 30.0,  0.0,
+                                      0.0,  0.0, 30.0);
+
     // atom-0 and 1 have overlap with each other, but neither of them
     // has overlap with atom-2
     std::vector<std::vector<ModuleBase::Vector3<double>>> tau_cart;
     tau_cart.emplace_back();
-    tau_cart[0].emplace_back(0.0, 0.0, 0.0);
-    tau_cart[0].emplace_back(1.0, 1.0, 1.0);
-    tau_cart[0].emplace_back(0.0, 0.0, 20.0);
+    tau_cart[0].emplace_back(0.0, 0.0,  0.0);
+    tau_cart[0].emplace_back(1.0, 1.0,  1.0);
+    tau_cart[0].emplace_back(0.0, 0.0, 15.0);
 
     const std::vector<int> natom = {int(tau_cart[0].size())};
     const std::vector<int> lmax_v = {lmax};
@@ -88,9 +94,8 @@ TEST_F(NumericalBasisTest, cal_overlap_Sq)
     // <jy|jy> and <jy|-\nabla^2|jy>
     const double S_thr = 1e-5;
     const double T_thr = 1e-3;
-    const auto S = cal_overlap_Sq('S', lmax, nbes, rcut, tau_cart, index);
-    const auto T = cal_overlap_Sq('T', lmax, nbes, rcut, tau_cart, index);
-
+    const auto S = cal_overlap_Sq('S', lmax, nbes, rcut, tau_cart, latvec, index);
+    const auto T = cal_overlap_Sq('T', lmax, nbes, rcut, tau_cart, latvec, index);
     int t1, a1, l1, m1, t2, a2, l2, m2; // values will be updated in the loop
     for (int i = 0; i < nao; ++i)
     {
@@ -154,6 +159,56 @@ TEST_F(NumericalBasisTest, cal_overlap_Sq)
         }
     }
 
+    // verifies that the calculated matrix is invariant w.r.t. translation
+    // across the cell boundary
+    tau_cart[0][0].x -= 0.5;
+    tau_cart[0][1].x -= 0.5;
+    tau_cart[0][2].x -= 0.5;
+    const auto S_wrap = cal_overlap_Sq('S', lmax, nbes, rcut, tau_cart, latvec, index);
+
+    for (int i = 0; i < nao; ++i)
+    {
+        std::tie(t1, a1, l1, m1) = index[i];
+        for (int j = 0; j < nao; ++j)
+        {
+            std::tie(t2, a2, l2, m2) = index[j];
+            for (int q1 = 0; q1 < nbes; ++q1)
+            {
+                for (int q2 = 0; q2 < nbes; ++q2)
+                {
+                    EXPECT_EQ(S(i, j, q1, q2), S_wrap(i, j, q1, q2));
+                }
+            }
+        }
+    }
 }
 
+TEST_F(NumericalBasisTest, neighbor_vec)
+{
+    const ModuleBase::Vector3<double> d0(2.5, 0.0, 0.0);
+    const ModuleBase::Matrix3 latvec(3.0, 0.0, 0.0,
+                                     0.0, 4.0, 0.0,
+                                     0.0, 0.0, 5.0);
+
+    const double r1 = 2.0;
+    auto d1 = neighbor_vec(d0, latvec, r1);
+    EXPECT_EQ(d1.size(), 1);
+    EXPECT_EQ(d1[0], ModuleBase::Vector3<double>(-0.5, 0.0, 0.0));
+
+    const double r2 = 3.6;
+    auto d2 = neighbor_vec(d0, latvec, r2);
+    EXPECT_EQ(d2.size(), 3);
+    EXPECT_EQ(d2[0], ModuleBase::Vector3<double>(-3.5, 0.0, 0.0));
+    EXPECT_EQ(d2[1], ModuleBase::Vector3<double>(-0.5, 0.0, 0.0));
+    EXPECT_EQ(d2[2], ModuleBase::Vector3<double>( 2.5, 0.0, 0.0));
+
+    const double r3 = 4.1;
+    auto d3 = neighbor_vec(d0, latvec, r3);
+    EXPECT_EQ(d3.size(), 5);
+    EXPECT_EQ(d3[0], ModuleBase::Vector3<double>(-3.5,  0.0, 0.0));
+    EXPECT_EQ(d3[1], ModuleBase::Vector3<double>(-0.5, -4.0, 0.0));
+    EXPECT_EQ(d3[2], ModuleBase::Vector3<double>(-0.5,  0.0, 0.0));
+    EXPECT_EQ(d3[3], ModuleBase::Vector3<double>(-0.5,  4.0, 0.0));
+    EXPECT_EQ(d3[4], ModuleBase::Vector3<double>( 2.5,  0.0, 0.0));
+}
 


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
This is a more thorough fix of #4266 , which results from structures that traverse the boundary of unit cell.

### Unit Tests and/or Case Tests for my changes


### What's changed?
The computation of <jY|jY> now takes periodic images into account.

### Any changes of core modules? (ignore if not applicable)
No
