### PR TITLE
Feature: add command line option --check-input to check input only

### DIFF
--- a/source/Makefile.Objects
+++ b/source/Makefile.Objects
@@ -464,6 +464,7 @@ OBJS_IO=input.o\
     init_info.o\
     readin_info.o\
     output_info.o\
+    parse_args.o\
 
 OBJS_IO_LCAO=cal_r_overlap_R.o\
       write_orb_info.o\

--- a/source/module_io/CMakeLists.txt
+++ b/source/module_io/CMakeLists.txt
@@ -31,6 +31,7 @@ list(APPEND objects
     output_potential.cpp
     #parameter_pool.cpp
     para_json.cpp
+    parse_args.cpp
 )
 
 list(APPEND objects_advanced

--- a/source/module_io/input.cpp
+++ b/source/module_io/input.cpp
@@ -70,6 +70,14 @@ void Input::Init(const std::string& fn)
                                           this->mdp.md_restart,
                                           this->out_alllog); // xiaohui add 2013-09-01
     Check();
+    // if only check the input, then quit
+    if (this->check_input)
+    {
+        std::cout << "----------------------------------------------------------" << std::endl;
+        std::cout << "  INPUT parameters have been successfully checked!" << std::endl;
+        std::cout << "----------------------------------------------------------" << std::endl;
+        exit(0);
+    }
 #ifdef VERSION
     const char* version = VERSION;
 #else

--- a/source/module_io/input.h
+++ b/source/module_io/input.h
@@ -642,6 +642,8 @@ class Input
     double pexsi_mu_guard = 0.2;
     double pexsi_elec_thr = 0.001;
     double pexsi_zero_thr = 1e-10;
+
+    bool check_input = false;
     
     std::time_t get_start_time(void) const
     {

--- a/source/module_io/parse_args.cpp
+++ b/source/module_io/parse_args.cpp
@@ -1,0 +1,37 @@
+#include "parse_args.h"
+#include <iostream>
+#include <cstdlib>
+#include "version.h"
+#include "module_io/input.h"
+
+namespace ModuleIO
+{
+
+void parse_args(int argc, char** argv)
+{
+    for (int i = 1; i < argc; ++i) // Start from 1 to skip the program name
+    {
+        std::string arg = argv[i];
+        if (arg == "--version" || arg == "-v" || arg == "-V")
+        {
+#ifdef VERSION
+            const char* version = VERSION;
+#else
+            const char* version = "unknown";
+#endif
+            std::cout << "ABACUS version " << version << std::endl;
+            std::exit(0);
+        }
+        else if (arg == "--check-input")
+        {
+            INPUT.check_input = true;
+        }
+        else
+        {
+            std::cerr << "Unknown argument: " << arg << std::endl;
+            std::exit(1);
+        }
+    }
+}
+
+}

--- a/source/module_io/parse_args.h
+++ b/source/module_io/parse_args.h
@@ -1,8 +1,5 @@
 #ifndef ModuleIO_PARSE_ARGS_H
 #define ModuleIO_PARSE_ARGS_H
-#include <iostream>
-#include <cstdlib>
-#include "version.h"
 
 namespace ModuleIO
 {
@@ -20,22 +17,7 @@ namespace ModuleIO
  * of the program , After that till argv[argc-1] every element is command -line 
  * arguments.
  */
-void parse_args(int argc, char** argv)
-{
-    if (argc > 1
-        && (std::string(argv[1]) == "--version" || std::string(argv[1]) == "-v" || std::string(argv[1]) == "-V"))
-    {
-#ifdef VERSION
-        const char* version = VERSION;
-#else
-        const char* version = "unknown";
-#endif
-        std::cout << "ABACUS version " << version << std::endl;
-        std::exit(0);
-    }
-    
-    return;
-}
+void parse_args(int argc, char** argv);
 } // namespace ModuleIO
 
 #endif

--- a/source/module_io/test/CMakeLists.txt
+++ b/source/module_io/test/CMakeLists.txt
@@ -110,7 +110,7 @@ AddTest(
 
 AddTest(
   TARGET io_parse_args
-  SOURCES parse_args_test.cpp
+  SOURCES parse_args_test.cpp ../parse_args.cpp
 )
 
 AddTest(

--- a/source/module_io/test/parse_args_test.cpp
+++ b/source/module_io/test/parse_args_test.cpp
@@ -1,11 +1,15 @@
 #include "gtest/gtest.h"
 #include "module_io/parse_args.h"
 #include "version.h"
+#include "module_io/input.h"
+
+Input INPUT;
 
 TEST(ParseArgsTest, OutVersionTest)
 {
     // Test case 1: no arguments
-    char* argv[] = {"test"};
+    char arg0[] = "test";
+    char* argv[] = {arg0};
     int argc = 1;
     testing::internal::CaptureStdout();
     ModuleIO::parse_args(argc, argv);
@@ -20,7 +24,8 @@ std::string output_ref = "ABACUS version unknown\n";
 #endif
 
     // Test case 2: --version argument
-    char* argv1[] = {"test", "--version"};
+    char arg1[] = "--version";
+    char* argv1[] = {arg0, arg1};
     argc = 2;
     testing::internal::CaptureStdout();
     EXPECT_EXIT(ModuleIO::parse_args(argc, argv1),::testing::ExitedWithCode(0),"");
@@ -28,7 +33,8 @@ std::string output_ref = "ABACUS version unknown\n";
     EXPECT_EQ(output_ref, output);
 
     // Test case 3: -v argument
-    char* argv2[] = {"test", "-v"};
+    char arg2[] = "-v";
+    char* argv2[] = {arg0, arg2};
     argc = 2;
     testing::internal::CaptureStdout();
     EXPECT_EXIT(ModuleIO::parse_args(argc, argv2),::testing::ExitedWithCode(0),"");
@@ -36,10 +42,21 @@ std::string output_ref = "ABACUS version unknown\n";
     EXPECT_EQ(output_ref, output);
 
     // Test case 4: -V argument
-    char* argv3[] = {"test", "-V"};
+    char arg3[] = "-V";
+    char* argv3[] = {arg0, arg3};
     argc = 2;
     testing::internal::CaptureStdout();
         EXPECT_EXIT(ModuleIO::parse_args(argc, argv3),::testing::ExitedWithCode(0),"");
     output = testing::internal::GetCapturedStdout();
     EXPECT_EQ(output_ref, output);
+}
+
+TEST(ParseArgsTest, CheckInput)
+{
+    char arg0[] = "test";
+    char arg1[] = "--check-input";
+    char* argv[] = {arg0, arg1};
+    int argc = 2;
+    ModuleIO::parse_args(argc, argv);
+    EXPECT_TRUE(INPUT.check_input);
 }


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?
- [x] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #3180 

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
The result:
abacus --check-input
```
                                                                                     
                              ABACUS v3.6.5

               Atomic-orbital Based Ab-initio Computation at UStc                    

                     Website: http://abacus.ustc.edu.cn/                             
               Documentation: https://abacus.deepmodeling.com/                       
                  Repository: https://github.com/abacusmodeling/abacus-develop       
                              https://github.com/deepmodeling/abacus-develop         
                      Commit: unknown

 Tue Jun 18 14:20:31 2024
 MAKE THE DIR         : OUT.ABACUS/
----------------------------------------------------------
  INPUT parameters have been successfully checked!
----------------------------------------------------------
```
### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
