### PR TITLE
Refactor: remove pdiagh pointers and redundant code in HSolverPW

### DIFF
--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -32,7 +32,6 @@ HSolverPW<T, Device>::HSolverPW(ModulePW::PW_Basis_K* wfc_basis_in, wavefunc* pw
     /*this->init(pbas_in);*/
 }
 
-
 template <typename T, typename Device>
 void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
                                  psi::Psi<T, Device>& psi,
@@ -733,7 +732,6 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm, psi::P
         DiagoIterAssist<T, Device>::avg_iter += static_cast<double>(
             dav_subspace
                 .diag(hpsi_func, subspace_func, psi.get_pointer(), psi.get_nbasis(), eigenvalue, is_occupied, scf));
-
     }
     else if (this->method == "bpcg")
     {

--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -734,11 +734,9 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm, psi::P
             dav_subspace
                 .diag(hpsi_func, subspace_func, psi.get_pointer(), psi.get_nbasis(), eigenvalue, is_occupied, scf));
 
-        this->pdiagh = nullptr;
     }
     else if (this->method == "bpcg")
     {
-        // this->pdiagh->diag(hm, psi, eigenvalue);
         DiagoBPCG<T, Device> bpcg(precondition.data());
         bpcg.init_iter(psi);
         bpcg.diag(hm, psi, eigenvalue);

--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -32,147 +32,6 @@ HSolverPW<T, Device>::HSolverPW(ModulePW::PW_Basis_K* wfc_basis_in, wavefunc* pw
     /*this->init(pbas_in);*/
 }
 
-template <typename T, typename Device>
-void HSolverPW<T, Device>::initDiagh(const psi::Psi<T, Device>& psi)
-{
-    if (this->method == "cg")
-    {
-        // if (this->pdiagh != nullptr)
-        // {
-        //     if (this->pdiagh->method != this->method)
-        //     {
-        //         delete reinterpret_cast<DiagoCG<T, Device>*>(this->pdiagh);
-        //     }
-        //     else
-        //     {
-        //         return;
-        //     }
-        // }
-
-        // this->pdiagh = new DiagoCG<T, Device>(precondition.data());
-
-        // // warp the subspace_func into a lambda function
-        // auto ngk_pointer = psi.get_ngk_pointer();
-        // auto subspace_func = [this, ngk_pointer](const ct::Tensor& psi_in, ct::Tensor& psi_out) {
-        //     // psi_in should be a 2D tensor:
-        //     // psi_in.shape() = [nbands, nbasis]
-        //     const auto ndim = psi_in.shape().ndim();
-        //     REQUIRES_OK(ndim == 2, "dims of psi_in should be less than or equal to 2");
-        //     // Convert a Tensor object to a psi::Psi object
-        //     auto psi_in_wrapper = psi::Psi<T, Device>(psi_in.data<T>(),
-        //                                               1,
-        //                                               psi_in.shape().dim_size(0),
-        //                                               psi_in.shape().dim_size(1),
-        //                                               ngk_pointer);
-        //     auto psi_out_wrapper = psi::Psi<T, Device>(psi_out.data<T>(),
-        //                                                1,
-        //                                                psi_out.shape().dim_size(0),
-        //                                                psi_out.shape().dim_size(1),
-        //                                                ngk_pointer);
-        //     auto eigen = ct::Tensor(ct::DataTypeToEnum<Real>::value,
-        //                             ct::DeviceType::CpuDevice,
-        //                             ct::TensorShape({psi_in.shape().dim_size(0)}));
-
-        //     DiagoIterAssist<T, Device>::diagH_subspace(hamilt_, psi_in_wrapper, psi_out_wrapper, eigen.data<Real>());
-        // };
-        // this->pdiagh = new DiagoCG<T, Device>(GlobalV::BASIS_TYPE,
-        //                                       GlobalV::CALCULATION,
-        //                                       DiagoIterAssist<T, Device>::need_subspace,
-        //                                       subspace_func,
-        //                                       DiagoIterAssist<T, Device>::PW_DIAG_THR,
-        //                                       DiagoIterAssist<T, Device>::PW_DIAG_NMAX,
-        //                                       GlobalV::NPROC_IN_POOL);
-        // this->pdiagh->method = this->method;
-    }
-    else if (this->method == "dav")
-    {
-        // #ifdef __MPI
-        //         const diag_comm_info comm_info = {POOL_WORLD, GlobalV::RANK_IN_POOL, GlobalV::NPROC_IN_POOL};
-        // #else
-        //         const diag_comm_info comm_info = {GlobalV::RANK_IN_POOL, GlobalV::NPROC_IN_POOL};
-        // #endif
-
-        //         if (this->pdiagh != nullptr)
-        //         {
-        //             if (this->pdiagh->method != this->method)
-        //             {
-        //                 delete (DiagoDavid<T, Device>*)this->pdiagh;
-
-        //                 this->pdiagh = new DiagoDavid<T, Device>(precondition.data(),
-        //                                                          GlobalV::PW_DIAG_NDIM,
-        //                                                          GlobalV::use_paw,
-        //                                                          comm_info);
-
-        //                 this->pdiagh->method = this->method;
-        //             }
-        //         }
-        //         else
-        //         {
-        //             this->pdiagh
-        //                 = new DiagoDavid<T, Device>(precondition.data(), GlobalV::PW_DIAG_NDIM, GlobalV::use_paw,
-        //                 comm_info);
-
-        //             this->pdiagh->method = this->method;
-        //         }
-    }
-    else if (this->method == "dav_subspace")
-    {
-        // #ifdef __MPI
-        //         const diag_comm_info comm_info = {POOL_WORLD, GlobalV::RANK_IN_POOL, GlobalV::NPROC_IN_POOL};
-        // #else
-        //         const diag_comm_info comm_info = {GlobalV::RANK_IN_POOL, GlobalV::NPROC_IN_POOL};
-        // #endif
-        //         if (this->pdiagh != nullptr)
-        //         {
-        //             if (this->pdiagh->method != this->method)
-        //             {
-        //                 delete (Diago_DavSubspace<T, Device>*)this->pdiagh;
-
-        //                 this->pdiagh = new Diago_DavSubspace<T, Device>(precondition.data(),
-        //                                                                 GlobalV::PW_DIAG_NDIM,
-        //                                                                 DiagoIterAssist<T, Device>::PW_DIAG_THR,
-        //                                                                 DiagoIterAssist<T, Device>::PW_DIAG_NMAX,
-        //                                                                 DiagoIterAssist<T, Device>::need_subspace,
-        //                                                                 comm_info);
-
-        //                 this->pdiagh->method = this->method;
-        //             }
-        //         }
-        //         else
-        //         {
-        //             this->pdiagh = new Diago_DavSubspace<T, Device>(precondition.data(),
-        //                                                             GlobalV::PW_DIAG_NDIM,
-        //                                                             DiagoIterAssist<T, Device>::PW_DIAG_THR,
-        //                                                             DiagoIterAssist<T, Device>::PW_DIAG_NMAX,
-        //                                                             DiagoIterAssist<T, Device>::need_subspace,
-        //                                                             comm_info);
-        //             this->pdiagh->method = this->method;
-        //         }
-    }
-    else if (this->method == "bpcg")
-    {
-        // if (this->pdiagh != nullptr)
-        // {
-        //     if (this->pdiagh->method != this->method)
-        //     {
-        //         delete (DiagoBPCG<T, Device>*)this->pdiagh;
-        //         this->pdiagh = new DiagoBPCG<T, Device>(precondition.data());
-        //         this->pdiagh->method = this->method;
-        //         reinterpret_cast<DiagoBPCG<T, Device>*>(this->pdiagh)->init_iter(psi);
-        //     }
-        // }
-        // else
-        // {
-        //     this->pdiagh = new DiagoBPCG<T, Device>(precondition.data());
-        //     this->pdiagh->method = this->method;
-        //     reinterpret_cast<DiagoBPCG<T, Device>*>(this->pdiagh)->init_iter(psi);
-        // }
-    }
-    else
-    {
-        ModuleBase::WARNING_QUIT("HSolverPW::solve", "This method of DiagH is not supported!");
-    }
-}
 
 template <typename T, typename Device>
 void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
@@ -188,7 +47,11 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
     this->hamilt_ = pHamilt;
     // select the method of diagonalization
     this->method = method_in;
-    this->initDiagh(psi);
+    // report the specified diagonalization method is not supported (not among the following methods)
+    if (this->method != "cg" && this->method != "dav" && this->method != "dav_subspace" && this->method != "bpcg")
+    {
+        ModuleBase::WARNING_QUIT("HSolverPW::solve", "This method of DiagH is not supported!");
+    }
 
     std::vector<Real> eigenvalues(pes->ekb.nr * pes->ekb.nc, 0);
 
@@ -656,29 +519,6 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt, // ESolver_
 template <typename T, typename Device>
 void HSolverPW<T, Device>::endDiagh()
 {
-    // DiagoCG would keep 9*nbasis memory in cache during loop-k
-    // it should be deleted before calculating charge
-    // if (this->method == "cg")
-    // {
-    //     delete reinterpret_cast<DiagoCG<T, Device>*>(this->pdiagh);
-    //     this->pdiagh = nullptr;
-    // }
-    // if (this->method == "dav")
-    // {
-    //     delete reinterpret_cast<DiagoDavid<T, Device>*>(this->pdiagh);
-    //     this->pdiagh = nullptr;
-    // }
-    // if (this->method == "dav_subspace")
-    // {
-    //     delete reinterpret_cast<Diago_DavSubspace<T, Device>*>(this->pdiagh);
-    //     this->pdiagh = nullptr;
-    // }
-    // if (this->method == "bpcg")
-    // {
-    //     delete reinterpret_cast<DiagoBPCG<T, Device>*>(this->pdiagh);
-    //     this->pdiagh = nullptr;
-    // }
-
     // in PW base, average iteration steps for each band and k-point should be printing
     if (DiagoIterAssist<T, Device>::avg_iter > 0.0)
     {

--- a/source/module_hsolver/hsolver_pw.h
+++ b/source/module_hsolver/hsolver_pw.h
@@ -64,7 +64,6 @@ class HSolverPW : public HSolver<T, Device>
     virtual Real set_diagethr(const int istep, const int iter, const Real drho) override;
     virtual Real reset_diagethr(std::ofstream& ofs_running, const Real hsover_error, const Real drho) override;
   protected:
-    void initDiagh(const psi::Psi<T, Device>& psi_in);
     void endDiagh();
     void hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm, psi::Psi<T, Device>& psi, Real* eigenvalue);
 

--- a/source/module_hsolver/hsolver_pw.h
+++ b/source/module_hsolver/hsolver_pw.h
@@ -6,7 +6,8 @@
 #include "module_basis/module_pw/pw_basis_k.h"
 #include "module_hamilt_pw/hamilt_pwdft/wavefunc.h"
 
-namespace hsolver {
+namespace hsolver
+{
 
 template <typename T, typename Device = base_device::DEVICE_CPU>
 class HSolverPW : public HSolver<T, Device>
@@ -14,21 +15,21 @@ class HSolverPW : public HSolver<T, Device>
   private:
     bool is_first_scf = true;
 
-    // Note GetTypeReal<T>::type will 
-    // return T if T is real type(float, double), 
+    // Note GetTypeReal<T>::type will
+    // return T if T is real type(float, double),
     // otherwise return the real type of T(complex<float>, complex<double>)
     using Real = typename GetTypeReal<T>::type;
 
   public:
     /**
-     * @brief diago_full_acc 
-     * If .TRUE. all the empty states are diagonalized at the same level of accuracy of the occupied ones. 
-     * Otherwise the empty states are diagonalized using a larger threshold 
+     * @brief diago_full_acc
+     * If .TRUE. all the empty states are diagonalized at the same level of accuracy of the occupied ones.
+     * Otherwise the empty states are diagonalized using a larger threshold
      * (this should not affect total energy, forces, and other ground-state properties).
-     * 
+     *
      */
     static bool diago_full_acc;
-    
+
     HSolverPW(ModulePW::PW_Basis_K* wfc_basis_in, wavefunc* pwf_in);
 
     /*void init(
@@ -37,7 +38,7 @@ class HSolverPW : public HSolver<T, Device>
     ) override;
     void update(//Input &in
     ) override;*/
-    
+
     /// @brief solve function for pw
     /// @param pHamilt interface to hamilt
     /// @param psi reference to psi
@@ -54,7 +55,7 @@ class HSolverPW : public HSolver<T, Device>
     /// @param psi reference to psi
     /// @param pes interface to elecstate
     /// @param transform transformation matrix between lcao and pw
-    /// @param skip_charge 
+    /// @param skip_charge
     void solve(hamilt::Hamilt<T, Device>* pHamilt,
                psi::Psi<T, Device>& psi,
                elecstate::ElecState* pes,
@@ -63,19 +64,18 @@ class HSolverPW : public HSolver<T, Device>
     virtual Real cal_hsolerror() override;
     virtual Real set_diagethr(const int istep, const int iter, const Real drho) override;
     virtual Real reset_diagethr(std::ofstream& ofs_running, const Real hsover_error, const Real drho) override;
+
   protected:
     void endDiagh();
     void hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm, psi::Psi<T, Device>& psi, Real* eigenvalue);
 
-    void updatePsiK(hamilt::Hamilt<T, Device>* pHamilt,
-                    psi::Psi<T, Device>& psi,
-                    const int ik);
+    void updatePsiK(hamilt::Hamilt<T, Device>* pHamilt, psi::Psi<T, Device>& psi, const int ik);
 
     ModulePW::PW_Basis_K* wfc_basis = nullptr;
     wavefunc* pwf = nullptr;
 
     // calculate the precondition array for diagonalization in PW base
-    void update_precondition(std::vector<Real> &h_diag, const int ik, const int npw);
+    void update_precondition(std::vector<Real>& h_diag, const int ik, const int npw);
 
     std::vector<Real> precondition;
     std::vector<Real> eigenvalues;
@@ -85,7 +85,7 @@ class HSolverPW : public HSolver<T, Device>
 
     hamilt::Hamilt<T, Device>* hamilt_ = nullptr;
 
-    Device * ctx = {};
+    Device* ctx = {};
     using resmem_var_op = base_device::memory::resize_memory_op<Real, base_device::DEVICE_CPU>;
     using delmem_var_op = base_device::memory::delete_memory_op<Real, base_device::DEVICE_CPU>;
     using castmem_2d_2h_op

--- a/source/module_hsolver/hsolver_pw_sdft.cpp
+++ b/source/module_hsolver/hsolver_pw_sdft.cpp
@@ -31,7 +31,11 @@ void HSolverPW_SDFT::solve(hamilt::Hamilt<std::complex<double>>* pHamilt,
 
     // select the method of diagonalization
     this->method = method_in;
-    this->initDiagh(psi);
+    // report the specified diagonalization method is not supported (not among the following methods)
+    if (this->method != "cg" && this->method != "dav" && this->method != "dav_subspace" && this->method != "bpcg")
+    {
+        ModuleBase::WARNING_QUIT("HSolverPW::solve", "This method of DiagH is not supported!");
+    }
 
     // part of KSDFT to get KS orbitals
     for (int ik = 0; ik < nks; ++ik)

--- a/source/module_hsolver/hsolver_pw_sdft.cpp
+++ b/source/module_hsolver/hsolver_pw_sdft.cpp
@@ -1,11 +1,11 @@
 #include "hsolver_pw_sdft.h"
 
-#include <algorithm>
-
 #include "module_base/global_function.h"
 #include "module_base/timer.h"
 #include "module_base/tool_title.h"
 #include "module_elecstate/module_charge/symmetry_rho.h"
+
+#include <algorithm>
 
 namespace hsolver
 {
@@ -25,7 +25,7 @@ void HSolverPW_SDFT::solve(hamilt::Hamilt<std::complex<double>>* pHamilt,
     const int nbands = psi.get_nbands();
     const int nks = psi.get_nk();
 
-	this->hamilt_ = pHamilt;
+    this->hamilt_ = pHamilt;
     // prepare for the precondition of diagonalization
     this->precondition.resize(psi.get_nbasis());
 
@@ -52,82 +52,82 @@ void HSolverPW_SDFT::solve(hamilt::Hamilt<std::complex<double>>* pHamilt,
         }
 
         stoiter.stohchi.current_ik = ik;
-		
+
 #ifdef __MPI
-			if(nbands > 0)
-			{
-				MPI_Bcast(&psi(ik,0,0), npwx*nbands, MPI_DOUBLE_COMPLEX , 0, PARAPW_WORLD);
-				MPI_Bcast(&(pes->ekb(ik, 0)), nbands, MPI_DOUBLE, 0, PARAPW_WORLD);
-			}
+        if (nbands > 0)
+        {
+            MPI_Bcast(&psi(ik, 0, 0), npwx * nbands, MPI_DOUBLE_COMPLEX, 0, PARAPW_WORLD);
+            MPI_Bcast(&(pes->ekb(ik, 0)), nbands, MPI_DOUBLE, 0, PARAPW_WORLD);
+        }
 #endif
-			stoiter.orthog(ik,psi,stowf);
-			stoiter.checkemm(ik,istep, iter, stowf);	//check and reset emax & emin
-		}
+        stoiter.orthog(ik, psi, stowf);
+        stoiter.checkemm(ik, istep, iter, stowf); // check and reset emax & emin
+    }
 
-		this->endDiagh();
+    this->endDiagh();
 
-		for (int ik = 0;ik < nks;ik++)
-		{
-			//init k
-			if(nks > 1) pHamilt->updateHk(ik);
-			stoiter.stohchi.current_ik = ik;
-			stoiter.calPn(ik, stowf);
-		}
+    for (int ik = 0; ik < nks; ik++)
+    {
+        // init k
+        if (nks > 1)
+            pHamilt->updateHk(ik);
+        stoiter.stohchi.current_ik = ik;
+        stoiter.calPn(ik, stowf);
+    }
 
-		stoiter.itermu(iter,pes);
-		stoiter.calHsqrtchi(stowf);
-		if(skip_charge)
-    	{
-    	    ModuleBase::timer::tick(this->classname, "solve");
-    	    return;
-    	}
-		//(5) calculate new charge density 
-		// calculate KS rho.
-		if(nbands > 0)
-		{
-			pes->psiToRho(psi);
-#ifdef __MPI
-            MPI_Bcast(&pes->f_en.eband, 1, MPI_DOUBLE, 0, PARAPW_WORLD);
-#endif
-		}
-		else
-		{
-			for(int is=0; is < GlobalV::NSPIN; is++)
-			{
-				ModuleBase::GlobalFunc::ZEROS(pes->charge->rho[is], pes->charge->nrxx);
-			}
-		}
-		// calculate stochastic rho
-		stoiter.sum_stoband(stowf,pes,pHamilt,wfc_basis);
-
-        //will do rho symmetry and energy calculation in esolver
+    stoiter.itermu(iter, pes);
+    stoiter.calHsqrtchi(stowf);
+    if (skip_charge)
+    {
         ModuleBase::timer::tick(this->classname, "solve");
         return;
     }
-	
-    double HSolverPW_SDFT::set_diagethr(const int istep, const int iter, const double drho)
-	{
-		if (iter == 1)
-    	{
-			if(istep == 0)
-    	    {
-    	    	if (GlobalV::init_chg == "file")
-    	    	{
-    	    	    this->diag_ethr = 1.0e-5;
-    	    	}
-    			this->diag_ethr = std::max(this->diag_ethr, GlobalV::PW_DIAG_THR);
-			}
-			else
-				this->diag_ethr = std::max(this->diag_ethr, 1.0e-5);
-    	}
-    	else
-    	{
-			if(GlobalV::NBANDS > 0 && this->stoiter.KS_ne > 1e-6)
-    	    	this->diag_ethr = std::min(this->diag_ethr, 0.1 * drho / std::max(1.0, this->stoiter.KS_ne));
-			else
-				this->diag_ethr = 0.0;
-			
-    	}
-		return this->diag_ethr;
-	}
+    //(5) calculate new charge density
+    // calculate KS rho.
+    if (nbands > 0)
+    {
+        pes->psiToRho(psi);
+#ifdef __MPI
+        MPI_Bcast(&pes->f_en.eband, 1, MPI_DOUBLE, 0, PARAPW_WORLD);
+#endif
+    }
+    else
+    {
+        for (int is = 0; is < GlobalV::NSPIN; is++)
+        {
+            ModuleBase::GlobalFunc::ZEROS(pes->charge->rho[is], pes->charge->nrxx);
+        }
+    }
+    // calculate stochastic rho
+    stoiter.sum_stoband(stowf, pes, pHamilt, wfc_basis);
+
+    // will do rho symmetry and energy calculation in esolver
+    ModuleBase::timer::tick(this->classname, "solve");
+    return;
 }
+
+double HSolverPW_SDFT::set_diagethr(const int istep, const int iter, const double drho)
+{
+    if (iter == 1)
+    {
+        if (istep == 0)
+        {
+            if (GlobalV::init_chg == "file")
+            {
+                this->diag_ethr = 1.0e-5;
+            }
+            this->diag_ethr = std::max(this->diag_ethr, GlobalV::PW_DIAG_THR);
+        }
+        else
+            this->diag_ethr = std::max(this->diag_ethr, 1.0e-5);
+    }
+    else
+    {
+        if (GlobalV::NBANDS > 0 && this->stoiter.KS_ne > 1e-6)
+            this->diag_ethr = std::min(this->diag_ethr, 0.1 * drho / std::max(1.0, this->stoiter.KS_ne));
+        else
+            this->diag_ethr = 0.0;
+    }
+    return this->diag_ethr;
+}
+} // namespace hsolver

--- a/source/module_hsolver/test/test_hsolver_pw.cpp
+++ b/source/module_hsolver/test/test_hsolver_pw.cpp
@@ -96,8 +96,6 @@ TEST_F(TestHSolverPW, solve)
     this->hs_d.method = "dav";
     this->hs_f.initialed_psi = false;
     this->hs_d.initialed_psi = false;
-    this->hs_f.initDiagh(psi_test_cf);
-    this->hs_d.initDiagh(psi_test_cd);
     // will not change state of initialed_psi in initDiagh
     EXPECT_EQ(this->hs_f.initialed_psi, false);
     EXPECT_EQ(this->hs_d.initialed_psi, false);

--- a/source/module_hsolver/test/test_hsolver_pw.cpp
+++ b/source/module_hsolver/test/test_hsolver_pw.cpp
@@ -5,11 +5,10 @@
 #define private public
 #define protected public
 
-#include "module_hsolver/hsolver_pw.h"
-#include "hsolver_supplementary_mock.h"
 #include "hsolver_pw_sup.h"
-
+#include "hsolver_supplementary_mock.h"
 #include "module_base/global_variable.h"
+#include "module_hsolver/hsolver_pw.h"
 
 /************************************************
  *  unit test of HSolverPW class
@@ -33,7 +32,7 @@
  */
 class TestHSolverPW : public ::testing::Test
 {
-	public:
+  public:
     ModulePW::PW_Basis_K pwbk;
     hsolver::HSolverPW<std::complex<float>, base_device::DEVICE_CPU> hs_f
         = hsolver::HSolverPW<std::complex<float>, base_device::DEVICE_CPU>(&pwbk, nullptr);
@@ -195,17 +194,17 @@ TEST_F(TestHSolverPW, solve)
 #include "module_base/timer.h"
 int main(int argc, char **argv)
 {
-	ModuleBase::timer::disable();
-	MPI_Init(&argc, &argv);
-	testing::InitGoogleTest(&argc, argv);
+    ModuleBase::timer::disable();
+    MPI_Init(&argc, &argv);
+    testing::InitGoogleTest(&argc, argv);
 
-	MPI_Comm_size(MPI_COMM_WORLD,&GlobalV::NPROC);
-	MPI_Comm_rank(MPI_COMM_WORLD,&GlobalV::MY_RANK);
-	int result = RUN_ALL_TESTS();
-	
-	MPI_Finalize();
-	
-	return result;
+    MPI_Comm_size(MPI_COMM_WORLD,&GlobalV::NPROC);
+    MPI_Comm_rank(MPI_COMM_WORLD,&GlobalV::MY_RANK);
+    int result = RUN_ALL_TESTS();
+
+    MPI_Finalize();
+
+    return result;
 }*/
 
 TEST_F(TestHSolverPW, SolveLcaoInPW)
@@ -221,15 +220,15 @@ TEST_F(TestHSolverPW, SolveLcaoInPW)
     psi::Psi<std::complex<float>> transform_test_cf;
     // transform psi, the old wanf2, has 2 local basis and 3 pw basis.
     // so in principle the hcc has dimension 3*3 to diagonalize
-    // 2 lowest eigenvalues will be selected and save to psi    
+    // 2 lowest eigenvalues will be selected and save to psi
     transform_test_cd.resize(1, 3, 3);
     transform_test_cf.resize(1, 3, 3);
 
     std::complex<double> psi_value_d = {0.0, 0.0};
     std::complex<float> psi_value_f = {0.0, 0.0};
-    for(int iband = 0; iband < transform_test_cd.get_nbands(); iband++)
+    for (int iband = 0; iband < transform_test_cd.get_nbands(); iband++)
     {
-        for(int ibasis = 0; ibasis < transform_test_cd.get_nbasis(); ibasis++)
+        for (int ibasis = 0; ibasis < transform_test_cd.get_nbasis(); ibasis++)
         {
             transform_test_cd.get_pointer()[iband * transform_test_cd.get_nbasis() + ibasis] = psi_value_d;
             transform_test_cf.get_pointer()[iband * transform_test_cf.get_nbasis() + ibasis] = psi_value_f;


### PR DESCRIPTION
### Linked Issue
#4373 

### What's changed?
- All reference to pdiagh has been removed in `hsolver_pw.cpp`.
- `initDiagh` has been removed. The relevant functionality has been incorporated into the `solve` function.
- Due to the `endDiagh` function and `pdiagh` still having functionality and being referenced in the lcao code, their definitions have been retained.
