### PR TITLE
CI: enable clang-tidy in CI by pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,8 @@ repos:
     hooks:
       - id: clang-format
         args: [-i]
-      # - id: clang-tidy
-      #   args: [-p=build, --fix-errors]
+      - id: clang-tidy
+        args: [-p=build, --fix-errors]
       # - id: oclint
       # - id: uncrustify
       # - id: cppcheck


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?

### Linked Issue
https://github.com/deepmodeling/abacus-develop/issues/3915

https://github.com/deepmodeling/abacus-develop/pull/4225
