### PR TITLE
Fix: remove the warning_quit when there are more than 50 basis of one atom

### DIFF
--- a/source/module_basis/module_ao/ORB_atomic.cpp
+++ b/source/module_basis/module_ao/ORB_atomic.cpp
@@ -45,9 +45,14 @@ void Numerical_Orbital::set_orbital_info
 	}
 
 	// we need this to generate numerical_orbital_lm.
-	if (total_nchi_in < 0 || total_nchi_in > 50) 
+	if (total_nchi_in < 0) 
 	{
-		ModuleBase::WARNING_QUIT("Numerical_Orbital::init", "total_nchi<0 || total_nchi>50");
+		ModuleBase::WARNING_QUIT("Numerical_Orbital::init", "total_nchi < 0");
+	}
+	else if (total_nchi_in > 50)
+	{
+		// this is a warning, not a quit.
+		ModuleBase::WARNING("Numerical_Orbital::init", "total_nchi > 50");
 	}
 	else 
 	{

--- a/source/module_basis/module_ao/ORB_atomic.cpp
+++ b/source/module_basis/module_ao/ORB_atomic.cpp
@@ -45,14 +45,9 @@ void Numerical_Orbital::set_orbital_info
 	}
 
 	// we need this to generate numerical_orbital_lm.
-	if (total_nchi_in < 0) 
+	if (total_nchi_in < 0 || total_nchi_in > 500) 
 	{
-		ModuleBase::WARNING_QUIT("Numerical_Orbital::init", "total_nchi < 0");
-	}
-	else if (total_nchi_in > 50)
-	{
-		// this is a warning, not a quit.
-		ModuleBase::WARNING("Numerical_Orbital::init", "total_nchi > 50");
+		ModuleBase::WARNING_QUIT("Numerical_Orbital::init", "total_nchi < 0 or > 500");
 	}
 	else 
 	{

--- a/source/module_basis/module_ao/ORB_atomic.cpp
+++ b/source/module_basis/module_ao/ORB_atomic.cpp
@@ -4,88 +4,85 @@ Numerical_Orbital_AtomRelation Numerical_Orbital::NOAR;
 
 Numerical_Orbital::Numerical_Orbital()
 {
-	//make std::pair of new and delete
-	//question remains
-	this->nchi = nullptr;
-	this->phiLN = new Numerical_Orbital_Lm[1];
-	this->rcut = 0.0;
-	this->max_nchi = 0;
-	this->type = 0;
+    // make std::pair of new and delete
+    // question remains
+    this->nchi = nullptr;
+    this->phiLN = new Numerical_Orbital_Lm[1];
+    this->rcut = 0.0;
+    this->max_nchi = 0;
+    this->type = 0;
 }
 
 Numerical_Orbital::~Numerical_Orbital()
 {
-	delete[] nchi;
-	delete[] phiLN;
+    delete[] nchi;
+    delete[] phiLN;
 }
 
-void Numerical_Orbital::set_orbital_info
-(
-    const int& type_in,
-    const std::string& label_in,
-    const int& lmax_in,
-    const int* nchi_in,
-    const int& total_nchi_in
-)
+void Numerical_Orbital::set_orbital_info(const int& type_in,
+                                         const std::string& label_in,
+                                         const int& lmax_in,
+                                         const int* nchi_in,
+                                         const int& total_nchi_in)
 {
-	//what is GlobalV::test_overlap
-	ModuleBase::TITLE("Numerical_Orbital", "set_type_info");
+    // what is GlobalV::test_overlap
+    ModuleBase::TITLE("Numerical_Orbital", "set_type_info");
 
-	// (1) set type,label,lmax
-	this->type = type_in;
-	this->label = label_in;
-	this->lmax = lmax_in;
+    // (1) set type,label,lmax
+    this->type = type_in;
+    this->label = label_in;
+    this->lmax = lmax_in;
 
-	// (2) set nchi and total nchi.
-	delete[] this->nchi;
-	this->nchi = new int[this->lmax+1];
-	for (int i = 0; i < this->lmax + 1; i++)
-	{
-		this->nchi[i] = nchi_in[i];
-	}
+    // (2) set nchi and total nchi.
+    delete[] this->nchi;
+    this->nchi = new int[this->lmax + 1];
+    for (int i = 0; i < this->lmax + 1; i++)
+    {
+        this->nchi[i] = nchi_in[i];
+    }
 
-	// we need this to generate numerical_orbital_lm.
-	if (total_nchi_in < 0 || total_nchi_in > 500) 
-	{
-		ModuleBase::WARNING_QUIT("Numerical_Orbital::init", "total_nchi < 0 or > 500");
-	}
-	else 
-	{
-		this->total_nchi = total_nchi_in;
-	}
+    // we need this to generate numerical_orbital_lm.
+    if (total_nchi_in < 0 || total_nchi_in > 500)
+    {
+        ModuleBase::WARNING_QUIT("Numerical_Orbital::init", "total_nchi < 0 or > 500");
+    }
+    else
+    {
+        this->total_nchi = total_nchi_in;
+    }
 
-	// (3) set the rcut and check the rcut
-	this->rcut = 0.0;
-	for (int i=0; i< total_nchi_in; i++)
-	{
-		this->rcut = this->phiLN[i].rcut;
-		for(int j=0; j< total_nchi_in; j++)
-		{
-			assert( rcut == this->phiLN[j].rcut );
-		}
-	}
-	assert(rcut > 0.0);
+    // (3) set the rcut and check the rcut
+    this->rcut = 0.0;
+    for (int i = 0; i < total_nchi_in; i++)
+    {
+        this->rcut = this->phiLN[i].rcut;
+        for (int j = 0; j < total_nchi_in; j++)
+        {
+            assert(rcut == this->phiLN[j].rcut);
+        }
+    }
+    assert(rcut > 0.0);
 
-	// (4) set max_nchi
-	this->max_nchi=0;
-	for(int L=0; L<lmax+1; L++)
-	{
-		max_nchi = std::max( max_nchi, nchi[L] ); 
-	}
+    // (4) set max_nchi
+    this->max_nchi = 0;
+    for (int L = 0; L < lmax + 1; L++)
+    {
+        max_nchi = std::max(max_nchi, nchi[L]);
+    }
 
-	// (8) set find_chi
-	assert( lmax+1 > 0 );
-	this->find_chi.create( lmax+1, max_nchi );
-	int ichi=0;
-	for(int L=0; L<=lmax; ++L)
-	{
-		for(int N=0; N<nchi[L]; ++N)
-		{
-			find_chi(L,N) = ichi;
-			++ichi;
-		}
-	}
-	assert(ichi == total_nchi);
+    // (8) set find_chi
+    assert(lmax + 1 > 0);
+    this->find_chi.create(lmax + 1, max_nchi);
+    int ichi = 0;
+    for (int L = 0; L <= lmax; ++L)
+    {
+        for (int N = 0; N < nchi[L]; ++N)
+        {
+            find_chi(L, N) = ichi;
+            ++ichi;
+        }
+    }
+    assert(ichi == total_nchi);
 
-	return;
+    return;
 }


### PR DESCRIPTION
### Background
Now the new orbital generation code support output of jY basis, if use directly in LCAO calculation, it indicates the fully relax of coefficients of jY basis in one particular system, rather than the ABACUS numerical atomic orbital which fixes the coefficients of jY basis "in some way" (actually by learning from training sets). Therefore it is meaningful to support the jY basis so that the orbital optimization task can be decoupled with development on functionalities, also means then the problem from "orbital quaility" can be excluded.

To generate jY basis, pull repo abacus_orbital_generation and in input script `SIAB_INPUT.json`, change "optimizer" to "none".

However, the jY basis always large, so need to remove the limit on number of atomic orbitals.

### Reminder
- [x] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #4458 

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
