### PR TITLE
Refactor: change `nkstot_ibz` and `kvec_d_ibz` from members into local variables

### DIFF
--- a/source/module_cell/klist.h
+++ b/source/module_cell/klist.h
@@ -11,10 +11,10 @@
 class K_Vectors
 {
   public:
-    std::vector<ModuleBase::Vector3<double>> kvec_c;     /// Cartesian coordinates of k points
-    std::vector<ModuleBase::Vector3<double>> kvec_d;     /// Direct coordinates of k points
+    std::vector<ModuleBase::Vector3<double>> kvec_c; /// Cartesian coordinates of k points
+    std::vector<ModuleBase::Vector3<double>> kvec_d; /// Direct coordinates of k points
 
-    std::vector<double> wk;     /// wk, weight of k points
+    std::vector<double> wk; /// wk, weight of k points
 
     std::vector<int> ngk; /// ngk, number of plane waves for each k point
     std::vector<int> isk; /// distinguish spin up and down k points
@@ -112,7 +112,6 @@ class K_Vectors
      */
     inline int getik_global(const int& ik) const;
 
-    
     int get_nks() const
     {
         return this->nks;
@@ -128,23 +127,26 @@ class K_Vectors
         return this->nkstot_full;
     }
 
-    void set_nks(int value) {
+    void set_nks(int value)
+    {
         this->nks = value;
     }
 
-    void set_nkstot(int value) {
+    void set_nkstot(int value)
+    {
         this->nkstot = value;
     }
 
-    void set_nkstot_full(int value) {
+    void set_nkstot_full(int value)
+    {
         this->nkstot_full = value;
     }
 
-private:
-    int nks;						// number of symmetry-reduced k points in this pool(processor, up+dw)
-    int nkstot;						/// number of symmetry-reduced k points in full k mesh
-    int nkstot_full;    /// number of k points before symmetry reduction in full k mesh
-    
+  private:
+    int nks;         // number of symmetry-reduced k points in this pool(processor, up+dw)
+    int nkstot;      /// number of symmetry-reduced k points in full k mesh
+    int nkstot_full; /// number of k points before symmetry reduction in full k mesh
+
     int nspin;
     bool kc_done;
     bool kd_done;
@@ -269,8 +271,8 @@ private:
      * be recalculated.
      */
     void update_use_ibz(const int& nkstot_ibz,
-        const std::vector<ModuleBase::Vector3<double>>& kvec_d_ibz,
-        const std::vector<double>& wk_ibz);
+                        const std::vector<ModuleBase::Vector3<double>>& kvec_d_ibz,
+                        const std::vector<double>& wk_ibz);
 
     /**
      * @brief Sets both the direct and Cartesian k-vectors.

--- a/source/module_cell/klist.h
+++ b/source/module_cell/klist.h
@@ -13,7 +13,6 @@ class K_Vectors
   public:
     std::vector<ModuleBase::Vector3<double>> kvec_c;     /// Cartesian coordinates of k points
     std::vector<ModuleBase::Vector3<double>> kvec_d;     /// Direct coordinates of k points
-    std::vector<ModuleBase::Vector3<double>> kvec_d_ibz; /// ibz Direct coordinates of k points
 
     std::vector<double> wk;     /// wk, weight of k points
     std::vector<double> wk_ibz; /// ibz kpoint wk ,weight of k points
@@ -125,11 +124,6 @@ class K_Vectors
         return this->nkstot;
     }
 
-    int get_nkstot_ibz() const
-    {
-        return this->nkstot_ibz;
-    }
-
     int get_nkstot_full() const
     {
         return this->nkstot_full;
@@ -143,19 +137,14 @@ class K_Vectors
         this->nkstot = value;
     }
 
-    void set_nkstot_ibz(int value) {
-        this->nkstot_ibz = value;
-    }
-
     void set_nkstot_full(int value) {
         this->nkstot_full = value;
     }
 
 private:
-    int nks;						// number of k points in this pool(processor, up+dw)
-    int nkstot;						/// total number of k points, equal to nkstot_ibz after reducing k points
-    int nkstot_ibz;             /// number of k points in IBZ
-    int nkstot_full;    /// number of k points in full k mesh
+    int nks;						// number of symmetry-reduced k points in this pool(processor, up+dw)
+    int nkstot;						/// number of symmetry-reduced k points in full k mesh
+    int nkstot_full;    /// number of k points before symmetry reduction in full k mesh
     
     int nspin;
     bool kc_done;
@@ -282,7 +271,7 @@ private:
      * updated, and the flag kc_done is set to false to indicate that the Cartesian coordinates of the k-points need to
      * be recalculated.
      */
-    void update_use_ibz(void);
+    void update_use_ibz(const int& nkstot_ibz, const std::vector<ModuleBase::Vector3<double>>& kvec_d_ibz);
 
     /**
      * @brief Sets both the direct and Cartesian k-vectors.

--- a/source/module_cell/klist.h
+++ b/source/module_cell/klist.h
@@ -15,7 +15,6 @@ class K_Vectors
     std::vector<ModuleBase::Vector3<double>> kvec_d;     /// Direct coordinates of k points
 
     std::vector<double> wk;     /// wk, weight of k points
-    std::vector<double> wk_ibz; /// ibz kpoint wk ,weight of k points
 
     std::vector<int> ngk; /// ngk, number of plane waves for each k point
     std::vector<int> isk; /// distinguish spin up and down k points
@@ -154,8 +153,6 @@ private:
     int k_nkstot;        // LiuXh add 20180619
     bool is_mp = false;  // Monkhorst-Pack
 
-    std::vector<int> ibz2bz; // mohan added 2009-05-18
-
     /**
      * @brief Resize the k-point related vectors according to the new k-point number.
      *
@@ -271,7 +268,9 @@ private:
      * updated, and the flag kc_done is set to false to indicate that the Cartesian coordinates of the k-points need to
      * be recalculated.
      */
-    void update_use_ibz(const int& nkstot_ibz, const std::vector<ModuleBase::Vector3<double>>& kvec_d_ibz);
+    void update_use_ibz(const int& nkstot_ibz,
+        const std::vector<ModuleBase::Vector3<double>>& kvec_d_ibz,
+        const std::vector<double>& wk_ibz);
 
     /**
      * @brief Sets both the direct and Cartesian k-vectors.

--- a/source/module_cell/test/klist_test.cpp
+++ b/source/module_cell/test/klist_test.cpp
@@ -196,8 +196,7 @@ protected:
 TEST_F(KlistTest, Construct)
 {
 	EXPECT_EQ(kv->get_nks(),0);
-	EXPECT_EQ(kv->get_nkstot(),0);
-	EXPECT_EQ(kv->get_nkstot_ibz(),0);
+    EXPECT_EQ(kv->get_nkstot(), 0);
 	EXPECT_EQ(kv->nspin,0);
 	EXPECT_EQ(kv->k_nkstot,0);
 	EXPECT_FALSE(kv->kc_done);
@@ -680,11 +679,8 @@ TEST_F(KlistTest, UpdateUseIBZ)
 	kv->nspin = 1;
 	kv->set_nkstot(3);
 	kv->set_nks(3);
-	kv->renew(kv->get_nkstot());
-	kv->set_nkstot_ibz(2);
-	kv->kvec_d_ibz.resize(kv->get_nkstot_ibz());
-	kv->wk_ibz.resize(kv->get_nkstot_ibz());
-	kv->update_use_ibz();
+    kv->renew(kv->get_nkstot());
+    kv->update_use_ibz(kv->get_nkstot(), std::vector<ModuleBase::Vector3<double>>(2, { 0,0,0 }));
 	EXPECT_EQ(kv->get_nkstot(),2);
 	EXPECT_EQ(kv->kvec_d.size(),2);
 	EXPECT_TRUE(kv->kd_done);
@@ -708,7 +704,7 @@ TEST_F(KlistTest, IbzKpoint)
     ModuleSymmetry::Symmetry::symm_flag = 1;
     bool match = true;
     kv->ibz_kpoint(symm, ModuleSymmetry::Symmetry::symm_flag, skpt, ucell, match);
-	EXPECT_EQ(kv->get_nkstot_ibz(),35);
+    EXPECT_EQ(kv->get_nkstot(), 35);
 	GlobalV::ofs_running<<skpt<<std::endl;
 	GlobalV::ofs_running.close();
 	ClearUcell();
@@ -733,7 +729,7 @@ TEST_F(KlistTest, IbzKpointIsMP)
     ModuleSymmetry::Symmetry::symm_flag = 0;
     bool match = true;
     kv->ibz_kpoint(symm, ModuleSymmetry::Symmetry::symm_flag, skpt, ucell, match);
-	EXPECT_EQ(kv->get_nkstot_ibz(),260);
+    EXPECT_EQ(kv->get_nks(), 260);
 	GlobalV::ofs_running<<skpt<<std::endl;
 	GlobalV::ofs_running.close();
 	ClearUcell();

--- a/source/module_cell/test/klist_test.cpp
+++ b/source/module_cell/test/klist_test.cpp
@@ -680,7 +680,7 @@ TEST_F(KlistTest, UpdateUseIBZ)
 	kv->set_nkstot(3);
 	kv->set_nks(3);
     kv->renew(kv->get_nkstot());
-    kv->update_use_ibz(kv->get_nkstot(), std::vector<ModuleBase::Vector3<double>>(2, { 0,0,0 }));
+    kv->update_use_ibz(2, std::vector<ModuleBase::Vector3<double>>(2, { 0,0,0 }), std::vector<double>(2, 0.0));
 	EXPECT_EQ(kv->get_nkstot(),2);
 	EXPECT_EQ(kv->kvec_d.size(),2);
 	EXPECT_TRUE(kv->kd_done);

--- a/source/module_cell/test/klist_test.cpp
+++ b/source/module_cell/test/klist_test.cpp
@@ -1,44 +1,81 @@
-#include<iostream>
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
-#include <streambuf>
 #include "module_base/mathzone.h"
-#include "module_cell/parallel_kpoints.h"
 #include "module_base/parallel_global.h"
+#include "module_cell/parallel_kpoints.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <iostream>
+#include <streambuf>
 #define private public
-#include "module_cell/klist.h"
-#include "module_elecstate/magnetism.h"
-#include "module_hamilt_pw/hamilt_pwdft/VNL_in_pw.h"
+#include "module_basis/module_ao/ORB_gaunt_table.h"
 #include "module_cell/atom_pseudo.h"
 #include "module_cell/atom_spec.h"
-#include "module_cell/unitcell.h"
+#include "module_cell/klist.h"
+#include "module_cell/parallel_kpoints.h"
 #include "module_cell/pseudo.h"
 #include "module_cell/setup_nonlocal.h"
+#include "module_cell/unitcell.h"
+#include "module_elecstate/magnetism.h"
+#include "module_hamilt_pw/hamilt_pwdft/VNL_in_pw.h"
 #include "module_hamilt_pw/hamilt_pwdft/parallel_grid.h"
-#include "module_cell/parallel_kpoints.h"
 #include "module_io/berryphase.h"
-#include "module_basis/module_ao/ORB_gaunt_table.h"
 
-bool berryphase::berry_phase_flag=0;
+bool berryphase::berry_phase_flag = 0;
 
-pseudo::pseudo(){}
-pseudo::~pseudo(){}
-Atom::Atom(){}
-Atom::~Atom(){}
-Atom_pseudo::Atom_pseudo(){}
-Atom_pseudo::~Atom_pseudo(){}
-InfoNonlocal::InfoNonlocal(){}
-InfoNonlocal::~InfoNonlocal(){}
-UnitCell::UnitCell(){}
-UnitCell::~UnitCell(){}
-Magnetism::Magnetism(){}
-Magnetism::~Magnetism(){}
-ORB_gaunt_table::ORB_gaunt_table(){}
-ORB_gaunt_table::~ORB_gaunt_table(){}
-pseudopot_cell_vl::pseudopot_cell_vl(){}
-pseudopot_cell_vl::~pseudopot_cell_vl(){}
-pseudopot_cell_vnl::pseudopot_cell_vnl(){}
-pseudopot_cell_vnl::~pseudopot_cell_vnl(){}
+pseudo::pseudo()
+{
+}
+pseudo::~pseudo()
+{
+}
+Atom::Atom()
+{
+}
+Atom::~Atom()
+{
+}
+Atom_pseudo::Atom_pseudo()
+{
+}
+Atom_pseudo::~Atom_pseudo()
+{
+}
+InfoNonlocal::InfoNonlocal()
+{
+}
+InfoNonlocal::~InfoNonlocal()
+{
+}
+UnitCell::UnitCell()
+{
+}
+UnitCell::~UnitCell()
+{
+}
+Magnetism::Magnetism()
+{
+}
+Magnetism::~Magnetism()
+{
+}
+ORB_gaunt_table::ORB_gaunt_table()
+{
+}
+ORB_gaunt_table::~ORB_gaunt_table()
+{
+}
+pseudopot_cell_vl::pseudopot_cell_vl()
+{
+}
+pseudopot_cell_vl::~pseudopot_cell_vl()
+{
+}
+pseudopot_cell_vnl::pseudopot_cell_vnl()
+{
+}
+pseudopot_cell_vnl::~pseudopot_cell_vnl()
+{
+}
 Soc::~Soc()
 {
 }
@@ -48,9 +85,9 @@ Fcoef::~Fcoef()
 
 namespace GlobalC
 {
-	Parallel_Kpoints Pkpoints;
-	UnitCell ucell;
-}
+Parallel_Kpoints Pkpoints;
+UnitCell ucell;
+} // namespace GlobalC
 
 /************************************************
  *  unit test of class K_Vectors
@@ -62,7 +99,7 @@ namespace GlobalC
  *     - basic parameters (nks,nkstot,nkstot_ibz) are set
  *   - read_kpoints()
  *     - ReadKpointsGammaOnlyLocal: GlobalV::GAMMA_ONLY_LOCAL = 1
- *     - ReadKpointsKspacing: generate KPT from kspacing parameter 
+ *     - ReadKpointsKspacing: generate KPT from kspacing parameter
  *     - ReadKpointsGamma: "Gamma" mode of `KPT` file
  *     - ReadKpointsMP: "MP" mode of `KPT` file
  *     - ReadKpointsLine: "Line" mode of `KPT` file
@@ -91,11 +128,11 @@ namespace GlobalC
  *     - UpdateUseIbz: update kpoints info by ibz kpoints info
  *   - ibz_kpoint()
  *     - IbzKpoint: generate IBZ kpoints
- *     - IbzKpointIsMP: generate IBZ kpoints for non-symmetry 
+ *     - IbzKpointIsMP: generate IBZ kpoints for non-symmetry
  *       and Monkhorst-Pack case
  */
 
-//abbriviated from module_symmetry/test/symmetry_test.cpp
+// abbriviated from module_symmetry/test/symmetry_test.cpp
 struct atomtype_
 {
     std::string atomname;
@@ -105,635 +142,641 @@ struct atomtype_
 struct stru_
 {
     int ibrav;
-    std::string point_group; // Schoenflies symbol
+    std::string point_group;    // Schoenflies symbol
     std::string point_group_hm; // Hermann-Mauguin notation.
     std::string space_group;
     std::vector<double> cell;
     std::vector<atomtype_> all_type;
 };
 
-std::vector<stru_> stru_lib{
-    stru_{1,
-          "O_h",
-          "m-3m",
-          "Pm-3m",
-          std::vector<double>{1., 0., 0., 0., 1., 0., 0., 0., 1.},
-          std::vector<atomtype_>{atomtype_{"C",
-                                           std::vector<std::vector<double>>{
-                                               {0., 0., 0.},
-                                           }}}}
-};
-//used to construct cell and analyse its symmetry
-
+std::vector<stru_> stru_lib{stru_{1,
+                                  "O_h",
+                                  "m-3m",
+                                  "Pm-3m",
+                                  std::vector<double>{1., 0., 0., 0., 1., 0., 0., 0., 1.},
+                                  std::vector<atomtype_>{atomtype_{"C",
+                                                                   std::vector<std::vector<double>>{
+                                                                       {0., 0., 0.},
+                                                                   }}}}};
+// used to construct cell and analyse its symmetry
 
 class KlistTest : public testing::Test
 {
-protected:
-	std::unique_ptr<K_Vectors> kv{new K_Vectors};
-	std::ifstream ifs;
-	std::ofstream ofs;
-	std::ofstream ofs_running;
-	std::string output;
+  protected:
+    std::unique_ptr<K_Vectors> kv{new K_Vectors};
+    std::ifstream ifs;
+    std::ofstream ofs;
+    std::ofstream ofs_running;
+    std::string output;
 
-	//used to construct cell and analyse its symmetry
-	UnitCell ucell;
-	void construct_ucell(stru_ &stru)
-	{
-	    std::vector<atomtype_> coord = stru.all_type;
-	    ucell.a1 = ModuleBase::Vector3<double>(stru.cell[0], stru.cell[1], stru.cell[2]);
-	    ucell.a2 = ModuleBase::Vector3<double>(stru.cell[3], stru.cell[4], stru.cell[5]);
-	    ucell.a3 = ModuleBase::Vector3<double>(stru.cell[6], stru.cell[7], stru.cell[8]);
-	    ucell.ntype = stru.all_type.size();
-	    ucell.atoms = new Atom[ucell.ntype];
-	    ucell.nat = 0;
-	    ucell.latvec.e11 = ucell.a1.x; ucell.latvec.e12 = ucell.a1.y; ucell.latvec.e13 = ucell.a1.z;
-	    ucell.latvec.e21 = ucell.a2.x; ucell.latvec.e22 = ucell.a2.y; ucell.latvec.e23 = ucell.a2.z;
-	    ucell.latvec.e31 = ucell.a3.x; ucell.latvec.e32 = ucell.a3.y; ucell.latvec.e33 = ucell.a3.z;
-	    ucell.GT = ucell.latvec.Inverse();
-	    ucell.G = ucell.GT.Transpose();
-	    ucell.lat0 = 1.8897261254578281;
-	    for (int i = 0; i < coord.size(); i++)
-	    {
-	        ucell.atoms[i].label = coord[i].atomname;
-	        ucell.atoms[i].na = coord[i].coordinate.size();
-	        ucell.atoms[i].tau = new ModuleBase::Vector3<double>[ucell.atoms[i].na];
-	        ucell.atoms[i].taud = new ModuleBase::Vector3<double>[ucell.atoms[i].na];
-	        for (int j = 0; j < ucell.atoms[i].na; j++)
-	        {
-	            std::vector<double> this_atom = coord[i].coordinate[j];
-	            ucell.atoms[i].tau[j] = ModuleBase::Vector3<double>(this_atom[0], this_atom[1], this_atom[2]);
-	            ModuleBase::Mathzone::Cartesian_to_Direct(ucell.atoms[i].tau[j].x,
-	                                                      ucell.atoms[i].tau[j].y,
-	                                                      ucell.atoms[i].tau[j].z,
-	                                                      ucell.a1.x,
-	                                                      ucell.a1.y,
-	                                                      ucell.a1.z,
-	                                                      ucell.a2.x,
-	                                                      ucell.a2.y,
-	                                                      ucell.a2.z,
-	                                                      ucell.a3.x,
-	                                                      ucell.a3.y,
-	                                                      ucell.a3.z,
-	                                                      ucell.atoms[i].taud[j].x,
-	                                                      ucell.atoms[i].taud[j].y,
-	                                                      ucell.atoms[i].taud[j].z);
-	        }
-	        ucell.nat += ucell.atoms[i].na;
-	    }
-	}
-	//clear ucell
-	void ClearUcell()
-	{
-	    for (int i = 0; i < ucell.ntype; i++)
-	    {
-	        delete[] ucell.atoms[i].tau;
-	        delete[] ucell.atoms[i].taud;
-	    }
-	    delete[] ucell.atoms;
-	}
+    // used to construct cell and analyse its symmetry
+    UnitCell ucell;
+    void construct_ucell(stru_& stru)
+    {
+        std::vector<atomtype_> coord = stru.all_type;
+        ucell.a1 = ModuleBase::Vector3<double>(stru.cell[0], stru.cell[1], stru.cell[2]);
+        ucell.a2 = ModuleBase::Vector3<double>(stru.cell[3], stru.cell[4], stru.cell[5]);
+        ucell.a3 = ModuleBase::Vector3<double>(stru.cell[6], stru.cell[7], stru.cell[8]);
+        ucell.ntype = stru.all_type.size();
+        ucell.atoms = new Atom[ucell.ntype];
+        ucell.nat = 0;
+        ucell.latvec.e11 = ucell.a1.x;
+        ucell.latvec.e12 = ucell.a1.y;
+        ucell.latvec.e13 = ucell.a1.z;
+        ucell.latvec.e21 = ucell.a2.x;
+        ucell.latvec.e22 = ucell.a2.y;
+        ucell.latvec.e23 = ucell.a2.z;
+        ucell.latvec.e31 = ucell.a3.x;
+        ucell.latvec.e32 = ucell.a3.y;
+        ucell.latvec.e33 = ucell.a3.z;
+        ucell.GT = ucell.latvec.Inverse();
+        ucell.G = ucell.GT.Transpose();
+        ucell.lat0 = 1.8897261254578281;
+        for (int i = 0; i < coord.size(); i++)
+        {
+            ucell.atoms[i].label = coord[i].atomname;
+            ucell.atoms[i].na = coord[i].coordinate.size();
+            ucell.atoms[i].tau = new ModuleBase::Vector3<double>[ucell.atoms[i].na];
+            ucell.atoms[i].taud = new ModuleBase::Vector3<double>[ucell.atoms[i].na];
+            for (int j = 0; j < ucell.atoms[i].na; j++)
+            {
+                std::vector<double> this_atom = coord[i].coordinate[j];
+                ucell.atoms[i].tau[j] = ModuleBase::Vector3<double>(this_atom[0], this_atom[1], this_atom[2]);
+                ModuleBase::Mathzone::Cartesian_to_Direct(ucell.atoms[i].tau[j].x,
+                                                          ucell.atoms[i].tau[j].y,
+                                                          ucell.atoms[i].tau[j].z,
+                                                          ucell.a1.x,
+                                                          ucell.a1.y,
+                                                          ucell.a1.z,
+                                                          ucell.a2.x,
+                                                          ucell.a2.y,
+                                                          ucell.a2.z,
+                                                          ucell.a3.x,
+                                                          ucell.a3.y,
+                                                          ucell.a3.z,
+                                                          ucell.atoms[i].taud[j].x,
+                                                          ucell.atoms[i].taud[j].y,
+                                                          ucell.atoms[i].taud[j].z);
+            }
+            ucell.nat += ucell.atoms[i].na;
+        }
+    }
+    // clear ucell
+    void ClearUcell()
+    {
+        for (int i = 0; i < ucell.ntype; i++)
+        {
+            delete[] ucell.atoms[i].tau;
+            delete[] ucell.atoms[i].taud;
+        }
+        delete[] ucell.atoms;
+    }
 };
 
 TEST_F(KlistTest, Construct)
 {
-	EXPECT_EQ(kv->get_nks(),0);
+    EXPECT_EQ(kv->get_nks(), 0);
     EXPECT_EQ(kv->get_nkstot(), 0);
-	EXPECT_EQ(kv->nspin,0);
-	EXPECT_EQ(kv->k_nkstot,0);
-	EXPECT_FALSE(kv->kc_done);
-	EXPECT_FALSE(kv->kd_done);
-	//just to set ucell info here, however it is used in the following tests
-	GlobalC::ucell.latvec.e11 = 10.0; GlobalC::ucell.latvec.e12 = 0.0; GlobalC::ucell.latvec.e13 = 0.0;
-	GlobalC::ucell.latvec.e21 = 0.0; GlobalC::ucell.latvec.e22 = 10.0; GlobalC::ucell.latvec.e23 = 0.0;
-	GlobalC::ucell.latvec.e31 = 0.0; GlobalC::ucell.latvec.e32 = 0.0; GlobalC::ucell.latvec.e33 = 10.0;
-	GlobalC::ucell.GT = GlobalC::ucell.latvec.Inverse();
-	GlobalC::ucell.G = GlobalC::ucell.GT.Transpose();
-	GlobalC::ucell.lat0 = 1.8897261254578281;
+    EXPECT_EQ(kv->nspin, 0);
+    EXPECT_EQ(kv->k_nkstot, 0);
+    EXPECT_FALSE(kv->kc_done);
+    EXPECT_FALSE(kv->kd_done);
+    // just to set ucell info here, however it is used in the following tests
+    GlobalC::ucell.latvec.e11 = 10.0;
+    GlobalC::ucell.latvec.e12 = 0.0;
+    GlobalC::ucell.latvec.e13 = 0.0;
+    GlobalC::ucell.latvec.e21 = 0.0;
+    GlobalC::ucell.latvec.e22 = 10.0;
+    GlobalC::ucell.latvec.e23 = 0.0;
+    GlobalC::ucell.latvec.e31 = 0.0;
+    GlobalC::ucell.latvec.e32 = 0.0;
+    GlobalC::ucell.latvec.e33 = 10.0;
+    GlobalC::ucell.GT = GlobalC::ucell.latvec.Inverse();
+    GlobalC::ucell.G = GlobalC::ucell.GT.Transpose();
+    GlobalC::ucell.lat0 = 1.8897261254578281;
 }
 
 TEST_F(KlistTest, MP)
 {
-	kv->nmp[0] = 2;
-	kv->nmp[1] = 2;
-	kv->nmp[2] = 2;
-	kv->koffset[0] = 0;
-	kv->koffset[1] = 0;
-	kv->koffset[2] = 0;
-	kv->nspin = 1;
-	int k_type = 0;
-	kv->Monkhorst_Pack(kv->nmp,kv->koffset,k_type);
-	/*
-	std::cout << " " <<std::endl;
-	for (int ik=0;ik<kv->get_nkstot();ik++)
-	{
-		std::cout<<kv->kvec_d[ik]<<std::endl;
-	}
-	*/
-	std::unique_ptr<K_Vectors> kv1{new K_Vectors};
-	kv1->nmp[0] = 2;
-	kv1->nmp[1] = 2;
-	kv1->nmp[2] = 2;
-	kv1->koffset[0] = 1;
-	kv1->koffset[1] = 1;
-	kv1->koffset[2] = 1;
-	kv1->nspin = 1;
-	k_type = 1;
-	kv1->Monkhorst_Pack(kv1->nmp,kv1->koffset,k_type);
-	//std::cout << " " <<std::endl;
-	for (int ik=0;ik<kv1->nkstot;ik++)
-	{
-		EXPECT_EQ(kv->kvec_d[ik].x,kv1->kvec_d[ik].x);
-		EXPECT_EQ(kv->kvec_d[ik].y,kv1->kvec_d[ik].y);
-		EXPECT_EQ(kv->kvec_d[ik].z,kv1->kvec_d[ik].z);
-		//std::cout<<kv1->kvec_d[ik]<<std::endl;
-	}
+    kv->nmp[0] = 2;
+    kv->nmp[1] = 2;
+    kv->nmp[2] = 2;
+    kv->koffset[0] = 0;
+    kv->koffset[1] = 0;
+    kv->koffset[2] = 0;
+    kv->nspin = 1;
+    int k_type = 0;
+    kv->Monkhorst_Pack(kv->nmp, kv->koffset, k_type);
+    /*
+    std::cout << " " <<std::endl;
+    for (int ik=0;ik<kv->get_nkstot();ik++)
+    {
+        std::cout<<kv->kvec_d[ik]<<std::endl;
+    }
+    */
+    std::unique_ptr<K_Vectors> kv1{new K_Vectors};
+    kv1->nmp[0] = 2;
+    kv1->nmp[1] = 2;
+    kv1->nmp[2] = 2;
+    kv1->koffset[0] = 1;
+    kv1->koffset[1] = 1;
+    kv1->koffset[2] = 1;
+    kv1->nspin = 1;
+    k_type = 1;
+    kv1->Monkhorst_Pack(kv1->nmp, kv1->koffset, k_type);
+    // std::cout << " " <<std::endl;
+    for (int ik = 0; ik < kv1->nkstot; ik++)
+    {
+        EXPECT_EQ(kv->kvec_d[ik].x, kv1->kvec_d[ik].x);
+        EXPECT_EQ(kv->kvec_d[ik].y, kv1->kvec_d[ik].y);
+        EXPECT_EQ(kv->kvec_d[ik].z, kv1->kvec_d[ik].z);
+        // std::cout<<kv1->kvec_d[ik]<<std::endl;
+    }
 }
 
 TEST_F(KlistTest, ReadKpointsGammaOnlyLocal)
 {
-	GlobalV::GAMMA_ONLY_LOCAL = 1;
-	std::string kfile = "KPT_GO";
-	kv->nspin = 1;
-	kv->read_kpoints(kfile);
-	ifs.open("KPT_GO");
-	std::string str((std::istreambuf_iterator<char>(ifs)),std::istreambuf_iterator<char>());
-	EXPECT_THAT(str,testing::HasSubstr("Gamma"));
-	EXPECT_THAT(str,testing::HasSubstr("1 1 1 0 0 0"));
-	ifs.close();
-	GlobalV::GAMMA_ONLY_LOCAL = 0; //this is important for the following tests because it is global
+    GlobalV::GAMMA_ONLY_LOCAL = 1;
+    std::string kfile = "KPT_GO";
+    kv->nspin = 1;
+    kv->read_kpoints(kfile);
+    ifs.open("KPT_GO");
+    std::string str((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    EXPECT_THAT(str, testing::HasSubstr("Gamma"));
+    EXPECT_THAT(str, testing::HasSubstr("1 1 1 0 0 0"));
+    ifs.close();
+    GlobalV::GAMMA_ONLY_LOCAL = 0; // this is important for the following tests because it is global
 }
 
 TEST_F(KlistTest, ReadKpointsKspacing)
 {
-	kv->nspin = 1;
-	GlobalV::KSPACING[0] = 0.052918; // 0.52918/Bohr = 1/A
-	GlobalV::KSPACING[1] = 0.052918; // 0.52918/Bohr = 1/A
-	GlobalV::KSPACING[2] = 0.052918; // 0.52918/Bohr = 1/A
-	std::string k_file = "./support/KPT3";
-	kv->read_kpoints(k_file);
-	EXPECT_EQ(kv->get_nkstot(),343);
-	GlobalV::KSPACING[0]=0.0;
-	GlobalV::KSPACING[1]=0.0;
-	GlobalV::KSPACING[2]=0.0;
+    kv->nspin = 1;
+    GlobalV::KSPACING[0] = 0.052918; // 0.52918/Bohr = 1/A
+    GlobalV::KSPACING[1] = 0.052918; // 0.52918/Bohr = 1/A
+    GlobalV::KSPACING[2] = 0.052918; // 0.52918/Bohr = 1/A
+    std::string k_file = "./support/KPT3";
+    kv->read_kpoints(k_file);
+    EXPECT_EQ(kv->get_nkstot(), 343);
+    GlobalV::KSPACING[0] = 0.0;
+    GlobalV::KSPACING[1] = 0.0;
+    GlobalV::KSPACING[2] = 0.0;
 }
 
 TEST_F(KlistTest, ReadKpointsKspacing3values)
 {
-	kv->nspin = 1;
-	GlobalV::KSPACING[0] = 0.052918; // 0.52918/Bohr = 1/A
-	GlobalV::KSPACING[1] = 0.06; // 0.52918/Bohr = 1/A
-	GlobalV::KSPACING[2] = 0.07; // 0.52918/Bohr = 1/A
-	std::string k_file = "./support/KPT3";
-	kv->read_kpoints(k_file);
-	EXPECT_EQ(kv->get_nkstot(),210);
-	GlobalV::KSPACING[0]=0.0;
-	GlobalV::KSPACING[1]=0.0;
-	GlobalV::KSPACING[2]=0.0;
+    kv->nspin = 1;
+    GlobalV::KSPACING[0] = 0.052918; // 0.52918/Bohr = 1/A
+    GlobalV::KSPACING[1] = 0.06;     // 0.52918/Bohr = 1/A
+    GlobalV::KSPACING[2] = 0.07;     // 0.52918/Bohr = 1/A
+    std::string k_file = "./support/KPT3";
+    kv->read_kpoints(k_file);
+    EXPECT_EQ(kv->get_nkstot(), 210);
+    GlobalV::KSPACING[0] = 0.0;
+    GlobalV::KSPACING[1] = 0.0;
+    GlobalV::KSPACING[2] = 0.0;
 }
 
 TEST_F(KlistTest, ReadKpointsInvalidKspacing3values)
 {
-	kv->nspin = 1;
-	GlobalV::KSPACING[0] = 0.052918; // 0.52918/Bohr = 1/A
-	GlobalV::KSPACING[1] = 0; // 0.52918/Bohr = 1/A
-	GlobalV::KSPACING[2] = 0.07; // 0.52918/Bohr = 1/A
-	std::string k_file = "./support/KPT3";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(kv->read_kpoints(k_file),::testing::ExitedWithCode(0),"");
-	output = testing::internal::GetCapturedStdout();
-	GlobalV::KSPACING[0]=0.0;
-	GlobalV::KSPACING[1]=0.0;
-	GlobalV::KSPACING[2]=0.0;
+    kv->nspin = 1;
+    GlobalV::KSPACING[0] = 0.052918; // 0.52918/Bohr = 1/A
+    GlobalV::KSPACING[1] = 0;        // 0.52918/Bohr = 1/A
+    GlobalV::KSPACING[2] = 0.07;     // 0.52918/Bohr = 1/A
+    std::string k_file = "./support/KPT3";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(kv->read_kpoints(k_file), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    GlobalV::KSPACING[0] = 0.0;
+    GlobalV::KSPACING[1] = 0.0;
+    GlobalV::KSPACING[2] = 0.0;
 }
 
 TEST_F(KlistTest, ReadKpointsGamma)
 {
-	std::string k_file = "./support/KPT";
-	kv->nspin = 1;
-	kv->read_kpoints(k_file);
-	EXPECT_EQ(kv->get_nkstot(),512);
+    std::string k_file = "./support/KPT";
+    kv->nspin = 1;
+    kv->read_kpoints(k_file);
+    EXPECT_EQ(kv->get_nkstot(), 512);
 }
 
 TEST_F(KlistTest, ReadKpointsMP)
 {
-	std::string k_file = "./support/KPT1";
-	kv->nspin = 1;
-	kv->read_kpoints(k_file);
-	EXPECT_EQ(kv->get_nkstot(),512);
+    std::string k_file = "./support/KPT1";
+    kv->nspin = 1;
+    kv->read_kpoints(k_file);
+    EXPECT_EQ(kv->get_nkstot(), 512);
 }
 
 TEST_F(KlistTest, ReadKpointsLine)
 {
-	ModuleSymmetry::Symmetry::symm_flag=0; 
-	// symm_flag is required in read_kpoints for a k list
-	std::string k_file = "./support/KPT2";
-	kv->nspin = 1;
-	kv->read_kpoints(k_file);
-	EXPECT_EQ(kv->get_nkstot(),122);
+    ModuleSymmetry::Symmetry::symm_flag = 0;
+    // symm_flag is required in read_kpoints for a k list
+    std::string k_file = "./support/KPT2";
+    kv->nspin = 1;
+    kv->read_kpoints(k_file);
+    EXPECT_EQ(kv->get_nkstot(), 122);
 }
 
 TEST_F(KlistTest, ReadKpointsCartesian)
 {
-	std::string k_file = "./support/KPT4";
-        //Cartesian: non-spin case nspin=1
-	kv->nspin = 1;
-	kv->read_kpoints(k_file);
-	EXPECT_EQ(kv->kvec_c.size(),5);
-	//spin case nspin=2
-	kv->nspin = 2;
-	kv->read_kpoints(k_file);
-	EXPECT_EQ(kv->kvec_c.size(),10);
+    std::string k_file = "./support/KPT4";
+    // Cartesian: non-spin case nspin=1
+    kv->nspin = 1;
+    kv->read_kpoints(k_file);
+    EXPECT_EQ(kv->kvec_c.size(), 5);
+    // spin case nspin=2
+    kv->nspin = 2;
+    kv->read_kpoints(k_file);
+    EXPECT_EQ(kv->kvec_c.size(), 10);
 }
 
 TEST_F(KlistTest, ReadKpointsLineCartesian)
 {
-	std::string k_file = "./support/KPT5";
-	//Line Cartesian: non-spin case nspin=1
-	kv->nspin = 1;
-	kv->set_kup_and_kdw();
-	// Read from k point file under the case of Line_Cartesian.
-	kv->read_kpoints(k_file);
-	EXPECT_EQ(kv->get_nkstot(),51);
-	EXPECT_EQ(kv->kvec_c.size(),51);
-	//Line Cartesian: spin case nspin=2
-	kv->nspin = 2;
-	// Read from k point file under the case of Line_Cartesian.
-	kv->read_kpoints(k_file);
-	EXPECT_EQ(kv->get_nkstot(),51);
-	EXPECT_EQ(kv->kvec_c.size(),102);
+    std::string k_file = "./support/KPT5";
+    // Line Cartesian: non-spin case nspin=1
+    kv->nspin = 1;
+    kv->set_kup_and_kdw();
+    // Read from k point file under the case of Line_Cartesian.
+    kv->read_kpoints(k_file);
+    EXPECT_EQ(kv->get_nkstot(), 51);
+    EXPECT_EQ(kv->kvec_c.size(), 51);
+    // Line Cartesian: spin case nspin=2
+    kv->nspin = 2;
+    // Read from k point file under the case of Line_Cartesian.
+    kv->read_kpoints(k_file);
+    EXPECT_EQ(kv->get_nkstot(), 51);
+    EXPECT_EQ(kv->kvec_c.size(), 102);
 }
 
 TEST_F(KlistTest, ReadKpointsDirect)
 {
-	std::string k_file = "./support/KPT6";
-	kv->nspin = 1;
-	kv->set_kup_and_kdw();
-	// Read from k point file under the case of Direct
-	kv->read_kpoints(k_file);
-	EXPECT_EQ(kv->get_nkstot(),6);
-	EXPECT_TRUE(kv->kd_done);
+    std::string k_file = "./support/KPT6";
+    kv->nspin = 1;
+    kv->set_kup_and_kdw();
+    // Read from k point file under the case of Direct
+    kv->read_kpoints(k_file);
+    EXPECT_EQ(kv->get_nkstot(), 6);
+    EXPECT_TRUE(kv->kd_done);
 }
 
 TEST_F(KlistTest, ReadKpointsWarning1)
 {
-	std::string k_file = "arbitrary_1";
-	kv->nspin = 1;
-	GlobalV::ofs_warning.open("klist_tmp_warning_1");
-	EXPECT_NO_THROW(kv->read_kpoints(k_file));
-	GlobalV::ofs_warning.close();
-	ifs.open("klist_tmp_warning_1");
-	std::string str((std::istreambuf_iterator<char>(ifs)),std::istreambuf_iterator<char>());
-	EXPECT_THAT(str, testing::HasSubstr("Can't find File name : arbitrary_1"));
-	ifs.close();
-	remove("klist_tmp_warning_1");
+    std::string k_file = "arbitrary_1";
+    kv->nspin = 1;
+    GlobalV::ofs_warning.open("klist_tmp_warning_1");
+    EXPECT_NO_THROW(kv->read_kpoints(k_file));
+    GlobalV::ofs_warning.close();
+    ifs.open("klist_tmp_warning_1");
+    std::string str((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    EXPECT_THAT(str, testing::HasSubstr("Can't find File name : arbitrary_1"));
+    ifs.close();
+    remove("klist_tmp_warning_1");
 }
 
 TEST_F(KlistTest, ReadKpointsWarning2)
 {
-	std::string k_file = "arbitrary_2";
-	ofs.open(k_file.c_str());
-	ofs<<"ARBITRARY";
-	ofs.close();
-	kv->nspin = 1;
-	GlobalV::ofs_warning.open("klist_tmp_warning_2");
-	EXPECT_NO_THROW(kv->read_kpoints(k_file));
-	GlobalV::ofs_warning.close();
-	ifs.open("klist_tmp_warning_2");
-	std::string str((std::istreambuf_iterator<char>(ifs)),std::istreambuf_iterator<char>());
-	EXPECT_THAT(str, testing::HasSubstr("symbol K_POINTS not found."));
-	ifs.close();
-	remove("klist_tmp_warning_2");
-	remove("arbitrary_2");
+    std::string k_file = "arbitrary_2";
+    ofs.open(k_file.c_str());
+    ofs << "ARBITRARY";
+    ofs.close();
+    kv->nspin = 1;
+    GlobalV::ofs_warning.open("klist_tmp_warning_2");
+    EXPECT_NO_THROW(kv->read_kpoints(k_file));
+    GlobalV::ofs_warning.close();
+    ifs.open("klist_tmp_warning_2");
+    std::string str((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    EXPECT_THAT(str, testing::HasSubstr("symbol K_POINTS not found."));
+    ifs.close();
+    remove("klist_tmp_warning_2");
+    remove("arbitrary_2");
 }
 
 TEST_F(KlistTest, ReadKpointsWarning3)
 {
-	std::string k_file = "arbitrary_3";
-	ofs.open(k_file.c_str());
-	ofs<<"KPOINTS"<<std::endl;
-	ofs<<"100001"<<std::endl;
-	ofs.close();
-	kv->nspin = 1;
-	GlobalV::ofs_warning.open("klist_tmp_warning_3");
-	EXPECT_NO_THROW(kv->read_kpoints(k_file));
-	GlobalV::ofs_warning.close();
-	ifs.open("klist_tmp_warning_3");
-	std::string str((std::istreambuf_iterator<char>(ifs)),std::istreambuf_iterator<char>());
-	EXPECT_THAT(str, testing::HasSubstr("nkstot > MAX_KPOINTS"));
-	ifs.close();
-	remove("klist_tmp_warning_3");
-	remove("arbitrary_3");
+    std::string k_file = "arbitrary_3";
+    ofs.open(k_file.c_str());
+    ofs << "KPOINTS" << std::endl;
+    ofs << "100001" << std::endl;
+    ofs.close();
+    kv->nspin = 1;
+    GlobalV::ofs_warning.open("klist_tmp_warning_3");
+    EXPECT_NO_THROW(kv->read_kpoints(k_file));
+    GlobalV::ofs_warning.close();
+    ifs.open("klist_tmp_warning_3");
+    std::string str((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    EXPECT_THAT(str, testing::HasSubstr("nkstot > MAX_KPOINTS"));
+    ifs.close();
+    remove("klist_tmp_warning_3");
+    remove("arbitrary_3");
 }
 
 TEST_F(KlistTest, ReadKpointsWarning4)
 {
-	std::string k_file = "arbitrary_4";
-	ofs.open(k_file.c_str());
-	ofs<<"KPOINTS"<<std::endl;
-	ofs<<"0"<<std::endl;
-	ofs<<"arbitrary"<<std::endl;
-	ofs.close();
-	kv->nspin = 1;
-	GlobalV::ofs_warning.open("klist_tmp_warning_4");
-	EXPECT_NO_THROW(kv->read_kpoints(k_file));
-	GlobalV::ofs_warning.close();
-	ifs.open("klist_tmp_warning_4");
-	std::string str((std::istreambuf_iterator<char>(ifs)),std::istreambuf_iterator<char>());
-	EXPECT_THAT(str, testing::HasSubstr("Error: neither Gamma nor Monkhorst-Pack."));
-	ifs.close();
-	remove("klist_tmp_warning_4");
-	remove("arbitrary_4");
+    std::string k_file = "arbitrary_4";
+    ofs.open(k_file.c_str());
+    ofs << "KPOINTS" << std::endl;
+    ofs << "0" << std::endl;
+    ofs << "arbitrary" << std::endl;
+    ofs.close();
+    kv->nspin = 1;
+    GlobalV::ofs_warning.open("klist_tmp_warning_4");
+    EXPECT_NO_THROW(kv->read_kpoints(k_file));
+    GlobalV::ofs_warning.close();
+    ifs.open("klist_tmp_warning_4");
+    std::string str((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    EXPECT_THAT(str, testing::HasSubstr("Error: neither Gamma nor Monkhorst-Pack."));
+    ifs.close();
+    remove("klist_tmp_warning_4");
+    remove("arbitrary_4");
 }
 
 TEST_F(KlistTest, ReadKpointsWarning5)
 {
-	std::string k_file = "arbitrary_5";
-	ofs.open(k_file.c_str());
-	ofs<<"KPOINTS"<<std::endl;
-	ofs<<"100000"<<std::endl;
-	ofs<<"arbitrary"<<std::endl;
-	ofs.close();
-        //Cartesian: non-spin case nspin=1
-	kv->nspin = 1;
-	GlobalV::ofs_warning.open("klist_tmp_warning_5");
-	EXPECT_NO_THROW(kv->read_kpoints(k_file));
-	GlobalV::ofs_warning.close();
-	ifs.open("klist_tmp_warning_5");
-	std::string str((std::istreambuf_iterator<char>(ifs)),std::istreambuf_iterator<char>());
-	EXPECT_THAT(str, testing::HasSubstr("Error : neither Cartesian nor Direct kpoint"));
-	ifs.close();
-	remove("klist_tmp_warning_5");
-	remove("arbitrary_5");
+    std::string k_file = "arbitrary_5";
+    ofs.open(k_file.c_str());
+    ofs << "KPOINTS" << std::endl;
+    ofs << "100000" << std::endl;
+    ofs << "arbitrary" << std::endl;
+    ofs.close();
+    // Cartesian: non-spin case nspin=1
+    kv->nspin = 1;
+    GlobalV::ofs_warning.open("klist_tmp_warning_5");
+    EXPECT_NO_THROW(kv->read_kpoints(k_file));
+    GlobalV::ofs_warning.close();
+    ifs.open("klist_tmp_warning_5");
+    std::string str((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    EXPECT_THAT(str, testing::HasSubstr("Error : neither Cartesian nor Direct kpoint"));
+    ifs.close();
+    remove("klist_tmp_warning_5");
+    remove("arbitrary_5");
 }
 
 TEST_F(KlistTest, ReadKpointsWarning6)
 {
-	std::string k_file = "arbitrary_6";
-	ofs.open(k_file.c_str());
-	ofs<<"KPOINTS"<<std::endl;
-	ofs<<"100000"<<std::endl;
-	ofs<<"Line_Cartesian"<<std::endl;
-	ofs.close();
-        //Cartesian: non-spin case nspin=1
-	kv->nspin = 1;
-	ModuleSymmetry::Symmetry::symm_flag = 1;
-	GlobalV::ofs_warning.open("klist_tmp_warning_6");
-	EXPECT_NO_THROW(kv->read_kpoints(k_file));
-	GlobalV::ofs_warning.close();
-	ifs.open("klist_tmp_warning_6");
-	std::string str((std::istreambuf_iterator<char>(ifs)),std::istreambuf_iterator<char>());
-	EXPECT_THAT(str, testing::HasSubstr("Line mode of k-points is open, please set symmetry to 0 or -1"));
-	ifs.close();
-	remove("klist_tmp_warning_6");
-	remove("arbitrary_6");
-	ModuleSymmetry::Symmetry::symm_flag = 0;
+    std::string k_file = "arbitrary_6";
+    ofs.open(k_file.c_str());
+    ofs << "KPOINTS" << std::endl;
+    ofs << "100000" << std::endl;
+    ofs << "Line_Cartesian" << std::endl;
+    ofs.close();
+    // Cartesian: non-spin case nspin=1
+    kv->nspin = 1;
+    ModuleSymmetry::Symmetry::symm_flag = 1;
+    GlobalV::ofs_warning.open("klist_tmp_warning_6");
+    EXPECT_NO_THROW(kv->read_kpoints(k_file));
+    GlobalV::ofs_warning.close();
+    ifs.open("klist_tmp_warning_6");
+    std::string str((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    EXPECT_THAT(str, testing::HasSubstr("Line mode of k-points is open, please set symmetry to 0 or -1"));
+    ifs.close();
+    remove("klist_tmp_warning_6");
+    remove("arbitrary_6");
+    ModuleSymmetry::Symmetry::symm_flag = 0;
 }
 
 TEST_F(KlistTest, ReadKpointsWarning7)
 {
-	std::string k_file = "arbitrary_7";
-	ofs.open(k_file.c_str());
-	ofs<<"KPOINTS"<<std::endl;
-	ofs<<"100000"<<std::endl;
-	ofs<<"Line_Direct"<<std::endl;
-	ofs.close();
-	kv->nspin = 1;
-	ModuleSymmetry::Symmetry::symm_flag = 1;
-	GlobalV::ofs_warning.open("klist_tmp_warning_7");
-	EXPECT_NO_THROW(kv->read_kpoints(k_file));
-	GlobalV::ofs_warning.close();
-	ifs.open("klist_tmp_warning_7");
-	std::string str((std::istreambuf_iterator<char>(ifs)),std::istreambuf_iterator<char>());
-	EXPECT_THAT(str, testing::HasSubstr("Line mode of k-points is open, please set symmetry to 0 or -1"));
-	ifs.close();
-	remove("klist_tmp_warning_7");
-	remove("arbitrary_7");
-	ModuleSymmetry::Symmetry::symm_flag = 0;
+    std::string k_file = "arbitrary_7";
+    ofs.open(k_file.c_str());
+    ofs << "KPOINTS" << std::endl;
+    ofs << "100000" << std::endl;
+    ofs << "Line_Direct" << std::endl;
+    ofs.close();
+    kv->nspin = 1;
+    ModuleSymmetry::Symmetry::symm_flag = 1;
+    GlobalV::ofs_warning.open("klist_tmp_warning_7");
+    EXPECT_NO_THROW(kv->read_kpoints(k_file));
+    GlobalV::ofs_warning.close();
+    ifs.open("klist_tmp_warning_7");
+    std::string str((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    EXPECT_THAT(str, testing::HasSubstr("Line mode of k-points is open, please set symmetry to 0 or -1"));
+    ifs.close();
+    remove("klist_tmp_warning_7");
+    remove("arbitrary_7");
+    ModuleSymmetry::Symmetry::symm_flag = 0;
 }
 
 TEST_F(KlistTest, SetKupKdown)
 {
-	std::string k_file = "./support/KPT4";
-	//Cartesian: non-spin case nspin=1
-	kv->nspin = 1;
-	kv->read_kpoints(k_file);
-	kv->set_kup_and_kdw();
-	for (int ik=0;ik<5;ik++)
-	{
-		EXPECT_EQ(kv->isk[ik],0);
-
-	}
-	kv->nspin = 4;
-	kv->read_kpoints(k_file);
-	kv->set_kup_and_kdw();
-	for (int ik=0;ik<5;ik++)
-	{
-		EXPECT_EQ(kv->isk[ik],0);
-		EXPECT_EQ(kv->isk[ik+5],0);
-		EXPECT_EQ(kv->isk[ik+10],0);
-		EXPECT_EQ(kv->isk[ik+15],0);
-	}
-	kv->nspin = 2;
-	kv->read_kpoints(k_file);
-	kv->set_kup_and_kdw();
-	for (int ik=0;ik<5;ik++)
-	{
-		EXPECT_EQ(kv->isk[ik],0);
-		EXPECT_EQ(kv->isk[ik+5],1);
-	}
+    std::string k_file = "./support/KPT4";
+    // Cartesian: non-spin case nspin=1
+    kv->nspin = 1;
+    kv->read_kpoints(k_file);
+    kv->set_kup_and_kdw();
+    for (int ik = 0; ik < 5; ik++)
+    {
+        EXPECT_EQ(kv->isk[ik], 0);
+    }
+    kv->nspin = 4;
+    kv->read_kpoints(k_file);
+    kv->set_kup_and_kdw();
+    for (int ik = 0; ik < 5; ik++)
+    {
+        EXPECT_EQ(kv->isk[ik], 0);
+        EXPECT_EQ(kv->isk[ik + 5], 0);
+        EXPECT_EQ(kv->isk[ik + 10], 0);
+        EXPECT_EQ(kv->isk[ik + 15], 0);
+    }
+    kv->nspin = 2;
+    kv->read_kpoints(k_file);
+    kv->set_kup_and_kdw();
+    for (int ik = 0; ik < 5; ik++)
+    {
+        EXPECT_EQ(kv->isk[ik], 0);
+        EXPECT_EQ(kv->isk[ik + 5], 1);
+    }
 }
-
 
 TEST_F(KlistTest, SetAfterVC)
 {
-	kv->nspin = 1;
-	kv->set_nkstot(1);
-	GlobalV::ofs_running.open("tmp_klist_1");
-	kv->renew(kv->get_nkstot());
-	kv->kvec_c[0].x = 0;
-	kv->kvec_c[0].y = 0;
-	kv->kvec_c[0].z = 0;
-	kv->set_after_vc(GlobalV::NSPIN, GlobalC::ucell.G,GlobalC::ucell.latvec);
-	EXPECT_TRUE(kv->kd_done);
-	EXPECT_TRUE(kv->kc_done);
-	EXPECT_DOUBLE_EQ(kv->kvec_d[0].x,0);
-	EXPECT_DOUBLE_EQ(kv->kvec_d[0].y,0);
-	EXPECT_DOUBLE_EQ(kv->kvec_d[0].z,0);
-	GlobalV::ofs_running.close();
-	remove("tmp_klist_1");
+    kv->nspin = 1;
+    kv->set_nkstot(1);
+    GlobalV::ofs_running.open("tmp_klist_1");
+    kv->renew(kv->get_nkstot());
+    kv->kvec_c[0].x = 0;
+    kv->kvec_c[0].y = 0;
+    kv->kvec_c[0].z = 0;
+    kv->set_after_vc(GlobalV::NSPIN, GlobalC::ucell.G, GlobalC::ucell.latvec);
+    EXPECT_TRUE(kv->kd_done);
+    EXPECT_TRUE(kv->kc_done);
+    EXPECT_DOUBLE_EQ(kv->kvec_d[0].x, 0);
+    EXPECT_DOUBLE_EQ(kv->kvec_d[0].y, 0);
+    EXPECT_DOUBLE_EQ(kv->kvec_d[0].z, 0);
+    GlobalV::ofs_running.close();
+    remove("tmp_klist_1");
 }
 
 TEST_F(KlistTest, PrintKlists)
 {
-	kv->nspin = 1;
-	kv->set_nkstot(1);
-	kv->set_nks(1);
-	GlobalV::ofs_running.open("tmp_klist_2");
-	kv->renew(kv->get_nkstot());
-	kv->kvec_c[0].x = 0;
-	kv->kvec_c[0].y = 0;
-	kv->kvec_c[0].z = 0;
-	kv->set_after_vc(GlobalV::NSPIN, GlobalC::ucell.G,GlobalC::ucell.latvec);
-	EXPECT_TRUE(kv->kd_done);
-	kv->print_klists(GlobalV::ofs_running);
-	GlobalV::ofs_running.close();
-	remove("tmp_klist_2");
+    kv->nspin = 1;
+    kv->set_nkstot(1);
+    kv->set_nks(1);
+    GlobalV::ofs_running.open("tmp_klist_2");
+    kv->renew(kv->get_nkstot());
+    kv->kvec_c[0].x = 0;
+    kv->kvec_c[0].y = 0;
+    kv->kvec_c[0].z = 0;
+    kv->set_after_vc(GlobalV::NSPIN, GlobalC::ucell.G, GlobalC::ucell.latvec);
+    EXPECT_TRUE(kv->kd_done);
+    kv->print_klists(GlobalV::ofs_running);
+    GlobalV::ofs_running.close();
+    remove("tmp_klist_2");
 }
 
 TEST_F(KlistTest, PrintKlistsWarnigQuit)
 {
-	kv->nspin = 1;
-	kv->set_nkstot(1);
-	kv->set_nks(2);
-	kv->renew(kv->get_nkstot());
-	kv->kvec_c[0].x = 0;
-	kv->kvec_c[0].y = 0;
-	kv->kvec_c[0].z = 0;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(kv->print_klists(GlobalV::ofs_running),
-			::testing::ExitedWithCode(0),"");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("nkstot < nks"));
+    kv->nspin = 1;
+    kv->set_nkstot(1);
+    kv->set_nks(2);
+    kv->renew(kv->get_nkstot());
+    kv->kvec_c[0].x = 0;
+    kv->kvec_c[0].y = 0;
+    kv->kvec_c[0].z = 0;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(kv->print_klists(GlobalV::ofs_running), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("nkstot < nks"));
 }
 
 TEST_F(KlistTest, SetBothKvecFinalSCF)
 {
-	kv->nspin = 1;
-	kv->set_nkstot(1);
-	kv->set_nks(1);
-	kv->renew(kv->get_nkstot());
-	kv->kvec_d[0].x = 0.0;
-	kv->kvec_d[0].y = 0.0;
-	kv->kvec_d[0].z = 0.0;
-	kv->kvec_c[0].x = 0.0;
-	kv->kvec_c[0].y = 0.0;
-	kv->kvec_c[0].z = 0.0;
-	std::string skpt;
-	GlobalV::FINAL_SCF = 1;
-	kv->kd_done = 0;
-	kv->kc_done = 0;
-	// case 1
-	kv->k_nkstot = 0;
-	kv->set_both_kvec(GlobalC::ucell.G,GlobalC::ucell.latvec,skpt);
-	EXPECT_TRUE(kv->kd_done);
-	EXPECT_TRUE(kv->kc_done);
-	// case 2
-	kv->k_nkstot = 1;
-	kv->k_kword = "D";
-	kv->set_both_kvec(GlobalC::ucell.G,GlobalC::ucell.latvec,skpt);
-	EXPECT_TRUE(kv->kd_done);
-	EXPECT_TRUE(kv->kc_done);
-	// case 3
-	kv->k_kword = "C";
-	kv->set_both_kvec(GlobalC::ucell.G,GlobalC::ucell.latvec,skpt);
-	EXPECT_TRUE(kv->kc_done);
-	EXPECT_TRUE(kv->kd_done);
-	// case 4
-	GlobalV::ofs_warning.open("klist_tmp_warning_8");
-	kv->k_kword = "arbitrary";
-	kv->set_both_kvec(GlobalC::ucell.G,GlobalC::ucell.latvec,skpt);
-	GlobalV::ofs_warning.close();
-	ifs.open("klist_tmp_warning_8");
-	std::string str((std::istreambuf_iterator<char>(ifs)),std::istreambuf_iterator<char>());
-	EXPECT_THAT(str, testing::HasSubstr("Error : neither Cartesian nor Direct kpoint."));
-	ifs.close();
-	remove("klist_tmp_warning_8");
+    kv->nspin = 1;
+    kv->set_nkstot(1);
+    kv->set_nks(1);
+    kv->renew(kv->get_nkstot());
+    kv->kvec_d[0].x = 0.0;
+    kv->kvec_d[0].y = 0.0;
+    kv->kvec_d[0].z = 0.0;
+    kv->kvec_c[0].x = 0.0;
+    kv->kvec_c[0].y = 0.0;
+    kv->kvec_c[0].z = 0.0;
+    std::string skpt;
+    GlobalV::FINAL_SCF = 1;
+    kv->kd_done = 0;
+    kv->kc_done = 0;
+    // case 1
+    kv->k_nkstot = 0;
+    kv->set_both_kvec(GlobalC::ucell.G, GlobalC::ucell.latvec, skpt);
+    EXPECT_TRUE(kv->kd_done);
+    EXPECT_TRUE(kv->kc_done);
+    // case 2
+    kv->k_nkstot = 1;
+    kv->k_kword = "D";
+    kv->set_both_kvec(GlobalC::ucell.G, GlobalC::ucell.latvec, skpt);
+    EXPECT_TRUE(kv->kd_done);
+    EXPECT_TRUE(kv->kc_done);
+    // case 3
+    kv->k_kword = "C";
+    kv->set_both_kvec(GlobalC::ucell.G, GlobalC::ucell.latvec, skpt);
+    EXPECT_TRUE(kv->kc_done);
+    EXPECT_TRUE(kv->kd_done);
+    // case 4
+    GlobalV::ofs_warning.open("klist_tmp_warning_8");
+    kv->k_kword = "arbitrary";
+    kv->set_both_kvec(GlobalC::ucell.G, GlobalC::ucell.latvec, skpt);
+    GlobalV::ofs_warning.close();
+    ifs.open("klist_tmp_warning_8");
+    std::string str((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    EXPECT_THAT(str, testing::HasSubstr("Error : neither Cartesian nor Direct kpoint."));
+    ifs.close();
+    remove("klist_tmp_warning_8");
 }
 
 TEST_F(KlistTest, SetBothKvec)
 {
-	kv->nspin = 1;
-	kv->set_nkstot(1);
-	kv->set_nks(1);
-	kv->renew(kv->get_nkstot());
-	kv->kvec_d[0].x = 0.0;
-	kv->kvec_d[0].y = 0.0;
-	kv->kvec_d[0].z = 0.0;
-	kv->kc_done = 0;
-	kv->kd_done = 1;
-	std::string skpt;
-	GlobalV::FINAL_SCF = 0;
-	kv->set_both_kvec(GlobalC::ucell.G,GlobalC::ucell.latvec,skpt);
-	EXPECT_TRUE(kv->kc_done);
-	kv->kc_done = 1;
-	kv->kd_done = 0;
-	kv->set_both_kvec(GlobalC::ucell.G,GlobalC::ucell.latvec,skpt);
-	EXPECT_TRUE(kv->kd_done);
+    kv->nspin = 1;
+    kv->set_nkstot(1);
+    kv->set_nks(1);
+    kv->renew(kv->get_nkstot());
+    kv->kvec_d[0].x = 0.0;
+    kv->kvec_d[0].y = 0.0;
+    kv->kvec_d[0].z = 0.0;
+    kv->kc_done = 0;
+    kv->kd_done = 1;
+    std::string skpt;
+    GlobalV::FINAL_SCF = 0;
+    kv->set_both_kvec(GlobalC::ucell.G, GlobalC::ucell.latvec, skpt);
+    EXPECT_TRUE(kv->kc_done);
+    kv->kc_done = 1;
+    kv->kd_done = 0;
+    kv->set_both_kvec(GlobalC::ucell.G, GlobalC::ucell.latvec, skpt);
+    EXPECT_TRUE(kv->kd_done);
 }
 
 TEST_F(KlistTest, NormalizeWk)
 {
-	kv->nspin = 1;
-	kv->set_nkstot(2);
-	kv->set_nks(2);
-	kv->renew(kv->get_nkstot());
-	kv->wk[0] = 1.0;
-	kv->wk[1] = 1.0;
-	int deg = 2;
-	kv->normalize_wk(deg);
-	EXPECT_DOUBLE_EQ(kv->wk[0],1.0);
-	EXPECT_DOUBLE_EQ(kv->wk[1],1.0);
+    kv->nspin = 1;
+    kv->set_nkstot(2);
+    kv->set_nks(2);
+    kv->renew(kv->get_nkstot());
+    kv->wk[0] = 1.0;
+    kv->wk[1] = 1.0;
+    int deg = 2;
+    kv->normalize_wk(deg);
+    EXPECT_DOUBLE_EQ(kv->wk[0], 1.0);
+    EXPECT_DOUBLE_EQ(kv->wk[1], 1.0);
 }
 
 TEST_F(KlistTest, UpdateUseIBZ)
 {
-	kv->nspin = 1;
-	kv->set_nkstot(3);
-	kv->set_nks(3);
+    kv->nspin = 1;
+    kv->set_nkstot(3);
+    kv->set_nks(3);
     kv->renew(kv->get_nkstot());
-    kv->update_use_ibz(2, std::vector<ModuleBase::Vector3<double>>(2, { 0,0,0 }), std::vector<double>(2, 0.0));
-	EXPECT_EQ(kv->get_nkstot(),2);
-	EXPECT_EQ(kv->kvec_d.size(),2);
-	EXPECT_TRUE(kv->kd_done);
-	EXPECT_FALSE(kv->kc_done);
+    kv->update_use_ibz(2, std::vector<ModuleBase::Vector3<double>>(2, {0, 0, 0}), std::vector<double>(2, 0.0));
+    EXPECT_EQ(kv->get_nkstot(), 2);
+    EXPECT_EQ(kv->kvec_d.size(), 2);
+    EXPECT_TRUE(kv->kd_done);
+    EXPECT_FALSE(kv->kc_done);
 }
 
 TEST_F(KlistTest, IbzKpoint)
 {
-	//construct cell and symmetry
-	ModuleSymmetry::Symmetry symm;
-	construct_ucell(stru_lib[0]);
-	GlobalV::ofs_running.open("tmp_klist_3");
+    // construct cell and symmetry
+    ModuleSymmetry::Symmetry symm;
+    construct_ucell(stru_lib[0]);
+    GlobalV::ofs_running.open("tmp_klist_3");
     symm.analy_sys(ucell.lat, ucell.st, ucell.atoms, GlobalV::ofs_running);
-	//read KPT
-	std::string k_file = "./support/KPT1";
-	kv->nspin = 1;
-	kv->read_kpoints(k_file);
-	EXPECT_EQ(kv->get_nkstot(),512);
-	//calculate ibz_kpoint
-	std::string skpt;
+    // read KPT
+    std::string k_file = "./support/KPT1";
+    kv->nspin = 1;
+    kv->read_kpoints(k_file);
+    EXPECT_EQ(kv->get_nkstot(), 512);
+    // calculate ibz_kpoint
+    std::string skpt;
     ModuleSymmetry::Symmetry::symm_flag = 1;
     bool match = true;
     kv->ibz_kpoint(symm, ModuleSymmetry::Symmetry::symm_flag, skpt, ucell, match);
     EXPECT_EQ(kv->get_nkstot(), 35);
-	GlobalV::ofs_running<<skpt<<std::endl;
-	GlobalV::ofs_running.close();
-	ClearUcell();
-	remove("tmp_klist_3");
+    GlobalV::ofs_running << skpt << std::endl;
+    GlobalV::ofs_running.close();
+    ClearUcell();
+    remove("tmp_klist_3");
 }
 
 TEST_F(KlistTest, IbzKpointIsMP)
 {
-	//construct cell and symmetry
-	ModuleSymmetry::Symmetry symm;
-	construct_ucell(stru_lib[0]);
-	GlobalV::ofs_running.open("tmp_klist_4");
+    // construct cell and symmetry
+    ModuleSymmetry::Symmetry symm;
+    construct_ucell(stru_lib[0]);
+    GlobalV::ofs_running.open("tmp_klist_4");
     symm.analy_sys(ucell.lat, ucell.st, ucell.atoms, GlobalV::ofs_running);
-	//read KPT
-	std::string k_file = "./support/KPT1";
-	kv->nspin = 1;
-	kv->read_kpoints(k_file);
-	EXPECT_EQ(kv->get_nkstot(),512);
-	EXPECT_TRUE(kv->is_mp);
-	//calculate ibz_kpoint
-	std::string skpt;
+    // read KPT
+    std::string k_file = "./support/KPT1";
+    kv->nspin = 1;
+    kv->read_kpoints(k_file);
+    EXPECT_EQ(kv->get_nkstot(), 512);
+    EXPECT_TRUE(kv->is_mp);
+    // calculate ibz_kpoint
+    std::string skpt;
     ModuleSymmetry::Symmetry::symm_flag = 0;
     bool match = true;
     kv->ibz_kpoint(symm, ModuleSymmetry::Symmetry::symm_flag, skpt, ucell, match);
     EXPECT_EQ(kv->get_nks(), 260);
-	GlobalV::ofs_running<<skpt<<std::endl;
-	GlobalV::ofs_running.close();
-	ClearUcell();
-	remove("tmp_klist_4");
+    GlobalV::ofs_running << skpt << std::endl;
+    GlobalV::ofs_running.close();
+    ClearUcell();
+    remove("tmp_klist_4");
 }
 
 #undef private

--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -639,8 +639,7 @@ void ESolver_KS<T, Device>::runner(const int istep, UnitCell& ucell)
 #ifdef __RAPIDJSON
     // add nkstot,nkstot_ibz to output json
     int Jnkstot = this->pelec->klist->get_nkstot();
-    int Jnkstot_ibz = this->pelec->klist->get_nkstot_ibz();
-    Json::add_nkstot(Jnkstot, Jnkstot_ibz);
+    Json::add_nkstot(Jnkstot);
 #endif //__RAPIDJSON
     return;
 };

--- a/source/module_io/json_output/init_info.cpp
+++ b/source/module_io/json_output/init_info.cpp
@@ -1,132 +1,129 @@
 #include "init_info.h"
-#include "module_io/input.h"
+
 #include "../para_json.h"
 #include "abacusjson.h"
+#include "module_io/input.h"
 
-
-//Add json objects to init
+// Add json objects to init
 namespace Json
 {
 
 #ifdef __RAPIDJSON
 
-
-
-void gen_init(UnitCell *ucell){
+void gen_init(UnitCell* ucell)
+{
     std::string pgname = ucell->symm.pgname;
     std::string spgname = ucell->symm.spgname;
-    AbacusJson::add_json({"init", "point_group"}, pgname,false);
-    AbacusJson::add_json({"init", "point_group_in_space"}, spgname,false);
+    AbacusJson::add_json({"init", "point_group"}, pgname, false);
+    AbacusJson::add_json({"init", "point_group_in_space"}, spgname, false);
 
     // Json::AbacusJson::add_Json(pgname,false,"init", "point_group");
     // Json::AbacusJson::add_Json(spgname,false,"init","point_group_in_space");
 
-    int  numAtoms = ucell->nat;
-    AbacusJson::add_json({"init", "natom"}, numAtoms,false);
-    AbacusJson::add_json({"init", "nband"}, GlobalV::NBANDS,false);
+    int numAtoms = ucell->nat;
+    AbacusJson::add_json({"init", "natom"}, numAtoms, false);
+    AbacusJson::add_json({"init", "nband"}, GlobalV::NBANDS, false);
 
     // Json::AbacusJson::add_Json(numAtoms,false,"init", "natom");
     // Json::AbacusJson::add_Json(GlobalV::NBANDS,false,"init", "nband");
 
-    int ntype = ucell->ntype,nelec_total=0;
+    int ntype = ucell->ntype, nelec_total = 0;
     for (int it = 0; it < ntype; it++)
     {
         std::string label = ucell->atoms[it].label;
         int atom_number = ucell->atoms[it].na;
         int number = ucell->atoms[it].ncpp.zv;
 
-        nelec_total+=ucell->atoms[it].ncpp.zv * ucell->atoms[it].na;
-        AbacusJson::add_json({"init", "natom_each_type",label}, atom_number,false);
-        AbacusJson::add_json({"init", "nelectron_each_type",label}, number,false);
+        nelec_total += ucell->atoms[it].ncpp.zv * ucell->atoms[it].na;
+        AbacusJson::add_json({"init", "natom_each_type", label}, atom_number, false);
+        AbacusJson::add_json({"init", "nelectron_each_type", label}, number, false);
 
+        // Json::AbacusJson::add_Json(number,false,"init", "nelectron_each_type",label);
+    }
 
-        //Json::AbacusJson::add_Json(number,false,"init", "nelectron_each_type",label);
-    }    
-    
-    AbacusJson::add_json({"init", "nelectron"}, nelec_total,false);
+    AbacusJson::add_json({"init", "nelectron"}, nelec_total, false);
 
     // Json::AbacusJson::add_Json(nelec_total,false,"init", "nelectron");
 }
 
-
-void add_nkstot(int nkstot) {
-    Json::AbacusJson::add_json({ "init", "nkstot" }, nkstot, false);
+void add_nkstot(int nkstot)
+{
+    Json::AbacusJson::add_json({"init", "nkstot"}, nkstot, false);
 
     // Json::AbacusJson::add_Json(nkstot,false,"init", "nkstot");
     // Json::AbacusJson::add_Json(nkstot_ibz,false,"init", "nkstot_ibz");
 }
 
-
-void gen_stru(UnitCell *ucell){
-    AbacusJson::add_json({"comment"},"Unless otherwise specified, the unit of energy is eV and the unit of length is Angstrom",false);
+void gen_stru(UnitCell* ucell)
+{
+    AbacusJson::add_json({"comment"},
+                         "Unless otherwise specified, the unit of energy is eV and the unit of length is Angstrom",
+                         false);
 
     int ntype = ucell->ntype;
 
-
-    
-    //array of pseudopotential file
+    // array of pseudopotential file
     std::string* pseudo_fn = ucell->pseudo_fn;
 
-    //array of orbital file
+    // array of orbital file
     std::string* orbital_fn = ucell->orbital_fn;
 
-
-    //add atom element,orbital file and pseudopotential file
-    for(int i=0;i<ntype;i++){
+    // add atom element,orbital file and pseudopotential file
+    for (int i = 0; i < ntype; i++)
+    {
         std::string atom_label = ucell->atoms[i].label;
 
         std::string atom_element = ucell->atoms[i].ncpp.psd;
 
-        Json::AbacusJson::add_json({"init","element",atom_label}, atom_element,false);
-
+        Json::AbacusJson::add_json({"init", "element", atom_label}, atom_element, false);
 
         std::string orbital_str = GlobalV::global_orbital_dir + orbital_fn[i];
-        if(!orbital_str.compare("")){
+        if (!orbital_str.compare(""))
+        {
             Json::jsonValue nullValue;
             nullValue.SetNull();
-            Json::AbacusJson::add_json({"init","orb",atom_label}, nullValue,false);
-        
-            // Json::AbacusJson::add_Json(nullValue,false,"init","orb",atom_label);
+            Json::AbacusJson::add_json({"init", "orb", atom_label}, nullValue, false);
 
-        }else {
-            Json::AbacusJson::add_json({"init","orb",atom_label}, orbital_str,false);
+            // Json::AbacusJson::add_Json(nullValue,false,"init","orb",atom_label);
+        }
+        else
+        {
+            Json::AbacusJson::add_json({"init", "orb", atom_label}, orbital_str, false);
             // Json::AbacusJson::add_Json(orbital_str,false,"init","orb",atom_label);
-        }    
+        }
         std::string pseudo_str = pseudo_fn[i];
-        Json::AbacusJson::add_json({"init","pp",atom_label}, pseudo_str,false);
+        Json::AbacusJson::add_json({"init", "pp", atom_label}, pseudo_str, false);
 
         // Json::AbacusJson::add_Json(pseudo_str,false,"init","pp",atom_label);
- 
     }
-    
 
-    //atom coordinate, mag and label
+    // atom coordinate, mag and label
     double lat0 = ucell->lat0;
     std::string* label = ucell->atom_label;
-    for(int i=0;i<ntype;i++){
+    for (int i = 0; i < ntype; i++)
+    {
         ModuleBase::Vector3<double>* tau = ucell->atoms[i].tau;
         int na = ucell->atoms[i].na;
-        for(int j=0;j<na;j++){
+        for (int j = 0; j < na; j++)
+        {
             Json::jsonValue coordinateArray(JarrayType);
-            coordinateArray.JPushBack(tau[j][0]*lat0);
-            coordinateArray.JPushBack(tau[j][1]*lat0);
-            coordinateArray.JPushBack(tau[j][2]*lat0);
-            Json::AbacusJson::add_json({"init","coordinate"}, coordinateArray,true);
+            coordinateArray.JPushBack(tau[j][0] * lat0);
+            coordinateArray.JPushBack(tau[j][1] * lat0);
+            coordinateArray.JPushBack(tau[j][2] * lat0);
+            Json::AbacusJson::add_json({"init", "coordinate"}, coordinateArray, true);
             // Json::AbacusJson::add_Json(coordinateArray,true,"init","coordinate");
- 
-            Json::AbacusJson::add_json({"init","mag"}, ucell->atoms[i].mag[j],true);
+
+            Json::AbacusJson::add_json({"init", "mag"}, ucell->atoms[i].mag[j], true);
 
             // Json::AbacusJson::add_Json(ucell->atoms[i].mag[j],true,"init","mag");
- 
-            std::string str = label[i];
-            Json::AbacusJson::add_json({"init","label"}, str,true);  
-            // Json::AbacusJson::add_Json(str,true,"init","label");      
-        }
 
+            std::string str = label[i];
+            Json::AbacusJson::add_json({"init", "label"}, str, true);
+            // Json::AbacusJson::add_Json(str,true,"init","label");
+        }
     }
 
-
-    //cell 
+    // cell
     {
         Json::jsonValue cellArray1(JarrayType);
         Json::jsonValue cellArray2(JarrayType);
@@ -140,17 +137,16 @@ void gen_stru(UnitCell *ucell){
         cellArray3.JPushBack(ucell->latvec.e31);
         cellArray3.JPushBack(ucell->latvec.e32);
         cellArray3.JPushBack(ucell->latvec.e33);
-        Json::AbacusJson::add_json({"init","cell"}, cellArray1,true);
-        Json::AbacusJson::add_json({"init","cell"}, cellArray2,true);
-        Json::AbacusJson::add_json({"init","cell"}, cellArray3,true);
+        Json::AbacusJson::add_json({"init", "cell"}, cellArray1, true);
+        Json::AbacusJson::add_json({"init", "cell"}, cellArray2, true);
+        Json::AbacusJson::add_json({"init", "cell"}, cellArray3, true);
 
-        // Json::AbacusJson::add_Json(cellArray1,true,"init","cell"); 
-        // Json::AbacusJson::add_Json(cellArray2,true,"init","cell");  
-        // Json::AbacusJson::add_Json(cellArray3,true,"init","cell");   
+        // Json::AbacusJson::add_Json(cellArray1,true,"init","cell");
+        // Json::AbacusJson::add_Json(cellArray2,true,"init","cell");
+        // Json::AbacusJson::add_Json(cellArray3,true,"init","cell");
     }
     return;
 }
-
 
 #endif
 } // namespace Json

--- a/source/module_io/json_output/init_info.cpp
+++ b/source/module_io/json_output/init_info.cpp
@@ -49,9 +49,8 @@ void gen_init(UnitCell *ucell){
 }
 
 
-void add_nkstot(int nkstot,int nkstot_ibz){
-    Json::AbacusJson::add_json({"init", "nkstot"}, nkstot,false);
-    Json::AbacusJson::add_json({"init", "nkstot_ibz"}, nkstot_ibz,false);
+void add_nkstot(int nkstot) {
+    Json::AbacusJson::add_json({ "init", "nkstot" }, nkstot, false);
 
     // Json::AbacusJson::add_Json(nkstot,false,"init", "nkstot");
     // Json::AbacusJson::add_Json(nkstot_ibz,false,"init", "nkstot_ibz");

--- a/source/module_io/json_output/init_info.h
+++ b/source/module_io/json_output/init_info.h
@@ -1,32 +1,31 @@
 #ifndef INIT_INFO_H
 #define INIT_INFO_H
-#include "module_cell/module_symmetry/symmetry.h"
 #include "module_cell/atom_spec.h"
+#include "module_cell/module_symmetry/symmetry.h"
 #include "module_cell/unitcell.h"
 
-
 /**
-* @brief In this part of the code to complete the init part of the json tree.
-*/
+ * @brief In this part of the code to complete the init part of the json tree.
+ */
 namespace Json
 {
 #ifdef __RAPIDJSON
 // void gen_init(ModuleSymmetry::Symmetry *symm,Atom *atoms);
 
 /**
-* @param ucell: ucell for reading json parameters.
-*/
-void gen_init(UnitCell *ucell);
+ * @param ucell: ucell for reading json parameters.
+ */
+void gen_init(UnitCell* ucell);
 
 /**
-* @param nkstot,nkstot_ibz: two param in json tree
-*/
+ * @param nkstot,nkstot_ibz: two param in json tree
+ */
 void add_nkstot(int nkstot);
 
 /**
-* @param ucell: ucell for reading structure init in abacus.
-*/
-void gen_stru(UnitCell *ucell);
+ * @param ucell: ucell for reading structure init in abacus.
+ */
+void gen_stru(UnitCell* ucell);
 #endif
-}
+} // namespace Json
 #endif

--- a/source/module_io/json_output/init_info.h
+++ b/source/module_io/json_output/init_info.h
@@ -21,7 +21,7 @@ void gen_init(UnitCell *ucell);
 /**
 * @param nkstot,nkstot_ibz: two param in json tree
 */
-void add_nkstot(int nkstot,int nkstot_ibz);
+void add_nkstot(int nkstot);
 
 /**
 * @param ucell: ucell for reading structure init in abacus.

--- a/source/module_io/json_output/test/para_json_test.cpp
+++ b/source/module_io/json_output/test/para_json_test.cpp
@@ -309,15 +309,14 @@ TEST(AbacusJsonTest, InitInfo)
     }
     // init the doc allocator
     Json::AbacusJson::doc.Parse("{}");
-    int Jnkstot=1,Jnkstot_ibz = 2;
+    int Jnkstot = 1;
 
-    Json::add_nkstot(Jnkstot,Jnkstot_ibz);
+    Json::add_nkstot(Jnkstot);
     Json::gen_init(&ucell);
 
 
     ASSERT_TRUE(Json::AbacusJson::doc.HasMember("init"));
     ASSERT_EQ(Json::AbacusJson::doc["init"]["nkstot"].GetInt(), 1);
-    ASSERT_EQ(Json::AbacusJson::doc["init"]["nkstot_ibz"].GetInt(), 2);
 
     ASSERT_EQ(Json::AbacusJson::doc["init"]["natom"].GetInt(), 6);
     ASSERT_EQ(Json::AbacusJson::doc["init"]["nband"].GetInt(), 10);

--- a/source/module_io/json_output/test/para_json_test.cpp
+++ b/source/module_io/json_output/test/para_json_test.cpp
@@ -2,11 +2,11 @@
 #define private public
 #define __RAPIDJSON 1
 #include "../abacusjson.h"
+#include "../general_info.h"
+#include "../init_info.h"
+#include "../readin_info.h"
 #include "module_io/input.h"
 #include "module_io/para_json.h"
-#include "../init_info.h"
-#include "../general_info.h"
-#include "../readin_info.h"
 #include "version.h"
 
 /************************************************
@@ -24,19 +24,18 @@
  * - Test the correctness of the json output of the Init info module.
  */
 
-
 TEST(AbacusJsonTest, AddJson)
 {
     Json::AbacusJson::doc.SetObject();
 
     // add a string
-    Json::AbacusJson::add_json({"key1"}, "value1",false);
+    Json::AbacusJson::add_json({"key1"}, "value1", false);
     ASSERT_TRUE(Json::AbacusJson::doc.HasMember("key1"));
     ASSERT_TRUE(Json::AbacusJson::doc["key1"].IsString());
     ASSERT_STREQ(Json::AbacusJson::doc["key1"].GetString(), "value1");
 
     // add a string to a nested object
-    Json::AbacusJson::add_json({"key2", "key3"}, "value2",false);
+    Json::AbacusJson::add_json({"key2", "key3"}, "value2", false);
     ASSERT_TRUE(Json::AbacusJson::doc.HasMember("key2"));
     ASSERT_TRUE(Json::AbacusJson::doc["key2"].IsObject());
     ASSERT_TRUE(Json::AbacusJson::doc["key2"].HasMember("key3"));
@@ -44,51 +43,48 @@ TEST(AbacusJsonTest, AddJson)
     ASSERT_STREQ(Json::AbacusJson::doc["key2"]["key3"].GetString(), "value2");
 
     // add an int
-    Json::AbacusJson::add_json({"key2"}, 123,false);
+    Json::AbacusJson::add_json({"key2"}, 123, false);
     ASSERT_TRUE(Json::AbacusJson::doc.HasMember("key2"));
     ASSERT_TRUE(Json::AbacusJson::doc["key2"].IsInt());
     ASSERT_EQ(Json::AbacusJson::doc["key2"].GetInt(), 123);
 
     // add a bool
-    Json::AbacusJson::add_json({"key3"}, true,false);
+    Json::AbacusJson::add_json({"key3"}, true, false);
     ASSERT_TRUE(Json::AbacusJson::doc.HasMember("key3"));
     ASSERT_TRUE(Json::AbacusJson::doc["key3"].IsBool());
     ASSERT_EQ(Json::AbacusJson::doc["key3"].GetBool(), true);
 
     // add a double
-    Json::AbacusJson::add_json({"key4"}, 1.23,false);
+    Json::AbacusJson::add_json({"key4"}, 1.23, false);
     ASSERT_TRUE(Json::AbacusJson::doc.HasMember("key4"));
     ASSERT_TRUE(Json::AbacusJson::doc["key4"].IsDouble());
     ASSERT_EQ(Json::AbacusJson::doc["key4"].GetDouble(), 1.23);
 
     // modify a value
-    Json::AbacusJson::add_json({"key4"}, 4.56,false);
+    Json::AbacusJson::add_json({"key4"}, 4.56, false);
     ASSERT_EQ(Json::AbacusJson::doc["key4"].GetDouble(), 4.56);
-    
 
-    //array test
-    Json::AbacusJson::add_json({"key6","key7"}, true,true);
-    Json::AbacusJson::add_json({"key6","key7"}, false,true);
+    // array test
+    Json::AbacusJson::add_json({"key6", "key7"}, true, true);
+    Json::AbacusJson::add_json({"key6", "key7"}, false, true);
 
-    
     // add key-val to a object array
-    for(int i=0;i<3;i++){
+    for (int i = 0; i < 3; i++)
+    {
         Json::jsonValue object(JobjectType);
-        object.JaddNormal("int",i);
+        object.JaddNormal("int", i);
 
-        std::string str = std::to_string(i*100);  
+        std::string str = std::to_string(i * 100);
         std::string str2 = "Kstring";
 
         object.JaddStringV("string", str);
         object.JaddStringK(str, "string");
         object.JaddStringKV(str2, str);
-        object.JaddNormal("double", 0.01*i);    
-        Json::AbacusJson::add_json({"array"}, object,true);
+        object.JaddNormal("double", 0.01 * i);
+        Json::AbacusJson::add_json({"array"}, object, true);
     }
-    Json::AbacusJson::add_json({"array",1,"new_add_notLast"}, "correct1",false);
-    Json::AbacusJson::add_json({"array",-1,"new_add_Last"}, "correct2",false);
-
-
+    Json::AbacusJson::add_json({"array", 1, "new_add_notLast"}, "correct1", false);
+    Json::AbacusJson::add_json({"array", -1, "new_add_Last"}, "correct2", false);
 
     // Validate json parameters in doc objects
 
@@ -97,8 +93,6 @@ TEST(AbacusJsonTest, AddJson)
     ASSERT_STREQ(Json::AbacusJson::doc["array"][0]["0"].GetString(), "string");
     ASSERT_STREQ(Json::AbacusJson::doc["array"][0]["Kstring"].GetString(), "0");
     ASSERT_STREQ(Json::AbacusJson::doc["array"][1]["new_add_notLast"].GetString(), "correct1");
-
-
 
     ASSERT_EQ(Json::AbacusJson::doc["array"][0]["double"].GetDouble(), 0.0);
 
@@ -116,11 +110,8 @@ TEST(AbacusJsonTest, AddJson)
     ASSERT_STREQ(Json::AbacusJson::doc["array"][2]["200"].GetString(), "string");
     ASSERT_STREQ(Json::AbacusJson::doc["array"][2]["Kstring"].GetString(), "200");
     ASSERT_EQ(Json::AbacusJson::doc["array"][2]["double"].GetDouble(), 0.02);
-    
-    
+
     ASSERT_STREQ(Json::AbacusJson::doc["array"][2]["new_add_Last"].GetString(), "correct2");
-
-
 
     // add array in array
     Json::jsonValue object0(JarrayType);
@@ -128,9 +119,8 @@ TEST(AbacusJsonTest, AddJson)
     object0.JPushBack(1);
     object0.JPushBack(2);
     object0.JPushBack(3);
-    
-    Json::jsonValue object1(JarrayType);
 
+    Json::jsonValue object1(JarrayType);
 
     object1.JPushBack(2.1);
     object1.JPushBack(3.1);
@@ -151,22 +141,19 @@ TEST(AbacusJsonTest, AddJson)
     object3.JPushBackString(astr2);
     object3.JPushBackString(astr3);
 
+    Json::AbacusJson::add_json({"Darray"}, object0, true);
+    Json::AbacusJson::add_json({"Darray"}, object1, true);
+    Json::AbacusJson::add_json({"Darray"}, object2, true);
+    Json::AbacusJson::add_json({"Darray"}, object3, true);
 
-    Json::AbacusJson::add_json({"Darray"}, object0,true);
-    Json::AbacusJson::add_json({"Darray"}, object1,true);
-    Json::AbacusJson::add_json({"Darray"}, object2,true);
-    Json::AbacusJson::add_json({"Darray"}, object3,true);
-
-    Json::AbacusJson::add_json({"Darray",1,0}, "new_add_method",false);
-    Json::AbacusJson::add_json({"Darray",1,-2}, 40,false);
+    Json::AbacusJson::add_json({"Darray", 1, 0}, "new_add_method", false);
+    Json::AbacusJson::add_json({"Darray", 1, -2}, 40, false);
 
     ASSERT_EQ(Json::AbacusJson::doc["Darray"][1][0].GetString(), "new_add_method");
 
     ASSERT_EQ(Json::AbacusJson::doc["Darray"][0][0].GetInt(), 1);
     ASSERT_EQ(Json::AbacusJson::doc["Darray"][0][1].GetInt(), 2);
     ASSERT_EQ(Json::AbacusJson::doc["Darray"][0][2].GetInt(), 3);
-
-
 
     ASSERT_EQ(Json::AbacusJson::doc["Darray"][1][1].GetDouble(), 40);
     ASSERT_EQ(Json::AbacusJson::doc["Darray"][1][2].GetDouble(), 4.1);
@@ -175,40 +162,31 @@ TEST(AbacusJsonTest, AddJson)
     ASSERT_STREQ(Json::AbacusJson::doc["Darray"][2][1].GetString(), "str2");
     ASSERT_STREQ(Json::AbacusJson::doc["Darray"][2][2].GetString(), "str3");
 
-
     ASSERT_STREQ(Json::AbacusJson::doc["Darray"][3][0].GetString(), "string1");
     ASSERT_STREQ(Json::AbacusJson::doc["Darray"][3][1].GetString(), "string2");
     ASSERT_STREQ(Json::AbacusJson::doc["Darray"][3][2].GetString(), "string3");
-
-
-
 }
 
 TEST(AbacusJsonTest, OutputJson)
 {
     Json::AbacusJson::doc.SetObject();
 
-
-    Json::AbacusJson::add_json({"key1"}, "value1",false);
-    Json::AbacusJson::add_json({"key2", "key3"}, 1,false);
-    Json::AbacusJson::add_json({"key4"}, 0.1,false);
-    Json::AbacusJson::add_json({"key5"}, true,false);
-
-
+    Json::AbacusJson::add_json({"key1"}, "value1", false);
+    Json::AbacusJson::add_json({"key2", "key3"}, 1, false);
+    Json::AbacusJson::add_json({"key4"}, 0.1, false);
+    Json::AbacusJson::add_json({"key5"}, true, false);
 
     Json::jsonValue object(JobjectType);
-    object.JaddNormal("int",1);
+    object.JaddNormal("int", 1);
     Json::jsonValue object2(JarrayType);
 
-    object.JaddNormal("arr",object2);
+    object.JaddNormal("arr", object2);
 
-
-    //array test
-    Json::AbacusJson::add_json({"key6","key7"}, object,true);
-    Json::AbacusJson::add_json({"key6","key7",0,"arr"}, 13,true);
-    Json::AbacusJson::add_json({"key6","key7",0,"arr"}, 14,true);
-    Json::AbacusJson::add_json({"key6","key7",0,"arr",0}, 1,true);
-
+    // array test
+    Json::AbacusJson::add_json({"key6", "key7"}, object, true);
+    Json::AbacusJson::add_json({"key6", "key7", 0, "arr"}, 13, true);
+    Json::AbacusJson::add_json({"key6", "key7", 0, "arr"}, 14, true);
+    Json::AbacusJson::add_json({"key6", "key7", 0, "arr", 0}, 1, true);
 
     std::string filename = "test.json";
     Json::AbacusJson::write_to_json(filename);
@@ -224,16 +202,15 @@ TEST(AbacusJsonTest, OutputJson)
     ASSERT_NE(content.find("\"key5\": true"), std::string::npos);
 
     file.close();
-
 }
 
 TEST(AbacusJsonTest, GeneralInfo)
 {
-    std::time_t time_now = std::time(NULL);
+    std::time_t time_now = std::time(nullptr);
     std::string start_time_str;
     Json::convert_time(time_now, start_time_str);
     INPUT.start_time = time_now;
-    
+
     INPUT.device = "cpu";
     INPUT.pseudo_dir = "./abacus/test/pseudo_dir";
     INPUT.orbital_dir = "./abacus/test/orbital_dir";
@@ -261,39 +238,42 @@ TEST(AbacusJsonTest, GeneralInfo)
     ASSERT_NE(content.find(start_time_str), std::string::npos);
 }
 
-
-
 #ifdef __LCAO
 #include "module_basis/module_ao/ORB_read.h"
-InfoNonlocal::InfoNonlocal(){}
-InfoNonlocal::~InfoNonlocal(){}
-LCAO_Orbitals::LCAO_Orbitals(){}
-LCAO_Orbitals::~LCAO_Orbitals(){}
+InfoNonlocal::InfoNonlocal()
+{
+}
+InfoNonlocal::~InfoNonlocal()
+{
+}
+LCAO_Orbitals::LCAO_Orbitals()
+{
+}
+LCAO_Orbitals::~LCAO_Orbitals()
+{
+}
 #endif
 Magnetism::Magnetism()
 {
-	this->tot_magnetization = 0.0;
-	this->abs_magnetization = 0.0;
-	this->start_magnetization = nullptr;
+    this->tot_magnetization = 0.0;
+    this->abs_magnetization = 0.0;
+    this->start_magnetization = nullptr;
 }
 Magnetism::~Magnetism()
 {
-	delete[] this->start_magnetization;
+    delete[] this->start_magnetization;
 }
 TEST(AbacusJsonTest, InitInfo)
 {
     UnitCell ucell;
     Atom atomlist[3];
 
-
     ucell.symm.pgname = "T_d";
     ucell.symm.spgname = "O_h";
-    ucell.atoms =atomlist;
+    ucell.atoms = atomlist;
     ucell.ntype = 3;
     GlobalV::NBANDS = 10;
 
-
-    
     ucell.atoms[0].label = "Si";
     ucell.atoms[0].ncpp.zv = 3;
     ucell.atoms[0].na = 1;
@@ -304,7 +284,8 @@ TEST(AbacusJsonTest, InitInfo)
     ucell.atoms[2].ncpp.zv = 5;
     ucell.atoms[2].na = 3;
     ucell.nat = 0;
-    for(int i=0;i<ucell.ntype;i++){
+    for (int i = 0; i < ucell.ntype; i++)
+    {
         ucell.nat += ucell.atoms[i].na;
     }
     // init the doc allocator
@@ -314,13 +295,11 @@ TEST(AbacusJsonTest, InitInfo)
     Json::add_nkstot(Jnkstot);
     Json::gen_init(&ucell);
 
-
     ASSERT_TRUE(Json::AbacusJson::doc.HasMember("init"));
     ASSERT_EQ(Json::AbacusJson::doc["init"]["nkstot"].GetInt(), 1);
 
     ASSERT_EQ(Json::AbacusJson::doc["init"]["natom"].GetInt(), 6);
     ASSERT_EQ(Json::AbacusJson::doc["init"]["nband"].GetInt(), 10);
-
 
     ASSERT_STREQ(Json::AbacusJson::doc["init"]["point_group"].GetString(), "T_d");
     ASSERT_STREQ(Json::AbacusJson::doc["init"]["point_group_in_space"].GetString(), "O_h");
@@ -334,29 +313,27 @@ TEST(AbacusJsonTest, InitInfo)
     ASSERT_EQ(Json::AbacusJson::doc["init"]["natom_each_type"]["O"].GetInt(), 3);
 }
 
-
-
-TEST(AbacusJsonTest, Init_stru_test){
-    //init ucell
+TEST(AbacusJsonTest, Init_stru_test)
+{
+    // init ucell
     UnitCell ucell;
 
     Atom atomlist[1];
     std::string label[1];
 
     ModuleBase::Matrix3 latvec;
-    latvec.e11=0.1;
-    latvec.e12=0.1;
-    latvec.e13=0.1;
+    latvec.e11 = 0.1;
+    latvec.e12 = 0.1;
+    latvec.e13 = 0.1;
 
-    latvec.e21=0.2;
-    latvec.e22=0.2;
-    latvec.e23=0.2;
+    latvec.e21 = 0.2;
+    latvec.e22 = 0.2;
+    latvec.e23 = 0.2;
 
-    latvec.e31=0.3;
-    latvec.e32=0.3;
-    latvec.e33=0.3;
+    latvec.e31 = 0.3;
+    latvec.e32 = 0.3;
+    latvec.e33 = 0.3;
     ucell.latvec = latvec;
-
 
     double lat0 = 10.0;
     ucell.ntype = 1;
@@ -367,28 +344,30 @@ TEST(AbacusJsonTest, Init_stru_test){
     ucell.lat0 = lat0;
 
     ModuleBase::Vector3<double> tau[2];
-    
+
     Json::AbacusJson::doc.Parse("{}");
 
     double mag[2];
-    //fill ucell
-    for(int i=0;i<1;i++){
-        ucell.atom_label[i]="Si";
+    // fill ucell
+    for (int i = 0; i < 1; i++)
+    {
+        ucell.atom_label[i] = "Si";
         atomlist[i].na = 2;
         atomlist[i].label = "Fe";
         ucell.pseudo_fn[i] = "si.ufp";
         ucell.atoms[i].tau = new ModuleBase::Vector3<double>[2];
         atomlist[i].mag = new double[2];
-        for(int j=0;j<atomlist[i].na;j++){
-            atomlist[i].mag[j] = j*131;
-            ucell.atoms[i].tau[j] = 0.1*j;
+        for (int j = 0; j < atomlist[i].na; j++)
+        {
+            atomlist[i].mag[j] = j * 131;
+            ucell.atoms[i].tau[j] = 0.1 * j;
         }
     }
     Json::gen_stru(&ucell);
 
     std::string filename = "readin.json";
     Json::AbacusJson::write_to_json(filename);
-    //compare result
+    // compare result
     ASSERT_TRUE(Json::AbacusJson::doc.HasMember("init"));
     ASSERT_EQ(Json::AbacusJson::doc["init"]["mag"][0].GetDouble(), 0);
     ASSERT_EQ(Json::AbacusJson::doc["init"]["mag"][1].GetDouble(), 131.0);
@@ -416,10 +395,4 @@ TEST(AbacusJsonTest, Init_stru_test){
     ASSERT_EQ(Json::AbacusJson::doc["init"]["cell"][2][0].GetDouble(), 0.3);
     ASSERT_EQ(Json::AbacusJson::doc["init"]["cell"][2][1].GetDouble(), 0.3);
     ASSERT_EQ(Json::AbacusJson::doc["init"]["cell"][2][2].GetDouble(), 0.3);
-
-
 }
-
-
-
-


### PR DESCRIPTION
`nkstot_ibz` and `kvec_d_ibz` are only used in `K_Vectors::ibz_kpoint` and have the same value as `nkstot` and `kvec_d` after symmetry reduction. They do not need to be members of class `K_Vectors`.

@1041176461 FYI