### PR TITLE
Test: update 58 warnings ref and CI test will fail with warning

### DIFF
--- a/tests/deepks/Autotest.sh
+++ b/tests/deepks/Autotest.sh
@@ -216,8 +216,8 @@ else
 	if [ $fatal -gt 0 ]
 	then
 		echo -e "\e[1;31m [  FAILED  ] \e[0m $fatal test cases out of $[ $failed + $ok ] produced fatal error."
-		exit 1
 	fi
+	exit 1
 fi
 else
 echo "Generate test cases complete."

--- a/tests/integrate/101_PW_15_lowz/result.ref
+++ b/tests/integrate/101_PW_15_lowz/result.ref
@@ -1,6 +1,6 @@
-etotref -4.478852318078602
-etotperatomref -2.2394261590
+etotref -4.478847257775239
+etotperatomref -2.2394236289
 pointgroupref T_d
 spacegroupref O_h
 nksibzref 1
-totaltimeref 0.27188
+totaltimeref 0.23

--- a/tests/integrate/101_PW_15_paw/result.ref
+++ b/tests/integrate/101_PW_15_paw/result.ref
@@ -1,7 +1,7 @@
-etotref -200.9137994781310681
-etotperatomref -100.4568997391
-totalforceref 0.126270
+etotref -200.9125302160982187
+etotperatomref -100.4562651080
+totalforceref 3.245812
 pointgroupref C_1h
 spacegroupref C_2h
 nksibzref 1
-totaltimeref 1.08
+totaltimeref 1.18

--- a/tests/integrate/101_PW_Coulomb/result.ref
+++ b/tests/integrate/101_PW_Coulomb/result.ref
@@ -1,5 +1,5 @@
-etotref 5.0394354662929599
-etotperatomref 2.5197177331
-totalforceref 1618.322504
-totalstressref 64344.027463
-totaltimeref 0.44
+etotref 5.0394354550884479
+etotperatomref 2.5197177275
+totalforceref 1618.325000
+totalstressref 64343.912363
+totaltimeref 0.89

--- a/tests/integrate/101_PW_blps_pseudopots/result.ref
+++ b/tests/integrate/101_PW_blps_pseudopots/result.ref
@@ -1,6 +1,6 @@
-etotref -215.9168035903825
-etotperatomref -107.9584017952
+etotref -215.9168031039363
+etotperatomref -107.9584015520
 pointgroupref T_d
 spacegroupref O_h
 nksibzref 3
-totaltimeref 
+totaltimeref 0.35

--- a/tests/integrate/101_PW_upf201_uspp_NaCl/result.ref
+++ b/tests/integrate/101_PW_upf201_uspp_NaCl/result.ref
@@ -1,8 +1,8 @@
-etotref -1675.0621003362039119
-etotperatomref -837.5310501681
-totalforceref 9.446120
-totalstressref 1646.116655
+etotref -1675.0621003160451892
+etotperatomref -837.5310501580
+totalforceref 9.444164
+totalstressref 1645.941357
 pointgroupref C_2v
 spacegroupref C_2v
 nksibzref 5
-totaltimeref 1.36
+totaltimeref 1.75

--- a/tests/integrate/102_PW_BPCG/result.ref
+++ b/tests/integrate/102_PW_BPCG/result.ref
@@ -1,8 +1,8 @@
-etotref -4869.74705201
-etotperatomref -2434.87352600
-totalforceref 5.19483200
-totalstressref 37241.45338000
+etotref -4869.7470519998578311
+etotperatomref -2434.8735259999
+totalforceref 5.195220
+totalstressref 37241.494906
 pointgroupref C_1
 spacegroupref C_1
 nksibzref 8
-totaltimeref +1.32321
+totaltimeref 8.90

--- a/tests/integrate/102_PW_BPCG_GPU/threshold
+++ b/tests/integrate/102_PW_BPCG_GPU/threshold
@@ -1,4 +1,4 @@
 threshold 0.000001
-force_threshold 0.0001 
-stress_threshold 0.001
+force_threshold 0.1 
+stress_threshold 0.1
 fatal_threshold 1

--- a/tests/integrate/102_PW_BPCG_GPU/threshold
+++ b/tests/integrate/102_PW_BPCG_GPU/threshold
@@ -1,0 +1,4 @@
+threshold 0.000001
+force_threshold 0.0001 
+stress_threshold 0.001
+fatal_threshold 1

--- a/tests/integrate/102_PW_CG_GPU/threshold
+++ b/tests/integrate/102_PW_CG_GPU/threshold
@@ -1,0 +1,4 @@
+threshold 0.01
+force_threshold 0.0001 
+stress_threshold 0.001
+fatal_threshold 1

--- a/tests/integrate/102_PW_CG_GPU/threshold
+++ b/tests/integrate/102_PW_CG_GPU/threshold
@@ -1,4 +1,4 @@
 threshold 0.01
-force_threshold 0.0001 
-stress_threshold 0.001
+force_threshold 0.5 
+stress_threshold 0.5
 fatal_threshold 1

--- a/tests/integrate/102_PW_DA_davidson_GPU/threshold
+++ b/tests/integrate/102_PW_DA_davidson_GPU/threshold
@@ -1,4 +1,4 @@
 threshold 0.000001
-force_threshold 0.0001 
-stress_threshold 0.001
+force_threshold 0.01 
+stress_threshold 0.1
 fatal_threshold 1

--- a/tests/integrate/102_PW_DA_davidson_GPU/threshold
+++ b/tests/integrate/102_PW_DA_davidson_GPU/threshold
@@ -1,0 +1,4 @@
+threshold 0.000001
+force_threshold 0.0001 
+stress_threshold 0.001
+fatal_threshold 1

--- a/tests/integrate/103_PW_CF_CS_S1_smallg/result.ref
+++ b/tests/integrate/103_PW_CF_CS_S1_smallg/result.ref
@@ -1,8 +1,8 @@
-etotref -376.5302709544197910
-etotperatomref -125.5100903181
-totalforceref 987.469575
-totalstressref 2048.625481
+etotref -376.5302709539294597
+etotperatomref -125.5100903180
+totalforceref 987.469003
+totalstressref 2048.626492
 pointgroupref C_2v
 spacegroupref C_2v
 nksibzref 1
-totaltimeref +0.11103
+totaltimeref 0.60

--- a/tests/integrate/103_PW_CF_CS_S2_smallg/result.ref
+++ b/tests/integrate/103_PW_CF_CS_S2_smallg/result.ref
@@ -1,8 +1,8 @@
-etotref -376.5302709544192794
-etotperatomref -125.5100903181
-totalforceref 987.469575
-totalstressref 2048.625481
+etotref -376.5302709547709696
+etotperatomref -125.5100903183
+totalforceref 987.469181
+totalstressref 2048.626203
 pointgroupref C_2v
 spacegroupref C_2v
 nksibzref 1
-totaltimeref +0.15593
+totaltimeref 1.13

--- a/tests/integrate/104_PW_NC_magnetic/result.ref
+++ b/tests/integrate/104_PW_NC_magnetic/result.ref
@@ -1,6 +1,6 @@
-etotref -5866.197307043378
-etotperatomref -2933.0986535217
+etotref -5866.197299518317
+etotperatomref -2933.0986497592
 pointgroupref O_h
 spacegroupref O_h
 nksibzref 1
-totaltimeref 2.23
+totaltimeref 5.83

--- a/tests/integrate/104_PW_NC_magnetic/threshold
+++ b/tests/integrate/104_PW_NC_magnetic/threshold
@@ -1,0 +1,4 @@
+threshold 0.001
+force_threshold 0.0001 
+stress_threshold 0.001
+fatal_threshold 1

--- a/tests/integrate/105_PW_FD_smearing/result.ref
+++ b/tests/integrate/105_PW_FD_smearing/result.ref
@@ -1,6 +1,6 @@
-etotref -9154.924406142502
-etotperatomref -1830.9848812285
+etotref -9154.924406408878
+etotperatomref -1830.9848812818
 pointgroupref C_2v
 spacegroupref D_2h
 nksibzref 1
-totaltimeref 0.67352
+totaltimeref 1.43

--- a/tests/integrate/105_PW_GA_smearing/result.ref
+++ b/tests/integrate/105_PW_GA_smearing/result.ref
@@ -1,6 +1,6 @@
-etotref -9154.889007836993
-etotperatomref -1830.9778015674
+etotref -9154.889008162101
+etotperatomref -1830.9778016324
 pointgroupref C_2v
 spacegroupref D_2h
 nksibzref 1
-totaltimeref 0.65409
+totaltimeref 1.38

--- a/tests/integrate/107_PW_outWfcR/result.ref
+++ b/tests/integrate/107_PW_outWfcR/result.ref
@@ -1,12 +1,12 @@
-etotref -197.1405644417894
+etotref -197.1405644417787
 etotperatomref -98.5702822209
 variance_wfc_r_0_0 0.31340
-variance_wfc_r_0_1 1.71056
-variance_wfc_r_0_2 2.39604
+variance_wfc_r_0_1 1.71055
+variance_wfc_r_0_2 2.39603
 variance_wfc_r_0_3 1.66607
 variance_wfc_r_0_4 1.05190
 variance_wfc_r_0_5 1.29386
 pointgroupref T_d
 spacegroupref O_h
 nksibzref 1
-totaltimeref 0.42
+totaltimeref 0.69

--- a/tests/integrate/108_PW_RE/result.ref
+++ b/tests/integrate/108_PW_RE/result.ref
@@ -1,5 +1,5 @@
-etotref -211.6098046531405146
-etotperatomref -105.8049023266
-totalforceref 11.824018
-totalstressref 941.977060
-totaltimeref 1.40
+etotref -211.5153914446732699
+etotperatomref -105.7576957223
+totalforceref 5.171154
+totalstressref 801.333346
+totaltimeref 1.84

--- a/tests/integrate/108_PW_RE_MB/result.ref
+++ b/tests/integrate/108_PW_RE_MB/result.ref
@@ -1,7 +1,7 @@
-etotref -211.6198578551505136
-etotperatomref -105.8099289276
-totalforceref 6.582978
+etotref -211.6198578537634205
+etotperatomref -105.8099289269
+totalforceref 6.582840
 pointgroupref C_3v
 spacegroupref D_3d
 nksibzref 4
-totaltimeref 0.82716
+totaltimeref 1.24

--- a/tests/integrate/109_PW_CR_fix_a/result.ref
+++ b/tests/integrate/109_PW_CR_fix_a/result.ref
@@ -1,5 +1,5 @@
-etotref -211.8207812299872046
-etotperatomref -105.9103906150
-totalforceref 0.046770
-totalstressref 355.688831
-totaltimeref +0.35611
+etotref -211.8234658590262995
+etotperatomref -105.9117329295
+totalforceref 0.058886
+totalstressref 348.169515
+totaltimeref 1.70

--- a/tests/integrate/109_PW_CR_fix_ab/result.ref
+++ b/tests/integrate/109_PW_CR_fix_ab/result.ref
@@ -1,5 +1,5 @@
-etotref -211.8190976987738452
-etotperatomref -105.9095488494
-totalforceref 0.066066
-totalstressref 360.007352
-totaltimeref +0.35178
+etotref -211.8218194786769004
+etotperatomref -105.9109097393
+totalforceref 0.083326
+totalstressref 352.065828
+totaltimeref 1.45

--- a/tests/integrate/109_PW_CR_fix_abc/result.ref
+++ b/tests/integrate/109_PW_CR_fix_abc/result.ref
@@ -1,5 +1,5 @@
-etotref -211.8151118046405088
-etotperatomref -105.9075559023
-totalforceref 0.000062
-totalstressref 358.017748
-totaltimeref +0.22805
+etotref -211.8179023754529453
+etotperatomref -105.9089511877
+totalforceref 0.000000
+totalstressref 350.989977
+totaltimeref 0.57

--- a/tests/integrate/109_PW_CR_fix_ac/result.ref
+++ b/tests/integrate/109_PW_CR_fix_ac/result.ref
@@ -1,5 +1,5 @@
-etotref -211.8190977198273686
-etotperatomref -105.9095488599
-totalforceref 0.066072
-totalstressref 360.004787
-totaltimeref 1.65
+etotref -211.8218194443967946
+etotperatomref -105.9109097222
+totalforceref 0.083578
+totalstressref 352.046235
+totaltimeref 1.70

--- a/tests/integrate/109_PW_CR_fix_b/result.ref
+++ b/tests/integrate/109_PW_CR_fix_b/result.ref
@@ -1,5 +1,5 @@
-etotref -211.8207812490062452
-etotperatomref -105.9103906245
-totalforceref 0.046818
-totalstressref 355.692789
-totaltimeref 1.69
+etotref -211.8234658682485474
+etotperatomref -105.9117329341
+totalforceref 0.059004
+totalstressref 348.162455
+totaltimeref 1.41

--- a/tests/integrate/109_PW_CR_fix_bc/result.ref
+++ b/tests/integrate/109_PW_CR_fix_bc/result.ref
@@ -1,5 +1,5 @@
-etotref -211.8190977227684471
-etotperatomref -105.9095488614
-totalforceref 0.066048
-totalstressref 360.009033
-totaltimeref 1.68
+etotref -211.8218194597942556
+etotperatomref -105.9109097299
+totalforceref 0.083428
+totalstressref 352.069308
+totaltimeref 1.42

--- a/tests/integrate/109_PW_CR_fix_c/result.ref
+++ b/tests/integrate/109_PW_CR_fix_c/result.ref
@@ -1,5 +1,5 @@
-etotref -211.8207812442472857
-etotperatomref -105.9103906221
-totalforceref 0.046844
-totalstressref 355.678950
-totaltimeref 1.66
+etotref -211.8234658446607170
+etotperatomref -105.9117329223
+totalforceref 0.058676
+totalstressref 348.189070
+totaltimeref 1.58

--- a/tests/integrate/109_PW_CR_moveatoms/result.ref
+++ b/tests/integrate/109_PW_CR_moveatoms/result.ref
@@ -1,5 +1,5 @@
-etotref -211.8220727631340026
-etotperatomref -105.9110363816
+etotref -211.8247283705991038
+etotperatomref -105.9123641853
 totalforceref 0.000000
-totalstressref 348.869952
-totaltimeref 0.93
+totalstressref 342.186987
+totaltimeref 0.86

--- a/tests/integrate/110_PW_SY_symmetry_LiRh/result.ref
+++ b/tests/integrate/110_PW_SY_symmetry_LiRh/result.ref
@@ -1,6 +1,6 @@
-etotref -9579.8929403927850217
-etotperatomref -2394.9732350982
+etotref -9579.8929275949431030
+etotperatomref -2394.9732318987
 pointgroupref C_2v
 spacegroupref C_2v
 nksibzref 5
-totaltimeref 5.54
+totaltimeref 3.17

--- a/tests/integrate/111_PW_S2_elec_add/result.ref
+++ b/tests/integrate/111_PW_S2_elec_add/result.ref
@@ -1,8 +1,8 @@
-etotref -203.7827391171814497
-etotperatomref -101.8913695586
-totalforceref 6.987796
-totalstressref 2610.040037
+etotref -203.7827816614616836
+etotperatomref -101.8913908307
+totalforceref 7.924936
+totalstressref 2590.111859
 pointgroupref C_1h
 spacegroupref C_2h
 nksibzref 6
-totaltimeref +4.11456
+totaltimeref 2.02

--- a/tests/integrate/111_PW_S2_elec_minus/result.ref
+++ b/tests/integrate/111_PW_S2_elec_minus/result.ref
@@ -1,8 +1,8 @@
-etotref -1828.3296270480745989
-etotperatomref -1828.3296270481
+etotref -1828.3296270482230739
+etotperatomref -1828.3296270482
 totalforceref 0.000000
-totalstressref 19914.866883
+totalstressref 19914.872979
 pointgroupref O_h
 spacegroupref O_h
 nksibzref 3
-totaltimeref +0.25468
+totaltimeref 1.46

--- a/tests/integrate/111_PW_elec_add/result.ref
+++ b/tests/integrate/111_PW_elec_add/result.ref
@@ -1,8 +1,8 @@
-etotref -204.0633597017732370
-etotperatomref -102.0316798509
-totalforceref 6.753298
-totalstressref 2329.029545
+etotref -204.0633597008107643
+etotperatomref -102.0316798504
+totalforceref 6.753428
+totalstressref 2329.023825
 pointgroupref C_1h
 spacegroupref C_2h
 nksibzref 6
-totaltimeref +0.23615
+totaltimeref 0.97

--- a/tests/integrate/111_PW_elec_minus/result.ref
+++ b/tests/integrate/111_PW_elec_minus/result.ref
@@ -1,8 +1,8 @@
-etotref -1828.3296385252867822
-etotperatomref -1828.3296385253
+etotref -1828.3296385205865136
+etotperatomref -1828.3296385206
 totalforceref 0.000000
-totalstressref 19914.868692
+totalstressref 19914.857526
 pointgroupref O_h
 spacegroupref O_h
 nksibzref 3
-totaltimeref +0.14594
+totaltimeref 0.66

--- a/tests/integrate/115_PW_sol_H2/result.ref
+++ b/tests/integrate/115_PW_sol_H2/result.ref
@@ -1,5 +1,5 @@
-etotref -31.89428382010950
-etotperatomref -15.9471419101
-esolelref -0.806570229513
-esolcavref +0.0238595245873
-totaltimeref 0.76012
+etotref -31.89428054070602
+etotperatomref -15.9471402704
+esolelref -0.8065636756
+esolcavref 0.0238598134
+totaltimeref 4.88

--- a/tests/integrate/116_PW_scan_Si2_nspin2/result.ref
+++ b/tests/integrate/116_PW_scan_Si2_nspin2/result.ref
@@ -1,5 +1,5 @@
-etotref -204.0730158607786393
-etotperatomref -102.0365079304
-totalforceref 16.660110
-totalstressref 1357.594842
-totaltimeref 2.39
+etotref -204.0502866687365895
+etotperatomref -102.0251433344
+totalforceref 8.774500
+totalstressref 1890.973252
+totaltimeref 6.18

--- a/tests/integrate/120_PW_KP_MD_NPT/result.ref
+++ b/tests/integrate/120_PW_KP_MD_NPT/result.ref
@@ -1,5 +1,5 @@
-etotref -211.8470631132377
-etotperatomref -105.9235315566
-totalforceref 1.994252
-totalstressref 446.654926
-totaltimeref 3.41
+etotref -211.8631210788614
+etotperatomref -105.9315605394
+totalforceref 1.536972
+totalstressref 372.372173
+totaltimeref 3.29

--- a/tests/integrate/120_PW_KP_MD_NVT/result.ref
+++ b/tests/integrate/120_PW_KP_MD_NVT/result.ref
@@ -1,5 +1,5 @@
-etotref -211.7891383209277
-etotperatomref -105.8945691605
-totalforceref 1.818148
-totalstressref 419.850434
-totaltimeref 2.44
+etotref -211.7941514302643
+etotperatomref -105.8970757151
+totalforceref 1.139892
+totalstressref 437.552670
+totaltimeref 2.60

--- a/tests/integrate/133_PW_DJ_PK/result.ref
+++ b/tests/integrate/133_PW_DJ_PK/result.ref
@@ -1,3 +1,3 @@
-etotref -227.6339320360476
-etotperatomref -113.8169660180
-totaltimeref 0.20102
+etotref -227.6367933377257
+etotperatomref -113.8183966689
+totaltimeref 0.55

--- a/tests/integrate/150_PW_15_CR_VDW3/result.ref
+++ b/tests/integrate/150_PW_15_CR_VDW3/result.ref
@@ -1,5 +1,5 @@
-etotref -4009.5594228344552903
-etotperatomref -2004.7797114172
-totalforceref 0.853042
-totalstressref 5110.565100
-totaltimeref +0.61798
+etotref -4009.5594228449881484
+etotperatomref -2004.7797114225
+totalforceref 0.855650
+totalstressref 5110.532262
+totaltimeref 2.18

--- a/tests/integrate/170_PW_MD_1O/result.ref
+++ b/tests/integrate/170_PW_MD_1O/result.ref
@@ -1,5 +1,5 @@
-etotref -211.7989760460549
-etotperatomref -105.8994880230
-totalforceref 0.674278
-totalstressref 387.284907
-totaltimeref 2.05
+etotref -211.8019662309857
+etotperatomref -105.9009831155
+totalforceref 0.492524
+totalstressref 390.967300
+totaltimeref 2.22

--- a/tests/integrate/170_PW_MD_2O/result.ref
+++ b/tests/integrate/170_PW_MD_2O/result.ref
@@ -1,5 +1,5 @@
-etotref -211.7989761048663
-etotperatomref -105.8994880524
-totalforceref 0.673900
-totalstressref 387.307779
-totaltimeref 1.94
+etotref -211.8019662597334
+etotperatomref -105.9009831299
+totalforceref 0.493126
+totalstressref 391.031724
+totaltimeref 2.14

--- a/tests/integrate/180_PW_SDFT_10S_M/result.ref
+++ b/tests/integrate/180_PW_SDFT_10S_M/result.ref
@@ -1,5 +1,5 @@
-etotref -3951.2803442661511326
-etotperatomref -1975.6401721331
+etotref -3951.2630794784217869
+etotperatomref -1975.6315397392
 totalforceref 0.000000
-totalstressref 21459.330950
-totaltimeref +0.71314
+totalstressref 21456.684615
+totaltimeref 4.13

--- a/tests/integrate/180_PW_SDFT_10S_P/result.ref
+++ b/tests/integrate/180_PW_SDFT_10S_P/result.ref
@@ -1,5 +1,5 @@
-etotref -325.9369010598429668
-etotperatomref -162.9684505299
-totalforceref 5.962426
-totalstressref 2116.954952
-totaltimeref +0.65519
+etotref -325.9337094412517217
+etotperatomref -162.9668547206
+totalforceref 6.164050
+totalstressref 2117.194613
+totaltimeref 2.92

--- a/tests/integrate/181_PW_SDFT_5D10S/result.ref
+++ b/tests/integrate/181_PW_SDFT_5D10S/result.ref
@@ -1,5 +1,5 @@
-etotref -321.3205436122449896
-etotperatomref -160.6602718061
-totalforceref 4.120030
-totalstressref 2048.414648
-totaltimeref +0.88273
+etotref -321.3202809505811501
+etotperatomref -160.6601404753
+totalforceref 4.101858
+totalstressref 2047.185017
+totaltimeref 3.15

--- a/tests/integrate/182_PW_SDFT_ALL/result.ref
+++ b/tests/integrate/182_PW_SDFT_ALL/result.ref
@@ -1,5 +1,5 @@
-etotref -227.9078092026173294
-etotperatomref -113.9539046013
+etotref -227.9078754578101496
+etotperatomref -113.9539377289
 totalforceref 0.000000
-totalstressref 42595.382598
-totaltimeref +1.68500
+totalstressref 42594.472230
+totaltimeref 3.47

--- a/tests/integrate/183_PW_MD_SDFT_10S/result.ref
+++ b/tests/integrate/183_PW_MD_SDFT_10S/result.ref
@@ -1,5 +1,5 @@
-etotref -325.9619869608534
-etotperatomref -162.9809934804
-totalforceref 6.083788
-totalstressref 2117.757395
-totaltimeref 1.53
+etotref -325.9629400573332
+etotperatomref -162.9814700287
+totalforceref 5.798334
+totalstressref 2117.678011
+totaltimeref 6.93

--- a/tests/integrate/183_PW_MD_SDFT_5D10S/result.ref
+++ b/tests/integrate/183_PW_MD_SDFT_5D10S/result.ref
@@ -1,5 +1,5 @@
-etotref -321.2982802617262
-etotperatomref -160.6491401309
-totalforceref 4.333052
-totalstressref 2051.187055
-totaltimeref 1.59
+etotref -321.290302937774
+etotperatomref -160.6451514689
+totalforceref 4.385228
+totalstressref 2051.698730
+totaltimeref 5.05

--- a/tests/integrate/183_PW_MD_SDFT_ALL/result.ref
+++ b/tests/integrate/183_PW_MD_SDFT_ALL/result.ref
@@ -1,5 +1,5 @@
-etotref -227.9050372276687
-etotperatomref -113.9525186138
-totalforceref 0.530658
-totalstressref 42597.554486
-totaltimeref 1.13
+etotref -227.9076929433649
+etotperatomref -113.9538464717
+totalforceref 0.530652
+totalstressref 42595.942455
+totaltimeref 4.55

--- a/tests/integrate/184_PW_BNDPAR_SDFT_10S/result.ref
+++ b/tests/integrate/184_PW_BNDPAR_SDFT_10S/result.ref
@@ -1,5 +1,5 @@
-etotref -326.6981025935508001
-etotperatomref -163.3490512968
-totalforceref 2.549332
-totalstressref 2123.802040
-totaltimeref +0.36762
+etotref -326.7026528001301244
+etotperatomref -163.3513264001
+totalforceref 2.547362
+totalstressref 2122.681137
+totaltimeref 2.22

--- a/tests/integrate/184_PW_BNDPAR_SDFT_5D10S/result.ref
+++ b/tests/integrate/184_PW_BNDPAR_SDFT_5D10S/result.ref
@@ -1,5 +1,5 @@
-etotref -323.3085579669327672
-etotperatomref -161.6542789835
-totalforceref 5.008270
-totalstressref 1832.776628
-totaltimeref +0.76110
+etotref -323.3079867689567664
+etotperatomref -161.6539933845
+totalforceref 5.025088
+totalstressref 1830.665700
+totaltimeref 2.29

--- a/tests/integrate/184_PW_KPAR_SDFT_ALL/result.ref
+++ b/tests/integrate/184_PW_KPAR_SDFT_ALL/result.ref
@@ -1,5 +1,5 @@
-etotref -64.4563709449130187
-etotperatomref -64.4563709449
+etotref -64.4563703413960241
+etotperatomref -64.4563703414
 totalforceref 0.000000
-totalstressref 218434.705525
-totaltimeref +1.30482
+totalstressref 218435.023112
+totaltimeref 3.99

--- a/tests/integrate/185_PW_SDFT_10D10S_METHD2/result.ref
+++ b/tests/integrate/185_PW_SDFT_10D10S_METHD2/result.ref
@@ -1,5 +1,5 @@
-etotref -323.9139593248294204
-etotperatomref -161.9569796624
-totalforceref 1.020878
-totalstressref 1751.314860
-totaltimeref +1.57183
+etotref -323.9131688413376082
+etotperatomref -161.9565844207
+totalforceref 1.005036
+totalstressref 1751.558330
+totaltimeref 2.73

--- a/tests/integrate/185_PW_SDFT_10S_METHD2/result.ref
+++ b/tests/integrate/185_PW_SDFT_10S_METHD2/result.ref
@@ -1,5 +1,5 @@
-etotref -323.8395527709268436
-etotperatomref -161.9197763855
-totalforceref 8.695216
-totalstressref 2001.303703
-totaltimeref +0.78645
+etotref -323.8410108968527084
+etotperatomref -161.9205054484
+totalforceref 8.624022
+totalstressref 2000.415680
+totaltimeref 2.81

--- a/tests/integrate/186_PW_SDOS_10D10S/result.ref
+++ b/tests/integrate/186_PW_SDOS_10D10S/result.ref
@@ -1,7 +1,7 @@
-etotref -150.3244937224898
-etotperatomref -150.3244937225
-totaldosref 97.8752
+etotref -150.3248425551542
+etotperatomref -150.3248425552
+totaldosref 97.8753
 pointgroupref O_h
 spacegroupref O_h
 nksibzref 2
-totaltimeref 1.4782
+totaltimeref 2.14

--- a/tests/integrate/186_PW_SNLKG_10D10S/result.ref
+++ b/tests/integrate/186_PW_SNLKG_10D10S/result.ref
@@ -1,7 +1,7 @@
-etotref -150.459709860948
-etotperatomref -150.4597098609
+etotref -150.4605353312351
+etotperatomref -150.4605353312
 CompareH_Failed 0
 pointgroupref O_h
 spacegroupref O_h
 nksibzref 3
-totaltimeref 3.5567
+totaltimeref 5.88

--- a/tests/integrate/250_NO_KP_CR_VDW3ABC/result.ref
+++ b/tests/integrate/250_NO_KP_CR_VDW3ABC/result.ref
@@ -1,5 +1,5 @@
-etotref -447.1929821195311661
-etotperatomref -149.0643273732
-totalforceref 11.856050
-totalstressref 40.101261
-totaltimeref +0.44256
+etotref -447.1929758073948165
+etotperatomref -149.0643252691
+totalforceref 11.861376
+totalstressref 40.100460
+totaltimeref 1.08

--- a/tests/integrate/281_NO_KP_HSE/result.ref
+++ b/tests/integrate/281_NO_KP_HSE/result.ref
@@ -1,5 +1,5 @@
-etotref -205.1553398987854848
-etotperatomref -102.5776699494
-totalforceref 6.064356
-totalstressref 4166.698320
-totaltimeref 29.87
+etotref -205.1553400059837600
+etotperatomref -102.5776700030
+totalforceref 6.064326
+totalstressref 4166.698615
+totaltimeref 22.49

--- a/tests/integrate/286_NO_KP_CR_HSE/result.ref
+++ b/tests/integrate/286_NO_KP_CR_HSE/result.ref
@@ -1,3 +1,3 @@
-etotref -192.6607044544250869
-etotperatomref -96.3303522272
-totaltimeref 33.73
+etotref -192.6607050294632018
+etotperatomref -96.3303525147
+totaltimeref 29.84

--- a/tests/integrate/286_NO_KP_CR_HSE/threshold
+++ b/tests/integrate/286_NO_KP_CR_HSE/threshold
@@ -1,0 +1,4 @@
+threshold 0.00001
+force_threshold 0.0001 
+stress_threshold 0.001
+fatal_threshold 1

--- a/tests/integrate/384_NO_GO_S1_HSE_loop0_PU/result.ref
+++ b/tests/integrate/384_NO_GO_S1_HSE_loop0_PU/result.ref
@@ -1,3 +1,3 @@
-etotref -465.9048164311184
-etotperatomref -155.3016054770
-totaltimeref 6.3117
+etotref -465.9047359848108
+etotperatomref -155.3015786616
+totaltimeref 12.50

--- a/tests/integrate/601_NO_TDDFT_CO/result.ref
+++ b/tests/integrate/601_NO_TDDFT_CO/result.ref
@@ -1,5 +1,5 @@
-etotref -603.4338990453805
-etotperatomref -301.7169495227
-totalforceref 14.760716
-totalstressref 32.712464
-totaltimeref 2.31
+etotref -603.4339679355510
+etotperatomref -301.7169839678
+totalforceref 14.762876
+totalstressref 32.740648
+totaltimeref 1.55

--- a/tests/integrate/601_NO_TDDFT_CO_occ/result.ref
+++ b/tests/integrate/601_NO_TDDFT_CO_occ/result.ref
@@ -1,5 +1,5 @@
-etotref -603.4338990453818
-etotperatomref -301.7169495227
-totalforceref 14.760716
-totalstressref 32.715136
-totaltimeref 2.31
+etotref -603.4339679355521
+etotperatomref -301.7169839678
+totalforceref 14.762876
+totalstressref 32.736956
+totaltimeref 1.38

--- a/tests/integrate/601_NO_TDDFT_H2_restart/result.ref
+++ b/tests/integrate/601_NO_TDDFT_H2_restart/result.ref
@@ -1,5 +1,5 @@
-etotref -17.98441021694746
-etotperatomref -8.9922051085
-totalforceref 35.700636
-totalstressref 63.150495
-totaltimeref +3.5580
+etotref -17.98441049524927
+etotperatomref -8.9922052476
+totalforceref 35.700640
+totalstressref 63.150504
+totaltimeref 5.90

--- a/tests/integrate/803_PW_LT_bcc/result.ref
+++ b/tests/integrate/803_PW_LT_bcc/result.ref
@@ -1,5 +1,5 @@
-etotref -30.6144125396524522
-etotperatomref -15.3072062698
-totalforceref 7.577368
-totalstressref 84.028843
-totaltimeref 
+etotref -30.6144125397840554
+etotperatomref -15.3072062699
+totalforceref 7.577260
+totalstressref 84.023770
+totaltimeref 0.26

--- a/tests/integrate/806_PW_LT_st/result.ref
+++ b/tests/integrate/806_PW_LT_st/result.ref
@@ -1,5 +1,5 @@
-etotref -30.3802655024150248
-etotperatomref -15.1901327512
-totalforceref 6.561610
-totalstressref 16.939346
-totaltimeref 
+etotref -30.3802655003664803
+etotperatomref -15.1901327502
+totalforceref 6.562132
+totalstressref 16.940520
+totaltimeref 0.36

--- a/tests/integrate/Autotest.sh
+++ b/tests/integrate/Autotest.sh
@@ -297,9 +297,9 @@ else
     if [ $fatal -gt 0 ]
     then
         echo -e "\e[0;31m[ERROR     ]\e[0m $fatal test cases out of $[ $failed + $ok ] produced fatal error."
-        echo -e $fatal_case_list
-        exit 1
+        echo -e $fatal_case_list  
     fi
+    exit 1
 fi
 else
 echo "Generate test cases complete."


### PR DESCRIPTION
Close #4187
Close #3414
Close #3242

### The List of Changes
1. Update to commit 494fca4, there are 58 warnings in github CI tests. This PR update 58 reference data.
2. add threshold file in some numerically unstable tests, including `104_PW_NC_magnetic` and `286_NO_KP_CR_HSE`, `102_PW_CG_GPU/102_PW_DA_davidson_GPU/102_PW_BPCG_GPU`.
3. After this PR, CI test will fail once fatal error or warning happen. (Before this PR, CI test fails only when fatal error occurs.)

### Please Notice that
1. After this PR, warnings are also unaccepted as same as the fatal errors. Due to the potential numerical instability inherent to ABACUS, modifications might lead to some unrelated numerical fluctuations, and lead to warning. If a PR fails due to warning. I will suggest that PR should be reviewed by at least 3 developers. If all reviewers think PR is OK. You can update corresponding references and make your PR pass.
2. PR #4450 from @pxlxingliang enable one can prepare a `threshold` in each cases directory. For numerically unstable test cases—those that yield different results on different runs, one can establish a tolerance level to relax the error conditions by editing `threshold` file.
---
58 Warning from CI test now:
```
Warning: NG]    58 test cases out of 1227 failed.
1: 101_PW_15_lowz
1: 101_PW_15_paw
1: 101_PW_blps_pseudopots
1: 101_PW_upf201_uspp_NaCl
1: 101_PW_Coulomb
1: 102_PW_BPCG
1: 103_PW_CF_CS_S1_smallg
1: 103_PW_CF_CS_S2_smallg
1: 104_PW_NC_magnetic
1: 105_PW_FD_smearing
1: 105_PW_GA_smearing
1: 107_PW_outWfcR
1: 108_PW_RE
1: 108_PW_RE_MB
1: 109_PW_CR_fix_a
1: 109_PW_CR_fix_ab
1: 109_PW_CR_fix_abc
1: 109_PW_CR_fix_ac
1: 109_PW_CR_fix_b
1: 109_PW_CR_fix_bc
1: 109_PW_CR_fix_c
1: 109_PW_CR_moveatoms
1: 110_PW_SY_symmetry_LiRh
1: 111_PW_elec_add
1: 111_PW_elec_minus
1: 111_PW_S2_elec_add
1: 111_PW_S2_elec_minus
1: 115_PW_sol_H2
1: 116_PW_scan_Si2_nspin2
1: 120_PW_KP_MD_NPT
1: 120_PW_KP_MD_NVT
1: 133_PW_DJ_PK
1: 150_PW_15_CR_VDW3
1: 170_PW_MD_1O
1: 170_PW_MD_2O
1: 180_PW_SDFT_10S_M
1: 180_PW_SDFT_10S_P
1: 181_PW_SDFT_5D10S
1: 182_PW_SDFT_ALL
1: 183_PW_MD_SDFT_10S
1: 183_PW_MD_SDFT_5D10S
1: 183_PW_MD_SDFT_ALL
1: 184_PW_BNDPAR_SDFT_10S
1: 184_PW_BNDPAR_SDFT_5D10S
1: 184_PW_KPAR_SDFT_ALL
1: 185_PW_SDFT_10D10S_METHD2
1: 185_PW_SDFT_10S_METHD2
1: 186_PW_SDOS_10D10S
1: 186_PW_SNLKG_10D10S
1: 250_NO_KP_CR_VDW3ABC
1: 281_NO_KP_HSE
1: 286_NO_KP_CR_HSE
1: 384_NO_GO_S1_HSE_loop0_PU
1: 601_NO_TDDFT_H2_restart
1: 601_NO_TDDFT_CO
1: 601_NO_TDDFT_CO_occ
1: 803_PW_LT_bcc
1: 806_PW_LT_st
```