### PR TITLE
Refactor: Initial removal of psi::Psi<T, Device> from Diago_DavSubspace

### DIFF
--- a/source/module_hsolver/diago_dav_subspace.h
+++ b/source/module_hsolver/diago_dav_subspace.h
@@ -36,7 +36,7 @@ class Diago_DavSubspace : public DiagH<T, Device>
 
              hamilt::Hamilt<T, Device>* phm_in,
              psi::Psi<T, Device>& phi,
-
+             
              Real* eigenvalue_in,
              const std::vector<bool>& is_occupied,
              const bool& scf_type);
@@ -105,7 +105,6 @@ class Diago_DavSubspace : public DiagH<T, Device>
                  const int& nband,
                  int& nbase,
                  const Real* eigenvalue,
-                 const psi::Psi<T, Device>& psi,
                  T* psi_iter,
                  T* hphi,
                  T* hcc,
@@ -124,7 +123,7 @@ class Diago_DavSubspace : public DiagH<T, Device>
 
     int diag_once(const Func& hpsi_func,
                   T* psi_in,
-                  psi::Psi<T, Device>& psi,
+                  const int psi_in_dmax,
                   Real* eigenvalue_in,
                   const std::vector<bool>& is_occupied);
 


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?

### Linked Issue
https://github.com/deepmodeling/abacus-develop/issues/4241
