### PR TITLE
CI: add clang-tidy `readability-braces-around-statements` setting

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,8 +6,8 @@ Checks: '
     modernize-use-bool-literals,
     modernize-use-nullptr,
     readability-avoid-return-with-void-value
+    readability-braces-around-statements
     
-
     # bugprone-*,
     # clang-analyzer-*,
     # clang-diagnostic-*,


### PR DESCRIPTION
### Details
Some code reviewer, like @mohanchen, hopes to automatically add curly braces after some control flow statements that do not use curly braces in some submitted PR, which is more conducive to the readability and cleanliness of the code. 

This is very beneficial for the development of large-scale software.


