### PR TITLE
Remove redundant code in "pw_gatherscatter.h"

### DIFF
--- a/source/module_basis/module_pw/fft.h
+++ b/source/module_basis/module_pw/fft.h
@@ -40,13 +40,13 @@ public:
 	FFT();
 	~FFT();
 	void clear(); //reset fft
-	
+
 	// init parameters of fft
-	void initfft(int nx_in, int ny_in, int nz_in, int lixy_in, int rixy_in, int ns_in, int nplane_in, 
+	void initfft(int nx_in, int ny_in, int nz_in, int lixy_in, int rixy_in, int ns_in, int nplane_in,
 				 int nproc_in, bool gamma_only_in, bool xprime_in = true, bool mpifft_in = false);
 
 	//init fftw_plans
-	void setupFFT(); 
+	void setupFFT();
 
 	//destroy fftw_plans
 	void cleanFFT();
@@ -105,7 +105,7 @@ public:
     template <typename FPTYPE>
     std::complex<FPTYPE>* get_auxr_3d_data() const;
 
-	int fft_mode = 0; ///< fftw mode 0: estimate, 1: measure, 2: patient, 3: exhaustive 
+	int fft_mode = 0; ///< fftw mode 0: estimate, 1: measure, 2: patient, 3: exhaustive
 
   private:
     bool gamma_only = false;

--- a/source/module_basis/module_pw/pw_gatherscatter.h
+++ b/source/module_basis/module_pw/pw_gatherscatter.h
@@ -15,12 +15,9 @@ template <typename T>
 void PW_Basis::gatherp_scatters(std::complex<T>* in, std::complex<T>* out) const
 {
     ModuleBase::timer::tick(this->classname, "gatherp_scatters");
-    
-    if(this->poolnproc == 1) //In this case nst=nstot, nz = nplane, 
+
+    if(this->poolnproc == 1) //In this case nst=nstot, nz = nplane,
     {
-#ifdef _OPENMP
-#pragma omp parallel for
-#endif
         for(int is = 0 ; is < this->nst ; ++is)
         {
             int ixy = this->istot2ixy[is];
@@ -78,7 +75,7 @@ void PW_Basis::gatherp_scatters(std::complex<T>* in, std::complex<T>* out) const
 			}
 		}
 	}
-   
+
 #endif
     ModuleBase::timer::tick(this->classname, "gatherp_scatters");
     return;
@@ -95,20 +92,14 @@ template <typename T>
 void PW_Basis::gathers_scatterp(std::complex<T>* in, std::complex<T>* out) const
 {
     ModuleBase::timer::tick(this->classname, "gathers_scatterp");
-    
-    if(this->poolnproc == 1) //In this case nrxx=fftnx*fftny*nz, nst = nstot, 
+
+    if(this->poolnproc == 1) //In this case nrxx=fftnx*fftny*nz, nst = nstot,
     {
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static, 4096/sizeof(T))
-#endif
         for(int i = 0; i < this->nrxx; ++i)
         {
             out[i] = std::complex<T>(0, 0);
         }
 
-#ifdef _OPENMP
-#pragma omp parallel for
-#endif
         for(int is = 0 ; is < this->nst ; ++is)
         {
             int ixy = istot2ixy[is];
@@ -125,7 +116,7 @@ void PW_Basis::gathers_scatterp(std::complex<T>* in, std::complex<T>* out) const
     }
 #ifdef __MPI
     // change (nz,ns) to (numz[ip],ns, poolnproc)
-    // Hence, we can send them at one time. 
+    // Hence, we can send them at one time.
 #ifdef _OPENMP
 #pragma omp parallel for collapse(2)
 #endif


### PR DESCRIPTION
When poolnproc == 1 ,  there's only 1 core running here. Parallelism is unnecessary