### PR TITLE
Refactor: removal of ORB_gen_tables in module_hamilt_lcao and module_esolver

### DIFF
--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -1369,7 +1369,7 @@ ModuleIO::Output_Mat_Sparse<TK> ESolver_KS_LCAO<TK, TR>::create_Output_Mat_Spars
                                            this->pelec->pot->get_effective_v(),
                                            this->orb_con.ParaV,
                                            this->GK, // mohan add 2024-04-01
-                                           uot_,
+                                           *(uot_->two_center_bundle),
                                            this->LM,
                                            GlobalC::GridD, // mohan add 2024-04-06
                                            this->kv,

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -533,7 +533,6 @@ void ESolver_KS_LCAO<TK, TR>::init_basis_lcao(ORB_control& orb_con, Input& inp, 
     // * reading the localized orbitals/projectors
     // * construct the interpolation tables.
 
-
     two_center_bundle_.build_orb(ucell.ntype, ucell.orbital_fn);
     two_center_bundle_.build_alpha(GlobalV::deepks_setorb, &ucell.descriptor_file);
     two_center_bundle_.build_orb_onsite(ucell.ntype, GlobalV::onsite_radius);

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -84,7 +84,6 @@ ESolver_KS_LCAO<TK, TR>::ESolver_KS_LCAO()
 template <typename TK, typename TR>
 ESolver_KS_LCAO<TK, TR>::~ESolver_KS_LCAO()
 {
-    delete uot_;
 }
 
 //------------------------------------------------------------------------------
@@ -370,7 +369,7 @@ void ESolver_KS_LCAO<TK, TR>::cal_force(ModuleBase::matrix& force)
                        this->LM,
                        this->GG, // mohan add 2024-04-01
                        this->GK, // mohan add 2024-04-01
-                       *(uot_->two_center_bundle),
+                       two_center_bundle_,
                        force,
                        this->scs,
                        this->sf,
@@ -534,26 +533,19 @@ void ESolver_KS_LCAO<TK, TR>::init_basis_lcao(ORB_control& orb_con, Input& inp, 
     // * reading the localized orbitals/projectors
     // * construct the interpolation tables.
 
-    // NOTE: This following raw pointer serves as a temporary step in
-    // LCAO refactoring. Eventually, it will be replaced by a shared_ptr,
-    // which is the only owner of the ORB_gen_tables object. All other
-    // usages will take a weak_ptr.
-    uot_ = new ORB_gen_tables;
-    auto& two_center_bundle = uot_->two_center_bundle;
 
-    two_center_bundle.reset(new TwoCenterBundle);
-    two_center_bundle->build_orb(ucell.ntype, ucell.orbital_fn);
-    two_center_bundle->build_alpha(GlobalV::deepks_setorb, &ucell.descriptor_file);
-    two_center_bundle->build_orb_onsite(ucell.ntype, GlobalV::onsite_radius);
+    two_center_bundle_.build_orb(ucell.ntype, ucell.orbital_fn);
+    two_center_bundle_.build_alpha(GlobalV::deepks_setorb, &ucell.descriptor_file);
+    two_center_bundle_.build_orb_onsite(ucell.ntype, GlobalV::onsite_radius);
     // currently deepks only use one descriptor file, so cast bool to int is fine
 
     // TODO Due to the omnipresence of GlobalC::ORB, we still have to rely
     // on the old interface for now.
-    two_center_bundle->to_LCAO_Orbitals(GlobalC::ORB, inp.lcao_ecut, inp.lcao_dk, inp.lcao_dr, inp.lcao_rmax);
+    two_center_bundle_.to_LCAO_Orbitals(GlobalC::ORB, inp.lcao_ecut, inp.lcao_dk, inp.lcao_dr, inp.lcao_rmax);
 
     ucell.infoNL.setupNonlocal(ucell.ntype, ucell.atoms, GlobalV::ofs_running, GlobalC::ORB);
 
-    two_center_bundle->build_beta(ucell.ntype, ucell.infoNL.Beta);
+    two_center_bundle_.build_beta(ucell.ntype, ucell.infoNL.Beta);
 
     int Lmax = 0;
 #ifdef __EXX
@@ -561,9 +553,9 @@ void ESolver_KS_LCAO<TK, TR>::init_basis_lcao(ORB_control& orb_con, Input& inp, 
 #endif
 
 #ifdef USE_NEW_TWO_CENTER
-    two_center_bundle->tabulate();
+    two_center_bundle_.tabulate();
 #else
-    two_center_bundle->tabulate(inp.lcao_ecut, inp.lcao_dk, inp.lcao_dr, inp.lcao_rmax);
+    two_center_bundle_.tabulate(inp.lcao_ecut, inp.lcao_dk, inp.lcao_dr, inp.lcao_rmax);
 #endif
 
     if (this->orb_con.setup_2d)
@@ -1369,7 +1361,7 @@ ModuleIO::Output_Mat_Sparse<TK> ESolver_KS_LCAO<TK, TR>::create_Output_Mat_Spars
                                            this->pelec->pot->get_effective_v(),
                                            this->orb_con.ParaV,
                                            this->GK, // mohan add 2024-04-01
-                                           *(uot_->two_center_bundle),
+                                           two_center_bundle_,
                                            this->LM,
                                            GlobalC::GridD, // mohan add 2024-04-06
                                            this->kv,

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -370,7 +370,7 @@ void ESolver_KS_LCAO<TK, TR>::cal_force(ModuleBase::matrix& force)
                        this->LM,
                        this->GG, // mohan add 2024-04-01
                        this->GK, // mohan add 2024-04-01
-                       uot_,
+                       *(uot_->two_center_bundle),
                        force,
                        this->scs,
                        this->sf,

--- a/source/module_esolver/esolver_ks_lcao.h
+++ b/source/module_esolver/esolver_ks_lcao.h
@@ -85,15 +85,7 @@ class ESolver_KS_LCAO : public ESolver_KS<TK>
 
     Grid_Technique GridT;
 
-    // The following variable is introduced in the stage-1 of LCAO
-    // refactoring. It is supposed to replace the previous GlobalC::UOT.
-    //
-    // This is the only place supposed to have the ownership; all other
-    // places should be considered as "borrowing" the object. Unfortunately,
-    // imposing shared_ptr/weak_ptr is only possible once GlobalC::UOT is
-    // completely removed from the code; we have to rely on raw pointers
-    // during the transition period.
-    ORB_gen_tables* uot_;
+    TwoCenterBundle two_center_bundle_;
 
     // Temporarily store the stress to unify the interface with PW,
     // because it's hard to seperate force and stress calculation in LCAO.

--- a/source/module_esolver/esolver_ks_lcao.h
+++ b/source/module_esolver/esolver_ks_lcao.h
@@ -103,7 +103,6 @@ class ESolver_KS_LCAO : public ESolver_KS<TK>
     void beforesolver(const int istep);
     //----------------------------------------------------------------------
 
-
     /// @brief create ModuleIO::Output_DM object to output density matrix
     ModuleIO::Output_DM create_Output_DM(int is, int iter);
 

--- a/source/module_esolver/esolver_ks_lcao_elec.cpp
+++ b/source/module_esolver/esolver_ks_lcao_elec.cpp
@@ -168,7 +168,7 @@ void ESolver_KS_LCAO<TK, TR>::beforesolver(const int istep)
             &(this->LOC),
             this->pelec->pot,
             this->kv,
-            *(uot_->two_center_bundle),
+            two_center_bundle_,
 #ifdef __EXX
             DM,
             GlobalC::exx_info.info_ri.real_number ? &this->exd->two_level_step : &this->exc->two_level_step);
@@ -190,7 +190,7 @@ void ESolver_KS_LCAO<TK, TR>::beforesolver(const int istep)
                                    GlobalC::ucell,
                                    GlobalC::ORB,
                                    GlobalC::GridD,
-                                   *(uot_->two_center_bundle->overlap_orb_alpha));
+                                   *(two_center_bundle_.overlap_orb_alpha));
 
         if (GlobalV::deepks_out_unittest)
         {
@@ -533,7 +533,7 @@ void ESolver_KS_LCAO<std::complex<double>, double>::get_S(void)
     {
         this->p_hamilt = new hamilt::HamiltLCAO<std::complex<double>, double>(&this->LM,
                                                                               this->kv,
-                                                                              *(uot_->two_center_bundle->overlap_orb));
+                                                                              *(two_center_bundle_.overlap_orb));
         dynamic_cast<hamilt::OperatorLCAO<std::complex<double>, double>*>(this->p_hamilt->ops)->contributeHR();
     }
 
@@ -572,7 +572,7 @@ void ESolver_KS_LCAO<std::complex<double>, std::complex<double>>::get_S(void)
         this->p_hamilt = new hamilt::HamiltLCAO<std::complex<double>, std::complex<double>>(
             &this->LM,
             this->kv,
-            *(uot_->two_center_bundle->overlap_orb));
+            *(two_center_bundle_.overlap_orb));
         dynamic_cast<hamilt::OperatorLCAO<std::complex<double>, std::complex<double>>*>(this->p_hamilt->ops)
             ->contributeHR();
     }

--- a/source/module_esolver/esolver_ks_lcao_elec.cpp
+++ b/source/module_esolver/esolver_ks_lcao_elec.cpp
@@ -169,7 +169,7 @@ void ESolver_KS_LCAO<TK, TR>::beforesolver(const int istep)
             &(this->LOC),
             this->pelec->pot,
             this->kv,
-            uot_,
+            *(uot_->two_center_bundle),
 #ifdef __EXX
             DM,
             GlobalC::exx_info.info_ri.real_number ? &this->exd->two_level_step : &this->exc->two_level_step);
@@ -187,11 +187,11 @@ void ESolver_KS_LCAO<TK, TR>::beforesolver(const int istep)
     {
         const Parallel_Orbitals* pv = this->LM.ParaV;
         // build and save <psi(0)|alpha(R)> at beginning
-        GlobalC::ld.build_psialpha(GlobalV::CAL_FORCE, GlobalC::ucell, GlobalC::ORB, GlobalC::GridD, *uot_);
+        GlobalC::ld.build_psialpha(GlobalV::CAL_FORCE, GlobalC::ucell, GlobalC::ORB, GlobalC::GridD, *(uot_->two_center_bundle->overlap_orb_alpha));
 
         if (GlobalV::deepks_out_unittest)
         {
-            GlobalC::ld.check_psialpha(GlobalV::CAL_FORCE, GlobalC::ucell, GlobalC::ORB, GlobalC::GridD, *uot_);
+            GlobalC::ld.check_psialpha(GlobalV::CAL_FORCE, GlobalC::ucell, GlobalC::ORB, GlobalC::GridD);
         }
     }
 #endif
@@ -528,7 +528,7 @@ void ESolver_KS_LCAO<std::complex<double>, double>::get_S(void)
 
     if (this->p_hamilt == nullptr)
     {
-        this->p_hamilt = new hamilt::HamiltLCAO<std::complex<double>, double>(&this->LM, this->kv, uot_);
+        this->p_hamilt = new hamilt::HamiltLCAO<std::complex<double>, double>(&this->LM, this->kv, *(uot_->two_center_bundle->overlap_orb));
         dynamic_cast<hamilt::OperatorLCAO<std::complex<double>, double>*>(this->p_hamilt->ops)->contributeHR();
     }
 
@@ -564,7 +564,7 @@ void ESolver_KS_LCAO<std::complex<double>, std::complex<double>>::get_S(void)
     this->LM.ParaV = &this->orb_con.ParaV;
     if (this->p_hamilt == nullptr)
     {
-        this->p_hamilt = new hamilt::HamiltLCAO<std::complex<double>, std::complex<double>>(&this->LM, this->kv, uot_);
+        this->p_hamilt = new hamilt::HamiltLCAO<std::complex<double>, std::complex<double>>(&this->LM, this->kv, *(uot_->two_center_bundle->overlap_orb));
         dynamic_cast<hamilt::OperatorLCAO<std::complex<double>, std::complex<double>>*>(this->p_hamilt->ops)
             ->contributeHR();
     }

--- a/source/module_esolver/esolver_ks_lcao_elec.cpp
+++ b/source/module_esolver/esolver_ks_lcao_elec.cpp
@@ -411,7 +411,7 @@ void ESolver_KS_LCAO<TK, TR>::others(const int istep)
                              GlobalC::ucell,
                              GlobalV::SEARCH_RADIUS,
                              GlobalV::test_atom_input,
-                             1);
+                             true);
         return;
     }
 
@@ -569,10 +569,10 @@ void ESolver_KS_LCAO<std::complex<double>, std::complex<double>>::get_S(void)
     this->LM.ParaV = &this->orb_con.ParaV;
     if (this->p_hamilt == nullptr)
     {
-        this->p_hamilt = new hamilt::HamiltLCAO<std::complex<double>, std::complex<double>>(
-            &this->LM,
-            this->kv,
-            *(two_center_bundle_.overlap_orb));
+        this->p_hamilt
+            = new hamilt::HamiltLCAO<std::complex<double>, std::complex<double>>(&this->LM,
+                                                                                 this->kv,
+                                                                                 *(two_center_bundle_.overlap_orb));
         dynamic_cast<hamilt::OperatorLCAO<std::complex<double>, std::complex<double>>*>(this->p_hamilt->ops)
             ->contributeHR();
     }

--- a/source/module_esolver/esolver_ks_lcao_elec.cpp
+++ b/source/module_esolver/esolver_ks_lcao_elec.cpp
@@ -21,8 +21,8 @@
 #include "module_hamilt_general/module_ewald/H_Ewald_pw.h"
 #include "module_hamilt_general/module_vdw/vdw.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/LCAO_domain.h"
-#include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/operator_lcao.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/op_exx_lcao.h"
+#include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/operator_lcao.h"
 #include "module_hamilt_lcao/module_deltaspin/spin_constrain.h"
 #include "module_io/dm_io.h"
 #include "module_io/rho_io.h"
@@ -54,14 +54,13 @@ void ESolver_KS_LCAO<TK, TR>::set_matrix_grid(Record_adj& ra)
     // ModuleBase::GlobalFunc::DONE(GlobalV::ofs_running,"SEARCH ADJACENT ATOMS");
 
     // (3) Periodic condition search for each grid.
-    double dr_uniform=0.001;
-	std::vector<double> rcuts;
+    double dr_uniform = 0.001;
+    std::vector<double> rcuts;
     std::vector<std::vector<double>> psi_u;
     std::vector<std::vector<double>> dpsi_u;
     std::vector<std::vector<double>> d2psi_u;
 
-    Gint_Tools::init_orb(dr_uniform, rcuts, GlobalC::ucell, 
-                            psi_u, dpsi_u, d2psi_u);
+    Gint_Tools::init_orb(dr_uniform, rcuts, GlobalC::ucell, psi_u, dpsi_u, d2psi_u);
 
     this->GridT.set_pbc_grid(this->pw_rho->nx,
                              this->pw_rho->ny,
@@ -187,7 +186,11 @@ void ESolver_KS_LCAO<TK, TR>::beforesolver(const int istep)
     {
         const Parallel_Orbitals* pv = this->LM.ParaV;
         // build and save <psi(0)|alpha(R)> at beginning
-        GlobalC::ld.build_psialpha(GlobalV::CAL_FORCE, GlobalC::ucell, GlobalC::ORB, GlobalC::GridD, *(uot_->two_center_bundle->overlap_orb_alpha));
+        GlobalC::ld.build_psialpha(GlobalV::CAL_FORCE,
+                                   GlobalC::ucell,
+                                   GlobalC::ORB,
+                                   GlobalC::GridD,
+                                   *(uot_->two_center_bundle->overlap_orb_alpha));
 
         if (GlobalV::deepks_out_unittest)
         {
@@ -528,7 +531,9 @@ void ESolver_KS_LCAO<std::complex<double>, double>::get_S(void)
 
     if (this->p_hamilt == nullptr)
     {
-        this->p_hamilt = new hamilt::HamiltLCAO<std::complex<double>, double>(&this->LM, this->kv, *(uot_->two_center_bundle->overlap_orb));
+        this->p_hamilt = new hamilt::HamiltLCAO<std::complex<double>, double>(&this->LM,
+                                                                              this->kv,
+                                                                              *(uot_->two_center_bundle->overlap_orb));
         dynamic_cast<hamilt::OperatorLCAO<std::complex<double>, double>*>(this->p_hamilt->ops)->contributeHR();
     }
 
@@ -564,7 +569,10 @@ void ESolver_KS_LCAO<std::complex<double>, std::complex<double>>::get_S(void)
     this->LM.ParaV = &this->orb_con.ParaV;
     if (this->p_hamilt == nullptr)
     {
-        this->p_hamilt = new hamilt::HamiltLCAO<std::complex<double>, std::complex<double>>(&this->LM, this->kv, *(uot_->two_center_bundle->overlap_orb));
+        this->p_hamilt = new hamilt::HamiltLCAO<std::complex<double>, std::complex<double>>(
+            &this->LM,
+            this->kv,
+            *(uot_->two_center_bundle->overlap_orb));
         dynamic_cast<hamilt::OperatorLCAO<std::complex<double>, std::complex<double>>*>(this->p_hamilt->ops)
             ->contributeHR();
     }

--- a/source/module_esolver/esolver_ks_lcao_tddft.cpp
+++ b/source/module_esolver/esolver_ks_lcao_tddft.cpp
@@ -89,9 +89,10 @@ void ESolver_KS_LCAO_TDDFT::before_all_runners(Input& inp, UnitCell& ucell)
     // 5) allocate H and S matrices according to computational resources
     this->LM.divide_HS_in_frag(GlobalV::GAMMA_ONLY_LOCAL, orb_con.ParaV, kv.get_nks());
 
-    // this part will be updated soon 
+    // this part will be updated soon
     // pass Hamilt-pointer to Operator
-    this->LOC.ParaV = this->LM.ParaV;;
+    this->LOC.ParaV = this->LM.ParaV;
+    ;
     this->LOWF.ParaV = this->LM.ParaV;
 
     // 6) initialize Density Matrix
@@ -105,7 +106,7 @@ void ESolver_KS_LCAO_TDDFT::before_all_runners(Input& inp, UnitCell& ucell)
         this->phsol->method = GlobalV::KS_SOLVER;
     }
 
-    // 8) initialize the charge density 
+    // 8) initialize the charge density
     this->pelec->charge->allocate(GlobalV::NSPIN);
     this->pelec->omega = GlobalC::ucell.omega; // this line is very odd.
 
@@ -118,10 +119,9 @@ void ESolver_KS_LCAO_TDDFT::before_all_runners(Input& inp, UnitCell& ucell)
                                                 &(pelec->f_en.etxc),
                                                 &(pelec->f_en.vtxc));
 
-    // this line should be optimized 
+    // this line should be optimized
     this->pelec_td = dynamic_cast<elecstate::ElecStateLCAO_TDDFT*>(this->pelec);
 }
-
 
 void ESolver_KS_LCAO_TDDFT::hamilt2density(const int istep, const int iter, const double ethr)
 {
@@ -284,17 +284,16 @@ void ESolver_KS_LCAO_TDDFT::update_pot(const int istep, const int iter)
         }
     }
 
-    if (elecstate::ElecStateLCAO<std::complex<double>>::out_wfc_lcao &&
-        (this->conv_elec || iter == GlobalV::SCF_NMAX) &&
-        (istep % GlobalV::out_interval == 0) )
+    if (elecstate::ElecStateLCAO<std::complex<double>>::out_wfc_lcao && (this->conv_elec || iter == GlobalV::SCF_NMAX)
+        && (istep % GlobalV::out_interval == 0))
     {
-            ModuleIO::write_wfc_nao(elecstate::ElecStateLCAO<std::complex<double>>::out_wfc_lcao,
-                           this->psi[0],
-                           this->pelec->ekb,
-                           this->pelec->wg,
-                           this->pelec->klist->kvec_c,
-                           this->orb_con.ParaV,
-                           istep);
+        ModuleIO::write_wfc_nao(elecstate::ElecStateLCAO<std::complex<double>>::out_wfc_lcao,
+                                this->psi[0],
+                                this->pelec->ekb,
+                                this->pelec->wg,
+                                this->pelec->klist->kvec_c,
+                                this->orb_con.ParaV,
+                                istep);
     }
 
     // Calculate new potential according to new Charge Density
@@ -324,15 +323,9 @@ void ESolver_KS_LCAO_TDDFT::update_pot(const int istep, const int iter)
         if (this->psi_laststep == nullptr)
         {
 #ifdef __MPI
-            this->psi_laststep = new psi::Psi<std::complex<double>>(kv.get_nks(),
-                                                                    ncol_nbands, 
-                                                                    nrow, 
-                                                                    nullptr);
+            this->psi_laststep = new psi::Psi<std::complex<double>>(kv.get_nks(), ncol_nbands, nrow, nullptr);
 #else
-            this->psi_laststep = new psi::Psi<std::complex<double>>(kv.get_nks(), 
-                                                                    nbands, 
-                                                                    nlocal,
-                                                                    nullptr);
+            this->psi_laststep = new psi::Psi<std::complex<double>>(kv.get_nks(), nbands, nlocal, nullptr);
 #endif
         }
 
@@ -434,7 +427,7 @@ void ESolver_KS_LCAO_TDDFT::after_scf(const int istep)
                                 *(uot_->two_center_bundle),
                                 tmp_DM->get_paraV_pointer(),
                                 this->RA,
-                                this->LM);     // mohan add 2024-04-02
+                                this->LM); // mohan add 2024-04-02
     }
     ESolver_KS_LCAO<std::complex<double>, double>::after_scf(istep);
 }
@@ -494,21 +487,14 @@ void ESolver_KS_LCAO_TDDFT::cal_edm_tddft(void)
         zcopy_(&nloc, s_mat.p, &inc, Sinv, &inc);
 
         vector<int> ipiv(nloc, 0);
-        int info=0;
+        int info = 0;
         const int one_int = 1;
 
-        pzgetrf_(&nlocal, 
-                 &nlocal, 
-                 Sinv, 
-                 &one_int, 
-                 &one_int, 
-                 this->LOC.ParaV->desc, 
-                 ipiv.data(), 
-                 &info);
+        pzgetrf_(&nlocal, &nlocal, Sinv, &one_int, &one_int, this->LOC.ParaV->desc, ipiv.data(), &info);
 
         int lwork = -1;
         int liwork = -1;
-       
+
         // if lwork == -1, then the size of work is (at least) of length 1.
         std::vector<std::complex<double>> work(1, 0);
 

--- a/source/module_esolver/esolver_ks_lcao_tddft.cpp
+++ b/source/module_esolver/esolver_ks_lcao_tddft.cpp
@@ -424,7 +424,7 @@ void ESolver_KS_LCAO_TDDFT::after_scf(const int istep)
                                 this->psi,
                                 pelec,
                                 kv,
-                                *(uot_->two_center_bundle),
+                                two_center_bundle_,
                                 tmp_DM->get_paraV_pointer(),
                                 this->RA,
                                 this->LM); // mohan add 2024-04-02

--- a/source/module_esolver/esolver_ks_lcao_tddft.cpp
+++ b/source/module_esolver/esolver_ks_lcao_tddft.cpp
@@ -431,7 +431,7 @@ void ESolver_KS_LCAO_TDDFT::after_scf(const int istep)
                                 this->psi,
                                 pelec,
                                 kv,
-                                uot_,
+                                *(uot_->two_center_bundle),
                                 tmp_DM->get_paraV_pointer(),
                                 this->RA,
                                 this->LM);     // mohan add 2024-04-02

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE.h
@@ -124,7 +124,7 @@ private:
         const Parallel_Orbitals& pv,
         const UnitCell& ucell,
         const LCAO_Orbitals& orb,
-        const ORB_gen_tables& uot,
+        const TwoCenterIntegrator& intor_orb_beta,
         Grid_Driver& gd,
         const bool isforce,
         const bool isstress,

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE.h
@@ -6,81 +6,79 @@
 #include "module_base/matrix.h"
 #include "module_elecstate/module_dm/density_matrix.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h"
+#include "module_hamilt_lcao/hamilt_lcaodft/force_stress_arrays.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/local_orbital_charge.h"
-#include "module_psi/psi.h"
 #include "module_hamilt_lcao/module_gint/gint_gamma.h"
 #include "module_hamilt_lcao/module_gint/gint_k.h"
-#include "module_hamilt_lcao/hamilt_lcaodft/force_stress_arrays.h"
-
+#include "module_psi/psi.h"
 
 #ifndef TGINT_H
 #define TGINT_H
-template <typename T> struct TGint;
+template <typename T>
+struct TGint;
 template <>
-struct TGint<double> {
+struct TGint<double>
+{
     using type = Gint_Gamma;
 };
 template <>
-struct TGint<std::complex<double>> {
+struct TGint<std::complex<double>>
+{
     using type = Gint_k;
 };
 #endif
 
-template<typename T> class Force_Stress_LCAO;
+template <typename T>
+class Force_Stress_LCAO;
 
-template<typename T>
+template <typename T>
 class Force_LCAO
 {
-public:
+  public:
     friend class Force_Stress_LCAO<T>;
 
-    Force_LCAO() {};
-    ~Force_LCAO() {};
+    Force_LCAO(){};
+    ~Force_LCAO(){};
 
-private:
-
+  private:
     const Parallel_Orbitals* ParaV;
 
     elecstate::Potential* pot;
 
     // orthonormal force + contribution from T and VNL
-    void ftable(
-        const bool isforce,
-        const bool isstress,
-        ForceStressArrays &fsr, // mohan add 2024-06-16
-        const UnitCell& ucell,
-        const psi::Psi<T>* psi,
-        const elecstate::ElecState* pelec,
-        ModuleBase::matrix& foverlap,
-        ModuleBase::matrix& ftvnl_dphi,
-        ModuleBase::matrix& fvnl_dbeta,
-        ModuleBase::matrix& fvl_dphi,
-        ModuleBase::matrix& soverlap,
-        ModuleBase::matrix& stvnl_dphi,
-        ModuleBase::matrix& svnl_dbeta,
-        ModuleBase::matrix& svl_dphi,
+    void ftable(const bool isforce,
+                const bool isstress,
+                ForceStressArrays& fsr, // mohan add 2024-06-16
+                const UnitCell& ucell,
+                const psi::Psi<T>* psi,
+                const elecstate::ElecState* pelec,
+                ModuleBase::matrix& foverlap,
+                ModuleBase::matrix& ftvnl_dphi,
+                ModuleBase::matrix& fvnl_dbeta,
+                ModuleBase::matrix& fvl_dphi,
+                ModuleBase::matrix& soverlap,
+                ModuleBase::matrix& stvnl_dphi,
+                ModuleBase::matrix& svnl_dbeta,
+                ModuleBase::matrix& svl_dphi,
 #ifdef __DEEPKS
-        ModuleBase::matrix& svnl_dalpha,
+                ModuleBase::matrix& svnl_dalpha,
 #endif
-        typename TGint<T>::type& gint,
-        const TwoCenterBundle& two_center_bundle,
-        const Parallel_Orbitals& pv,
-        LCAO_Matrix& lm,
-        const K_Vectors* kv = nullptr,
-        Record_adj* ra = nullptr);
-
+                typename TGint<T>::type& gint,
+                const TwoCenterBundle& two_center_bundle,
+                const Parallel_Orbitals& pv,
+                LCAO_Matrix& lm,
+                const K_Vectors* kv = nullptr,
+                Record_adj* ra = nullptr);
 
     // get the ds, dt, dvnl.
-    void allocate(
-        const Parallel_Orbitals& pv,
-        LCAO_Matrix& lm,
-        ForceStressArrays& fsr, // mohan add 2024-06-15
-        const TwoCenterBundle& two_center_bundle,
-        const int& nks = 0,
-        const std::vector<ModuleBase::Vector3<double>>& kvec_d = {});
+    void allocate(const Parallel_Orbitals& pv,
+                  LCAO_Matrix& lm,
+                  ForceStressArrays& fsr, // mohan add 2024-06-15
+                  const TwoCenterBundle& two_center_bundle,
+                  const int& nks = 0,
+                  const std::vector<ModuleBase::Vector3<double>>& kvec_d = {});
 
-
-    void finish_ftable(ForceStressArrays &fsr);
+    void finish_ftable(ForceStressArrays& fsr);
 
     void average_force(double* fm);
 
@@ -91,61 +89,59 @@ private:
     // forces related to energy density matrix
     //-------------------------------------------------------------
 
-    void cal_fedm(
-        const bool isforce,
-        const bool isstress,
-        ForceStressArrays &fsr,
-        const UnitCell& ucell,
-        const elecstate::DensityMatrix<T, double>* dm,
-        const psi::Psi<T>* psi,
-        const Parallel_Orbitals& pv,
-        const elecstate::ElecState* pelec,
-        LCAO_Matrix& lm,
-        ModuleBase::matrix& foverlap,
-        ModuleBase::matrix& soverlap,
-        const K_Vectors* kv = nullptr,
-        Record_adj* ra = nullptr);
+    void cal_fedm(const bool isforce,
+                  const bool isstress,
+                  ForceStressArrays& fsr,
+                  const UnitCell& ucell,
+                  const elecstate::DensityMatrix<T, double>* dm,
+                  const psi::Psi<T>* psi,
+                  const Parallel_Orbitals& pv,
+                  const elecstate::ElecState* pelec,
+                  LCAO_Matrix& lm,
+                  ModuleBase::matrix& foverlap,
+                  ModuleBase::matrix& soverlap,
+                  const K_Vectors* kv = nullptr,
+                  Record_adj* ra = nullptr);
 
     //-------------------------------------------------------------
     // forces related to kinetic and non-local pseudopotentials
     //--------------------------------------------------------------
-    void cal_ftvnl_dphi(
-        const elecstate::DensityMatrix<T, double>* dm,
-        const Parallel_Orbitals& pv,
-        const UnitCell& ucell,
-        ForceStressArrays &fsr,
-        const bool isforce,
-        const bool isstress,
-        ModuleBase::matrix& ftvnl_dphi,
-        ModuleBase::matrix& stvnl_dphi,
-        Record_adj* ra = nullptr);
+    void cal_ftvnl_dphi(const elecstate::DensityMatrix<T, double>* dm,
+                        const Parallel_Orbitals& pv,
+                        const UnitCell& ucell,
+                        ForceStressArrays& fsr,
+                        const bool isforce,
+                        const bool isstress,
+                        ModuleBase::matrix& ftvnl_dphi,
+                        ModuleBase::matrix& stvnl_dphi,
+                        Record_adj* ra = nullptr);
 
     void cal_fvnl_dbeta(const elecstate::DensityMatrix<T, double>* dm,
-        const Parallel_Orbitals& pv,
-        const UnitCell& ucell,
-        const LCAO_Orbitals& orb,
-        const TwoCenterIntegrator& intor_orb_beta,
-        Grid_Driver& gd,
-        const bool isforce,
-        const bool isstress,
-        ModuleBase::matrix& fvnl_dbeta,
-        ModuleBase::matrix& svnl_dbeta);
+                        const Parallel_Orbitals& pv,
+                        const UnitCell& ucell,
+                        const LCAO_Orbitals& orb,
+                        const TwoCenterIntegrator& intor_orb_beta,
+                        Grid_Driver& gd,
+                        const bool isforce,
+                        const bool isstress,
+                        ModuleBase::matrix& fvnl_dbeta,
+                        ModuleBase::matrix& svnl_dbeta);
 
     //-------------------------------------------
     // forces related to local pseudopotentials
     //-------------------------------------------
     void cal_fvl_dphi(const bool isforce,
-        const bool isstress,
-        const elecstate::Potential* pot_in,
-        typename TGint<T>::type& gint,
-        ModuleBase::matrix& fvl_dphi,
-        ModuleBase::matrix& svl_dphi);
+                      const bool isstress,
+                      const elecstate::Potential* pot_in,
+                      typename TGint<T>::type& gint,
+                      ModuleBase::matrix& fvl_dphi,
+                      ModuleBase::matrix& svl_dphi);
 };
 
 // this namespace used to store global function for some stress operation
 namespace StressTools
 {
-    // set upper matrix to whole matrix
-    void stress_fill(const double& lat0_, const double& omega_, ModuleBase::matrix& stress_matrix);
+// set upper matrix to whole matrix
+void stress_fill(const double& lat0_, const double& omega_, ModuleBase::matrix& stress_matrix);
 } // namespace StressTools
 #endif

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE.h
@@ -63,7 +63,7 @@ private:
         ModuleBase::matrix& svnl_dalpha,
 #endif
         typename TGint<T>::type& gint,
-        const ORB_gen_tables* uot,
+        const TwoCenterBundle& two_center_bundle,
         const Parallel_Orbitals& pv,
         LCAO_Matrix& lm,
         const K_Vectors* kv = nullptr,
@@ -75,7 +75,7 @@ private:
         const Parallel_Orbitals& pv,
         LCAO_Matrix& lm,
         ForceStressArrays& fsr, // mohan add 2024-06-15
-        const ORB_gen_tables* uot,
+        const TwoCenterBundle& two_center_bundle,
         const int& nks = 0,
         const std::vector<ModuleBase::Vector3<double>>& kvec_d = {});
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
@@ -35,7 +35,7 @@ void Force_Stress_LCAO<T>::getForceStress(const bool isforce,
                                           LCAO_Matrix& lm,
                                           Gint_Gamma& gint_gamma, // mohan add 2024-04-01
                                           Gint_k& gint_k,         // mohan add 2024-04-01
-                                          const ORB_gen_tables* uot,
+                                          const TwoCenterBundle& two_center_bundle,
                                           ModuleBase::matrix& fcs,
                                           ModuleBase::matrix& scs,
                                           const Structure_Factor& sf,
@@ -161,7 +161,7 @@ void Force_Stress_LCAO<T>::getForceStress(const bool isforce,
 #endif
                         gint_gamma,
                         gint_k,
-                        uot,
+                        two_center_bundle,
                         pv,
                         lm,
                         kv);
@@ -255,7 +255,7 @@ void Force_Stress_LCAO<T>::getForceStress(const bool isforce,
                                                                    nullptr,
                                                                    GlobalC::ucell,
                                                                    &GlobalC::GridD,
-                                                                   uot->two_center_bundle->overlap_orb_onsite.get(),
+                                                                   two_center_bundle.overlap_orb_onsite.get(),
                                                                    &GlobalC::dftu,
                                                                    *(lm.ParaV));
 
@@ -768,7 +768,7 @@ void Force_Stress_LCAO<double>::integral_part(const bool isGammaOnly,
 #endif
                                               Gint_Gamma& gint_gamma, // mohan add 2024-04-01
                                               Gint_k& gint_k,         // mohan add 2024-04-01
-                                              const ORB_gen_tables* uot,
+                                              const TwoCenterBundle& two_center_bundle,
                                               const Parallel_Orbitals& pv,
                                               LCAO_Matrix& lm,
                                               const K_Vectors& kv)
@@ -792,7 +792,7 @@ void Force_Stress_LCAO<double>::integral_part(const bool isGammaOnly,
                svnl_dalpha,
 #endif
                gint_gamma,
-               uot,
+               two_center_bundle,
                pv,
                lm);
     return;
@@ -818,7 +818,7 @@ void Force_Stress_LCAO<std::complex<double>>::integral_part(const bool isGammaOn
 #endif
                                                             Gint_Gamma& gint_gamma,
                                                             Gint_k& gint_k,
-                                                            const ORB_gen_tables* uot,
+                                                            const TwoCenterBundle& two_center_bundle,
                                                             const Parallel_Orbitals& pv,
                                                             LCAO_Matrix& lm,
                                                             const K_Vectors& kv)
@@ -841,7 +841,7 @@ void Force_Stress_LCAO<std::complex<double>>::integral_part(const bool isGammaOn
                svnl_dalpha,
 #endif
                gint_k,
-               uot,
+               two_center_bundle,
                pv,
                lm,
                &kv,

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
@@ -13,11 +13,11 @@
 #ifdef __EXX
 #include "module_ri/Exx_LRI.h"
 #endif
+#include "force_stress_arrays.h"
 #include "module_hamilt_lcao/module_gint/gint_gamma.h"
 #include "module_hamilt_lcao/module_gint/gint_k.h"
-#include "force_stress_arrays.h"
 
-template<typename T>
+template <typename T>
 class Force_Stress_LCAO
 {
     // mohan add 2021-02-09
@@ -30,26 +30,26 @@ class Force_Stress_LCAO
     ~Force_Stress_LCAO();
 
     void getForceStress(const bool isforce,
-        const bool isstress,
-        const bool istestf,
-        const bool istests,
-		Parallel_Orbitals &pv,
-		const elecstate::ElecState* pelec,
-        const psi::Psi<T>* psi,
-		LCAO_Matrix &lm,
-		Gint_Gamma &gint_gamma, // mohan add 2024-04-01
-		Gint_k &gint_k, // mohan add 2024-04-01
-        const TwoCenterBundle& two_center_bundle,
-        ModuleBase::matrix& fcs,
-        ModuleBase::matrix& scs,
-        const Structure_Factor& sf,
-        const K_Vectors& kv,
-        ModulePW::PW_Basis* rhopw,
+                        const bool isstress,
+                        const bool istestf,
+                        const bool istests,
+                        Parallel_Orbitals& pv,
+                        const elecstate::ElecState* pelec,
+                        const psi::Psi<T>* psi,
+                        LCAO_Matrix& lm,
+                        Gint_Gamma& gint_gamma, // mohan add 2024-04-01
+                        Gint_k& gint_k,         // mohan add 2024-04-01
+                        const TwoCenterBundle& two_center_bundle,
+                        ModuleBase::matrix& fcs,
+                        ModuleBase::matrix& scs,
+                        const Structure_Factor& sf,
+                        const K_Vectors& kv,
+                        ModulePW::PW_Basis* rhopw,
 #ifdef __EXX
-        Exx_LRI<double>& exx_lri_double,
-        Exx_LRI<std::complex<double>>& exx_lri_complex,
-#endif  
-        ModuleSymmetry::Symmetry* symm);
+                        Exx_LRI<double>& exx_lri_double,
+                        Exx_LRI<std::complex<double>>& exx_lri_complex,
+#endif
+                        ModuleSymmetry::Symmetry* symm);
 
   private:
     int nat;
@@ -71,30 +71,29 @@ class Force_Stress_LCAO
                         ModulePW::PW_Basis* rhopw,
                         const Structure_Factor& sf);
 
-    void integral_part(
-        const bool isGammaOnly,
-        const bool isforce,
-        const bool isstress,
-        ForceStressArrays &fsr, // mohan add 2024-06-15
-        const elecstate::ElecState* pelec,
-        const psi::Psi<T>* psi,
-        ModuleBase::matrix& foverlap,
-        ModuleBase::matrix& ftvnl_dphi,
-        ModuleBase::matrix& fvnl_dbeta,
-        ModuleBase::matrix& fvl_dphi,
-        ModuleBase::matrix& soverlap,
-        ModuleBase::matrix& stvnl_dphi,
-        ModuleBase::matrix& svnl_dbeta,
-        ModuleBase::matrix& svl_dphi,
+    void integral_part(const bool isGammaOnly,
+                       const bool isforce,
+                       const bool isstress,
+                       ForceStressArrays& fsr, // mohan add 2024-06-15
+                       const elecstate::ElecState* pelec,
+                       const psi::Psi<T>* psi,
+                       ModuleBase::matrix& foverlap,
+                       ModuleBase::matrix& ftvnl_dphi,
+                       ModuleBase::matrix& fvnl_dbeta,
+                       ModuleBase::matrix& fvl_dphi,
+                       ModuleBase::matrix& soverlap,
+                       ModuleBase::matrix& stvnl_dphi,
+                       ModuleBase::matrix& svnl_dbeta,
+                       ModuleBase::matrix& svl_dphi,
 #if __DEEPKS
-        ModuleBase::matrix& svnl_dalpha,
+                       ModuleBase::matrix& svnl_dalpha,
 #endif
-		Gint_Gamma &gint_gamma,
-		Gint_k &gint_k,
-        const TwoCenterBundle& two_center_bundle,
-	    const Parallel_Orbitals &pv,
-		LCAO_Matrix &lm,
-		const K_Vectors& kv);
+                       Gint_Gamma& gint_gamma,
+                       Gint_k& gint_k,
+                       const TwoCenterBundle& two_center_bundle,
+                       const Parallel_Orbitals& pv,
+                       LCAO_Matrix& lm,
+                       const K_Vectors& kv);
 
     void calStressPwPart(ModuleBase::matrix& sigmadvl,
                          ModuleBase::matrix& sigmahar,
@@ -109,7 +108,7 @@ class Force_Stress_LCAO
     static double force_invalid_threshold_ev;
 };
 
-template<typename T>
+template <typename T>
 double Force_Stress_LCAO<T>::force_invalid_threshold_ev = 0.00;
 
 #endif

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
@@ -39,7 +39,7 @@ class Force_Stress_LCAO
 		LCAO_Matrix &lm,
 		Gint_Gamma &gint_gamma, // mohan add 2024-04-01
 		Gint_k &gint_k, // mohan add 2024-04-01
-        const ORB_gen_tables* uot,
+        const TwoCenterBundle& two_center_bundle,
         ModuleBase::matrix& fcs,
         ModuleBase::matrix& scs,
         const Structure_Factor& sf,
@@ -91,7 +91,7 @@ class Force_Stress_LCAO
 #endif
 		Gint_Gamma &gint_gamma,
 		Gint_k &gint_k,
-        const ORB_gen_tables* uot,
+        const TwoCenterBundle& two_center_bundle,
 	    const Parallel_Orbitals &pv,
 		LCAO_Matrix &lm,
 		const K_Vectors& kv);

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_gamma.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_gamma.cpp
@@ -17,7 +17,7 @@ void Force_LCAO<double>::allocate(
     const Parallel_Orbitals& pv,
     LCAO_Matrix& lm,
     ForceStressArrays& fsr, // mohan add 2024-06-15
-    const ORB_gen_tables* uot,
+    const TwoCenterBundle& two_center_bundle,
     const int& nks,
     const std::vector<ModuleBase::Vector3<double>>& kvec_d)
 {
@@ -77,7 +77,7 @@ void Force_LCAO<double>::allocate(
 			GlobalC::ucell, 
 			GlobalC::ORB, 
 			pv,
-			*(uot->two_center_bundle), 
+			two_center_bundle, 
 			&GlobalC::GridD, 
 			lm.Sloc.data());
 
@@ -102,7 +102,7 @@ void Force_LCAO<double>::allocate(
 			GlobalC::ucell, 
 			GlobalC::ORB, 
 			pv,
-			*(uot->two_center_bundle), 
+			two_center_bundle, 
 			&GlobalC::GridD, 
 			lm.Hloc_fixed.data());
 
@@ -113,7 +113,7 @@ void Force_LCAO<double>::allocate(
 			cal_deri, 
 			GlobalC::ucell, 
 			GlobalC::ORB, 
-			*(uot->two_center_bundle->overlap_orb_beta), 
+			*(two_center_bundle.overlap_orb_beta), 
 			&GlobalC::GridD);
 
     // calculate asynchronous S matrix to output for Hefei-NAMD
@@ -131,7 +131,7 @@ void Force_LCAO<double>::allocate(
 				GlobalC::ucell, 
 				GlobalC::ORB, 
 				pv,
-				*(uot->two_center_bundle), 
+				two_center_bundle, 
 				&GlobalC::GridD, 
 				lm.Sloc.data(), 
 				INPUT.cal_syns, 
@@ -240,7 +240,7 @@ void Force_LCAO<double>::ftable(
     ModuleBase::matrix& svnl_dalpha,
 #endif
     TGint<double>::type& gint,
-    const ORB_gen_tables* uot,
+    const TwoCenterBundle& two_center_bundle,
     const Parallel_Orbitals& pv,
     LCAO_Matrix& lm,
     const K_Vectors* kv,
@@ -262,7 +262,7 @@ void Force_LCAO<double>::ftable(
 			pv, 
 			lm,
             fsr,
-			uot);
+			two_center_bundle);
 
     // calculate the force related to 'energy density matrix'.
 	this->cal_fedm(
@@ -293,7 +293,7 @@ void Force_LCAO<double>::ftable(
 			pv, 
 			ucell, 
 			GlobalC::ORB, 
-			*(uot->two_center_bundle->overlap_orb_beta), 
+			*(two_center_bundle.overlap_orb_beta), 
 			GlobalC::GridD, 
 			isforce, 
 			isstress, 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_gamma.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_gamma.cpp
@@ -77,7 +77,7 @@ void Force_LCAO<double>::allocate(
 			GlobalC::ucell, 
 			GlobalC::ORB, 
 			pv,
-			*uot, 
+			*(uot->two_center_bundle), 
 			&GlobalC::GridD, 
 			lm.Sloc.data());
 
@@ -102,7 +102,7 @@ void Force_LCAO<double>::allocate(
 			GlobalC::ucell, 
 			GlobalC::ORB, 
 			pv,
-			*uot, 
+			*(uot->two_center_bundle), 
 			&GlobalC::GridD, 
 			lm.Hloc_fixed.data());
 
@@ -113,7 +113,7 @@ void Force_LCAO<double>::allocate(
 			cal_deri, 
 			GlobalC::ucell, 
 			GlobalC::ORB, 
-			*uot, 
+			*(uot->two_center_bundle->overlap_orb_beta), 
 			&GlobalC::GridD);
 
     // calculate asynchronous S matrix to output for Hefei-NAMD
@@ -131,7 +131,7 @@ void Force_LCAO<double>::allocate(
 				GlobalC::ucell, 
 				GlobalC::ORB, 
 				pv,
-				*uot, 
+				*(uot->two_center_bundle), 
 				&GlobalC::GridD, 
 				lm.Sloc.data(), 
 				INPUT.cal_syns, 
@@ -293,7 +293,7 @@ void Force_LCAO<double>::ftable(
 			pv, 
 			ucell, 
 			GlobalC::ORB, 
-			*uot, 
+			*(uot->two_center_bundle->overlap_orb_beta), 
 			GlobalC::GridD, 
 			isforce, 
 			isstress, 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_gamma.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_gamma.cpp
@@ -7,19 +7,18 @@
 #ifdef __DEEPKS
 #include "module_hamilt_lcao/module_deepks/LCAO_deepks.h" //caoyu add for deepks on 20210813
 #endif
-#include "module_io/write_HS.h"
+#include "module_cell/module_neighbor/sltk_grid_driver.h" //GridD
 #include "module_elecstate/elecstate_lcao.h"
-#include "module_cell/module_neighbor/sltk_grid_driver.h"  //GridD
-#include "module_hamilt_lcao/hamilt_lcaodft/LCAO_domain.h" 
+#include "module_hamilt_lcao/hamilt_lcaodft/LCAO_domain.h"
+#include "module_io/write_HS.h"
 
-template<>
-void Force_LCAO<double>::allocate(
-    const Parallel_Orbitals& pv,
-    LCAO_Matrix& lm,
-    ForceStressArrays& fsr, // mohan add 2024-06-15
-    const TwoCenterBundle& two_center_bundle,
-    const int& nks,
-    const std::vector<ModuleBase::Vector3<double>>& kvec_d)
+template <>
+void Force_LCAO<double>::allocate(const Parallel_Orbitals& pv,
+                                  LCAO_Matrix& lm,
+                                  ForceStressArrays& fsr, // mohan add 2024-06-15
+                                  const TwoCenterBundle& two_center_bundle,
+                                  const int& nks,
+                                  const std::vector<ModuleBase::Vector3<double>>& kvec_d)
 {
     ModuleBase::TITLE("Force_LCAO", "allocate");
     ModuleBase::timer::tick("Force_LCAO", "allocate");
@@ -69,17 +68,16 @@ void Force_LCAO<double>::allocate(
         ModuleBase::Memory::record("Stress::dSH_GO", sizeof(double) * pv.nloc * 12);
     }
     // calculate dS in LCAO basis
-	LCAO_domain::build_ST_new(
-            lm,
-            fsr,
-			'S', 
-			cal_deri, 
-			GlobalC::ucell, 
-			GlobalC::ORB, 
-			pv,
-			two_center_bundle, 
-			&GlobalC::GridD, 
-			lm.Sloc.data());
+    LCAO_domain::build_ST_new(lm,
+                              fsr,
+                              'S',
+                              cal_deri,
+                              GlobalC::ucell,
+                              GlobalC::ORB,
+                              pv,
+                              two_center_bundle,
+                              &GlobalC::GridD,
+                              lm.Sloc.data());
 
     // calculate dT in LCAP
     // allocation dt
@@ -94,27 +92,25 @@ void Force_LCAO<double>::allocate(
 
     // calculate dT
     // calculate T + VNL(P1) in LCAO basis
-	LCAO_domain::build_ST_new(
-            lm,
-            fsr,
-			'T', 
-			cal_deri, 
-			GlobalC::ucell, 
-			GlobalC::ORB, 
-			pv,
-			two_center_bundle, 
-			&GlobalC::GridD, 
-			lm.Hloc_fixed.data());
+    LCAO_domain::build_ST_new(lm,
+                              fsr,
+                              'T',
+                              cal_deri,
+                              GlobalC::ucell,
+                              GlobalC::ORB,
+                              pv,
+                              two_center_bundle,
+                              &GlobalC::GridD,
+                              lm.Hloc_fixed.data());
 
-    LCAO_domain::build_Nonlocal_mu_new(
-			lm, 
-            fsr,
-			lm.Hloc_fixed.data(), 
-			cal_deri, 
-			GlobalC::ucell, 
-			GlobalC::ORB, 
-			*(two_center_bundle.overlap_orb_beta), 
-			&GlobalC::GridD);
+    LCAO_domain::build_Nonlocal_mu_new(lm,
+                                       fsr,
+                                       lm.Hloc_fixed.data(),
+                                       cal_deri,
+                                       GlobalC::ucell,
+                                       GlobalC::ORB,
+                                       *(two_center_bundle.overlap_orb_beta),
+                                       &GlobalC::GridD);
 
     // calculate asynchronous S matrix to output for Hefei-NAMD
     if (INPUT.cal_syns)
@@ -123,53 +119,52 @@ void Force_LCAO<double>::allocate(
 
         lm.zeros_HSgamma('S');
 
-		LCAO_domain::build_ST_new(
-                lm,
-                fsr,
-				'S', 
-				cal_deri, 
-				GlobalC::ucell, 
-				GlobalC::ORB, 
-				pv,
-				two_center_bundle, 
-				&GlobalC::GridD, 
-				lm.Sloc.data(), 
-				INPUT.cal_syns, 
-				INPUT.dmax);
+        LCAO_domain::build_ST_new(lm,
+                                  fsr,
+                                  'S',
+                                  cal_deri,
+                                  GlobalC::ucell,
+                                  GlobalC::ORB,
+                                  pv,
+                                  two_center_bundle,
+                                  &GlobalC::GridD,
+                                  lm.Sloc.data(),
+                                  INPUT.cal_syns,
+                                  INPUT.dmax);
 
         bool bit = false; // LiuXh, 2017-03-21
 
-		ModuleIO::save_mat(0, 
-				lm.Hloc.data(), 
-				GlobalV::NLOCAL, 
-				bit, 
-				GlobalV::out_ndigits, 
-				0, 
-				GlobalV::out_app_flag, 
-				"H", 
-				"data-" + std::to_string(0), 
-				pv,
-				GlobalV::DRANK);
+        ModuleIO::save_mat(0,
+                           lm.Hloc.data(),
+                           GlobalV::NLOCAL,
+                           bit,
+                           GlobalV::out_ndigits,
+                           0,
+                           GlobalV::out_app_flag,
+                           "H",
+                           "data-" + std::to_string(0),
+                           pv,
+                           GlobalV::DRANK);
 
-		ModuleIO::save_mat(0, 
-				lm.Sloc.data(), 
-				GlobalV::NLOCAL, 
-				bit, 
-				GlobalV::out_ndigits, 
-				0, 
-				GlobalV::out_app_flag, 
-				"S", 
-				"data-" + std::to_string(0), 
-				pv,
-				GlobalV::DRANK);
-	}
+        ModuleIO::save_mat(0,
+                           lm.Sloc.data(),
+                           GlobalV::NLOCAL,
+                           bit,
+                           GlobalV::out_ndigits,
+                           0,
+                           GlobalV::out_app_flag,
+                           "S",
+                           "data-" + std::to_string(0),
+                           pv,
+                           GlobalV::DRANK);
+    }
 
     ModuleBase::timer::tick("Force_LCAO", "allocate");
     return;
 }
 
-template<>
-void Force_LCAO<double>::finish_ftable(ForceStressArrays &fsr)
+template <>
+void Force_LCAO<double>::finish_ftable(ForceStressArrays& fsr)
 {
     delete[] fsr.DSloc_x;
     delete[] fsr.DSloc_y;
@@ -196,7 +191,7 @@ void Force_LCAO<double>::finish_ftable(ForceStressArrays &fsr)
     return;
 }
 
-template<>
+template <>
 void Force_LCAO<double>::test(Parallel_Orbitals& pv, double* mm, const std::string& name)
 {
     std::cout << "\n PRINT " << name << std::endl;
@@ -220,31 +215,30 @@ void Force_LCAO<double>::test(Parallel_Orbitals& pv, double* mm, const std::stri
 }
 
 // be called in force_lo.cpp
-template<>
-void Force_LCAO<double>::ftable(
-    const bool isforce,
-    const bool isstress,
-    ForceStressArrays &fsr, // mohan add 2024-06-16
-    const UnitCell& ucell,
-    const psi::Psi<double>* psi,
-    const elecstate::ElecState* pelec,
-    ModuleBase::matrix& foverlap,
-    ModuleBase::matrix& ftvnl_dphi,
-    ModuleBase::matrix& fvnl_dbeta,
-    ModuleBase::matrix& fvl_dphi,
-    ModuleBase::matrix& soverlap,
-    ModuleBase::matrix& stvnl_dphi,
-    ModuleBase::matrix& svnl_dbeta,
-    ModuleBase::matrix& svl_dphi,
+template <>
+void Force_LCAO<double>::ftable(const bool isforce,
+                                const bool isstress,
+                                ForceStressArrays& fsr, // mohan add 2024-06-16
+                                const UnitCell& ucell,
+                                const psi::Psi<double>* psi,
+                                const elecstate::ElecState* pelec,
+                                ModuleBase::matrix& foverlap,
+                                ModuleBase::matrix& ftvnl_dphi,
+                                ModuleBase::matrix& fvnl_dbeta,
+                                ModuleBase::matrix& fvl_dphi,
+                                ModuleBase::matrix& soverlap,
+                                ModuleBase::matrix& stvnl_dphi,
+                                ModuleBase::matrix& svnl_dbeta,
+                                ModuleBase::matrix& svl_dphi,
 #ifdef __DEEPKS
-    ModuleBase::matrix& svnl_dalpha,
+                                ModuleBase::matrix& svnl_dalpha,
 #endif
-    TGint<double>::type& gint,
-    const TwoCenterBundle& two_center_bundle,
-    const Parallel_Orbitals& pv,
-    LCAO_Matrix& lm,
-    const K_Vectors* kv,
-    Record_adj* ra)
+                                TGint<double>::type& gint,
+                                const TwoCenterBundle& two_center_bundle,
+                                const Parallel_Orbitals& pv,
+                                LCAO_Matrix& lm,
+                                const K_Vectors* kv,
+                                Record_adj* ra)
 {
     ModuleBase::TITLE("Force_LCAO", "ftable");
     ModuleBase::timer::tick("Force_LCAO", "ftable");
@@ -255,58 +249,27 @@ void Force_LCAO<double>::ftable(
 
     this->ParaV = dm->get_paraV_pointer();
 
-
     // allocate DSloc_x, DSloc_y, DSloc_z
     // allocate DHloc_fixed_x, DHloc_fixed_y, DHloc_fixed_z
-	this->allocate(
-			pv, 
-			lm,
-            fsr,
-			two_center_bundle);
+    this->allocate(pv, lm, fsr, two_center_bundle);
 
     // calculate the force related to 'energy density matrix'.
-	this->cal_fedm(
-			isforce, 
-			isstress, 
-            fsr,
-            ucell,
-            dm,
-			psi, 
-			pv, 
-			pelec, 
-			lm, 
-			foverlap, 
-			soverlap);
+    this->cal_fedm(isforce, isstress, fsr, ucell, dm, psi, pv, pelec, lm, foverlap, soverlap);
 
-	this->cal_ftvnl_dphi(
-			dm, 
-			pv, 
-			ucell, 
-			fsr, 
-			isforce, 
-			isstress, 
-			ftvnl_dphi, 
-			stvnl_dphi);
+    this->cal_ftvnl_dphi(dm, pv, ucell, fsr, isforce, isstress, ftvnl_dphi, stvnl_dphi);
 
-	this->cal_fvnl_dbeta(
-			dm, 
-			pv, 
-			ucell, 
-			GlobalC::ORB, 
-			*(two_center_bundle.overlap_orb_beta), 
-			GlobalC::GridD, 
-			isforce, 
-			isstress, 
-			fvnl_dbeta, 
-			svnl_dbeta);
+    this->cal_fvnl_dbeta(dm,
+                         pv,
+                         ucell,
+                         GlobalC::ORB,
+                         *(two_center_bundle.overlap_orb_beta),
+                         GlobalC::GridD,
+                         isforce,
+                         isstress,
+                         fvnl_dbeta,
+                         svnl_dbeta);
 
-	this->cal_fvl_dphi(
-			isforce, 
-			isstress, 
-			pelec->pot, 
-			gint, 
-			fvl_dphi, 
-			svl_dphi);
+    this->cal_fvl_dphi(isforce, isstress, pelec->pot, gint, fvl_dphi, svl_dphi);
 
     // caoyu add for DeePKS
 #ifdef __DEEPKS
@@ -314,23 +277,13 @@ void Force_LCAO<double>::ftable(
     {
         const std::vector<std::vector<double>>& dm_gamma = dm->get_DMK_vector();
 
-		GlobalC::ld.cal_projected_DM(
-				dm, 
-				ucell, 
-				GlobalC::ORB, 
-				GlobalC::GridD);
+        GlobalC::ld.cal_projected_DM(dm, ucell, GlobalC::ORB, GlobalC::GridD);
 
         GlobalC::ld.cal_descriptor(ucell.nat);
 
         GlobalC::ld.cal_gedm(ucell.nat);
 
-        GlobalC::ld.cal_f_delta_gamma(
-            dm_gamma,
-            ucell,
-            GlobalC::ORB,
-            GlobalC::GridD,
-            isstress,
-            svnl_dalpha);
+        GlobalC::ld.cal_f_delta_gamma(dm_gamma, ucell, GlobalC::ORB, GlobalC::GridD, isstress, svnl_dalpha);
 
 #ifdef __MPI
         Parallel_Reduce::reduce_all(GlobalC::ld.F_delta.c, GlobalC::ld.F_delta.nr * GlobalC::ld.F_delta.nc);
@@ -391,10 +344,10 @@ void stress_fill(const double& lat0_, const double& omega_, ModuleBase::matrix& 
     {
         for (int j = 0; j < 3; ++j)
         {
-			if (j > i)
-			{
-				stress_matrix(j, i) = stress_matrix(i, j);
-			}
+            if (j > i)
+            {
+                stress_matrix(j, i) = stress_matrix(i, j);
+            }
             stress_matrix(i, j) *= weight;
         }
     }

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_k.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_k.cpp
@@ -93,7 +93,7 @@ void Force_LCAO<std::complex<double>>::allocate(const Parallel_Orbitals& pv,
                               GlobalC::ucell,
                               GlobalC::ORB,
                               pv,
-                              *uot,
+                              *(uot->two_center_bundle),
                               &GlobalC::GridD,
                               nullptr); // delete lm.SlocR
 
@@ -124,7 +124,7 @@ void Force_LCAO<std::complex<double>>::allocate(const Parallel_Orbitals& pv,
                               GlobalC::ucell,
                               GlobalC::ORB,
                               pv,
-                              *uot,
+                              *(uot->two_center_bundle),
                               &GlobalC::GridD,
                               nullptr); // delete lm.Hloc_fixedR
 
@@ -135,7 +135,7 @@ void Force_LCAO<std::complex<double>>::allocate(const Parallel_Orbitals& pv,
                                        cal_deri,
                                        GlobalC::ucell,
                                        GlobalC::ORB,
-                                       *uot,
+                                       *(uot->two_center_bundle->overlap_orb_beta),
                                        &GlobalC::GridD);
 
     // calculate asynchronous S matrix to output for Hefei-NAMD
@@ -150,7 +150,7 @@ void Force_LCAO<std::complex<double>>::allocate(const Parallel_Orbitals& pv,
                                   GlobalC::ucell,
                                   GlobalC::ORB,
                                   pv,
-                                  *uot,
+                                  *(uot->two_center_bundle),
                                   &(GlobalC::GridD),
                                   nullptr, // delete lm.SlocR
                                   INPUT.cal_syns,
@@ -339,7 +339,7 @@ void Force_LCAO<std::complex<double>>::ftable(const bool isforce,
     // doing on the real space grid.
     this->cal_fvl_dphi(isforce, isstress, pelec->pot, gint, fvl_dphi, svl_dphi);
 
-    this->cal_fvnl_dbeta(dm, pv, ucell, GlobalC::ORB, *uot, GlobalC::GridD, isforce, isstress, fvnl_dbeta, svnl_dbeta);
+    this->cal_fvnl_dbeta(dm, pv, ucell, GlobalC::ORB, *(uot->two_center_bundle->overlap_orb_beta), GlobalC::GridD, isforce, isstress, fvnl_dbeta, svnl_dbeta);
 
 #ifdef __DEEPKS
     if (GlobalV::deepks_scf)

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_k.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_k.cpp
@@ -339,7 +339,16 @@ void Force_LCAO<std::complex<double>>::ftable(const bool isforce,
     // doing on the real space grid.
     this->cal_fvl_dphi(isforce, isstress, pelec->pot, gint, fvl_dphi, svl_dphi);
 
-    this->cal_fvnl_dbeta(dm, pv, ucell, GlobalC::ORB, *(two_center_bundle.overlap_orb_beta), GlobalC::GridD, isforce, isstress, fvnl_dbeta, svnl_dbeta);
+    this->cal_fvnl_dbeta(dm,
+                         pv,
+                         ucell,
+                         GlobalC::ORB,
+                         *(two_center_bundle.overlap_orb_beta),
+                         GlobalC::GridD,
+                         isforce,
+                         isstress,
+                         fvnl_dbeta,
+                         svnl_dbeta);
 
 #ifdef __DEEPKS
     if (GlobalV::deepks_scf)

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_k.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_k.cpp
@@ -26,7 +26,7 @@ template <>
 void Force_LCAO<std::complex<double>>::allocate(const Parallel_Orbitals& pv,
                                                 LCAO_Matrix& lm,
                                                 ForceStressArrays& fsr, // mohan add 2024-06-15
-                                                const ORB_gen_tables* uot,
+                                                const TwoCenterBundle& two_center_bundle,
                                                 const int& nks,
                                                 const std::vector<ModuleBase::Vector3<double>>& kvec_d)
 {
@@ -93,7 +93,7 @@ void Force_LCAO<std::complex<double>>::allocate(const Parallel_Orbitals& pv,
                               GlobalC::ucell,
                               GlobalC::ORB,
                               pv,
-                              *(uot->two_center_bundle),
+                              two_center_bundle,
                               &GlobalC::GridD,
                               nullptr); // delete lm.SlocR
 
@@ -124,7 +124,7 @@ void Force_LCAO<std::complex<double>>::allocate(const Parallel_Orbitals& pv,
                               GlobalC::ucell,
                               GlobalC::ORB,
                               pv,
-                              *(uot->two_center_bundle),
+                              two_center_bundle,
                               &GlobalC::GridD,
                               nullptr); // delete lm.Hloc_fixedR
 
@@ -135,7 +135,7 @@ void Force_LCAO<std::complex<double>>::allocate(const Parallel_Orbitals& pv,
                                        cal_deri,
                                        GlobalC::ucell,
                                        GlobalC::ORB,
-                                       *(uot->two_center_bundle->overlap_orb_beta),
+                                       *(two_center_bundle.overlap_orb_beta),
                                        &GlobalC::GridD);
 
     // calculate asynchronous S matrix to output for Hefei-NAMD
@@ -150,7 +150,7 @@ void Force_LCAO<std::complex<double>>::allocate(const Parallel_Orbitals& pv,
                                   GlobalC::ucell,
                                   GlobalC::ORB,
                                   pv,
-                                  *(uot->two_center_bundle),
+                                  two_center_bundle,
                                   &(GlobalC::GridD),
                                   nullptr, // delete lm.SlocR
                                   INPUT.cal_syns,
@@ -311,7 +311,7 @@ void Force_LCAO<std::complex<double>>::ftable(const bool isforce,
                                               ModuleBase::matrix& svnl_dalpha,
 #endif
                                               TGint<std::complex<double>>::type& gint,
-                                              const ORB_gen_tables* uot,
+                                              const TwoCenterBundle& two_center_bundle,
                                               const Parallel_Orbitals& pv,
                                               LCAO_Matrix& lm,
                                               const K_Vectors* kv,
@@ -326,7 +326,7 @@ void Force_LCAO<std::complex<double>>::ftable(const bool isforce,
     this->allocate(pv,
                    lm,
                    fsr, // mohan add 2024-06-16
-                   uot,
+                   two_center_bundle,
                    kv->get_nks(),
                    kv->kvec_d);
 
@@ -339,7 +339,7 @@ void Force_LCAO<std::complex<double>>::ftable(const bool isforce,
     // doing on the real space grid.
     this->cal_fvl_dphi(isforce, isstress, pelec->pot, gint, fvl_dphi, svl_dphi);
 
-    this->cal_fvnl_dbeta(dm, pv, ucell, GlobalC::ORB, *(uot->two_center_bundle->overlap_orb_beta), GlobalC::GridD, isforce, isstress, fvnl_dbeta, svnl_dbeta);
+    this->cal_fvnl_dbeta(dm, pv, ucell, GlobalC::ORB, *(two_center_bundle.overlap_orb_beta), GlobalC::GridD, isforce, isstress, fvnl_dbeta, svnl_dbeta);
 
 #ifdef __DEEPKS
     if (GlobalV::deepks_scf)

--- a/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_domain.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_domain.h
@@ -7,10 +7,9 @@
 
 #include "module_base/global_function.h"
 #include "module_base/global_variable.h"
-#include "module_basis/module_ao/ORB_gen_tables.h"
+#include "module_basis/module_nao/two_center_bundle.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h"
-#include "module_basis/module_ao/ORB_gen_tables.h"
 #include "module_base/vector3.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/force_stress_arrays.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/LCAO_HS_arrays.hpp"
@@ -24,7 +23,7 @@ namespace LCAO_domain
 			double* Hloc,
 			const UnitCell& ucell,
 			const LCAO_Orbitals& orb,
-			const ORB_gen_tables& uot,
+			const TwoCenterIntegrator& intor_orb_beta,
 			Grid_Driver* GridD);
 
 
@@ -35,7 +34,7 @@ namespace LCAO_domain
 			const bool& calc_deri,
 			const UnitCell& ucell,
 			const LCAO_Orbitals& orb,
-			const ORB_gen_tables& uot,
+			const TwoCenterIntegrator& intor_orb_beta,
 			Grid_Driver* GridD);
 
     /**
@@ -97,7 +96,7 @@ namespace LCAO_domain
 	void single_overlap(
             LCAO_Matrix& lm,
 			const LCAO_Orbitals& orb,
-			const ORB_gen_tables& uot,
+			const TwoCenterBundle& two_center_bundle,
 			const Parallel_Orbitals& pv,
 			const UnitCell& ucell,
 			const int nspin,
@@ -132,7 +131,7 @@ namespace LCAO_domain
 	void single_derivative(
             ForceStressArrays& fsr,
 			const LCAO_Orbitals& orb,
-			const ORB_gen_tables& uot,
+			const TwoCenterBundle& two_center_bundle,
 			const Parallel_Orbitals& pv,
 			const UnitCell& ucell,
 			const int nspin,
@@ -171,7 +170,7 @@ namespace LCAO_domain
 			const UnitCell& ucell,
 			const LCAO_Orbitals& orb,
 			const Parallel_Orbitals& pv,
-			const ORB_gen_tables& uot,
+			const TwoCenterBundle& two_center_bundle,
 			Grid_Driver* GridD,
 			double* SHlocR,
 			bool cal_syns = false,

--- a/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_domain.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_domain.h
@@ -1,185 +1,175 @@
 #ifndef LCAO_DOMAIN_H
 #define LCAO_DOMAIN_H
 
-#include "module_hamilt_lcao/module_gint/grid_technique.h"
-#include "module_hamilt_lcao/module_gint/gint_gamma.h"
-#include "module_hamilt_lcao/module_gint/gint_k.h"
-
 #include "module_base/global_function.h"
 #include "module_base/global_variable.h"
+#include "module_base/vector3.h"
 #include "module_basis/module_nao/two_center_bundle.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
-#include "module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h"
-#include "module_base/vector3.h"
-#include "module_hamilt_lcao/hamilt_lcaodft/force_stress_arrays.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/LCAO_HS_arrays.hpp"
+#include "module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h"
+#include "module_hamilt_lcao/hamilt_lcaodft/force_stress_arrays.h"
+#include "module_hamilt_lcao/module_gint/gint_gamma.h"
+#include "module_hamilt_lcao/module_gint/gint_k.h"
+#include "module_hamilt_lcao/module_gint/grid_technique.h"
 
 namespace LCAO_domain
 {
 
-    // can used in gamma algorithm.
-	void build_Nonlocal_beta_new(
-			LCAO_Matrix &lm,
-			double* Hloc,
-			const UnitCell& ucell,
-			const LCAO_Orbitals& orb,
-			const TwoCenterIntegrator& intor_orb_beta,
-			Grid_Driver* GridD);
+// can used in gamma algorithm.
+void build_Nonlocal_beta_new(LCAO_Matrix& lm,
+                             double* Hloc,
+                             const UnitCell& ucell,
+                             const LCAO_Orbitals& orb,
+                             const TwoCenterIntegrator& intor_orb_beta,
+                             Grid_Driver* GridD);
 
+void build_Nonlocal_mu_new(LCAO_Matrix& lm,
+                           ForceStressArrays& fsr, // mohan 2024-06-16
+                           double* HlocR,
+                           const bool& calc_deri,
+                           const UnitCell& ucell,
+                           const LCAO_Orbitals& orb,
+                           const TwoCenterIntegrator& intor_orb_beta,
+                           Grid_Driver* GridD);
 
-    void build_Nonlocal_mu_new(
-			LCAO_Matrix &lm,
-            ForceStressArrays &fsr, // mohan 2024-06-16 
-			double* HlocR,
-			const bool& calc_deri,
-			const UnitCell& ucell,
-			const LCAO_Orbitals& orb,
-			const TwoCenterIntegrator& intor_orb_beta,
-			Grid_Driver* GridD);
+/**
+ * @brief prepare gird integration
+ */
+void grid_prepare(const Grid_Technique& gt,
+                  Gint_Gamma& gint_gamma,
+                  Gint_k& gint_k,
+                  const ModulePW::PW_Basis& rhopw,
+                  const ModulePW::PW_Basis_Big& bigpw);
 
-    /**
-     * @brief prepare gird integration
-    */
-	void grid_prepare(
-			const Grid_Technique& gt, 
-			Gint_Gamma &gint_gamma,
-			Gint_k &gint_k,
-			const ModulePW::PW_Basis& rhopw, 
-			const ModulePW::PW_Basis_Big& bigpw);
+/**
+ * @brief set the elements of force-related matrices in LCAO method
+ */
+void set_force(const Parallel_Orbitals& pv,
+               const int& iw1_all,
+               const int& iw2_all,
+               const double& vx,
+               const double& vy,
+               const double& vz,
+               const char& dtype,
+               double* dsloc_x,
+               double* dsloc_y,
+               double* dsloc_z,
+               double* dhloc_fixed_x,
+               double* dhloc_fixed_y,
+               double* dhloc_fixed_z);
 
-    /**
-     * @brief set the elements of force-related matrices in LCAO method 
-    */
-    void set_force (
-            const Parallel_Orbitals &pv,
-            const int& iw1_all,
-            const int& iw2_all,
-            const double& vx,
-            const double& vy,
-            const double& vz,
-            const char &dtype,
-            double* dsloc_x,
-            double* dsloc_y,
-            double* dsloc_z,
-            double* dhloc_fixed_x,
-            double* dhloc_fixed_y,
-            double* dhloc_fixed_z);
+/**
+ * @brief set the elements of stress-related matrices in LCAO method
+ */
+void set_stress(const Parallel_Orbitals& pv,
+                const int& iw1_all,
+                const int& iw2_all,
+                const double& vx,
+                const double& vy,
+                const double& vz,
+                const char& dtype,
+                const ModuleBase::Vector3<double>& dtau,
+                double* dsloc_11,
+                double* dsloc_12,
+                double* dsloc_13,
+                double* dsloc_22,
+                double* dsloc_23,
+                double* dsloc_33,
+                double* dhloc_fixed_11,
+                double* dhloc_fixed_12,
+                double* dhloc_fixed_13,
+                double* dhloc_fixed_22,
+                double* dhloc_fixed_23,
+                double* dhloc_fixed_33);
 
-    /**
-     * @brief set the elements of stress-related matrices in LCAO method 
-    */
-	void set_stress (
-			const Parallel_Orbitals &pv,
-			const int& iw1_all,
-			const int& iw2_all,
-			const double& vx,
-			const double& vy,
-			const double& vz,
-			const char &dtype,
-			const ModuleBase::Vector3<double> &dtau,
-			double* dsloc_11,
-			double* dsloc_12,
-			double* dsloc_13,
-			double* dsloc_22,
-			double* dsloc_23,
-			double* dsloc_33,
-			double* dhloc_fixed_11,
-			double* dhloc_fixed_12,
-			double* dhloc_fixed_13,
-			double* dhloc_fixed_22,
-			double* dhloc_fixed_23,
-			double* dhloc_fixed_33);
+/**
+ * @brief set each element without derivatives
+ */
+void single_overlap(LCAO_Matrix& lm,
+                    const LCAO_Orbitals& orb,
+                    const TwoCenterBundle& two_center_bundle,
+                    const Parallel_Orbitals& pv,
+                    const UnitCell& ucell,
+                    const int nspin,
+                    const bool cal_stress,
+                    const int iw1_all,
+                    const int iw2_all,
+                    const int m1,
+                    const int m2,
+                    const char& dtype,
+                    const int T1,
+                    const int L1,
+                    const int N1,
+                    const int T2,
+                    const int L2,
+                    const int N2,
+                    const ModuleBase::Vector3<double>& dtau,
+                    const ModuleBase::Vector3<double>& tau1,
+                    const ModuleBase::Vector3<double>& tau2,
+                    const int npol,
+                    const int jj,
+                    const int jj0,
+                    const int kk,
+                    const int kk0,
+                    int& nnr,       // output value
+                    int& total_nnr, // output value
+                    double* olm,    // output value
+                    double* HSloc); // output value
 
-    /**
-     * @brief set each element without derivatives 
-    */
-	void single_overlap(
-            LCAO_Matrix& lm,
-			const LCAO_Orbitals& orb,
-			const TwoCenterBundle& two_center_bundle,
-			const Parallel_Orbitals& pv,
-			const UnitCell& ucell,
-			const int nspin,
-			const bool cal_stress,
-			const int iw1_all,
-            const int iw2_all,
-			const int m1, 
-			const int m2,
-			const char &dtype,
-			const int T1,
-			const int L1,
-			const int N1,
-			const int T2,
-			const int L2,
-			const int N2,
-			const ModuleBase::Vector3<double> &dtau,
-			const ModuleBase::Vector3<double> &tau1,
-			const ModuleBase::Vector3<double> &tau2,
-			const int npol,
-			const int jj,
-			const int jj0,
-			const int kk,
-			const int kk0,
-			int& nnr,  // output value
-			int& total_nnr, // output value
-			double *olm,    // output value
-			double *HSloc); // output value
+/**
+ * @brief set each element of T matrices
+ */
+void single_derivative(ForceStressArrays& fsr,
+                       const LCAO_Orbitals& orb,
+                       const TwoCenterBundle& two_center_bundle,
+                       const Parallel_Orbitals& pv,
+                       const UnitCell& ucell,
+                       const int nspin,
+                       const bool cal_stress,
+                       const int iw1_all,
+                       const int iw2_all,
+                       const int m1,
+                       const int m2,
+                       const char& dtype,
+                       const int T1,
+                       const int L1,
+                       const int N1,
+                       const int T2,
+                       const int L2,
+                       const int N2,
+                       const ModuleBase::Vector3<double>& dtau,
+                       const ModuleBase::Vector3<double>& tau1,
+                       const ModuleBase::Vector3<double>& tau2,
+                       const int npol,
+                       const int jj,
+                       const int jj0,
+                       const int kk,
+                       const int kk0,
+                       int& nnr,       // output value
+                       int& total_nnr, // output value
+                       double* olm);   // output value
 
-    /**
-     * @brief set each element of T matrices 
-    */
-	void single_derivative(
-            ForceStressArrays& fsr,
-			const LCAO_Orbitals& orb,
-			const TwoCenterBundle& two_center_bundle,
-			const Parallel_Orbitals& pv,
-			const UnitCell& ucell,
-			const int nspin,
-			const bool cal_stress,
-            const int iw1_all,
-            const int iw2_all,
-			const int m1, 
-			const int m2,
-			const char &dtype,
-			const int T1,
-			const int L1,
-			const int N1,
-			const int T2,
-			const int L2,
-			const int N2,
-			const ModuleBase::Vector3<double> &dtau,
-			const ModuleBase::Vector3<double> &tau1,
-			const ModuleBase::Vector3<double> &tau2,
-			const int npol,
-			const int jj,
-			const int jj0,
-			const int kk,
-			const int kk0,
-			int& nnr,  // output value
-			int& total_nnr, // output value
-			double *olm); // output value 
+/**
+ * @brief set the elements of S and T matrices
+ */
+void build_ST_new(LCAO_Matrix& lm,
+                  ForceStressArrays& fsr,
+                  const char& dtype,
+                  const bool& cal_deri,
+                  const UnitCell& ucell,
+                  const LCAO_Orbitals& orb,
+                  const Parallel_Orbitals& pv,
+                  const TwoCenterBundle& two_center_bundle,
+                  Grid_Driver* GridD,
+                  double* SHlocR,
+                  bool cal_syns = false,
+                  double dmax = 0.0);
 
-    /**
-     * @brief set the elements of S and T matrices 
-    */
-    void build_ST_new(
-			LCAO_Matrix& lm,
-			ForceStressArrays& fsr,
-			const char& dtype,
-			const bool& cal_deri,
-			const UnitCell& ucell,
-			const LCAO_Orbitals& orb,
-			const Parallel_Orbitals& pv,
-			const TwoCenterBundle& two_center_bundle,
-			Grid_Driver* GridD,
-			double* SHlocR,
-			bool cal_syns = false,
-			double dmax = 0.0);
-
-	/**
-	 * @brief set zeros for HSR matrices 
-	*/
-	void zeros_HSR(const char &mtype, LCAO_HS_Arrays& HS_arrays);
-}
+/**
+ * @brief set zeros for HSR matrices
+ */
+void zeros_HSR(const char& mtype, LCAO_HS_Arrays& HS_arrays);
+} // namespace LCAO_domain
 
 #endif

--- a/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_nl_beta.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_nl_beta.cpp
@@ -12,7 +12,7 @@ void build_Nonlocal_beta_new(LCAO_Matrix& lm,
                              double* HSloc,
                              const UnitCell& ucell,
                              const LCAO_Orbitals& orb,
-                             const ORB_gen_tables& uot,
+                             const TwoCenterIntegrator& intor_orb_beta,
                              Grid_Driver* GridD) // update by liuyu 2021-04-07
 {
     ModuleBase::TITLE("LCAO_domain", "b_NL_beta_new");
@@ -106,7 +106,7 @@ void build_Nonlocal_beta_new(LCAO_Matrix& lm,
                     int M1 = (m1 % 2 == 0) ? -m1 / 2 : (m1 + 1) / 2;
 
                     ModuleBase::Vector3<double> dtau = ucell.atoms[T0].tau[I0] - tau1;
-                    uot.two_center_bundle->overlap_orb_beta->snap(T1, L1, N1, M1, T0, dtau * ucell.lat0, false, nlm);
+                    intor_orb_beta.snap(T1, L1, N1, M1, T0, dtau * ucell.lat0, false, nlm);
 
 #ifdef _OPENMP
                     nlm_tot_thread[ad_count].insert({iw1_all, nlm[0]});

--- a/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_nl_mu.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_nl_mu.cpp
@@ -14,7 +14,7 @@ void build_Nonlocal_mu_new(LCAO_Matrix& lm,
                            const bool& calc_deri,
                            const UnitCell& ucell,
                            const LCAO_Orbitals& orb,
-                           const ORB_gen_tables& uot,
+                           const TwoCenterIntegrator& intor_orb_beta,
                            Grid_Driver* GridD)
 {
     ModuleBase::TITLE("LCAO_domain", "vnl_mu_new");
@@ -125,7 +125,7 @@ void build_Nonlocal_mu_new(LCAO_Matrix& lm,
                 int M1 = (m1 % 2 == 0) ? -m1 / 2 : (m1 + 1) / 2;
 
                 ModuleBase::Vector3<double> dtau = tau - tau1;
-                uot.two_center_bundle->overlap_orb_beta->snap(T1, L1, N1, M1, it, dtau * ucell.lat0, calc_deri, nlm);
+                intor_orb_beta.snap(T1, L1, N1, M1, it, dtau * ucell.lat0, calc_deri, nlm);
 
                 if (!calc_deri)
                 {

--- a/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_set_st.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_set_st.cpp
@@ -7,7 +7,7 @@ namespace LCAO_domain
 
 void single_derivative(ForceStressArrays& fsr,
                        const LCAO_Orbitals& orb,
-                       const ORB_gen_tables& uot,
+                       const TwoCenterBundle& two_center_bundle,
                        const Parallel_Orbitals& pv,
                        const UnitCell& ucell,
                        const int nspin,
@@ -45,10 +45,10 @@ void single_derivative(ForceStressArrays& fsr,
     switch (dtype)
     {
     case 'S':
-        uot.two_center_bundle->overlap_orb->calculate(T1, L1, N1, M1, T2, L2, N2, M2, dtau * ucell.lat0, nullptr, olm);
+        two_center_bundle.overlap_orb->calculate(T1, L1, N1, M1, T2, L2, N2, M2, dtau * ucell.lat0, nullptr, olm);
         break;
     case 'T':
-        uot.two_center_bundle->kinetic_orb->calculate(T1, L1, N1, M1, T2, L2, N2, M2, dtau * ucell.lat0, nullptr, olm);
+        two_center_bundle.kinetic_orb->calculate(T1, L1, N1, M1, T2, L2, N2, M2, dtau * ucell.lat0, nullptr, olm);
         break;
     default: // not supposed to happen
         ModuleBase::WARNING_QUIT("LCAO_domain::build_ST_new", "dtype must be S or T");
@@ -204,7 +204,7 @@ void single_derivative(ForceStressArrays& fsr,
 
 void single_overlap(LCAO_Matrix& lm,
                     const LCAO_Orbitals& orb,
-                    const ORB_gen_tables& uot,
+                    const TwoCenterBundle& two_center_bundle,
                     const Parallel_Orbitals& pv,
                     const UnitCell& ucell,
                     const int nspin,
@@ -243,10 +243,10 @@ void single_overlap(LCAO_Matrix& lm,
     switch (dtype)
     {
     case 'S':
-        uot.two_center_bundle->overlap_orb->calculate(T1, L1, N1, M1, T2, L2, N2, M2, dtau * ucell.lat0, olm);
+        two_center_bundle.overlap_orb->calculate(T1, L1, N1, M1, T2, L2, N2, M2, dtau * ucell.lat0, olm);
         break;
     case 'T':
-        uot.two_center_bundle->kinetic_orb->calculate(T1, L1, N1, M1, T2, L2, N2, M2, dtau * ucell.lat0, olm);
+        two_center_bundle.kinetic_orb->calculate(T1, L1, N1, M1, T2, L2, N2, M2, dtau * ucell.lat0, olm);
         break;
     default: // not supposed to happen
         ModuleBase::WARNING_QUIT("LCAO_domain::build_ST_new", "dtype must be S or T");
@@ -316,7 +316,7 @@ void build_ST_new(LCAO_Matrix& lm,
                   const UnitCell& ucell,
                   const LCAO_Orbitals& orb,
                   const Parallel_Orbitals& pv,
-                  const ORB_gen_tables& uot,
+                  const TwoCenterBundle& two_center_bundle,
                   Grid_Driver* GridD,
                   double* HSloc,
                   bool cal_syns,
@@ -424,7 +424,7 @@ void build_ST_new(LCAO_Matrix& lm,
                             {
                                 single_overlap(lm,
                                                orb,
-                                               uot,
+                                               two_center_bundle,
                                                pv,
                                                ucell,
                                                nspin,
@@ -457,7 +457,7 @@ void build_ST_new(LCAO_Matrix& lm,
                             {
                                 single_derivative(fsr,
                                                   orb,
-                                                  uot,
+                                                  two_center_bundle,
                                                   pv,
                                                   ucell,
                                                   nspin,

--- a/source/module_hamilt_lcao/hamilt_lcaodft/fvnl_dbeta_gamma.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/fvnl_dbeta_gamma.cpp
@@ -10,7 +10,7 @@ void Force_LCAO<double>::cal_fvnl_dbeta(const elecstate::DensityMatrix<double, d
                                         const Parallel_Orbitals& pv,
                                         const UnitCell& ucell,
                                         const LCAO_Orbitals& orb,
-                                        const ORB_gen_tables& uot,
+                                        const TwoCenterIntegrator& intor_orb_beta,
                                         Grid_Driver& gd,
                                         const bool isforce,
                                         const bool isstress,
@@ -79,7 +79,7 @@ void Force_LCAO<double>::cal_fvnl_dbeta(const elecstate::DensityMatrix<double, d
 
                 ModuleBase::Vector3<double> dtau = ucell.atoms[T0].tau[I0] - tau1;
 
-                uot.two_center_bundle->overlap_orb_beta->snap(T1, L1, N1, M1, T0, dtau * ucell.lat0, true, nlm);
+                intor_orb_beta.snap(T1, L1, N1, M1, T0, dtau * ucell.lat0, true, nlm);
 
                 assert(nlm.size() == 4);
                 nlm_tot[ad1].insert({iw1, nlm});

--- a/source/module_hamilt_lcao/hamilt_lcaodft/fvnl_dbeta_k.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/fvnl_dbeta_k.cpp
@@ -29,7 +29,7 @@ void Force_LCAO<std::complex<double>>::cal_fvnl_dbeta(const elecstate::DensityMa
                                                       const Parallel_Orbitals& pv,
                                                       const UnitCell& ucell,
                                                       const LCAO_Orbitals& orb,
-                                                      const ORB_gen_tables& uot,
+                                                      const TwoCenterIntegrator& intor_orb_beta,
                                                       Grid_Driver& gd,
                                                       const bool isforce,
                                                       const bool isstress,
@@ -109,7 +109,7 @@ void Force_LCAO<std::complex<double>>::cal_fvnl_dbeta(const elecstate::DensityMa
                 int M1 = (m1 % 2 == 0) ? -m1 / 2 : (m1 + 1) / 2;
 
                 ModuleBase::Vector3<double> dtau = tau - tau1;
-                uot.two_center_bundle->overlap_orb_beta->snap(T1, L1, N1, M1, it, dtau * ucell.lat0, true, nlm);
+                intor_orb_beta.snap(T1, L1, N1, M1, it, dtau * ucell.lat0, true, nlm);
 
                 nlm_cur.insert({iw1_all, nlm});
             } // end iw

--- a/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.cpp
@@ -153,15 +153,14 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
         // in general case, target HR is this->hR, while target HK is LCAO_Matrix::Hloc
         if (GlobalV::VNL_IN_H)
         {
-            Operator<TK>* nonlocal
-                = new NonlocalNew<OperatorLCAO<TK, TR>>(LM_in,
-                                                        this->kv->kvec_d,
-                                                        this->hR,
-                                                        &(this->getHk(LM_in)),
-                                                        &GlobalC::ucell,
-                                                        &GlobalC::GridD,
-                                                        two_center_bundle.overlap_orb_beta.get(),
-                                                        LM_in->ParaV);
+            Operator<TK>* nonlocal = new NonlocalNew<OperatorLCAO<TK, TR>>(LM_in,
+                                                                           this->kv->kvec_d,
+                                                                           this->hR,
+                                                                           &(this->getHk(LM_in)),
+                                                                           &GlobalC::ucell,
+                                                                           &GlobalC::GridD,
+                                                                           two_center_bundle.overlap_orb_beta.get(),
+                                                                           LM_in->ParaV);
             this->getOperator()->add(nonlocal);
         }
 
@@ -306,15 +305,14 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
         // in general case, target HR is this->hR, while target HK is LCAO_Matrix::Hloc2
         if (GlobalV::VNL_IN_H)
         {
-            Operator<TK>* nonlocal
-                = new NonlocalNew<OperatorLCAO<TK, TR>>(LM_in,
-                                                        this->kv->kvec_d,
-                                                        this->hR,
-                                                        &(this->getHk(LM_in)),
-                                                        &GlobalC::ucell,
-                                                        &GlobalC::GridD,
-                                                        two_center_bundle.overlap_orb_beta.get(),
-                                                        LM_in->ParaV);
+            Operator<TK>* nonlocal = new NonlocalNew<OperatorLCAO<TK, TR>>(LM_in,
+                                                                           this->kv->kvec_d,
+                                                                           this->hR,
+                                                                           &(this->getHk(LM_in)),
+                                                                           &GlobalC::ucell,
+                                                                           &GlobalC::GridD,
+                                                                           two_center_bundle.overlap_orb_beta.get(),
+                                                                           LM_in->ParaV);
             // TDDFT velocity gague will calculate full non-local potential including the original one and the
             // correction on its own. So the original non-local potential term should be skipped
             if (GlobalV::ESOLVER_TYPE != "tddft" || elecstate::H_TDDFT_pw::stype != 1)

--- a/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.cpp
@@ -36,7 +36,7 @@ namespace hamilt
 {
 
 template <typename TK, typename TR>
-HamiltLCAO<TK, TR>::HamiltLCAO(LCAO_Matrix* LM_in, const K_Vectors& kv_in, const ORB_gen_tables* uot)
+HamiltLCAO<TK, TR>::HamiltLCAO(LCAO_Matrix* LM_in, const K_Vectors& kv_in, const TwoCenterIntegrator& intor_overlap_orb)
 {
     this->classname = "HamiltLCAO";
 
@@ -54,7 +54,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(LCAO_Matrix* LM_in, const K_Vectors& kv_in, const
                                                                &(this->getSk(LM_in)),
                                                                &GlobalC::ucell,
                                                                &GlobalC::GridD,
-                                                               uot->two_center_bundle->overlap_orb.get(),
+                                                               &intor_overlap_orb,
                                                                LM_in->ParaV);
 }
 
@@ -65,7 +65,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                Local_Orbital_Charge* loc_in,
                                elecstate::Potential* pot_in,
                                const K_Vectors& kv_in,
-                               const ORB_gen_tables* uot,
+                               const TwoCenterBundle& two_center_bundle,
                                elecstate::DensityMatrix<TK, double>* DM_in,
                                int* exx_two_level_step)
 {
@@ -130,7 +130,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                    &(this->getSk(LM_in)),
                                                                    &GlobalC::ucell,
                                                                    &GlobalC::GridD,
-                                                                   uot->two_center_bundle->overlap_orb.get(),
+                                                                   two_center_bundle.overlap_orb.get(),
                                                                    LM_in->ParaV);
 
         // kinetic term (<psi|T|psi>),
@@ -144,7 +144,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                            &(this->getHk(LM_in)),
                                                                            &GlobalC::ucell,
                                                                            &GlobalC::GridD,
-                                                                           uot->two_center_bundle->kinetic_orb.get(),
+                                                                           two_center_bundle.kinetic_orb.get(),
                                                                            LM_in->ParaV);
             this->getOperator()->add(ekinetic);
         }
@@ -160,7 +160,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                         &(this->getHk(LM_in)),
                                                         &GlobalC::ucell,
                                                         &GlobalC::GridD,
-                                                        uot->two_center_bundle->overlap_orb_beta.get(),
+                                                        two_center_bundle.overlap_orb_beta.get(),
                                                         LM_in->ParaV);
             this->getOperator()->add(nonlocal);
         }
@@ -200,7 +200,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                     &(this->getHk(LM_in)),
                                                                     &GlobalC::ucell,
                                                                     &GlobalC::GridD,
-                                                                    uot,
+                                                                    two_center_bundle.overlap_orb_alpha.get(),
                                                                     this->kv->get_nks(),
                                                                     DM_in);
             this->getOperator()->add(deepks);
@@ -227,7 +227,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                       &(this->getHk(LM_in)),
                                                       GlobalC::ucell,
                                                       &GlobalC::GridD,
-                                                      uot->two_center_bundle->overlap_orb_onsite.get(),
+                                                      two_center_bundle.overlap_orb_onsite.get(),
                                                       &GlobalC::dftu,
                                                       *(LM_in->ParaV));
             }
@@ -276,7 +276,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                      &(this->getSk(LM_in)),
                                                                      &GlobalC::ucell,
                                                                      &GlobalC::GridD,
-                                                                     uot->two_center_bundle->overlap_orb.get(),
+                                                                     two_center_bundle.overlap_orb.get(),
                                                                      LM_in->ParaV);
         if (this->getOperator() == nullptr)
         {
@@ -297,7 +297,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                            &(this->getHk(LM_in)),
                                                                            &GlobalC::ucell,
                                                                            &GlobalC::GridD,
-                                                                           uot->two_center_bundle->kinetic_orb.get(),
+                                                                           two_center_bundle.kinetic_orb.get(),
                                                                            LM_in->ParaV);
             this->getOperator()->add(ekinetic);
         }
@@ -313,7 +313,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                         &(this->getHk(LM_in)),
                                                         &GlobalC::ucell,
                                                         &GlobalC::GridD,
-                                                        uot->two_center_bundle->overlap_orb_beta.get(),
+                                                        two_center_bundle.overlap_orb_beta.get(),
                                                         LM_in->ParaV);
             // TDDFT velocity gague will calculate full non-local potential including the original one and the
             // correction on its own. So the original non-local potential term should be skipped
@@ -337,7 +337,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                     &(this->getHk(LM_in)),
                                                                     &GlobalC::ucell,
                                                                     &GlobalC::GridD,
-                                                                    uot,
+                                                                    two_center_bundle.overlap_orb_alpha.get(),
                                                                     this->kv->get_nks(),
                                                                     DM_in);
             this->getOperator()->add(deepks);
@@ -362,7 +362,6 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                              &(this->getHk(LM_in)),
                                                                              &GlobalC::ucell,
                                                                              &GlobalC::GridD,
-                                                                             uot,
                                                                              LM_in->ParaV);
             this->getOperator()->add(td_nonlocal);
         }
@@ -385,7 +384,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                       &(this->getHk(LM_in)),
                                                       GlobalC::ucell,
                                                       &GlobalC::GridD,
-                                                      uot->two_center_bundle->overlap_orb_onsite.get(),
+                                                      two_center_bundle.overlap_orb_onsite.get(),
                                                       &GlobalC::dftu,
                                                       *(LM_in->ParaV));
             }

--- a/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h
@@ -30,13 +30,13 @@ class HamiltLCAO : public Hamilt<TK>
         Local_Orbital_Charge* loc_in,
         elecstate::Potential* pot_in,
         const K_Vectors& kv_in,
-        const ORB_gen_tables* uot,
+        const TwoCenterBundle& two_center_bundle,
         elecstate::DensityMatrix<TK, double>* DM_in,
         int* exx_two_level_step = nullptr);
     /**
      * @brief Constructor of vacuum Operators, only HR and SR will be initialed as empty HContainer
     */
-    HamiltLCAO(LCAO_Matrix* LM_in, const K_Vectors& kv_in, const ORB_gen_tables* uot);
+    HamiltLCAO(LCAO_Matrix* LM_in, const K_Vectors& kv_in, const TwoCenterIntegrator& intor_overlap_orb);
 
     ~HamiltLCAO()
     {

--- a/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h
@@ -1,6 +1,7 @@
 #ifndef HAMILTLCAO_H
 #define HAMILTLCAO_H
 
+#include "module_elecstate/module_dm/density_matrix.h"
 #include "module_elecstate/potentials/potential_new.h"
 #include "module_hamilt_general/hamilt.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h"
@@ -9,7 +10,6 @@
 #include "module_hamilt_lcao/module_gint/gint_gamma.h"
 #include "module_hamilt_lcao/module_gint/gint_k.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
-#include "module_elecstate/module_dm/density_matrix.h"
 
 namespace hamilt
 {
@@ -23,19 +23,19 @@ class HamiltLCAO : public Hamilt<TK>
     /**
      * @brief Constructor of Hamiltonian for LCAO base
      * HR and SR will be allocated with Operators
-    */
+     */
     HamiltLCAO(Gint_Gamma* GG_in,
-        Gint_k* GK_in,
-        LCAO_Matrix* LM_in,
-        Local_Orbital_Charge* loc_in,
-        elecstate::Potential* pot_in,
-        const K_Vectors& kv_in,
-        const TwoCenterBundle& two_center_bundle,
-        elecstate::DensityMatrix<TK, double>* DM_in,
-        int* exx_two_level_step = nullptr);
+               Gint_k* GK_in,
+               LCAO_Matrix* LM_in,
+               Local_Orbital_Charge* loc_in,
+               elecstate::Potential* pot_in,
+               const K_Vectors& kv_in,
+               const TwoCenterBundle& two_center_bundle,
+               elecstate::DensityMatrix<TK, double>* DM_in,
+               int* exx_two_level_step = nullptr);
     /**
      * @brief Constructor of vacuum Operators, only HR and SR will be initialed as empty HContainer
-    */
+     */
     HamiltLCAO(LCAO_Matrix* LM_in, const K_Vectors& kv_in, const TwoCenterIntegrator& intor_overlap_orb);
 
     ~HamiltLCAO()
@@ -66,12 +66,12 @@ class HamiltLCAO : public Hamilt<TK>
 
     /**
      * @brief special for LCAO, update SK only
-     * 
+     *
      * @param ik target K point
      * @param hk_type 0: SK is row-major, 1: SK is collumn-major
      * @return void
-    */
-    void updateSk(const int ik, LCAO_Matrix* LM_in, const int hk_type=0);
+     */
+    void updateSk(const int ik, LCAO_Matrix* LM_in, const int hk_type = 0);
 
     // core function: return H(k) and S(k) matrixs for direct solving eigenvalues.
     // not used in PW base
@@ -79,7 +79,7 @@ class HamiltLCAO : public Hamilt<TK>
     void matrix(MatrixBlock<TK>& hk_in, MatrixBlock<TK>& sk_in) override;
 
   private:
-    const K_Vectors *kv = nullptr;
+    const K_Vectors* kv = nullptr;
 
     // Real space Hamiltonian
     HContainer<TR>* hR = nullptr;
@@ -94,8 +94,8 @@ class HamiltLCAO : public Hamilt<TK>
     int current_spin = 0;
 
     // sk and hk will be refactored to HamiltLCAO later
-    //std::vector<TK> sk;
-    //std::vector<TK> hk;
+    // std::vector<TK> sk;
+    // std::vector<TK> hk;
 };
 
 } // namespace hamilt

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.cpp
@@ -22,11 +22,11 @@ DeePKS<OperatorLCAO<TK, TR>>::DeePKS(Local_Orbital_Charge* loc_in,
                                      std::vector<TK>* hK_in,
                                      const UnitCell* ucell_in,
                                      Grid_Driver* GridD_in,
-                                     const ORB_gen_tables* uot,
+                                     const TwoCenterIntegrator* intor_orb_alpha,
                                      const int& nks_in,
                                      elecstate::DensityMatrix<TK, double>* DM_in)
     : loc(loc_in), nks(nks_in), ucell(ucell_in), OperatorLCAO<TK, TR>(LM_in, kvec_d_in, hR_in, hK_in), DM(DM_in),
-      uot_(uot)
+      intor_orb_alpha_(intor_orb_alpha)
 {
     this->cal_type = calculation_type::lcao_deepks;
 #ifdef __DEEPKS
@@ -285,8 +285,7 @@ void hamilt::DeePKS<hamilt::OperatorLCAO<TK, TR>>::pre_calculate_nlm(
             int M1 = (m1 % 2 == 0) ? -m1 / 2 : (m1 + 1) / 2;
 
             ModuleBase::Vector3<double> dtau = tau0 - tau1;
-            uot_->two_center_bundle->overlap_orb_alpha
-                ->snap(T1, L1, N1, M1, 0, dtau * ucell->lat0, false /*calc_deri*/, nlm);
+            intor_orb_alpha_->snap(T1, L1, N1, M1, 0, dtau * ucell->lat0, false /*calc_deri*/, nlm);
             nlm_in[ad].insert({all_indexes[iw1l], nlm[0]});
             if (npol == 2)
                 nlm_in[ad].insert({all_indexes[iw1l + 1], nlm[0]});

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.h
@@ -1,11 +1,11 @@
 #ifndef DEEPKSLCAO_H
 #define DEEPKSLCAO_H
-#include "module_hamilt_lcao/hamilt_lcaodft/local_orbital_charge.h"
 #include "module_basis/module_ao/parallel_orbitals.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
+#include "module_elecstate/module_dm/density_matrix.h"
+#include "module_hamilt_lcao/hamilt_lcaodft/local_orbital_charge.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
 #include "operator_lcao.h"
-#include "module_elecstate/module_dm/density_matrix.h"
 
 namespace hamilt
 {
@@ -30,35 +30,35 @@ class DeePKS<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
 {
   public:
     DeePKS<OperatorLCAO<TK, TR>>(Local_Orbital_Charge* loc_in,
-                            LCAO_Matrix* LM_in,
-                            const std::vector<ModuleBase::Vector3<double>>& kvec_d_in,
-                            HContainer<TR>* hR_in,
-                            std::vector<TK>* hK_in,
-                            const UnitCell* ucell_in,
-                            Grid_Driver* GridD_in,
-                            const TwoCenterIntegrator* intor_orb_alpha,
-                            const int& nks_in,
-                            elecstate::DensityMatrix<TK,double>* DM_in);
+                                 LCAO_Matrix* LM_in,
+                                 const std::vector<ModuleBase::Vector3<double>>& kvec_d_in,
+                                 HContainer<TR>* hR_in,
+                                 std::vector<TK>* hK_in,
+                                 const UnitCell* ucell_in,
+                                 Grid_Driver* GridD_in,
+                                 const TwoCenterIntegrator* intor_orb_alpha,
+                                 const int& nks_in,
+                                 elecstate::DensityMatrix<TK, double>* DM_in);
     ~DeePKS();
 
     /**
      * @brief contribute the DeePKS correction to real space Hamiltonian
      * this function is used for update hR and H_V_delta
-    */
+     */
     virtual void contributeHR() override;
 #ifdef __DEEPKS
     /**
      * @brief contribute the DeePKS correction for each k-point to ld.H_V_delta or ld.H_V_delta_k
      * this function is not used for update hK, but for DeePKS module
      * @param ik: the index of k-point
-    */
+     */
     virtual void contributeHk(int ik) override;
 #endif
 
   private:
     Local_Orbital_Charge* loc;
 
-    elecstate::DensityMatrix<TK,double>* DM;
+    elecstate::DensityMatrix<TK, double>* DM;
 
     const UnitCell* ucell = nullptr;
 
@@ -85,17 +85,14 @@ class DeePKS<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
     /**
      * @brief calculate the HR local matrix of <I,J,R> atom pair
      */
-    void cal_HR_IJR(const double* hr_in,
-        const int& row_size,
-        const int& col_size,
-        TR* data_pointer);
+    void cal_HR_IJR(const double* hr_in, const int& row_size, const int& col_size, TR* data_pointer);
 
     void pre_calculate_nlm(const int iat0, std::vector<std::unordered_map<int, std::vector<double>>>& nlm_in);
     std::vector<std::vector<std::unordered_map<int, std::vector<double>>>> nlm_tot;
     /**
      * @brief initialize H_V_delta, search the nearest neighbor atoms
      * used for calculate the DeePKS real space Hamiltonian correction with specific <I,J,R> atom-pairs
-    */
+     */
     std::vector<AdjacentAtomInfo> adjs_all;
 #endif
     const int& nks;

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.h
@@ -36,7 +36,7 @@ class DeePKS<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                             std::vector<TK>* hK_in,
                             const UnitCell* ucell_in,
                             Grid_Driver* GridD_in,
-                            const ORB_gen_tables* uot,
+                            const TwoCenterIntegrator* intor_orb_alpha,
                             const int& nks_in,
                             elecstate::DensityMatrix<TK,double>* DM_in);
     ~DeePKS();
@@ -65,7 +65,7 @@ class DeePKS<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
     HContainer<TR>* H_V_delta = nullptr;
 
     // the following variable is introduced temporarily during LCAO refactoring
-    const ORB_gen_tables* uot_ = nullptr;
+    const TwoCenterIntegrator* intor_orb_alpha_ = nullptr;
 
 #ifdef __DEEPKS
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/dftu_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/dftu_lcao.cpp
@@ -2,7 +2,6 @@
 
 #include "module_base/timer.h"
 #include "module_base/tool_title.h"
-#include "module_basis/module_ao/ORB_gen_tables.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/operator_lcao.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer_funcs.h"

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/ekinetic_new.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/ekinetic_new.cpp
@@ -2,7 +2,6 @@
 
 #include "module_base/timer.h"
 #include "module_base/tool_title.h"
-#include "module_basis/module_ao/ORB_gen_tables.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/operator_lcao.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer_funcs.h"

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/nonlocal_new.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/nonlocal_new.cpp
@@ -2,7 +2,6 @@
 
 #include "module_base/timer.h"
 #include "module_base/tool_title.h"
-#include "module_basis/module_ao/ORB_gen_tables.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/operator_lcao.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer_funcs.h"

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/overlap_new.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/overlap_new.cpp
@@ -2,7 +2,6 @@
 
 #include "module_base/timer.h"
 #include "module_base/tool_title.h"
-#include "module_basis/module_ao/ORB_gen_tables.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/operator_lcao.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer_funcs.h"

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/overlap_new.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/overlap_new.h
@@ -1,7 +1,7 @@
-#ifndef OVERLAPNEW_H
-#define OVERLAPNEW_H
-#include "module_basis/module_nao/two_center_integrator.h"
+#ifndef W_ABACUS_DEVELOP_ABACUS_DEVELOP_SOURCE_MODULE_HAMILT_LCAO_HAMILT_LCAODFT_OPERATOR_LCAO_OVERLAP_NEW_H
+#define W_ABACUS_DEVELOP_ABACUS_DEVELOP_SOURCE_MODULE_HAMILT_LCAO_HAMILT_LCAODFT_OPERATOR_LCAO_OVERLAP_NEW_H
 #include "module_basis/module_ao/parallel_orbitals.h"
+#include "module_basis/module_nao/two_center_integrator.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
 #include "module_cell/unitcell.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/operator_lcao.h"

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/overlap_new.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/overlap_new.h
@@ -1,6 +1,6 @@
 #ifndef OVERLAPNEW_H
 #define OVERLAPNEW_H
-#include "module_basis/module_ao/ORB_gen_tables.h"
+#include "module_basis/module_nao/two_center_integrator.h"
 #include "module_basis/module_ao/parallel_orbitals.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
 #include "module_cell/unitcell.h"

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_nonlocal_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_nonlocal_lcao.cpp
@@ -19,9 +19,8 @@ hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::TDNonlocal(
     std::vector<TK>* hK_in,
     const UnitCell* ucell_in,
     Grid_Driver* GridD_in,
-    const ORB_gen_tables* uot,
     const Parallel_Orbitals* paraV)
-    : hamilt::OperatorLCAO<TK, TR>(LM_in, kvec_d_in, hR_in, hK_in), uot_(uot)
+    : hamilt::OperatorLCAO<TK, TR>(LM_in, kvec_d_in, hR_in, hK_in)
 {
     this->cal_type = calculation_type::lcao_tddft_velocity;
     this->ucell = ucell_in;

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_nonlocal_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_nonlocal_lcao.cpp
@@ -1,25 +1,24 @@
 #include "td_nonlocal_lcao.h"
 
-#include "module_hamilt_lcao/module_tddft/snap_psibeta_half_tddft.h"
+#include "module_base/timer.h"
+#include "module_base/tool_title.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/operator_lcao.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer_funcs.h"
-#include "module_base/timer.h"
-#include "module_base/tool_title.h"
+#include "module_hamilt_lcao/module_tddft/snap_psibeta_half_tddft.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
 #ifdef _OPENMP
 #include <unordered_set>
 #endif
 
 template <typename TK, typename TR>
-hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::TDNonlocal(
-    LCAO_Matrix* LM_in,
-    const std::vector<ModuleBase::Vector3<double>>& kvec_d_in,
-    hamilt::HContainer<TR>* hR_in,
-    std::vector<TK>* hK_in,
-    const UnitCell* ucell_in,
-    Grid_Driver* GridD_in,
-    const Parallel_Orbitals* paraV)
+hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::TDNonlocal(LCAO_Matrix* LM_in,
+                                                             const std::vector<ModuleBase::Vector3<double>>& kvec_d_in,
+                                                             hamilt::HContainer<TR>* hR_in,
+                                                             std::vector<TK>* hK_in,
+                                                             const UnitCell* ucell_in,
+                                                             Grid_Driver* GridD_in,
+                                                             const Parallel_Orbitals* paraV)
     : hamilt::OperatorLCAO<TK, TR>(LM_in, kvec_d_in, hR_in, hK_in)
 {
     this->cal_type = calculation_type::lcao_tddft_velocity;
@@ -31,7 +30,7 @@ hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::TDNonlocal(
 #endif
     // initialize HR to get adjs info.
     this->init_td();
-    this->initialize_HR(Grid,this->LM->ParaV);
+    this->initialize_HR(Grid, this->LM->ParaV);
 }
 
 // destructor
@@ -46,13 +45,12 @@ hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::~TDNonlocal()
 template <typename TK, typename TR>
 void hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::init_td(void)
 {
-    //calculate At in cartesian coorinates.
-	this->cart_At=TD_Velocity::td_vel_op->cart_At;
+    // calculate At in cartesian coorinates.
+    this->cart_At = TD_Velocity::td_vel_op->cart_At;
 }
 // initialize_HR()
 template <typename TK, typename TR>
-void hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::initialize_HR(Grid_Driver* GridD,
-                                                                      const Parallel_Orbitals* paraV)
+void hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::initialize_HR(Grid_Driver* GridD, const Parallel_Orbitals* paraV)
 {
     if (elecstate::H_TDDFT_pw::stype != 1)
     {
@@ -80,8 +78,8 @@ void hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::initialize_HR(Grid_Driver
             const ModuleBase::Vector3<int>& R_index1 = adjs.box[ad1];
             // choose the real adjacent atoms
             const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
-            // Note: the distance of atoms should less than the cutoff radius, 
-            // When equal, the theoretical value of matrix element is zero, 
+            // Note: the distance of atoms should less than the cutoff radius,
+            // When equal, the theoretical value of matrix element is zero,
             // but the calculated value is not zero due to the numerical error, which would lead to result changes.
             if (this->ucell->cal_dtau(iat0, iat1, R_index1).norm() * this->ucell->lat0
                 < orb.Phi[T1].getRcut() + this->ucell->infoNL.Beta[T0].get_rcut_max())
@@ -106,21 +104,21 @@ void hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::initialize_HR_tmp(const P
     }
     ModuleBase::TITLE("TDNonlocal", "initialize_HR_tmp");
     ModuleBase::timer::tick("TDNonlocal", "initialize_HR_tmp");
-    
+
     for (int i = 0; i < this->hR->size_atom_pairs(); ++i)
     {
         hamilt::AtomPair<TR>& tmp = this->hR->get_atom_pair(i);
-        for(int ir = 0;ir < tmp.get_R_size(); ++ir )
+        for (int ir = 0; ir < tmp.get_R_size(); ++ir)
         {
             const ModuleBase::Vector3<int> R_index = tmp.get_R_index(ir);
             const int iat1 = tmp.get_atom_i();
-            const int iat2 = tmp.get_atom_j(); 
+            const int iat2 = tmp.get_atom_j();
 
             hamilt::AtomPair<std::complex<double>> tmp1(iat1, iat2, R_index, paraV);
             this->hR_tmp->insert_pair(tmp1);
         }
     }
-    this->hR_tmp->allocate(nullptr,true);
+    this->hR_tmp->allocate(nullptr, true);
 
     ModuleBase::timer::tick("TDNonlocal", "initialize_HR_tmp");
 }
@@ -136,104 +134,104 @@ void hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::calculate_HR()
     // 1. calculate <psi|beta> for each pair of atoms
 #ifdef _OPENMP
 #pragma omp parallel
-{
-    std::unordered_set<int> atom_row_list;
-    #pragma omp for
-    for (int iat0 = 0; iat0 < this->ucell->nat; iat0++)
     {
-        atom_row_list.insert(iat0);
-    }
-#endif
-    for (int iat0 = 0; iat0 < this->ucell->nat; iat0++)
-    {
-        auto tau0 = ucell->get_tau(iat0);
-        int T0, I0;
-        ucell->iat2iait(iat0, &I0, &T0);
-        AdjacentAtomInfo& adjs = this->adjs_all[iat0];
-
-        std::vector<std::unordered_map<int, std::vector<std::complex<double>>>> nlm_tot;
-        nlm_tot.resize(adjs.adj_num + 1);
-
-        for (int ad = 0; ad < adjs.adj_num + 1; ++ad)
+        std::unordered_set<int> atom_row_list;
+#pragma omp for
+        for (int iat0 = 0; iat0 < this->ucell->nat; iat0++)
         {
-            const int T1 = adjs.ntype[ad];
-            const int I1 = adjs.natom[ad];
-            const int iat1 = ucell->itia2iat(T1, I1);
-            const ModuleBase::Vector3<double>& tau1 = adjs.adjacent_tau[ad];
-            const Atom* atom1 = &ucell->atoms[T1];
-
-            const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
-            auto all_indexes = paraV->get_indexes_row(iat1);
-#ifdef _OPENMP
-            if(atom_row_list.find(iat1) == atom_row_list.end())
-            {
-                all_indexes.clear();
-            }
-#endif
-            auto col_indexes = paraV->get_indexes_col(iat1);
-            // insert col_indexes into all_indexes to get universal set with no repeat elements
-            all_indexes.insert(all_indexes.end(), col_indexes.begin(), col_indexes.end());
-            std::sort(all_indexes.begin(), all_indexes.end());
-            all_indexes.erase(std::unique(all_indexes.begin(), all_indexes.end()), all_indexes.end());
-            for (int iw1l = 0; iw1l < all_indexes.size(); iw1l += npol)
-            {
-                const int iw1 = all_indexes[iw1l] / npol;
-                std::vector<std::vector<std::complex<double>>> nlm;
-                // nlm is a vector of vectors, but size of outer vector is only 1 here
-                // If we are calculating force, we need also to store the gradient
-                // and size of outer vector is then 4
-                // inner loop : all projectors (L0,M0)
-
-                // snap_psibeta_half_tddft() are used to calculate <psi|exp(iAr)|beta>
-                module_tddft::snap_psibeta_half_tddft(
-                    orb,
-                    this->ucell->infoNL,
-                    nlm,
-                    tau1 * this->ucell->lat0,
-                    T1,
-                    atom1->iw2l[iw1],
-                    atom1->iw2m[iw1],
-                    atom1->iw2n[iw1],
-                    tau0 * this->ucell->lat0,
-                    T0,
-                    -cart_At/2.0,
-                    0);
-                nlm_tot[ad].insert({all_indexes[iw1l], nlm[0]});
-            }
+            atom_row_list.insert(iat0);
         }
-// 2. calculate <psi_I|beta>D<beta|psi_{J,R}> for each pair of <IJR> atoms
-        for (int ad1 = 0; ad1 < adjs.adj_num + 1; ++ad1)
-        {
-            const int T1 = adjs.ntype[ad1];
-            const int I1 = adjs.natom[ad1];
-            const int iat1 = ucell->itia2iat(T1, I1);
-#ifdef _OPENMP
-            if(atom_row_list.find(iat1) == atom_row_list.end())
-            {
-                continue;
-            }
 #endif
-            ModuleBase::Vector3<int>& R_index1 = adjs.box[ad1];
-            for (int ad2 = 0; ad2 < adjs.adj_num + 1; ++ad2)
+        for (int iat0 = 0; iat0 < this->ucell->nat; iat0++)
+        {
+            auto tau0 = ucell->get_tau(iat0);
+            int T0, I0;
+            ucell->iat2iait(iat0, &I0, &T0);
+            AdjacentAtomInfo& adjs = this->adjs_all[iat0];
+
+            std::vector<std::unordered_map<int, std::vector<std::complex<double>>>> nlm_tot;
+            nlm_tot.resize(adjs.adj_num + 1);
+
+            for (int ad = 0; ad < adjs.adj_num + 1; ++ad)
             {
-                const int T2 = adjs.ntype[ad2];
-                const int I2 = adjs.natom[ad2];
-                const int iat2 = ucell->itia2iat(T2, I2);
-                ModuleBase::Vector3<int>& R_index2 = adjs.box[ad2];
-                ModuleBase::Vector3<int> R_vector(R_index2[0] - R_index1[0],
-                                                  R_index2[1] - R_index1[1],
-                                                  R_index2[2] - R_index1[2]);
-                hamilt::BaseMatrix<std::complex<double>>* tmp = this->hR_tmp->find_matrix(iat1, iat2, R_vector[0], R_vector[1], R_vector[2]);
-                // if not found , skip this pair of atoms
-                if (tmp != nullptr)
+                const int T1 = adjs.ntype[ad];
+                const int I1 = adjs.natom[ad];
+                const int iat1 = ucell->itia2iat(T1, I1);
+                const ModuleBase::Vector3<double>& tau1 = adjs.adjacent_tau[ad];
+                const Atom* atom1 = &ucell->atoms[T1];
+
+                const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
+                auto all_indexes = paraV->get_indexes_row(iat1);
+#ifdef _OPENMP
+                if (atom_row_list.find(iat1) == atom_row_list.end())
                 {
-                    this->cal_HR_IJR(iat1, iat2, T0, paraV, nlm_tot[ad1], nlm_tot[ad2], tmp->get_pointer());
+                    all_indexes.clear();
+                }
+#endif
+                auto col_indexes = paraV->get_indexes_col(iat1);
+                // insert col_indexes into all_indexes to get universal set with no repeat elements
+                all_indexes.insert(all_indexes.end(), col_indexes.begin(), col_indexes.end());
+                std::sort(all_indexes.begin(), all_indexes.end());
+                all_indexes.erase(std::unique(all_indexes.begin(), all_indexes.end()), all_indexes.end());
+                for (int iw1l = 0; iw1l < all_indexes.size(); iw1l += npol)
+                {
+                    const int iw1 = all_indexes[iw1l] / npol;
+                    std::vector<std::vector<std::complex<double>>> nlm;
+                    // nlm is a vector of vectors, but size of outer vector is only 1 here
+                    // If we are calculating force, we need also to store the gradient
+                    // and size of outer vector is then 4
+                    // inner loop : all projectors (L0,M0)
+
+                    // snap_psibeta_half_tddft() are used to calculate <psi|exp(iAr)|beta>
+                    module_tddft::snap_psibeta_half_tddft(orb,
+                                                          this->ucell->infoNL,
+                                                          nlm,
+                                                          tau1 * this->ucell->lat0,
+                                                          T1,
+                                                          atom1->iw2l[iw1],
+                                                          atom1->iw2m[iw1],
+                                                          atom1->iw2n[iw1],
+                                                          tau0 * this->ucell->lat0,
+                                                          T0,
+                                                          -cart_At / 2.0,
+                                                          0);
+                    nlm_tot[ad].insert({all_indexes[iw1l], nlm[0]});
+                }
+            }
+            // 2. calculate <psi_I|beta>D<beta|psi_{J,R}> for each pair of <IJR> atoms
+            for (int ad1 = 0; ad1 < adjs.adj_num + 1; ++ad1)
+            {
+                const int T1 = adjs.ntype[ad1];
+                const int I1 = adjs.natom[ad1];
+                const int iat1 = ucell->itia2iat(T1, I1);
+#ifdef _OPENMP
+                if (atom_row_list.find(iat1) == atom_row_list.end())
+                {
+                    continue;
+                }
+#endif
+                ModuleBase::Vector3<int>& R_index1 = adjs.box[ad1];
+                for (int ad2 = 0; ad2 < adjs.adj_num + 1; ++ad2)
+                {
+                    const int T2 = adjs.ntype[ad2];
+                    const int I2 = adjs.natom[ad2];
+                    const int iat2 = ucell->itia2iat(T2, I2);
+                    ModuleBase::Vector3<int>& R_index2 = adjs.box[ad2];
+                    ModuleBase::Vector3<int> R_vector(R_index2[0] - R_index1[0],
+                                                      R_index2[1] - R_index1[1],
+                                                      R_index2[2] - R_index1[2]);
+                    hamilt::BaseMatrix<std::complex<double>>* tmp
+                        = this->hR_tmp->find_matrix(iat1, iat2, R_vector[0], R_vector[1], R_vector[2]);
+                    // if not found , skip this pair of atoms
+                    if (tmp != nullptr)
+                    {
+                        this->cal_HR_IJR(iat1, iat2, T0, paraV, nlm_tot[ad1], nlm_tot[ad2], tmp->get_pointer());
+                    }
                 }
             }
         }
-    }
 #ifdef _OPENMP
-}
+    }
 #endif
 
     ModuleBase::timer::tick("TDNonlocal", "calculate_HR");
@@ -283,12 +281,12 @@ void hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::cal_HR_IJR(
 #endif
             for (int is = 0; is < npol * npol; ++is)
             {
-                std::complex<double> nlm_tmp = std::complex<double>{0,0};
+                std::complex<double> nlm_tmp = std::complex<double>{0, 0};
                 for (int no = 0; no < this->ucell->atoms[T0].ncpp.non_zero_count_soc[is]; no++)
                 {
                     const int p1 = this->ucell->atoms[T0].ncpp.index1_soc[is][no];
                     const int p2 = this->ucell->atoms[T0].ncpp.index2_soc[is][no];
-                    //this->ucell->atoms[T0].ncpp.get_d(is, p1, p2, tmp_d);
+                    // this->ucell->atoms[T0].ncpp.get_d(is, p1, p2, tmp_d);
                     this->ucell->atoms[T0].ncpp.get_d(is, p2, p1, tmp_d);
                     nlm_tmp += nlm1[p1] * std::conj(nlm2[p2]) * (*tmp_d);
                 }
@@ -319,7 +317,7 @@ void hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::contributeHR()
         return;
     }
     if (!this->hR_tmp_done)
-    {   
+    {
         if (this->hR_tmp == nullptr)
         {
             this->hR_tmp = new hamilt::HContainer<std::complex<double>>(this->LM->ParaV);
@@ -327,7 +325,7 @@ void hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::contributeHR()
             this->initialize_HR_tmp(this->LM->ParaV);
             this->allocated = true;
         }
-        if(this->next_sub_op != nullptr)
+        if (this->next_sub_op != nullptr)
         {
             // pass pointer of hR_tmp to the next node
             static_cast<OperatorLCAO<TK, TR>*>(this->next_sub_op)->set_HR_fixed(this->hR_tmp);
@@ -339,23 +337,24 @@ void hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::contributeHR()
     ModuleBase::timer::tick("TDNonlocal", "contributeHR");
     return;
 }
-template<typename TK, typename TR>
+template <typename TK, typename TR>
 void hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::contributeHk(int ik)
 {
     return;
 }
-template<>
+template <>
 void hamilt::TDNonlocal<hamilt::OperatorLCAO<std::complex<double>, double>>::contributeHk(int ik)
 {
     if (TD_Velocity::tddft_velocity == false)
     {
         return;
     }
-    else{        
+    else
+    {
         ModuleBase::TITLE("TDNonlocal", "contributeHk");
         ModuleBase::timer::tick("TDNonlocal", "contributeHk");
-        //folding inside HR to HK
-        if(ModuleBase::GlobalFunc::IS_COLUMN_MAJOR_KS_SOLVER())
+        // folding inside HR to HK
+        if (ModuleBase::GlobalFunc::IS_COLUMN_MAJOR_KS_SOLVER())
         {
             const int nrow = this->LM->ParaV->get_row_size();
             folding_HR(*this->hR_tmp, this->hK->data(), this->kvec_d[ik], nrow, 1);
@@ -365,7 +364,7 @@ void hamilt::TDNonlocal<hamilt::OperatorLCAO<std::complex<double>, double>>::con
             const int ncol = this->LM->ParaV->get_col_size();
             folding_HR(*this->hR_tmp, this->hK->data(), this->kvec_d[ik], ncol, 0);
         }
-        
+
         ModuleBase::timer::tick("TDNonlocal", "contributeHk");
     }
 }

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_nonlocal_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_nonlocal_lcao.cpp
@@ -43,7 +43,7 @@ hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::~TDNonlocal()
     }
 }
 template <typename TK, typename TR>
-void hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::init_td(void)
+void hamilt::TDNonlocal<hamilt::OperatorLCAO<TK, TR>>::init_td()
 {
     // calculate At in cartesian coorinates.
     this->cart_At = TD_Velocity::td_vel_op->cart_At;

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_nonlocal_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_nonlocal_lcao.h
@@ -1,14 +1,14 @@
 #ifndef TDNONLOCAL_H
 #define TDNONLOCAL_H
-#include <unordered_map>
-
 #include "module_basis/module_ao/parallel_orbitals.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
 #include "module_cell/unitcell.h"
+#include "module_elecstate/potentials/H_TDDFT_pw.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/operator_lcao.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
-#include "module_elecstate/potentials/H_TDDFT_pw.h"
 #include "module_hamilt_lcao/module_tddft/td_velocity.h"
+
+#include <unordered_map>
 
 namespace hamilt
 {
@@ -35,12 +35,12 @@ class TDNonlocal<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
 {
   public:
     TDNonlocal<OperatorLCAO<TK, TR>>(LCAO_Matrix* LM_in,
-                                      const std::vector<ModuleBase::Vector3<double>>& kvec_d_in,
-                                      hamilt::HContainer<TR>* hR_in,
-                                      std::vector<TK>* hK_in,
-                                      const UnitCell* ucell_in,
-                                      Grid_Driver* GridD_in,
-                                      const Parallel_Orbitals* paraV);
+                                     const std::vector<ModuleBase::Vector3<double>>& kvec_d_in,
+                                     hamilt::HContainer<TR>* hR_in,
+                                     std::vector<TK>* hK_in,
+                                     const UnitCell* ucell_in,
+                                     Grid_Driver* GridD_in,
+                                     const Parallel_Orbitals* paraV);
     ~TDNonlocal<OperatorLCAO<TK, TR>>();
 
     /**
@@ -56,7 +56,8 @@ class TDNonlocal<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
     const UnitCell* ucell = nullptr;
 
     HContainer<TR>* HR = nullptr;
-    /// @brief Store real space hamiltonian. TD term should include imaginary part, thus it has to be complex type. Only shared between TD operators.
+    /// @brief Store real space hamiltonian. TD term should include imaginary part, thus it has to be complex type. Only
+    /// shared between TD operators.
     HContainer<std::complex<double>>* hR_tmp = nullptr;
     Grid_Driver* Grid = nullptr;
 
@@ -76,7 +77,7 @@ class TDNonlocal<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
     /**
      * @brief initialize HR_tmp
      * Allocate the memory for HR_tmp with the same size as HR
-    */
+     */
     void initialize_HR_tmp(const Parallel_Orbitals* paraV);
     /// @brief init vector potential for td_nonlocal term
     void init_td(void);

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_nonlocal_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_nonlocal_lcao.h
@@ -3,7 +3,6 @@
 #include <unordered_map>
 
 #include "module_basis/module_ao/parallel_orbitals.h"
-#include "module_basis/module_ao/ORB_gen_tables.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
 #include "module_cell/unitcell.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/operator_lcao.h"
@@ -41,7 +40,6 @@ class TDNonlocal<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                                       std::vector<TK>* hK_in,
                                       const UnitCell* ucell_in,
                                       Grid_Driver* GridD_in,
-                                      const ORB_gen_tables* uot,
                                       const Parallel_Orbitals* paraV);
     ~TDNonlocal<OperatorLCAO<TK, TR>>();
 
@@ -61,9 +59,6 @@ class TDNonlocal<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
     /// @brief Store real space hamiltonian. TD term should include imaginary part, thus it has to be complex type. Only shared between TD operators.
     HContainer<std::complex<double>>* hR_tmp = nullptr;
     Grid_Driver* Grid = nullptr;
-
-    // this variable is introduced temporarily during LCAO refactoring
-    const ORB_gen_tables* uot_;
 
     bool allocated = false;
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/spar_dh.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/spar_dh.cpp
@@ -4,7 +4,7 @@
 
 void sparse_format::cal_dH(LCAO_Matrix& lm,
                            Grid_Driver& grid,
-                           const ORB_gen_tables* uot,
+                           const TwoCenterBundle& two_center_bundle,
                            const int& current_spin,
                            const double& sparse_thr,
                            Gint_k& gint_k)
@@ -37,7 +37,7 @@ void sparse_format::cal_dH(LCAO_Matrix& lm,
                                   GlobalC::ucell,
                                   GlobalC::ORB,
                                   *lm.ParaV,
-                                  *uot,
+                                  two_center_bundle,
                                   &GlobalC::GridD,
                                   nullptr); // delete unused parameter lm.Hloc_fixedR
 
@@ -52,7 +52,7 @@ void sparse_format::cal_dH(LCAO_Matrix& lm,
                                   GlobalC::ucell,
                                   GlobalC::ORB,
                                   *lm.ParaV,
-                                  *uot,
+                                  two_center_bundle,
                                   &GlobalC::GridD,
                                   nullptr); // delete unused parameter lm.Hloc_fixedR
     }
@@ -63,7 +63,7 @@ void sparse_format::cal_dH(LCAO_Matrix& lm,
                                        true,
                                        GlobalC::ucell,
                                        GlobalC::ORB,
-                                       *uot,
+                                       *(two_center_bundle.overlap_orb_beta),
                                        &GlobalC::GridD);
 
     sparse_format::cal_dSTN_R(lm, fsr_dh, grid, current_spin, sparse_thr);

--- a/source/module_hamilt_lcao/hamilt_lcaodft/spar_dh.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/spar_dh.h
@@ -12,7 +12,7 @@ namespace sparse_format
 	void cal_dH(
 			LCAO_Matrix &lm,
 			Grid_Driver &grid,
-            const ORB_gen_tables* uot,
+            const TwoCenterBundle& two_center_bundle,
 			const int &current_spin, 
 			const double &sparse_thr,
 			Gint_k &gint_k);

--- a/source/module_hamilt_lcao/hamilt_lcaodft/spar_dh.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/spar_dh.h
@@ -1,34 +1,30 @@
-#ifndef SPARSE_FORMAT_DH_H 
+#ifndef SPARSE_FORMAT_DH_H
 #define SPARSE_FORMAT_DH_H
 
 #include "module_cell/module_neighbor/sltk_atom_arrange.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
-#include "module_hamilt_pw/hamilt_pwdft/global.h"
-#include "module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/force_stress_arrays.h"
+#include "module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h"
+#include "module_hamilt_pw/hamilt_pwdft/global.h"
 
 namespace sparse_format
 {
-	void cal_dH(
-			LCAO_Matrix &lm,
-			Grid_Driver &grid,
+void cal_dH(LCAO_Matrix& lm,
+            Grid_Driver& grid,
             const TwoCenterBundle& two_center_bundle,
-			const int &current_spin, 
-			const double &sparse_thr,
-			Gint_k &gint_k);
+            const int& current_spin,
+            const double& sparse_thr,
+            Gint_k& gint_k);
 
-	// be called by 'cal_dH_sparse'
-	void set_R_range(
-			std::set<Abfs::Vector3_Order<int>> &all_R_coor,
-			Grid_Driver &grid);
+// be called by 'cal_dH_sparse'
+void set_R_range(std::set<Abfs::Vector3_Order<int>>& all_R_coor, Grid_Driver& grid);
 
-	// be called by 'cal_dH_sparse' 
-	void cal_dSTN_R(
-			LCAO_Matrix &lm,
-            ForceStressArrays &fsr, // mohan add 2024-06-16
-		    Grid_Driver &grid,
-			const int &current_spin, 
-			const double &sparse_thr);
-}
+// be called by 'cal_dH_sparse'
+void cal_dSTN_R(LCAO_Matrix& lm,
+                ForceStressArrays& fsr, // mohan add 2024-06-16
+                Grid_Driver& grid,
+                const int& current_spin,
+                const double& sparse_thr);
+} // namespace sparse_format
 
 #endif

--- a/source/module_hamilt_lcao/hamilt_lcaodft/spar_st.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/spar_st.cpp
@@ -47,7 +47,7 @@ void sparse_format::cal_TR(const UnitCell& ucell,
                            LCAO_Matrix& lm,
                            LCAO_HS_Arrays& HS_arrays,
                            Grid_Driver& grid,
-                           const ORB_gen_tables* uot,
+                           const TwoCenterBundle& two_center_bundle,
                            const double& sparse_thr)
 {
     ModuleBase::TITLE("sparse_format", "cal_TR");
@@ -68,7 +68,7 @@ void sparse_format::cal_TR(const UnitCell& ucell,
                               ucell,
                               GlobalC::ORB,
                               pv,
-                              *uot,
+                              two_center_bundle,
                               &(GlobalC::GridD),
                               HS_arrays.Hloc_fixedR.data());
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/spar_st.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/spar_st.h
@@ -22,7 +22,7 @@ void cal_TR(const UnitCell& ucell,
             LCAO_Matrix& lm,
             LCAO_HS_Arrays& HS_arrays,
             Grid_Driver& grid,
-            const ORB_gen_tables* uot,
+            const TwoCenterBundle& two_center_bundle,
             const double& sparse_thr);
 
 //! cal_STN_R_for_T is only called by cal_TR

--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks.h
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks.h
@@ -1,26 +1,23 @@
-#ifndef LCAO_DESCRIPTOR_H
-#define LCAO_DESCRIPTOR_H
+#ifndef W_ABACUS_DEVELOP_ABACUS_DEVELOP_SOURCE_MODULE_HAMILT_LCAO_MODULE_DEEPKS_LCAO_DEEPKS_H
+#define W_ABACUS_DEVELOP_ABACUS_DEVELOP_SOURCE_MODULE_HAMILT_LCAO_MODULE_DEEPKS_LCAO_DEEPKS_H
 
 #ifdef __DEEPKS
 
-#include "module_base/intarray.h"
 #include "module_base/complexmatrix.h"
-#include "module_basis/module_nao/two_center_integrator.h"
-#include <unordered_map>
-
-#include "torch/script.h"
-#include "torch/csrc/autograd/autograd.h"
-#include "torch/csrc/api/include/torch/linalg.h"
-
-#include "module_cell/module_neighbor/sltk_grid_driver.h"
-#include "module_basis/module_ao/parallel_orbitals.h"
-#include "module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h"
-#include "module_elecstate/module_dm/density_matrix.h"
 #include "module_base/intarray.h"
-#include "module_base/complexmatrix.h"
-#include "module_io/winput.h"
 #include "module_base/matrix.h"
 #include "module_base/timer.h"
+#include "module_basis/module_ao/parallel_orbitals.h"
+#include "module_basis/module_nao/two_center_integrator.h"
+#include "module_cell/module_neighbor/sltk_grid_driver.h"
+#include "module_elecstate/module_dm/density_matrix.h"
+#include "module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h"
+#include "module_io/winput.h"
+#include "torch/csrc/api/include/torch/linalg.h"
+#include "torch/csrc/autograd/autograd.h"
+#include "torch/script.h"
+
+#include <unordered_map>
 
 ///
 /// The LCAO_Deepks contains subroutines for implementation of the DeePKS method in atomic basis.
@@ -33,7 +30,7 @@
 ///    and grad_vx = d/dX (D)
 /// 2. loading the model, which requires interfaces with libtorch
 /// 3. applying the correction potential, delta_V, in Kohn-Sham Hamiltonian and calculation of energy, force, stress
-/// 
+///
 /// For details of DeePKS method, you can refer to [DeePKS paper](https://pubs.acs.org/doi/10.1021/acs.jctc.0c00872).
 ///
 ///
@@ -43,526 +40,528 @@
 class LCAO_Deepks
 {
 
-//-------------------
-// public variables
-//-------------------
-public:
-    
+    //-------------------
+    // public variables
+    //-------------------
+  public:
     ///(Unit: Ry) Correction energy provided by NN
     double E_delta = 0.0;
     ///(Unit: Ry)  \f$tr(\rho H_\delta), \rho = \sum_i{c_{i, \mu}c_{i,\nu}} \f$ (for gamma_only)
     double e_delta_band = 0.0;
-    
-    ///(Unit: Ry)  \f$tr(\rho_{HL} H_\delta), 
-    ///\rho_{HL} = c_{L, \mu}c_{L,\nu} - c_{H, \mu}c_{H,\nu} \f$ (for gamma_only)
-    ModuleBase::matrix	o_delta;
 
-    ///Correction term to the Hamiltonian matrix: \f$\langle\psi|V_\delta|\psi\rangle\f$ (for gamma only)
+    ///(Unit: Ry)  \f$tr(\rho_{HL} H_\delta),
+    ///\rho_{HL} = c_{L, \mu}c_{L,\nu} - c_{H, \mu}c_{H,\nu} \f$ (for gamma_only)
+    ModuleBase::matrix o_delta;
+
+    /// Correction term to the Hamiltonian matrix: \f$\langle\psi|V_\delta|\psi\rangle\f$ (for gamma only)
     std::vector<double> H_V_delta;
-    ///Correction term to Hamiltonian, for multi-k
-    ///In R space:
+    /// Correction term to Hamiltonian, for multi-k
+    /// In R space:
     double* H_V_deltaR;
-    ///In k space:
+    /// In k space:
     std::vector<std::vector<std::complex<double>>> H_V_delta_k;
 
     ///(Unit: Ry/Bohr) Total Force due to the DeePKS correction term \f$E_{\delta}\f$
-    ModuleBase::matrix	F_delta;
+    ModuleBase::matrix F_delta;
 
-    //k index of HOMO for multi-k bandgap label. QO added 2022-01-24
+    // k index of HOMO for multi-k bandgap label. QO added 2022-01-24
     int h_ind = 0;
-    
-    //k index of LUMO for multi-k bandgap label. QO added 2022-01-24
+
+    // k index of LUMO for multi-k bandgap label. QO added 2022-01-24
     int l_ind = 0;
 
-    //functions for hr status: 1. get value; 2. set value;
-    int get_hr_cal(){ return this->hr_cal; }
-    void set_hr_cal(bool cal){ this->hr_cal = cal; }
+    // functions for hr status: 1. get value; 2. set value;
+    int get_hr_cal()
+    {
+        return this->hr_cal;
+    }
+    void set_hr_cal(bool cal)
+    {
+        this->hr_cal = cal;
+    }
 
     // temporary add two getters for inl_index and gedm
-    int get_inl(const int& T0, const int& I0, const int& L0, const int& N0) { return inl_index[T0](I0, L0, N0); }
-    const double* get_gedms(const int& inl){ return gedm[inl]; }
+    int get_inl(const int& T0, const int& I0, const int& L0, const int& N0)
+    {
+        return inl_index[T0](I0, L0, N0);
+    }
+    const double* get_gedms(const int& inl)
+    {
+        return gedm[inl];
+    }
 
-    int get_lmaxd(){return lmaxd;}
-//-------------------
-// private variables
-//-------------------
-private:
-
-	int lmaxd = 0; //max l of descirptors
-	int nmaxd = 0; //#. descriptors per l
-	int inlmax = 0; //tot. number {i,n,l} - atom, n, l
+    int get_lmaxd()
+    {
+        return lmaxd;
+    }
+    //-------------------
+    // private variables
+    //-------------------
+  private:
+    int lmaxd = 0;  // max l of descirptors
+    int nmaxd = 0;  //#. descriptors per l
+    int inlmax = 0; // tot. number {i,n,l} - atom, n, l
     int nat_gdm = 0;
     int nks_V_delta = 0;
 
-    bool init_pdm = false; //for DeePKS NSCF calculation
-    
-	// deep neural network module that provides corrected Hamiltonian term and
-	// related derivatives.
-	torch::jit::script::Module module;
+    bool init_pdm = false; // for DeePKS NSCF calculation
+
+    // deep neural network module that provides corrected Hamiltonian term and
+    // related derivatives.
+    torch::jit::script::Module module;
 
     // saves <psi(0)|alpha(R)>, for gamma only
-    std::vector<std::vector<std::unordered_map<int,std::vector<std::vector<double>>>>> nlm_save;
-    
+    std::vector<std::vector<std::unordered_map<int, std::vector<std::vector<double>>>>> nlm_save;
+
     // saves <psi(0)|alpha(R)>, for multi_k
-    typedef std::tuple<int,int,int,int> key_tuple;
-    std::vector<std::map<key_tuple,std::unordered_map<int,std::vector<std::vector<double>>>>> nlm_save_k;
+    typedef std::tuple<int, int, int, int> key_tuple;
+    std::vector<std::map<key_tuple, std::unordered_map<int, std::vector<std::vector<double>>>>> nlm_save_k;
 
     // projected density matrix
-	double** pdm;	//[tot_Inl][2l+1][2l+1]	caoyu modified 2021-05-07; if equivariant version: [nat][nlm*nlm]
-	std::vector<torch::Tensor> pdm_tensor;
+    double** pdm; //[tot_Inl][2l+1][2l+1]	caoyu modified 2021-05-07; if equivariant version: [nat][nlm*nlm]
+    std::vector<torch::Tensor> pdm_tensor;
 
-	// descriptors
-	std::vector<torch::Tensor> d_tensor;
+    // descriptors
+    std::vector<torch::Tensor> d_tensor;
 
-	//gedm:dE/dD, [tot_Inl][2l+1][2l+1]	(E: Hartree)
-	std::vector<torch::Tensor> gedm_tensor;
+    // gedm:dE/dD, [tot_Inl][2l+1][2l+1]	(E: Hartree)
+    std::vector<torch::Tensor> gedm_tensor;
 
-	//gdmx: dD/dX		\sum_{mu,nu} 2*c_mu*c_nu * <dpsi_mu/dx|alpha_m><alpha_m'|psi_nu>
-	double*** gdmx;	//[natom][tot_Inl][2l+1][2l+1]
-	double*** gdmy;
-	double*** gdmz;
+    // gdmx: dD/dX		\sum_{mu,nu} 2*c_mu*c_nu * <dpsi_mu/dx|alpha_m><alpha_m'|psi_nu>
+    double*** gdmx; //[natom][tot_Inl][2l+1][2l+1]
+    double*** gdmy;
+    double*** gdmz;
 
-    //gdm_epsl: dD/d\epsilon_{\alpha\beta}
-    double*** gdm_epsl; //[6][tot_Inl][2l+1][2l+1] 
+    // gdm_epsl: dD/d\epsilon_{\alpha\beta}
+    double*** gdm_epsl; //[6][tot_Inl][2l+1][2l+1]
 
-    //dD/d\epsilon_{\alpha\beta}, tensor form of gdm_epsl
+    // dD/d\epsilon_{\alpha\beta}, tensor form of gdm_epsl
     std::vector<torch::Tensor> gdmepsl_vector;
 
-    //gv_epsl:d(d)/d\epsilon_{\alpha\beta}, [natom][6][des_per_atom]
+    // gv_epsl:d(d)/d\epsilon_{\alpha\beta}, [natom][6][des_per_atom]
     torch::Tensor gvepsl_tensor;
 
-	///dE/dD, autograd from loaded model(E: Ry)
-	double** gedm;	//[tot_Inl][2l+1][2l+1]
+    /// dE/dD, autograd from loaded model(E: Ry)
+    double** gedm; //[tot_Inl][2l+1][2l+1]
 
-    //gvx:d(d)/dX, [natom][3][natom][des_per_atom]
+    // gvx:d(d)/dX, [natom][3][natom][des_per_atom]
     torch::Tensor gvx_tensor;
 
-    //d(d)/dD, autograd from torch::linalg::eigh
+    // d(d)/dD, autograd from torch::linalg::eigh
     std::vector<torch::Tensor> gevdm_vector;
 
-    //dD/dX, tensor form of gdmx
+    // dD/dX, tensor form of gdmx
     std::vector<torch::Tensor> gdmr_vector;
 
-    //orbital_pdm_shell:[1,Inl,nm*nm]; \langle \phi_\mu|\alpha\rangle\langle\alpha|\phi_\nu\rnalge
+    // orbital_pdm_shell:[1,Inl,nm*nm]; \langle \phi_\mu|\alpha\rangle\langle\alpha|\phi_\nu\rnalge
     double**** orbital_pdm_shell;
-    //orbital_precalc:[1,NAt,NDscrpt]; gvdm*orbital_pdm_shell
+    // orbital_precalc:[1,NAt,NDscrpt]; gvdm*orbital_pdm_shell
     torch::Tensor orbital_precalc_tensor;
 
-    ///size of descriptor(projector) basis set
+    /// size of descriptor(projector) basis set
     int n_descriptor;
 
-	// \sum_L{Nchi(L)*(2L+1)}
-	int des_per_atom;
+    // \sum_L{Nchi(L)*(2L+1)}
+    int des_per_atom;
 
-	ModuleBase::IntArray* alpha_index;
-	ModuleBase::IntArray* inl_index;	//caoyu add 2021-05-07
-	int* inl_l;	//inl_l[inl_index] = l of descriptor with inl_index
+    ModuleBase::IntArray* alpha_index;
+    ModuleBase::IntArray* inl_index; // caoyu add 2021-05-07
+    int* inl_l;                      // inl_l[inl_index] = l of descriptor with inl_index
 
-    // HR status, 
+    // HR status,
     // true : HR should be calculated
     // false : HR has been calculated
     bool hr_cal = true;
 
-//-------------------
-// subroutines, grouped according to the file they are in:
-//-------------------
+    //-------------------
+    // subroutines, grouped according to the file they are in:
+    //-------------------
 
-//-------------------
-// LCAO_deepks.cpp
-//-------------------
+    //-------------------
+    // LCAO_deepks.cpp
+    //-------------------
 
-//This file contains constructor and destructor of the class LCAO_deepks, 
-//as well as subroutines for initializing and releasing relevant data structures 
+    // This file contains constructor and destructor of the class LCAO_deepks,
+    // as well as subroutines for initializing and releasing relevant data structures
 
-//Other than the constructor and the destructor, it contains 3 types of subroutines:
-//1. subroutines that are related to calculating descriptors:
-//  - init : allocates some arrays
-//  - init_index : records the index (inl)
-//  - allocate_nlm : allocates data structures (nlm_save) which is used to store <chi|alpha>
-//2. subroutines that are related to calculating force label:
-//  - init_gdmx : allocates gdmx; it is a private subroutine
-//  - del_gdmx : releases gdmx
-//3. subroutines that are related to V_delta:
-//  - allocate_V_delta : allocates H_V_delta; if calculating force, it also calls
-//      init_gdmx, as well as allocating F_delta
-//  - allocate_V_deltaR : allcoates H_V_deltaR, for multi-k calculations
+    // Other than the constructor and the destructor, it contains 3 types of subroutines:
+    // 1. subroutines that are related to calculating descriptors:
+    //   - init : allocates some arrays
+    //   - init_index : records the index (inl)
+    //   - allocate_nlm : allocates data structures (nlm_save) which is used to store <chi|alpha>
+    // 2. subroutines that are related to calculating force label:
+    //   - init_gdmx : allocates gdmx; it is a private subroutine
+    //   - del_gdmx : releases gdmx
+    // 3. subroutines that are related to V_delta:
+    //   - allocate_V_delta : allocates H_V_delta; if calculating force, it also calls
+    //       init_gdmx, as well as allocating F_delta
+    //   - allocate_V_deltaR : allcoates H_V_deltaR, for multi-k calculations
 
-public:
-
+  public:
     explicit LCAO_Deepks();
     ~LCAO_Deepks();
 
-    ///Allocate memory and calculate the index of descriptor in all atoms. 
+    /// Allocate memory and calculate the index of descriptor in all atoms.
     ///(only for descriptor part, not including scf)
-    void init(const LCAO_Orbitals &orb,
-        const int nat,
-        const int ntype,
-        const Parallel_Orbitals& pv_in,
-        std::vector<int> na);
+    void init(const LCAO_Orbitals& orb,
+              const int nat,
+              const int ntype,
+              const Parallel_Orbitals& pv_in,
+              std::vector<int> na);
 
-    ///Allocate memory for correction to Hamiltonian
+    /// Allocate memory for correction to Hamiltonian
     void allocate_V_delta(const int nat, const int nks = 1);
     void allocate_V_deltaR(const int nnr);
 
     // array for storing gdmx, used for calculating gvx
-	void init_gdmx(const int nat);
-	//void del_gdmx(const int nat);
-	void del_gdmx();
+    void init_gdmx(const int nat);
+    // void del_gdmx(const int nat);
+    void del_gdmx();
 
     // array for storing gdm_epsl, used for calculating gvx
-	void init_gdmepsl();
-	void del_gdmepsl();
+    void init_gdmepsl();
+    void del_gdmepsl();
 
-private:
-
+  private:
     // arrange index of descriptor in all atoms
-	void init_index(const int ntype,
-        const int nat,
-        std::vector<int> na,
-        const int tot_inl,
-        const LCAO_Orbitals &orb);
+    void init_index(const int ntype, const int nat, std::vector<int> na, const int tot_inl, const LCAO_Orbitals& orb);
     // data structure that saves <psi|alpha>
     void allocate_nlm(const int nat);
 
-    //for bandgap label calculation; QO added on 2022-1-7
+    // for bandgap label calculation; QO added on 2022-1-7
     void init_orbital_pdm_shell(const int nks);
     void del_orbital_pdm_shell(const int nks);
 
-//-------------------
-// LCAO_deepks_psialpha.cpp
-//-------------------
+    //-------------------
+    // LCAO_deepks_psialpha.cpp
+    //-------------------
 
-//wenfei 2022-1-5
-//This file contains 2 subroutines:
-//1. build_psialpha, which calculates the overlap
-//between atomic basis and projector alpha : <psi_mu|alpha>
-//which will be used in calculating pdm, gdmx, H_V_delta, F_delta;
-//2. check_psialpha, which prints the results into .dat files
-//for checking
+    // wenfei 2022-1-5
+    // This file contains 2 subroutines:
+    // 1. build_psialpha, which calculates the overlap
+    // between atomic basis and projector alpha : <psi_mu|alpha>
+    // which will be used in calculating pdm, gdmx, H_V_delta, F_delta;
+    // 2. check_psialpha, which prints the results into .dat files
+    // for checking
 
-public:
+  public:
+    // calculates <chi|alpha>
+    void build_psialpha(const bool& cal_deri /**< [in] 0 for 2-center intergration, 1 for its derivation*/,
+                        const UnitCell& ucell,
+                        const LCAO_Orbitals& orb,
+                        Grid_Driver& GridD,
+                        const TwoCenterIntegrator& overlap_orb_alpha);
 
-    //calculates <chi|alpha>
-    void build_psialpha(const bool& cal_deri/**< [in] 0 for 2-center intergration, 1 for its derivation*/,
-        const UnitCell &ucell,
-        const LCAO_Orbitals &orb,
-        Grid_Driver& GridD,
-        const TwoCenterIntegrator& overlap_orb_alpha);
+    void check_psialpha(const bool& cal_deri /**< [in] 0 for 2-center intergration, 1 for its derivation*/,
+                        const UnitCell& ucell,
+                        const LCAO_Orbitals& orb,
+                        Grid_Driver& GridD);
 
-    void check_psialpha(const bool& cal_deri/**< [in] 0 for 2-center intergration, 1 for its derivation*/,
-        const UnitCell &ucell,
-        const LCAO_Orbitals &orb,
-        Grid_Driver& GridD);
+    //-------------------
+    // LCAO_deepks_pdm.cpp
+    //-------------------
 
-//-------------------
-// LCAO_deepks_pdm.cpp
-//-------------------
+    // This file contains subroutines for calculating pdm,
+    // which is defind as sum_mu,nu rho_mu,nu (<chi_mu|alpha><alpha|chi_nu>);
+    // as well as gdmx, which is the gradient of pdm, defined as
+    // sum_mu,nu rho_mu,nu d/dX(<chi_mu|alpha><alpha|chi_nu>)
 
-//This file contains subroutines for calculating pdm,
-//which is defind as sum_mu,nu rho_mu,nu (<chi_mu|alpha><alpha|chi_nu>);
-//as well as gdmx, which is the gradient of pdm, defined as
-//sum_mu,nu rho_mu,nu d/dX(<chi_mu|alpha><alpha|chi_nu>)
+    // It also contains subroutines for printing pdm and gdmx
+    // for checking purpose
 
-//It also contains subroutines for printing pdm and gdmx
-//for checking purpose
+    // There are 6 subroutines in this file:
+    // 1. cal_projected_DM, which is used for calculating pdm for gamma point calculation
+    // 2. cal_projected_DM_k, counterpart of 1, for multi-k
+    // 3. check_projected_dm, which prints pdm to descriptor.dat
 
-//There are 6 subroutines in this file:
-//1. cal_projected_DM, which is used for calculating pdm for gamma point calculation
-//2. cal_projected_DM_k, counterpart of 1, for multi-k
-//3. check_projected_dm, which prints pdm to descriptor.dat
+    // 4. cal_gdmx, calculating gdmx (and optionally gdm_epsl for stress) for gamma point
+    // 5. cal_gdmx_k, counterpart of 3, for multi-k
+    // 6. check_gdmx, which prints gdmx to a series of .dat files
 
-//4. cal_gdmx, calculating gdmx (and optionally gdm_epsl for stress) for gamma point
-//5. cal_gdmx_k, counterpart of 3, for multi-k
-//6. check_gdmx, which prints gdmx to a series of .dat files
+  public:
+    /// calculate projected density matrix:
+    /// pdm = sum_i,occ <phi_i|alpha1><alpha2|phi_k>
+    void cal_projected_DM(const elecstate::DensityMatrix<double, double>* dm,
+                          const UnitCell& ucell,
+                          const LCAO_Orbitals& orb,
+                          Grid_Driver& GridD);
+    void cal_projected_DM_k(const elecstate::DensityMatrix<std::complex<double>, double>* dm,
+                            const UnitCell& ucell,
+                            const LCAO_Orbitals& orb,
+                            Grid_Driver& GridD);
+    void check_projected_dm();
 
-public:
+    void cal_projected_DM_equiv(const elecstate::DensityMatrix<double, double>* dm,
+                                const UnitCell& ucell,
+                                const LCAO_Orbitals& orb,
+                                Grid_Driver& GridD);
+    void cal_projected_DM_k_equiv(const elecstate::DensityMatrix<std::complex<double>, double>* dm,
+                                  const UnitCell& ucell,
+                                  const LCAO_Orbitals& orb,
+                                  Grid_Driver& GridD);
 
-    ///calculate projected density matrix:
-    ///pdm = sum_i,occ <phi_i|alpha1><alpha2|phi_k>
-    void cal_projected_DM(
-        const elecstate::DensityMatrix<double, double>* dm,
-        const UnitCell &ucell,
-        const LCAO_Orbitals &orb,
-        Grid_Driver& GridD);
-    void cal_projected_DM_k(
-        const elecstate::DensityMatrix<std::complex<double>, double>* dm,
-        const UnitCell &ucell,
-        const LCAO_Orbitals &orb,
-        Grid_Driver& GridD);
-    void check_projected_dm(void);
-
-    void cal_projected_DM_equiv(
-        const elecstate::DensityMatrix<double, double>* dm,
-        const UnitCell &ucell,
-        const LCAO_Orbitals &orb,
-        Grid_Driver& GridD);
-    void cal_projected_DM_k_equiv(
-        const elecstate::DensityMatrix<std::complex<double>, double>* dm,
-        const UnitCell &ucell,
-        const LCAO_Orbitals &orb,
-        Grid_Driver& GridD);
-        
-    //calculate the gradient of pdm with regard to atomic positions
-    //d/dX D_{Inl,mm'}
-    void cal_gdmx(//const ModuleBase::matrix& dm,
+    // calculate the gradient of pdm with regard to atomic positions
+    // d/dX D_{Inl,mm'}
+    void cal_gdmx( // const ModuleBase::matrix& dm,
         const std::vector<double>& dm,
-        const UnitCell &ucell,
-        const LCAO_Orbitals &orb,
+        const UnitCell& ucell,
+        const LCAO_Orbitals& orb,
         Grid_Driver& GridD,
         const bool isstress);
-    void cal_gdmx_k(//const std::vector<ModuleBase::ComplexMatrix>& dm,
+    void cal_gdmx_k( // const std::vector<ModuleBase::ComplexMatrix>& dm,
         const std::vector<std::vector<std::complex<double>>>& dm,
-        const UnitCell &ucell,
-        const LCAO_Orbitals &orb,
+        const UnitCell& ucell,
+        const LCAO_Orbitals& orb,
         Grid_Driver& GridD,
         const int nks,
-        const std::vector<ModuleBase::Vector3<double>> &kvec_d,
+        const std::vector<ModuleBase::Vector3<double>>& kvec_d,
         const bool isstress);
     void check_gdmx(const int nat);
 
-//-------------------
-// LCAO_deepks_vdelta.cpp
-//-------------------
+    //-------------------
+    // LCAO_deepks_vdelta.cpp
+    //-------------------
 
-//This file contains subroutines related to V_delta, which is the deepks contribution to Hamiltonian
-//defined as |alpha>V(D)<alpha|
-//as well as subroutines for printing them for checking
-//It also contains subroutine related to calculating e_delta_bands, which is basically
-//tr (rho * V_delta)
+    // This file contains subroutines related to V_delta, which is the deepks contribution to Hamiltonian
+    // defined as |alpha>V(D)<alpha|
+    // as well as subroutines for printing them for checking
+    // It also contains subroutine related to calculating e_delta_bands, which is basically
+    // tr (rho * V_delta)
 
-//Four subroutines are contained in the file:
-//5. cal_e_delta_band : calculates e_delta_bands for gamma only
-//6. cal_e_delta_band_k : counterpart of 4, for multi-k
+    // Four subroutines are contained in the file:
+    // 5. cal_e_delta_band : calculates e_delta_bands for gamma only
+    // 6. cal_e_delta_band_k : counterpart of 4, for multi-k
 
-public:
+  public:
+    /// calculate tr(\rho V_delta)
+    // void cal_e_delta_band(const std::vector<ModuleBase::matrix>& dm/**<[in] density matrix*/);
+    void cal_e_delta_band(const std::vector<std::vector<double>>& dm /**<[in] density matrix*/);
+    // void cal_e_delta_band_k(const std::vector<ModuleBase::ComplexMatrix>& dm/**<[in] density matrix*/,
+    //     const int nks);
+    void cal_e_delta_band_k(const std::vector<std::vector<std::complex<double>>>& dm /**<[in] density matrix*/,
+                            const int nks);
 
-    ///calculate tr(\rho V_delta)
-    //void cal_e_delta_band(const std::vector<ModuleBase::matrix>& dm/**<[in] density matrix*/);
-    void cal_e_delta_band(const std::vector<std::vector<double>>& dm/**<[in] density matrix*/);
-    //void cal_e_delta_band_k(const std::vector<ModuleBase::ComplexMatrix>& dm/**<[in] density matrix*/,
-    //    const int nks);
-    void cal_e_delta_band_k(const std::vector<std::vector<std::complex<double>>>& dm/**<[in] density matrix*/,
-        const int nks);
+    //-------------------
+    // LCAO_deepks_fdelta.cpp
+    //-------------------
 
-//-------------------
-// LCAO_deepks_fdelta.cpp
-//-------------------
+    // This file contains subroutines for calculating F_delta,
+    // which is defind as sum_mu,nu rho_mu,nu d/dX (<chi_mu|alpha>V(D)<alpha|chi_nu>)
 
-//This file contains subroutines for calculating F_delta,
-//which is defind as sum_mu,nu rho_mu,nu d/dX (<chi_mu|alpha>V(D)<alpha|chi_nu>)
+    // There are 3 subroutines in this file:
+    // 1. cal_f_delta_gamma, which is used for gamma point calculation
+    // 2. cal_f_delta_k, which is used for multi-k calculation
+    // 3. check_f_delta, which prints F_delta into F_delta.dat for checking
 
-//There are 3 subroutines in this file:
-//1. cal_f_delta_gamma, which is used for gamma point calculation
-//2. cal_f_delta_k, which is used for multi-k calculation
-//3. check_f_delta, which prints F_delta into F_delta.dat for checking
-
-public:
-
-    //for gamma only, pulay and HF terms of force are calculated together
-    void cal_f_delta_gamma(//const std::vector<ModuleBase::matrix>& dm/**< [in] density matrix*/,
+  public:
+    // for gamma only, pulay and HF terms of force are calculated together
+    void cal_f_delta_gamma( // const std::vector<ModuleBase::matrix>& dm/**< [in] density matrix*/,
         const std::vector<std::vector<double>>& dm,
-        const UnitCell &ucell,
-        const LCAO_Orbitals &orb,
+        const UnitCell& ucell,
+        const LCAO_Orbitals& orb,
         Grid_Driver& GridD,
-        const bool isstress, ModuleBase::matrix& svnl_dalpha);
+        const bool isstress,
+        ModuleBase::matrix& svnl_dalpha);
 
-    //for multi-k, pulay and HF terms of force are calculated together
-    void cal_f_delta_k(//const std::vector<ModuleBase::ComplexMatrix>& dm/**<[in] density matrix*/,
+    // for multi-k, pulay and HF terms of force are calculated together
+    void cal_f_delta_k( // const std::vector<ModuleBase::ComplexMatrix>& dm/**<[in] density matrix*/,
         const std::vector<std::vector<std::complex<double>>>& dm,
-        const UnitCell &ucell,
-        const LCAO_Orbitals &orb,
+        const UnitCell& ucell,
+        const LCAO_Orbitals& orb,
         Grid_Driver& GridD,
         const int nks,
-        const std::vector<ModuleBase::Vector3<double>> &kvec_d,
-        const bool isstress, ModuleBase::matrix& svnl_dalpha);
+        const std::vector<ModuleBase::Vector3<double>>& kvec_d,
+        const bool isstress,
+        ModuleBase::matrix& svnl_dalpha);
 
     void check_f_delta(const int nat, ModuleBase::matrix& svnl_dalpha);
 
-//-------------------
-// LCAO_deepks_odelta.cpp
-//-------------------
+    //-------------------
+    // LCAO_deepks_odelta.cpp
+    //-------------------
 
-//This file contains subroutines for calculating O_delta,
-//which corresponds to the correction of the band gap. 
+    // This file contains subroutines for calculating O_delta,
+    // which corresponds to the correction of the band gap.
 
-//There are two subroutines in this file:
-//1. cal_o_delta, which is used for gamma point calculation
-//2. cal_o_delta_k, which is used for multi-k calculation
+    // There are two subroutines in this file:
+    // 1. cal_o_delta, which is used for gamma point calculation
+    // 2. cal_o_delta_k, which is used for multi-k calculation
 
-public:
-    
-    void cal_o_delta(const std::vector<std::vector<ModuleBase::matrix>>& dm_hl/**<[in] modified density matrix that contains HOMO and LUMO only*/);
-    void cal_o_delta_k(const std::vector<std::vector<ModuleBase::ComplexMatrix>>& dm_hl/**<[in] modified density matrix that contains HOMO and LUMO only*/,
-        const int nks);
+  public:
+    void cal_o_delta(const std::vector<std::vector<ModuleBase::matrix>>&
+                         dm_hl /**<[in] modified density matrix that contains HOMO and LUMO only*/);
+    void cal_o_delta_k(const std::vector<std::vector<ModuleBase::ComplexMatrix>>&
+                           dm_hl /**<[in] modified density matrix that contains HOMO and LUMO only*/,
+                       const int nks);
 
-//-------------------
-// LCAO_deepks_torch.cpp
-//-------------------
+    //-------------------
+    // LCAO_deepks_torch.cpp
+    //-------------------
 
-//This file contains interfaces with libtorch,
-//including loading of model and calculating gradients
-//as well as subroutines that prints the results for checking
+    // This file contains interfaces with libtorch,
+    // including loading of model and calculating gradients
+    // as well as subroutines that prints the results for checking
 
-//The file contains 8 subroutines:
-//1. cal_descriptor : obtains descriptors which are eigenvalues of pdm
-//      by calling torch::linalg::eigh
-//2. check_descriptor : prints descriptor for checking
-//3. cal_gvx : gvx is used for training with force label, which is gradient of descriptors, 
-//      calculated by d(des)/dX = d(pdm)/dX * d(des)/d(pdm) = gdmx * gvdm
-//      using einsum
-//4. check_gvx : prints gvx into gvx.dat for checking
-//5. cal_gvepsl : gvepsl is used for training with stress label, which is derivative of 
-//      descriptors wrt strain tensor, calculated by 
-//      d(des)/d\epsilon_{ab} = d(pdm)/d\epsilon_{ab} * d(des)/d(pdm) = gdm_epsl * gvdm
-//      using einsum
-//6. cal_gvdm : d(des)/d(pdm)
-//      calculated using torch::autograd::grad
-//7. load_model : loads model for applying V_delta
-//8. cal_gedm : calculates d(E_delta)/d(pdm)
-//      this is the term V(D) that enters the expression H_V_delta = |alpha>V(D)<alpha|
-//      caculated using torch::autograd::grad
-//9. check_gedm : prints gedm for checking
-//10. cal_orbital_precalc : orbital_precalc is usted for training with orbital label, 
-//                         which equals gvdm * orbital_pdm_shell, 
-//                         orbital_pdm_shell[1,Inl,nm*nm] = dm_hl * overlap * overlap
-//11. cal_orbital_precalc_k : orbital_precalc is usted for training with orbital label, 
-//                         for multi-k case, which equals gvdm * orbital_pdm_shell, 
-//                         orbital_pdm_shell[1,Inl,nm*nm] = dm_hl_k * overlap * overlap
+    // The file contains 8 subroutines:
+    // 1. cal_descriptor : obtains descriptors which are eigenvalues of pdm
+    //       by calling torch::linalg::eigh
+    // 2. check_descriptor : prints descriptor for checking
+    // 3. cal_gvx : gvx is used for training with force label, which is gradient of descriptors,
+    //       calculated by d(des)/dX = d(pdm)/dX * d(des)/d(pdm) = gdmx * gvdm
+    //       using einsum
+    // 4. check_gvx : prints gvx into gvx.dat for checking
+    // 5. cal_gvepsl : gvepsl is used for training with stress label, which is derivative of
+    //       descriptors wrt strain tensor, calculated by
+    //       d(des)/d\epsilon_{ab} = d(pdm)/d\epsilon_{ab} * d(des)/d(pdm) = gdm_epsl * gvdm
+    //       using einsum
+    // 6. cal_gvdm : d(des)/d(pdm)
+    //       calculated using torch::autograd::grad
+    // 7. load_model : loads model for applying V_delta
+    // 8. cal_gedm : calculates d(E_delta)/d(pdm)
+    //       this is the term V(D) that enters the expression H_V_delta = |alpha>V(D)<alpha|
+    //       caculated using torch::autograd::grad
+    // 9. check_gedm : prints gedm for checking
+    // 10. cal_orbital_precalc : orbital_precalc is usted for training with orbital label,
+    //                          which equals gvdm * orbital_pdm_shell,
+    //                          orbital_pdm_shell[1,Inl,nm*nm] = dm_hl * overlap * overlap
+    // 11. cal_orbital_precalc_k : orbital_precalc is usted for training with orbital label,
+    //                          for multi-k case, which equals gvdm * orbital_pdm_shell,
+    //                          orbital_pdm_shell[1,Inl,nm*nm] = dm_hl_k * overlap * overlap
 
-public:
-
-    ///Calculates descriptors
-    ///which are eigenvalues of pdm in blocks of I_n_l
-	void cal_descriptor(const int nat);
-    ///print descriptors based on LCAO basis
-    void check_descriptor(const UnitCell &ucell);
+  public:
+    /// Calculates descriptors
+    /// which are eigenvalues of pdm in blocks of I_n_l
+    void cal_descriptor(const int nat);
+    /// print descriptors based on LCAO basis
+    void check_descriptor(const UnitCell& ucell);
 
     void cal_descriptor_equiv(const int nat);
 
-    ///calculates gradient of descriptors w.r.t atomic positions
+    /// calculates gradient of descriptors w.r.t atomic positions
     ///----------------------------------------------------
-    ///m, n: 2*l+1
-    ///v: eigenvalues of dm , 2*l+1
-    ///a,b: natom 
-    /// - (a: the center of descriptor orbitals
-    /// - b: the atoms whose force being calculated)
-    ///gvdm*gdmx->gvx
+    /// m, n: 2*l+1
+    /// v: eigenvalues of dm , 2*l+1
+    /// a,b: natom
+    ///  - (a: the center of descriptor orbitals
+    ///  - b: the atoms whose force being calculated)
+    /// gvdm*gdmx->gvx
     ///----------------------------------------------------
     void cal_gvx(const int nat);
     void check_gvx(const int nat);
 
-    //for stress
+    // for stress
     void cal_gvepsl(const int nat);
 
-    //load the trained neural network model
+    // load the trained neural network model
     void load_model(const std::string& model_file);
 
-    ///calculate partial of energy correction to descriptors
+    /// calculate partial of energy correction to descriptors
     void cal_gedm(const int nat);
-    void check_gedm(void);
+    void check_gedm();
     void cal_gedm_equiv(const int nat);
 
-    //calculates orbital_precalc
-    void cal_orbital_precalc(const std::vector<std::vector<ModuleBase::matrix>>& dm_hl/**<[in] density matrix*/,
-        const int nat,
-        const UnitCell &ucell,
-        const LCAO_Orbitals &orb,
-        Grid_Driver& GridD);
-    
-    //calculates orbital_precalc for multi-k case
-    void cal_orbital_precalc_k(const std::vector<std::vector<ModuleBase::ComplexMatrix>>& dm_hl/**<[in] density matrix*/,
+    // calculates orbital_precalc
+    void cal_orbital_precalc(const std::vector<std::vector<ModuleBase::matrix>>& dm_hl /**<[in] density matrix*/,
+                             const int nat,
+                             const UnitCell& ucell,
+                             const LCAO_Orbitals& orb,
+                             Grid_Driver& GridD);
+
+    // calculates orbital_precalc for multi-k case
+    void cal_orbital_precalc_k(
+        const std::vector<std::vector<ModuleBase::ComplexMatrix>>& dm_hl /**<[in] density matrix*/,
         const int nat,
         const int nks,
-        const std::vector<ModuleBase::Vector3<double>> &kvec_d,
-        const UnitCell &ucell,
-        const LCAO_Orbitals &orb,
+        const std::vector<ModuleBase::Vector3<double>>& kvec_d,
+        const UnitCell& ucell,
+        const LCAO_Orbitals& orb,
         Grid_Driver& GridD);
 
-
-private:
+  private:
     const Parallel_Orbitals* pv;
     void cal_gvdm(const int nat);
 
-//-------------------
-// LCAO_deepks_io.cpp
-//-------------------
+    //-------------------
+    // LCAO_deepks_io.cpp
+    //-------------------
 
-//This file contains subroutines that contains interface with libnpy
-//since many arrays must be saved in numpy format
-//It also contains subroutines for printing density matrices
-//which is used in unit tests
+    // This file contains subroutines that contains interface with libnpy
+    // since many arrays must be saved in numpy format
+    // It also contains subroutines for printing density matrices
+    // which is used in unit tests
 
-//There are 2 subroutines for printing density matrices:
-//1. print_dm : for gamma only
-//2. print_dm_k : for multi-k
+    // There are 2 subroutines for printing density matrices:
+    // 1. print_dm : for gamma only
+    // 2. print_dm_k : for multi-k
 
-//And 6 which prints quantities in .npy format 
-//3. save_npy_d : descriptor ->dm_eig.npy
-//4. save_npy_gvx : gvx ->grad_vx.npy
-//5. save_npy_e : energy
-//6. save_npy_f : force
-//7. save_npy_s : stress
-//8. save_npy_o: orbital
-//9. save_npy_orbital_precalc: orbital_precalc -> orbital_precalc.npy
+    // And 6 which prints quantities in .npy format
+    // 3. save_npy_d : descriptor ->dm_eig.npy
+    // 4. save_npy_gvx : gvx ->grad_vx.npy
+    // 5. save_npy_e : energy
+    // 6. save_npy_f : force
+    // 7. save_npy_s : stress
+    // 8. save_npy_o: orbital
+    // 9. save_npy_orbital_precalc: orbital_precalc -> orbital_precalc.npy
 
-public:
-  
-    ///print density matrices
-    //void print_dm(const ModuleBase::matrix &dm);
-    void print_dm(const std::vector<double> &dm);
-    //void print_dm_k(const int nks, const std::vector<ModuleBase::ComplexMatrix>& dm);
+  public:
+    /// print density matrices
+    // void print_dm(const ModuleBase::matrix &dm);
+    void print_dm(const std::vector<double>& dm);
+    // void print_dm_k(const int nks, const std::vector<ModuleBase::ComplexMatrix>& dm);
     void print_dm_k(const int nks, const std::vector<std::vector<std::complex<double>>>& dm);
 
-	///----------------------------------------------------------------------
-	///The following 4 functions save the `[dm_eig], [e_base], [f_base], [grad_vx]`
-	///of current configuration as `.npy` file, when `deepks_scf = 1`.
-	///After a full group of consfigurations are calculated,
-    ///we need a python script to `load` and `torch.cat` these `.npy` files,
-    ///and get `l_e_delta,npy` and `l_f_delta.npy` corresponding to the exact E, F data.
-    /// 
+    ///----------------------------------------------------------------------
+    /// The following 4 functions save the `[dm_eig], [e_base], [f_base], [grad_vx]`
+    /// of current configuration as `.npy` file, when `deepks_scf = 1`.
+    /// After a full group of consfigurations are calculated,
+    /// we need a python script to `load` and `torch.cat` these `.npy` files,
+    /// and get `l_e_delta,npy` and `l_f_delta.npy` corresponding to the exact E, F data.
+    ///
     /// Unit of energy: Ry
     ///
     /// Unit of force: Ry/Bohr
     ///----------------------------------------------------------------------
-	void save_npy_d(const int nat);
-	void save_npy_e(const double &e/**<[in] \f$E_{base}\f$ or \f$E_{tot}\f$, in Ry*/,const std::string &e_file);
-	void save_npy_f(const ModuleBase::matrix &fbase/**<[in] \f$F_{base}\f$ or \f$F_{tot}\f$, in Ry/Bohr*/,
-        const std::string &f_file, const int nat);
+    void save_npy_d(const int nat);
+    void save_npy_e(const double& e /**<[in] \f$E_{base}\f$ or \f$E_{tot}\f$, in Ry*/, const std::string& e_file);
+    void save_npy_f(const ModuleBase::matrix& fbase /**<[in] \f$F_{base}\f$ or \f$F_{tot}\f$, in Ry/Bohr*/,
+                    const std::string& f_file,
+                    const int nat);
 
-    void save_npy_s(const ModuleBase::matrix &sbase/**<[in] \f$S_{base}\f$ or \f$S_{tot}\f$, in Ry/Bohr^3*/,
-        const std::string &s_file, const double omega);
+    void save_npy_s(const ModuleBase::matrix& sbase /**<[in] \f$S_{base}\f$ or \f$S_{tot}\f$, in Ry/Bohr^3*/,
+                    const std::string& s_file,
+                    const double omega);
     void save_npy_gvx(const int nat);
     void save_npy_gvepsl(const int nat);
 
-    //QO added on 2021-12-15
-    void save_npy_o(const ModuleBase::matrix &bandgap/**<[in] \f$E_{base}\f$ or \f$E_{tot}\f$, in Ry*/, const std::string &o_file, const int nks);
+    // QO added on 2021-12-15
+    void save_npy_o(const ModuleBase::matrix& bandgap /**<[in] \f$E_{base}\f$ or \f$E_{tot}\f$, in Ry*/,
+                    const std::string& o_file,
+                    const int nks);
     void save_npy_orbital_precalc(const int nat, const int nks);
 
     void load_npy_gedm(const int nat);
 
-//-------------------
-// LCAO_deepks_mpi.cpp
-//-------------------
+    //-------------------
+    // LCAO_deepks_mpi.cpp
+    //-------------------
 
-//This file contains only one subroutine, allsum_deepks
-//which is used to perform allsum on a two-level pointer
-//It is used in a few places in the deepks code
+    // This file contains only one subroutine, allsum_deepks
+    // which is used to perform allsum on a two-level pointer
+    // It is used in a few places in the deepks code
 
 #ifdef __MPI
 
-public:
-    //reduces a dim 2 array
-    void allsum_deepks(
-        int inlmax, //first dimension
-        int ndim, //second dimension
-        double** mat); //the array being reduced 
+  public:
+    // reduces a dim 2 array
+    void allsum_deepks(int inlmax,    // first dimension
+                       int ndim,      // second dimension
+                       double** mat); // the array being reduced
 #endif
-
 };
 
 namespace GlobalC
 {
-    extern LCAO_Deepks ld;
+extern LCAO_Deepks ld;
 }
 
 #endif

--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks.h
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks.h
@@ -13,9 +13,8 @@
 #include "module_elecstate/module_dm/density_matrix.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h"
 #include "module_io/winput.h"
-#include "torch/csrc/api/include/torch/linalg.h"
-#include "torch/csrc/autograd/autograd.h"
-#include "torch/script.h"
+#include <torch/torch.h>
+#include <torch/script.h>
 
 #include <unordered_map>
 

--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks.h
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks.h
@@ -5,7 +5,7 @@
 
 #include "module_base/intarray.h"
 #include "module_base/complexmatrix.h"
-#include "module_basis/module_ao/ORB_gen_tables.h"
+#include "module_basis/module_nao/two_center_integrator.h"
 #include <unordered_map>
 
 #include "torch/script.h"
@@ -247,13 +247,12 @@ public:
         const UnitCell &ucell,
         const LCAO_Orbitals &orb,
         Grid_Driver& GridD,
-        const ORB_gen_tables &UOT);
+        const TwoCenterIntegrator& overlap_orb_alpha);
 
     void check_psialpha(const bool& cal_deri/**< [in] 0 for 2-center intergration, 1 for its derivation*/,
         const UnitCell &ucell,
         const LCAO_Orbitals &orb,
-        Grid_Driver& GridD,
-        const ORB_gen_tables &UOT);
+        Grid_Driver& GridD);
 
 //-------------------
 // LCAO_deepks_pdm.cpp

--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks.h
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks.h
@@ -13,9 +13,9 @@
 #include "module_elecstate/module_dm/density_matrix.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h"
 #include "module_io/winput.h"
-#include <torch/torch.h>
-#include <torch/script.h>
 
+#include <torch/script.h>
+#include <torch/torch.h>
 #include <unordered_map>
 
 ///

--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks_psialpha.cpp
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks_psialpha.cpp
@@ -16,7 +16,7 @@ void LCAO_Deepks::build_psialpha(const bool& calc_deri,
                                  const UnitCell& ucell,
                                  const LCAO_Orbitals& orb,
                                  Grid_Driver& GridD,
-                                 const ORB_gen_tables& UOT)
+                                 const TwoCenterIntegrator& overlap_orb_alpha)
 {
     ModuleBase::TITLE("LCAO_Deepks", "build_psialpha");
     ModuleBase::timer::tick("LCAO_Deepks", "build_psialpha");
@@ -99,8 +99,7 @@ void LCAO_Deepks::build_psialpha(const bool& calc_deri,
                     int M1 = (m1 % 2 == 0) ? -m1 / 2 : (m1 + 1) / 2;
 
                     ModuleBase::Vector3<double> dtau = ucell.atoms[T0].tau[I0] - tau1;
-                    UOT.two_center_bundle->overlap_orb_alpha
-                        ->snap(T1, L1, N1, M1, 0, dtau * ucell.lat0, calc_deri, nlm);
+                    overlap_orb_alpha.snap(T1, L1, N1, M1, 0, dtau * ucell.lat0, calc_deri, nlm);
 
                     if (GlobalV::GAMMA_ONLY_LOCAL)
                     {
@@ -133,8 +132,7 @@ void LCAO_Deepks::build_psialpha(const bool& calc_deri,
 void LCAO_Deepks::check_psialpha(const bool& calc_deri,
                                  const UnitCell& ucell,
                                  const LCAO_Orbitals& orb,
-                                 Grid_Driver& GridD,
-                                 const ORB_gen_tables& UOT)
+                                 Grid_Driver& GridD)
 {
     ModuleBase::TITLE("LCAO_Deepks", "check_psialpha");
     ModuleBase::timer::tick("LCAO_Deepks", "check_psialpha");

--- a/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test.cpp
+++ b/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test.cpp
@@ -14,8 +14,8 @@ test_deepks::~test_deepks()
 
 void test_deepks::check_dstable(void)
 {
-	OGT.talpha.print_Table_DSR(ORB);
-	this->compare_with_ref("S_I_mu_alpha.dat","S_I_mu_alpha_ref.dat");
+	//OGT.talpha.print_Table_DSR(ORB);
+	//this->compare_with_ref("S_I_mu_alpha.dat","S_I_mu_alpha_ref.dat");
 }
 
 void test_deepks::check_psialpha(void)
@@ -36,13 +36,13 @@ void test_deepks::check_psialpha(void)
 		ucell,
 		ORB,
         Test_Deepks::GridD,
-		OGT);
+		overlap_orb_alpha_);
 
 	ld.check_psialpha(GlobalV::CAL_FORCE,
 		ucell,
 		ORB,
-        Test_Deepks::GridD,
-		OGT);
+        Test_Deepks::GridD);
+
 	this->compare_with_ref("psialpha.dat","psialpha_ref.dat");
 	this->compare_with_ref("dpsialpha_x.dat","dpsialpha_x_ref.dat");
 	this->compare_with_ref("dpsialpha_y.dat","dpsialpha_y_ref.dat");

--- a/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test.cpp
+++ b/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test.cpp
@@ -2,51 +2,41 @@
 
 namespace Test_Deepks
 {
-	Grid_Driver GridD(GlobalV::test_deconstructor,GlobalV::test_grid_driver,GlobalV::test_grid);
+Grid_Driver GridD(GlobalV::test_deconstructor, GlobalV::test_grid_driver, GlobalV::test_grid);
 }
 
 test_deepks::test_deepks()
-{}
+{
+}
 
 test_deepks::~test_deepks()
-{}
-
+{
+}
 
 void test_deepks::check_dstable(void)
 {
-	//OGT.talpha.print_Table_DSR(ORB);
-	//this->compare_with_ref("S_I_mu_alpha.dat","S_I_mu_alpha_ref.dat");
+    // OGT.talpha.print_Table_DSR(ORB);
+    // this->compare_with_ref("S_I_mu_alpha.dat","S_I_mu_alpha_ref.dat");
 }
 
 void test_deepks::check_psialpha(void)
 {
-	std::vector<int> na;
-	na.resize(ucell.ntype);
-	for(int it=0;it<ucell.ntype;it++)
-	{
-		na[it] = ucell.atoms[it].na;
-	}
-	ld.init(ORB,
-		ucell.nat,
-        ucell.ntype,
-        ParaO,
-        na);
+    std::vector<int> na;
+    na.resize(ucell.ntype);
+    for (int it = 0; it < ucell.ntype; it++)
+    {
+        na[it] = ucell.atoms[it].na;
+    }
+    ld.init(ORB, ucell.nat, ucell.ntype, ParaO, na);
 
-	ld.build_psialpha(GlobalV::CAL_FORCE,
-		ucell,
-		ORB,
-        Test_Deepks::GridD,
-		overlap_orb_alpha_);
+    ld.build_psialpha(GlobalV::CAL_FORCE, ucell, ORB, Test_Deepks::GridD, overlap_orb_alpha_);
 
-	ld.check_psialpha(GlobalV::CAL_FORCE,
-		ucell,
-		ORB,
-        Test_Deepks::GridD);
+    ld.check_psialpha(GlobalV::CAL_FORCE, ucell, ORB, Test_Deepks::GridD);
 
-	this->compare_with_ref("psialpha.dat","psialpha_ref.dat");
-	this->compare_with_ref("dpsialpha_x.dat","dpsialpha_x_ref.dat");
-	this->compare_with_ref("dpsialpha_y.dat","dpsialpha_y_ref.dat");
-	this->compare_with_ref("dpsialpha_z.dat","dpsialpha_z_ref.dat");	
+    this->compare_with_ref("psialpha.dat", "psialpha_ref.dat");
+    this->compare_with_ref("dpsialpha_x.dat", "dpsialpha_x_ref.dat");
+    this->compare_with_ref("dpsialpha_y.dat", "dpsialpha_y_ref.dat");
+    this->compare_with_ref("dpsialpha_z.dat", "dpsialpha_z_ref.dat");
 }
 
 void test_deepks::read_dm(void)
@@ -55,270 +45,242 @@ void test_deepks::read_dm(void)
     dm.resize(1);
     dm[0].create(GlobalV::NLOCAL, GlobalV::NLOCAL);
 
-	for (int mu=0;mu<GlobalV::NLOCAL;mu++)
-	{
-		for (int nu=0;nu<GlobalV::NLOCAL;nu++)
-		{
-			double c;
-			ifs >> c;
-			dm[0](mu,nu)=c;
-		}
-	}
+    for (int mu = 0; mu < GlobalV::NLOCAL; mu++)
+    {
+        for (int nu = 0; nu < GlobalV::NLOCAL; nu++)
+        {
+            double c;
+            ifs >> c;
+            dm[0](mu, nu) = c;
+        }
+    }
 }
 
 void test_deepks::read_dm_k(const int nks)
 {
-	dm_k.resize(nks);
-	std::stringstream ss;
-	for(int ik=0;ik<nks;ik++)
-	{
+    dm_k.resize(nks);
+    std::stringstream ss;
+    for (int ik = 0; ik < nks; ik++)
+    {
         ss.str("");
-        ss<<"dm_"<<ik;
+        ss << "dm_" << ik;
         std::ifstream ifs(ss.str().c_str());
-		dm_k[ik].create(GlobalV::NLOCAL,GlobalV::NLOCAL);
+        dm_k[ik].create(GlobalV::NLOCAL, GlobalV::NLOCAL);
 
-		for (int mu=0;mu<GlobalV::NLOCAL;mu++)
-		{
-			for (int nu=0;nu<GlobalV::NLOCAL;nu++)
-			{
-				std::complex<double> c;
-				ifs >> c;
-				dm_k[ik](mu,nu)=c;
-			}
-		}
-	}
+        for (int mu = 0; mu < GlobalV::NLOCAL; mu++)
+        {
+            for (int nu = 0; nu < GlobalV::NLOCAL; nu++)
+            {
+                std::complex<double> c;
+                ifs >> c;
+                dm_k[ik](mu, nu) = c;
+            }
+        }
+    }
 }
 
 void test_deepks::set_dm_new(void)
 {
-	// dm_gamma
-	dm_new.resize(dm.size());
-	for(int i = 0; i < dm.size(); i++)
-	{
-		dm_new[i].resize(dm[i].nr * dm[i].nc);
-		dm_new[i].assign(dm[i].c, dm[i].c + dm[i].nr * dm[i].nc);
-	}
+    // dm_gamma
+    dm_new.resize(dm.size());
+    for (int i = 0; i < dm.size(); i++)
+    {
+        dm_new[i].resize(dm[i].nr * dm[i].nc);
+        dm_new[i].assign(dm[i].c, dm[i].c + dm[i].nr * dm[i].nc);
+    }
 }
 
 void test_deepks::set_dm_k_new(void)
 {
-	// dm_k
-	dm_k_new.resize(dm_k.size());
-	for(int i = 0; i < dm_k.size(); i++)
-	{
-		dm_k_new[i].resize(dm_k[i].nr * dm_k[i].nc);
-		dm_k_new[i].assign(dm_k[i].c, dm_k[i].c + dm_k[i].nr * dm_k[i].nc);
-	}
+    // dm_k
+    dm_k_new.resize(dm_k.size());
+    for (int i = 0; i < dm_k.size(); i++)
+    {
+        dm_k_new[i].resize(dm_k[i].nr * dm_k[i].nc);
+        dm_k_new[i].assign(dm_k[i].c, dm_k[i].c + dm_k[i].nr * dm_k[i].nc);
+    }
 }
 
 void test_deepks::check_pdm(void)
 {
-	if(GlobalV::GAMMA_ONLY_LOCAL)
-	{
-		this->read_dm();
-		this->set_dm_new();
-		this->ld.cal_projected_DM(dm_new,
-			ucell,
-			ORB,
-            Test_Deepks::GridD);
-	}
-	else
-	{
-		this->read_dm_k(kv.get_nkstot());
-		this->set_dm_k_new();
-		this->ld.cal_projected_DM_k(dm_k_new,
-			ucell,
-			ORB,
-            Test_Deepks::GridD);		
-	}
-	this->ld.check_projected_dm();
-	this->compare_with_ref("pdm.dat","pdm_ref.dat");
+    if (GlobalV::GAMMA_ONLY_LOCAL)
+    {
+        this->read_dm();
+        this->set_dm_new();
+        this->ld.cal_projected_DM(dm_new, ucell, ORB, Test_Deepks::GridD);
+    }
+    else
+    {
+        this->read_dm_k(kv.get_nkstot());
+        this->set_dm_k_new();
+        this->ld.cal_projected_DM_k(dm_k_new, ucell, ORB, Test_Deepks::GridD);
+    }
+    this->ld.check_projected_dm();
+    this->compare_with_ref("pdm.dat", "pdm_ref.dat");
 }
 
 void test_deepks::check_gdmx(void)
 {
-	this->ld.init_gdmx(ucell.nat);
-	if(GlobalV::GAMMA_ONLY_LOCAL)
-	{
-		this->ld.cal_gdmx(dm_new[0],
-			ucell,
-			ORB,
-            Test_Deepks::GridD,
-			0);
-	}
-	else
-	{
-		this->ld.cal_gdmx_k(dm_k_new,
-			ucell,
-			ORB,
-            Test_Deepks::GridD,
-			kv.get_nkstot(),
-			kv.kvec_d,
-			0);			
-	}
-	this->ld.check_gdmx(ucell.nat);
+    this->ld.init_gdmx(ucell.nat);
+    if (GlobalV::GAMMA_ONLY_LOCAL)
+    {
+        this->ld.cal_gdmx(dm_new[0], ucell, ORB, Test_Deepks::GridD, 0);
+    }
+    else
+    {
+        this->ld.cal_gdmx_k(dm_k_new, ucell, ORB, Test_Deepks::GridD, kv.get_nkstot(), kv.kvec_d, 0);
+    }
+    this->ld.check_gdmx(ucell.nat);
 
-	for(int ia=0;ia<ucell.nat;ia++)
-	{
-		std::stringstream ss;
-		std::stringstream ss1;
-		ss.str("");
-        ss<<"gdmx_"<<ia<<".dat";
-		ss1.str("");
-        ss1<<"gdmx_"<<ia<<"_ref.dat";
-		
-		this->compare_with_ref(ss.str(),ss1.str());
-
+    for (int ia = 0; ia < ucell.nat; ia++)
+    {
+        std::stringstream ss;
+        std::stringstream ss1;
         ss.str("");
-        ss<<"gdmy_"<<ia<<".dat";
-		ss1.str("");
-        ss1<<"gdmy_"<<ia<<"_ref.dat";
-		this->compare_with_ref(ss.str(),ss1.str());
-
-        ss.str("");
-        ss<<"gdmz_"<<ia<<".dat";
+        ss << "gdmx_" << ia << ".dat";
         ss1.str("");
-        ss1<<"gdmz_"<<ia<<"_ref.dat";
-		this->compare_with_ref(ss.str(),ss1.str());
-	}	
+        ss1 << "gdmx_" << ia << "_ref.dat";
+
+        this->compare_with_ref(ss.str(), ss1.str());
+
+        ss.str("");
+        ss << "gdmy_" << ia << ".dat";
+        ss1.str("");
+        ss1 << "gdmy_" << ia << "_ref.dat";
+        this->compare_with_ref(ss.str(), ss1.str());
+
+        ss.str("");
+        ss << "gdmz_" << ia << ".dat";
+        ss1.str("");
+        ss1 << "gdmz_" << ia << "_ref.dat";
+        this->compare_with_ref(ss.str(), ss1.str());
+    }
 }
 
 void test_deepks::check_descriptor(void)
 {
-	this->ld.cal_descriptor(ucell.nat);
-	this->ld.check_descriptor(ucell);
-	this->compare_with_ref("descriptor.dat","descriptor_ref.dat");
+    this->ld.cal_descriptor(ucell.nat);
+    this->ld.check_descriptor(ucell);
+    this->compare_with_ref("descriptor.dat", "descriptor_ref.dat");
 }
 
 void test_deepks::check_gvx(void)
 {
-	this->ld.cal_gvx(ucell.nat);
-	this->ld.check_gvx(ucell.nat);
+    this->ld.cal_gvx(ucell.nat);
+    this->ld.check_gvx(ucell.nat);
 
-	for(int ia=0;ia<ucell.nat;ia++)
-	{
-		std::stringstream ss;
-		std::stringstream ss1;
-		ss.str("");
-        ss<<"gvx_"<<ia<<".dat";
-		ss1.str("");
-        ss1<<"gvx_"<<ia<<"_ref.dat";
-		this->compare_with_ref(ss.str(),ss1.str());
-
+    for (int ia = 0; ia < ucell.nat; ia++)
+    {
+        std::stringstream ss;
+        std::stringstream ss1;
         ss.str("");
-        ss<<"gvy_"<<ia<<".dat";
-		ss1.str("");
-        ss1<<"gvy_"<<ia<<"_ref.dat";
-		this->compare_with_ref(ss.str(),ss1.str());
-
-        ss.str("");
-        ss<<"gvz_"<<ia<<".dat";
+        ss << "gvx_" << ia << ".dat";
         ss1.str("");
-        ss1<<"gvz_"<<ia<<"_ref.dat";
-		this->compare_with_ref(ss.str(),ss1.str());
-	}
+        ss1 << "gvx_" << ia << "_ref.dat";
+        this->compare_with_ref(ss.str(), ss1.str());
+
+        ss.str("");
+        ss << "gvy_" << ia << ".dat";
+        ss1.str("");
+        ss1 << "gvy_" << ia << "_ref.dat";
+        this->compare_with_ref(ss.str(), ss1.str());
+
+        ss.str("");
+        ss << "gvz_" << ia << ".dat";
+        ss1.str("");
+        ss1 << "gvz_" << ia << "_ref.dat";
+        this->compare_with_ref(ss.str(), ss1.str());
+    }
 }
 
 void test_deepks::check_edelta(void)
 {
-	this->ld.load_model("model.ptg");
-	if(GlobalV::GAMMA_ONLY_LOCAL)
-	{
+    this->ld.load_model("model.ptg");
+    if (GlobalV::GAMMA_ONLY_LOCAL)
+    {
         this->ld.allocate_V_delta(ucell.nat);
-	}
-	else
-	{
+    }
+    else
+    {
         this->ld.allocate_V_delta(ucell.nat, kv.get_nkstot());
-	}
-	this->ld.cal_gedm(ucell.nat);
+    }
+    this->ld.cal_gedm(ucell.nat);
 
-	std::ofstream ofs("E_delta.dat");
-	ofs << std::setprecision(10) << this->ld.E_delta << std::endl;
-	ofs.close();
-	this->compare_with_ref("E_delta.dat","E_delta_ref.dat");
-	
-	this->ld.check_gedm();
-	this->compare_with_ref("gedm.dat","gedm_ref.dat");
+    std::ofstream ofs("E_delta.dat");
+    ofs << std::setprecision(10) << this->ld.E_delta << std::endl;
+    ofs.close();
+    this->compare_with_ref("E_delta.dat", "E_delta_ref.dat");
+
+    this->ld.check_gedm();
+    this->compare_with_ref("gedm.dat", "gedm_ref.dat");
 }
 
 void test_deepks::check_e_deltabands(void)
 {
-	if(GlobalV::GAMMA_ONLY_LOCAL)
-	{
+    if (GlobalV::GAMMA_ONLY_LOCAL)
+    {
         this->ld.cal_e_delta_band(dm_new);
-	}
-	else
-	{
-		this->folding_nnr(kv);
+    }
+    else
+    {
+        this->folding_nnr(kv);
         this->ld.cal_e_delta_band_k(dm_k_new, kv.get_nkstot());
-	}
+    }
 
-	std::ofstream ofs("E_delta_bands.dat");
-	ofs << std::setprecision(10) << this->ld.e_delta_band << std::endl;
-	ofs.close();
-	this->compare_with_ref("E_delta_bands.dat","E_delta_bands_ref.dat");
+    std::ofstream ofs("E_delta_bands.dat");
+    ofs << std::setprecision(10) << this->ld.e_delta_band << std::endl;
+    ofs.close();
+    this->compare_with_ref("E_delta_bands.dat", "E_delta_bands_ref.dat");
 }
 
 void test_deepks::check_f_delta()
 {
-	ModuleBase::matrix svnl_dalpha;
-	svnl_dalpha.create(3,3);
-	if(GlobalV::GAMMA_ONLY_LOCAL)
-	{
-		ld.cal_f_delta_gamma(dm_new,
-            ucell,
-            ORB,
-            Test_Deepks::GridD,
-            1, svnl_dalpha);
-	}
-	else
-	{
-		ld.cal_f_delta_k(dm_k_new,
-			ucell,
-            ORB,
-            Test_Deepks::GridD,
-			kv.get_nkstot(),
-			kv.kvec_d,
-			1,svnl_dalpha);
-	}
-	ld.check_f_delta(ucell.nat, svnl_dalpha);
+    ModuleBase::matrix svnl_dalpha;
+    svnl_dalpha.create(3, 3);
+    if (GlobalV::GAMMA_ONLY_LOCAL)
+    {
+        ld.cal_f_delta_gamma(dm_new, ucell, ORB, Test_Deepks::GridD, 1, svnl_dalpha);
+    }
+    else
+    {
+        ld.cal_f_delta_k(dm_k_new, ucell, ORB, Test_Deepks::GridD, kv.get_nkstot(), kv.kvec_d, 1, svnl_dalpha);
+    }
+    ld.check_f_delta(ucell.nat, svnl_dalpha);
 
-	this->compare_with_ref("F_delta.dat","F_delta_ref.dat");
+    this->compare_with_ref("F_delta.dat", "F_delta_ref.dat");
 }
 
-void test_deepks::compare_with_ref(
-	const std::string f1,
-	const std::string f2)
+void test_deepks::compare_with_ref(const std::string f1, const std::string f2)
 {
-	this->total_check+=1;
-	std::ifstream file1(f1.c_str());
-	std::ifstream file2(f2.c_str());
-	double test_thr=1e-8;
+    this->total_check += 1;
+    std::ifstream file1(f1.c_str());
+    std::ifstream file2(f2.c_str());
+    double test_thr = 1e-8;
 
-	std::string word1;
-	std::string word2;
-	while(file1 >> word1)
-	{
-		file2 >> word2;
-		if((word1[0]-'0'>=0 && word1[0]-'0'<10)||word1[0]=='-')
-		{
-			double num1 = std::stof(word1);
-			double num2 = std::stof(word2);
-			if(std::abs(num1-num2)>test_thr)
-			{
-				this->failed_check+=1;
-				std::cout << "\e[1;31m [  FAILED  ] \e[0m" << f1.c_str() << " inconsistent!" << std::endl;
-				return;
-			}			
-		}
-		else
-		{
-			if(word1!=word2)
-			{
-				this->failed_check+=1;
-				return;
-			}
-		}
-	}
-	return;
+    std::string word1;
+    std::string word2;
+    while (file1 >> word1)
+    {
+        file2 >> word2;
+        if ((word1[0] - '0' >= 0 && word1[0] - '0' < 10) || word1[0] == '-')
+        {
+            double num1 = std::stof(word1);
+            double num2 = std::stof(word2);
+            if (std::abs(num1 - num2) > test_thr)
+            {
+                this->failed_check += 1;
+                std::cout << "\e[1;31m [  FAILED  ] \e[0m" << f1.c_str() << " inconsistent!" << std::endl;
+                return;
+            }
+        }
+        else
+        {
+            if (word1 != word2)
+            {
+                this->failed_check += 1;
+                return;
+            }
+        }
+    }
+    return;
 }

--- a/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test.h
+++ b/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test.h
@@ -31,8 +31,11 @@ public:
     ~test_deepks();
 
 	LCAO_Orbitals ORB;
-	ORB_gen_tables OGT;
 	ORB_control ooo;
+
+    RadialCollection orb_;
+    RadialCollection alpha_;
+    TwoCenterIntegrator overlap_orb_alpha_;
 
 	UnitCell ucell;
 

--- a/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test.h
+++ b/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test.h
@@ -1,14 +1,11 @@
-#include "module_base/global_variable.h"
-#include "module_base/global_function.h"
-
-#include "module_basis/module_ao/ORB_control.h"	
-#include "module_basis/module_ao/ORB_read.h"
-
-#include "module_cell/unitcell.h"
-
-#include "module_cell/module_neighbor/sltk_grid_driver.h"
-#include "module_cell/module_neighbor/sltk_atom_arrange.h"
 #include "klist.h"
+#include "module_base/global_function.h"
+#include "module_base/global_variable.h"
+#include "module_basis/module_ao/ORB_control.h"
+#include "module_basis/module_ao/ORB_read.h"
+#include "module_cell/module_neighbor/sltk_atom_arrange.h"
+#include "module_cell/module_neighbor/sltk_grid_driver.h"
+#include "module_cell/unitcell.h"
 //#include "parallel_orbitals.h"
 
 #include "../LCAO_deepks.h"
@@ -20,90 +17,88 @@
 
 namespace Test_Deepks
 {
-    extern Grid_Driver GridD;
+extern Grid_Driver GridD;
 }
 
 class test_deepks
 {
 
-public:
+  public:
     test_deepks();
     ~test_deepks();
 
-	LCAO_Orbitals ORB;
-	ORB_control ooo;
+    LCAO_Orbitals ORB;
+    ORB_control ooo;
 
     RadialCollection orb_;
     RadialCollection alpha_;
     TwoCenterIntegrator overlap_orb_alpha_;
 
-	UnitCell ucell;
+    UnitCell ucell;
 
     Parallel_Orbitals ParaO;
-	Test_Deepks::K_Vectors kv;
-	LCAO_Deepks ld;
+    Test_Deepks::K_Vectors kv;
+    LCAO_Deepks ld;
 
-	int failed_check = 0;
-	int total_check = 0;
+    int failed_check = 0;
+    int total_check = 0;
 
-	int my_rank = 0;
+    int my_rank = 0;
 
-	double lcao_ecut = 0; // (Ry)
-	double lcao_dk = 0.01;
-	double lcao_dr = 0.01;
-	double lcao_rmax = 30; // (a.u.)
+    double lcao_ecut = 0; // (Ry)
+    double lcao_dk = 0.01;
+    double lcao_dr = 0.01;
+    double lcao_rmax = 30; // (a.u.)
 
-	int out_mat_r = 0;
+    int out_mat_r = 0;
 
-	int lmax=2;
-	int ntype=0;
-	int nnr;
+    int lmax = 2;
+    int ntype = 0;
+    int nnr;
 
-	std::vector<ModuleBase::matrix> dm;
-	std::vector<ModuleBase::ComplexMatrix> dm_k;
+    std::vector<ModuleBase::matrix> dm;
+    std::vector<ModuleBase::ComplexMatrix> dm_k;
 
-	std::vector<std::vector<double>> dm_new;
-	std::vector<std::vector<std::complex<double>>> dm_k_new;
+    std::vector<std::vector<double>> dm_new;
+    std::vector<std::vector<std::complex<double>>> dm_k_new;
 
-//preparation
-	void preparation();
-	void set_parameters();//set some global variables
-	void setup_cell();
+    // preparation
+    void preparation();
+    void set_parameters(); // set some global variables
+    void setup_cell();
 
-	void count_ntype(); //from STRU, count types of elements
-	void set_ekcut();	//from LCAO files, read and set ekcut
+    void count_ntype(); // from STRU, count types of elements
+    void set_ekcut();   // from LCAO files, read and set ekcut
 
-	void prep_neighbour();
-	void setup_kpt();
-	void set_orbs(const double &lat0_in);
+    void prep_neighbour();
+    void setup_kpt();
+    void set_orbs(const double& lat0_in);
 
-	void cal_nnr();
-	void folding_nnr(const Test_Deepks::K_Vectors &kv);
+    void cal_nnr();
+    void folding_nnr(const Test_Deepks::K_Vectors& kv);
 
-// tranfer Matrix into vector<T>
-	void set_dm_new();
-	void set_dm_k_new();
+    // tranfer Matrix into vector<T>
+    void set_dm_new();
+    void set_dm_k_new();
 
-//checking
-	void check_dstable(void);
-	void check_psialpha(void);
+    // checking
+    void check_dstable(void);
+    void check_psialpha(void);
 
-	void read_dm(void);
-	void read_dm_k(const int nks);
+    void read_dm(void);
+    void read_dm_k(const int nks);
 
-	void check_pdm(void);
-	void check_gdmx(void);
+    void check_pdm(void);
+    void check_gdmx(void);
 
-	void check_descriptor(void);
-	void check_gvx(void);
+    void check_descriptor(void);
+    void check_gvx(void);
 
-	void check_edelta(void);
+    void check_edelta(void);
 
-	void check_e_deltabands(void);
-	void check_f_delta(void);
+    void check_e_deltabands(void);
+    void check_f_delta(void);
 
-	//compares numbers stored in two files
-	void compare_with_ref(
-		const std::string f1,
-		const std::string f2);
+    // compares numbers stored in two files
+    void compare_with_ref(const std::string f1, const std::string f2);
 };

--- a/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test_prep.cpp
+++ b/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test_prep.cpp
@@ -4,174 +4,170 @@
 void test_deepks::preparation()
 {
     this->count_ntype();
-	this->set_parameters();
+    this->set_parameters();
 
     this->setup_cell();
 
-	this->setup_kpt();
+    this->setup_kpt();
 
-	this->set_ekcut();
-	this->set_orbs(ucell.lat0);
-	this->prep_neighbour();
+    this->set_ekcut();
+    this->set_orbs(ucell.lat0);
+    this->prep_neighbour();
 
     this->ParaO.set_serial(GlobalV::NLOCAL, GlobalV::NLOCAL);
 }
 
 void test_deepks::set_parameters()
 {
-	GlobalV::BASIS_TYPE = "lcao";
-	// GlobalV::global_pseudo_type= "auto";
-	GlobalV::PSEUDORCUT = 15.0;
-	GlobalV::global_out_dir="./";
-	GlobalV::ofs_warning.open("warning.log");
-	GlobalV::ofs_running.open("running.log");
-	GlobalV::deepks_setorb=1;
-	GlobalV::CAL_FORCE=1;
-	
-	std::ifstream ifs("INPUT");
-	char word[80];
-	ifs >> word;
-	ifs >> GlobalV::GAMMA_ONLY_LOCAL;
-	ifs.close();
+    GlobalV::BASIS_TYPE = "lcao";
+    // GlobalV::global_pseudo_type= "auto";
+    GlobalV::PSEUDORCUT = 15.0;
+    GlobalV::global_out_dir = "./";
+    GlobalV::ofs_warning.open("warning.log");
+    GlobalV::ofs_running.open("running.log");
+    GlobalV::deepks_setorb = 1;
+    GlobalV::CAL_FORCE = 1;
 
-	ucell.latName = "none";
-	ucell.ntype = ntype;
-	return;
+    std::ifstream ifs("INPUT");
+    char word[80];
+    ifs >> word;
+    ifs >> GlobalV::GAMMA_ONLY_LOCAL;
+    ifs.close();
+
+    ucell.latName = "none";
+    ucell.ntype = ntype;
+    return;
 }
 
 void test_deepks::count_ntype()
 {
-	GlobalV::ofs_running << "count number of atom types" << std::endl;
-	std::ifstream ifs("STRU",std::ios::in);
+    GlobalV::ofs_running << "count number of atom types" << std::endl;
+    std::ifstream ifs("STRU", std::ios::in);
 
-	if (!ifs)
-	{
-		GlobalV::ofs_running << "ERROR : file STRU does not exist" <<std::endl;
-		exit(1);
-	}
+    if (!ifs)
+    {
+        GlobalV::ofs_running << "ERROR : file STRU does not exist" << std::endl;
+        exit(1);
+    }
 
-	ModuleBase::GlobalFunc::SCAN_BEGIN(ifs,"ATOMIC_SPECIES");	
-	
-	ntype = 0;
+    ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "ATOMIC_SPECIES");
 
-	std::string x;
-	ifs.rdstate();
-	while ( ifs.good() )
-	{
-//read a line
-		std::getline(ifs,x);
+    ntype = 0;
 
-//trim white space
-		const char* typeOfWhitespaces = " \t\n\r\f\v";
-		x.erase(x.find_last_not_of(typeOfWhitespaces) + 1);
-		x.erase(0,x.find_first_not_of(typeOfWhitespaces));
+    std::string x;
+    ifs.rdstate();
+    while (ifs.good())
+    {
+        // read a line
+        std::getline(ifs, x);
 
-		if(x=="LATTICE_CONSTANT" || x=="NUMERICAL_ORBITAL" 
-            || x=="LATTICE_VECTORS" || x=="ATOMIC_POSITIONS"
-            || x=="NUMERICAL_DESCRIPTOR") break;
+        // trim white space
+        const char* typeOfWhitespaces = " \t\n\r\f\v";
+        x.erase(x.find_last_not_of(typeOfWhitespaces) + 1);
+        x.erase(0, x.find_first_not_of(typeOfWhitespaces));
 
-		std::string tmpid=x.substr(0,1);
-		if(!x.empty() && tmpid!="#") ntype++;
-	}
+        if (x == "LATTICE_CONSTANT" || x == "NUMERICAL_ORBITAL" || x == "LATTICE_VECTORS" || x == "ATOMIC_POSITIONS"
+            || x == "NUMERICAL_DESCRIPTOR")
+            break;
 
-	GlobalV::ofs_running << "ntype : "<< ntype << std::endl;
-	ifs.close();
+        std::string tmpid = x.substr(0, 1);
+        if (!x.empty() && tmpid != "#")
+            ntype++;
+    }
 
-	return;
+    GlobalV::ofs_running << "ntype : " << ntype << std::endl;
+    ifs.close();
+
+    return;
 }
 
 void test_deepks::set_ekcut()
 {
-	GlobalV::ofs_running << "set lcao_ecut from LCAO files" << std::endl;
-	//set as max of ekcut from every element
+    GlobalV::ofs_running << "set lcao_ecut from LCAO files" << std::endl;
+    // set as max of ekcut from every element
 
-	lcao_ecut=0.0;
-	std::ifstream in_ao;
+    lcao_ecut = 0.0;
+    std::ifstream in_ao;
 
-	for(int it=0;it<ntype;it++)
-	{
-		double ek_current;
+    for (int it = 0; it < ntype; it++)
+    {
+        double ek_current;
 
-		in_ao.open(ucell.orbital_fn[it].c_str());
-		if(!in_ao)
-		{
-			GlobalV::ofs_running << "error : cannot find LCAO file : " << ucell.orbital_fn[it] << std::endl;
-		}
+        in_ao.open(ucell.orbital_fn[it].c_str());
+        if (!in_ao)
+        {
+            GlobalV::ofs_running << "error : cannot find LCAO file : " << ucell.orbital_fn[it] << std::endl;
+        }
 
-		std::string word;
-		while (in_ao.good())
-		{
-			in_ao >> word;
-			if(word == "Cutoff(Ry)") break;
-		}
-		in_ao >> ek_current;
-		lcao_ecut = std::max(lcao_ecut,ek_current);
+        std::string word;
+        while (in_ao.good())
+        {
+            in_ao >> word;
+            if (word == "Cutoff(Ry)")
+                break;
+        }
+        in_ao >> ek_current;
+        lcao_ecut = std::max(lcao_ecut, ek_current);
 
-		in_ao.close();
-	}
+        in_ao.close();
+    }
 
-	ORB.ecutwfc=lcao_ecut;
-	GlobalV::ofs_running << "lcao_ecut : " << lcao_ecut << std::endl;
-	
-	return;
+    ORB.ecutwfc = lcao_ecut;
+    GlobalV::ofs_running << "lcao_ecut : " << lcao_ecut << std::endl;
+
+    return;
 }
 
 void test_deepks::setup_cell()
 {
-	ucell.setup_cell("STRU", GlobalV::ofs_running);
+    ucell.setup_cell("STRU", GlobalV::ofs_running);
     ucell.read_pseudo(GlobalV::ofs_running);
 
-	return;
+    return;
 }
 
 void test_deepks::prep_neighbour()
 {
-    double search_radius = atom_arrange::set_sr_NL(
-        GlobalV::ofs_running,
-        GlobalV::OUT_LEVEL,
-        ORB.get_rcutmax_Phi(),
-		ucell.infoNL.get_rcutmax_Beta(),
-        GlobalV::GAMMA_ONLY_LOCAL);
+    double search_radius = atom_arrange::set_sr_NL(GlobalV::ofs_running,
+                                                   GlobalV::OUT_LEVEL,
+                                                   ORB.get_rcutmax_Phi(),
+                                                   ucell.infoNL.get_rcutmax_Beta(),
+                                                   GlobalV::GAMMA_ONLY_LOCAL);
 
-    atom_arrange::search(
-        GlobalV::SEARCH_PBC,
-        GlobalV::ofs_running,
-        Test_Deepks::GridD,
-        ucell,
-        search_radius,
-        GlobalV::test_atom_input);
+    atom_arrange::search(GlobalV::SEARCH_PBC,
+                         GlobalV::ofs_running,
+                         Test_Deepks::GridD,
+                         ucell,
+                         search_radius,
+                         GlobalV::test_atom_input);
 }
 
-void test_deepks::set_orbs(const double &lat0_in)
+void test_deepks::set_orbs(const double& lat0_in)
 {
-	for(int it=0;it<ntype;it++)
-	{
-		ooo.read_orb_first(
-			GlobalV::ofs_running,
-			ORB,
-			ucell.ntype,
-            GlobalV::global_orbital_dir,
-            ucell.orbital_fn,
-            ucell.descriptor_file,
-			ucell.lmax,
-			lcao_ecut,
-			lcao_dk,
-			lcao_dr,
-			lcao_rmax,
-			GlobalV::deepks_setorb,
-			out_mat_r,
-			GlobalV::CAL_FORCE,
-			my_rank);
-		
-		ucell.infoNL.setupNonlocal(
-			ucell.ntype,
-			ucell.atoms,
-			GlobalV::ofs_running,
-			ORB);
+    for (int it = 0; it < ntype; it++)
+    {
+        ooo.read_orb_first(GlobalV::ofs_running,
+                           ORB,
+                           ucell.ntype,
+                           GlobalV::global_orbital_dir,
+                           ucell.orbital_fn,
+                           ucell.descriptor_file,
+                           ucell.lmax,
+                           lcao_ecut,
+                           lcao_dk,
+                           lcao_dr,
+                           lcao_rmax,
+                           GlobalV::deepks_setorb,
+                           out_mat_r,
+                           GlobalV::CAL_FORCE,
+                           my_rank);
+
+        ucell.infoNL.setupNonlocal(ucell.ntype, ucell.atoms, GlobalV::ofs_running, ORB);
 
         std::vector<std::string> file_orb(ntype);
-        std::transform(ucell.orbital_fn, ucell.orbital_fn + ntype, file_orb.begin(),
-                [](const std::string& file) { return GlobalV::global_orbital_dir + file; });
+        std::transform(ucell.orbital_fn, ucell.orbital_fn + ntype, file_orb.begin(), [](const std::string& file) {
+            return GlobalV::global_orbital_dir + file;
+        });
         orb_.build(ntype, file_orb.data());
 
         std::string file_alpha = GlobalV::global_orbital_dir + ucell.descriptor_file;
@@ -184,18 +180,17 @@ void test_deepks::set_orbs(const double &lat0_in)
         GlobalV::ofs_running << "read and set from orbital_file : " << ORB.orbital_file[it] << std::endl;
         GlobalV::ofs_running << "ucell.ntype, ucell.lmax : " << ucell.ntype << " " << ucell.lmax << std::endl;
 #endif
-	}
-	return;
+    }
+    return;
 }
 
 void test_deepks::setup_kpt()
 {
-	this->kv.set(
-		"KPT",
-		GlobalV::NSPIN,
-		ucell.G,
-		ucell.latvec,
-		GlobalV::GAMMA_ONLY_LOCAL,
-		GlobalV::ofs_running,
-		GlobalV::ofs_warning);
+    this->kv.set("KPT",
+                 GlobalV::NSPIN,
+                 ucell.G,
+                 ucell.latvec,
+                 GlobalV::GAMMA_ONLY_LOCAL,
+                 GlobalV::ofs_running,
+                 GlobalV::ofs_warning);
 }

--- a/source/module_hamilt_lcao/module_deepks/test/Makefile.Objects
+++ b/source/module_hamilt_lcao/module_deepks/test/Makefile.Objects
@@ -68,8 +68,7 @@ ORB_nonlocal_lm.o\
 ORB_gaunt_table.o\
 ORB_table_beta.o\
 ORB_table_phi.o\
-ORB_table_alpha.o\
-ORB_gen_tables.o\
+ORB_table_alpha.o
 
 OBJS_NEIGHBOR=sltk_adjacent_set.o\
 sltk_atom_arrange.o\

--- a/source/module_hamilt_lcao/module_dftu/dftu.cpp
+++ b/source/module_hamilt_lcao/module_dftu/dftu.cpp
@@ -5,7 +5,6 @@
 #include "module_base/inverse_matrix.h"
 #include "module_base/memory.h"
 #include "module_base/timer.h"
-#include "module_basis/module_ao/ORB_gen_tables.h"
 #include "module_elecstate/module_charge/charge.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
 #include "module_elecstate/magnetism.h"

--- a/source/module_hamilt_lcao/module_dftu/dftu.cpp
+++ b/source/module_hamilt_lcao/module_dftu/dftu.cpp
@@ -4,25 +4,25 @@
 #include "module_base/global_function.h"
 #include "module_base/inverse_matrix.h"
 #include "module_base/memory.h"
-#include "module_base/timer.h"
-#include "module_elecstate/module_charge/charge.h"
-#include "module_hamilt_pw/hamilt_pwdft/global.h"
-#include "module_elecstate/magnetism.h"
-#include "module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h"
 #include "module_base/scalapack_connector.h"
+#include "module_base/timer.h"
+#include "module_elecstate/magnetism.h"
+#include "module_elecstate/module_charge/charge.h"
+#include "module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h"
+#include "module_hamilt_pw/hamilt_pwdft/global.h"
 
 #include <cmath>
 #include <complex>
+#include <cstdio>
+#include <cstring>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
-#include <stdio.h>
-#include <string.h>
 
 namespace GlobalC
 {
-	ModuleDFTU::DFTU dftu;
+ModuleDFTU::DFTU dftu;
 }
 
 namespace ModuleDFTU
@@ -50,9 +50,9 @@ void DFTU::init(UnitCell& cell, // unitcell class
 
     // needs reconstructions in future
     // global parameters, need to be removed in future
-    const int npol = GlobalV::NPOL; // number of polarization directions
+    const int npol = GlobalV::NPOL;     // number of polarization directions
     const int nlocal = GlobalV::NLOCAL; // number of total local orbitals
-    const int nspin = GlobalV::NSPIN; // number of spins
+    const int nspin = GlobalV::NSPIN;   // number of spins
 
     this->EU = 0.0;
 
@@ -221,20 +221,20 @@ void DFTU::cal_energy_correction(const int istep)
         const int LC = orbital_corr[T];
         for (int I = 0; I < GlobalC::ucell.atoms[T].na; I++)
         {
-			if (LC == -1)
-			{
-				continue;
-			}
+            if (LC == -1)
+            {
+                continue;
+            }
 
             const int iat = GlobalC::ucell.itia2iat(T, I);
             const int L = orbital_corr[T];
 
             for (int l = 0; l < NL; l++)
             {
-				if (l != orbital_corr[T])
-				{
-					continue;
-				}
+                if (l != orbital_corr[T])
+                {
+                    continue;
+                }
 
                 const int N = GlobalC::ucell.atoms[T].l_nchi[l];
 
@@ -243,10 +243,10 @@ void DFTU::cal_energy_correction(const int istep)
                 // part 1: calculate the DFT+U energy correction
                 for (int n = 0; n < N; n++)
                 {
-					if (n != 0)
-					{
-						continue;
-					}
+                    if (n != 0)
+                    {
+                        continue;
+                    }
 
                     if (GlobalV::NSPIN == 1 || GlobalV::NSPIN == 2)
                     {
@@ -264,15 +264,15 @@ void DFTU::cal_energy_correction(const int istep)
                                                  * this->locale[iat][l][n][spin](m1, m0);
                                 }
                             }
-							if (Yukawa)
-							{
-								this->EU += 0.5 * (this->U_Yukawa[T][l][n] - this->J_Yukawa[T][l][n])
-									* (nm_trace - nm2_trace);
-							}
-							else
-							{
-								this->EU += 0.5 * this->U[T] * (nm_trace - nm2_trace);
-							}
+                            if (Yukawa)
+                            {
+                                this->EU += 0.5 * (this->U_Yukawa[T][l][n] - this->J_Yukawa[T][l][n])
+                                            * (nm_trace - nm2_trace);
+                            }
+                            else
+                            {
+                                this->EU += 0.5 * this->U[T] * (nm_trace - nm2_trace);
+                            }
                         }
                     }
                     else if (GlobalV::NSPIN == 4) // SOC
@@ -299,15 +299,15 @@ void DFTU::cal_energy_correction(const int istep)
                                 }
                             }
                         }
-						if (Yukawa)
-						{
-							this->EU
-								+= 0.5 * (this->U_Yukawa[T][l][n] - this->J_Yukawa[T][l][n]) * (nm_trace - nm2_trace);
-						}
-						else
-						{
-							this->EU += 0.5 * this->U[T] * (nm_trace - nm2_trace);
-						}
+                        if (Yukawa)
+                        {
+                            this->EU
+                                += 0.5 * (this->U_Yukawa[T][l][n] - this->J_Yukawa[T][l][n]) * (nm_trace - nm2_trace);
+                        }
+                        else
+                        {
+                            this->EU += 0.5 * this->U[T] * (nm_trace - nm2_trace);
+                        }
                     }
 
                     // calculate the double counting term included in eband
@@ -327,14 +327,14 @@ void DFTU::cal_energy_correction(const int istep)
                                         for (int is = 0; is < 2; is++)
                                         {
                                             double VU = 0.0;
-                                            VU = get_onebody_eff_pot(T, iat, l, n, is, m1_all, m2_all, 0);
+                                            VU = get_onebody_eff_pot(T, iat, l, n, is, m1_all, m2_all, false);
                                             EU_dc += VU * this->locale[iat][l][n][is](m1_all, m2_all);
                                         }
                                     }
                                     else if (GlobalV::NSPIN == 4) // SOC
                                     {
                                         double VU = 0.0;
-                                        VU = get_onebody_eff_pot(T, iat, l, n, 0, m1_all, m2_all, 0);
+                                        VU = get_onebody_eff_pot(T, iat, l, n, 0, m1_all, m2_all, false);
                                         EU_dc += VU * this->locale[iat][l][n][0](m1_all, m2_all);
                                     }
                                 }
@@ -342,9 +342,9 @@ void DFTU::cal_energy_correction(const int istep)
                         }
                     }
                 } // end n
-            } // end L
-        } // end I
-    } // end T
+            }     // end L
+        }         // end I
+    }             // end T
 
     // substract the double counting EU_dc included in band energy eband
     this->EU -= EU_dc;
@@ -356,11 +356,12 @@ void DFTU::cal_energy_correction(const int istep)
 void DFTU::uramping_update()
 {
     // if uramping < 0.1, use the original U
-    if(this->uramping < 0.01) return;
+    if (this->uramping < 0.01)
+        return;
     // loop to change U
-    for(int i = 0; i < this->U0.size(); i++)
+    for (int i = 0; i < this->U0.size(); i++)
     {
-        if (this->U[i] + this->uramping < this->U0[i] ) 
+        if (this->U[i] + this->uramping < this->U0[i])
         {
             this->U[i] += this->uramping;
         }
@@ -373,9 +374,9 @@ void DFTU::uramping_update()
 
 bool DFTU::u_converged()
 {
-    for(int i = 0; i < this->U0.size(); i++)
+    for (int i = 0; i < this->U0.size(); i++)
     {
-        if (this->U[i] != this->U0[i]) 
+        if (this->U[i] != this->U0[i])
         {
             return false;
         }
@@ -397,13 +398,13 @@ void DFTU::set_dmr(const elecstate::DensityMatrix<double, double>* dmr)
 
 const hamilt::HContainer<double>* DFTU::get_dmr(int ispin) const
 {
-    if(this->dm_in_dftu_d != nullptr)
+    if (this->dm_in_dftu_d != nullptr)
     {
-        return this->dm_in_dftu_d->get_DMR_pointer(ispin+1);
+        return this->dm_in_dftu_d->get_DMR_pointer(ispin + 1);
     }
-    else if(this->dm_in_dftu_cd != nullptr)
+    else if (this->dm_in_dftu_cd != nullptr)
     {
-        return this->dm_in_dftu_cd->get_DMR_pointer(ispin+1);
+        return this->dm_in_dftu_cd->get_DMR_pointer(ispin + 1);
     }
     else
     {

--- a/source/module_hamilt_lcao/module_dftu/dftu_force.cpp
+++ b/source/module_hamilt_lcao/module_dftu/dftu_force.cpp
@@ -18,7 +18,6 @@
 #include "module_base/inverse_matrix.h"
 #include "module_base/parallel_reduce.h"
 #include "module_base/timer.h"
-#include "module_basis/module_ao/ORB_gen_tables.h"
 #include "module_elecstate/magnetism.h"
 #include "module_elecstate/module_charge/charge.h"
 #include "module_elecstate/elecstate_lcao.h"

--- a/source/module_hamilt_lcao/module_dftu/dftu_force.cpp
+++ b/source/module_hamilt_lcao/module_dftu/dftu_force.cpp
@@ -2,8 +2,17 @@
 // Author:Xin Qu
 // DATE : 2019-12-10
 //==========================================================
-#include <stdio.h>
-#include <string.h>
+#include "dftu.h"
+#include "module_base/constants.h"
+#include "module_base/global_function.h"
+#include "module_base/inverse_matrix.h"
+#include "module_base/parallel_reduce.h"
+#include "module_base/timer.h"
+#include "module_elecstate/elecstate_lcao.h"
+#include "module_elecstate/magnetism.h"
+#include "module_elecstate/module_charge/charge.h"
+#include "module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h"
+#include "module_hamilt_pw/hamilt_pwdft/global.h"
 
 #include <cmath>
 #include <complex>
@@ -11,40 +20,52 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
-
-#include "dftu.h"
-#include "module_base/constants.h"
-#include "module_base/global_function.h"
-#include "module_base/inverse_matrix.h"
-#include "module_base/parallel_reduce.h"
-#include "module_base/timer.h"
-#include "module_elecstate/magnetism.h"
-#include "module_elecstate/module_charge/charge.h"
-#include "module_elecstate/elecstate_lcao.h"
-#include "module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h"
-#include "module_hamilt_pw/hamilt_pwdft/global.h"
+#include <stdio.h>
+#include <string.h>
 
 extern "C"
 {
-  //I'm not sure what's happenig here, but the interface in scalapack_connecter.h
-  //does not seem to work, so I'll use this one here
-  void pzgemm_(
-		const char *transa, const char *transb,
-		const int *M, const int *N, const int *K,
-		const std::complex<double> *alpha,
-		const std::complex<double> *A, const int *IA, const int *JA, const int *DESCA,
-		const std::complex<double> *B, const int *IB, const int *JB, const int *DESCB,
-		const std::complex<double> *beta,
-		std::complex<double> *C, const int *IC, const int *JC, const int *DESCC);
-  
-  void pdgemm_(
-		const char *transa, const char *transb,
-		const int *M, const int *N, const int *K,
-		const double *alpha,
-		const double *A, const int *IA, const int *JA, const int *DESCA,
-		const double *B, const int *IB, const int *JB, const int *DESCB,
-		const double *beta,
-		double *C, const int *IC, const int *JC, const int *DESCC);
+    // I'm not sure what's happenig here, but the interface in scalapack_connecter.h
+    // does not seem to work, so I'll use this one here
+    void pzgemm_(const char* transa,
+                 const char* transb,
+                 const int* M,
+                 const int* N,
+                 const int* K,
+                 const std::complex<double>* alpha,
+                 const std::complex<double>* A,
+                 const int* IA,
+                 const int* JA,
+                 const int* DESCA,
+                 const std::complex<double>* B,
+                 const int* IB,
+                 const int* JB,
+                 const int* DESCB,
+                 const std::complex<double>* beta,
+                 std::complex<double>* C,
+                 const int* IC,
+                 const int* JC,
+                 const int* DESCC);
+
+    void pdgemm_(const char* transa,
+                 const char* transb,
+                 const int* M,
+                 const int* N,
+                 const int* K,
+                 const double* alpha,
+                 const double* A,
+                 const int* IA,
+                 const int* JA,
+                 const int* DESCA,
+                 const double* B,
+                 const int* IB,
+                 const int* JB,
+                 const int* DESCB,
+                 const double* beta,
+                 double* C,
+                 const int* IC,
+                 const int* JC,
+                 const int* DESCC);
 }
 
 namespace ModuleDFTU
@@ -60,7 +81,7 @@ void DFTU::force_stress(const elecstate::ElecState* pelec,
 {
     ModuleBase::TITLE("DFTU", "force_stress");
     ModuleBase::timer::tick("DFTU", "force_stress");
-  
+
     const int nlocal = GlobalV::NLOCAL;
 
     this->LM = &lm;
@@ -93,57 +114,50 @@ void DFTU::force_stress(const elecstate::ElecState* pelec,
 
             this->cal_VU_pot_mat_real(spin, false, VU);
 
-            const std::vector<std::vector<double>>& dmk = 
-                dynamic_cast<const elecstate::ElecStateLCAO<double>*> (pelec)->get_DM()->get_DMK_vector();
+            const std::vector<std::vector<double>>& dmk
+                = dynamic_cast<const elecstate::ElecStateLCAO<double>*>(pelec)->get_DM()->get_DMK_vector();
 
 #ifdef __MPI
-			pdgemm_(&transT, 
-					&transN,
-					&nlocal, 
-					&nlocal, 
-					&nlocal,
-					&alpha, 
-					dmk[spin].data(), 
-					&one_int, 
-					&one_int, 
-					pv.desc, 
-					VU, 
-					&one_int, 
-					&one_int, 
-					pv.desc,
+            pdgemm_(&transT,
+                    &transN,
+                    &nlocal,
+                    &nlocal,
+                    &nlocal,
+                    &alpha,
+                    dmk[spin].data(),
+                    &one_int,
+                    &one_int,
+                    pv.desc,
+                    VU,
+                    &one_int,
+                    &one_int,
+                    pv.desc,
                     &beta,
-					&rho_VU[0], 
-					&one_int, 
-					&one_int, 
-					pv.desc);
+                    &rho_VU[0],
+                    &one_int,
+                    &one_int,
+                    pv.desc);
 #endif
 
             delete[] VU;
 
-			if (GlobalV::CAL_FORCE)  
-			{
-				this->cal_force_gamma(
-						&rho_VU[0], 
-						pv,
-						fsr.DSloc_x,
-						fsr.DSloc_y,
-						fsr.DSloc_z,
-						force_dftu);
-			}
+            if (GlobalV::CAL_FORCE)
+            {
+                this->cal_force_gamma(&rho_VU[0], pv, fsr.DSloc_x, fsr.DSloc_y, fsr.DSloc_z, force_dftu);
+            }
 
-			if (GlobalV::CAL_STRESS) 
-			{
-				this->cal_stress_gamma(
-						GlobalC::ucell,
-						pv,
-						&GlobalC::GridD,
-						fsr.DSloc_x,
-						fsr.DSloc_y,
-						fsr.DSloc_z,
-						fsr.DH_r,
-						&rho_VU[0], 
-						stress_dftu);
-			}
+            if (GlobalV::CAL_STRESS)
+            {
+                this->cal_stress_gamma(GlobalC::ucell,
+                                       pv,
+                                       &GlobalC::GridD,
+                                       fsr.DSloc_x,
+                                       fsr.DSloc_y,
+                                       fsr.DSloc_z,
+                                       fsr.DH_r,
+                                       &rho_VU[0],
+                                       stress_dftu);
+            }
         } // ik
     }
     else
@@ -151,8 +165,8 @@ void DFTU::force_stress(const elecstate::ElecState* pelec,
         const char transN = 'N';
         const char transT = 'T';
         const int one_int = 1;
-		const std::complex<double> alpha(1.0,0.0);
-        const std::complex<double> beta(0.0,0.0);
+        const std::complex<double> alpha(1.0, 0.0);
+        const std::complex<double> beta(0.0, 0.0);
 
         std::vector<std::complex<double>> rho_VU(pv.nloc);
 
@@ -164,41 +178,43 @@ void DFTU::force_stress(const elecstate::ElecState* pelec,
 
             this->cal_VU_pot_mat_complex(spin, false, VU);
 
-            const std::vector<std::vector<std::complex<double>>>& dmk = 
-                dynamic_cast<const elecstate::ElecStateLCAO<std::complex<double>>*> (pelec)->get_DM()->get_DMK_vector();
+            const std::vector<std::vector<std::complex<double>>>& dmk
+                = dynamic_cast<const elecstate::ElecStateLCAO<std::complex<double>>*>(pelec)
+                      ->get_DM()
+                      ->get_DMK_vector();
 
 #ifdef __MPI
-			pzgemm_(&transT, 
-					&transN,
-					&nlocal, 
-					&nlocal, 
-					&nlocal,
-					&alpha, 
-					dmk[ik].data(), 
-					&one_int, 
-					&one_int, 
-					pv.desc, 
-					VU, 
-					&one_int, 
-					&one_int, 
-					pv.desc,
-					&beta,
-					&rho_VU[0], 
-					&one_int, 
-					&one_int, 
-					pv.desc);
+            pzgemm_(&transT,
+                    &transN,
+                    &nlocal,
+                    &nlocal,
+                    &nlocal,
+                    &alpha,
+                    dmk[ik].data(),
+                    &one_int,
+                    &one_int,
+                    pv.desc,
+                    VU,
+                    &one_int,
+                    &one_int,
+                    pv.desc,
+                    &beta,
+                    &rho_VU[0],
+                    &one_int,
+                    &one_int,
+                    pv.desc);
 #endif
 
             delete[] VU;
 
-			if (GlobalV::CAL_FORCE)  
-			{
-				cal_force_k (fsr, pv, ik, &rho_VU[0], force_dftu, kv.kvec_d);
-			}
-			if (GlobalV::CAL_STRESS) 
-			{
-				cal_stress_k(fsr, pv, ik, &rho_VU[0], stress_dftu, kv.kvec_d);
-			}
+            if (GlobalV::CAL_FORCE)
+            {
+                cal_force_k(fsr, pv, ik, &rho_VU[0], force_dftu, kv.kvec_d);
+            }
+            if (GlobalV::CAL_STRESS)
+            {
+                cal_stress_k(fsr, pv, ik, &rho_VU[0], stress_dftu, kv.kvec_d);
+            }
         } // ik
     }
 
@@ -215,7 +231,8 @@ void DFTU::force_stress(const elecstate::ElecState* pelec,
         {
             for (int j = 0; j < 3; j++)
             {
-                if (i > j) stress_dftu(i, j) = stress_dftu(j, i);
+                if (i > j)
+                    stress_dftu(i, j) = stress_dftu(j, i);
             }
         }
 
@@ -232,13 +249,12 @@ void DFTU::force_stress(const elecstate::ElecState* pelec,
     return;
 }
 
-void DFTU::cal_force_k(
-        ForceStressArrays &fsr,
-        const Parallel_Orbitals &pv,
-		const int ik, 
-		const std::complex<double>* rho_VU, 
-		ModuleBase::matrix& force_dftu,
-		const std::vector<ModuleBase::Vector3<double>>& kvec_d)
+void DFTU::cal_force_k(ForceStressArrays& fsr,
+                       const Parallel_Orbitals& pv,
+                       const int ik,
+                       const std::complex<double>* rho_VU,
+                       ModuleBase::matrix& force_dftu,
+                       const std::vector<ModuleBase::Vector3<double>>& kvec_d)
 {
     ModuleBase::TITLE("DFTU", "cal_force_k");
     ModuleBase::timer::tick("DFTU", "cal_force_k");
@@ -246,31 +262,36 @@ void DFTU::cal_force_k(
     const char transN = 'N';
     const char transC = 'C';
     const int one_int = 1;
-    const std::complex<double> zero(0.0,0.0);
-    const std::complex<double> one(1.0,0.0);
+    const std::complex<double> zero(0.0, 0.0);
+    const std::complex<double> one(1.0, 0.0);
 
     std::vector<std::complex<double>> dm_VU_dSm(pv.nloc);
     std::vector<std::complex<double>> dSm_k(pv.nloc);
 
     for (int dim = 0; dim < 3; dim++)
     {
-        this->folding_matrix_k(
-				fsr, 
-				pv, 
-				ik, 
-				dim + 1, 
-				0, 
-				&dSm_k[0], 
-				kvec_d);
+        this->folding_matrix_k(fsr, pv, ik, dim + 1, 0, &dSm_k[0], kvec_d);
 
 #ifdef __MPI
-        pzgemm_(&transN, &transC,
-                &GlobalV::NLOCAL, &GlobalV::NLOCAL, &GlobalV::NLOCAL,
-                &one, 
-                &dSm_k[0], &one_int, &one_int, pv.desc, 
-                rho_VU, &one_int, &one_int, pv.desc,
+        pzgemm_(&transN,
+                &transC,
+                &GlobalV::NLOCAL,
+                &GlobalV::NLOCAL,
+                &GlobalV::NLOCAL,
+                &one,
+                &dSm_k[0],
+                &one_int,
+                &one_int,
+                pv.desc,
+                rho_VU,
+                &one_int,
+                &one_int,
+                pv.desc,
                 &zero,
-                &dm_VU_dSm[0], &one_int, &one_int, pv.desc);
+                &dm_VU_dSm[0],
+                &one_int,
+                &one_int,
+                pv.desc);
 #endif
 
         for (int ir = 0; ir < pv.nrow; ir++)
@@ -283,19 +304,32 @@ void DFTU::cal_force_k(
                 const int iwt2 = pv.local2global_col(ic);
                 const int irc = ic * pv.nrow + ir;
 
-                if (iwt1 == iwt2) force_dftu(iat1, dim) += dm_VU_dSm[irc].real();
+                if (iwt1 == iwt2)
+                    force_dftu(iat1, dim) += dm_VU_dSm[irc].real();
 
             } // end ic
-        } // end ir
+        }     // end ir
 
 #ifdef __MPI
-        pzgemm_(&transN, &transN,
-                &GlobalV::NLOCAL, &GlobalV::NLOCAL, &GlobalV::NLOCAL,
-                &one, 
-                &dSm_k[0], &one_int, &one_int, pv.desc, 
-                rho_VU, &one_int, &one_int, pv.desc,
+        pzgemm_(&transN,
+                &transN,
+                &GlobalV::NLOCAL,
+                &GlobalV::NLOCAL,
+                &GlobalV::NLOCAL,
+                &one,
+                &dSm_k[0],
+                &one_int,
+                &one_int,
+                pv.desc,
+                rho_VU,
+                &one_int,
+                &one_int,
+                pv.desc,
                 &zero,
-                &dm_VU_dSm[0], &one_int, &one_int, pv.desc);
+                &dm_VU_dSm[0],
+                &one_int,
+                &one_int,
+                pv.desc);
 #endif
 
         for (int it = 0; it < GlobalC::ucell.ntype; it++)
@@ -303,19 +337,22 @@ void DFTU::cal_force_k(
             const int NL = GlobalC::ucell.atoms[it].nwl + 1;
             const int LC = orbital_corr[it];
 
-            if (LC == -1) continue;
+            if (LC == -1)
+                continue;
             for (int ia = 0; ia < GlobalC::ucell.atoms[it].na; ia++)
             {
                 const int iat = GlobalC::ucell.itia2iat(it, ia);
 
                 for (int l = 0; l < NL; l++)
                 {
-                    if (l != orbital_corr[it]) continue;
+                    if (l != orbital_corr[it])
+                        continue;
                     const int N = GlobalC::ucell.atoms[it].l_nchi[l];
 
                     for (int n = 0; n < N; n++)
                     {
-                        if (n != 0) continue;
+                        if (n != 0)
+                            continue;
 
                         for (int m = 0; m < 2 * l + 1; m++)
                         {
@@ -324,39 +361,39 @@ void DFTU::cal_force_k(
                                 const int iwt = this->iatlnmipol2iwt[iat][l][n][m][ipol];
                                 const int mu = pv.global2local_row(iwt);
                                 const int nu = pv.global2local_col(iwt);
-                                if (mu < 0 || nu < 0) continue;
+                                if (mu < 0 || nu < 0)
+                                    continue;
 
                                 force_dftu(iat, dim) += dm_VU_dSm[nu * pv.nrow + mu].real();
                             }
                         } //
-                    } // n
-                } // l
-            } // ia
-        } // it
-    } // end dim
+                    }     // n
+                }         // l
+            }             // ia
+        }                 // it
+    }                     // end dim
     ModuleBase::timer::tick("DFTU", "cal_force_k");
 
     return;
 }
 
-void DFTU::cal_stress_k(
-		ForceStressArrays &fsr,
-		const Parallel_Orbitals &pv,
-		const int ik,
-		const std::complex<double>* rho_VU,
-		ModuleBase::matrix& stress_dftu,
-		const std::vector<ModuleBase::Vector3<double>>& kvec_d)
+void DFTU::cal_stress_k(ForceStressArrays& fsr,
+                        const Parallel_Orbitals& pv,
+                        const int ik,
+                        const std::complex<double>* rho_VU,
+                        ModuleBase::matrix& stress_dftu,
+                        const std::vector<ModuleBase::Vector3<double>>& kvec_d)
 {
     ModuleBase::TITLE("DFTU", "cal_stress_k");
     ModuleBase::timer::tick("DFTU", "cal_stress_k");
-  
+
     const int nlocal = GlobalV::NLOCAL;
 
     const char transN = 'N';
     const int one_int = 1;
-    const std::complex<double> minus_half(-0.5,0.0);
-    const std::complex<double> zero(0.0,0.0);
-    const std::complex<double> one(1.0,0.0);
+    const std::complex<double> minus_half(-0.5, 0.0);
+    const std::complex<double> zero(0.0, 0.0);
+    const std::complex<double> one(1.0, 0.0);
 
     std::vector<std::complex<double>> dm_VU_sover(pv.nloc);
     std::vector<std::complex<double>> dSR_k(pv.nloc);
@@ -365,35 +402,34 @@ void DFTU::cal_stress_k(
     {
         for (int dim2 = dim1; dim2 < 3; dim2++)
         {
-			this->folding_matrix_k(
-					fsr, // mohan add 2024-06-16 
-					pv, 
-					ik, 
-					dim1 + 4, 
-					dim2, 
-					&dSR_k[0], 
-					kvec_d);
+            this->folding_matrix_k(fsr, // mohan add 2024-06-16
+                                   pv,
+                                   ik,
+                                   dim1 + 4,
+                                   dim2,
+                                   &dSR_k[0],
+                                   kvec_d);
 
 #ifdef __MPI
-			pzgemm_(&transN, 
-					&transN,
-					&nlocal, 
-					&nlocal, 
-					&nlocal,
-					&minus_half, 
-					rho_VU, 
-					&one_int, 
-					&one_int, 
-					pv.desc, 
-					&dSR_k[0], 
-					&one_int, 
-					&one_int, 
-					pv.desc,
-					&zero,
-					&dm_VU_sover[0], 
-					&one_int, 
-					&one_int, 
-					pv.desc);
+            pzgemm_(&transN,
+                    &transN,
+                    &nlocal,
+                    &nlocal,
+                    &nlocal,
+                    &minus_half,
+                    rho_VU,
+                    &one_int,
+                    &one_int,
+                    pv.desc,
+                    &dSR_k[0],
+                    &one_int,
+                    &one_int,
+                    pv.desc,
+                    &zero,
+                    &dm_VU_sover[0],
+                    &one_int,
+                    &one_int,
+                    pv.desc);
 #endif
 
             for (int ir = 0; ir < pv.nrow; ir++)
@@ -404,24 +440,24 @@ void DFTU::cal_stress_k(
                     const int iwt2 = pv.local2global_col(ic);
                     const int irc = ic * pv.nrow + ir;
 
-                    if (iwt1 == iwt2) stress_dftu(dim1, dim2) += 2.0 * dm_VU_sover[irc].real();
+                    if (iwt1 == iwt2)
+                        stress_dftu(dim1, dim2) += 2.0 * dm_VU_sover[irc].real();
                 } // end ic
-            } // end ir
+            }     // end ir
 
         } // end dim2
-    } // end dim1
+    }     // end dim1
     ModuleBase::timer::tick("DFTU", "cal_stress_k");
 
     return;
 }
 
-void DFTU::cal_force_gamma(
-		const double* rho_VU, 
-        const Parallel_Orbitals &pv,
-        double* dsloc_x,
-        double* dsloc_y,
-        double* dsloc_z,
-		ModuleBase::matrix& force_dftu)
+void DFTU::cal_force_gamma(const double* rho_VU,
+                           const Parallel_Orbitals& pv,
+                           double* dsloc_x,
+                           double* dsloc_y,
+                           double* dsloc_z,
+                           ModuleBase::matrix& force_dftu)
 {
     ModuleBase::TITLE("DFTU", "cal_force_gamma");
     ModuleBase::timer::tick("DFTU", "cal_force_gamma");
@@ -434,27 +470,39 @@ void DFTU::cal_force_gamma(
     for (int dim = 0; dim < 3; dim++)
     {
         double* tmp_ptr;
-		if (dim == 0)    
-		{
-			tmp_ptr = dsloc_x;
-		}
-		else if (dim == 1) 
-		{
-			tmp_ptr = dsloc_y;
-		}
-		else if (dim == 2) 
-		{
-			tmp_ptr = dsloc_z;
-		}
+        if (dim == 0)
+        {
+            tmp_ptr = dsloc_x;
+        }
+        else if (dim == 1)
+        {
+            tmp_ptr = dsloc_y;
+        }
+        else if (dim == 2)
+        {
+            tmp_ptr = dsloc_z;
+        }
 
 #ifdef __MPI
-        pdgemm_(&transN, &transT,
-				&GlobalV::NLOCAL, &GlobalV::NLOCAL, &GlobalV::NLOCAL,
-				&one, 
-				tmp_ptr, &one_int, &one_int, pv.desc, 
-				rho_VU, &one_int, &one_int, pv.desc,
-				&zero,
-				&dm_VU_dSm[0], &one_int, &one_int, pv.desc);
+        pdgemm_(&transN,
+                &transT,
+                &GlobalV::NLOCAL,
+                &GlobalV::NLOCAL,
+                &GlobalV::NLOCAL,
+                &one,
+                tmp_ptr,
+                &one_int,
+                &one_int,
+                pv.desc,
+                rho_VU,
+                &one_int,
+                &one_int,
+                pv.desc,
+                &zero,
+                &dm_VU_dSm[0],
+                &one_int,
+                &one_int,
+                pv.desc);
 #endif
 
         for (int ir = 0; ir < pv.nrow; ir++)
@@ -467,19 +515,32 @@ void DFTU::cal_force_gamma(
                 const int iwt2 = pv.local2global_col(ic);
                 const int irc = ic * pv.nrow + ir;
 
-                if (iwt1 == iwt2) force_dftu(iat1, dim) += dm_VU_dSm[irc];
+                if (iwt1 == iwt2)
+                    force_dftu(iat1, dim) += dm_VU_dSm[irc];
 
             } // end ic
-        } // end ir
+        }     // end ir
 
 #ifdef __MPI
-        pdgemm_(&transN, &transT,
-				&GlobalV::NLOCAL, &GlobalV::NLOCAL, &GlobalV::NLOCAL,
-				&one, 
-				tmp_ptr, &one_int, &one_int, pv.desc, 
-				rho_VU, &one_int, &one_int, pv.desc,
-				&zero,
-				&dm_VU_dSm[0], &one_int, &one_int, pv.desc);
+        pdgemm_(&transN,
+                &transT,
+                &GlobalV::NLOCAL,
+                &GlobalV::NLOCAL,
+                &GlobalV::NLOCAL,
+                &one,
+                tmp_ptr,
+                &one_int,
+                &one_int,
+                pv.desc,
+                rho_VU,
+                &one_int,
+                &one_int,
+                pv.desc,
+                &zero,
+                &dm_VU_dSm[0],
+                &one_int,
+                &one_int,
+                pv.desc);
 #endif
 
         for (int it = 0; it < GlobalC::ucell.ntype; it++)
@@ -487,20 +548,23 @@ void DFTU::cal_force_gamma(
             const int NL = GlobalC::ucell.atoms[it].nwl + 1;
             const int LC = orbital_corr[it];
 
-            if (LC == -1) continue;
+            if (LC == -1)
+                continue;
             for (int ia = 0; ia < GlobalC::ucell.atoms[it].na; ia++)
             {
                 const int iat = GlobalC::ucell.itia2iat(it, ia);
 
                 for (int l = 0; l < NL; l++)
                 {
-                    if (l != orbital_corr[it]) continue;
+                    if (l != orbital_corr[it])
+                        continue;
 
                     const int N = GlobalC::ucell.atoms[it].l_nchi[l];
 
                     for (int n = 0; n < N; n++)
                     {
-                        if (n != 0) continue;
+                        if (n != 0)
+                            continue;
 
                         // Calculate the local occupation number matrix
                         for (int m = 0; m < 2 * l + 1; m++)
@@ -510,15 +574,16 @@ void DFTU::cal_force_gamma(
                                 const int iwt = this->iatlnmipol2iwt[iat][l][n][m][ipol];
                                 const int mu = pv.global2local_row(iwt);
                                 const int nu = pv.global2local_col(iwt);
-                                if (mu < 0 || nu < 0) continue;
+                                if (mu < 0 || nu < 0)
+                                    continue;
 
                                 force_dftu(iat, dim) += dm_VU_dSm[nu * pv.nrow + mu];
                             }
                         } //
-                    } // n
-                } // l
-            } // ia
-        } // it
+                    }     // n
+                }         // l
+            }             // ia
+        }                 // it
 
     } // end dim
     ModuleBase::timer::tick("DFTU", "cal_force_gamma");
@@ -526,16 +591,15 @@ void DFTU::cal_force_gamma(
     return;
 }
 
-void DFTU::cal_stress_gamma(
-    const UnitCell &ucell,
-    const Parallel_Orbitals &pv,
-    Grid_Driver* gd,
-    double* dsloc_x,
-    double* dsloc_y,
-    double* dsloc_z,
-    double* dh_r,
-    const double* rho_VU, 
-    ModuleBase::matrix& stress_dftu)
+void DFTU::cal_stress_gamma(const UnitCell& ucell,
+                            const Parallel_Orbitals& pv,
+                            Grid_Driver* gd,
+                            double* dsloc_x,
+                            double* dsloc_y,
+                            double* dsloc_z,
+                            double* dh_r,
+                            const double* rho_VU,
+                            ModuleBase::matrix& stress_dftu)
 {
     ModuleBase::TITLE("DFTU", "cal_stress_gamma");
     ModuleBase::timer::tick("DFTU", "cal_stress_gamma");
@@ -555,38 +619,28 @@ void DFTU::cal_stress_gamma(
     {
         for (int dim2 = dim1; dim2 < 3; dim2++)
         {
-			this->fold_dSR_gamma(
-					ucell,
-					pv,
-					gd,
-					dsloc_x,
-					dsloc_y,
-					dsloc_z,
-					dh_r,
-					dim1, 
-					dim2, 
-					&dSR_gamma[0]);
+            this->fold_dSR_gamma(ucell, pv, gd, dsloc_x, dsloc_y, dsloc_z, dh_r, dim1, dim2, &dSR_gamma[0]);
 
 #ifdef __MPI
-			pdgemm_(&transN, 
-					&transN,
-					&nlocal, 
-					&nlocal, 
-					&nlocal,
-					&minus_half, 
-					rho_VU, 
-					&one_int, 
-					&one_int, 
-					pv.desc, 
-					&dSR_gamma[0], 
-					&one_int, 
-					&one_int, 
-					pv.desc,
-					&zero,
-					&dm_VU_sover[0], 
-					&one_int, 
-					&one_int, 
-					pv.desc);
+            pdgemm_(&transN,
+                    &transN,
+                    &nlocal,
+                    &nlocal,
+                    &nlocal,
+                    &minus_half,
+                    rho_VU,
+                    &one_int,
+                    &one_int,
+                    pv.desc,
+                    &dSR_gamma[0],
+                    &one_int,
+                    &one_int,
+                    pv.desc,
+                    &zero,
+                    &dm_VU_sover[0],
+                    &one_int,
+                    &one_int,
+                    pv.desc);
 #endif
 
             for (int ir = 0; ir < this->LM->ParaV->nrow; ir++)
@@ -598,12 +652,13 @@ void DFTU::cal_stress_gamma(
                     const int iwt2 = this->LM->ParaV->local2global_col(ic);
                     const int irc = ic * this->LM->ParaV->nrow + ir;
 
-                    if (iwt1 == iwt2) stress_dftu(dim1, dim2) += 2.0 * dm_VU_sover[irc];
+                    if (iwt1 == iwt2)
+                        stress_dftu(dim1, dim2) += 2.0 * dm_VU_sover[irc];
                 } // end ic
-            } // end ir
+            }     // end ir
 
         } // end dim2
-    } // end dim1
+    }     // end dim1
     ModuleBase::timer::tick("DFTU", "cal_stress_gamma");
     return;
 }

--- a/source/module_hamilt_lcao/module_tddft/snap_psibeta_half_tddft.cpp
+++ b/source/module_hamilt_lcao/module_tddft/snap_psibeta_half_tddft.cpp
@@ -1,266 +1,270 @@
 #include "snap_psibeta_half_tddft.h"
 
-#include "module_base/timer.h"
-#include "module_base/math_integral.h"
-#include "module_base/ylm.h"
 #include "module_base/constants.h"
+#include "module_base/math_integral.h"
+#include "module_base/timer.h"
+#include "module_base/ylm.h"
 
 namespace module_tddft
 {
 
-void snap_psibeta_half_tddft(
-	const LCAO_Orbitals &orb,
-	const InfoNonlocal &infoNL_,
-	std::vector<std::vector<std::complex<double>>> &nlm,
-	const ModuleBase::Vector3<double> &R1,
-	const int &T1,
-	const int &L1,
-	const int &m1,
-	const int &N1,
-	const ModuleBase::Vector3<double> &R0, // The projector.
-	const int &T0,
-	const ModuleBase::Vector3<double> &A,
-	const bool &calc_deri) // mohan add 2021-04-25)
+void snap_psibeta_half_tddft(const LCAO_Orbitals& orb,
+                             const InfoNonlocal& infoNL_,
+                             std::vector<std::vector<std::complex<double>>>& nlm,
+                             const ModuleBase::Vector3<double>& R1,
+                             const int& T1,
+                             const int& L1,
+                             const int& m1,
+                             const int& N1,
+                             const ModuleBase::Vector3<double>& R0, // The projector.
+                             const int& T0,
+                             const ModuleBase::Vector3<double>& A,
+                             const bool& calc_deri) // mohan add 2021-04-25)
 {
-	ModuleBase::timer::tick("module_tddft", "snap_psibeta_half_tddft");
+    ModuleBase::timer::tick("module_tddft", "snap_psibeta_half_tddft");
 
-	//find number of projectors on atom R0
-	const int nproj = infoNL_.nproj[T0];
-	if(nproj==0)
-	{
-		if(calc_deri)
-		{
-			nlm.resize(4);
-		}
-		else
-		{
-			nlm.resize(1);
-		}
-		return;	
-	}
+    // find number of projectors on atom R0
+    const int nproj = infoNL_.nproj[T0];
+    if (nproj == 0)
+    {
+        if (calc_deri)
+        {
+            nlm.resize(4);
+        }
+        else
+        {
+            nlm.resize(1);
+        }
+        return;
+    }
 
-	std::vector<bool> calproj;
-	calproj.resize(nproj);
-	std::vector<int> rmesh1;
-	rmesh1.resize(nproj);
+    std::vector<bool> calproj;
+    calproj.resize(nproj);
+    std::vector<int> rmesh1;
+    rmesh1.resize(nproj);
 
-	if(calc_deri)
-	{
-		nlm.resize(4);
-	}
-	else
-	{
-		nlm.resize(1);
-	}
+    if (calc_deri)
+    {
+        nlm.resize(4);
+    }
+    else
+    {
+        nlm.resize(1);
+    }
 
-	//Count number of projectors (l,m)
-	int natomwfc = 0;
-	for (int ip = 0;ip < nproj;ip++)
-	{
-		//============================
-		// Use pseudo-atomic orbitals
-		//============================
-		
-		const int L0 = infoNL_.Beta[T0].Proj[ip].getL(); // mohan add 2021-05-07
-		natomwfc += 2* L0 +1;
-	}
+    // Count number of projectors (l,m)
+    int natomwfc = 0;
+    for (int ip = 0; ip < nproj; ip++)
+    {
+        //============================
+        // Use pseudo-atomic orbitals
+        //============================
 
-	for(int dim=0;dim<nlm.size();dim++)
-	{
-		nlm[dim].resize(natomwfc);
-		for (auto &x : nlm[dim])
-		{
-    		x=0.0;
-		}
-	}
+        const int L0 = infoNL_.Beta[T0].Proj[ip].getL(); // mohan add 2021-05-07
+        natomwfc += 2 * L0 + 1;
+    }
 
-	//rcut of orbtials and projectors
-	//in our calculation, we always put orbital phi at the left side of <phi|beta>
-	//because <phi|beta> = <beta|phi>
-	const double Rcut1 = orb.Phi[T1].getRcut();
-	const ModuleBase::Vector3<double> dRa = R0 - R1;
+    for (int dim = 0; dim < nlm.size(); dim++)
+    {
+        nlm[dim].resize(natomwfc);
+        for (auto& x: nlm[dim])
+        {
+            x = 0.0;
+        }
+    }
 
-	double distance10 = dRa.norm();
+    // rcut of orbtials and projectors
+    // in our calculation, we always put orbital phi at the left side of <phi|beta>
+    // because <phi|beta> = <beta|phi>
+    const double Rcut1 = orb.Phi[T1].getRcut();
+    const ModuleBase::Vector3<double> dRa = R0 - R1;
 
-	bool all_out = true;
-	for (int ip = 0; ip < nproj; ip++)
-	{
-		const double Rcut0 = infoNL_.Beta[T0].Proj[ip].getRcut();
-		if (distance10 > (Rcut1 + Rcut0))
-		{
-			calproj[ip] = false;
-		}
-		else
-		{
-			all_out = false;
-			calproj[ip] = true;
-		}
-	}
+    double distance10 = dRa.norm();
 
-	if (all_out)
-	{
-		ModuleBase::timer::tick("module_tddft", "snap_psibeta_half_tddft");
-		return;
-	}
+    bool all_out = true;
+    for (int ip = 0; ip < nproj; ip++)
+    {
+        const double Rcut0 = infoNL_.Beta[T0].Proj[ip].getRcut();
+        if (distance10 > (Rcut1 + Rcut0))
+        {
+            calproj[ip] = false;
+        }
+        else
+        {
+            all_out = false;
+            calproj[ip] = true;
+        }
+    }
 
-	auto Polynomial_Interpolation = [](const int &mesh_r, const double *psi_r, const double *r_radial, const double &x) -> double
-	{
-		int left = 0;
-		int right = mesh_r - 1;
-		while (left <= right)
-		{
-			int mid = left + (right - left) / 2;
-			if (r_radial[mid] == x)
-			{
-				left = mid;
-				right = mid;
-				return psi_r[mid];
-			}
-			else if (r_radial[mid] < x)
-			{
-				left = mid + 1;
-			}
-			else
-			{
-				right = mid - 1;
-			}
-		}
+    if (all_out)
+    {
+        ModuleBase::timer::tick("module_tddft", "snap_psibeta_half_tddft");
+        return;
+    }
 
-		double y = 0.0;
-		if (right > mesh_r - 4) return y;
-		
-		double x0 = r_radial[right];
-		double x1 = r_radial[right+1];
-		double x2 = r_radial[right+2];
-		double x3 = r_radial[right+3];
+    auto Polynomial_Interpolation
+        = [](const int& mesh_r, const double* psi_r, const double* r_radial, const double& x) -> double {
+        int left = 0;
+        int right = mesh_r - 1;
+        while (left <= right)
+        {
+            int mid = left + (right - left) / 2;
+            if (r_radial[mid] == x)
+            {
+                left = mid;
+                right = mid;
+                return psi_r[mid];
+            }
+            else if (r_radial[mid] < x)
+            {
+                left = mid + 1;
+            }
+            else
+            {
+                right = mid - 1;
+            }
+        }
 
-		double y0 = psi_r[right];
-		double y1 = psi_r[right+1];
-		double y2 = psi_r[right+2];
-		double y3 = psi_r[right+3];
+        double y = 0.0;
+        if (right > mesh_r - 4)
+            return y;
 
-		y = (x-x1) * (x-x2) * (x-x3) / (x0-x1) / (x0-x2) / (x0-x3) * y0
-		  + (x-x0) * (x-x2) * (x-x3) / (x1-x0) / (x1-x2) / (x1-x3) * y1
-		  + (x-x0) * (x-x1) * (x-x3) / (x2-x0) / (x2-x1) / (x2-x3) * y2
-		  + (x-x0) * (x-x1) * (x-x2) / (x3-x0) / (x3-x1) / (x3-x2) * y3;
+        double x0 = r_radial[right];
+        double x1 = r_radial[right + 1];
+        double x2 = r_radial[right + 2];
+        double x3 = r_radial[right + 3];
 
-		return y;
-	};
+        double y0 = psi_r[right];
+        double y1 = psi_r[right + 1];
+        double y2 = psi_r[right + 2];
+        double y3 = psi_r[right + 3];
 
-	const int mesh_r1 = orb.Phi[T1].PhiLN(L1, N1).getNr();
-	const double* psi_1 = orb.Phi[T1].PhiLN(L1, N1).getPsi();
-	const double* radial1 = orb.Phi[T1].PhiLN(L1, N1).getRadial();
+        y = (x - x1) * (x - x2) * (x - x3) / (x0 - x1) / (x0 - x2) / (x0 - x3) * y0
+            + (x - x0) * (x - x2) * (x - x3) / (x1 - x0) / (x1 - x2) / (x1 - x3) * y1
+            + (x - x0) * (x - x1) * (x - x3) / (x2 - x0) / (x2 - x1) / (x2 - x3) * y2
+            + (x - x0) * (x - x1) * (x - x2) / (x3 - x0) / (x3 - x1) / (x3 - x2) * y3;
 
-	int ridial_grid_num = 140;
+        return y;
+    };
+
+    const int mesh_r1 = orb.Phi[T1].PhiLN(L1, N1).getNr();
+    const double* psi_1 = orb.Phi[T1].PhiLN(L1, N1).getPsi();
+    const double* radial1 = orb.Phi[T1].PhiLN(L1, N1).getRadial();
+
+    int ridial_grid_num = 140;
     int angular_grid_num = 110;
-    double *r_ridial = new double[ridial_grid_num];
-    double *weights_ridial = new double[ridial_grid_num];
-    
-	int index = 0;
-	for (int nb = 0; nb < nproj; nb++)
-	{
-		const int L0 = infoNL_.Beta[T0].Proj[nb].getL();
-		if (!calproj[nb])
-		{
-			index += 2 * L0 + 1;
-			continue;
-		}
+    double* r_ridial = new double[ridial_grid_num];
+    double* weights_ridial = new double[ridial_grid_num];
 
-		const int mesh_r0 = infoNL_.Beta[T0].Proj[nb].getNr();
-		const double* beta_r = infoNL_.Beta[T0].Proj[nb].getBeta_r();
-		const double* radial0 = infoNL_.Beta[T0].Proj[nb].getRadial();
+    int index = 0;
+    for (int nb = 0; nb < nproj; nb++)
+    {
+        const int L0 = infoNL_.Beta[T0].Proj[nb].getL();
+        if (!calproj[nb])
+        {
+            index += 2 * L0 + 1;
+            continue;
+        }
 
-		double Rcut0 = infoNL_.Beta[T0].Proj[nb].getRcut();
-		ModuleBase::Integral::Gauss_Legendre_grid_and_weight(radial0[0], radial0[mesh_r0-1], ridial_grid_num, r_ridial, weights_ridial);
+        const int mesh_r0 = infoNL_.Beta[T0].Proj[nb].getNr();
+        const double* beta_r = infoNL_.Beta[T0].Proj[nb].getBeta_r();
+        const double* radial0 = infoNL_.Beta[T0].Proj[nb].getRadial();
 
-		// test by jingan
-		// std::cout << "Rcut = " << Rcut0 << std::endl;
-		// for (int ttt = 0; ttt < mesh_r0; ttt++)
-		// {
-		// 	std::cout << infoNL_.Beta[T0].Proj[nb].getRadial(ttt) << ",  ";
-		// }
-		// std::cout << std::endl;
-		// for (int ttt = 0; ttt < mesh_r0; ttt++)
-		// {
-		// 	std::cout << infoNL_.Beta[T0].Proj[nb].getBeta_r(ttt) << ",  ";
-		// }
-		// std::cout << std::endl;
-		// std::cout << "L0 = " << L0 << std::endl;
-		// test by jingan
+        double Rcut0 = infoNL_.Beta[T0].Proj[nb].getRcut();
+        ModuleBase::Integral::Gauss_Legendre_grid_and_weight(radial0[0],
+                                                             radial0[mesh_r0 - 1],
+                                                             ridial_grid_num,
+                                                             r_ridial,
+                                                             weights_ridial);
 
-		double A_phase = A * R0;
-		std::complex<double> exp_iAR0 = std::exp(ModuleBase::IMAG_UNIT*A_phase);
+        // test by jingan
+        // std::cout << "Rcut = " << Rcut0 << std::endl;
+        // for (int ttt = 0; ttt < mesh_r0; ttt++)
+        // {
+        // 	std::cout << infoNL_.Beta[T0].Proj[nb].getRadial(ttt) << ",  ";
+        // }
+        // std::cout << std::endl;
+        // for (int ttt = 0; ttt < mesh_r0; ttt++)
+        // {
+        // 	std::cout << infoNL_.Beta[T0].Proj[nb].getBeta_r(ttt) << ",  ";
+        // }
+        // std::cout << std::endl;
+        // std::cout << "L0 = " << L0 << std::endl;
+        // test by jingan
 
-		for (int ir = 0; ir < ridial_grid_num; ir++)
-		{
-			std::vector<std::complex<double>> result_angular(2*L0+1, 0.0);
-			for (int ian = 0; ian < angular_grid_num; ian++)
-			{
-				double x = ModuleBase::Integral::Lebedev_Laikov_grid110_x[ian];
-				double y = ModuleBase::Integral::Lebedev_Laikov_grid110_y[ian];
-				double z = ModuleBase::Integral::Lebedev_Laikov_grid110_z[ian];
-				double weights_angular = ModuleBase::Integral::Lebedev_Laikov_grid110_w[ian];
-				ModuleBase::Vector3<double> r_angular_tmp(x, y, z);
+        double A_phase = A * R0;
+        std::complex<double> exp_iAR0 = std::exp(ModuleBase::IMAG_UNIT * A_phase);
 
-				ModuleBase::Vector3<double> r_coor = r_ridial[ir] * r_angular_tmp;
-				ModuleBase::Vector3<double> tmp_r_coor = r_coor + dRa;
-				double tmp_r_coor_norm = tmp_r_coor.norm();
-				ModuleBase::Vector3<double> tmp_r_unit;
-				if (tmp_r_coor_norm > 1e-10)
-				{
-					tmp_r_unit = tmp_r_coor / tmp_r_coor_norm;
-				}
+        for (int ir = 0; ir < ridial_grid_num; ir++)
+        {
+            std::vector<std::complex<double>> result_angular(2 * L0 + 1, 0.0);
+            for (int ian = 0; ian < angular_grid_num; ian++)
+            {
+                double x = ModuleBase::Integral::Lebedev_Laikov_grid110_x[ian];
+                double y = ModuleBase::Integral::Lebedev_Laikov_grid110_y[ian];
+                double z = ModuleBase::Integral::Lebedev_Laikov_grid110_z[ian];
+                double weights_angular = ModuleBase::Integral::Lebedev_Laikov_grid110_w[ian];
+                ModuleBase::Vector3<double> r_angular_tmp(x, y, z);
 
-				if (tmp_r_coor_norm > Rcut1) continue;
+                ModuleBase::Vector3<double> r_coor = r_ridial[ir] * r_angular_tmp;
+                ModuleBase::Vector3<double> tmp_r_coor = r_coor + dRa;
+                double tmp_r_coor_norm = tmp_r_coor.norm();
+                ModuleBase::Vector3<double> tmp_r_unit;
+                if (tmp_r_coor_norm > 1e-10)
+                {
+                    tmp_r_unit = tmp_r_coor / tmp_r_coor_norm;
+                }
 
-				std::vector<double> rly0;
-				ModuleBase::Ylm::rl_sph_harm (L0, x, y, z, rly0);
+                if (tmp_r_coor_norm > Rcut1)
+                    continue;
 
-				std::vector<double> rly1;
-            	ModuleBase::Ylm::rl_sph_harm (L1, tmp_r_unit.x, tmp_r_unit.y, tmp_r_unit.z, rly1);
+                std::vector<double> rly0;
+                ModuleBase::Ylm::rl_sph_harm(L0, x, y, z, rly0);
 
-				double phase = A * r_coor;
-				std::complex<double> exp_iAr = std::exp(ModuleBase::IMAG_UNIT*phase);
+                std::vector<double> rly1;
+                ModuleBase::Ylm::rl_sph_harm(L1, tmp_r_unit.x, tmp_r_unit.y, tmp_r_unit.z, rly1);
 
-				for (int m0 = 0; m0 < 2 * L0 + 1; m0++)
-				{
-					result_angular[m0] += exp_iAr * rly0[L0*L0+m0] * rly1[L1*L1+m1]
-										* Polynomial_Interpolation(mesh_r1, psi_1, radial1, tmp_r_coor_norm)
-										* weights_angular;
-				}
+                double phase = A * r_coor;
+                std::complex<double> exp_iAr = std::exp(ModuleBase::IMAG_UNIT * phase);
 
-			}
+                for (int m0 = 0; m0 < 2 * L0 + 1; m0++)
+                {
+                    result_angular[m0] += exp_iAr * rly0[L0 * L0 + m0] * rly1[L1 * L1 + m1]
+                                          * Polynomial_Interpolation(mesh_r1, psi_1, radial1, tmp_r_coor_norm)
+                                          * weights_angular;
+                }
+            }
 
-			int index_tmp = index;
-			if(!calc_deri)
-			{
-				double temp = Polynomial_Interpolation(mesh_r0, beta_r, radial0, r_ridial[ir]) * r_ridial[ir] * weights_ridial[ir];
-				for (int m0 = 0; m0 < 2 * L0 + 1; m0++)
-				{
-					nlm[0][index_tmp] += temp * result_angular[m0] * exp_iAR0;
-					index_tmp++;
-				}
-				
-			}
-		}
+            int index_tmp = index;
+            if (!calc_deri)
+            {
+                double temp = Polynomial_Interpolation(mesh_r0, beta_r, radial0, r_ridial[ir]) * r_ridial[ir]
+                              * weights_ridial[ir];
+                for (int m0 = 0; m0 < 2 * L0 + 1; m0++)
+                {
+                    nlm[0][index_tmp] += temp * result_angular[m0] * exp_iAR0;
+                    index_tmp++;
+                }
+            }
+        }
 
-		index += 2 * L0 + 1;
-	}
+        index += 2 * L0 + 1;
+    }
 
-	for(int dim = 0; dim < nlm.size(); dim++)
-	{
-		for (auto &x : nlm[dim])
-		{
-    		x = std::conj(x); // <phi|exp^{-iAr}|beta>
-		}
-	}
+    for (int dim = 0; dim < nlm.size(); dim++)
+    {
+        for (auto& x: nlm[dim])
+        {
+            x = std::conj(x); // <phi|exp^{-iAr}|beta>
+        }
+    }
 
-	delete[] r_ridial;
+    delete[] r_ridial;
     delete[] weights_ridial;
-	assert(index == natomwfc);
-	ModuleBase::timer::tick("module_tddft", "snap_psibeta_half_tddft");
+    assert(index == natomwfc);
+    ModuleBase::timer::tick("module_tddft", "snap_psibeta_half_tddft");
 
-	return;
+    return;
 }
 
 } // namespace module_tddft

--- a/source/module_hamilt_lcao/module_tddft/snap_psibeta_half_tddft.cpp
+++ b/source/module_hamilt_lcao/module_tddft/snap_psibeta_half_tddft.cpp
@@ -22,7 +22,7 @@ void snap_psibeta_half_tddft(
 	const ModuleBase::Vector3<double> &A,
 	const bool &calc_deri) // mohan add 2021-04-25)
 {
-	ModuleBase::timer::tick("ORB_gen_tables", "snap_psibeta_half_tddft");
+	ModuleBase::timer::tick("module_tddft", "snap_psibeta_half_tddft");
 
 	//find number of projectors on atom R0
 	const int nproj = infoNL_.nproj[T0];
@@ -99,7 +99,7 @@ void snap_psibeta_half_tddft(
 
 	if (all_out)
 	{
-		ModuleBase::timer::tick("ORB_gen_tables", "snap_psibeta_half_tddft");
+		ModuleBase::timer::tick("module_tddft", "snap_psibeta_half_tddft");
 		return;
 	}
 
@@ -258,7 +258,7 @@ void snap_psibeta_half_tddft(
 	delete[] r_ridial;
     delete[] weights_ridial;
 	assert(index == natomwfc);
-	ModuleBase::timer::tick("ORB_gen_tables", "snap_psibeta_half_tddft");
+	ModuleBase::timer::tick("module_tddft", "snap_psibeta_half_tddft");
 
 	return;
 }

--- a/source/module_hamilt_pw/hamilt_pwdft/VNL_in_pw.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/VNL_in_pw.cpp
@@ -9,7 +9,6 @@
 #include "module_base/math_ylmreal.h"
 #include "module_base/memory.h"
 #include "module_base/timer.h"
-#include "module_basis/module_ao/ORB_gen_tables.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
 #include "module_hamilt_pw/hamilt_pwdft/kernels/vnl_op.h"
 #include "module_hamilt_pw/hamilt_pwdft/wavefunc.h"

--- a/source/module_hamilt_pw/hamilt_pwdft/VNL_in_pw.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/VNL_in_pw.cpp
@@ -8,11 +8,11 @@
 #include "module_base/math_sphbes.h"
 #include "module_base/math_ylmreal.h"
 #include "module_base/memory.h"
+#include "module_base/module_device/device.h"
 #include "module_base/timer.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
 #include "module_hamilt_pw/hamilt_pwdft/kernels/vnl_op.h"
 #include "module_hamilt_pw/hamilt_pwdft/wavefunc.h"
-#include "module_base/module_device/device.h"
 
 pseudopot_cell_vnl::pseudopot_cell_vnl()
 {
@@ -20,12 +20,15 @@ pseudopot_cell_vnl::pseudopot_cell_vnl()
 
 pseudopot_cell_vnl::~pseudopot_cell_vnl()
 {
-    if(GlobalV::use_paw) return;
+    if (GlobalV::use_paw)
+        return;
     delete[] indv_ijkb0;
 }
 
-void pseudopot_cell_vnl::release_memory() {
-    if (this->nhm <= 0 || memory_released) return;
+void pseudopot_cell_vnl::release_memory()
+{
+    if (this->nhm <= 0 || memory_released)
+        return;
     if (GlobalV::device_flag == "gpu")
     {
         if (GlobalV::precision_flag == "single")
@@ -81,7 +84,8 @@ void pseudopot_cell_vnl::init(const int ntype,
                               const ModulePW::PW_Basis_K* wfc_basis,
                               const bool allocate_vkb)
 {
-    if(GlobalV::use_paw) return;
+    if (GlobalV::use_paw)
+        return;
 
     ModuleBase::TITLE("pseudopot_cell_vnl", "init");
     ModuleBase::timer::tick("ppcell_vnl", "init");
@@ -296,7 +300,8 @@ void pseudopot_cell_vnl::init(const int ntype,
 //----------------------------------------------------------
 void pseudopot_cell_vnl::getvnl(const int& ik, ModuleBase::ComplexMatrix& vkb_in) const
 {
-    if(GlobalV::use_paw) return;
+    if (GlobalV::use_paw)
+        return;
     if (GlobalV::test_pp)
         ModuleBase::TITLE("pseudopot_cell_vnl", "getvnl");
     ModuleBase::timer::tick("pp_cell_vnl", "getvnl");
@@ -401,7 +406,8 @@ void pseudopot_cell_vnl::getvnl(const int& ik, ModuleBase::ComplexMatrix& vkb_in
 template <typename FPTYPE, typename Device>
 void pseudopot_cell_vnl::getvnl(Device* ctx, const int& ik, std::complex<FPTYPE>* vkb_in) const
 {
-    if(GlobalV::use_paw) return;
+    if (GlobalV::use_paw)
+        return;
     if (GlobalV::test_pp)
         ModuleBase::TITLE("pseudopot_cell_vnl", "getvnl");
     ModuleBase::timer::tick("pp_cell_vnl", "getvnl");
@@ -527,7 +533,8 @@ void pseudopot_cell_vnl::getvnl(Device* ctx, const int& ik, std::complex<FPTYPE>
 
 void pseudopot_cell_vnl::init_vnl(UnitCell& cell, const ModulePW::PW_Basis* rho_basis)
 {
-    if(GlobalV::use_paw) return;
+    if (GlobalV::use_paw)
+        return;
     ModuleBase::TITLE("pseudopot_cell_vnl", "init_vnl");
     ModuleBase::timer::tick("ppcell_vnl", "init_vnl");
 
@@ -656,20 +663,22 @@ void pseudopot_cell_vnl::init_vnl(UnitCell& cell, const ModulePW::PW_Basis* rho_
             for (int ip = 0; ip < Nprojectors; ++ip)
             {
                 const int ir = static_cast<int>(indv(it, ip));
-                for(int ip2=0; ip2<Nprojectors; ++ip2)
-				{
-					const int is = static_cast<int>( indv(it, ip2) );
-					int ijs =0;
-					for(int is1=0;is1<2;++is1)
-					{
-						for(int is2=0;is2<2;++is2)
-						{
-							this->dvan_so(ijs,it,ip,ip2) = cell.atoms[it].ncpp.dion(ir, is) * soc.fcoef(it,is1,is2,ip,ip2);
-							++ijs;
-							if(ir != is) soc.fcoef(it,is1,is2,ip,ip2) = std::complex<double>(0.0,0.0);
-						}
-					}
-				}
+                for (int ip2 = 0; ip2 < Nprojectors; ++ip2)
+                {
+                    const int is = static_cast<int>(indv(it, ip2));
+                    int ijs = 0;
+                    for (int is1 = 0; is1 < 2; ++is1)
+                    {
+                        for (int is2 = 0; is2 < 2; ++is2)
+                        {
+                            this->dvan_so(ijs, it, ip, ip2)
+                                = cell.atoms[it].ncpp.dion(ir, is) * soc.fcoef(it, is1, is2, ip, ip2);
+                            ++ijs;
+                            if (ir != is)
+                                soc.fcoef(it, is1, is2, ip, ip2) = std::complex<double>(0.0, 0.0);
+                        }
+                    }
+                }
             }
         }
         else
@@ -841,8 +850,10 @@ void pseudopot_cell_vnl::init_vnl(UnitCell& cell, const ModulePW::PW_Basis* rho_
         delete[] aux;
         delete[] jl;
     }
-    if (GlobalV::device_flag == "gpu") {
-        if (GlobalV::precision_flag == "single") {
+    if (GlobalV::device_flag == "gpu")
+    {
+        if (GlobalV::precision_flag == "single")
+        {
             castmem_d2s_h2d_op()(gpu_ctx, cpu_ctx, this->s_indv, this->indv.c, this->indv.nr * this->indv.nc);
             castmem_d2s_h2d_op()(gpu_ctx, cpu_ctx, this->s_nhtol, this->nhtol.c, this->nhtol.nr * this->nhtol.nc);
             castmem_d2s_h2d_op()(gpu_ctx, cpu_ctx, this->s_nhtolm, this->nhtolm.c, this->nhtolm.nr * this->nhtolm.nc);
@@ -863,8 +874,10 @@ void pseudopot_cell_vnl::init_vnl(UnitCell& cell, const ModulePW::PW_Basis* rho_
         syncmem_d2d_h2d_op()(gpu_ctx, cpu_ctx, this->d_tab, this->tab.ptr, this->tab.getSize());
         syncmem_d2d_h2d_op()(gpu_ctx, cpu_ctx, this->d_qq_nt, this->qq_nt.ptr, this->qq_nt.getSize());
     }
-    else {
-        if (GlobalV::precision_flag == "single") {
+    else
+    {
+        if (GlobalV::precision_flag == "single")
+        {
             castmem_d2s_h2h_op()(cpu_ctx, cpu_ctx, this->s_indv, this->indv.c, this->indv.nr * this->indv.nc);
             castmem_d2s_h2h_op()(cpu_ctx, cpu_ctx, this->s_nhtol, this->nhtol.c, this->nhtol.nr * this->nhtol.nc);
             castmem_d2s_h2h_op()(cpu_ctx, cpu_ctx, this->s_nhtolm, this->nhtolm.c, this->nhtolm.nr * this->nhtolm.nc);
@@ -874,9 +887,9 @@ void pseudopot_cell_vnl::init_vnl(UnitCell& cell, const ModulePW::PW_Basis* rho_
         }
         // There's no need to synchronize double precision pointers while in a CPU environment.
     }
-	ModuleBase::timer::tick("ppcell_vnl","init_vnl");
-	GlobalV::ofs_running << "\n Init Non-Local-Pseudopotential done." << std::endl;
-	return;
+    ModuleBase::timer::tick("ppcell_vnl", "init_vnl");
+    GlobalV::ofs_running << "\n Init Non-Local-Pseudopotential done." << std::endl;
+    return;
 }
 
 void pseudopot_cell_vnl::compute_qrad(UnitCell& cell)
@@ -1114,36 +1127,36 @@ void pseudopot_cell_vnl::radial_fft_q(Device* ctx,
 #ifdef __LCAO
 std::complex<double> pseudopot_cell_vnl::Cal_C(int alpha, int lu, int mu, int L, int M) // pengfei Li  2018-3-23
 {
-	std::complex<double> cf;
-	if(alpha == 0)
-	{
-		cf = -sqrt(4*ModuleBase::PI/3)*CG(lu,mu,1,1,L,M);
-	}
-	else if(alpha == 1)
-	{
-		cf = -sqrt(4*ModuleBase::PI/3)*CG(lu,mu,1,2,L,M);
-	}
-	else if(alpha == 2)
-	{
-		cf = sqrt(4*ModuleBase::PI/3)*CG(lu,mu,1,0,L,M);
-	}
-	else
-	{
-		ModuleBase::WARNING_QUIT("pseudopot_cell_vnl_alpha", "alpha must be 0~2");
-	}
-	
-	return cf;
+    std::complex<double> cf;
+    if (alpha == 0)
+    {
+        cf = -sqrt(4 * ModuleBase::PI / 3) * CG(lu, mu, 1, 1, L, M);
+    }
+    else if (alpha == 1)
+    {
+        cf = -sqrt(4 * ModuleBase::PI / 3) * CG(lu, mu, 1, 2, L, M);
+    }
+    else if (alpha == 2)
+    {
+        cf = sqrt(4 * ModuleBase::PI / 3) * CG(lu, mu, 1, 0, L, M);
+    }
+    else
+    {
+        ModuleBase::WARNING_QUIT("pseudopot_cell_vnl_alpha", "alpha must be 0~2");
+    }
+
+    return cf;
 }
 
-double pseudopot_cell_vnl::CG(int l1, int m1, int l2, int m2, int L, int M)      // pengfei Li 2018-3-23
+double pseudopot_cell_vnl::CG(int l1, int m1, int l2, int m2, int L, int M) // pengfei Li 2018-3-23
 {
-	int dim = L*L+M;
-	int dim1 = l1*l1+m1;
-	int dim2 = l2*l2+m2;
-	
-	//double A = MGT.Gaunt_Coefficients(dim1, dim2, dim);
-	
-	return MGT.Gaunt_Coefficients(dim1, dim2, dim);
+    int dim = L * L + M;
+    int dim1 = l1 * l1 + m1;
+    int dim2 = l2 * l2 + m2;
+
+    // double A = MGT.Gaunt_Coefficients(dim1, dim2, dim);
+
+    return MGT.Gaunt_Coefficients(dim1, dim2, dim);
 }
 
 // void pseudopot_cell_vnl::getvnl_alpha(const int &ik)           // pengfei Li  2018-3-23
@@ -1151,11 +1164,11 @@ double pseudopot_cell_vnl::CG(int l1, int m1, int l2, int m2, int L, int M)     
 // 	if(GlobalV::test_pp) ModuleBase::TITLE("pseudopot_cell_vnl","getvnl_alpha");
 // 	ModuleBase::timer::tick("pp_cell_vnl","getvnl_alpha");
 
-// 	if(lmaxkb < 0) 
+// 	if(lmaxkb < 0)
 // 	{
 // 		return;
 // 	}
-	
+
 // 	const int npw = this->wfcpw->npwk[ik];
 // 	int ig, ia, nb, ih, lu, mu;
 
@@ -1164,7 +1177,7 @@ double pseudopot_cell_vnl::CG(int l1, int m1, int l2, int m2, int L, int M)     
 
 // 	ModuleBase::matrix ylm(x1, npw);
 // 	ModuleBase::Vector3<double> *gk = new ModuleBase::Vector3<double>[npw];
-// 	for (ig = 0;ig < npw;ig++) 
+// 	for (ig = 0;ig < npw;ig++)
 // 	{
 // 		gk[ig] = this->wfcpw->getgpluskcar(ik,ig);
 // 	}
@@ -1177,8 +1190,8 @@ double pseudopot_cell_vnl::CG(int l1, int m1, int l2, int m2, int L, int M)     
 // 		{
 // 			vkb1_alpha[i][j] = new std::complex<double>[npw];
 // 		}
-// 	}	
-	
+// 	}
+
 // 	vkb_alpha = new std::complex<double>**[3];
 // 	for(int i=0; i<3; i++)
 // 	{
@@ -1188,12 +1201,12 @@ double pseudopot_cell_vnl::CG(int l1, int m1, int l2, int m2, int L, int M)     
 // 			vkb_alpha[i][j] = new std::complex<double>[this->wfcpw->npwk_max];
 // 		}
 // 	}
-	
+
 // 	ModuleBase::YlmReal::Ylm_Real(x1, npw, gk, ylm);
 
 // 	MGT.init_Gaunt_CH( lmaxkb + 2 );
 // 	MGT.init_Gaunt( lmaxkb + 2 );
-	
+
 // 	int jkb = 0;
 // 	for(int it = 0;it < GlobalC::ucell.ntype;it++)
 // 	{
@@ -1209,13 +1222,13 @@ double pseudopot_cell_vnl::CG(int l1, int m1, int l2, int m2, int L, int M)     
 // 			{
 // 				ModuleBase::GlobalFunc::ZEROS(vkb1_alpha[i][j], npw);
 // 			}
-			
+
 // 		for (ih = 0;ih < nh; ih++)
 // 		{
 // 			lu = static_cast<int>( nhtol(it, ih));
 // 			mu = static_cast<int>( nhtolm(it, ih)) - lu * lu;
 // 			nb = static_cast<int>( indv(it, ih));
-			
+
 // 			for (int L= std::abs(lu - 1); L<= (lu + 1); L++)
 // 			{
 // 				for (ig = 0;ig < npw;ig++)
@@ -1223,7 +1236,7 @@ double pseudopot_cell_vnl::CG(int l1, int m1, int l2, int m2, int L, int M)     
 // 					const double gnorm = gk[ig].norm() * GlobalC::ucell.tpiba;
 // 					vq [ig] = ModuleBase::PolyInt::Polynomial_Interpolation(
 // 							this->tab_alpha, it, nb, L, GlobalV::NQX, GlobalV::DQ, gnorm);
-					
+
 // 					for (int M=0; M<2*L+1; M++)
 // 					{
 // 						int lm = L*L + M;
@@ -1232,10 +1245,11 @@ double pseudopot_cell_vnl::CG(int l1, int m1, int l2, int m2, int L, int M)     
 // 							std::complex<double> c = Cal_C(alpha,lu, mu, L, M);
 // 							/*if(alpha == 0)
 // 							{
-// 								std::cout<<"lu= "<<lu<<"  mu= "<<mu<<"  L= "<<L<<"  M= "<<M<<" alpha = "<<alpha<<"  "<<c<<std::endl;
+// 								std::cout<<"lu= "<<lu<<"  mu= "<<mu<<"  L= "<<L<<"  M= "<<M<<" alpha = "<<alpha<<"
+// "<<c<<std::endl;
 // 							}*/
 // 							vkb1_alpha[alpha][ih][ig] += c * vq[ig] * ylm(lm, ig) * pow( ModuleBase::NEG_IMAG_UNIT, L);
-// 						}	
+// 						}
 // 					}
 // 				}
 // 			}
@@ -1263,87 +1277,85 @@ double pseudopot_cell_vnl::CG(int l1, int m1, int l2, int m2, int L, int M)     
 // 	delete [] vq;
 // 	ModuleBase::timer::tick("pp_cell_vnl","getvnl_alpha");
 // 	return;
-// } 
+// }
 #endif
 
-void pseudopot_cell_vnl::init_vnl_alpha(void)          // pengfei Li 2018-3-23
+void pseudopot_cell_vnl::init_vnl_alpha(void) // pengfei Li 2018-3-23
 {
-	if(GlobalV::test_pp) ModuleBase::TITLE("pseudopot_cell_vnl","init_vnl_alpha");
-	ModuleBase::timer::tick("ppcell_vnl","init_vnl_alpha");
+    if (GlobalV::test_pp)
+        ModuleBase::TITLE("pseudopot_cell_vnl", "init_vnl_alpha");
+    ModuleBase::timer::tick("ppcell_vnl", "init_vnl_alpha");
 
-	for(int it=0;it<GlobalC::ucell.ntype;it++)
-	{
-		int BetaIndex=0;
-		//const int Nprojectors = GlobalC::ucell.atoms[it].nh;
-		for (int ib=0; ib<GlobalC::ucell.atoms[it].ncpp.nbeta; ib++)
-		{
-			const int l = GlobalC::ucell.atoms[it].ncpp.lll [ib];
-			for(int m=0; m<2*l+1; m++)
-			{
-				this->nhtol(it,BetaIndex) = l;
-				this->nhtolm(it,BetaIndex) = l*l + m;
-				this->indv(it,BetaIndex) = ib;
-				++BetaIndex;
-			}
-		}
-	} 
+    for (int it = 0; it < GlobalC::ucell.ntype; it++)
+    {
+        int BetaIndex = 0;
+        // const int Nprojectors = GlobalC::ucell.atoms[it].nh;
+        for (int ib = 0; ib < GlobalC::ucell.atoms[it].ncpp.nbeta; ib++)
+        {
+            const int l = GlobalC::ucell.atoms[it].ncpp.lll[ib];
+            for (int m = 0; m < 2 * l + 1; m++)
+            {
+                this->nhtol(it, BetaIndex) = l;
+                this->nhtolm(it, BetaIndex) = l * l + m;
+                this->indv(it, BetaIndex) = ib;
+                ++BetaIndex;
+            }
+        }
+    }
 
+    // max number of beta functions
+    const int nbrx = 10;
 
-	// max number of beta functions
-	const int nbrx = 10;
+    const double pref = ModuleBase::FOUR_PI / sqrt(GlobalC::ucell.omega);
+    this->tab_alpha.create(GlobalC::ucell.ntype, nbrx, lmaxkb + 2, GlobalV::NQX);
+    this->tab_alpha.zero_out();
+    GlobalV::ofs_running << "\n Init Non-Local PseudoPotential table( including L index) : ";
+    for (int it = 0; it < GlobalC::ucell.ntype; it++)
+    {
+        const int nbeta = GlobalC::ucell.atoms[it].ncpp.nbeta;
+        int kkbeta = GlobalC::ucell.atoms[it].ncpp.kkbeta;
 
-	const double pref = ModuleBase::FOUR_PI / sqrt(GlobalC::ucell.omega);
-	this->tab_alpha.create(GlobalC::ucell.ntype, nbrx, lmaxkb+2, GlobalV::NQX);
-	this->tab_alpha.zero_out();
-	GlobalV::ofs_running<<"\n Init Non-Local PseudoPotential table( including L index) : ";
-	for (int it = 0;it < GlobalC::ucell.ntype;it++)  
-	{
-		const int nbeta = GlobalC::ucell.atoms[it].ncpp.nbeta;
-		int kkbeta = GlobalC::ucell.atoms[it].ncpp.kkbeta;
+        // mohan modify 2008-3-31
+        // mohan add kkbeta>0 2009-2-27
+        if ((kkbeta % 2 == 0) && kkbeta > 0)
+        {
+            kkbeta--;
+        }
 
-		//mohan modify 2008-3-31
-		//mohan add kkbeta>0 2009-2-27
-		if ( (kkbeta%2 == 0) && kkbeta>0 )
-		{
-			kkbeta--;
-		}
+        double* jl = new double[kkbeta];
+        double* aux = new double[kkbeta];
 
-		double *jl = new double[kkbeta];
-		double *aux  = new double[kkbeta];
+        for (int ib = 0; ib < nbeta; ib++)
+        {
+            for (int L = 0; L <= lmaxkb + 1; L++)
+            {
+                for (int iq = 0; iq < GlobalV::NQX; iq++)
+                {
+                    const double q = iq * GlobalV::DQ;
+                    ModuleBase::Sphbes::Spherical_Bessel(kkbeta, GlobalC::ucell.atoms[it].ncpp.r, q, L, jl);
 
-		for (int ib = 0;ib < nbeta;ib++)
-		{
-			for (int L = 0; L <= lmaxkb+1; L++)
-			{
-				for (int iq = 0; iq < GlobalV::NQX; iq++)
-				{
-					const double q = iq * GlobalV::DQ;
-					ModuleBase::Sphbes::Spherical_Bessel(kkbeta, GlobalC::ucell.atoms[it].ncpp.r, q, L, jl);
-					
-					for (int ir = 0;ir < kkbeta;ir++)
-					{
-						aux[ir] = GlobalC::ucell.atoms[it].ncpp.betar(ib, ir) * jl[ir] * 
-								  GlobalC::ucell.atoms[it].ncpp.r[ir] * GlobalC::ucell.atoms[it].ncpp.r[ir];
-					}
-					double vqint;
-					ModuleBase::Integral::Simpson_Integral(kkbeta, aux, GlobalC::ucell.atoms[it].ncpp.rab, vqint);
-					this->tab_alpha(it, ib, L, iq) = vqint * pref;
-				}
-			}
-		} 
-		delete[] aux;
-		delete[] jl;
-	}
-	ModuleBase::timer::tick("ppcell_vnl","init_vnl_alpha");
-	GlobalV::ofs_running << "\n Init Non-Local-Pseudopotential done(including L)." << std::endl;
-	return;
+                    for (int ir = 0; ir < kkbeta; ir++)
+                    {
+                        aux[ir] = GlobalC::ucell.atoms[it].ncpp.betar(ib, ir) * jl[ir]
+                                  * GlobalC::ucell.atoms[it].ncpp.r[ir] * GlobalC::ucell.atoms[it].ncpp.r[ir];
+                    }
+                    double vqint;
+                    ModuleBase::Integral::Simpson_Integral(kkbeta, aux, GlobalC::ucell.atoms[it].ncpp.rab, vqint);
+                    this->tab_alpha(it, ib, L, iq) = vqint * pref;
+                }
+            }
+        }
+        delete[] aux;
+        delete[] jl;
+    }
+    ModuleBase::timer::tick("ppcell_vnl", "init_vnl_alpha");
+    GlobalV::ofs_running << "\n Init Non-Local-Pseudopotential done(including L)." << std::endl;
+    return;
 }
 
-
-
-void pseudopot_cell_vnl::print_vnl(std::ofstream &ofs)
+void pseudopot_cell_vnl::print_vnl(std::ofstream& ofs)
 {
-	output::printr3_d(ofs, " tab : ", tab);
+    output::printr3_d(ofs, " tab : ", tab);
 }
 
 // ----------------------------------------------------------------------
@@ -1351,15 +1363,16 @@ void pseudopot_cell_vnl::cal_effective_D(const ModuleBase::matrix& veff,
                                          const ModulePW::PW_Basis* rho_basis,
                                          UnitCell& cell)
 {
-    if(GlobalV::use_paw) return;
+    if (GlobalV::use_paw)
+        return;
     ModuleBase::TITLE("pseudopot_cell_vnl", "cal_effective_D");
 
     /*
-	recalculate effective coefficient matrix for non-local pseudo-potential
-	1. assign to each atom from element;
-	2. extend to each spin when nspin larger than 1
-	3. rotate to effective matrix when spin-orbital coupling is used
-	*/
+    recalculate effective coefficient matrix for non-local pseudo-potential
+    1. assign to each atom from element;
+    2. extend to each spin when nspin larger than 1
+    3. rotate to effective matrix when spin-orbital coupling is used
+    */
 
     if (!GlobalV::use_uspp)
     {
@@ -1453,8 +1466,10 @@ void pseudopot_cell_vnl::cal_effective_D(const ModuleBase::matrix& veff,
             }
         }
     }
-    if (GlobalV::device_flag == "gpu") {
-        if (GlobalV::precision_flag == "single") {
+    if (GlobalV::device_flag == "gpu")
+    {
+        if (GlobalV::precision_flag == "single")
+        {
             castmem_d2s_h2d_op()(gpu_ctx,
                                  cpu_ctx,
                                  this->s_deeq,
@@ -1466,7 +1481,8 @@ void pseudopot_cell_vnl::cal_effective_D(const ModuleBase::matrix& veff,
                                  this->deeq_nc.ptr,
                                  GlobalV::NSPIN * cell.nat * this->nhm * this->nhm);
         }
-        else {
+        else
+        {
             syncmem_z2z_h2d_op()(gpu_ctx,
                                  cpu_ctx,
                                  this->z_deeq_nc,
@@ -1479,8 +1495,10 @@ void pseudopot_cell_vnl::cal_effective_D(const ModuleBase::matrix& veff,
                              this->deeq.ptr,
                              GlobalV::NSPIN * cell.nat * this->nhm * this->nhm);
     }
-    else {
-        if (GlobalV::precision_flag == "single") {
+    else
+    {
+        if (GlobalV::precision_flag == "single")
+        {
             castmem_d2s_h2h_op()(cpu_ctx,
                                  cpu_ctx,
                                  this->s_deeq,
@@ -1827,20 +1845,20 @@ template void pseudopot_cell_vnl::radial_fft_q<double, base_device::DEVICE_CPU>(
                                                                                 const double*,
                                                                                 std::complex<double>*) const;
 #if defined(__CUDA) || defined(__ROCM)
-    template void pseudopot_cell_vnl::radial_fft_q<float, base_device::DEVICE_GPU>(base_device::DEVICE_GPU*,
-                                                                                   const int,
-                                                                                   const int,
-                                                                                   const int,
-                                                                                   const int,
-                                                                                   const float*,
-                                                                                   const float*,
-                                                                                   std::complex<float>*) const;
-    template void pseudopot_cell_vnl::radial_fft_q<double, base_device::DEVICE_GPU>(base_device::DEVICE_GPU*,
-                                                                                    const int,
-                                                                                    const int,
-                                                                                    const int,
-                                                                                    const int,
-                                                                                    const double*,
-                                                                                    const double*,
-                                                                                    std::complex<double>*) const;
+template void pseudopot_cell_vnl::radial_fft_q<float, base_device::DEVICE_GPU>(base_device::DEVICE_GPU*,
+                                                                               const int,
+                                                                               const int,
+                                                                               const int,
+                                                                               const int,
+                                                                               const float*,
+                                                                               const float*,
+                                                                               std::complex<float>*) const;
+template void pseudopot_cell_vnl::radial_fft_q<double, base_device::DEVICE_GPU>(base_device::DEVICE_GPU*,
+                                                                                const int,
+                                                                                const int,
+                                                                                const int,
+                                                                                const int,
+                                                                                const double*,
+                                                                                const double*,
+                                                                                std::complex<double>*) const;
 #endif

--- a/source/module_hamilt_pw/hamilt_pwdft/VNL_in_pw.h
+++ b/source/module_hamilt_pw/hamilt_pwdft/VNL_in_pw.h
@@ -11,7 +11,7 @@
 #include "module_hamilt_pw/hamilt_pwdft/structure_factor.h"
 #include "module_psi/psi.h"
 #ifdef __LCAO
-#include "module_basis/module_ao/ORB_gen_tables.h"
+#include "module_basis/module_ao/ORB_gaunt_table.h"
 #endif
 
 //==========================================================

--- a/source/module_hamilt_pw/hamilt_pwdft/VNL_in_pw.h
+++ b/source/module_hamilt_pw/hamilt_pwdft/VNL_in_pw.h
@@ -18,38 +18,37 @@
 // Calculate the non-local pseudopotential in reciprocal
 // space using plane wave as basis set.
 //==========================================================
-class pseudopot_cell_vnl: public pseudopot_cell_vl
+class pseudopot_cell_vnl : public pseudopot_cell_vl
 {
 
-public:
-
-	pseudopot_cell_vnl();
+  public:
+    pseudopot_cell_vnl();
     ~pseudopot_cell_vnl();
     void init(const int ntype,
               Structure_Factor* psf_in,
               const ModulePW::PW_Basis_K* wfc_basis = nullptr,
               const bool allocate_vkb = 1);
 
-    double cell_factor; //LiuXh add 20180619
+    double cell_factor; // LiuXh add 20180619
 
-	int nkb; // total number of beta functions considering all atoms
+    int nkb; // total number of beta functions considering all atoms
 
-	int lmaxkb; // max angular momentum for non-local projectors
+    int lmaxkb; // max angular momentum for non-local projectors
 
     void init_vnl(UnitCell& cell, const ModulePW::PW_Basis* rho_basis);
 
     template <typename FPTYPE, typename Device>
-    void getvnl(Device * ctx, const int &ik, std::complex<FPTYPE>* vkb_in)const;
+    void getvnl(Device* ctx, const int& ik, std::complex<FPTYPE>* vkb_in) const;
 
-    void getvnl(const int &ik, ModuleBase::ComplexMatrix& vkb_in)const;
+    void getvnl(const int& ik, ModuleBase::ComplexMatrix& vkb_in) const;
 
-	// void getvnl_alpha(const int &ik);
+    // void getvnl_alpha(const int &ik);
 
-	void init_vnl_alpha(void);
+    void init_vnl_alpha(void);
 
-	void initgradq_vnl(const UnitCell &cell);
+    void initgradq_vnl(const UnitCell& cell);
 
-	void getgradq_vnl(const int ik);
+    void getgradq_vnl(const int ik);
 
     //===============================================================
     // MEMBER VARIABLES :
@@ -66,25 +65,25 @@ public:
 
     int lmaxq;
 
-	ModuleBase::matrix indv;		// indes linking  atomic beta's to beta's in the solid
-	ModuleBase::matrix nhtol;      	// correspondence n <-> angular momentum l
-	ModuleBase::matrix nhtolm;     	// correspondence n <-> combined lm index for (l,m)
-	ModuleBase::matrix nhtoj;		// new added
+    ModuleBase::matrix indv;   // indes linking  atomic beta's to beta's in the solid
+    ModuleBase::matrix nhtol;  // correspondence n <-> angular momentum l
+    ModuleBase::matrix nhtolm; // correspondence n <-> combined lm index for (l,m)
+    ModuleBase::matrix nhtoj;  // new added
 
-	ModuleBase::realArray dvan;		//(:,:,:),  the D functions of the solid
-	ModuleBase::ComplexArray dvan_so;	//(:,:,:),  spin-orbit case,  added by zhengdy-soc
+    ModuleBase::realArray dvan;       //(:,:,:),  the D functions of the solid
+    ModuleBase::ComplexArray dvan_so; //(:,:,:),  spin-orbit case,  added by zhengdy-soc
 
-	ModuleBase::realArray tab;		//(:,:,:), interpolation table for PPs: 4pi/sqrt(V) * \int betar(r)jl(qr)rdr
-	ModuleBase::realArray tab_alpha;
-	ModuleBase::realArray tab_at;	//(:,:,:), interpolation table for atomic wfc
-	ModuleBase::realArray tab_dq;   //4pi/sqrt(V) * \int betar(r)*djl(qr)/d(qr)*r^2 dr
+    ModuleBase::realArray tab; //(:,:,:), interpolation table for PPs: 4pi/sqrt(V) * \int betar(r)jl(qr)rdr
+    ModuleBase::realArray tab_alpha;
+    ModuleBase::realArray tab_at; //(:,:,:), interpolation table for atomic wfc
+    ModuleBase::realArray tab_dq; // 4pi/sqrt(V) * \int betar(r)*djl(qr)/d(qr)*r^2 dr
 
-	ModuleBase::realArray deeq;		//(:,:,:,:), the integral of V_eff and Q_{nm}
-	bool multi_proj = false;
-    float *s_deeq = nullptr;
-    double *d_deeq = nullptr;
-	ModuleBase::ComplexArray deeq_nc;	//(:,:,:,:), the spin-orbit case
-    std::complex<float> *c_deeq_nc = nullptr; // GPU array of deeq_nc
+    ModuleBase::realArray deeq; //(:,:,:,:), the integral of V_eff and Q_{nm}
+    bool multi_proj = false;
+    float* s_deeq = nullptr;
+    double* d_deeq = nullptr;
+    ModuleBase::ComplexArray deeq_nc;          //(:,:,:,:), the spin-orbit case
+    std::complex<float>* c_deeq_nc = nullptr;  // GPU array of deeq_nc
     std::complex<double>* z_deeq_nc = nullptr; // GPU array of deeq_nc
 
     // liuyu add 2023-10-03
@@ -186,16 +185,16 @@ public:
 
   private:
     bool memory_released = false;
-    float *s_nhtol = nullptr;
-    float *s_nhtolm = nullptr;
-    float *s_indv = nullptr;
-    float *s_tab = nullptr;
+    float* s_nhtol = nullptr;
+    float* s_nhtolm = nullptr;
+    float* s_indv = nullptr;
+    float* s_tab = nullptr;
     std::complex<float>* c_vkb = nullptr;
 
-    double *d_nhtol = nullptr;
-    double *d_nhtolm = nullptr;
-    double *d_indv = nullptr;
-    double *d_tab = nullptr;
+    double* d_nhtol = nullptr;
+    double* d_nhtolm = nullptr;
+    double* d_indv = nullptr;
+    double* d_tab = nullptr;
     std::complex<double>* z_vkb = nullptr;
 
     const ModulePW::PW_Basis_K* wfcpw = nullptr;

--- a/source/module_io/output_mat_sparse.cpp
+++ b/source/module_io/output_mat_sparse.cpp
@@ -16,7 +16,7 @@ namespace ModuleIO
         const ModuleBase::matrix &v_eff,
         const Parallel_Orbitals &pv,
         Gint_k &gint_k, // mohan add 2024-04-01
-        const ORB_gen_tables* uot,
+        const TwoCenterBundle& two_center_bundle,
         LCAO_Matrix &lm,
         Grid_Driver &grid, // mohan add 2024-04-06
         const K_Vectors& kv,
@@ -29,7 +29,7 @@ namespace ModuleIO
       _v_eff(v_eff),
       _pv(pv),
       _gint_k(gint_k), // mohan add 2024-04-01
-      uot_(uot),
+      two_center_bundle_(two_center_bundle),
       _lm(lm),
       _grid(grid), // mohan add 2024-04-06
       _kv(kv),
@@ -68,7 +68,7 @@ void Output_Mat_Sparse<std::complex<double>>::write(void)
                 this->_pv, 
 				this->_lm, 
 				this->_grid,
-                uot_); // LiuXh add 2019-07-15
+                two_center_bundle_); // LiuXh add 2019-07-15
     }
 
     //! generate a file containing the derivatives of the Hamiltonian matrix (in Ry/Bohr)
@@ -80,7 +80,7 @@ void Output_Mat_Sparse<std::complex<double>>::write(void)
 				this->_gint_k, // mohan add 2024-04-01
 				this->_lm,
                 this->_grid, // mohan add 2024-04-06
-                uot_,
+                two_center_bundle_,
 				_kv); // LiuXh add 2019-07-15
 	}
 

--- a/source/module_io/output_mat_sparse.cpp
+++ b/source/module_io/output_mat_sparse.cpp
@@ -1,88 +1,69 @@
 #include "output_mat_sparse.h"
+
 #include "cal_r_overlap_R.h"
-#include "write_HS_R.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h" // for ucell
+#include "write_HS_R.h"
 
 namespace ModuleIO
 {
 
-    template<typename T>
-    Output_Mat_Sparse<T>::Output_Mat_Sparse(
-        int out_mat_hsR,
-        int out_mat_dh,
-        int out_mat_t,
-        int out_mat_r,
-        int istep,
-        const ModuleBase::matrix &v_eff,
-        const Parallel_Orbitals &pv,
-        Gint_k &gint_k, // mohan add 2024-04-01
-        const TwoCenterBundle& two_center_bundle,
-        LCAO_Matrix &lm,
-        Grid_Driver &grid, // mohan add 2024-04-06
-        const K_Vectors& kv,
-        hamilt::Hamilt<T>* p_ham)
-    : _out_mat_hsR(out_mat_hsR),
-      _out_mat_dh(out_mat_dh),
-      _out_mat_t(out_mat_t),
-      _out_mat_r(out_mat_r),
-      _istep(istep),
-      _v_eff(v_eff),
-      _pv(pv),
-      _gint_k(gint_k), // mohan add 2024-04-01
-      two_center_bundle_(two_center_bundle),
-      _lm(lm),
-      _grid(grid), // mohan add 2024-04-06
-      _kv(kv),
-      _p_ham(p_ham)
+template <typename T>
+Output_Mat_Sparse<T>::Output_Mat_Sparse(int out_mat_hsR,
+                                        int out_mat_dh,
+                                        int out_mat_t,
+                                        int out_mat_r,
+                                        int istep,
+                                        const ModuleBase::matrix& v_eff,
+                                        const Parallel_Orbitals& pv,
+                                        Gint_k& gint_k, // mohan add 2024-04-01
+                                        const TwoCenterBundle& two_center_bundle,
+                                        LCAO_Matrix& lm,
+                                        Grid_Driver& grid, // mohan add 2024-04-06
+                                        const K_Vectors& kv,
+                                        hamilt::Hamilt<T>* p_ham)
+    : _out_mat_hsR(out_mat_hsR), _out_mat_dh(out_mat_dh), _out_mat_t(out_mat_t), _out_mat_r(out_mat_r), _istep(istep),
+      _v_eff(v_eff), _pv(pv), _gint_k(gint_k),                     // mohan add 2024-04-01
+      two_center_bundle_(two_center_bundle), _lm(lm), _grid(grid), // mohan add 2024-04-06
+      _kv(kv), _p_ham(p_ham)
 {
 }
 
-template<>
-void Output_Mat_Sparse<double>::write(void) 
+template <>
+void Output_Mat_Sparse<double>::write()
 {
 }
 
-
-template<>
-void Output_Mat_Sparse<std::complex<double>>::write(void)
+template <>
+void Output_Mat_Sparse<std::complex<double>>::write()
 {
-    //! generate a file containing the Hamiltonian and S(overlap) matrices 
+    //! generate a file containing the Hamiltonian and S(overlap) matrices
     if (_out_mat_hsR)
     {
-		output_HSR(
-				_istep, 
-				this->_v_eff, 
-                this->_pv,
-				this->_lm, 
-                this->_grid,
-				_kv, 
-				_p_ham);
+        output_HSR(_istep, this->_v_eff, this->_pv, this->_lm, this->_grid, _kv, _p_ham);
     }
 
     //! generate a file containing the kinetic energy matrix
     if (_out_mat_t)
     {
-		output_TR(
-				_istep, 
-                GlobalC::ucell,
-                this->_pv, 
-				this->_lm, 
-				this->_grid,
-                two_center_bundle_); // LiuXh add 2019-07-15
+        output_TR(_istep,
+                  GlobalC::ucell,
+                  this->_pv,
+                  this->_lm,
+                  this->_grid,
+                  two_center_bundle_); // LiuXh add 2019-07-15
     }
 
     //! generate a file containing the derivatives of the Hamiltonian matrix (in Ry/Bohr)
     if (_out_mat_dh)
     {
-		output_dHR(
-				_istep, 
-				this->_v_eff, 
-				this->_gint_k, // mohan add 2024-04-01
-				this->_lm,
-                this->_grid, // mohan add 2024-04-06
-                two_center_bundle_,
-				_kv); // LiuXh add 2019-07-15
-	}
+        output_dHR(_istep,
+                   this->_v_eff,
+                   this->_gint_k, // mohan add 2024-04-01
+                   this->_lm,
+                   this->_grid, // mohan add 2024-04-06
+                   two_center_bundle_,
+                   _kv); // LiuXh add 2019-07-15
+    }
 
     // add by jingan for out r_R matrix 2019.8.14
     if (_out_mat_r)

--- a/source/module_io/output_mat_sparse.h
+++ b/source/module_io/output_mat_sparse.h
@@ -1,6 +1,7 @@
 #ifndef OUTPUT_MAT_SPARSE_H
 #define OUTPUT_MAT_SPARSE_H
 
+#include "module_basis/module_nao/two_center_bundle.h"
 #include "module_basis/module_ao/parallel_orbitals.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h"
 #include "module_hamilt_lcao/module_gint/gint_k.h"
@@ -21,7 +22,7 @@ class Output_Mat_Sparse
                       const ModuleBase::matrix& v_eff,
                       const Parallel_Orbitals& pv,
                       Gint_k& gint_k,         // mohan add 2024-04-01
-                      const ORB_gen_tables* uot,
+                      const TwoCenterBundle& two_center_bundle,
                       LCAO_Matrix& lm,
                       Grid_Driver& grid, // mohan add 2024-04-06
                       const K_Vectors& kv,
@@ -51,7 +52,7 @@ class Output_Mat_Sparse
     Gint_k& _gint_k; // mohan add 2024-04-01
 
     // introduced temporarily for LCAO refactoring
-    const ORB_gen_tables* uot_;
+    const TwoCenterBundle& two_center_bundle_;
 
     LCAO_Matrix& _lm;
 

--- a/source/module_io/output_mat_sparse.h
+++ b/source/module_io/output_mat_sparse.h
@@ -1,8 +1,8 @@
 #ifndef OUTPUT_MAT_SPARSE_H
 #define OUTPUT_MAT_SPARSE_H
 
-#include "module_basis/module_nao/two_center_bundle.h"
 #include "module_basis/module_ao/parallel_orbitals.h"
+#include "module_basis/module_nao/two_center_bundle.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h"
 #include "module_hamilt_lcao/module_gint/gint_k.h"
 #include "module_hsolver/hsolver_lcao.h"
@@ -21,7 +21,7 @@ class Output_Mat_Sparse
                       int istep,
                       const ModuleBase::matrix& v_eff,
                       const Parallel_Orbitals& pv,
-                      Gint_k& gint_k,         // mohan add 2024-04-01
+                      Gint_k& gint_k, // mohan add 2024-04-01
                       const TwoCenterBundle& two_center_bundle,
                       LCAO_Matrix& lm,
                       Grid_Driver& grid, // mohan add 2024-04-06

--- a/source/module_io/td_current_io.cpp
+++ b/source/module_io/td_current_io.cpp
@@ -18,7 +18,7 @@ void ModuleIO::Init_DS_tmp(
 		const Parallel_Orbitals& pv,
 		LCAO_Matrix &lm,
         ForceStressArrays &fsr,
-        const ORB_gen_tables* uot)
+        const TwoCenterBundle& two_center_bundle)
 {    
     ModuleBase::TITLE("ModuleIO", "Init_DS_tmp");
     ModuleBase::timer::tick("ModuleIO", "Init_DS_tmp");
@@ -45,7 +45,7 @@ void ModuleIO::Init_DS_tmp(
         GlobalC::ucell, 
         GlobalC::ORB, 
         pv,
-        *uot, 
+        two_center_bundle, 
         &GlobalC::GridD, 
         nullptr); // delete lm.SlocR
 
@@ -154,7 +154,7 @@ void ModuleIO::write_current(const int istep,
                                 const psi::Psi<std::complex<double>>* psi,
                                 const elecstate::ElecState* pelec,
                                 const K_Vectors& kv,
-                                const ORB_gen_tables* uot,
+                                const TwoCenterBundle& two_center_bundle,
                                 const Parallel_Orbitals* pv,
 								Record_adj& ra,
 								LCAO_Matrix &lm) // mohan add 2024-04-02
@@ -167,7 +167,7 @@ void ModuleIO::write_current(const int istep,
     ForceStressArrays fsr_c;
 
     //Init_DS_tmp
-    Init_DS_tmp(*pv, lm, fsr_c, uot);
+    Init_DS_tmp(*pv, lm, fsr_c, two_center_bundle);
 
     // construct a DensityMatrix object
     elecstate::DensityMatrix<std::complex<double>, double> DM(&kv,pv,GlobalV::NSPIN);

--- a/source/module_io/td_current_io.cpp
+++ b/source/module_io/td_current_io.cpp
@@ -1,25 +1,24 @@
 #include "td_current_io.h"
-#include "module_hamilt_lcao/hamilt_lcaodft/LCAO_domain.h"
 
 #include "module_base/global_function.h"
 #include "module_base/global_variable.h"
-#include "module_base/vector3.h"
-#include "module_base/timer.h"
 #include "module_base/libm/libm.h"
-#include "module_base/tool_threading.h"
-#include "module_hamilt_pw/hamilt_pwdft/global.h"
-#include "module_elecstate/module_dm/cal_dm_psi.h"
 #include "module_base/parallel_reduce.h"
+#include "module_base/timer.h"
+#include "module_base/tool_threading.h"
+#include "module_base/vector3.h"
+#include "module_elecstate/module_dm/cal_dm_psi.h"
 #include "module_elecstate/potentials/H_TDDFT_pw.h"
+#include "module_hamilt_lcao/hamilt_lcaodft/LCAO_domain.h"
+#include "module_hamilt_pw/hamilt_pwdft/global.h"
 
 #ifdef __LCAO
-//init DSloc_R for current calculation
-void ModuleIO::Init_DS_tmp(
-		const Parallel_Orbitals& pv,
-		LCAO_Matrix &lm,
-        ForceStressArrays &fsr,
-        const TwoCenterBundle& two_center_bundle)
-{    
+// init DSloc_R for current calculation
+void ModuleIO::Init_DS_tmp(const Parallel_Orbitals& pv,
+                           LCAO_Matrix& lm,
+                           ForceStressArrays& fsr,
+                           const TwoCenterBundle& two_center_bundle)
+{
     ModuleBase::TITLE("ModuleIO", "Init_DS_tmp");
     ModuleBase::timer::tick("ModuleIO", "Init_DS_tmp");
     const int nnr = pv.nnr;
@@ -37,25 +36,23 @@ void ModuleIO::Init_DS_tmp(
 
     ModuleBase::OMP_PARALLEL(init_DSloc_Rxyz);
     bool cal_deri = true;
-    LCAO_domain::build_ST_new(
-        lm,
-        fsr,
-        'S', 
-        cal_deri, 
-        GlobalC::ucell, 
-        GlobalC::ORB, 
-        pv,
-        two_center_bundle, 
-        &GlobalC::GridD, 
-        nullptr); // delete lm.SlocR
+    LCAO_domain::build_ST_new(lm,
+                              fsr,
+                              'S',
+                              cal_deri,
+                              GlobalC::ucell,
+                              GlobalC::ORB,
+                              pv,
+                              two_center_bundle,
+                              &GlobalC::GridD,
+                              nullptr); // delete lm.SlocR
 
     ModuleBase::timer::tick("ModuleIO", "Init_DS_tmp");
     return;
 }
 
-
-//destory DSloc_R so it can be used normally in the following force calculation
-void ModuleIO::destory_DS_tmp(ForceStressArrays &fsr)
+// destory DSloc_R so it can be used normally in the following force calculation
+void ModuleIO::destory_DS_tmp(ForceStressArrays& fsr)
 {
     ModuleBase::TITLE("ModuleIO", "destory_DS_tmp");
     ModuleBase::timer::tick("ModuleIO", "destory_DS_tmp");
@@ -65,7 +62,6 @@ void ModuleIO::destory_DS_tmp(ForceStressArrays &fsr)
     ModuleBase::timer::tick("ModuleIO", "destory_DS_tmp");
     return;
 }
-
 
 void ModuleIO::cal_tmp_DM(elecstate::DensityMatrix<std::complex<double>, double>& DM, const int ik, const int nspin)
 {
@@ -80,7 +76,7 @@ void ModuleIO::cal_tmp_DM(elecstate::DensityMatrix<std::complex<double>, double>
         // set zero since this function is called in every scf step
         tmp_DMR->set_zero();
 #ifdef _OPENMP
-        #pragma omp parallel for
+#pragma omp parallel for
 #endif
         for (int i = 0; i < tmp_DMR->size_atom_pairs(); ++i)
         {
@@ -106,43 +102,43 @@ void ModuleIO::cal_tmp_DM(elecstate::DensityMatrix<std::complex<double>, double>
                 }
 #endif
                 // only ik
-                if(GlobalV::NSPIN !=4 )
+                if (GlobalV::NSPIN != 4)
                 {
-                // cal k_phase
-                // if TK==std::complex<double>, kphase is e^{ikR}
-                const ModuleBase::Vector3<double> dR(r_index.x, r_index.y, r_index.z);
-                const double arg = (DM.get_kv_pointer()->kvec_d[ik] * dR) * ModuleBase::TWO_PI;
-                double sinp, cosp;
-                ModuleBase::libm::sincos(arg, &sinp, &cosp);
-                std::complex<double> kphase = std::complex<double>(cosp, sinp);
-                // set DMR element
-                double* tmp_DMR_pointer = tmp_matrix->get_pointer();
-                std::complex<double>* tmp_DMK_pointer = DM.get_DMK_pointer(ik + ik_begin);
-                double* DMK_real_pointer = nullptr;
-                double* DMK_imag_pointer = nullptr;
-                // jump DMK to fill DMR
-                // DMR is row-major, DMK is column-major
-                tmp_DMK_pointer += col_ap * DM.get_paraV_pointer()->nrow + row_ap;
-                for (int mu = 0; mu < DM.get_paraV_pointer()->get_row_size(iat1); ++mu)
-                {
-                    DMK_real_pointer = (double*)tmp_DMK_pointer;
-                    DMK_imag_pointer = DMK_real_pointer + 1;
-                    BlasConnector::axpy(DM.get_paraV_pointer()->get_col_size(iat2),
-                                        kphase.imag(),
-                                        DMK_real_pointer,
-                                        ld_hk2,
-                                        tmp_DMR_pointer,
-                                        1);
-                    // "-" since i^2 = -1
-                    BlasConnector::axpy(DM.get_paraV_pointer()->get_col_size(iat2),
-                                        kphase.real(),
-                                        DMK_imag_pointer,
-                                        ld_hk2,
-                                        tmp_DMR_pointer,
-                                        1);
-                    tmp_DMK_pointer += 1;
-                    tmp_DMR_pointer += DM.get_paraV_pointer()->get_col_size(iat2);
-                }
+                    // cal k_phase
+                    // if TK==std::complex<double>, kphase is e^{ikR}
+                    const ModuleBase::Vector3<double> dR(r_index.x, r_index.y, r_index.z);
+                    const double arg = (DM.get_kv_pointer()->kvec_d[ik] * dR) * ModuleBase::TWO_PI;
+                    double sinp, cosp;
+                    ModuleBase::libm::sincos(arg, &sinp, &cosp);
+                    std::complex<double> kphase = std::complex<double>(cosp, sinp);
+                    // set DMR element
+                    double* tmp_DMR_pointer = tmp_matrix->get_pointer();
+                    std::complex<double>* tmp_DMK_pointer = DM.get_DMK_pointer(ik + ik_begin);
+                    double* DMK_real_pointer = nullptr;
+                    double* DMK_imag_pointer = nullptr;
+                    // jump DMK to fill DMR
+                    // DMR is row-major, DMK is column-major
+                    tmp_DMK_pointer += col_ap * DM.get_paraV_pointer()->nrow + row_ap;
+                    for (int mu = 0; mu < DM.get_paraV_pointer()->get_row_size(iat1); ++mu)
+                    {
+                        DMK_real_pointer = (double*)tmp_DMK_pointer;
+                        DMK_imag_pointer = DMK_real_pointer + 1;
+                        BlasConnector::axpy(DM.get_paraV_pointer()->get_col_size(iat2),
+                                            kphase.imag(),
+                                            DMK_real_pointer,
+                                            ld_hk2,
+                                            tmp_DMR_pointer,
+                                            1);
+                        // "-" since i^2 = -1
+                        BlasConnector::axpy(DM.get_paraV_pointer()->get_col_size(iat2),
+                                            kphase.real(),
+                                            DMK_imag_pointer,
+                                            ld_hk2,
+                                            tmp_DMR_pointer,
+                                            1);
+                        tmp_DMK_pointer += 1;
+                        tmp_DMR_pointer += DM.get_paraV_pointer()->get_col_size(iat2);
+                    }
                 }
             }
         }
@@ -151,13 +147,13 @@ void ModuleIO::cal_tmp_DM(elecstate::DensityMatrix<std::complex<double>, double>
 }
 
 void ModuleIO::write_current(const int istep,
-                                const psi::Psi<std::complex<double>>* psi,
-                                const elecstate::ElecState* pelec,
-                                const K_Vectors& kv,
-                                const TwoCenterBundle& two_center_bundle,
-                                const Parallel_Orbitals* pv,
-								Record_adj& ra,
-								LCAO_Matrix &lm) // mohan add 2024-04-02
+                             const psi::Psi<std::complex<double>>* psi,
+                             const elecstate::ElecState* pelec,
+                             const K_Vectors& kv,
+                             const TwoCenterBundle& two_center_bundle,
+                             const Parallel_Orbitals* pv,
+                             Record_adj& ra,
+                             LCAO_Matrix& lm) // mohan add 2024-04-02
 {
 
     ModuleBase::TITLE("ModuleIO", "write_current");
@@ -166,32 +162,32 @@ void ModuleIO::write_current(const int istep,
     // mohan add 2024-06-16
     ForceStressArrays fsr_c;
 
-    //Init_DS_tmp
+    // Init_DS_tmp
     Init_DS_tmp(*pv, lm, fsr_c, two_center_bundle);
 
     // construct a DensityMatrix object
-    elecstate::DensityMatrix<std::complex<double>, double> DM(&kv,pv,GlobalV::NSPIN);
-    
+    elecstate::DensityMatrix<std::complex<double>, double> DM(&kv, pv, GlobalV::NSPIN);
+
     elecstate::cal_dm_psi(DM.get_paraV_pointer(), pelec->wg, psi[0], DM);
-    
-    //loc.cal_dm_R(edm_k, ra, edm2d, kv);
+
+    // loc.cal_dm_R(edm_k, ra, edm2d, kv);
 
     // cal_dm_2d
-    DM.init_DMR(ra,&GlobalC::ucell);
+    DM.init_DMR(ra, &GlobalC::ucell);
     for (int ik = 0; ik < DM.get_DMK_nks(); ++ik)
     {
         cal_tmp_DM(DM, ik, pv->nspin);
-        //check later
+        // check later
         double current_ik[3] = {0.0, 0.0, 0.0};
         int total_irr = 0;
 #ifdef _OPENMP
 #pragma omp parallel
         {
             int num_threads = omp_get_num_threads();
-            //ModuleBase::matrix local_soverlap(3, 3);
+            // ModuleBase::matrix local_soverlap(3, 3);
             int local_total_irr = 0;
 #else
-        //ModuleBase::matrix& local_soverlap = soverlap;
+        // ModuleBase::matrix& local_soverlap = soverlap;
         int& local_total_irr = total_irr;
 #endif
 
@@ -226,7 +222,8 @@ void ModuleIO::write_current(const int istep,
                     double Rz = ra.info[iat][cb][2];
                     // get BaseMatrix
                     hamilt::BaseMatrix<double>* tmp_matrix = DM.get_DMR_pointer(1)->find_matrix(iat1, iat2, Rx, Ry, Rz);
-                    if(tmp_matrix == nullptr) continue;
+                    if (tmp_matrix == nullptr)
+                        continue;
                     int row_ap = pv->atom_begin_row[iat1];
                     int col_ap = pv->atom_begin_col[iat2];
                     // get DMR
@@ -235,7 +232,7 @@ void ModuleIO::write_current(const int istep,
                         for (int nu = 0; nu < pv->get_col_size(iat2); ++nu)
                         {
                             // here do not sum over spin due to EDM.sum_DMR_spin();
-                            double edm2d1 = tmp_matrix->get_value(mu,nu);
+                            double edm2d1 = tmp_matrix->get_value(mu, nu);
                             double edm2d2 = 2.0 * edm2d1;
                             current_ik[0] -= edm2d2 * fsr_c.DSloc_Rx[irr];
                             current_ik[1] -= edm2d2 * fsr_c.DSloc_Ry[irr];
@@ -245,7 +242,7 @@ void ModuleIO::write_current(const int istep,
                         } // end kk
                     }     // end jj
                 }         // end cb
-            } // end iat
+            }             // end iat
 #ifdef _OPENMP
 #pragma omp critical(cal_foverlap_k_reduce)
             {
@@ -254,21 +251,21 @@ void ModuleIO::write_current(const int istep,
         }
 #endif
         Parallel_Reduce::reduce_all(current_ik, 3);
-        //MPI_Reduce(local_current_ik, current_ik, 3, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
-        if(GlobalV::MY_RANK==0)
+        // MPI_Reduce(local_current_ik, current_ik, 3, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+        if (GlobalV::MY_RANK == 0)
         {
-            std::string filename = GlobalV::global_out_dir + "current_" + std::to_string(ik)+".dat";
+            std::string filename = GlobalV::global_out_dir + "current_" + std::to_string(ik) + ".dat";
             std::ofstream fout;
             fout.open(filename, std::ios::app);
             fout << std::setprecision(16);
             fout << std::scientific;
-            //fout << "# current_x current_y current_z" << std::endl;
+            // fout << "# current_x current_y current_z" << std::endl;
             fout << current_ik[0] << " " << current_ik[1] << " " << current_ik[2] << std::endl;
             fout.close();
         }
-        //write end
+        // write end
         ModuleBase::timer::tick("ModuleIO", "write_current");
-    }//end nks
+    } // end nks
     destory_DS_tmp(fsr_c);
     return;
 }

--- a/source/module_io/td_current_io.h
+++ b/source/module_io/td_current_io.h
@@ -14,7 +14,7 @@ void write_current(const int istep,
                     const psi::Psi<std::complex<double>>* psi,
                     const elecstate::ElecState* pelec,
                     const K_Vectors& kv,
-                    const ORB_gen_tables* uot,
+                    const TwoCenterBundle& two_center_bundle,
                     const Parallel_Orbitals* pv,
 					Record_adj& ra,
 					LCAO_Matrix &lm); // mohan add 2024-04-02
@@ -27,7 +27,7 @@ void Init_DS_tmp(
 		const Parallel_Orbitals& pv,
 		LCAO_Matrix &lm,
         ForceStressArrays &fsr,
-        const ORB_gen_tables* uot);
+        const TwoCenterBundle& two_center_bundle);
 
 /// @brief DS_locR will be initialized again in force calculation, so it must be destoryed here.
 void destory_DS_tmp(ForceStressArrays &fsr);

--- a/source/module_io/td_current_io.h
+++ b/source/module_io/td_current_io.h
@@ -1,37 +1,36 @@
 #ifndef TD_CURRENT_H
 #define TD_CURRENT_H
 
-#include "module_elecstate/module_dm/density_matrix.h"
 #include "module_elecstate/elecstate_lcao.h"
-#include "module_psi/psi.h"
+#include "module_elecstate/module_dm/density_matrix.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/force_stress_arrays.h"
+#include "module_psi/psi.h"
 
 namespace ModuleIO
 {
 #ifdef __LCAO
 /// @brief func to output current, only used in tddft
 void write_current(const int istep,
-                    const psi::Psi<std::complex<double>>* psi,
-                    const elecstate::ElecState* pelec,
-                    const K_Vectors& kv,
-                    const TwoCenterBundle& two_center_bundle,
-                    const Parallel_Orbitals* pv,
-					Record_adj& ra,
-					LCAO_Matrix &lm); // mohan add 2024-04-02
+                   const psi::Psi<std::complex<double>>* psi,
+                   const elecstate::ElecState* pelec,
+                   const K_Vectors& kv,
+                   const TwoCenterBundle& two_center_bundle,
+                   const Parallel_Orbitals* pv,
+                   Record_adj& ra,
+                   LCAO_Matrix& lm); // mohan add 2024-04-02
 
 /// @brief calculate sum_n[𝜌_(𝑛𝑘,𝜇𝜈)] for current calculation
 void cal_tmp_DM(elecstate::DensityMatrix<std::complex<double>, double>& DM, const int ik, const int nspin);
 
 /// @brief Init DS_locR for currrent calculation
-void Init_DS_tmp(
-		const Parallel_Orbitals& pv,
-		LCAO_Matrix &lm,
-        ForceStressArrays &fsr,
-        const TwoCenterBundle& two_center_bundle);
+void Init_DS_tmp(const Parallel_Orbitals& pv,
+                 LCAO_Matrix& lm,
+                 ForceStressArrays& fsr,
+                 const TwoCenterBundle& two_center_bundle);
 
 /// @brief DS_locR will be initialized again in force calculation, so it must be destoryed here.
-void destory_DS_tmp(ForceStressArrays &fsr);
+void destory_DS_tmp(ForceStressArrays& fsr);
 
 #endif // __LCAO
-}
+} // namespace ModuleIO
 #endif // TD_CURRENT_H

--- a/source/module_io/write_HS_R.cpp
+++ b/source/module_io/write_HS_R.cpp
@@ -66,7 +66,7 @@ void ModuleIO::output_dHR(const int& istep,
                           Gint_k& gint_k,    // mohan add 2024-04-01
                           LCAO_Matrix& lm,   // mohan add 2024-04-01
                           Grid_Driver& grid, // mohan add 2024-04-06
-                          const ORB_gen_tables* uot,
+                          const TwoCenterBundle& two_center_bundle,
                           const K_Vectors& kv,
                           const bool& binary,
                           const double& sparse_thr)
@@ -83,7 +83,7 @@ void ModuleIO::output_dHR(const int& istep,
         // mohan add 2024-04-01
         const int cspin = 0;
 
-        sparse_format::cal_dH(lm, grid, uot, cspin, sparse_thr, gint_k);
+        sparse_format::cal_dH(lm, grid, two_center_bundle, cspin, sparse_thr, gint_k);
     }
     else if (nspin == 2)
     {
@@ -102,7 +102,7 @@ void ModuleIO::output_dHR(const int& istep,
                 }
             }
 
-            sparse_format::cal_dH(lm, grid, uot, cspin, sparse_thr, gint_k);
+            sparse_format::cal_dH(lm, grid, two_center_bundle, cspin, sparse_thr, gint_k);
         }
     }
     // mohan update 2024-04-01
@@ -144,7 +144,7 @@ void ModuleIO::output_TR(const int istep,
                          const Parallel_Orbitals& pv,
                          LCAO_Matrix& lm,
                          Grid_Driver& grid,
-                         const ORB_gen_tables* uot,
+                         const TwoCenterBundle& two_center_bundle,
                          const std::string& TR_filename,
                          const bool& binary,
                          const double& sparse_thr)
@@ -165,7 +165,7 @@ void ModuleIO::output_TR(const int istep,
     // need Hloc_fixedR
     LCAO_HS_Arrays HS_arrays;
 
-    sparse_format::cal_TR(ucell, pv, lm, HS_arrays, grid, uot, sparse_thr);
+    sparse_format::cal_TR(ucell, pv, lm, HS_arrays, grid, two_center_bundle, sparse_thr);
 
     ModuleIO::save_sparse(lm.TR_sparse, lm.all_R_coor, sparse_thr, binary, sst.str().c_str(), *(lm.ParaV), "T", istep);
 

--- a/source/module_io/write_HS_R.h
+++ b/source/module_io/write_HS_R.h
@@ -7,6 +7,7 @@
 #include "module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h"
 #include "module_hamilt_lcao/module_gint/gint_k.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
+#include "module_basis/module_nao/two_center_bundle.h"
 
 namespace ModuleIO
 {
@@ -30,7 +31,7 @@ namespace ModuleIO
 			Gint_k& gint_k,  // mohan add 2024-04-01
 			LCAO_Matrix &lm,  // mohan add 2024-04-01
             Grid_Driver &grid, // mohan add 2024-04-06
-            const ORB_gen_tables* uot,
+            const TwoCenterBundle& two_center_bundle,
             const K_Vectors& kv,
             const bool& binary = false,
             const double& sparse_threshold = 1e-10);
@@ -41,7 +42,7 @@ namespace ModuleIO
             const Parallel_Orbitals &pv,
 			LCAO_Matrix &lm,
             Grid_Driver &grid,
-            const ORB_gen_tables* uot,
+            const TwoCenterBundle& two_center_bundle,
             const std::string& TR_filename = "data-TR-sparse_SPIN0.csr",
             const bool& binary = false,
             const double& sparse_threshold = 1e-10);

--- a/source/module_io/write_HS_R.h
+++ b/source/module_io/write_HS_R.h
@@ -2,59 +2,55 @@
 #define WRITE_HS_R_H
 
 #include "module_base/matrix.h"
+#include "module_basis/module_nao/two_center_bundle.h"
 #include "module_cell/klist.h"
 #include "module_hamilt_general/hamilt.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/LCAO_matrix.h"
 #include "module_hamilt_lcao/module_gint/gint_k.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
-#include "module_basis/module_nao/two_center_bundle.h"
 
 namespace ModuleIO
 {
-        void output_HSR(
-            const int &istep,
-            const ModuleBase::matrix& v_eff,
-			const Parallel_Orbitals &pv,
-			LCAO_Matrix &lm,
-            Grid_Driver &grid, // mohan add 2024-04-06
-            const K_Vectors& kv,
-            hamilt::Hamilt<std::complex<double>>* p_ham,
-            const std::string& SR_filename = "data-SR-sparse_SPIN0.csr",
-            const std::string& HR_filename_up = "data-HR-sparse_SPIN0.csr",
-            const std::string HR_filename_down = "data-HR-sparse_SPIN1.csr",
-            const bool& binary = false,
-            const double& sparse_threshold = 1e-10); //LiuXh add 2019-07-15, modify in 2021-12-3
+void output_HSR(const int& istep,
+                const ModuleBase::matrix& v_eff,
+                const Parallel_Orbitals& pv,
+                LCAO_Matrix& lm,
+                Grid_Driver& grid, // mohan add 2024-04-06
+                const K_Vectors& kv,
+                hamilt::Hamilt<std::complex<double>>* p_ham,
+                const std::string& SR_filename = "data-SR-sparse_SPIN0.csr",
+                const std::string& HR_filename_up = "data-HR-sparse_SPIN0.csr",
+                const std::string HR_filename_down = "data-HR-sparse_SPIN1.csr",
+                const bool& binary = false,
+                const double& sparse_threshold = 1e-10); // LiuXh add 2019-07-15, modify in 2021-12-3
 
-        void output_dHR(
-            const int &istep,
-			const ModuleBase::matrix& v_eff,
-			Gint_k& gint_k,  // mohan add 2024-04-01
-			LCAO_Matrix &lm,  // mohan add 2024-04-01
-            Grid_Driver &grid, // mohan add 2024-04-06
-            const TwoCenterBundle& two_center_bundle,
-            const K_Vectors& kv,
-            const bool& binary = false,
-            const double& sparse_threshold = 1e-10);
+void output_dHR(const int& istep,
+                const ModuleBase::matrix& v_eff,
+                Gint_k& gint_k,    // mohan add 2024-04-01
+                LCAO_Matrix& lm,   // mohan add 2024-04-01
+                Grid_Driver& grid, // mohan add 2024-04-06
+                const TwoCenterBundle& two_center_bundle,
+                const K_Vectors& kv,
+                const bool& binary = false,
+                const double& sparse_threshold = 1e-10);
 
-        void output_TR(
-			const int istep,
-			const UnitCell &ucell,
-            const Parallel_Orbitals &pv,
-			LCAO_Matrix &lm,
-            Grid_Driver &grid,
-            const TwoCenterBundle& two_center_bundle,
-            const std::string& TR_filename = "data-TR-sparse_SPIN0.csr",
-            const bool& binary = false,
-            const double& sparse_threshold = 1e-10);
+void output_TR(const int istep,
+               const UnitCell& ucell,
+               const Parallel_Orbitals& pv,
+               LCAO_Matrix& lm,
+               Grid_Driver& grid,
+               const TwoCenterBundle& two_center_bundle,
+               const std::string& TR_filename = "data-TR-sparse_SPIN0.csr",
+               const bool& binary = false,
+               const double& sparse_threshold = 1e-10);
 
-        void output_SR(
-            Parallel_Orbitals &pv, 
-            LCAO_Matrix &lm,
-            Grid_Driver &grid,
-            hamilt::Hamilt<std::complex<double>>* p_ham,
-            const std::string& SR_filename = "data-SR-sparse_SPIN0.csr",
-            const bool& binary = false,
-            const double& sparse_threshold = 1e-10);
-}
+void output_SR(Parallel_Orbitals& pv,
+               LCAO_Matrix& lm,
+               Grid_Driver& grid,
+               hamilt::Hamilt<std::complex<double>>* p_ham,
+               const std::string& SR_filename = "data-SR-sparse_SPIN0.csr",
+               const bool& binary = false,
+               const double& sparse_threshold = 1e-10);
+} // namespace ModuleIO
 
 #endif


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
#4079


### What's changed?
The old two center integration class, ORB_gen_tables, is removed from the code.

### Any changes of core modules? (ignore if not applicable)
No.
