### PR TITLE
refactor: add new option auto for init_chg

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -554,6 +554,7 @@ These variables are used to control general system parameters.
 
   - atomic: the density is starting from the summation of the atomic density of single atoms.
   - file: the density will be read in from a binary file `charge-density.dat` first. If it does not exist, the charge density will be read in from cube files. Besides, when you do `nspin=1` calculation, you only need the density file SPIN1_CHG.cube. However, if you do `nspin=2` calculation, you also need the density file SPIN2_CHG.cube. The density file should be output with these names if you set out_chg = 1 in INPUT file.
+  - auto: abacus will try to read density from file first, if not found, it will use atomic density.
 - **Default**: atomic
 
 ### init_vel

--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -554,7 +554,7 @@ These variables are used to control general system parameters.
 
   - atomic: the density is starting from the summation of the atomic density of single atoms.
   - file: the density will be read in from a binary file `charge-density.dat` first. If it does not exist, the charge density will be read in from cube files. Besides, when you do `nspin=1` calculation, you only need the density file SPIN1_CHG.cube. However, if you do `nspin=2` calculation, you also need the density file SPIN2_CHG.cube. The density file should be output with these names if you set out_chg = 1 in INPUT file.
-  - auto: abacus will try to read density from file first, if not found, it will use atomic density.
+  - auto: Abacus first attempts to read the density from a file; if not found, it defaults to using atomic density.
 - **Default**: atomic
 
 ### init_vel

--- a/docs/advanced/scf/initialization.md
+++ b/docs/advanced/scf/initialization.md
@@ -9,6 +9,7 @@ In LCAO basis, wavefunction can be read to calculate initial charge density. The
 `init_chg` is used for choosing the method of charge density initialization.
  - `atomic` : initial charge density by atomic charge density from pseudopotential file under keyword `PP_RHOATOM` 
  - `file` : initial charge density from files produced by previous calculations with [`out_chg 1`](../elec_properties/charge.md).
+ - `auto`: first try to read charge density from file, if not found, use atomic charge density.
 
 ## Wave function
 `init_wfc` is used for choosing the method of wavefunction coefficient initialization.

--- a/docs/advanced/scf/initialization.md
+++ b/docs/advanced/scf/initialization.md
@@ -9,7 +9,7 @@ In LCAO basis, wavefunction can be read to calculate initial charge density. The
 `init_chg` is used for choosing the method of charge density initialization.
  - `atomic` : initial charge density by atomic charge density from pseudopotential file under keyword `PP_RHOATOM` 
  - `file` : initial charge density from files produced by previous calculations with [`out_chg 1`](../elec_properties/charge.md).
- - `auto`: first try to read charge density from file, if not found, use atomic charge density.
+ - `auto`: Abacus first attempts to read the density from a file; if not found, it defaults to using atomic density.
 
 ## Wave function
 `init_wfc` is used for choosing the method of wavefunction coefficient initialization.

--- a/source/module_elecstate/module_charge/charge_init.cpp
+++ b/source/module_elecstate/module_charge/charge_init.cpp
@@ -22,34 +22,31 @@
 void Charge::init_rho(elecstate::efermi& eferm_iout,
                       const ModuleBase::ComplexMatrix& strucFac,
                       const int& nbz,
-                      const int& bz)
-{
-    ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "init_chg", GlobalV::init_chg);
+                      const int& bz) {
+    ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,
+                                "init_chg",
+                                GlobalV::init_chg);
 
     std::cout << " START CHARGE      : " << GlobalV::init_chg << std::endl;
     bool read_error = false;
-    if (GlobalV::init_chg == "file" || GlobalV::init_chg == "auto")
-    {
+    if (GlobalV::init_chg == "file" || GlobalV::init_chg == "auto") {
         GlobalV::ofs_running << " try to read charge from file : " << std::endl;
 
         // try to read charge from binary file first, which is the same as QE
         // liuyu 2023-12-05
         std::stringstream binary;
         binary << GlobalV::global_readin_dir << "charge-density.dat";
-        if (ModuleIO::read_rhog(binary.str(), rhopw, rhog))
-        {
-            GlobalV::ofs_running << " Read in the charge density: " << binary.str() << std::endl;
-            for (int is = 0; is < GlobalV::NSPIN; ++is)
-            {
+        if (ModuleIO::read_rhog(binary.str(), rhopw, rhog)) {
+            GlobalV::ofs_running
+                << " Read in the charge density: " << binary.str() << std::endl;
+            for (int is = 0; is < GlobalV::NSPIN; ++is) {
                 rhopw->recip2real(rhog[is], rho[is]);
             }
-        }
-        else
-        {
-            for (int is = 0; is < GlobalV::NSPIN; ++is)
-            {
+        } else {
+            for (int is = 0; is < GlobalV::NSPIN; ++is) {
                 std::stringstream ssc;
-                ssc << GlobalV::global_readin_dir << "SPIN" << is + 1 << "_CHG.cube";
+                ssc << GlobalV::global_readin_dir << "SPIN" << is + 1
+                    << "_CHG.cube";
                 double& ef_tmp = eferm_iout.get_ef(is);
                 if (ModuleIO::read_rho(
 #ifdef __MPI
@@ -68,63 +65,61 @@ void Charge::init_rho(elecstate::efermi& eferm_iout,
                         this->rhopw->nz,
                         ef_tmp,
                         &(GlobalC::ucell),
-                        this->prenspin))
-                {
-                    GlobalV::ofs_running << " Read in the charge density: " << ssc.str() << std::endl;
-                }
-                else if (is > 0)
-                {
-                    if (prenspin == 1)
-                    {
-                        GlobalV::ofs_running << " Didn't read in the charge density but autoset it for spin " << is + 1
-                                             << std::endl;
-                        for (int ir = 0; ir < this->rhopw->nrxx; ir++)
-                        {
+                        this->prenspin)) {
+                    GlobalV::ofs_running
+                        << " Read in the charge density: " << ssc.str()
+                        << std::endl;
+                } else if (is > 0) {
+                    if (prenspin == 1) {
+                        GlobalV::ofs_running
+                            << " Didn't read in the charge density but autoset "
+                               "it for spin "
+                            << is + 1 << std::endl;
+                        for (int ir = 0; ir < this->rhopw->nrxx; ir++) {
                             this->rho[is][ir] = 0.0;
                         }
                     }
                     //
-                    else if (prenspin == 2)
-                    { // read up and down , then rearrange them.
-                        if (is == 1)
-                        {
-                            std::cout << "Incomplete charge density file!" << std::endl;
+                    else if (prenspin
+                             == 2) { // read up and down , then rearrange them.
+                        if (is == 1) {
+                            std::cout << "Incomplete charge density file!"
+                                      << std::endl;
                             read_error = true;
                             break;
-                        }
-                        else if (is == 2)
-                        {
-                            GlobalV::ofs_running << " Didn't read in the charge density but would rearrange it later. "
+                        } else if (is == 2) {
+                            GlobalV::ofs_running
+                                << " Didn't read in the charge density but "
+                                   "would rearrange it later. "
+                                << std::endl;
+                        } else if (is == 3) {
+                            GlobalV::ofs_running << " rearrange charge density "
                                                  << std::endl;
-                        }
-                        else if (is == 3)
-                        {
-                            GlobalV::ofs_running << " rearrange charge density " << std::endl;
-                            for (int ir = 0; ir < this->rhopw->nrxx; ir++)
-                            {
-                                this->rho[3][ir] = this->rho[0][ir] - this->rho[1][ir];
-                                this->rho[0][ir] = this->rho[0][ir] + this->rho[1][ir];
+                            for (int ir = 0; ir < this->rhopw->nrxx; ir++) {
+                                this->rho[3][ir]
+                                    = this->rho[0][ir] - this->rho[1][ir];
+                                this->rho[0][ir]
+                                    = this->rho[0][ir] + this->rho[1][ir];
                                 this->rho[1][ir] = 0.0;
                                 this->rho[2][ir] = 0.0;
                             }
                         }
                     }
-                }
-                else
-                {
+                } else {
                     read_error = true;
                     break;
                 }
             }
 
-            if (XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5)
-            {
-                for (int is = 0; is < GlobalV::NSPIN; is++)
-                {
+            if (XC_Functional::get_func_type() == 3
+                || XC_Functional::get_func_type() == 5) {
+                for (int is = 0; is < GlobalV::NSPIN; is++) {
                     std::stringstream ssc;
-                    ssc << GlobalV::global_readin_dir << "SPIN" << is + 1 << "_TAU.cube";
-                    GlobalV::ofs_running << " try to read kinetic energy density from file : " << ssc.str()
-                                         << std::endl;
+                    ssc << GlobalV::global_readin_dir << "SPIN" << is + 1
+                        << "_TAU.cube";
+                    GlobalV::ofs_running
+                        << " try to read kinetic energy density from file : "
+                        << ssc.str() << std::endl;
                     // mohan update 2012-02-10, sunliang update 2023-03-09
                     if (ModuleIO::read_rho(
 #ifdef __MPI
@@ -143,56 +138,68 @@ void Charge::init_rho(elecstate::efermi& eferm_iout,
                             this->rhopw->nz,
                             eferm_iout.ef,
                             &(GlobalC::ucell),
-                            this->prenspin))
-                    {
-                        GlobalV::ofs_running << " Read in the kinetic energy density: " << ssc.str() << std::endl;
+                            this->prenspin)) {
+                        GlobalV::ofs_running
+                            << " Read in the kinetic energy density: "
+                            << ssc.str() << std::endl;
                     }
                 }
             }
         }
     }
-    if (read_error)
-    {
-        std::cout << " WARNING: Failed to read charge density from file. Possible reasons: " << std::endl;
-        std::cout << " - not found: The default directory of SPIN1_CHG.cube is OUT.suffix, \n"
+    if (read_error) {
+        std::cout << " WARNING: Failed to read charge density from file. "
+                     "Possible reasons: "
+                  << std::endl;
+        std::cout << " - not found: The default directory of SPIN1_CHG.cube is "
+                     "OUT.suffix, \n"
                      "or you must set read_file_dir to a specific directory. "
                   << std::endl;
-        std::cout << " - parameter mismatch: check the previous warning." << std::endl;
-        if (GlobalV::init_chg == "auto")
-        {
+        std::cout << " - parameter mismatch: check the previous warning."
+                  << std::endl;
+        if (GlobalV::init_chg == "auto") {
             std::cout << " Use atomic initialization instead." << std::endl;
-        }
-        else if (GlobalV::init_chg == "file")
-        {
-            ModuleBase::WARNING_QUIT("Charge::init_rho", "Failed to read in charge density from file. And if you want to use atomic charge initialization, please set init_chg to atomic in INPUT.");
+        } else if (GlobalV::init_chg == "file") {
+            ModuleBase::WARNING_QUIT(
+                "Charge::init_rho",
+                "Failed to read in charge density from file. And if you want "
+                "to use atomic charge initialization, please set init_chg to "
+                "atomic in INPUT.");
         }
     }
 
-    if (GlobalV::init_chg == "atomic" || (GlobalV::init_chg == "auto" && read_error)) // mohan add 2007-10-17
+    if (GlobalV::init_chg == "atomic"
+        || (GlobalV::init_chg == "auto" && read_error)) // mohan add 2007-10-17
     {
-        this->atomic_rho(GlobalV::NSPIN, GlobalC::ucell.omega, rho, strucFac, GlobalC::ucell);
+        this->atomic_rho(GlobalV::NSPIN,
+                         GlobalC::ucell.omega,
+                         rho,
+                         strucFac,
+                         GlobalC::ucell);
 
-        // liuyu 2023-06-29 : move here from atomic_rho(), which will be called several times in charge extrapolation
-        // wenfei 2021-7-29 : initial tau = 3/5 rho^2/3, Thomas-Fermi
-        if (XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5)
-        {
+        // liuyu 2023-06-29 : move here from atomic_rho(), which will be called
+        // several times in charge extrapolation wenfei 2021-7-29 : initial tau
+        // = 3/5 rho^2/3, Thomas-Fermi
+        if (XC_Functional::get_func_type() == 3
+            || XC_Functional::get_func_type() == 5) {
             const double pi = 3.141592653589790;
             const double fact = (3.0 / 5.0) * pow(3.0 * pi * pi, 2.0 / 3.0);
-            for (int is = 0; is < GlobalV::NSPIN; ++is)
-            {
-                for (int ir = 0; ir < this->rhopw->nrxx; ++ir)
-                {
-                    kin_r[is][ir] = fact * pow(std::abs(rho[is][ir]) * GlobalV::NSPIN, 5.0 / 3.0) / GlobalV::NSPIN;
+            for (int is = 0; is < GlobalV::NSPIN; ++is) {
+                for (int ir = 0; ir < this->rhopw->nrxx; ++ir) {
+                    kin_r[is][ir]
+                        = fact
+                          * pow(std::abs(rho[is][ir]) * GlobalV::NSPIN,
+                                5.0 / 3.0)
+                          / GlobalV::NSPIN;
                 }
             }
         }
     }
 
     // Peize Lin add 2020.04.04
-    if (GlobalC::restart.info_load.load_charge && !GlobalC::restart.info_load.load_charge_finish)
-    {
-        for (int is = 0; is < GlobalV::NSPIN; ++is)
-        {
+    if (GlobalC::restart.info_load.load_charge
+        && !GlobalC::restart.info_load.load_charge_finish) {
+        for (int is = 0; is < GlobalV::NSPIN; ++is) {
             GlobalC::restart.load_disk("charge", is, this->nrxx, rho[is]);
         }
         GlobalC::restart.info_load.load_charge_finish = true;
@@ -205,8 +212,7 @@ void Charge::init_rho(elecstate::efermi& eferm_iout,
 //==========================================================
 // computes the core charge on the real space 3D mesh.
 //==========================================================
-void Charge::set_rho_core(const ModuleBase::ComplexMatrix& structure_factor)
-{
+void Charge::set_rho_core(const ModuleBase::ComplexMatrix& structure_factor) {
     ModuleBase::TITLE("Charge", "set_rho_core");
     ModuleBase::timer::tick("Charge", "set_rho_core");
 
@@ -222,17 +228,14 @@ void Charge::set_rho_core(const ModuleBase::ComplexMatrix& structure_factor)
     // int ig = 0;
 
     bool bl = false;
-    for (int it = 0; it < GlobalC::ucell.ntype; it++)
-    {
-        if (GlobalC::ucell.atoms[it].ncpp.nlcc)
-        {
+    for (int it = 0; it < GlobalC::ucell.ntype; it++) {
+        if (GlobalC::ucell.atoms[it].ncpp.nlcc) {
             bl = true;
             break;
         }
     }
 
-    if (!bl)
-    {
+    if (!bl) {
         ModuleBase::GlobalFunc::ZEROS(this->rho_core, this->rhopw->nrxx);
         ModuleBase::timer::tick("Charge", "set_rho_core");
         return;
@@ -244,33 +247,31 @@ void Charge::set_rho_core(const ModuleBase::ComplexMatrix& structure_factor)
     // three dimension.
     std::complex<double>* vg = new std::complex<double>[this->rhopw->npw];
 
-    for (int it = 0; it < GlobalC::ucell.ntype; it++)
-    {
-        if (GlobalC::ucell.atoms[it].ncpp.nlcc)
-        {
+    for (int it = 0; it < GlobalC::ucell.ntype; it++) {
+        if (GlobalC::ucell.atoms[it].ncpp.nlcc) {
             //----------------------------------------------------------
             // EXPLAIN : drhoc compute the radial fourier transform for
             // each shell of g vec
             //----------------------------------------------------------
-            this->non_linear_core_correction(GlobalC::ppcell.numeric,
-                                             GlobalC::ucell.atoms[it].ncpp.msh,
-                                             GlobalC::ucell.atoms[it].ncpp.r,
-                                             GlobalC::ucell.atoms[it].ncpp.rab,
-                                             GlobalC::ucell.atoms[it].ncpp.rho_atc,
-                                             rhocg);
+            this->non_linear_core_correction(
+                GlobalC::ppcell.numeric,
+                GlobalC::ucell.atoms[it].ncpp.msh,
+                GlobalC::ucell.atoms[it].ncpp.r,
+                GlobalC::ucell.atoms[it].ncpp.rab,
+                GlobalC::ucell.atoms[it].ncpp.rho_atc,
+                rhocg);
             //----------------------------------------------------------
             // EXPLAIN : multiply by the structure factor and sum
             //----------------------------------------------------------
-            for (int ig = 0; ig < this->rhopw->npw; ig++)
-            {
-                vg[ig] += structure_factor(it, ig) * rhocg[this->rhopw->ig2igg[ig]];
+            for (int ig = 0; ig < this->rhopw->npw; ig++) {
+                vg[ig] += structure_factor(it, ig)
+                          * rhocg[this->rhopw->ig2igg[ig]];
             }
         }
     }
 
     // for tmp use.
-    for (int ig = 0; ig < this->rhopw->npw; ig++)
-    {
+    for (int ig = 0; ig < this->rhopw->npw; ig++) {
         this->rhog_core[ig] = vg[ig];
     }
 
@@ -279,20 +280,21 @@ void Charge::set_rho_core(const ModuleBase::ComplexMatrix& structure_factor)
     // test on the charge and computation of the core energy
     double rhoima = 0.0;
     double rhoneg = 0.0;
-    for (int ir = 0; ir < this->rhopw->nrxx; ir++)
-    {
-        rhoneg += std::min(0.0, this->rhopw->ft.get_auxr_data<double>()[ir].real());
+    for (int ir = 0; ir < this->rhopw->nrxx; ir++) {
+        rhoneg += std::min(0.0,
+                           this->rhopw->ft.get_auxr_data<double>()[ir].real());
         rhoima += std::abs(this->rhopw->ft.get_auxr_data<double>()[ir].imag());
         // NOTE: Core charge is computed in reciprocal space and brought to real
         // space by FFT. For non smooth core charges (or insufficient cut-off)
         // this may result in negative values in some grid points.
-        // Up to October 1999 the core charge was forced to be positive definite.
-        // This induces an error in the force, and probably stress, calculation if
-        // the number of grid points where the core charge would be otherwise neg
-        // is large. The error disappears for sufficiently high cut-off, but may be
-        // rather large and it is better to leave the core charge as it is.
-        // If you insist to have it positive definite (with the possible problems
-        // mentioned above) uncomment the following lines.  SdG, Oct 15 1999
+        // Up to October 1999 the core charge was forced to be positive
+        // definite. This induces an error in the force, and probably stress,
+        // calculation if the number of grid points where the core charge would
+        // be otherwise neg is large. The error disappears for sufficiently high
+        // cut-off, but may be rather large and it is better to leave the core
+        // charge as it is. If you insist to have it positive definite (with the
+        // possible problems mentioned above) uncomment the following lines.
+        // SdG, Oct 15 1999
     }
 
     // mohan fix bug 2011-04-03
@@ -312,8 +314,7 @@ void Charge::set_rho_core(const ModuleBase::ComplexMatrix& structure_factor)
     return;
 } // end subroutine set_rhoc
 
-void Charge::set_rho_core_paw()
-{
+void Charge::set_rho_core_paw() {
     ModuleBase::TITLE("Charge", "set_rho_core_paw");
 #ifdef USE_PAW
     double* tmp = new double[nrxx];
@@ -329,8 +330,7 @@ void Charge::non_linear_core_correction(const bool& numeric,
                                         const double* r,
                                         const double* rab,
                                         const double* rhoc,
-                                        double* rhocg) const
-{
+                                        double* rhocg) const {
     ModuleBase::TITLE("charge", "drhoc");
 
     // use labmda instead of repeating codes
@@ -340,50 +340,52 @@ void Charge::non_linear_core_correction(const bool& numeric,
         double* aux;
 
         // here we compute the fourier transform is the charge in numeric form
-        if (numeric)
-        {
+        if (numeric) {
             aux = new double[mesh];
             // G=0 term
 
             int igl0 = 0;
-            if (this->rhopw->gg_uniq[0] < 1.0e-8)
-            {
+            if (this->rhopw->gg_uniq[0] < 1.0e-8) {
                 // single thread term
-                if (thread_id == 0)
-                {
-                    for (int ir = 0; ir < mesh; ir++)
-                    {
+                if (thread_id == 0) {
+                    for (int ir = 0; ir < mesh; ir++) {
                         aux[ir] = r[ir] * r[ir] * rhoc[ir];
                     }
-                    ModuleBase::Integral::Simpson_Integral(mesh, aux, rab, rhocg1);
+                    ModuleBase::Integral::Simpson_Integral(mesh,
+                                                           aux,
+                                                           rab,
+                                                           rhocg1);
                     // rhocg [1] = fpi * rhocg1 / omega;
-                    rhocg[0] = ModuleBase::FOUR_PI * rhocg1 / GlobalC::ucell.omega; // mohan modify 2008-01-19
+                    rhocg[0]
+                        = ModuleBase::FOUR_PI * rhocg1
+                          / GlobalC::ucell.omega; // mohan modify 2008-01-19
                 }
                 igl0 = 1;
             }
 
             int igl_beg, igl_end;
             // exclude igl0
-            ModuleBase::TASK_DIST_1D(num_threads, thread_id, this->rhopw->ngg - igl0, igl_beg, igl_end);
+            ModuleBase::TASK_DIST_1D(num_threads,
+                                     thread_id,
+                                     this->rhopw->ngg - igl0,
+                                     igl_beg,
+                                     igl_end);
             igl_beg += igl0;
             igl_end += igl_beg;
 
             // G <> 0 term
-            for (int igl = igl_beg; igl < igl_end; igl++)
-            {
+            for (int igl = igl_beg; igl < igl_end; igl++) {
                 gx = sqrt(this->rhopw->gg_uniq[igl] * GlobalC::ucell.tpiba2);
                 ModuleBase::Sphbes::Spherical_Bessel(mesh, r, gx, 0, aux);
-                for (int ir = 0; ir < mesh; ir++)
-                {
+                for (int ir = 0; ir < mesh; ir++) {
                     aux[ir] = r[ir] * r[ir] * rhoc[ir] * aux[ir];
                 } //  enddo
                 ModuleBase::Integral::Simpson_Integral(mesh, aux, rab, rhocg1);
-                rhocg[igl] = ModuleBase::FOUR_PI * rhocg1 / GlobalC::ucell.omega;
+                rhocg[igl]
+                    = ModuleBase::FOUR_PI * rhocg1 / GlobalC::ucell.omega;
             } //  enddo
             delete[] aux;
-        }
-        else
-        {
+        } else {
             // here the case where the charge is in analytic form,
             // check old version before 2008-12-9
         }

--- a/source/module_elecstate/module_charge/charge_init.cpp
+++ b/source/module_elecstate/module_charge/charge_init.cpp
@@ -160,7 +160,7 @@ void Charge::init_rho(elecstate::efermi& eferm_iout, const ModuleBase::ComplexMa
         }
         else if (GlobalV::init_chg == "file")
         {
-            ModuleBase::WARNING_QUIT("Charge::init_rho", "Failed to read in charge density from file.");
+            ModuleBase::WARNING_QUIT("Charge::init_rho", "Failed to read in charge density from file. And if you want to use atomic charge initialization, please set init_chg to atomic in INPUT.");
         }
     }
 

--- a/source/module_elecstate/module_charge/charge_init.cpp
+++ b/source/module_elecstate/module_charge/charge_init.cpp
@@ -25,7 +25,7 @@ void Charge::init_rho(elecstate::efermi& eferm_iout, const ModuleBase::ComplexMa
 
     std::cout << " START CHARGE      : " << GlobalV::init_chg << std::endl;
     bool read_error = false;
-    if (GlobalV::init_chg == "file")
+    if (GlobalV::init_chg == "file" || GlobalV::init_chg == "auto")
     {
         GlobalV::ofs_running << " try to read charge from file : " << std::endl;
 
@@ -154,10 +154,18 @@ void Charge::init_rho(elecstate::efermi& eferm_iout, const ModuleBase::ComplexMa
         std::cout << " - not found: The default directory of SPIN1_CHG.cube is OUT.suffix, \n"
             "or you must set read_file_dir to a specific directory. " << std::endl;
         std::cout << " - parameter mismatch: check the previous warning." << std::endl;
-        std::cout << " Use atomic initialization instead." << std::endl;
+        if (GlobalV::init_chg == "auto")
+        {
+            std::cout << " Use atomic initialization instead." << std::endl;
+        }
+        else if (GlobalV::init_chg == "file")
+        {
+            ModuleBase::WARNING_QUIT("Charge::init_rho", "Failed to read in charge density from file.");
+        }
     }
 
-    if (GlobalV::init_chg != "file" || read_error) // mohan add 2007-10-17
+    if (GlobalV::init_chg == "atomic" || 
+        (GlobalV::init_chg == "auto" && read_error)) // mohan add 2007-10-17
     {
         this->atomic_rho(GlobalV::NSPIN, GlobalC::ucell.omega, rho, strucFac, GlobalC::ucell);
 

--- a/source/module_io/input.cpp
+++ b/source/module_io/input.cpp
@@ -24,8 +24,7 @@
 #include <vector>
 Input INPUT;
 
-void Input::Init(const std::string& fn)
-{
+void Input::Init(const std::string& fn) {
     ModuleBase::timer::tick("Input", "Init");
     this->Default();
 
@@ -38,17 +37,20 @@ void Input::Init(const std::string& fn)
 #ifdef __MPI
     Parallel_Common::bcast_bool(input_error);
 #endif
-    if (input_error == 1)
-    {
-        ModuleBase::WARNING_QUIT("Input", "Bad parameter, please check the input parameters in file INPUT", 1);
+    if (input_error == 1) {
+        ModuleBase::WARNING_QUIT(
+            "Input",
+            "Bad parameter, please check the input parameters in file INPUT",
+            1);
     }
 
 #ifdef __MPI
     Parallel_Common::bcast_bool(success);
 #endif
-    if (!success)
-    {
-        ModuleBase::WARNING_QUIT("Input::Init", "Error during readin parameters.", 1);
+    if (!success) {
+        ModuleBase::WARNING_QUIT("Input::Init",
+                                 "Error during readin parameters.",
+                                 1);
     }
 #ifdef __MPI
     this->Bcast();
@@ -62,19 +64,24 @@ void Input::Init(const std::string& fn)
     bool out_dir = false;
     if (!out_app_flag && (out_mat_hs2 || out_mat_r || out_mat_t || out_mat_dh))
         out_dir = true;
-    ModuleBase::Global_File::make_dir_out(this->suffix,
-                                          this->calculation,
-                                          out_dir,
-                                          GlobalV::MY_RANK,
-                                          this->mdp.md_restart,
-                                          this->out_alllog); // xiaohui add 2013-09-01
+    ModuleBase::Global_File::make_dir_out(
+        this->suffix,
+        this->calculation,
+        out_dir,
+        GlobalV::MY_RANK,
+        this->mdp.md_restart,
+        this->out_alllog); // xiaohui add 2013-09-01
     Check();
     // if only check the input, then quit
-    if (this->check_input)
-    {
-        std::cout << "----------------------------------------------------------" << std::endl;
-        std::cout << "  INPUT parameters have been successfully checked!" << std::endl;
-        std::cout << "----------------------------------------------------------" << std::endl;
+    if (this->check_input) {
+        std::cout
+            << "----------------------------------------------------------"
+            << std::endl;
+        std::cout << "  INPUT parameters have been successfully checked!"
+                  << std::endl;
+        std::cout
+            << "----------------------------------------------------------"
+            << std::endl;
         exit(0);
     }
 #ifdef VERSION
@@ -90,27 +97,42 @@ void Input::Init(const std::string& fn)
 #endif
     time_t time_now = time(NULL);
     start_time = time_now;
-    GlobalV::ofs_running << "                                                                                     "
+    GlobalV::ofs_running << "                                                  "
+                            "                                   "
                          << std::endl;
-    GlobalV::ofs_running << "                              ABACUS " << version << std::endl << std::endl;
-    GlobalV::ofs_running << "               Atomic-orbital Based Ab-initio Computation at UStc                    "
+    GlobalV::ofs_running << "                              ABACUS " << version
                          << std::endl
                          << std::endl;
-    GlobalV::ofs_running << "                     Website: http://abacus.ustc.edu.cn/                             "
+    GlobalV::ofs_running << "               Atomic-orbital Based Ab-initio "
+                            "Computation at UStc                    "
+                         << std::endl
                          << std::endl;
-    GlobalV::ofs_running << "               Documentation: https://abacus.deepmodeling.com/                       "
+    GlobalV::ofs_running
+        << "                     Website: http://abacus.ustc.edu.cn/           "
+           "                  "
+        << std::endl;
+    GlobalV::ofs_running
+        << "               Documentation: https://abacus.deepmodeling.com/     "
+           "                  "
+        << std::endl;
+    GlobalV::ofs_running
+        << "                  Repository: "
+           "https://github.com/abacusmodeling/abacus-develop       "
+        << std::endl;
+    GlobalV::ofs_running
+        << "                              "
+           "https://github.com/deepmodeling/abacus-develop         "
+        << std::endl;
+    GlobalV::ofs_running << "                      Commit: " << commit
+                         << std::endl
                          << std::endl;
-    GlobalV::ofs_running << "                  Repository: https://github.com/abacusmodeling/abacus-develop       "
-                         << std::endl;
-    GlobalV::ofs_running << "                              https://github.com/deepmodeling/abacus-develop         "
-                         << std::endl;
-    GlobalV::ofs_running << "                      Commit: " << commit << std::endl << std::endl;
     GlobalV::ofs_running << std::setiosflags(std::ios::right);
 
 #ifdef __MPI
-    // GlobalV::ofs_running << "    Version: Parallel, under ALPHA test" << std::endl;
-    // GlobalV::ofs_running << "    Version: Parallel, in development" << std::endl;
-    // GlobalV::ofs_running << "    Processor Number is " << GlobalV::NPROC << std::endl;
+    // GlobalV::ofs_running << "    Version: Parallel, under ALPHA test" <<
+    // std::endl; GlobalV::ofs_running << "    Version: Parallel, in
+    // development" << std::endl; GlobalV::ofs_running << "    Processor Number
+    // is " << GlobalV::NPROC << std::endl;
     ModuleBase::TITLE("Input", "init");
     ModuleBase::TITLE("Input", "Bcast");
 #else
@@ -118,31 +140,41 @@ void Input::Init(const std::string& fn)
     ModuleBase::TITLE("Input", "init");
 #endif
     GlobalV::ofs_running << "    Start Time is " << ctime(&time_now);
-    GlobalV::ofs_running << "                                                                                     "
+    GlobalV::ofs_running << "                                                  "
+                            "                                   "
                          << std::endl;
-    GlobalV::ofs_running << " ------------------------------------------------------------------------------------"
+    GlobalV::ofs_running << " -------------------------------------------------"
+                            "-----------------------------------"
                          << std::endl;
 
     GlobalV::ofs_running << std::setiosflags(std::ios::left);
     std::cout << std::setiosflags(std::ios::left);
 
     GlobalV::ofs_running << "\n READING GENERAL INFORMATION" << std::endl;
-    ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "global_out_dir", GlobalV::global_out_dir);
-    ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "global_in_card", GlobalV::global_in_card);
-    ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "pseudo_dir", GlobalV::global_pseudo_dir);
-    ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "orbital_dir", GlobalV::global_orbital_dir);
+    ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,
+                                "global_out_dir",
+                                GlobalV::global_out_dir);
+    ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,
+                                "global_in_card",
+                                GlobalV::global_in_card);
+    ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,
+                                "pseudo_dir",
+                                GlobalV::global_pseudo_dir);
+    ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running,
+                                "orbital_dir",
+                                GlobalV::global_orbital_dir);
 
     // ModuleBase::GlobalFunc::OUT(
     //     GlobalV::ofs_running,
     //     "pseudo_type",
-    //     pseudo_type); // mohan add 2013-05-20 (xiaohui add 2013-06-23, GlobalV::global_pseudo_type -> pseudo_type)
+    //     pseudo_type); // mohan add 2013-05-20 (xiaohui add 2013-06-23,
+    //     GlobalV::global_pseudo_type -> pseudo_type)
 
     ModuleBase::timer::tick("Input", "Init");
     return;
 }
 
-void Input::Default(void)
-{
+void Input::Default(void) {
     ModuleBase::TITLE("Input", "Default");
     //----------------------------------------------------------
     // main parameters
@@ -201,8 +233,7 @@ void Input::Default(void)
     out_wannier_mmn = true;
     out_wannier_unk = false;
     out_wannier_wvfn_formatted = true;
-    for (int i = 0; i < 3; i++)
-    {
+    for (int i = 0; i < 3; i++) {
         kspacing[i] = 0;
     }
     min_dist_coef = 0.2;
@@ -226,7 +257,8 @@ void Input::Default(void)
     init_vel = false;
     ref_cell_factor = 1.0;
     symmetry_prec = 1.0e-6;    // LiuXh add 2021-08-12, accuracy for symmetry
-    symmetry_autoclose = true; // whether to close symmetry automatically when error occurs in symmetry analysis
+    symmetry_autoclose = true; // whether to close symmetry automatically when
+                               // error occurs in symmetry analysis
     cal_force = 0;
     force_thr = 1.0e-3;
     force_thr_ev2 = 0;
@@ -278,7 +310,8 @@ void Input::Default(void)
     //----------------------------------------------------------
     // diagonalization
     //----------------------------------------------------------
-    // diago_type = "default"; xiaohui modify 2013-09-01 //mohan update 2012-02-06
+    // diago_type = "default"; xiaohui modify 2013-09-01 //mohan update
+    // 2012-02-06
     diago_proc = 0; // if 0, then diago_proc = GlobalV::NPROC
     pw_diag_nmax = 50;
     diago_cg_prec = 1; // mohan add 2012-03-31
@@ -298,8 +331,10 @@ void Input::Default(void)
     //----------------------------------------------------------
     // iteration
     //----------------------------------------------------------
-    scf_thr = -1.0;    // the default value (1e-9 for pw, and 1e-7 for lcao) will be set in Default_2
-    scf_thr_type = -1; // the default value (1 for pw, and 2 for lcao) will be set in Default_2
+    scf_thr = -1.0; // the default value (1e-9 for pw, and 1e-7 for lcao) will
+                    // be set in Default_2
+    scf_thr_type = -1; // the default value (1 for pw, and 2 for lcao) will be
+                       // set in Default_2
     scf_nmax = 100;
     relax_nmax = 0;
     out_stru = 0;
@@ -307,8 +342,10 @@ void Input::Default(void)
     // occupation
     //----------------------------------------------------------
     occupations = "smearing";
-    smearing_method = "gauss"; // this setting is based on the report in Issue #2847
-    smearing_sigma = 0.015;    // this setting is based on the report in Issue #2847
+    smearing_method
+        = "gauss"; // this setting is based on the report in Issue #2847
+    smearing_sigma
+        = 0.015; // this setting is based on the report in Issue #2847
     //----------------------------------------------------------
     //  charge mixing
     //----------------------------------------------------------
@@ -318,9 +355,10 @@ void Input::Default(void)
     mixing_restart = 0.0;
     mixing_gg0 = 1.00;       // use Kerker defaultly
     mixing_beta_mag = -10.0; // only set when nspin == 2 || nspin == 4
-    mixing_gg0_mag = 0.0;    // defaultly exclude Kerker from mixing magnetic density
-    mixing_gg0_min = 0.1;    // defaultly minimum kerker coefficient
-    mixing_angle = -10.0;    // defaultly close for npsin = 4
+    mixing_gg0_mag
+        = 0.0; // defaultly exclude Kerker from mixing magnetic density
+    mixing_gg0_min = 0.1; // defaultly minimum kerker coefficient
+    mixing_angle = -10.0; // defaultly close for npsin = 4
     mixing_tau = false;
     mixing_dftu = false;
     mixing_dmr = false; // whether to mixing real space density matrix
@@ -465,7 +503,8 @@ void Input::Default(void)
     // xiaohui add 2015-09-16
     input_error = 0;
 
-    //----------------------------------------------------------			//Fuxiang He add 2016-10-26
+    //----------------------------------------------------------			//Fuxiang
+    //He add 2016-10-26
     // tddft
     //----------------------------------------------------------
     td_force_dt = 0.02;
@@ -539,7 +578,8 @@ void Input::Default(void)
     // td_hhg_t0 = "700";
     // td_hhg_sigma = "30"; // fs
 
-    //----------------------------------------------------------			//Fuxiang He add 2016-10-26
+    //----------------------------------------------------------			//Fuxiang
+    //He add 2016-10-26
     // constrained DFT
     //----------------------------------------------------------
     // GlobalV::ocp = 0;
@@ -554,7 +594,8 @@ void Input::Default(void)
 
     out_mul = false; // qi feng add 2019/9/10
 
-    //----------------------------------------------------------			//Peize Lin add 2020-04-04
+    //----------------------------------------------------------			//Peize
+    //Lin add 2020-04-04
     // restart
     //----------------------------------------------------------
     restart_save = false;
@@ -568,8 +609,9 @@ void Input::Default(void)
     //==========================================================
     //    DFT+U     Xin Qu added on 2020-10-29
     //==========================================================
-    dft_plus_u = 0; // 2:DFT+U correction with dual occupations 1:DFT+U correction with full occupations; 0: standard
-                    // DFT calcullation
+    dft_plus_u
+        = 0; // 2:DFT+U correction with dual occupations 1:DFT+U correction with
+             // full occupations; 0: standard DFT calcullation
     yukawa_potential = false;
     yukawa_lambda = -1.0;
     omc = 0;
@@ -696,8 +738,7 @@ void Input::Default(void)
     return;
 }
 
-bool Input::Read(const std::string& fn)
-{
+bool Input::Read(const std::string& fn) {
     ModuleBase::TITLE("Input", "Read");
 
     if (GlobalV::MY_RANK != 0)
@@ -705,8 +746,7 @@ bool Input::Read(const std::string& fn)
 
     std::ifstream ifs(fn.c_str(), std::ios::in); // "in_datas/input_parameters"
 
-    if (!ifs)
-    {
+    if (!ifs) {
         std::cout << " Can't find the INPUT file." << std::endl;
         return false;
     }
@@ -720,30 +760,29 @@ bool Input::Read(const std::string& fn)
 
     // ifs >> std::setiosflags(ios::uppercase);
     ifs.rdstate();
-    while (ifs.good())
-    {
+    while (ifs.good()) {
         ifs >> word;
         ifs.ignore(150, '\n');
-        if (strcmp(word, "INPUT_PARAMETERS") == 0)
-        {
+        if (strcmp(word, "INPUT_PARAMETERS") == 0) {
             ierr = 1;
             break;
         }
         ifs.rdstate();
     }
 
-    if (ierr == 0)
-    {
+    if (ierr == 0) {
         std::cout << " Error parameter list. "
-                  << " The parameter list always starts with key word 'INPUT_PARAMETERS'. " << std::endl;
+                  << " The parameter list always starts with key word "
+                     "'INPUT_PARAMETERS'. "
+                  << std::endl;
         return false; // return error : false
     }
 
-    bool plast_find = false; // whether the parameter md_plast is found liuyu 2024-01-28
+    bool plast_find
+        = false; // whether the parameter md_plast is found liuyu 2024-01-28
 
     ifs.rdstate();
-    while (ifs.good())
-    {
+    while (ifs.good()) {
         ifs >> word1;
         if (ifs.eof())
             break;
@@ -755,444 +794,280 @@ bool Input::Read(const std::string& fn)
         if (strcmp("suffix", word) == 0) // out dir
         {
             read_value(ifs, suffix);
-        }
-        else if (strcmp("stru_file", word) == 0) // xiaohui modify 2015-02-01
+        } else if (strcmp("stru_file", word) == 0) // xiaohui modify 2015-02-01
         {
             read_value(ifs, stru_file); // xiaohui modify 2015-02-01
-        }
-        else if (strcmp("pseudo_dir", word) == 0)
-        {
+        } else if (strcmp("pseudo_dir", word) == 0) {
             read_value(ifs, pseudo_dir);
         }
-        // else if (strcmp("pseudo_type", word) == 0) // mohan add 2013-05-20 (xiaohui add 2013-06-23)
+        // else if (strcmp("pseudo_type", word) == 0) // mohan add 2013-05-20
+        // (xiaohui add 2013-06-23)
         // {
         //     read_value(ifs, pseudo_type);
         // }
         else if (strcmp("orbital_dir", word) == 0) // liuyu add 2021-08-14
         {
             read_value(ifs, orbital_dir);
-        }
-        else if (strcmp("kpoint_file", word) == 0) // xiaohui modify 2015-02-01
+        } else if (strcmp("kpoint_file", word)
+                   == 0) // xiaohui modify 2015-02-01
         {
             read_value(ifs, kpoint_file); // xiaohui modify 2015-02-01
-        }
-        else if (strcmp("wannier_card", word) == 0) // mohan add 2009-12-25
+        } else if (strcmp("wannier_card", word) == 0) // mohan add 2009-12-25
         {
             read_value(ifs, wannier_card);
-        }
-        else if (strcmp("latname", word) == 0) // which material
+        } else if (strcmp("latname", word) == 0) // which material
         {
             read_value(ifs, latname);
-        }
-        else if (strcmp("pseudo_rcut", word) == 0) //
+        } else if (strcmp("pseudo_rcut", word) == 0) //
         {
             read_value(ifs, pseudo_rcut);
-        }
-        else if (strcmp("pseudo_mesh", word) == 0) //
+        } else if (strcmp("pseudo_mesh", word) == 0) //
         {
             read_bool(ifs, pseudo_mesh);
-        }
-        else if (strcmp("calculation", word) == 0) // which type calculation
+        } else if (strcmp("calculation", word) == 0) // which type calculation
         {
             read_value(ifs, calculation);
-        }
-        else if (strcmp("esolver_type", word) == 0)
-        {
+        } else if (strcmp("esolver_type", word) == 0) {
             read_value(ifs, esolver_type);
-        }
-        else if (strcmp("ntype", word) == 0) // number of atom types
+        } else if (strcmp("ntype", word) == 0) // number of atom types
         {
             read_value(ifs, ntype);
-        }
-        else if (strcmp("nbands", word) == 0) // number of atom bands
+        } else if (strcmp("nbands", word) == 0) // number of atom bands
         {
             read_value(ifs, nbands);
-        }
-        else if (strcmp("nbands_sto", word) == 0) // number of stochastic bands
+        } else if (strcmp("nbands_sto", word)
+                   == 0) // number of stochastic bands
         {
             std::string nbsto_str;
             read_value(ifs, nbndsto_str);
-            if (nbndsto_str != "all")
-            {
+            if (nbndsto_str != "all") {
                 nbands_sto = std::stoi(nbndsto_str);
             }
-        }
-        else if (strcmp("kspacing", word) == 0)
-        {
+        } else if (strcmp("kspacing", word) == 0) {
             read_kspacing(ifs);
-        }
-        else if (strcmp("min_dist_coef", word) == 0)
-        {
+        } else if (strcmp("min_dist_coef", word) == 0) {
             read_value(ifs, min_dist_coef);
-        }
-        else if (strcmp("nbands_istate", word) == 0) // number of atom bands
+        } else if (strcmp("nbands_istate", word) == 0) // number of atom bands
         {
             read_value(ifs, nbands_istate);
             // Originally disabled in line 2401.
             // if (nbands_istate < 0)
             // 	ModuleBase::WARNING_QUIT("Input", "NBANDS_ISTATE must > 0");
-        }
-        else if (strcmp("bands_to_print", word) == 0)
-        {
+        } else if (strcmp("bands_to_print", word) == 0) {
             getline(ifs, bands_to_print_);
-        }
-        else if (strcmp("nche_sto", word) == 0) // Chebyshev expansion order
+        } else if (strcmp("nche_sto", word) == 0) // Chebyshev expansion order
         {
             read_value(ifs, nche_sto);
-        }
-        else if (strcmp("seed_sto", word) == 0)
-        {
+        } else if (strcmp("seed_sto", word) == 0) {
             read_value(ifs, seed_sto);
-        }
-        else if (strcmp("initsto_ecut", word) == 0)
-        {
+        } else if (strcmp("initsto_ecut", word) == 0) {
             read_value(ifs, initsto_ecut);
-        }
-        else if (strcmp("pw_seed", word) == 0)
-        {
+        } else if (strcmp("pw_seed", word) == 0) {
             read_value(ifs, pw_seed);
-        }
-        else if (strcmp("emax_sto", word) == 0)
-        {
+        } else if (strcmp("emax_sto", word) == 0) {
             read_value(ifs, emax_sto);
-        }
-        else if (strcmp("emin_sto", word) == 0)
-        {
+        } else if (strcmp("emin_sto", word) == 0) {
             read_value(ifs, emin_sto);
-        }
-        else if (strcmp("initsto_freq", word) == 0)
-        {
+        } else if (strcmp("initsto_freq", word) == 0) {
             read_value(ifs, initsto_freq);
-        }
-        else if (strcmp("method_sto", word) == 0)
-        {
+        } else if (strcmp("method_sto", word) == 0) {
             read_value(ifs, method_sto);
-        }
-        else if (strcmp("npart_sto", word) == 0)
-        {
+        } else if (strcmp("npart_sto", word) == 0) {
             read_value(ifs, npart_sto);
-        }
-        else if (strcmp("cal_cond", word) == 0)
-        {
+        } else if (strcmp("cal_cond", word) == 0) {
             read_bool(ifs, cal_cond);
-        }
-        else if (strcmp("cond_che_thr", word) == 0)
-        {
+        } else if (strcmp("cond_che_thr", word) == 0) {
             read_value(ifs, cond_che_thr);
-        }
-        else if (strcmp("cond_dw", word) == 0)
-        {
+        } else if (strcmp("cond_dw", word) == 0) {
             read_value(ifs, cond_dw);
-        }
-        else if (strcmp("cond_wcut", word) == 0)
-        {
+        } else if (strcmp("cond_wcut", word) == 0) {
             read_value(ifs, cond_wcut);
-        }
-        else if (strcmp("cond_dt", word) == 0)
-        {
+        } else if (strcmp("cond_dt", word) == 0) {
             read_value(ifs, cond_dt);
-        }
-        else if (strcmp("cond_dtbatch", word) == 0)
-        {
+        } else if (strcmp("cond_dtbatch", word) == 0) {
             read_value(ifs, cond_dtbatch);
-        }
-        else if (strcmp("cond_smear", word) == 0)
-        {
+        } else if (strcmp("cond_smear", word) == 0) {
             read_value(ifs, cond_smear);
-        }
-        else if (strcmp("cond_fwhm", word) == 0)
-        {
+        } else if (strcmp("cond_fwhm", word) == 0) {
             read_value(ifs, cond_fwhm);
-        }
-        else if (strcmp("cond_nonlocal", word) == 0)
-        {
+        } else if (strcmp("cond_nonlocal", word) == 0) {
             read_bool(ifs, cond_nonlocal);
-        }
-        else if (strcmp("bndpar", word) == 0)
-        {
+        } else if (strcmp("bndpar", word) == 0) {
             read_value(ifs, bndpar);
-        }
-        else if (strcmp("kpar", word) == 0) // number of pools
+        } else if (strcmp("kpar", word) == 0) // number of pools
         {
             read_value(ifs, kpar);
-        }
-        else if (strcmp("berry_phase", word) == 0) // berry phase calculation
+        } else if (strcmp("berry_phase", word) == 0) // berry phase calculation
         {
             read_bool(ifs, berry_phase);
-        }
-        else if (strcmp("gdir", word) == 0) // berry phase calculation
+        } else if (strcmp("gdir", word) == 0) // berry phase calculation
         {
             read_value(ifs, gdir);
-        }
-        else if (strcmp("towannier90", word) == 0) // add by jingan for wannier90
+        } else if (strcmp("towannier90", word)
+                   == 0) // add by jingan for wannier90
         {
             read_bool(ifs, towannier90);
-        }
-        else if (strcmp("nnkpfile", word) == 0) // add by jingan for wannier90
+        } else if (strcmp("nnkpfile", word) == 0) // add by jingan for wannier90
         {
             read_value(ifs, nnkpfile);
-        }
-        else if (strcmp("wannier_spin", word) == 0) // add by jingan for wannier90
+        } else if (strcmp("wannier_spin", word)
+                   == 0) // add by jingan for wannier90
         {
             read_value(ifs, wannier_spin);
-        }
-        else if (strcmp("wannier_method", word) == 0) // add by jingan for wannier90
+        } else if (strcmp("wannier_method", word)
+                   == 0) // add by jingan for wannier90
         {
             read_value(ifs, wannier_method);
-        }
-        else if (strcmp("out_wannier_mmn", word) == 0) // add by renxi for wannier90
+        } else if (strcmp("out_wannier_mmn", word)
+                   == 0) // add by renxi for wannier90
         {
             read_bool(ifs, out_wannier_mmn);
-        }
-        else if (strcmp("out_wannier_amn", word) == 0) // add by renxi for wannier90
+        } else if (strcmp("out_wannier_amn", word)
+                   == 0) // add by renxi for wannier90
         {
             read_bool(ifs, out_wannier_amn);
-        }
-        else if (strcmp("out_wannier_unk", word) == 0) // add by renxi for wannier90
+        } else if (strcmp("out_wannier_unk", word)
+                   == 0) // add by renxi for wannier90
         {
             read_bool(ifs, out_wannier_unk);
-        }
-        else if (strcmp("out_wannier_eig", word) == 0) // add by renxi for wannier90
+        } else if (strcmp("out_wannier_eig", word)
+                   == 0) // add by renxi for wannier90
         {
             read_bool(ifs, out_wannier_eig);
-        }
-        else if (strcmp("out_wannier_wvfn_formatted", word) == 0)
-        {
+        } else if (strcmp("out_wannier_wvfn_formatted", word) == 0) {
             read_bool(ifs, out_wannier_wvfn_formatted);
         }
         //----------------------------------------------------------
         // electrons / spin
         //----------------------------------------------------------
-        else if (strcmp("dft_functional", word) == 0)
-        {
+        else if (strcmp("dft_functional", word) == 0) {
             read_value(ifs, dft_functional);
-        }
-        else if (strcmp("xc_temperature", word) == 0)
-        {
+        } else if (strcmp("xc_temperature", word) == 0) {
             read_value(ifs, xc_temperature);
-        }
-        else if (strcmp("nspin", word) == 0)
-        {
+        } else if (strcmp("nspin", word) == 0) {
             read_value(ifs, nspin);
-        }
-        else if (strcmp("nelec", word) == 0)
-        {
+        } else if (strcmp("nelec", word) == 0) {
             read_value(ifs, nelec);
-        }
-        else if (strcmp("nelec_delta", word) == 0)
-        {
+        } else if (strcmp("nelec_delta", word) == 0) {
             read_value(ifs, nelec_delta);
-        }
-        else if (strcmp("nupdown", word) == 0)
-        {
+        } else if (strcmp("nupdown", word) == 0) {
             two_fermi = true;
             read_value(ifs, nupdown);
-        }
-        else if (strcmp("lmaxmax", word) == 0)
-        {
+        } else if (strcmp("lmaxmax", word) == 0) {
             read_value(ifs, lmaxmax);
         }
         //----------------------------------------------------------
         // new function
         //----------------------------------------------------------
-        else if (strcmp("basis_type", word) == 0)
-        {
+        else if (strcmp("basis_type", word) == 0) {
             read_value(ifs, basis_type);
         } // xiaohui add 2013-09-01
-        else if (strcmp("ks_solver", word) == 0)
-        {
+        else if (strcmp("ks_solver", word) == 0) {
             read_value(ifs, ks_solver);
         } // xiaohui add 2013-09-01
-        else if (strcmp("search_radius", word) == 0)
-        {
+        else if (strcmp("search_radius", word) == 0) {
             read_value(ifs, search_radius);
-        }
-        else if (strcmp("search_pbc", word) == 0)
-        {
+        } else if (strcmp("search_pbc", word) == 0) {
             read_bool(ifs, search_pbc);
-        }
-        else if (strcmp("symmetry", word) == 0)
-        {
+        } else if (strcmp("symmetry", word) == 0) {
             read_value(ifs, symmetry);
-        }
-        else if (strcmp("init_vel", word) == 0)
-        {
+        } else if (strcmp("init_vel", word) == 0) {
             read_bool(ifs, init_vel);
-        }
-        else if (strcmp("ref_cell_factor", word) == 0)
-        {
+        } else if (strcmp("ref_cell_factor", word) == 0) {
             read_value(ifs, ref_cell_factor);
-        }
-        else if (strcmp("symmetry_prec", word) == 0) // LiuXh add 2021-08-12, accuracy for symmetry
+        } else if (strcmp("symmetry_prec", word)
+                   == 0) // LiuXh add 2021-08-12, accuracy for symmetry
         {
             read_value(ifs, symmetry_prec);
-        }
-        else if (strcmp("symmetry_autoclose", word) == 0)
-        {
+        } else if (strcmp("symmetry_autoclose", word) == 0) {
             read_value(ifs, symmetry_autoclose);
-        }
-        else if (strcmp("cal_force", word) == 0)
-        {
+        } else if (strcmp("cal_force", word) == 0) {
             read_bool(ifs, cal_force);
-        }
-        else if (strcmp("force_thr", word) == 0)
-        {
+        } else if (strcmp("force_thr", word) == 0) {
             read_value(ifs, force_thr);
-        }
-        else if (strcmp("force_thr_ev", word) == 0)
-        {
+        } else if (strcmp("force_thr_ev", word) == 0) {
             read_value(ifs, force_thr);
             force_thr = force_thr / 13.6058 * 0.529177;
-        }
-        else if (strcmp("force_thr_ev2", word) == 0)
-        {
+        } else if (strcmp("force_thr_ev2", word) == 0) {
             read_value(ifs, force_thr_ev2);
-        }
-        else if (strcmp("stress_thr", word) == 0)
-        {
+        } else if (strcmp("stress_thr", word) == 0) {
             read_value(ifs, stress_thr);
-        }
-        else if (strcmp("press1", word) == 0)
-        {
+        } else if (strcmp("press1", word) == 0) {
             read_value(ifs, press1);
-        }
-        else if (strcmp("press2", word) == 0)
-        {
+        } else if (strcmp("press2", word) == 0) {
             read_value(ifs, press2);
-        }
-        else if (strcmp("press3", word) == 0)
-        {
+        } else if (strcmp("press3", word) == 0) {
             read_value(ifs, press3);
-        }
-        else if (strcmp("cal_stress", word) == 0)
-        {
+        } else if (strcmp("cal_stress", word) == 0) {
             read_bool(ifs, cal_stress);
-        }
-        else if (strcmp("fixed_axes", word) == 0)
-        {
+        } else if (strcmp("fixed_axes", word) == 0) {
             read_value(ifs, fixed_axes);
-        }
-        else if (strcmp("fixed_ibrav", word) == 0)
-        {
+        } else if (strcmp("fixed_ibrav", word) == 0) {
             read_bool(ifs, fixed_ibrav);
-        }
-        else if (strcmp("fixed_atoms", word) == 0)
-        {
+        } else if (strcmp("fixed_atoms", word) == 0) {
             read_bool(ifs, fixed_atoms);
-        }
-        else if (strcmp("relax_method", word) == 0)
-        {
+        } else if (strcmp("relax_method", word) == 0) {
             read_value(ifs, relax_method);
-        }
-        else if (strcmp("relax_cg_thr", word) == 0) // pengfei add 2013-08-15
+        } else if (strcmp("relax_cg_thr", word) == 0) // pengfei add 2013-08-15
         {
             read_value(ifs, relax_cg_thr);
-        }
-        else if (strcmp("out_level", word) == 0)
-        {
+        } else if (strcmp("out_level", word) == 0) {
             read_value(ifs, out_level);
             out_md_control = true;
-        }
-        else if (strcmp("relax_bfgs_w1", word) == 0)
-        {
+        } else if (strcmp("relax_bfgs_w1", word) == 0) {
             read_value(ifs, relax_bfgs_w1);
-        }
-        else if (strcmp("relax_bfgs_w2", word) == 0)
-        {
+        } else if (strcmp("relax_bfgs_w2", word) == 0) {
             read_value(ifs, relax_bfgs_w2);
-        }
-        else if (strcmp("relax_bfgs_rmax", word) == 0)
-        {
+        } else if (strcmp("relax_bfgs_rmax", word) == 0) {
             read_value(ifs, relax_bfgs_rmax);
-        }
-        else if (strcmp("relax_bfgs_rmin", word) == 0)
-        {
+        } else if (strcmp("relax_bfgs_rmin", word) == 0) {
             read_value(ifs, relax_bfgs_rmin);
-        }
-        else if (strcmp("relax_bfgs_init", word) == 0)
-        {
+        } else if (strcmp("relax_bfgs_init", word) == 0) {
             read_value(ifs, relax_bfgs_init);
-        }
-        else if (strcmp("relax_scale_force", word) == 0)
-        {
+        } else if (strcmp("relax_scale_force", word) == 0) {
             read_value(ifs, relax_scale_force);
-        }
-        else if (strcmp("relax_new", word) == 0)
-        {
+        } else if (strcmp("relax_new", word) == 0) {
             read_bool(ifs, relax_new);
-        }
-        else if (strcmp("use_paw", word) == 0)
-        {
+        } else if (strcmp("use_paw", word) == 0) {
             read_bool(ifs, use_paw);
         }
         //----------------------------------------------------------
         // plane waves
         //----------------------------------------------------------
-        else if (strcmp("gamma_only", word) == 0)
-        {
+        else if (strcmp("gamma_only", word) == 0) {
             read_bool(ifs, gamma_only);
-        }
-        else if (strcmp("fft_mode", word) == 0)
-        {
+        } else if (strcmp("fft_mode", word) == 0) {
             read_value(ifs, fft_mode);
-        }
-        else if (strcmp("ecutwfc", word) == 0)
-        {
+        } else if (strcmp("ecutwfc", word) == 0) {
             read_value(ifs, ecutwfc);
-        }
-        else if (strcmp("ecutrho", word) == 0)
-        {
+        } else if (strcmp("ecutrho", word) == 0) {
             read_value(ifs, ecutrho);
-        }
-        else if (strcmp("nx", word) == 0)
-        {
+        } else if (strcmp("nx", word) == 0) {
             read_value(ifs, nx);
             ncx = nx;
-        }
-        else if (strcmp("ny", word) == 0)
-        {
+        } else if (strcmp("ny", word) == 0) {
             read_value(ifs, ny);
             ncy = ny;
-        }
-        else if (strcmp("nz", word) == 0)
-        {
+        } else if (strcmp("nz", word) == 0) {
             read_value(ifs, nz);
             ncz = nz;
-        }
-        else if (strcmp("bx", word) == 0)
-        {
+        } else if (strcmp("bx", word) == 0) {
             read_value(ifs, bx);
-        }
-        else if (strcmp("by", word) == 0)
-        {
+        } else if (strcmp("by", word) == 0) {
             read_value(ifs, by);
-        }
-        else if (strcmp("bz", word) == 0)
-        {
+        } else if (strcmp("bz", word) == 0) {
             read_value(ifs, bz);
-        }
-        else if (strcmp("ndx", word) == 0)
-        {
+        } else if (strcmp("ndx", word) == 0) {
             read_value(ifs, ndx);
-        }
-        else if (strcmp("ndy", word) == 0)
-        {
+        } else if (strcmp("ndy", word) == 0) {
             read_value(ifs, ndy);
-        }
-        else if (strcmp("ndz", word) == 0)
-        {
+        } else if (strcmp("ndz", word) == 0) {
             read_value(ifs, ndz);
-        }
-        else if (strcmp("erf_ecut", word) == 0)
-        {
+        } else if (strcmp("erf_ecut", word) == 0) {
             read_value(ifs, erf_ecut);
-        }
-        else if (strcmp("erf_height", word) == 0)
-        {
+        } else if (strcmp("erf_height", word) == 0) {
             read_value(ifs, erf_height);
-        }
-        else if (strcmp("erf_sigma", word) == 0)
-        {
+        } else if (strcmp("erf_sigma", word) == 0) {
             read_value(ifs, erf_sigma);
         }
         //----------------------------------------------------------
@@ -1202,95 +1077,54 @@ bool Input::Read(const std::string& fn)
         //{
         //    read_value(ifs, diago_type);
         //} xiaohui modify 2013-09-01
-        else if (strcmp("diago_proc", word) == 0)
-        {
+        else if (strcmp("diago_proc", word) == 0) {
             read_value(ifs, diago_proc);
-        }
-        else if (strcmp("pw_diag_nmax", word) == 0)
-        {
+        } else if (strcmp("pw_diag_nmax", word) == 0) {
             read_value(ifs, pw_diag_nmax);
-        }
-        else if (strcmp("diago_cg_prec", word) == 0) // mohan add 2012-03-31
+        } else if (strcmp("diago_cg_prec", word) == 0) // mohan add 2012-03-31
         {
             read_value(ifs, diago_cg_prec);
-        }
-        else if (strcmp("pw_diag_ndim", word) == 0)
-        {
+        } else if (strcmp("pw_diag_ndim", word) == 0) {
             read_value(ifs, pw_diag_ndim);
-        }
-        else if (strcmp("diago_full_acc", word) == 0)
-        {
+        } else if (strcmp("diago_full_acc", word) == 0) {
             read_value(ifs, diago_full_acc);
-        }
-        else if (strcmp("pw_diag_thr", word) == 0)
-        {
+        } else if (strcmp("pw_diag_thr", word) == 0) {
             read_value(ifs, pw_diag_thr);
-        }
-        else if (strcmp("nb2d", word) == 0)
-        {
+        } else if (strcmp("nb2d", word) == 0) {
             read_value(ifs, nb2d);
-        }
-        else if (strcmp("nurse", word) == 0)
-        {
+        } else if (strcmp("nurse", word) == 0) {
             read_value(ifs, nurse);
-        }
-        else if (strcmp("colour", word) == 0)
-        {
+        } else if (strcmp("colour", word) == 0) {
             read_bool(ifs, colour);
-        }
-        else if (strcmp("nbspline", word) == 0)
-        {
+        } else if (strcmp("nbspline", word) == 0) {
             read_value(ifs, nbspline);
-        }
-        else if (strcmp("t_in_h", word) == 0)
-        {
+        } else if (strcmp("t_in_h", word) == 0) {
             read_bool(ifs, t_in_h);
-        }
-        else if (strcmp("vl_in_h", word) == 0)
-        {
+        } else if (strcmp("vl_in_h", word) == 0) {
             read_bool(ifs, vl_in_h);
-        }
-        else if (strcmp("vnl_in_h", word) == 0)
-        {
+        } else if (strcmp("vnl_in_h", word) == 0) {
             read_bool(ifs, vnl_in_h);
-        }
-        else if (strcmp("vh_in_h", word) == 0)
-        {
+        } else if (strcmp("vh_in_h", word) == 0) {
             read_bool(ifs, vh_in_h);
-        }
-        else if (strcmp("vion_in_h", word) == 0)
-        {
+        } else if (strcmp("vion_in_h", word) == 0) {
             read_bool(ifs, vion_in_h);
-        }
-        else if (strcmp("test_force", word) == 0)
-        {
+        } else if (strcmp("test_force", word) == 0) {
             read_bool(ifs, test_force);
-        }
-        else if (strcmp("test_stress", word) == 0)
-        {
+        } else if (strcmp("test_stress", word) == 0) {
             read_bool(ifs, test_stress);
         }
         //----------------------------------------------------------
         // iteration
         //----------------------------------------------------------
-        else if (strcmp("scf_thr", word) == 0)
-        {
+        else if (strcmp("scf_thr", word) == 0) {
             read_value(ifs, scf_thr);
-        }
-        else if (strcmp("scf_thr_type", word) == 0)
-        {
+        } else if (strcmp("scf_thr_type", word) == 0) {
             read_value(ifs, scf_thr_type);
-        }
-        else if (strcmp("scf_nmax", word) == 0)
-        {
+        } else if (strcmp("scf_nmax", word) == 0) {
             read_value(ifs, scf_nmax);
-        }
-        else if (strcmp("relax_nmax", word) == 0)
-        {
+        } else if (strcmp("relax_nmax", word) == 0) {
             read_value(ifs, this->relax_nmax);
-        }
-        else if (strcmp("out_stru", word) == 0)
-        {
+        } else if (strcmp("out_stru", word) == 0) {
             read_bool(ifs, out_stru);
         }
         //----------------------------------------------------------
@@ -1300,16 +1134,11 @@ bool Input::Read(const std::string& fn)
         //{
         //    read_value(ifs, occupations);
         //}
-        else if (strcmp("smearing_method", word) == 0)
-        {
+        else if (strcmp("smearing_method", word) == 0) {
             read_value(ifs, smearing_method);
-        }
-        else if (strcmp("smearing_sigma", word) == 0)
-        {
+        } else if (strcmp("smearing_sigma", word) == 0) {
             read_value(ifs, smearing_sigma);
-        }
-        else if (strcmp("smearing_sigma_temp", word) == 0)
-        {
+        } else if (strcmp("smearing_sigma_temp", word) == 0) {
             double smearing_sigma_temp;
             read_value(ifs, smearing_sigma_temp);
             smearing_sigma = smearing_sigma_temp * 3.166815e-6;
@@ -1317,247 +1146,147 @@ bool Input::Read(const std::string& fn)
         //----------------------------------------------------------
         // charge mixing
         //----------------------------------------------------------
-        else if (strcmp("mixing_type", word) == 0)
-        {
+        else if (strcmp("mixing_type", word) == 0) {
             read_value(ifs, mixing_mode);
-        }
-        else if (strcmp("mixing_beta", word) == 0)
-        {
+        } else if (strcmp("mixing_beta", word) == 0) {
             read_value(ifs, mixing_beta);
-        }
-        else if (strcmp("mixing_ndim", word) == 0)
-        {
+        } else if (strcmp("mixing_ndim", word) == 0) {
             read_value(ifs, mixing_ndim);
-        }
-        else if (strcmp("mixing_restart", word) == 0)
-        {
+        } else if (strcmp("mixing_restart", word) == 0) {
             read_value(ifs, mixing_restart);
-        }
-        else if (strcmp("mixing_gg0", word) == 0) // mohan add 2014-09-27
+        } else if (strcmp("mixing_gg0", word) == 0) // mohan add 2014-09-27
         {
             read_value(ifs, mixing_gg0);
-        }
-        else if (strcmp("mixing_beta_mag", word) == 0)
-        {
+        } else if (strcmp("mixing_beta_mag", word) == 0) {
             read_value(ifs, mixing_beta_mag);
-        }
-        else if (strcmp("mixing_gg0_mag", word) == 0)
-        {
+        } else if (strcmp("mixing_gg0_mag", word) == 0) {
             read_value(ifs, mixing_gg0_mag);
-        }
-        else if (strcmp("mixing_gg0_min", word) == 0)
-        {
+        } else if (strcmp("mixing_gg0_min", word) == 0) {
             read_value(ifs, mixing_gg0_min);
-        }
-        else if (strcmp("mixing_angle", word) == 0)
-        {
+        } else if (strcmp("mixing_angle", word) == 0) {
             read_value(ifs, mixing_angle);
-        }
-        else if (strcmp("mixing_tau", word) == 0)
-        {
+        } else if (strcmp("mixing_tau", word) == 0) {
             read_bool(ifs, mixing_tau);
-        }
-        else if (strcmp("mixing_dftu", word) == 0)
-        {
+        } else if (strcmp("mixing_dftu", word) == 0) {
             read_bool(ifs, mixing_dftu);
-        }
-        else if (strcmp("mixing_dmr", word) == 0)
-        {
+        } else if (strcmp("mixing_dmr", word) == 0) {
             read_bool(ifs, mixing_dmr);
         }
         //----------------------------------------------------------
         // charge / potential / wavefunction
         //----------------------------------------------------------
-        else if (strcmp("read_file_dir", word) == 0)
-        {
+        else if (strcmp("read_file_dir", word) == 0) {
             read_value(ifs, read_file_dir);
-        }
-        else if (strcmp("init_wfc", word) == 0)
-        {
+        } else if (strcmp("init_wfc", word) == 0) {
             read_value(ifs, init_wfc);
-        }
-        else if (strcmp("psi_initializer", word) == 0)
-        {
+        } else if (strcmp("psi_initializer", word) == 0) {
             read_value(ifs, psi_initializer);
-        }
-        else if (strcmp("mem_saver", word) == 0)
-        {
+        } else if (strcmp("mem_saver", word) == 0) {
             read_value(ifs, mem_saver);
-        }
-        else if (strcmp("printe", word) == 0)
-        {
+        } else if (strcmp("printe", word) == 0) {
             read_value(ifs, printe);
-        }
-        else if (strcmp("init_chg", word) == 0)
-        {
+        } else if (strcmp("init_chg", word) == 0) {
             read_value(ifs, init_chg);
-        }
-        else if (strcmp("chg_extrap", word) == 0) // xiaohui modify 2015-02-01
+        } else if (strcmp("chg_extrap", word) == 0) // xiaohui modify 2015-02-01
         {
             read_value(ifs, chg_extrap); // xiaohui modify 2015-02-01
-        }
-        else if (strcmp("out_freq_elec", word) == 0)
-        {
+        } else if (strcmp("out_freq_elec", word) == 0) {
             read_value(ifs, out_freq_elec);
-        }
-        else if (strcmp("out_freq_ion", word) == 0)
-        {
+        } else if (strcmp("out_freq_ion", word) == 0) {
             read_value(ifs, out_freq_ion);
-        }
-        else if (strcmp("out_chg", word) == 0)
-        {
+        } else if (strcmp("out_chg", word) == 0) {
             read_value(ifs, out_chg);
-        }
-        else if (strcmp("out_dm", word) == 0)
-        {
+        } else if (strcmp("out_dm", word) == 0) {
             read_bool(ifs, out_dm);
-        }
-        else if (strcmp("out_dm1", word) == 0)
-        {
+        } else if (strcmp("out_dm1", word) == 0) {
             read_bool(ifs, out_dm1);
-        }
-        else if (strcmp("out_bandgap", word) == 0) // for bandgap printing
+        } else if (strcmp("out_bandgap", word) == 0) // for bandgap printing
         {
             read_bool(ifs, out_bandgap);
-        }
-        else if (strcmp("deepks_out_labels", word) == 0) // caoyu added 2020-11-24, mohan modified 2021-01-03
+        } else if (strcmp("deepks_out_labels", word)
+                   == 0) // caoyu added 2020-11-24, mohan modified 2021-01-03
         {
             read_bool(ifs, deepks_out_labels);
-        }
-        else if (strcmp("deepks_scf", word) == 0) // caoyu added 2020-11-24, mohan modified 2021-01-03
+        } else if (strcmp("deepks_scf", word)
+                   == 0) // caoyu added 2020-11-24, mohan modified 2021-01-03
         {
             read_bool(ifs, deepks_scf);
-        }
-        else if (strcmp("deepks_equiv", word) == 0)
-        {
+        } else if (strcmp("deepks_equiv", word) == 0) {
             read_bool(ifs, deepks_equiv);
-        }
-        else if (strcmp("deepks_bandgap", word) == 0) // caoyu added 2020-11-24, mohan modified 2021-01-03
+        } else if (strcmp("deepks_bandgap", word)
+                   == 0) // caoyu added 2020-11-24, mohan modified 2021-01-03
         {
             read_bool(ifs, deepks_bandgap);
-        }
-        else if (strcmp("deepks_out_unittest", word) == 0) // mohan added 2021-01-03
+        } else if (strcmp("deepks_out_unittest", word)
+                   == 0) // mohan added 2021-01-03
         {
             read_bool(ifs, deepks_out_unittest);
-        }
-        else if (strcmp("deepks_model", word) == 0) // caoyu added 2021-06-03
+        } else if (strcmp("deepks_model", word) == 0) // caoyu added 2021-06-03
         {
             read_value(ifs, deepks_model);
-        }
-        else if (strcmp("out_pot", word) == 0)
-        {
+        } else if (strcmp("out_pot", word) == 0) {
             read_value(ifs, out_pot);
-        }
-        else if (strcmp("out_wfc_pw", word) == 0)
-        {
+        } else if (strcmp("out_wfc_pw", word) == 0) {
             read_value(ifs, out_wfc_pw);
-        }
-        else if (strcmp("out_wfc_r", word) == 0)
-        {
+        } else if (strcmp("out_wfc_r", word) == 0) {
             read_bool(ifs, out_wfc_r);
         }
         // mohan add 20090909
-        else if (strcmp("out_dos", word) == 0)
-        {
+        else if (strcmp("out_dos", word) == 0) {
             read_value(ifs, out_dos);
-        }
-        else if (strcmp("out_band", word) == 0)
-        {
+        } else if (strcmp("out_band", word) == 0) {
             read_value2stdvector(ifs, out_band);
             if (out_band.size() == 1)
                 out_band.push_back(8);
-        }
-        else if (strcmp("out_proj_band", word) == 0)
-        {
+        } else if (strcmp("out_proj_band", word) == 0) {
             read_bool(ifs, out_proj_band);
-        }
-        else if (strcmp("out_mat_hs", word) == 0)
-        {
+        } else if (strcmp("out_mat_hs", word) == 0) {
             read_value2stdvector(ifs, out_mat_hs);
             if (out_mat_hs.size() == 1)
                 out_mat_hs.push_back(8);
         }
         // LiuXh add 2019-07-15
-        else if (strcmp("out_mat_hs2", word) == 0)
-        {
+        else if (strcmp("out_mat_hs2", word) == 0) {
             read_bool(ifs, out_mat_hs2);
-        }
-        else if (strcmp("out_mat_t", word) == 0)
-        {
+        } else if (strcmp("out_mat_t", word) == 0) {
             read_bool(ifs, out_mat_t);
-        }
-        else if (strcmp("out_mat_dh", word) == 0)
-        {
+        } else if (strcmp("out_mat_dh", word) == 0) {
             read_bool(ifs, out_mat_dh);
-        }
-        else if (strcmp("out_mat_xc", word) == 0)
-        {
+        } else if (strcmp("out_mat_xc", word) == 0) {
             read_bool(ifs, out_mat_xc);
-        }
-        else if (strcmp("out_hr_npz", word) == 0)
-        {
+        } else if (strcmp("out_hr_npz", word) == 0) {
             read_bool(ifs, out_hr_npz);
-        }
-        else if (strcmp("out_dm_npz", word) == 0)
-        {
+        } else if (strcmp("out_dm_npz", word) == 0) {
             read_bool(ifs, out_dm_npz);
-        }
-        else if (strcmp("dm_to_rho", word) == 0)
-        {
+        } else if (strcmp("dm_to_rho", word) == 0) {
             read_bool(ifs, dm_to_rho);
-        }
-        else if (strcmp("out_interval", word) == 0)
-        {
+        } else if (strcmp("out_interval", word) == 0) {
             read_value(ifs, out_interval);
-        }
-        else if (strcmp("out_app_flag", word) == 0)
-        {
+        } else if (strcmp("out_app_flag", word) == 0) {
             read_bool(ifs, out_app_flag);
-        }
-        else if (strcmp("out_ndigits", word) == 0)
-        {
+        } else if (strcmp("out_ndigits", word) == 0) {
             read_value(ifs, out_ndigits);
-        }
-        else if (strcmp("out_mat_r", word) == 0)
-        {
+        } else if (strcmp("out_mat_r", word) == 0) {
             read_bool(ifs, out_mat_r);
-        }
-        else if (strcmp("out_wfc_lcao", word) == 0)
-        {
+        } else if (strcmp("out_wfc_lcao", word) == 0) {
             read_value(ifs, out_wfc_lcao);
-        }
-        else if (strcmp("out_alllog", word) == 0)
-        {
+        } else if (strcmp("out_alllog", word) == 0) {
             read_bool(ifs, out_alllog);
-        }
-        else if (strcmp("out_element_info", word) == 0)
-        {
+        } else if (strcmp("out_element_info", word) == 0) {
             read_bool(ifs, out_element_info);
-        }
-        else if (strcmp("dos_emin_ev", word) == 0)
-        {
+        } else if (strcmp("dos_emin_ev", word) == 0) {
             read_value(ifs, dos_emin_ev);
             dos_setemin = true;
-        }
-        else if (strcmp("dos_emax_ev", word) == 0)
-        {
+        } else if (strcmp("dos_emax_ev", word) == 0) {
             read_value(ifs, dos_emax_ev);
             dos_setemax = true;
-        }
-        else if (strcmp("dos_edelta_ev", word) == 0)
-        {
+        } else if (strcmp("dos_edelta_ev", word) == 0) {
             read_value(ifs, dos_edelta_ev);
-        }
-        else if (strcmp("dos_scale", word) == 0)
-        {
+        } else if (strcmp("dos_scale", word) == 0) {
             read_value(ifs, dos_scale);
-        }
-        else if (strcmp("dos_sigma", word) == 0)
-        {
+        } else if (strcmp("dos_sigma", word) == 0) {
             read_value(ifs, dos_sigma);
-        }
-        else if (strcmp("dos_nche", word) == 0)
-        {
+        } else if (strcmp("dos_nche", word) == 0) {
             read_value(ifs, dos_nche);
         }
 
@@ -1565,385 +1294,209 @@ bool Input::Read(const std::string& fn)
         // Parameters about LCAO
         // mohan add 2009-11-11
         //----------------------------------------------------------
-        else if (strcmp("lcao_ecut", word) == 0)
-        {
+        else if (strcmp("lcao_ecut", word) == 0) {
             read_value(ifs, lcao_ecut);
-        }
-        else if (strcmp("lcao_dk", word) == 0)
-        {
+        } else if (strcmp("lcao_dk", word) == 0) {
             read_value(ifs, lcao_dk);
-        }
-        else if (strcmp("lcao_dr", word) == 0)
-        {
+        } else if (strcmp("lcao_dr", word) == 0) {
             read_value(ifs, lcao_dr);
-        }
-        else if (strcmp("lcao_rmax", word) == 0)
-        {
+        } else if (strcmp("lcao_rmax", word) == 0) {
             read_value(ifs, lcao_rmax);
-        }
-        else if (strcmp("onsite_radius", word) == 0)
-        {
+        } else if (strcmp("onsite_radius", word) == 0) {
             read_value(ifs, onsite_radius);
-        }
-        else if (strcmp("num_stream", word) == 0)
-        {
+        } else if (strcmp("num_stream", word) == 0) {
             read_value(ifs, nstream);
         }
         //----------------------------------------------------------
         // Molecule Dynamics
         // Yu Liu add 2021-07-30
         //----------------------------------------------------------
-        else if (strcmp("md_type", word) == 0)
-        {
+        else if (strcmp("md_type", word) == 0) {
             read_value(ifs, mdp.md_type);
-        }
-        else if (strcmp("md_thermostat", word) == 0)
-        {
+        } else if (strcmp("md_thermostat", word) == 0) {
             read_value(ifs, mdp.md_thermostat);
-        }
-        else if (strcmp("md_nraise", word) == 0)
-        {
+        } else if (strcmp("md_nraise", word) == 0) {
             read_value(ifs, mdp.md_nraise);
-        }
-        else if (strcmp("cal_syns", word) == 0)
-        {
+        } else if (strcmp("cal_syns", word) == 0) {
             read_value(ifs, cal_syns);
-        }
-        else if (strcmp("dmax", word) == 0)
-        {
+        } else if (strcmp("dmax", word) == 0) {
             read_value(ifs, dmax);
-        }
-        else if (strcmp("md_tolerance", word) == 0)
-        {
+        } else if (strcmp("md_tolerance", word) == 0) {
             read_value(ifs, mdp.md_tolerance);
-        }
-        else if (strcmp("md_nstep", word) == 0)
-        {
+        } else if (strcmp("md_nstep", word) == 0) {
             read_value(ifs, mdp.md_nstep);
-        }
-        else if (strcmp("md_dt", word) == 0)
-        {
+        } else if (strcmp("md_dt", word) == 0) {
             read_value(ifs, mdp.md_dt);
-        }
-        else if (strcmp("md_tchain", word) == 0)
-        {
+        } else if (strcmp("md_tchain", word) == 0) {
             read_value(ifs, mdp.md_tchain);
-        }
-        else if (strcmp("md_tfirst", word) == 0)
-        {
+        } else if (strcmp("md_tfirst", word) == 0) {
             read_value(ifs, mdp.md_tfirst);
-        }
-        else if (strcmp("md_tlast", word) == 0)
-        {
+        } else if (strcmp("md_tlast", word) == 0) {
             read_value(ifs, mdp.md_tlast);
-        }
-        else if (strcmp("md_dumpfreq", word) == 0)
-        {
+        } else if (strcmp("md_dumpfreq", word) == 0) {
             read_value(ifs, mdp.md_dumpfreq);
-        }
-        else if (strcmp("md_restartfreq", word) == 0)
-        {
+        } else if (strcmp("md_restartfreq", word) == 0) {
             read_value(ifs, mdp.md_restartfreq);
-        }
-        else if (strcmp("md_seed", word) == 0)
-        {
+        } else if (strcmp("md_seed", word) == 0) {
             read_value(ifs, mdp.md_seed);
-        }
-        else if (strcmp("md_prec_level", word) == 0)
-        {
+        } else if (strcmp("md_prec_level", word) == 0) {
             read_value(ifs, mdp.md_prec_level);
-        }
-        else if (strcmp("md_restart", word) == 0)
-        {
+        } else if (strcmp("md_restart", word) == 0) {
             read_bool(ifs, mdp.md_restart);
-        }
-        else if (strcmp("md_pmode", word) == 0)
-        {
+        } else if (strcmp("md_pmode", word) == 0) {
             read_value(ifs, mdp.md_pmode);
-        }
-        else if (strcmp("md_pcouple", word) == 0)
-        {
+        } else if (strcmp("md_pcouple", word) == 0) {
             read_value(ifs, mdp.md_pcouple);
-        }
-        else if (strcmp("md_pchain", word) == 0)
-        {
+        } else if (strcmp("md_pchain", word) == 0) {
             read_value(ifs, mdp.md_pchain);
-        }
-        else if (strcmp("md_pfirst", word) == 0)
-        {
+        } else if (strcmp("md_pfirst", word) == 0) {
             read_value(ifs, mdp.md_pfirst);
-            if (!plast_find)
-            {
+            if (!plast_find) {
                 mdp.md_plast = mdp.md_pfirst;
             }
-        }
-        else if (strcmp("md_plast", word) == 0)
-        {
+        } else if (strcmp("md_plast", word) == 0) {
             read_value(ifs, mdp.md_plast);
             plast_find = true;
-        }
-        else if (strcmp("md_pfreq", word) == 0)
-        {
+        } else if (strcmp("md_pfreq", word) == 0) {
             read_value(ifs, mdp.md_pfreq);
-        }
-        else if (strcmp("lj_rcut", word) == 0)
-        {
+        } else if (strcmp("lj_rcut", word) == 0) {
             read_value(ifs, mdp.lj_rcut);
-        }
-        else if (strcmp("lj_epsilon", word) == 0)
-        {
+        } else if (strcmp("lj_epsilon", word) == 0) {
             read_value(ifs, mdp.lj_epsilon);
-        }
-        else if (strcmp("lj_sigma", word) == 0)
-        {
+        } else if (strcmp("lj_sigma", word) == 0) {
             read_value(ifs, mdp.lj_sigma);
-        }
-        else if (strcmp("msst_direction", word) == 0)
-        {
+        } else if (strcmp("msst_direction", word) == 0) {
             read_value(ifs, mdp.msst_direction);
-        }
-        else if (strcmp("msst_vel", word) == 0)
-        {
+        } else if (strcmp("msst_vel", word) == 0) {
             read_value(ifs, mdp.msst_vel);
-        }
-        else if (strcmp("msst_vis", word) == 0)
-        {
+        } else if (strcmp("msst_vis", word) == 0) {
             read_value(ifs, mdp.msst_vis);
-        }
-        else if (strcmp("msst_tscale", word) == 0)
-        {
+        } else if (strcmp("msst_tscale", word) == 0) {
             read_value(ifs, mdp.msst_tscale);
-        }
-        else if (strcmp("msst_qmass", word) == 0)
-        {
+        } else if (strcmp("msst_qmass", word) == 0) {
             read_value(ifs, mdp.msst_qmass);
-        }
-        else if (strcmp("md_tfreq", word) == 0)
-        {
+        } else if (strcmp("md_tfreq", word) == 0) {
             read_value(ifs, mdp.md_tfreq);
-        }
-        else if (strcmp("md_damp", word) == 0)
-        {
+        } else if (strcmp("md_damp", word) == 0) {
             read_value(ifs, mdp.md_damp);
-        }
-        else if (strcmp("pot_file", word) == 0)
-        {
+        } else if (strcmp("pot_file", word) == 0) {
             read_value(ifs, mdp.pot_file);
-        }
-        else if (strcmp("dump_force", word) == 0)
-        {
+        } else if (strcmp("dump_force", word) == 0) {
             read_bool(ifs, mdp.dump_force);
-        }
-        else if (strcmp("dump_vel", word) == 0)
-        {
+        } else if (strcmp("dump_vel", word) == 0) {
             read_bool(ifs, mdp.dump_vel);
-        }
-        else if (strcmp("dump_virial", word) == 0)
-        {
+        } else if (strcmp("dump_virial", word) == 0) {
             read_bool(ifs, mdp.dump_virial);
         }
         //----------------------------------------------------------
         // efield and dipole correction
         // Yu Liu add 2022-05-18
         //----------------------------------------------------------
-        else if (strcmp("efield_flag", word) == 0)
-        {
+        else if (strcmp("efield_flag", word) == 0) {
             read_bool(ifs, efield_flag);
-        }
-        else if (strcmp("dip_cor_flag", word) == 0)
-        {
+        } else if (strcmp("dip_cor_flag", word) == 0) {
             read_bool(ifs, dip_cor_flag);
-        }
-        else if (strcmp("efield_dir", word) == 0)
-        {
+        } else if (strcmp("efield_dir", word) == 0) {
             read_value(ifs, efield_dir);
-        }
-        else if (strcmp("efield_pos_max", word) == 0)
-        {
+        } else if (strcmp("efield_pos_max", word) == 0) {
             read_value(ifs, efield_pos_max);
-        }
-        else if (strcmp("efield_pos_dec", word) == 0)
-        {
+        } else if (strcmp("efield_pos_dec", word) == 0) {
             read_value(ifs, efield_pos_dec);
-        }
-        else if (strcmp("efield_amp", word) == 0)
-        {
+        } else if (strcmp("efield_amp", word) == 0) {
             read_value(ifs, efield_amp);
         }
         //----------------------------------------------------------
         // gatefield (compensating charge)
         // Yu Liu add 2022-09-13
         //----------------------------------------------------------
-        else if (strcmp("gate_flag", word) == 0)
-        {
+        else if (strcmp("gate_flag", word) == 0) {
             read_bool(ifs, gate_flag);
-        }
-        else if (strcmp("zgate", word) == 0)
-        {
+        } else if (strcmp("zgate", word) == 0) {
             read_value(ifs, zgate);
-        }
-        else if (strcmp("relax", word) == 0)
-        {
+        } else if (strcmp("relax", word) == 0) {
             read_bool(ifs, relax);
-        }
-        else if (strcmp("block", word) == 0)
-        {
+        } else if (strcmp("block", word) == 0) {
             read_bool(ifs, block);
-        }
-        else if (strcmp("block_down", word) == 0)
-        {
+        } else if (strcmp("block_down", word) == 0) {
             read_value(ifs, block_down);
-        }
-        else if (strcmp("block_up", word) == 0)
-        {
+        } else if (strcmp("block_up", word) == 0) {
             read_value(ifs, block_up);
-        }
-        else if (strcmp("block_height", word) == 0)
-        {
+        } else if (strcmp("block_height", word) == 0) {
             read_value(ifs, block_height);
         }
         //----------------------------------------------------------
         // tddft
         // Fuxiang He add 2016-10-26
         //----------------------------------------------------------
-        else if (strcmp("td_force_dt", word) == 0)
-        {
+        else if (strcmp("td_force_dt", word) == 0) {
             read_value(ifs, td_force_dt);
-        }
-        else if (strcmp("td_vext", word) == 0)
-        {
+        } else if (strcmp("td_vext", word) == 0) {
             read_value(ifs, td_vext);
-        }
-        else if (strcmp("td_vext_dire", word) == 0)
-        {
+        } else if (strcmp("td_vext_dire", word) == 0) {
             getline(ifs, td_vext_dire);
-        }
-        else if (strcmp("out_dipole", word) == 0)
-        {
+        } else if (strcmp("out_dipole", word) == 0) {
             read_value(ifs, out_dipole);
-        }
-        else if (strcmp("out_current", word) == 0)
-        {
+        } else if (strcmp("out_current", word) == 0) {
             read_value(ifs, out_current);
-        }
-        else if (strcmp("out_efield", word) == 0)
-        {
+        } else if (strcmp("out_efield", word) == 0) {
             read_value(ifs, out_efield);
-        }
-        else if (strcmp("out_vecpot", word) == 0)
-        {
+        } else if (strcmp("out_vecpot", word) == 0) {
             read_value(ifs, out_vecpot);
-        }
-        else if (strcmp("init_vecpot_file", word) == 0)
-        {
+        } else if (strcmp("init_vecpot_file", word) == 0) {
             read_value(ifs, init_vecpot_file);
-        }
-        else if (strcmp("td_print_eij", word) == 0)
-        {
+        } else if (strcmp("td_print_eij", word) == 0) {
             read_value(ifs, td_print_eij);
-        }
-        else if (strcmp("td_edm", word) == 0)
-        {
+        } else if (strcmp("td_edm", word) == 0) {
             read_value(ifs, td_edm);
-        }
-        else if (strcmp("td_propagator", word) == 0)
-        {
+        } else if (strcmp("td_propagator", word) == 0) {
             read_value(ifs, propagator);
-        }
-        else if (strcmp("td_stype", word) == 0)
-        {
+        } else if (strcmp("td_stype", word) == 0) {
             read_value(ifs, td_stype);
-        }
-        else if (strcmp("td_ttype", word) == 0)
-        {
+        } else if (strcmp("td_ttype", word) == 0) {
             getline(ifs, td_ttype);
-        }
-        else if (strcmp("td_tstart", word) == 0)
-        {
+        } else if (strcmp("td_tstart", word) == 0) {
             read_value(ifs, td_tstart);
-        }
-        else if (strcmp("td_tend", word) == 0)
-        {
+        } else if (strcmp("td_tend", word) == 0) {
             read_value(ifs, td_tend);
-        }
-        else if (strcmp("td_lcut1", word) == 0)
-        {
+        } else if (strcmp("td_lcut1", word) == 0) {
             read_value(ifs, td_lcut1);
-        }
-        else if (strcmp("td_lcut2", word) == 0)
-        {
+        } else if (strcmp("td_lcut2", word) == 0) {
             read_value(ifs, td_lcut2);
-        }
-        else if (strcmp("td_gauss_freq", word) == 0)
-        {
+        } else if (strcmp("td_gauss_freq", word) == 0) {
             getline(ifs, td_gauss_freq);
-        }
-        else if (strcmp("td_gauss_phase", word) == 0)
-        {
+        } else if (strcmp("td_gauss_phase", word) == 0) {
             getline(ifs, td_gauss_phase);
-        }
-        else if (strcmp("td_gauss_sigma", word) == 0)
-        {
+        } else if (strcmp("td_gauss_sigma", word) == 0) {
             getline(ifs, td_gauss_sigma);
-        }
-        else if (strcmp("td_gauss_t0", word) == 0)
-        {
+        } else if (strcmp("td_gauss_t0", word) == 0) {
             getline(ifs, td_gauss_t0);
-        }
-        else if (strcmp("td_gauss_amp", word) == 0)
-        {
+        } else if (strcmp("td_gauss_amp", word) == 0) {
             getline(ifs, td_gauss_amp);
-        }
-        else if (strcmp("td_trape_freq", word) == 0)
-        {
+        } else if (strcmp("td_trape_freq", word) == 0) {
             getline(ifs, td_trape_freq);
-        }
-        else if (strcmp("td_trape_phase", word) == 0)
-        {
+        } else if (strcmp("td_trape_phase", word) == 0) {
             getline(ifs, td_trape_phase);
-        }
-        else if (strcmp("td_trape_t1", word) == 0)
-        {
+        } else if (strcmp("td_trape_t1", word) == 0) {
             getline(ifs, td_trape_t1);
-        }
-        else if (strcmp("td_trape_t2", word) == 0)
-        {
+        } else if (strcmp("td_trape_t2", word) == 0) {
             getline(ifs, td_trape_t2);
-        }
-        else if (strcmp("td_trape_t3", word) == 0)
-        {
+        } else if (strcmp("td_trape_t3", word) == 0) {
             getline(ifs, td_trape_t3);
-        }
-        else if (strcmp("td_trape_amp", word) == 0)
-        {
+        } else if (strcmp("td_trape_amp", word) == 0) {
             getline(ifs, td_trape_amp);
-        }
-        else if (strcmp("td_trigo_freq1", word) == 0)
-        {
+        } else if (strcmp("td_trigo_freq1", word) == 0) {
             getline(ifs, td_trigo_freq1);
-        }
-        else if (strcmp("td_trigo_freq2", word) == 0)
-        {
+        } else if (strcmp("td_trigo_freq2", word) == 0) {
             getline(ifs, td_trigo_freq2);
-        }
-        else if (strcmp("td_trigo_phase1", word) == 0)
-        {
+        } else if (strcmp("td_trigo_phase1", word) == 0) {
             getline(ifs, td_trigo_phase1);
-        }
-        else if (strcmp("td_trigo_phase2", word) == 0)
-        {
+        } else if (strcmp("td_trigo_phase2", word) == 0) {
             getline(ifs, td_trigo_phase2);
-        }
-        else if (strcmp("td_trigo_amp", word) == 0)
-        {
+        } else if (strcmp("td_trigo_amp", word) == 0) {
             getline(ifs, td_trigo_amp);
-        }
-        else if (strcmp("td_heavi_t0", word) == 0)
-        {
+        } else if (strcmp("td_heavi_t0", word) == 0) {
             getline(ifs, td_heavi_t0);
-        }
-        else if (strcmp("td_heavi_amp", word) == 0)
-        {
+        } else if (strcmp("td_heavi_amp", word) == 0) {
             getline(ifs, td_heavi_amp);
         }
         // else if (strcmp("td_hhg_amp1", word) == 0)
@@ -1982,218 +1535,120 @@ bool Input::Read(const std::string& fn)
         // vdw
         // jiyy add 2019-08-04
         //----------------------------------------------------------
-        else if (strcmp("vdw_method", word) == 0)
-        {
+        else if (strcmp("vdw_method", word) == 0) {
             read_value(ifs, vdw_method);
-        }
-        else if (strcmp("vdw_s6", word) == 0)
-        {
+        } else if (strcmp("vdw_s6", word) == 0) {
             read_value(ifs, vdw_s6);
-        }
-        else if (strcmp("vdw_s8", word) == 0)
-        {
+        } else if (strcmp("vdw_s8", word) == 0) {
             read_value(ifs, vdw_s8);
-        }
-        else if (strcmp("vdw_a1", word) == 0)
-        {
+        } else if (strcmp("vdw_a1", word) == 0) {
             read_value(ifs, vdw_a1);
-        }
-        else if (strcmp("vdw_a2", word) == 0)
-        {
+        } else if (strcmp("vdw_a2", word) == 0) {
             read_value(ifs, vdw_a2);
-        }
-        else if (strcmp("vdw_d", word) == 0)
-        {
+        } else if (strcmp("vdw_d", word) == 0) {
             read_value(ifs, vdw_d);
-        }
-        else if (strcmp("vdw_abc", word) == 0)
-        {
+        } else if (strcmp("vdw_abc", word) == 0) {
             read_bool(ifs, vdw_abc);
-        }
-        else if (strcmp("vdw_cutoff_radius", word) == 0)
-        {
+        } else if (strcmp("vdw_cutoff_radius", word) == 0) {
             read_value(ifs, vdw_cutoff_radius);
-        }
-        else if (strcmp("vdw_radius_unit", word) == 0)
-        {
+        } else if (strcmp("vdw_radius_unit", word) == 0) {
             read_value(ifs, vdw_radius_unit);
-        }
-        else if (strcmp("vdw_cn_thr", word) == 0)
-        {
+        } else if (strcmp("vdw_cn_thr", word) == 0) {
             read_value(ifs, vdw_cn_thr);
-        }
-        else if (strcmp("vdw_cn_thr_unit", word) == 0)
-        {
+        } else if (strcmp("vdw_cn_thr_unit", word) == 0) {
             read_value(ifs, vdw_cn_thr_unit);
-        }
-        else if (strcmp("vdw_c6_file", word) == 0)
-        {
+        } else if (strcmp("vdw_c6_file", word) == 0) {
             read_value(ifs, vdw_C6_file);
-        }
-        else if (strcmp("vdw_c6_unit", word) == 0)
-        {
+        } else if (strcmp("vdw_c6_unit", word) == 0) {
             read_value(ifs, vdw_C6_unit);
-        }
-        else if (strcmp("vdw_r0_file", word) == 0)
-        {
+        } else if (strcmp("vdw_r0_file", word) == 0) {
             read_value(ifs, vdw_R0_file);
-        }
-        else if (strcmp("vdw_r0_unit", word) == 0)
-        {
+        } else if (strcmp("vdw_r0_unit", word) == 0) {
             read_value(ifs, vdw_R0_unit);
-        }
-        else if (strcmp("vdw_cutoff_type", word) == 0)
-        {
+        } else if (strcmp("vdw_cutoff_type", word) == 0) {
             read_value(ifs, vdw_cutoff_type);
-        }
-        else if (strcmp("vdw_cutoff_period", word) == 0)
-        {
+        } else if (strcmp("vdw_cutoff_period", word) == 0) {
             ifs >> vdw_cutoff_period.x >> vdw_cutoff_period.y;
             read_value(ifs, vdw_cutoff_period.z);
         }
         //--------------------------------------------------------
         // restart           Peize Lin 2020-04-04
         //--------------------------------------------------------
-        else if (strcmp("restart_save", word) == 0)
-        {
+        else if (strcmp("restart_save", word) == 0) {
             read_bool(ifs, restart_save);
-        }
-        else if (strcmp("restart_load", word) == 0)
-        {
+        } else if (strcmp("restart_load", word) == 0) {
             read_bool(ifs, restart_load);
-        }
-        else if (strcmp("ocp", word) == 0)
-        {
+        } else if (strcmp("ocp", word) == 0) {
             read_bool(ifs, ocp);
-        }
-        else if (strcmp("ocp_set", word) == 0)
-        {
+        } else if (strcmp("ocp_set", word) == 0) {
             getline(ifs, ocp_set);
             //			ifs.ignore(150, '\n');
-        }
-        else if (strcmp("out_mul", word) == 0)
-        {
+        } else if (strcmp("out_mul", word) == 0) {
             read_bool(ifs, out_mul);
         } // qifeng add 2019/9/10
         //----------------------------------------------------------
         // exx
         // Peize Lin add 2018-06-20
         //----------------------------------------------------------
-        else if (strcmp("exx_hybrid_alpha", word) == 0)
-        {
+        else if (strcmp("exx_hybrid_alpha", word) == 0) {
             read_value(ifs, exx_hybrid_alpha);
-        }
-        else if (strcmp("exx_hse_omega", word) == 0)
-        {
+        } else if (strcmp("exx_hse_omega", word) == 0) {
             read_value(ifs, exx_hse_omega);
-        }
-        else if (strcmp("exx_separate_loop", word) == 0)
-        {
+        } else if (strcmp("exx_separate_loop", word) == 0) {
             read_bool(ifs, exx_separate_loop);
-        }
-        else if (strcmp("exx_hybrid_step", word) == 0)
-        {
+        } else if (strcmp("exx_hybrid_step", word) == 0) {
             read_value(ifs, exx_hybrid_step);
-        }
-        else if (strcmp("exx_mixing_beta", word) == 0)
-        {
+        } else if (strcmp("exx_mixing_beta", word) == 0) {
             read_value(ifs, exx_mixing_beta);
-        }
-        else if (strcmp("exx_lambda", word) == 0)
-        {
+        } else if (strcmp("exx_lambda", word) == 0) {
             read_value(ifs, exx_lambda);
-        }
-        else if (strcmp("exx_real_number", word) == 0)
-        {
+        } else if (strcmp("exx_real_number", word) == 0) {
             read_value(ifs, exx_real_number);
-        }
-        else if (strcmp("exx_pca_threshold", word) == 0)
-        {
+        } else if (strcmp("exx_pca_threshold", word) == 0) {
             read_value(ifs, exx_pca_threshold);
-        }
-        else if (strcmp("exx_c_threshold", word) == 0)
-        {
+        } else if (strcmp("exx_c_threshold", word) == 0) {
             read_value(ifs, exx_c_threshold);
-        }
-        else if (strcmp("exx_v_threshold", word) == 0)
-        {
+        } else if (strcmp("exx_v_threshold", word) == 0) {
             read_value(ifs, exx_v_threshold);
-        }
-        else if (strcmp("exx_dm_threshold", word) == 0)
-        {
+        } else if (strcmp("exx_dm_threshold", word) == 0) {
             read_value(ifs, exx_dm_threshold);
-        }
-        else if (strcmp("exx_schwarz_threshold", word) == 0)
-        {
+        } else if (strcmp("exx_schwarz_threshold", word) == 0) {
             read_value(ifs, exx_schwarz_threshold);
-        }
-        else if (strcmp("exx_cauchy_threshold", word) == 0)
-        {
+        } else if (strcmp("exx_cauchy_threshold", word) == 0) {
             read_value(ifs, exx_cauchy_threshold);
-        }
-        else if (strcmp("exx_c_grad_threshold", word) == 0)
-        {
+        } else if (strcmp("exx_c_grad_threshold", word) == 0) {
             read_value(ifs, exx_c_grad_threshold);
-        }
-        else if (strcmp("exx_v_grad_threshold", word) == 0)
-        {
+        } else if (strcmp("exx_v_grad_threshold", word) == 0) {
             read_value(ifs, exx_v_grad_threshold);
-        }
-        else if (strcmp("exx_cauchy_force_threshold", word) == 0)
-        {
+        } else if (strcmp("exx_cauchy_force_threshold", word) == 0) {
             read_value(ifs, exx_cauchy_force_threshold);
-        }
-        else if (strcmp("exx_cauchy_stress_threshold", word) == 0)
-        {
+        } else if (strcmp("exx_cauchy_stress_threshold", word) == 0) {
             read_value(ifs, exx_cauchy_stress_threshold);
-        }
-        else if (strcmp("exx_ccp_threshold", word) == 0)
-        {
+        } else if (strcmp("exx_ccp_threshold", word) == 0) {
             read_value(ifs, exx_ccp_threshold);
-        }
-        else if (strcmp("exx_ccp_rmesh_times", word) == 0)
-        {
+        } else if (strcmp("exx_ccp_rmesh_times", word) == 0) {
             read_value(ifs, exx_ccp_rmesh_times);
-        }
-        else if (strcmp("exx_distribute_type", word) == 0)
-        {
+        } else if (strcmp("exx_distribute_type", word) == 0) {
             read_value(ifs, exx_distribute_type);
-        }
-        else if (strcmp("exx_opt_orb_lmax", word) == 0)
-        {
+        } else if (strcmp("exx_opt_orb_lmax", word) == 0) {
             read_value(ifs, exx_opt_orb_lmax);
-        }
-        else if (strcmp("exx_opt_orb_ecut", word) == 0)
-        {
+        } else if (strcmp("exx_opt_orb_ecut", word) == 0) {
             read_value(ifs, exx_opt_orb_ecut);
-        }
-        else if (strcmp("exx_opt_orb_tolerence", word) == 0)
-        {
+        } else if (strcmp("exx_opt_orb_tolerence", word) == 0) {
             read_value(ifs, exx_opt_orb_tolerence);
-        }
-        else if (strcmp("noncolin", word) == 0)
-        {
+        } else if (strcmp("noncolin", word) == 0) {
             read_bool(ifs, noncolin);
-        }
-        else if (strcmp("lspinorb", word) == 0)
-        {
+        } else if (strcmp("lspinorb", word) == 0) {
             read_bool(ifs, lspinorb);
-        }
-        else if (strcmp("soc_lambda", word) == 0)
-        {
+        } else if (strcmp("soc_lambda", word) == 0) {
             read_value(ifs, soc_lambda);
-        }
-        else if (strcmp("cell_factor", word) == 0)
-        {
+        } else if (strcmp("cell_factor", word) == 0) {
             read_value(ifs, cell_factor);
-        }
-        else if (strcmp("test_skip_ewald", word) == 0)
-        {
+        } else if (strcmp("test_skip_ewald", word) == 0) {
             read_bool(ifs, test_skip_ewald);
         }
         //----------------------------------------------------------
-        else if (strcmp("dft_plus_u", word) == 0)
-        {
+        else if (strcmp("dft_plus_u", word) == 0) {
             read_value(ifs, dft_plus_u);
         }
         // ignore to avoid error
@@ -2207,22 +1662,19 @@ bool Input::Read(const std::string& fn)
             ifs.ignore(150, '\n');
         else if (strcmp("yukawa_lambda", word) == 0)
             ifs.ignore(150, '\n');
-        else if (strcmp("uramping", word) == 0)
-        {
+        else if (strcmp("uramping", word) == 0) {
             ifs.ignore(150, '\n');
         }
         //----------------------------------------------------------------------------------
         //         Xin Qu added on 2020-08 for DFT+DMFT
         //----------------------------------------------------------------------------------
-        else if (strcmp("dft_plus_dmft", word) == 0)
-        {
+        else if (strcmp("dft_plus_dmft", word) == 0) {
             read_bool(ifs, dft_plus_dmft);
         }
         //----------------------------------------------------------------------------------
         //         Rong Shi added for RPA
         //----------------------------------------------------------------------------------
-        else if (strcmp("rpa", word) == 0)
-        {
+        else if (strcmp("rpa", word) == 0) {
             read_bool(ifs, rpa);
             if (rpa)
                 GlobalV::rpa_setorb = true;
@@ -2230,332 +1682,197 @@ bool Input::Read(const std::string& fn)
         //----------------------------------------------------------------------------------
         //    implicit solvation model       sunml added on 2022-04-04
         //----------------------------------------------------------------------------------
-        else if (strcmp("imp_sol", word) == 0)
-        {
+        else if (strcmp("imp_sol", word) == 0) {
             read_bool(ifs, imp_sol);
-        }
-        else if (strcmp("eb_k", word) == 0)
-        {
+        } else if (strcmp("eb_k", word) == 0) {
             read_value(ifs, eb_k);
-        }
-        else if (strcmp("tau", word) == 0)
-        {
+        } else if (strcmp("tau", word) == 0) {
             read_value(ifs, tau);
-        }
-        else if (strcmp("sigma_k", word) == 0)
-        {
+        } else if (strcmp("sigma_k", word) == 0) {
             read_value(ifs, sigma_k);
-        }
-        else if (strcmp("nc_k", word) == 0)
-        {
+        } else if (strcmp("nc_k", word) == 0) {
             read_value(ifs, nc_k);
         }
         //----------------------------------------------------------------------------------
         //    OFDFT sunliang added on 2022-05-05
         //----------------------------------------------------------------------------------
-        else if (strcmp("of_kinetic", word) == 0)
-        {
+        else if (strcmp("of_kinetic", word) == 0) {
             read_value(ifs, of_kinetic);
-        }
-        else if (strcmp("of_method", word) == 0)
-        {
+        } else if (strcmp("of_method", word) == 0) {
             read_value(ifs, of_method);
-        }
-        else if (strcmp("of_conv", word) == 0)
-        {
+        } else if (strcmp("of_conv", word) == 0) {
             read_value(ifs, of_conv);
-        }
-        else if (strcmp("of_tole", word) == 0)
-        {
+        } else if (strcmp("of_tole", word) == 0) {
             read_value(ifs, of_tole);
-        }
-        else if (strcmp("of_tolp", word) == 0)
-        {
+        } else if (strcmp("of_tolp", word) == 0) {
             read_value(ifs, of_tolp);
-        }
-        else if (strcmp("of_tf_weight", word) == 0)
-        {
+        } else if (strcmp("of_tf_weight", word) == 0) {
             read_value(ifs, of_tf_weight);
-        }
-        else if (strcmp("of_vw_weight", word) == 0)
-        {
+        } else if (strcmp("of_vw_weight", word) == 0) {
             read_value(ifs, of_vw_weight);
-        }
-        else if (strcmp("of_wt_alpha", word) == 0)
-        {
+        } else if (strcmp("of_wt_alpha", word) == 0) {
             read_value(ifs, of_wt_alpha);
-        }
-        else if (strcmp("of_wt_beta", word) == 0)
-        {
+        } else if (strcmp("of_wt_beta", word) == 0) {
             read_value(ifs, of_wt_beta);
-        }
-        else if (strcmp("of_wt_rho0", word) == 0)
-        {
+        } else if (strcmp("of_wt_rho0", word) == 0) {
             read_value(ifs, of_wt_rho0);
-        }
-        else if (strcmp("of_hold_rho0", word) == 0)
-        {
+        } else if (strcmp("of_hold_rho0", word) == 0) {
             read_bool(ifs, of_hold_rho0);
-        }
-        else if (strcmp("of_lkt_a", word) == 0)
-        {
+        } else if (strcmp("of_lkt_a", word) == 0) {
             read_value(ifs, of_lkt_a);
-        }
-        else if (strcmp("of_full_pw", word) == 0)
-        {
+        } else if (strcmp("of_full_pw", word) == 0) {
             read_bool(ifs, of_full_pw);
-        }
-        else if (strcmp("of_full_pw_dim", word) == 0)
-        {
+        } else if (strcmp("of_full_pw_dim", word) == 0) {
             read_value(ifs, of_full_pw_dim);
-        }
-        else if (strcmp("of_read_kernel", word) == 0)
-        {
+        } else if (strcmp("of_read_kernel", word) == 0) {
             read_bool(ifs, of_read_kernel);
-        }
-        else if (strcmp("of_kernel_file", word) == 0)
-        {
+        } else if (strcmp("of_kernel_file", word) == 0) {
             read_value(ifs, of_kernel_file);
-        }
-        else if (strcmp("bessel_nao_smooth", word) == 0)
-        {
+        } else if (strcmp("bessel_nao_smooth", word) == 0) {
             read_value(ifs, bessel_nao_smooth);
-        }
-        else if (strcmp("bessel_nao_sigma", word) == 0)
-        {
+        } else if (strcmp("bessel_nao_sigma", word) == 0) {
             read_value(ifs, bessel_nao_sigma);
-        }
-        else if (strcmp("bessel_nao_ecut", word) == 0)
-        {
+        } else if (strcmp("bessel_nao_ecut", word) == 0) {
             read_value(ifs, bessel_nao_ecut);
-        }
-        else if (strcmp("bessel_nao_rcut", word) == 0)
-        {
+        } else if (strcmp("bessel_nao_rcut", word) == 0) {
             // read_value(ifs, bessel_nao_rcut);
             read_value2stdvector(ifs, bessel_nao_rcuts);
-            bessel_nao_rcut = bessel_nao_rcuts[0]; // also compatible with old input file
-        }
-        else if (strcmp("bessel_nao_tolerence", word) == 0)
-        {
+            bessel_nao_rcut
+                = bessel_nao_rcuts[0]; // also compatible with old input file
+        } else if (strcmp("bessel_nao_tolerence", word) == 0) {
             read_value(ifs, bessel_nao_tolerence);
-        }
-        else if (strcmp("bessel_descriptor_lmax", word) == 0)
-        {
+        } else if (strcmp("bessel_descriptor_lmax", word) == 0) {
             read_value(ifs, bessel_descriptor_lmax);
-        }
-        else if (strcmp("bessel_descriptor_smooth", word) == 0)
-        {
+        } else if (strcmp("bessel_descriptor_smooth", word) == 0) {
             read_value(ifs, bessel_descriptor_smooth);
-        }
-        else if (strcmp("bessel_descriptor_sigma", word) == 0)
-        {
+        } else if (strcmp("bessel_descriptor_sigma", word) == 0) {
             read_value(ifs, bessel_descriptor_sigma);
-        }
-        else if (strcmp("bessel_descriptor_ecut", word) == 0)
-        {
+        } else if (strcmp("bessel_descriptor_ecut", word) == 0) {
             read_value(ifs, bessel_descriptor_ecut);
-        }
-        else if (strcmp("bessel_descriptor_rcut", word) == 0)
-        {
+        } else if (strcmp("bessel_descriptor_rcut", word) == 0) {
             read_value(ifs, bessel_descriptor_rcut);
-        }
-        else if (strcmp("bessel_descriptor_tolerence", word) == 0)
-        {
+        } else if (strcmp("bessel_descriptor_tolerence", word) == 0) {
             read_value(ifs, bessel_descriptor_tolerence);
         }
         //----------------------------------------------------------------------------------
         //    device control denghui added on 2022-11-05
         //----------------------------------------------------------------------------------
-        else if (strcmp("device", word) == 0)
-        {
+        else if (strcmp("device", word) == 0) {
             read_value(ifs, device);
         }
         //----------------------------------------------------------------------------------
         //    precision control denghui added on 2023-01-01
         //----------------------------------------------------------------------------------
-        else if (strcmp("precision", word) == 0)
-        {
+        else if (strcmp("precision", word) == 0) {
             read_value(ifs, precision);
         }
         //----------------------------------------------------------------------------------
         //    Deltaspin
         //----------------------------------------------------------------------------------
-        else if (strcmp("sc_mag_switch", word) == 0)
-        {
+        else if (strcmp("sc_mag_switch", word) == 0) {
             read_bool(ifs, sc_mag_switch);
-        }
-        else if (strcmp("decay_grad_switch", word) == 0)
-        {
+        } else if (strcmp("decay_grad_switch", word) == 0) {
             read_bool(ifs, decay_grad_switch);
-        }
-        else if (strcmp("sc_thr", word) == 0)
-        {
+        } else if (strcmp("sc_thr", word) == 0) {
             read_value(ifs, sc_thr);
-        }
-        else if (strcmp("nsc", word) == 0)
-        {
+        } else if (strcmp("nsc", word) == 0) {
             read_value(ifs, nsc);
-        }
-        else if (strcmp("nsc_min", word) == 0)
-        {
+        } else if (strcmp("nsc_min", word) == 0) {
             read_value(ifs, nsc_min);
-        }
-        else if (strcmp("sc_scf_nmin", word) == 0)
-        {
+        } else if (strcmp("sc_scf_nmin", word) == 0) {
             read_value(ifs, sc_scf_nmin);
-        }
-        else if (strcmp("alpha_trial", word) == 0)
-        {
+        } else if (strcmp("alpha_trial", word) == 0) {
             read_value(ifs, alpha_trial);
-        }
-        else if (strcmp("sccut", word) == 0)
-        {
+        } else if (strcmp("sccut", word) == 0) {
             read_value(ifs, sccut);
-        }
-        else if (strcmp("sc_file", word) == 0)
-        {
+        } else if (strcmp("sc_file", word) == 0) {
             read_value(ifs, sc_file);
         }
         //----------------------------------------------------------------------------------
         //    Quasiatomic orbital
         //----------------------------------------------------------------------------------
-        else if (strcmp("qo_switch", word) == 0)
-        {
+        else if (strcmp("qo_switch", word) == 0) {
             read_bool(ifs, qo_switch);
-        }
-        else if (strcmp("qo_basis", word) == 0)
-        {
+        } else if (strcmp("qo_basis", word) == 0) {
             read_value(ifs, qo_basis);
-        }
-        else if (strcmp("qo_thr", word) == 0)
-        {
+        } else if (strcmp("qo_thr", word) == 0) {
             read_value(ifs, qo_thr);
-        }
-        else if (strcmp("qo_strategy", word) == 0)
-        {
+        } else if (strcmp("qo_strategy", word) == 0) {
             read_value2stdvector(ifs, qo_strategy);
-        }
-        else if (strcmp("qo_screening_coeff", word) == 0)
-        {
+        } else if (strcmp("qo_screening_coeff", word) == 0) {
             read_value2stdvector(ifs, qo_screening_coeff);
         }
         //----------------------------------------------------------------------------------
         //    PEXSI
         //----------------------------------------------------------------------------------
-        else if (strcmp("pexsi_npole", word) == 0)
-        {
+        else if (strcmp("pexsi_npole", word) == 0) {
             read_value(ifs, pexsi_npole);
-        }
-        else if (strcmp("pexsi_inertia", word) == 0)
-        {
+        } else if (strcmp("pexsi_inertia", word) == 0) {
             read_value(ifs, pexsi_inertia);
-        }
-        else if (strcmp("pexsi_nmax", word) == 0)
-        {
+        } else if (strcmp("pexsi_nmax", word) == 0) {
             read_value(ifs, pexsi_nmax);
         }
         // else if (strcmp("pexsi_symbolic", word) == 0)
         // {
         //     read_value(ifs, pexsi_symbolic);
         // }
-        else if (strcmp("pexsi_comm", word) == 0)
-        {
+        else if (strcmp("pexsi_comm", word) == 0) {
             read_value(ifs, pexsi_comm);
-        }
-        else if (strcmp("pexsi_storage", word) == 0)
-        {
+        } else if (strcmp("pexsi_storage", word) == 0) {
             read_value(ifs, pexsi_storage);
-        }
-        else if (strcmp("pexsi_ordering", word) == 0)
-        {
+        } else if (strcmp("pexsi_ordering", word) == 0) {
             read_value(ifs, pexsi_ordering);
-        }
-        else if (strcmp("pexsi_row_ordering", word) == 0)
-        {
+        } else if (strcmp("pexsi_row_ordering", word) == 0) {
             read_value(ifs, pexsi_row_ordering);
-        }
-        else if (strcmp("pexsi_nproc", word) == 0)
-        {
+        } else if (strcmp("pexsi_nproc", word) == 0) {
             read_value(ifs, pexsi_nproc);
-        }
-        else if (strcmp("pexsi_symm", word) == 0)
-        {
+        } else if (strcmp("pexsi_symm", word) == 0) {
             read_value(ifs, pexsi_symm);
-        }
-        else if (strcmp("pexsi_trans", word) == 0)
-        {
+        } else if (strcmp("pexsi_trans", word) == 0) {
             read_value(ifs, pexsi_trans);
-        }
-        else if (strcmp("pexsi_method", word) == 0)
-        {
+        } else if (strcmp("pexsi_method", word) == 0) {
             read_value(ifs, pexsi_method);
-        }
-        else if (strcmp("pexsi_nproc_pole", word) == 0)
-        {
+        } else if (strcmp("pexsi_nproc_pole", word) == 0) {
             read_value(ifs, pexsi_nproc_pole);
         }
         // else if (strcmp("pexsi_spin", word) == 0)
         // {
         //     read_value(ifs, pexsi_spin);
         // }
-        else if (strcmp("pexsi_temp", word) == 0)
-        {
+        else if (strcmp("pexsi_temp", word) == 0) {
             read_value(ifs, pexsi_temp);
-        }
-        else if (strcmp("pexsi_gap", word) == 0)
-        {
+        } else if (strcmp("pexsi_gap", word) == 0) {
             read_value(ifs, pexsi_gap);
-        }
-        else if (strcmp("pexsi_delta_e", word) == 0)
-        {
+        } else if (strcmp("pexsi_delta_e", word) == 0) {
             read_value(ifs, pexsi_delta_e);
-        }
-        else if (strcmp("pexsi_mu_lower", word) == 0)
-        {
+        } else if (strcmp("pexsi_mu_lower", word) == 0) {
             read_value(ifs, pexsi_mu_lower);
-        }
-        else if (strcmp("pexsi_mu_upper", word) == 0)
-        {
+        } else if (strcmp("pexsi_mu_upper", word) == 0) {
             read_value(ifs, pexsi_mu_upper);
-        }
-        else if (strcmp("pexsi_mu", word) == 0)
-        {
+        } else if (strcmp("pexsi_mu", word) == 0) {
             read_value(ifs, pexsi_mu);
-        }
-        else if (strcmp("pexsi_mu_thr", word) == 0)
-        {
+        } else if (strcmp("pexsi_mu_thr", word) == 0) {
             read_value(ifs, pexsi_mu_thr);
-        }
-        else if (strcmp("pexsi_mu_expand", word) == 0)
-        {
+        } else if (strcmp("pexsi_mu_expand", word) == 0) {
             read_value(ifs, pexsi_mu_expand);
-        }
-        else if (strcmp("pexsi_mu_guard", word) == 0)
-        {
+        } else if (strcmp("pexsi_mu_guard", word) == 0) {
             read_value(ifs, pexsi_mu_guard);
-        }
-        else if (strcmp("pexsi_elec_thr", word) == 0)
-        {
+        } else if (strcmp("pexsi_elec_thr", word) == 0) {
             read_value(ifs, pexsi_elec_thr);
-        }
-        else if (strcmp("pexsi_zero_thr", word) == 0)
-        {
+        } else if (strcmp("pexsi_zero_thr", word) == 0) {
             read_value(ifs, pexsi_zero_thr);
         }
         //==========================================================
         // variables for elpa
         //==========================================================
-        else if (strcmp("elpa_num_thread", word) == 0)
-        {
+        else if (strcmp("elpa_num_thread", word) == 0) {
             read_value(ifs, elpa_num_thread);
-        }
-        else
-        {
+        } else {
             // xiaohui add 2015-09-15
-            if (word[0] != '#' && word[0] != '/')
-            {
+            if (word[0] != '#' && word[0] != '/') {
                 input_error = 1;
-                std::cout << " THE PARAMETER NAME '" << word << "' IS NOT USED!" << std::endl;
+                std::cout << " THE PARAMETER NAME '" << word << "' IS NOT USED!"
+                          << std::endl;
             }
             // mohan screen this 2012-06-30
             //			std::cout << " THE PARAMETER NAME '" << word
@@ -2572,156 +1889,127 @@ bool Input::Read(const std::string& fn)
            std::cout << "gamma_only_local = " << gamma_only_local <<std::endl;
         }*/
 
-        if (ifs.eof() != 0)
-        {
+        if (ifs.eof() != 0) {
             break;
-        }
-        else if (ifs.bad() != 0)
-        {
+        } else if (ifs.bad() != 0) {
             std::cout << " Bad input parameters. " << std::endl;
             return false;
-        }
-        else if (ifs.fail() != 0)
-        {
+        } else if (ifs.fail() != 0) {
             std::cout << " word = " << word << std::endl;
             std::cout << " Fail to read parameters. " << std::endl;
             ifs.clear();
             return false;
-        }
-        else if (ifs.good() == 0)
-        {
+        } else if (ifs.good() == 0) {
             break;
         }
     }
 
     // sunliang added on 2022-12-06
-    // To check if ntype in INPUT is equal to the atom species in STRU, if ntype is not set in INPUT, we will set it
-    // according to STRU.
-    if (this->stru_file == "")
-    {
+    // To check if ntype in INPUT is equal to the atom species in STRU, if ntype
+    // is not set in INPUT, we will set it according to STRU.
+    if (this->stru_file == "") {
         this->stru_file = "STRU";
     }
     double ntype_stru = this->count_ntype(this->stru_file);
-    if (this->ntype == 0)
-    {
+    if (this->ntype == 0) {
         this->ntype = ntype_stru;
-        GlobalV::ofs_running << "ntype in INPUT is 0, and it is automatically set to " << this->ntype
-                             << " according to STRU" << std::endl;
-    }
-    else if (this->ntype != ntype_stru)
-    {
-        ModuleBase::WARNING_QUIT("Input", "The ntype in INPUT is not equal to the ntype counted in STRU, check it.");
+        GlobalV::ofs_running
+            << "ntype in INPUT is 0, and it is automatically set to "
+            << this->ntype << " according to STRU" << std::endl;
+    } else if (this->ntype != ntype_stru) {
+        ModuleBase::WARNING_QUIT("Input",
+                                 "The ntype in INPUT is not equal to the ntype "
+                                 "counted in STRU, check it.");
     }
 
     //----------------------------------------------------------
     //       DFT+U    Xin Qu  added on 2020-10-29
     //----------------------------------------------------------
     hubbard_u = new double[ntype];
-    for (int i = 0; i < ntype; i++)
-    {
+    for (int i = 0; i < ntype; i++) {
         hubbard_u[i] = 0.0;
     }
 
     orbital_corr = new int[ntype];
-    for (int i = 0; i < ntype; i++)
-    {
+    for (int i = 0; i < ntype; i++) {
         orbital_corr[i] = -1;
     }
 
-    if (dft_plus_u)
-    {
+    if (dft_plus_u) {
         ifs.clear();
         ifs.seekg(0); // move to the beginning of the file
         ifs.rdstate();
-        while (ifs.good())
-        {
+        while (ifs.good()) {
             ifs >> word1;
             if (ifs.eof() != 0)
                 break;
-            strtolower(word1, word); // convert uppercase std::string to lower case; word1 --> word
+            strtolower(word1, word); // convert uppercase std::string to lower
+                                     // case; word1 --> word
 
-            if (strcmp("yukawa_potential", word) == 0)
-            {
+            if (strcmp("yukawa_potential", word) == 0) {
                 read_bool(ifs, yukawa_potential);
-            }
-            else if (strcmp("yukawa_lambda", word) == 0)
-            {
+            } else if (strcmp("yukawa_lambda", word) == 0) {
                 ifs >> yukawa_lambda;
-            }
-            else if (strcmp("uramping", word) == 0)
-            {
+            } else if (strcmp("uramping", word) == 0) {
                 read_value(ifs, uramping);
                 uramping /= ModuleBase::Ry_to_eV;
-            }
-            else if (strcmp("hubbard_u", word) == 0)
-            {
-                for (int i = 0; i < ntype; i++)
-                {
+            } else if (strcmp("hubbard_u", word) == 0) {
+                for (int i = 0; i < ntype; i++) {
                     ifs >> hubbard_u[i];
                     hubbard_u[i] /= ModuleBase::Ry_to_eV;
                 }
-            }
-            else if (strcmp("orbital_corr", word) == 0)
-            {
-                for (int i = 0; i < ntype; i++)
-                {
+            } else if (strcmp("orbital_corr", word) == 0) {
+                for (int i = 0; i < ntype; i++) {
                     ifs >> orbital_corr[i];
                 }
-            }
-            else if (strcmp("omc", word) == 0)
-            {
+            } else if (strcmp("omc", word) == 0) {
                 read_value(ifs, omc);
-            }
-            else
-            {
+            } else {
                 ifs.ignore(150, '\n');
             }
 
-            if (ifs.eof() != 0)
-            {
+            if (ifs.eof() != 0) {
                 break;
             }
         }
 
-        for (int i = 0; i < ntype; i++)
-        {
+        for (int i = 0; i < ntype; i++) {
 
-            if (hubbard_u[i] < -1.0e-3)
-            {
+            if (hubbard_u[i] < -1.0e-3) {
                 std::cout << " WRONG ARGUMENTS OF hubbard_u " << std::endl;
                 exit(0);
             }
 
-            if ((orbital_corr[i] != -1) && (orbital_corr[i] != 0) && (orbital_corr[i] != 1) && (orbital_corr[i] != 2)
-                && (orbital_corr[i] != 3))
-            {
+            if ((orbital_corr[i] != -1) && (orbital_corr[i] != 0)
+                && (orbital_corr[i] != 1) && (orbital_corr[i] != 2)
+                && (orbital_corr[i] != 3)) {
                 std::cout << " WRONG ARGUMENTS OF orbital_corr " << std::endl;
                 exit(0);
             }
         }
 
         bool close_plus_u = 1;
-        for (int i = 0; i < ntype; i++)
-        {
+        for (int i = 0; i < ntype; i++) {
             if (orbital_corr[i] != -1)
                 close_plus_u = 0;
         }
-        if (close_plus_u)
-        {
+        if (close_plus_u) {
             dft_plus_u = 0;
-            GlobalV::ofs_running << "No atoms are correlated, DFT+U is closed!!!" << std::endl;
+            GlobalV::ofs_running
+                << "No atoms are correlated, DFT+U is closed!!!" << std::endl;
         }
 
-        if (strcmp("lcao", basis_type.c_str()) != 0)
-        {
-            std::cout << " WRONG ARGUMENTS OF basis_type, only lcao is support " << std::endl;
+        if (strcmp("lcao", basis_type.c_str()) != 0) {
+            std::cout << " WRONG ARGUMENTS OF basis_type, only lcao is support "
+                      << std::endl;
             exit(0);
         }
 
-        if (strcmp("genelpa", ks_solver.c_str()) != 0 && strcmp(ks_solver.c_str(), "scalapack_gvx") != 0
-            && strcmp(ks_solver.c_str(), "default") != 0)
-        {
-            std::cout << " WRONG ARGUMENTS OF ks_solver in DFT+U routine, only genelpa and scalapack_gvx are supported "
+        if (strcmp("genelpa", ks_solver.c_str()) != 0
+            && strcmp(ks_solver.c_str(), "scalapack_gvx") != 0
+            && strcmp(ks_solver.c_str(), "default") != 0) {
+            std::cout << " WRONG ARGUMENTS OF ks_solver in DFT+U routine, only "
+                         "genelpa and scalapack_gvx are supported "
                       << std::endl;
             std::cout << " You'are using " << ks_solver.c_str() << std::endl;
             exit(0);
@@ -2731,82 +2019,70 @@ bool Input::Read(const std::string& fn)
     //----------------------------------------------------------
     //       DFT+DMFT    Xin Qu  added on 2020-08
     //----------------------------------------------------------
-    if (dft_plus_dmft)
-    {
+    if (dft_plus_dmft) {
         ifs.clear();
         ifs.seekg(0); // move to the beginning of the file
         ifs.rdstate();
-        while (ifs.good())
-        {
+        while (ifs.good()) {
             ifs >> word1;
-            strtolower(word1, word); // convert uppercase std::string to lower case; word1 --> word
+            strtolower(word1, word); // convert uppercase std::string to lower
+                                     // case; word1 --> word
 
-            if (strcmp("hubbard_u", word) == 0)
-            {
-                for (int i = 0; i < ntype; i++)
-                {
+            if (strcmp("hubbard_u", word) == 0) {
+                for (int i = 0; i < ntype; i++) {
                     ifs >> hubbard_u[i];
                     hubbard_u[i] /= ModuleBase::Ry_to_eV;
                 }
-            }
-            else if (strcmp("orbital_corr", word) == 0)
-            {
-                for (int i = 0; i < ntype; i++)
-                {
+            } else if (strcmp("orbital_corr", word) == 0) {
+                for (int i = 0; i < ntype; i++) {
                     ifs >> orbital_corr[i];
                 }
-            }
-            else
+            } else
                 ifs.ignore(150, '\n');
 
             if (ifs.eof() != 0)
                 break;
         }
 
-        for (int i = 0; i < ntype; i++)
-        {
+        for (int i = 0; i < ntype; i++) {
 
-            if (hubbard_u[i] < -1.0e-3)
-            {
+            if (hubbard_u[i] < -1.0e-3) {
                 std::cout << " WRONG ARGUMENTS OF hubbard_u " << std::endl;
                 exit(0);
             }
 
-            if ((orbital_corr[i] != -1) && (orbital_corr[i] != 0) && (orbital_corr[i] != 1) && (orbital_corr[i] != 2)
-                && (orbital_corr[i] != 3))
-            {
+            if ((orbital_corr[i] != -1) && (orbital_corr[i] != 0)
+                && (orbital_corr[i] != 1) && (orbital_corr[i] != 2)
+                && (orbital_corr[i] != 3)) {
                 std::cout << " WRONG ARGUMENTS OF orbital_corr " << std::endl;
                 exit(0);
             }
         }
 
         bool dmft_flag = false;
-        for (int i = 0; i < ntype; i++)
-        {
-            if (orbital_corr[i] != -1)
-            {
+        for (int i = 0; i < ntype; i++) {
+            if (orbital_corr[i] != -1) {
                 dmft_flag = true;
                 break;
             }
         }
 
-        if (!dmft_flag)
-        {
+        if (!dmft_flag) {
             std::cout << "No atoms are correlated!!!" << std::endl;
             exit(0);
         }
 
-        if (strcmp("lcao", basis_type.c_str()) != 0)
-        {
-            std::cout << " WRONG ARGUMENTS OF basis_type, only lcao is support " << std::endl;
+        if (strcmp("lcao", basis_type.c_str()) != 0) {
+            std::cout << " WRONG ARGUMENTS OF basis_type, only lcao is support "
+                      << std::endl;
             exit(0);
         }
 
         /*
         if (strcmp("genelpa", ks_solver.c_str()) != 0)
         {
-            std::cout << " WRONG ARGUMENTS OF ks_solver in DFT+DMFT routine, only genelpa is support " << std::endl;
-            exit(0);
+            std::cout << " WRONG ARGUMENTS OF ks_solver in DFT+DMFT routine,
+        only genelpa is support " << std::endl; exit(0);
         }
          */
     }
@@ -2814,11 +2090,19 @@ bool Input::Read(const std::string& fn)
     if (basis_type == "pw" && gamma_only != 0) // pengfei Li add 2015-1-31
     {
         gamma_only = 0;
-        GlobalV::ofs_running << " WARNING : gamma_only has not been implemented for pw yet" << std::endl;
-        GlobalV::ofs_running << " the INPUT parameter gamma_only has been reset to 0" << std::endl;
-        GlobalV::ofs_running << " and a new KPT is generated with gamma point as the only k point" << std::endl;
+        GlobalV::ofs_running
+            << " WARNING : gamma_only has not been implemented for pw yet"
+            << std::endl;
+        GlobalV::ofs_running
+            << " the INPUT parameter gamma_only has been reset to 0"
+            << std::endl;
+        GlobalV::ofs_running << " and a new KPT is generated with gamma point "
+                                "as the only k point"
+                             << std::endl;
 
-        GlobalV::ofs_warning << " Auto generating k-points file: " << GlobalV::global_kpoint_card << std::endl;
+        GlobalV::ofs_warning
+            << " Auto generating k-points file: " << GlobalV::global_kpoint_card
+            << std::endl;
         std::ofstream ofs(GlobalV::global_kpoint_card.c_str());
         ofs << "K_POINTS" << std::endl;
         ofs << "0" << std::endl;
@@ -2827,36 +2111,39 @@ bool Input::Read(const std::string& fn)
         ofs.close();
 
         // std::cout << "gamma_only =" << gamma_only << std::endl;
-    }
-    else if ((basis_type == "lcao" || basis_type == "lcao_in_pw") && (gamma_only == 1))
-    {
+    } else if ((basis_type == "lcao" || basis_type == "lcao_in_pw")
+               && (gamma_only == 1)) {
         gamma_only_local = 1;
         // std::cout << "gamma_only_local =" << gamma_only_local << std::endl;
-        if (esolver_type == "tddft")
-        {
-            GlobalV::ofs_running << " WARNING : gamma_only is not applicable for tddft" << std::endl;
+        if (esolver_type == "tddft") {
+            GlobalV::ofs_running
+                << " WARNING : gamma_only is not applicable for tddft"
+                << std::endl;
             gamma_only_local = 0;
         }
     }
-    if ((out_mat_r || out_mat_hs2 || out_mat_t || out_mat_dh || out_hr_npz || out_dm_npz || dm_to_rho)
-        && gamma_only_local)
-    {
+    if ((out_mat_r || out_mat_hs2 || out_mat_t || out_mat_dh || out_hr_npz
+         || out_dm_npz || dm_to_rho)
+        && gamma_only_local) {
         ModuleBase::WARNING_QUIT("Input",
-                                 "printing of H(R)/S(R)/dH(R)/T(R)/DM(R) is not available for gamma only calculations");
+                                 "printing of H(R)/S(R)/dH(R)/T(R)/DM(R) is "
+                                 "not available for gamma only calculations");
     }
-    if (dm_to_rho && GlobalV::NPROC > 1)
-    {
-        ModuleBase::WARNING_QUIT("Input", "dm_to_rho is not available for parallel calculations");
+    if (dm_to_rho && GlobalV::NPROC > 1) {
+        ModuleBase::WARNING_QUIT(
+            "Input",
+            "dm_to_rho is not available for parallel calculations");
     }
-    if (out_hr_npz || out_dm_npz || dm_to_rho)
-    {
+    if (out_hr_npz || out_dm_npz || dm_to_rho) {
 #ifndef __USECNPY
-        ModuleBase::WARNING_QUIT("Input", "to write in npz format, please recompile with -DENABLE_CNPY=1");
+        ModuleBase::WARNING_QUIT(
+            "Input",
+            "to write in npz format, please recompile with -DENABLE_CNPY=1");
 #endif
     }
-    if (out_mat_dh && nspin == 4)
-    {
-        ModuleBase::WARNING_QUIT("Input", "priting of dH not available for nspin = 4");
+    if (out_mat_dh && nspin == 4) {
+        ModuleBase::WARNING_QUIT("Input",
+                                 "priting of dH not available for nspin = 4");
     }
 
     return true;
@@ -2870,109 +2157,80 @@ void Input::Default_2(void) // jiyy add 2019-08-04
     // vdw
     // jiyy add 2019-08-04
     //==========================================================
-    if (vdw_s6 == "default")
-    {
-        if (vdw_method == "d2")
-        {
+    if (vdw_s6 == "default") {
+        if (vdw_method == "d2") {
             vdw_s6 = "0.75";
-        }
-        else if (vdw_method == "d3_0" || vdw_method == "d3_bj")
-        {
+        } else if (vdw_method == "d3_0" || vdw_method == "d3_bj") {
             vdw_s6 = "1.0";
         }
     }
-    if (vdw_s8 == "default")
-    {
-        if (vdw_method == "d3_0")
-        {
+    if (vdw_s8 == "default") {
+        if (vdw_method == "d3_0") {
             vdw_s8 = "0.722";
-        }
-        else if (vdw_method == "d3_bj")
-        {
+        } else if (vdw_method == "d3_bj") {
             vdw_s8 = "0.7875";
         }
     }
-    if (vdw_a1 == "default")
-    {
-        if (vdw_method == "d3_0")
-        {
+    if (vdw_a1 == "default") {
+        if (vdw_method == "d3_0") {
             vdw_a1 = "1.217";
-        }
-        else if (vdw_method == "d3_bj")
-        {
+        } else if (vdw_method == "d3_bj") {
             vdw_a1 = "0.4289";
         }
     }
-    if (vdw_a2 == "default")
-    {
-        if (vdw_method == "d3_0")
-        {
+    if (vdw_a2 == "default") {
+        if (vdw_method == "d3_0") {
             vdw_a2 = "1.0";
-        }
-        else if (vdw_method == "d3_bj")
-        {
+        } else if (vdw_method == "d3_bj") {
             vdw_a2 = "4.4407";
         }
     }
-    if (vdw_cutoff_radius == "default")
-    {
-        if (vdw_method == "d2")
-        {
+    if (vdw_cutoff_radius == "default") {
+        if (vdw_method == "d2") {
             vdw_cutoff_radius = "56.6918";
-        }
-        else if (vdw_method == "d3_0" || vdw_method == "d3_bj")
-        {
+        } else if (vdw_method == "d3_0" || vdw_method == "d3_bj") {
             vdw_cutoff_radius = "95";
         }
     }
 
-    if (nx * ny * nz && ndx * ndy * ndz == 0)
-    {
+    if (nx * ny * nz && ndx * ndy * ndz == 0) {
         ndx = nx;
         ndy = ny;
         ndz = nz;
     }
-    if (ndx * ndy * ndz && nx * ny * nz == 0)
-    {
+    if (ndx * ndy * ndz && nx * ny * nz == 0) {
         nx = ndx;
         ny = ndy;
         nz = ndz;
     }
-    if (ndx > nx || ndy > ny || ndz > nz)
-    {
+    if (ndx > nx || ndy > ny || ndz > nz) {
         GlobalV::double_grid = true;
     }
 
-    if (ecutrho <= 0.0)
-    {
+    if (ecutrho <= 0.0) {
         ecutrho = 4.0 * ecutwfc;
     }
-    if (nx * ny * nz == 0 && ecutrho / ecutwfc > 4 + 1e-8)
-    {
+    if (nx * ny * nz == 0 && ecutrho / ecutwfc > 4 + 1e-8) {
         GlobalV::double_grid = true;
     }
 
-    if (esolver_type == "sdft" && psi_initializer)
-    {
-        GlobalV::ofs_warning << "psi_initializer is not available for sdft, it is automatically set to false"
+    if (esolver_type == "sdft" && psi_initializer) {
+        GlobalV::ofs_warning << "psi_initializer is not available for sdft, it "
+                                "is automatically set to false"
                              << std::endl;
         psi_initializer = false;
     }
 
-    if (nbndsto_str == "all")
-    {
+    if (nbndsto_str == "all") {
         nbands_sto = 0;
-    }
-    else if (nbndsto_str == "0" && esolver_type == "sdft")
-    {
+    } else if (nbndsto_str == "0" && esolver_type == "sdft") {
         esolver_type = "ksdft";
     }
     if (esolver_type != "sdft")
         bndpar = 1;
     if (bndpar > GlobalV::NPROC)
         bndpar = GlobalV::NPROC;
-    if (method_sto != 1 && method_sto != 2)
-    {
+    if (method_sto != 1 && method_sto != 2) {
         method_sto = 2;
     }
     if (of_wt_rho0 != 0)
@@ -2982,60 +2240,62 @@ void Input::Default_2(void) // jiyy add 2019-08-04
     if (of_kinetic != "wt")
         of_read_kernel = false; // sunliang add 2022-09-12
 
-    if (dft_functional == "default" && use_paw)
-    {
-        ModuleBase::WARNING_QUIT("Input", "dft_functional must be set when use_paw is true");
+    if (dft_functional == "default" && use_paw) {
+        ModuleBase::WARNING_QUIT(
+            "Input",
+            "dft_functional must be set when use_paw is true");
     }
 
-    if (exx_hybrid_alpha == "default")
-    {
+    if (exx_hybrid_alpha == "default") {
         std::string dft_functional_lower = dft_functional;
-        std::transform(dft_functional.begin(), dft_functional.end(), dft_functional_lower.begin(), tolower);
+        std::transform(dft_functional.begin(),
+                       dft_functional.end(),
+                       dft_functional_lower.begin(),
+                       tolower);
         if (dft_functional_lower == "hf")
             exx_hybrid_alpha = "1";
-        else if (dft_functional_lower == "pbe0" || dft_functional_lower == "hse" || dft_functional_lower == "scan0")
+        else if (dft_functional_lower == "pbe0" || dft_functional_lower == "hse"
+                 || dft_functional_lower == "scan0")
             exx_hybrid_alpha = "0.25";
-        else // no exx in scf, but will change to non-zero in postprocess like rpa
+        else // no exx in scf, but will change to non-zero in postprocess like
+             // rpa
             exx_hybrid_alpha = "0";
     }
-    if (exx_real_number == "default")
-    {
+    if (exx_real_number == "default") {
         if (gamma_only)
             exx_real_number = "1";
         else
             exx_real_number = "0";
     }
-    if (exx_ccp_rmesh_times == "default")
-    {
+    if (exx_ccp_rmesh_times == "default") {
         std::string dft_functional_lower = dft_functional;
-        std::transform(dft_functional.begin(), dft_functional.end(), dft_functional_lower.begin(), tolower);
-        if (dft_functional_lower == "hf" || dft_functional_lower == "pbe0" || dft_functional_lower == "scan0")
+        std::transform(dft_functional.begin(),
+                       dft_functional.end(),
+                       dft_functional_lower.begin(),
+                       tolower);
+        if (dft_functional_lower == "hf" || dft_functional_lower == "pbe0"
+            || dft_functional_lower == "scan0")
             exx_ccp_rmesh_times = "5";
         else if (dft_functional_lower == "hse")
             exx_ccp_rmesh_times = "1.5";
         else // no exx in scf
             exx_ccp_rmesh_times = "1";
     }
-    if (symmetry == "default")
-    { // deal with no-forced default value
-        if (gamma_only || calculation == "nscf" || calculation == "get_S" || calculation == "get_pchg"
-            || calculation == "get_wf")
-            symmetry = "0"; // if md or exx, symmetry will be force-set to 0 or -1 later
+    if (symmetry == "default") { // deal with no-forced default value
+        if (gamma_only || calculation == "nscf" || calculation == "get_S"
+            || calculation == "get_pchg" || calculation == "get_wf")
+            symmetry = "0"; // if md or exx, symmetry will be force-set to 0 or
+                            // -1 later
         else
             symmetry = "1";
     }
-    if (diago_proc <= 0)
-    {
+    if (diago_proc <= 0) {
+        diago_proc = GlobalV::NPROC;
+    } else if (diago_proc > GlobalV::NPROC) {
         diago_proc = GlobalV::NPROC;
     }
-    else if (diago_proc > GlobalV::NPROC)
-    {
-        diago_proc = GlobalV::NPROC;
-    }
-    if (calculation == "scf")
-    {
-        if (mem_saver == 1)
-        {
+    if (calculation == "scf") {
+        if (mem_saver == 1) {
             mem_saver = 0;
             ModuleBase::GlobalFunc::AUTO_SET("mem_saver", "0");
         }
@@ -3046,35 +2306,31 @@ void Input::Default_2(void) // jiyy add 2019-08-04
                     cal_force = 1;
                 else
                 {
-                    cal_force = 0;//modified by zhengdy-soc, can't calculate force now!
-                    std::cout<<"sorry, can't calculate force with soc now, would be implement in next
-           version!"<<std::endl;
+                    cal_force = 0;//modified by zhengdy-soc, can't calculate
+           force now! std::cout<<"sorry, can't calculate force with soc now,
+           would be implement in next version!"<<std::endl;
                 }
         */
         this->relax_nmax = 1;
-    }
-    else if (calculation == "relax") // pengfei 2014-10-13
+    } else if (calculation == "relax") // pengfei 2014-10-13
     {
-        if (mem_saver == 1)
-        {
+        if (mem_saver == 1) {
             mem_saver = 0;
             ModuleBase::GlobalFunc::AUTO_SET("mem_saver", "0");
         }
         cal_force = 1;
         if (!this->relax_nmax)
             this->relax_nmax = 50;
-    }
-    else if (calculation == "nscf" || calculation == "get_S")
-    {
+    } else if (calculation == "nscf" || calculation == "get_S") {
         GlobalV::CALCULATION = "nscf";
         this->relax_nmax = 1;
         out_stru = 0;
 
         if (basis_type == "pw"
-            && calculation == "get_S") // xiaohui add 2013-09-01. Attention! maybe there is some problem
+            && calculation == "get_S") // xiaohui add 2013-09-01. Attention!
+                                       // maybe there is some problem
         {
-            if (pw_diag_thr > 1.0e-3)
-            {
+            if (pw_diag_thr > 1.0e-3) {
                 pw_diag_thr = 1.0e-5;
             }
         }
@@ -3083,14 +2339,11 @@ void Input::Default_2(void) // jiyy add 2019-08-04
             cal_force = false;
             ModuleBase::GlobalFunc::AUTO_SET("cal_force", "false");
         }
-        if (init_chg != "file")
-        {
+        if (init_chg != "file") {
             init_chg = "file";
             ModuleBase::GlobalFunc::AUTO_SET("init_chg", init_chg);
         }
-    }
-    else if (calculation == "get_pchg")
-    {
+    } else if (calculation == "get_pchg") {
         GlobalV::CALCULATION = "get_pchg";
         this->relax_nmax = 1;
         out_stru = 0;
@@ -3105,9 +2358,7 @@ void Input::Default_2(void) // jiyy add 2019-08-04
         out_dm = 0;
         out_dm1 = 0;
         out_pot = 0;
-    }
-    else if (calculation == "get_wf")
-    {
+    } else if (calculation == "get_wf") {
         GlobalV::CALCULATION = "get_wf"; // mohan fix 2011-11-04
         this->relax_nmax = 1;
         out_stru = 0;
@@ -3122,60 +2373,49 @@ void Input::Default_2(void) // jiyy add 2019-08-04
         out_dm = 0;
         out_dm1 = 0;
         out_pot = 0;
-    }
-    else if (calculation == "md") // mohan add 2011-11-04
+    } else if (calculation == "md") // mohan add 2011-11-04
     {
         GlobalV::CALCULATION = "md";
         symmetry = "0";
         cal_force = 1;
-        if (mdp.md_nstep == 0)
-        {
-            GlobalV::ofs_running << "md_nstep should be set. Autoset md_nstep to 50!" << std::endl;
+        if (mdp.md_nstep == 0) {
+            GlobalV::ofs_running
+                << "md_nstep should be set. Autoset md_nstep to 50!"
+                << std::endl;
             mdp.md_nstep = 50;
         }
         if (!out_md_control)
             out_level = "m"; // zhengdy add 2019-04-07
 
-        if (mdp.md_tfreq == 0)
-        {
+        if (mdp.md_tfreq == 0) {
             mdp.md_tfreq = 1.0 / 40 / mdp.md_dt;
         }
-        if (mdp.md_pfreq == 0)
-        {
+        if (mdp.md_pfreq == 0) {
             mdp.md_pfreq = 1.0 / 400 / mdp.md_dt;
         }
-        if (mdp.md_tfirst < 0 || mdp.md_restart)
-        {
+        if (mdp.md_tfirst < 0 || mdp.md_restart) {
             init_vel = 1;
         }
-        if (esolver_type == "lj" || esolver_type == "dp" || mdp.md_type == "msst" || mdp.md_type == "npt")
-        {
+        if (esolver_type == "lj" || esolver_type == "dp"
+            || mdp.md_type == "msst" || mdp.md_type == "npt") {
             cal_stress = 1;
         }
 
         // md_prec_level only used in vc-md  liuyu 2023-03-27
-        if (mdp.md_type != "msst" && mdp.md_type != "npt")
-        {
+        if (mdp.md_type != "msst" && mdp.md_type != "npt") {
             mdp.md_prec_level = 0;
         }
-    }
-    else if (calculation == "cell-relax") // mohan add 2011-11-04
+    } else if (calculation == "cell-relax") // mohan add 2011-11-04
     {
         cal_force = 1;
         cal_stress = 1;
         if (!this->relax_nmax)
             this->relax_nmax = 50;
-    }
-    else if (calculation == "test_memory")
-    {
+    } else if (calculation == "test_memory") {
         this->relax_nmax = 1;
-    }
-    else if (calculation == "test_neighbour")
-    {
+    } else if (calculation == "test_neighbour") {
         this->relax_nmax = 1;
-    }
-    else if (calculation == "gen_bessel")
-    {
+    } else if (calculation == "gen_bessel") {
         this->relax_nmax = 1;
     }
 
@@ -3185,47 +2425,41 @@ void Input::Default_2(void) // jiyy add 2019-08-04
         {
             ks_solver = "cg";
             ModuleBase::GlobalFunc::AUTO_SET("ks_solver", "cg");
-        }
-        else if (ks_solver == "cg")
-        {
+        } else if (ks_solver == "cg") {
             GlobalV::ofs_warning << " It's ok to use cg." << std::endl;
             // new rule, mohan add 2012-02-11
             // otherwise, there need wave functions transfers
             // if(diago_type=="cg") xiaohui modify 2013-09-01
-            if (diago_proc != GlobalV::NPROC)
-            {
-                ModuleBase::WARNING("Input", "when CG is used for diago, diago_proc==GlobalV::NPROC");
+            if (diago_proc != GlobalV::NPROC) {
+                ModuleBase::WARNING(
+                    "Input",
+                    "when CG is used for diago, diago_proc==GlobalV::NPROC");
                 diago_proc = GlobalV::NPROC;
             }
-        }
-        else if (ks_solver == "dav" || ks_solver == "dav_subspace")
-        {
+        } else if (ks_solver == "dav" || ks_solver == "dav_subspace") {
             GlobalV::ofs_warning << " It's ok to use dav." << std::endl;
         }
         //
         bx = 1;
         by = 1;
         bz = 1;
-    }
-    else if (basis_type == "lcao_in_pw")
-    {
-        if (ks_solver != "lapack")
-        {
-            ModuleBase::WARNING_QUIT("Input", "ks_solver must be lapack when basis_type is lcao_in_pw");
-        }
-        else
-        {
+    } else if (basis_type == "lcao_in_pw") {
+        if (ks_solver != "lapack") {
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "ks_solver must be lapack when basis_type is lcao_in_pw");
+        } else {
             /*
                 then psi initialization setting adjustment
             */
-            if (!psi_initializer)
-            {
+            if (!psi_initializer) {
                 psi_initializer = true;
             }
-            if (init_wfc != "nao")
-            {
+            if (init_wfc != "nao") {
                 init_wfc = "nao";
-                GlobalV::ofs_warning << "init_wfc is set to nao when basis_type is lcao_in_pw" << std::endl;
+                GlobalV::ofs_warning
+                    << "init_wfc is set to nao when basis_type is lcao_in_pw"
+                    << std::endl;
             }
         }
         /*
@@ -3234,18 +2468,12 @@ void Input::Default_2(void) // jiyy add 2019-08-04
         bx = 1;
         by = 1;
         bz = 1;
-    }
-    else if (basis_type == "lcao")
-    {
-        if (ks_solver == "default")
-        {
-            if (device == "gpu")
-            {
+    } else if (basis_type == "lcao") {
+        if (ks_solver == "default") {
+            if (device == "gpu") {
                 ks_solver = "cusolver";
                 ModuleBase::GlobalFunc::AUTO_SET("ks_solver", "cusolver");
-            }
-            else
-            {
+            } else {
 #ifdef __ELPA
                 ks_solver = "genelpa";
                 ModuleBase::GlobalFunc::AUTO_SET("ks_solver", "genelpa");
@@ -3255,16 +2483,16 @@ void Input::Default_2(void) // jiyy add 2019-08-04
 #endif
             }
         }
-        if (lcao_ecut == 0)
-        {
+        if (lcao_ecut == 0) {
             lcao_ecut = ecutwfc;
             ModuleBase::GlobalFunc::AUTO_SET("lcao_ecut", ecutwfc);
         }
 
-        // if calculation is get_wf, function source/module_basis/module_pw/pw_basis_k_big.h/distribute_r()
-        // will calculate nbx/nby/nbz by divide nx/ny/nz by bx/by/bz, so bx/by/bz should not be 0
-        if (calculation == "get_wf")
-        {
+        // if calculation is get_wf, function
+        // source/module_basis/module_pw/pw_basis_k_big.h/distribute_r() will
+        // calculate nbx/nby/nbz by divide nx/ny/nz by bx/by/bz, so bx/by/bz
+        // should not be 0
+        if (calculation == "get_wf") {
             if (!bx)
                 bx = 1;
             if (!by)
@@ -3272,173 +2500,134 @@ void Input::Default_2(void) // jiyy add 2019-08-04
             if (!bz)
                 bz = 1;
         }
-        if (dft_plus_u == 1 && onsite_radius == 0.0)
-        {
+        if (dft_plus_u == 1 && onsite_radius == 0.0) {
             // autoset onsite_radius to 5.0 as default
             onsite_radius = 5.0;
         }
     }
 
-    if (basis_type == "pw" || basis_type == "lcao_in_pw")
-    {
-        if (gamma_only_local)
-        {
+    if (basis_type == "pw" || basis_type == "lcao_in_pw") {
+        if (gamma_only_local) {
             // means you can use > 1 number of k points.
             gamma_only_local = 0;
             ModuleBase::GlobalFunc::AUTO_SET("gamma_only_local", "0");
         }
     }
     // added by linpz 2023/02/13
-    if (bessel_nao_ecut == "default")
-    {
+    if (bessel_nao_ecut == "default") {
         bessel_nao_ecut = std::to_string(ecutwfc);
     }
-    if (bessel_descriptor_ecut == "default")
-    {
+    if (bessel_descriptor_ecut == "default") {
         bessel_descriptor_ecut = std::to_string(ecutwfc);
     }
     // charge extrapolation liuyu 2023/09/16
-    if (chg_extrap == "default" && calculation == "md")
-    {
+    if (chg_extrap == "default" && calculation == "md") {
         chg_extrap = "second-order";
-    }
-    else if (chg_extrap == "default" && (calculation == "relax" || calculation == "cell-relax"))
-    {
+    } else if (chg_extrap == "default"
+               && (calculation == "relax" || calculation == "cell-relax")) {
         chg_extrap = "first-order";
-    }
-    else if (chg_extrap == "default")
-    {
+    } else if (chg_extrap == "default") {
         chg_extrap = "atomic";
     }
 
-    if (calculation != "md")
-    {
+    if (calculation != "md") {
         mdp.md_prec_level = 0;
     }
 
-    if (scf_thr == -1.0)
-    {
-        if (basis_type == "lcao" || basis_type == "lcao_in_pw")
-        {
+    if (scf_thr == -1.0) {
+        if (basis_type == "lcao" || basis_type == "lcao_in_pw") {
             scf_thr = 1.0e-7;
-        }
-        else if (basis_type == "pw" and calculation != "nscf")
-        {
+        } else if (basis_type == "pw" and calculation != "nscf") {
             scf_thr = 1.0e-9;
-        }
-        else if (basis_type == "pw" and calculation == "nscf")
-        {
+        } else if (basis_type == "pw" and calculation == "nscf") {
             scf_thr = 1.0e-6;
-            // In NSCF calculation, the diagonalization threshold is set to 0.1*scf/nelec.
-            // In other words, the scf_thr is used to control diagonalization convergence
-            // threthod in NSCF. In this case, the default 1.0e-9 is too strict.
-            // renxi 20230908
+            // In NSCF calculation, the diagonalization threshold is set to
+            // 0.1*scf/nelec. In other words, the scf_thr is used to control
+            // diagonalization convergence threthod in NSCF. In this case, the
+            // default 1.0e-9 is too strict. renxi 20230908
         }
     }
 
-    if (scf_thr_type == -1)
-    {
-        if (basis_type == "lcao" || basis_type == "lcao_in_pw")
-        {
+    if (scf_thr_type == -1) {
+        if (basis_type == "lcao" || basis_type == "lcao_in_pw") {
             scf_thr_type = 2;
-        }
-        else if (basis_type == "pw")
-        {
+        } else if (basis_type == "pw") {
             scf_thr_type = 1;
         }
     }
 
-    if (qo_switch)
-    {
+    if (qo_switch) {
         /* parameter logic of QO */
         out_mat_hs[0] = 1; // print H(k) and S(k)
         out_wfc_lcao = 1;  // print wave function in lcao basis in kspace
         symmetry = "-1";   // disable kpoint reduce
     }
-    if (qo_screening_coeff.size() != ntype)
-    {
-        if (qo_basis == "pswfc")
-        {
-            double default_screening_coeff = (qo_screening_coeff.size() == 1) ? qo_screening_coeff[0] : 0.1;
+    if (qo_screening_coeff.size() != ntype) {
+        if (qo_basis == "pswfc") {
+            double default_screening_coeff = (qo_screening_coeff.size() == 1)
+                                                 ? qo_screening_coeff[0]
+                                                 : 0.1;
             qo_screening_coeff.resize(ntype, default_screening_coeff);
-        }
-        else
-        {
-            // if length of qo_screening_coeff is not 0, turn on Slater screening
+        } else {
+            // if length of qo_screening_coeff is not 0, turn on Slater
+            // screening
         }
     }
-    if (qo_strategy.size() != ntype)
-    {
-        if (qo_strategy.size() == 1)
-        {
+    if (qo_strategy.size() != ntype) {
+        if (qo_strategy.size() == 1) {
             qo_strategy.resize(ntype, qo_strategy[0]);
-        }
-        else
-        {
+        } else {
             std::string default_strategy;
             if (qo_basis == "hydrogen")
                 default_strategy = "energy-valence";
             else if ((qo_basis == "pswfc") || (qo_basis == "szv"))
                 default_strategy = "all";
-            else
-            {
-                ModuleBase::WARNING_QUIT("Input",
-                                         "When setting default values for qo_strategy, unexpected/unknown qo_basis is "
-                                         "found. Please check it.");
+            else {
+                ModuleBase::WARNING_QUIT(
+                    "Input",
+                    "When setting default values for qo_strategy, "
+                    "unexpected/unknown qo_basis is "
+                    "found. Please check it.");
             }
             qo_strategy.resize(ntype, default_strategy);
         }
     }
 
     // set nspin with noncolin
-    if (noncolin || lspinorb)
-    {
+    if (noncolin || lspinorb) {
         nspin = 4;
     }
 
     // mixing parameters
-    if (mixing_beta < 0.0)
-    {
-        if (nspin == 1)
-        {
+    if (mixing_beta < 0.0) {
+        if (nspin == 1) {
             mixing_beta = 0.8;
-        }
-        else if (nspin == 2)
+        } else if (nspin == 2) {
+            mixing_beta = 0.4;
+            mixing_beta_mag = 1.6;
+            mixing_gg0_mag = 0.0;
+        } else if (nspin == 4) // I will add this
         {
             mixing_beta = 0.4;
             mixing_beta_mag = 1.6;
             mixing_gg0_mag = 0.0;
         }
-        else if (nspin == 4) // I will add this
-        {
-            mixing_beta = 0.4;
-            mixing_beta_mag = 1.6;
-            mixing_gg0_mag = 0.0;
-        }
-    }
-    else
-    {
-        if ((nspin == 2 || nspin == 4) && mixing_beta_mag < 0.0)
-        {
-            if (mixing_beta <= 0.4)
-            {
+    } else {
+        if ((nspin == 2 || nspin == 4) && mixing_beta_mag < 0.0) {
+            if (mixing_beta <= 0.4) {
                 mixing_beta_mag = 4 * mixing_beta;
-            }
-            else
-            {
+            } else {
                 mixing_beta_mag = 1.6; // 1.6 can be discussed
             }
         }
     }
 
-    if (efield_flag)
-    {
+    if (efield_flag) {
         symmetry = "0";
     }
 }
 #ifdef __MPI
-void Input::Bcast()
-{
+void Input::Bcast() {
     ModuleBase::TITLE("Input", "Bcast");
 
     //	std::cout << "\n Bcast()" << std::endl;
@@ -3448,7 +2637,8 @@ void Input::Bcast()
     Parallel_Common::bcast_string(suffix);
     Parallel_Common::bcast_string(stru_file); // xiaohui modify 2015-02-01
     Parallel_Common::bcast_string(pseudo_dir);
-    // Parallel_Common::bcast_string(pseudo_type); // mohan add 2013-05-20 (xiaohui add 2013-06-23)
+    // Parallel_Common::bcast_string(pseudo_type); // mohan add 2013-05-20
+    // (xiaohui add 2013-06-23)
     Parallel_Common::bcast_string(orbital_dir);
     Parallel_Common::bcast_string(kpoint_file); // xiaohui modify 2015-02-01
     Parallel_Common::bcast_string(wannier_card);
@@ -3462,8 +2652,7 @@ void Input::Bcast()
     Parallel_Common::bcast_int(nbands_sto);
     Parallel_Common::bcast_int(nbands_istate);
     Parallel_Common::bcast_string(bands_to_print_);
-    for (int i = 0; i < 3; i++)
-    {
+    for (int i = 0; i < 3; i++) {
         Parallel_Common::bcast_double(kspacing[i]);
     }
     Parallel_Common::bcast_double(min_dist_coef);
@@ -3517,7 +2706,8 @@ void Input::Bcast()
     Parallel_Common::bcast_string(symmetry);
     Parallel_Common::bcast_bool(init_vel); // liuyu 2021-07-14
     Parallel_Common::bcast_double(ref_cell_factor);
-    Parallel_Common::bcast_double(symmetry_prec); // LiuXh add 2021-08-12, accuracy for symmetry
+    Parallel_Common::bcast_double(
+        symmetry_prec); // LiuXh add 2021-08-12, accuracy for symmetry
     Parallel_Common::bcast_bool(symmetry_autoclose);
     Parallel_Common::bcast_bool(cal_force);
     Parallel_Common::bcast_double(force_thr);
@@ -3623,7 +2813,8 @@ void Input::Bcast()
     Parallel_Common::bcast_bool(out_dm1);
     Parallel_Common::bcast_bool(out_bandgap); // for bandgap printing
 
-    Parallel_Common::bcast_bool(deepks_out_labels); // caoyu added 2020-11-24, mohan modified 2021-01-03
+    Parallel_Common::bcast_bool(
+        deepks_out_labels); // caoyu added 2020-11-24, mohan modified 2021-01-03
     Parallel_Common::bcast_bool(deepks_scf);
     Parallel_Common::bcast_bool(deepks_bandgap);
     Parallel_Common::bcast_bool(deepks_out_unittest);
@@ -3635,11 +2826,13 @@ void Input::Bcast()
     Parallel_Common::bcast_bool(out_wfc_r);
     Parallel_Common::bcast_int(out_dos);
     if (GlobalV::MY_RANK != 0)
-        out_band.resize(2); /* If this line is absent, will cause segmentation fault in io_input_test_para */
+        out_band.resize(2); /* If this line is absent, will cause segmentation
+                               fault in io_input_test_para */
     Parallel_Common::bcast_int(out_band.data(), 2);
     Parallel_Common::bcast_bool(out_proj_band);
     if (GlobalV::MY_RANK != 0)
-        out_mat_hs.resize(2); /* If this line is absent, will cause segmentation fault in io_input_test_para */
+        out_mat_hs.resize(2); /* If this line is absent, will cause segmentation
+                                 fault in io_input_test_para */
     Parallel_Common::bcast_int(out_mat_hs.data(), 2);
     Parallel_Common::bcast_bool(out_mat_hs2); // LiuXh add 2019-07-15
     Parallel_Common::bcast_bool(out_mat_t);
@@ -3850,14 +3043,12 @@ void Input::Bcast()
     Parallel_Common::bcast_double(uramping);
     Parallel_Common::bcast_int(omc);
     Parallel_Common::bcast_double(yukawa_lambda);
-    if (GlobalV::MY_RANK != 0)
-    {
+    if (GlobalV::MY_RANK != 0) {
         hubbard_u = new double[this->ntype];
         orbital_corr = new int[this->ntype];
     }
 
-    for (int i = 0; i < this->ntype; i++)
-    {
+    for (int i = 0; i < this->ntype; i++) {
         Parallel_Common::bcast_double(hubbard_u[i]);
         Parallel_Common::bcast_int(orbital_corr[i]);
     }
@@ -3911,7 +3102,8 @@ void Input::Bcast()
     /* newly support vector/list input of bessel_nao_rcut */
     int nrcut = bessel_nao_rcuts.size();
     Parallel_Common::bcast_int(nrcut);
-    if (nrcut != 0) /* as long as its value is really given, bcast, otherwise not */
+    if (nrcut
+        != 0) /* as long as its value is really given, bcast, otherwise not */
     {
         bessel_nao_rcuts.resize(nrcut);
         Parallel_Common::bcast_double(bessel_nao_rcuts.data(), nrcut);
@@ -3989,23 +3181,22 @@ void Input::Bcast()
 }
 #endif
 
-void Input::Check(void)
-{
+void Input::Check(void) {
     ModuleBase::TITLE("Input", "Check");
 
-    if (ecutrho / ecutwfc < 4 - 1e-8)
-    {
+    if (ecutrho / ecutwfc < 4 - 1e-8) {
         ModuleBase::WARNING_QUIT("Input", "ecutrho/ecutwfc must >= 4");
     }
 
-    if (ndx < nx || ndy < ny || ndz < nz)
-    {
-        ModuleBase::WARNING_QUIT("Input", "smooth grids is denser than dense grids");
+    if (ndx < nx || ndy < ny || ndz < nz) {
+        ModuleBase::WARNING_QUIT("Input",
+                                 "smooth grids is denser than dense grids");
     }
 
     if (nbands < 0)
         ModuleBase::WARNING_QUIT("Input", "NBANDS must >= 0");
-    //	if(nbands_istate < 0) ModuleBase::WARNING_QUIT("Input","NBANDS_ISTATE must > 0");
+    //	if(nbands_istate < 0) ModuleBase::WARNING_QUIT("Input","NBANDS_ISTATE
+    //must > 0");
     if (nb2d < 0)
         ModuleBase::WARNING_QUIT("Input", "nb2d must > 0");
     if (ntype <= 0)
@@ -4014,300 +3205,295 @@ void Input::Check(void)
         // std::cout << "diago_proc=" << diago_proc << std::endl;
         // std::cout << " NPROC=" << GlobalV::NPROC << std::endl;
 #ifndef USE_PAW
-    if (use_paw)
-    {
+    if (use_paw) {
         ModuleBase::WARNING_QUIT("Input", "to use PAW, compile with USE_PAW");
-        if (basis_type != "pw")
-        {
+        if (basis_type != "pw") {
             ModuleBase::WARNING_QUIT("Input", "PAW is for pw basis only");
         }
     }
 #endif
 
-    if (diago_proc > 1 && basis_type == "lcao" && diago_proc != GlobalV::NPROC)
-    {
-        ModuleBase::WARNING_QUIT("Input", "please don't set diago_proc with lcao base");
+    if (diago_proc > 1 && basis_type == "lcao"
+        && diago_proc != GlobalV::NPROC) {
+        ModuleBase::WARNING_QUIT("Input",
+                                 "please don't set diago_proc with lcao base");
     }
     int kspacing_zero_num = 0;
-    for (int i = 0; i < 3; i++)
-    {
-        if (kspacing[i] < 0.0)
-        {
+    for (int i = 0; i < 3; i++) {
+        if (kspacing[i] < 0.0) {
             ModuleBase::WARNING_QUIT("Input", "kspacing must > 0");
-        }
-        else if (kspacing[i] == 0.0)
-        {
+        } else if (kspacing[i] == 0.0) {
             kspacing_zero_num++;
         }
     }
-    if (kspacing_zero_num > 0 && kspacing_zero_num < 3)
-    {
-        std::cout << "kspacing: " << kspacing[0] << " " << kspacing[1] << " " << kspacing[2] << std::endl;
+    if (kspacing_zero_num > 0 && kspacing_zero_num < 3) {
+        std::cout << "kspacing: " << kspacing[0] << " " << kspacing[1] << " "
+                  << kspacing[2] << std::endl;
         ModuleBase::WARNING_QUIT("Input", "kspacing must > 0");
     }
 
-    if (nelec < 0.0)
-    {
+    if (nelec < 0.0) {
         ModuleBase::WARNING_QUIT("Input", "nelec < 0 is not allowed !");
     }
 
-    if (dip_cor_flag && !efield_flag)
-    {
-        ModuleBase::WARNING_QUIT("Input", "dipole correction is not active if efield_flag=false !");
+    if (dip_cor_flag && !efield_flag) {
+        ModuleBase::WARNING_QUIT(
+            "Input",
+            "dipole correction is not active if efield_flag=false !");
     }
 
-    if (gate_flag && efield_flag && !dip_cor_flag)
-    {
-        ModuleBase::WARNING_QUIT("Input", "gate field cannot be used with efield if dip_cor_flag=false !");
+    if (gate_flag && efield_flag && !dip_cor_flag) {
+        ModuleBase::WARNING_QUIT(
+            "Input",
+            "gate field cannot be used with efield if dip_cor_flag=false !");
     }
 
-    if (ref_cell_factor < 1.0)
-    {
-        ModuleBase::WARNING_QUIT("Input", "ref_cell_factor must not be less than 1.0");
+    if (ref_cell_factor < 1.0) {
+        ModuleBase::WARNING_QUIT("Input",
+                                 "ref_cell_factor must not be less than 1.0");
     }
 
     //----------------------------------------------------------
     // main parameters / electrons / spin ( 1/16 )
     //----------------------------------------------------------
-    if (calculation == "nscf" || calculation == "get_S")
-    {
-        if (out_dos == 3 && symmetry == "1")
-        {
-            ModuleBase::WARNING_QUIT("Input::Check",
-                                     "symmetry can't be used for out_dos==3(Fermi Surface Plotting) by now.");
+    if (calculation == "nscf" || calculation == "get_S") {
+        if (out_dos == 3 && symmetry == "1") {
+            ModuleBase::WARNING_QUIT(
+                "Input::Check",
+                "symmetry can't be used for out_dos==3(Fermi Surface Plotting) "
+                "by now.");
         }
-    }
-    else if (calculation == "get_pchg")
-    {
+    } else if (calculation == "get_pchg") {
         if (basis_type == "pw") // xiaohui add 2013-09-01
         {
-            ModuleBase::WARNING_QUIT("Input::Check", "calculate = get_pchg is only availble for LCAO.");
+            ModuleBase::WARNING_QUIT(
+                "Input::Check",
+                "calculate = get_pchg is only availble for LCAO.");
         }
-    }
-    else if (calculation == "get_wf")
-    {
+    } else if (calculation == "get_wf") {
         if (basis_type == "pw") // xiaohui add 2013-09-01
         {
-            ModuleBase::WARNING_QUIT("Input::Check", "calculate = get_wf is only availble for LCAO.");
+            ModuleBase::WARNING_QUIT(
+                "Input::Check",
+                "calculate = get_wf is only availble for LCAO.");
         }
-    }
-    else if (calculation == "md") // mohan add 2011-11-04
+    } else if (calculation == "md") // mohan add 2011-11-04
     {
         // deal with input parameters , 2019-04-30
         if (mdp.md_dt < 0)
-            ModuleBase::WARNING_QUIT("Input::Check", "time interval of MD calculation should be set!");
-        if (mdp.md_type == "msst")
-        {
-            if (mdp.msst_qmass <= 0)
-            {
-                ModuleBase::WARNING_QUIT("Input::Check", "msst_qmass must be greater than 0!");
+            ModuleBase::WARNING_QUIT(
+                "Input::Check",
+                "time interval of MD calculation should be set!");
+        if (mdp.md_type == "msst") {
+            if (mdp.msst_qmass <= 0) {
+                ModuleBase::WARNING_QUIT("Input::Check",
+                                         "msst_qmass must be greater than 0!");
             }
         }
-        if (esolver_type == "dp")
-        {
-            if (access(mdp.pot_file.c_str(), 0) == -1)
-            {
-                ModuleBase::WARNING_QUIT("Input::Check", "Can not find DP model !");
+        if (esolver_type == "dp") {
+            if (access(mdp.pot_file.c_str(), 0) == -1) {
+                ModuleBase::WARNING_QUIT("Input::Check",
+                                         "Can not find DP model !");
             }
         }
-    }
-    else if (calculation == "gen_bessel")
-    {
-        if (basis_type != "pw")
-        {
-            ModuleBase::WARNING_QUIT("Input", "to generate descriptors, please use pw basis");
+    } else if (calculation == "gen_bessel") {
+        if (basis_type != "pw") {
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "to generate descriptors, please use pw basis");
         }
     }
     // else if (calculation == "ofdft") // sunliang added on 2022-05-05
     // {
     //     if (pseudo_type != "blps")
     //     {
-    //         ModuleBase::WARNING_QUIT("Input::Check", "pseudo_type in ofdft should be set as blps");
+    //         ModuleBase::WARNING_QUIT("Input::Check", "pseudo_type in ofdft
+    //         should be set as blps");
     //     }
     // }
-    else if (calculation != "scf" && calculation != "relax" && calculation != "cell-relax"
-             && calculation != "test_memory" && calculation != "test_neighbour")
-    {
+    else if (calculation != "scf" && calculation != "relax"
+             && calculation != "cell-relax" && calculation != "test_memory"
+             && calculation != "test_neighbour") {
         ModuleBase::WARNING_QUIT("Input", "check 'calculation' !");
     }
-    if (init_chg != "atomic" && init_chg != "file" && init_chg != "auto")
-    {
-        ModuleBase::WARNING_QUIT("Input", "wrong 'init_chg', not 'atomic', 'file', 'auto', please check");
+    if (init_chg != "atomic" && init_chg != "file" && init_chg != "auto") {
+        ModuleBase::WARNING_QUIT(
+            "Input",
+            "wrong 'init_chg', not 'atomic', 'file', 'auto', please check");
     }
-    if (gamma_only_local == 0)
-    {
-        if (out_dm == 1)
-        {
-            ModuleBase::WARNING_QUIT("Input", "out_dm with k-point algorithm is not implemented yet.");
+    if (gamma_only_local == 0) {
+        if (out_dm == 1) {
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "out_dm with k-point algorithm is not implemented yet.");
         }
-    }
-    else
-    {
-        if (out_dm1 == 1)
-        {
+    } else {
+        if (out_dm1 == 1) {
             ModuleBase::WARNING_QUIT("Input", "out_dm1 is only for multi-k");
         }
     }
 
-    if ((init_wfc != "atomic") && (init_wfc != "random") && (init_wfc != "atomic+random") && (init_wfc != "nao")
-        && (init_wfc != "nao+random") && (init_wfc != "file"))
-    {
-        if (psi_initializer)
-        {
+    if ((init_wfc != "atomic") && (init_wfc != "random")
+        && (init_wfc != "atomic+random") && (init_wfc != "nao")
+        && (init_wfc != "nao+random") && (init_wfc != "file")) {
+        if (psi_initializer) {
             ModuleBase::WARNING_QUIT(
                 "Input",
-                "wrong init_wfc, please use 'random', 'atomic(+random)', 'nao(+random)' or 'file' ");
-        }
-        else
-        {
-            ModuleBase::WARNING_QUIT("Input", "wrong init_wfc, please use 'atomic' or 'random' or 'file' ");
+                "wrong init_wfc, please use 'random', 'atomic(+random)', "
+                "'nao(+random)' or 'file' ");
+        } else {
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "wrong init_wfc, please use 'atomic' or 'random' or 'file' ");
         }
     }
 
-    if (nbands > 100000)
-    {
+    if (nbands > 100000) {
         ModuleBase::WARNING_QUIT("Input", "nbnd >100000, out of range");
     }
-    if (nelec > 0 && nbands > 0 && nelec > 2 * nbands)
-    {
+    if (nelec > 0 && nbands > 0 && nelec > 2 * nbands) {
         ModuleBase::WARNING_QUIT("Input", "nelec > 2*nbnd , bands not enough!");
     }
-    if (nspin != 1 && nspin != 2 && nspin != 4)
-    {
-        ModuleBase::WARNING_QUIT("Input", "nspin does not equal to 1, 2, or 4!");
+    if (nspin != 1 && nspin != 2 && nspin != 4) {
+        ModuleBase::WARNING_QUIT("Input",
+                                 "nspin does not equal to 1, 2, or 4!");
     }
     if (basis_type == "pw") // xiaohui add 2013-09-01
     {
         if (ks_solver == "genelpa") // yshen add 2016-07-20
         {
-            ModuleBase::WARNING_QUIT("Input", "genelpa can not be used with plane wave basis.");
-        }
-        else if (ks_solver == "scalapack_gvx") // Peize Lin add 2020.11.14
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "genelpa can not be used with plane wave basis.");
+        } else if (ks_solver == "scalapack_gvx") // Peize Lin add 2020.11.14
         {
-            ModuleBase::WARNING_QUIT("Input", "scalapack_gvx can not be used with plane wave basis.");
-        }
-        else if (ks_solver == "lapack")
-        {
-            ModuleBase::WARNING_QUIT("Input", "lapack can not be used with plane wave basis.");
-        }
-        else if (ks_solver == "pexsi")
-        {
-            ModuleBase::WARNING_QUIT("Input", "pexsi can not be used with plane wave basis.");
-        }
-        else if (ks_solver != "default" && ks_solver != "cg" && ks_solver != "dav" && ks_solver != "dav_subspace"
-                 && ks_solver != "bpcg")
-        {
-            ModuleBase::WARNING_QUIT("Input", "please check the ks_solver parameter!");
-        }
-
-        if (gamma_only)
-        {
-            ModuleBase::WARNING_QUIT("Input", "gamma_only not implemented for plane wave now.");
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "scalapack_gvx can not be used with plane wave basis.");
+        } else if (ks_solver == "lapack") {
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "lapack can not be used with plane wave basis.");
+        } else if (ks_solver == "pexsi") {
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "pexsi can not be used with plane wave basis.");
+        } else if (ks_solver != "default" && ks_solver != "cg"
+                   && ks_solver != "dav" && ks_solver != "dav_subspace"
+                   && ks_solver != "bpcg") {
+            ModuleBase::WARNING_QUIT("Input",
+                                     "please check the ks_solver parameter!");
         }
 
-        if (out_proj_band == 1)
-        {
-            ModuleBase::WARNING_QUIT("Input", "out_proj_band not implemented for plane wave now.");
+        if (gamma_only) {
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "gamma_only not implemented for plane wave now.");
         }
 
-        if (out_dos == 3)
-        {
-            ModuleBase::WARNING_QUIT("Input", "Fermi Surface Plotting not implemented for plane wave now.");
+        if (out_proj_band == 1) {
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "out_proj_band not implemented for plane wave now.");
         }
 
-        if (sc_mag_switch)
-        {
-            ModuleBase::WARNING_QUIT("Input", "Non-colliner Spin-constrained DFT not implemented for plane wave now.");
+        if (out_dos == 3) {
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "Fermi Surface Plotting not implemented for plane wave now.");
         }
-    }
-    else if (basis_type == "lcao")
-    {
-        if (ks_solver == "cg")
-        {
-            ModuleBase::WARNING_QUIT("Input", "not ready for cg method in lcao ."); // xiaohui add 2013-09-04
+
+        if (sc_mag_switch) {
+            ModuleBase::WARNING_QUIT("Input",
+                                     "Non-colliner Spin-constrained DFT not "
+                                     "implemented for plane wave now.");
         }
-        else if (ks_solver == "cg_in_lcao")
-        {
+    } else if (basis_type == "lcao") {
+        if (ks_solver == "cg") {
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "not ready for cg method in lcao ."); // xiaohui add 2013-09-04
+        } else if (ks_solver == "cg_in_lcao") {
             GlobalV::ofs_warning << "cg_in_lcao is under testing" << std::endl;
-        }
-        else if (ks_solver == "genelpa")
-        {
+        } else if (ks_solver == "genelpa") {
 #ifndef __MPI
-            ModuleBase::WARNING_QUIT("Input", "genelpa can not be used for series version.");
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "genelpa can not be used for series version.");
 #endif
 #ifndef __ELPA
             ModuleBase::WARNING_QUIT(
                 "Input",
-                "Can not use genelpa if abacus is not compiled with ELPA. Please change ks_solver to scalapack_gvx.");
+                "Can not use genelpa if abacus is not compiled with ELPA. "
+                "Please change ks_solver to scalapack_gvx.");
 #endif
-        }
-        else if (ks_solver == "scalapack_gvx")
-        {
+        } else if (ks_solver == "scalapack_gvx") {
 #ifdef __MPI
-            GlobalV::ofs_warning << "scalapack_gvx is under testing" << std::endl;
+            GlobalV::ofs_warning << "scalapack_gvx is under testing"
+                                 << std::endl;
 #else
-            ModuleBase::WARNING_QUIT("Input", "scalapack_gvx can not be used for series version.");
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "scalapack_gvx can not be used for series version.");
 #endif
-        }
-        else if (ks_solver == "lapack")
-        {
+        } else if (ks_solver == "lapack") {
 #ifdef __MPI
-            ModuleBase::WARNING_QUIT("Input",
-                                     "ks_solver=lapack is not an option for parallel version of ABACUS (try genelpa).");
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "ks_solver=lapack is not an option for parallel version of "
+                "ABACUS (try genelpa).");
 #else
             GlobalV::ofs_warning << " It's ok to use lapack." << std::endl;
 #endif
-        }
-        else if (ks_solver == "cusolver")
-        {
+        } else if (ks_solver == "cusolver") {
 #ifndef __MPI
-            ModuleBase::WARNING_QUIT("Input", "Cusolver can not be used for series version.");
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "Cusolver can not be used for series version.");
 #endif
-        }
-        else if (ks_solver == "cusolvermp")
-        {
+        } else if (ks_solver == "cusolvermp") {
 #ifndef __MPI
-            ModuleBase::WARNING_QUIT("Input", "CusolverMP can not be used for series version.");
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "CusolverMP can not be used for series version.");
 #endif
-        }
-        else if (ks_solver == "pexsi")
-        {
+        } else if (ks_solver == "pexsi") {
 #ifdef __PEXSI
             GlobalV::ofs_warning << " It's ok to use pexsi." << std::endl;
 #else
             ModuleBase::WARNING_QUIT(
                 "Input",
-                "Can not use PEXSI if abacus is not compiled with PEXSI. Please change ks_solver to scalapack_gvx.");
+                "Can not use PEXSI if abacus is not compiled with PEXSI. "
+                "Please change ks_solver to scalapack_gvx.");
 #endif
-        }
-        else if (ks_solver != "default")
-        {
-            ModuleBase::WARNING_QUIT("Input", "please check the ks_solver parameter!");
-        }
-
-        if (kpar > 1)
-        {
-            ModuleBase::WARNING_QUIT("Input", "kpar > 1 has not been supported for lcao calculation.");
+        } else if (ks_solver != "default") {
+            ModuleBase::WARNING_QUIT("Input",
+                                     "please check the ks_solver parameter!");
         }
 
-        if (out_wfc_lcao != 0 && out_wfc_lcao != 1 && out_wfc_lcao != 2)
-        {
-            ModuleBase::WARNING_QUIT("Input", "out_wfc_lcao must be 0, 1, or 2");
+        if (kpar > 1) {
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "kpar > 1 has not been supported for lcao calculation.");
         }
-    }
-    else if (basis_type == "lcao_in_pw")
-    {
-        if (ks_solver != "lapack")
-        {
-            ModuleBase::WARNING_QUIT("Input", "LCAO in plane wave can only done with lapack.");
+
+        if (out_wfc_lcao != 0 && out_wfc_lcao != 1 && out_wfc_lcao != 2) {
+            ModuleBase::WARNING_QUIT("Input",
+                                     "out_wfc_lcao must be 0, 1, or 2");
         }
-    }
-    else
-    {
-        ModuleBase::WARNING_QUIT("Input", "please check the basis_type parameter!");
+    } else if (basis_type == "lcao_in_pw") {
+        if (ks_solver != "lapack") {
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "LCAO in plane wave can only done with lapack.");
+        }
+    } else {
+        ModuleBase::WARNING_QUIT("Input",
+                                 "please check the basis_type parameter!");
     }
     /*
-    if (basis_type == "lcao" && !gamma_only_local) // xiaohui add 2013-09-01. Attention! Maybe there is some problem.
+    if (basis_type == "lcao" && !gamma_only_local) // xiaohui add 2013-09-01.
+    Attention! Maybe there is some problem.
     {
         ModuleBase::WARNING("Input", "gamma_only_local algorithm is not used.");
     }
@@ -4318,135 +3504,135 @@ void Input::Check(void)
     {
         if (basis_type != "lcao_in_pw") // xiaohui add 2013-09-01
         {
-            ModuleBase::WARNING_QUIT("Input", "lapack can not be used when nproc > 1");
+            ModuleBase::WARNING_QUIT("Input", "lapack can not be used when nproc
+    > 1");
         }
     }
     */
     // pengfei add 13-8-10 a new method cg to bfgs
-    if (relax_method != "sd" && relax_method != "cg" && relax_method != "bfgs" && relax_method != "cg_bfgs")
-    {
-        ModuleBase::WARNING_QUIT("Input", "relax_method can only be sd, cg, bfgs or cg_bfgs.");
+    if (relax_method != "sd" && relax_method != "cg" && relax_method != "bfgs"
+        && relax_method != "cg_bfgs") {
+        ModuleBase::WARNING_QUIT(
+            "Input",
+            "relax_method can only be sd, cg, bfgs or cg_bfgs.");
     }
 
-    if (bx > 10 || by > 10 || bz > 10)
-    {
-        ModuleBase::WARNING_QUIT("Input", "bx, or by, or bz is larger than 10!");
+    if (bx > 10 || by > 10 || bz > 10) {
+        ModuleBase::WARNING_QUIT("Input",
+                                 "bx, or by, or bz is larger than 10!");
     }
     // jiyy add 2019-08-04
-    if (vdw_method == "d2" || vdw_method == "d3_0" || vdw_method == "d3_bj")
-    {
-        if ((vdw_C6_unit != "Jnm6/mol") && (vdw_C6_unit != "eVA6"))
-        {
-            ModuleBase::WARNING_QUIT("Input", "vdw_C6_unit must be Jnm6/mol or eVA6");
+    if (vdw_method == "d2" || vdw_method == "d3_0" || vdw_method == "d3_bj") {
+        if ((vdw_C6_unit != "Jnm6/mol") && (vdw_C6_unit != "eVA6")) {
+            ModuleBase::WARNING_QUIT("Input",
+                                     "vdw_C6_unit must be Jnm6/mol or eVA6");
         }
-        if ((vdw_R0_unit != "A") && (vdw_R0_unit != "Bohr"))
-        {
+        if ((vdw_R0_unit != "A") && (vdw_R0_unit != "Bohr")) {
             ModuleBase::WARNING_QUIT("Input", "vdw_R0_unit must be A or Bohr");
         }
-        if ((vdw_cutoff_type != "radius") && (vdw_cutoff_type != "period"))
-        {
-            ModuleBase::WARNING_QUIT("Input", "vdw_cutoff_type must be radius or period");
+        if ((vdw_cutoff_type != "radius") && (vdw_cutoff_type != "period")) {
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "vdw_cutoff_type must be radius or period");
         }
-        if ((vdw_cutoff_period.x <= 0) || (vdw_cutoff_period.y <= 0) || (vdw_cutoff_period.z <= 0))
-        {
-            ModuleBase::WARNING_QUIT("Input", "vdw_cutoff_period <= 0 is not allowd");
+        if ((vdw_cutoff_period.x <= 0) || (vdw_cutoff_period.y <= 0)
+            || (vdw_cutoff_period.z <= 0)) {
+            ModuleBase::WARNING_QUIT("Input",
+                                     "vdw_cutoff_period <= 0 is not allowd");
         }
-        if (std::stod(vdw_cutoff_radius) <= 0)
-        {
-            ModuleBase::WARNING_QUIT("Input", "vdw_cutoff_radius <= 0 is not allowd");
+        if (std::stod(vdw_cutoff_radius) <= 0) {
+            ModuleBase::WARNING_QUIT("Input",
+                                     "vdw_cutoff_radius <= 0 is not allowd");
         }
-        if ((vdw_radius_unit != "A") && (vdw_radius_unit != "Bohr"))
-        {
-            ModuleBase::WARNING_QUIT("Input", "vdw_radius_unit must be A or Bohr");
+        if ((vdw_radius_unit != "A") && (vdw_radius_unit != "Bohr")) {
+            ModuleBase::WARNING_QUIT("Input",
+                                     "vdw_radius_unit must be A or Bohr");
         }
-        if (vdw_cn_thr <= 0)
-        {
+        if (vdw_cn_thr <= 0) {
             ModuleBase::WARNING_QUIT("Input", "vdw_cn_thr <= 0 is not allowd");
         }
-        if ((vdw_cn_thr_unit != "A") && (vdw_cn_thr_unit != "Bohr"))
-        {
-            ModuleBase::WARNING_QUIT("Input", "vdw_cn_thr_unit must be A or Bohr");
+        if ((vdw_cn_thr_unit != "A") && (vdw_cn_thr_unit != "Bohr")) {
+            ModuleBase::WARNING_QUIT("Input",
+                                     "vdw_cn_thr_unit must be A or Bohr");
         }
     }
 
     std::string dft_functional_lower = dft_functional;
-    std::transform(dft_functional.begin(), dft_functional.end(), dft_functional_lower.begin(), tolower);
-    if (dft_functional_lower == "hf" || dft_functional_lower == "pbe0" || dft_functional_lower == "hse"
-        || dft_functional_lower == "scan0")
-    {
+    std::transform(dft_functional.begin(),
+                   dft_functional.end(),
+                   dft_functional_lower.begin(),
+                   tolower);
+    if (dft_functional_lower == "hf" || dft_functional_lower == "pbe0"
+        || dft_functional_lower == "hse" || dft_functional_lower == "scan0") {
         const double exx_hybrid_alpha_value = std::stod(exx_hybrid_alpha);
-        if (exx_hybrid_alpha_value < 0 || exx_hybrid_alpha_value > 1)
-        {
-            ModuleBase::WARNING_QUIT("INPUT", "must 0 <= exx_hybrid_alpha <= 1");
+        if (exx_hybrid_alpha_value < 0 || exx_hybrid_alpha_value > 1) {
+            ModuleBase::WARNING_QUIT("INPUT",
+                                     "must 0 <= exx_hybrid_alpha <= 1");
         }
-        if (exx_hybrid_step <= 0)
-        {
+        if (exx_hybrid_step <= 0) {
             ModuleBase::WARNING_QUIT("INPUT", "must exx_hybrid_step > 0");
         }
         const double exx_ccp_rmesh_times_value = std::stod(exx_ccp_rmesh_times);
-        if (exx_ccp_rmesh_times_value < 1)
-        {
+        if (exx_ccp_rmesh_times_value < 1) {
             ModuleBase::WARNING_QUIT("INPUT", "must exx_ccp_rmesh_times >= 1");
         }
-        if (exx_distribute_type != "htime" && exx_distribute_type != "kmeans2" && exx_distribute_type != "kmeans1"
-            && exx_distribute_type != "order")
-        {
-            ModuleBase::WARNING_QUIT("INPUT", "exx_distribute_type must be htime or kmeans2 or kmeans1");
+        if (exx_distribute_type != "htime" && exx_distribute_type != "kmeans2"
+            && exx_distribute_type != "kmeans1"
+            && exx_distribute_type != "order") {
+            ModuleBase::WARNING_QUIT(
+                "INPUT",
+                "exx_distribute_type must be htime or kmeans2 or kmeans1");
         }
     }
-    if (dft_functional_lower == "opt_orb")
-    {
-        if (exx_opt_orb_lmax < 0)
-        {
+    if (dft_functional_lower == "opt_orb") {
+        if (exx_opt_orb_lmax < 0) {
             ModuleBase::WARNING_QUIT("INPUT", "exx_opt_orb_lmax must >=0");
         }
-        if (exx_opt_orb_ecut < 0)
-        {
+        if (exx_opt_orb_ecut < 0) {
             ModuleBase::WARNING_QUIT("INPUT", "exx_opt_orb_ecut must >=0");
         }
-        if (exx_opt_orb_tolerence < 0)
-        {
+        if (exx_opt_orb_tolerence < 0) {
             ModuleBase::WARNING_QUIT("INPUT", "exx_opt_orb_tolerence must >=0");
         }
     }
-    if (rpa)
-    {
-        if (rpa_ccp_rmesh_times < 1)
-        {
+    if (rpa) {
+        if (rpa_ccp_rmesh_times < 1) {
             ModuleBase::WARNING_QUIT("INPUT", "must rpa_ccp_rmesh_times >= 1");
         }
     }
 
-    if (berry_phase)
-    {
-        if (basis_type != "pw" && basis_type != "lcao")
-        {
-            ModuleBase::WARNING_QUIT("Input", "calculate berry phase, please set basis_type = pw or lcao");
+    if (berry_phase) {
+        if (basis_type != "pw" && basis_type != "lcao") {
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "calculate berry phase, please set basis_type = pw or lcao");
         }
-        if (calculation != "nscf")
-        {
-            ModuleBase::WARNING_QUIT("Input", "calculate berry phase, please set calculation = nscf");
+        if (calculation != "nscf") {
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "calculate berry phase, please set calculation = nscf");
         }
-        if (!(gdir == 1 || gdir == 2 || gdir == 3))
-        {
-            ModuleBase::WARNING_QUIT("Input", "calculate berry phase, please set gdir = 1 or 2 or 3");
+        if (!(gdir == 1 || gdir == 2 || gdir == 3)) {
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "calculate berry phase, please set gdir = 1 or 2 or 3");
         }
     }
 
-    if (towannier90)
-    {
-        if (basis_type == "lcao_in_pw")
-        {
+    if (towannier90) {
+        if (basis_type == "lcao_in_pw") {
             /*
                 Developer's notes: on the repair of lcao_in_pw
 
-                lcao_in_pw is a special basis_type, for scf calculation, it follows workflow of pw,
-                but for nscf the toWannier90 calculation, the interface is in ESolver_KS_LCAO_elec,
-                therefore lcao_in_pw for towannier90 calculation follows lcao.
+                lcao_in_pw is a special basis_type, for scf calculation, it
+               follows workflow of pw, but for nscf the toWannier90 calculation,
+               the interface is in ESolver_KS_LCAO_elec, therefore lcao_in_pw
+               for towannier90 calculation follows lcao.
 
                 In the future lcao_in_pw will have its own ESolver.
 
-                2023/12/22 use new psi_initializer to expand numerical atomic orbitals, ykhuang
+                2023/12/22 use new psi_initializer to expand numerical atomic
+               orbitals, ykhuang
             */
             basis_type = "lcao";
             wannier_method = 1; // it is the way to call toWannier90_lcao_in_pw
@@ -4455,146 +3641,136 @@ void Input::Check(void)
 #else
             ks_solver = "scalapack_gvx";
 #endif
-        }
-        else
-        {
-            if ((basis_type != "pw") && (basis_type != "lcao"))
-            {
-                ModuleBase::WARNING_QUIT("Input", "to use towannier90, please set basis_type = pw, lcao or lcao_in_pw");
+        } else {
+            if ((basis_type != "pw") && (basis_type != "lcao")) {
+                ModuleBase::WARNING_QUIT("Input",
+                                         "to use towannier90, please set "
+                                         "basis_type = pw, lcao or lcao_in_pw");
             }
         }
-        if (calculation != "nscf")
-        {
-            ModuleBase::WARNING_QUIT("Input", "to use towannier90, please set calculation = nscf");
+        if (calculation != "nscf") {
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "to use towannier90, please set calculation = nscf");
         }
-        if (nspin == 2)
-        {
-            if (!(wannier_spin == "up" || wannier_spin == "down"))
-            {
-                ModuleBase::WARNING_QUIT("Input", "to use towannier90, please set wannier_spin = up or down");
+        if (nspin == 2) {
+            if (!(wannier_spin == "up" || wannier_spin == "down")) {
+                ModuleBase::WARNING_QUIT(
+                    "Input",
+                    "to use towannier90, please set wannier_spin = up or down");
             }
         }
     }
 
-    if (read_file_dir != "auto")
-    {
+    if (read_file_dir != "auto") {
         const std::string ss = "test -d " + read_file_dir;
-        if (system(ss.c_str()))
-        {
-            ModuleBase::WARNING_QUIT("Input", "please set right files directory for reading in.");
+        if (system(ss.c_str())) {
+            ModuleBase::WARNING_QUIT(
+                "Input",
+                "please set right files directory for reading in.");
         }
     }
 
     if (true) // Numerical_Basis::output_overlap()
     {
-        if (std::stod(bessel_nao_ecut) < 0)
-        {
+        if (std::stod(bessel_nao_ecut) < 0) {
             ModuleBase::WARNING_QUIT("INPUT", "bessel_nao_ecut must >=0");
         }
-        if (bessel_nao_rcut < 0)
-        {
+        if (bessel_nao_rcut < 0) {
             ModuleBase::WARNING_QUIT("INPUT", "bessel_nao_rcut must >=0");
         }
     }
     if (true) // Numerical_Descriptor::output_descriptor()
     {
-        if (std::stod(bessel_descriptor_ecut) < 0)
-        {
-            ModuleBase::WARNING_QUIT("INPUT", "bessel_descriptor_ecut must >=0");
+        if (std::stod(bessel_descriptor_ecut) < 0) {
+            ModuleBase::WARNING_QUIT("INPUT",
+                                     "bessel_descriptor_ecut must >=0");
         }
-        if (bessel_descriptor_rcut < 0)
-        {
-            ModuleBase::WARNING_QUIT("INPUT", "bessel_descriptor_rcut must >=0");
+        if (bessel_descriptor_rcut < 0) {
+            ModuleBase::WARNING_QUIT("INPUT",
+                                     "bessel_descriptor_rcut must >=0");
         }
     }
 
-    if (sc_mag_switch)
-    {
+    if (sc_mag_switch) {
         std::stringstream ss;
-        ss << "This feature is not stable yet and might lead to erroneous results.\n"
+        ss << "This feature is not stable yet and might lead to erroneous "
+              "results.\n"
            << " Please wait for the official release version.";
         ModuleBase::WARNING_QUIT("Input", ss.str());
     }
     // Deltaspin variables checking
-    if (sc_mag_switch)
-    {
-        if (sc_file == "none")
-        {
-            ModuleBase::WARNING_QUIT("INPUT", "sc_file (json format) must be set when sc_mag_switch > 0");
-        }
-        else
-        {
+    if (sc_mag_switch) {
+        if (sc_file == "none") {
+            ModuleBase::WARNING_QUIT(
+                "INPUT",
+                "sc_file (json format) must be set when sc_mag_switch > 0");
+        } else {
             const std::string ss = "test -f " + sc_file;
-            if (system(ss.c_str()))
-            {
+            if (system(ss.c_str())) {
                 ModuleBase::WARNING_QUIT("INPUT", "sc_file does not exist");
             }
         }
-        if (nspin != 4 && nspin != 2)
-        {
-            ModuleBase::WARNING_QUIT("INPUT", "nspin must be 2 or 4 when sc_mag_switch > 0");
+        if (nspin != 4 && nspin != 2) {
+            ModuleBase::WARNING_QUIT(
+                "INPUT",
+                "nspin must be 2 or 4 when sc_mag_switch > 0");
         }
-        if (calculation != "scf")
-        {
-            ModuleBase::WARNING_QUIT("INPUT", "calculation must be scf when sc_mag_switch > 0");
+        if (calculation != "scf") {
+            ModuleBase::WARNING_QUIT(
+                "INPUT",
+                "calculation must be scf when sc_mag_switch > 0");
         }
-        if (sc_thr <= 0)
-        {
+        if (sc_thr <= 0) {
             ModuleBase::WARNING_QUIT("INPUT", "sc_thr must > 0");
         }
-        if (nsc <= 0)
-        {
+        if (nsc <= 0) {
             ModuleBase::WARNING_QUIT("INPUT", "nsc must > 0");
         }
-        if (nsc_min <= 0)
-        {
+        if (nsc_min <= 0) {
             ModuleBase::WARNING_QUIT("INPUT", "nsc_min must > 0");
         }
-        if (sc_scf_nmin < 2)
-        {
+        if (sc_scf_nmin < 2) {
             ModuleBase::WARNING_QUIT("INPUT", "sc_scf_nmin must >= 2");
         }
-        if (alpha_trial <= 0)
-        {
+        if (alpha_trial <= 0) {
             ModuleBase::WARNING_QUIT("INPUT", "alpha_trial must > 0");
         }
-        if (sccut <= 0)
-        {
+        if (sccut <= 0) {
             ModuleBase::WARNING_QUIT("INPUT", "sccut must > 0");
         }
-        if (nupdown > 0.0)
-        {
-            ModuleBase::WARNING_QUIT("INPUT", "nupdown should not be set when sc_mag_switch > 0");
+        if (nupdown > 0.0) {
+            ModuleBase::WARNING_QUIT(
+                "INPUT",
+                "nupdown should not be set when sc_mag_switch > 0");
         }
     }
-    if (qo_switch)
-    {
+    if (qo_switch) {
         /* first about rationality of parameters */
-        if (qo_basis == "pswfc")
-        {
-            for (auto screen_coeff: qo_screening_coeff)
-            {
-                if (screen_coeff < 0)
-                {
-                    ModuleBase::WARNING_QUIT("INPUT", "screening coefficient must >= 0 to tune the pswfc decay");
+        if (qo_basis == "pswfc") {
+            for (auto screen_coeff: qo_screening_coeff) {
+                if (screen_coeff < 0) {
+                    ModuleBase::WARNING_QUIT("INPUT",
+                                             "screening coefficient must >= 0 "
+                                             "to tune the pswfc decay");
                 }
-                if (std::fabs(screen_coeff) < 1e-6)
-                {
+                if (std::fabs(screen_coeff) < 1e-6) {
                     ModuleBase::WARNING("INPUT",
-                                        "every low screening coefficient might yield very high computational cost");
+                                        "every low screening coefficient might "
+                                        "yield very high computational cost");
                 }
             }
-        }
-        else if (qo_basis == "hydrogen")
-        {
-            if (qo_thr > 1e-6)
-            {
-                ModuleBase::WARNING("INPUT", "too high the convergence threshold might yield unacceptable result");
+        } else if (qo_basis == "hydrogen") {
+            if (qo_thr > 1e-6) {
+                ModuleBase::WARNING("INPUT",
+                                    "too high the convergence threshold might "
+                                    "yield unacceptable result");
             }
         }
         /* then size of std::vector<> parameters */
         if (qo_screening_coeff.size() != ntype)
-            ModuleBase::WARNING_QUIT("INPUT", "qo_screening_coeff.size() != ntype");
+            ModuleBase::WARNING_QUIT("INPUT",
+                                     "qo_screening_coeff.size() != ntype");
         if (qo_strategy.size() != ntype)
             ModuleBase::WARNING_QUIT("INPUT", "qo_strategy.size() != ntype");
     }
@@ -4602,46 +3778,30 @@ void Input::Check(void)
     return;
 }
 
-void Input::close_log(void) const
-{
+void Input::close_log(void) const {
 
     ModuleBase::Global_File::close_all_log(GlobalV::MY_RANK, this->out_alllog);
 }
 
-void Input::read_bool(std::ifstream& ifs, bool& var)
-{
+void Input::read_bool(std::ifstream& ifs, bool& var) {
     std::string str;
     ifs >> str;
-    for (auto& i: str)
-    {
+    for (auto& i: str) {
         i = tolower(i);
     }
-    if (str == "true")
-    {
+    if (str == "true") {
         var = true;
-    }
-    else if (str == "false")
-    {
+    } else if (str == "false") {
         var = false;
-    }
-    else if (str == "1")
-    {
+    } else if (str == "1") {
         var = true;
-    }
-    else if (str == "0")
-    {
+    } else if (str == "0") {
         var = false;
-    }
-    else if (str == "t")
-    {
+    } else if (str == "t") {
         var = true;
-    }
-    else if (str == "f")
-    {
+    } else if (str == "f") {
         var = false;
-    }
-    else
-    {
+    } else {
         std::string warningstr = "Bad boolean parameter ";
         warningstr.append(str);
         warningstr.append(", please check the input parameters in file INPUT");
@@ -4651,12 +3811,10 @@ void Input::read_bool(std::ifstream& ifs, bool& var)
     return;
 }
 
-void Input::strtolower(char* sa, char* sb)
-{
+void Input::strtolower(char* sa, char* sb) {
     char c;
     int len = strlen(sa);
-    for (int i = 0; i < len; i++)
-    {
+    for (int i = 0; i < len; i++) {
         c = sa[i];
         sb[i] = tolower(c);
     }
@@ -4664,57 +3822,66 @@ void Input::strtolower(char* sa, char* sb)
 }
 
 template <typename T>
-void Input::read_value2stdvector(std::ifstream& ifs, std::vector<T>& var)
-{
+void Input::read_value2stdvector(std::ifstream& ifs, std::vector<T>& var) {
     // reset var
     var.clear();
     var.shrink_to_fit();
     std::string line;
-    std::getline(ifs, line);                                                              // read the whole rest of line
-    line = (line.find('#') == std::string::npos) ? line : line.substr(0, line.find('#')); // remove comments
+    std::getline(ifs, line); // read the whole rest of line
+    line = (line.find('#') == std::string::npos)
+               ? line
+               : line.substr(0, line.find('#')); // remove comments
     std::vector<std::string> tmp;
     std::string::size_type start = 0, end = 0;
     while ((start = line.find_first_not_of(" \t\n", end))
-           != std::string::npos) // find the first not of delimiters but not reaches the end
+           != std::string::npos) // find the first not of delimiters but not
+                                 // reaches the end
     {
-        end = line.find_first_of(" \t\n", start);       // find the first of delimiters starting from start pos
-        tmp.push_back(line.substr(start, end - start)); // push back the substring
+        end = line.find_first_of(
+            " \t\n",
+            start); // find the first of delimiters starting from start pos
+        tmp.push_back(
+            line.substr(start, end - start)); // push back the substring
     }
     var.resize(tmp.size());
-    // capture "this"'s member function cast_string and iterate from tmp.begin() to tmp.end(), transform to var.begin()
-    std::transform(tmp.begin(), tmp.end(), var.begin(), [this](const std::string& s) { return cast_string<T>(s); });
+    // capture "this"'s member function cast_string and iterate from tmp.begin()
+    // to tmp.end(), transform to var.begin()
+    std::transform(tmp.begin(),
+                   tmp.end(),
+                   var.begin(),
+                   [this](const std::string& s) { return cast_string<T>(s); });
 }
-template void Input::read_value2stdvector(std::ifstream& ifs, std::vector<int>& var);
-template void Input::read_value2stdvector(std::ifstream& ifs, std::vector<double>& var);
-template void Input::read_value2stdvector(std::ifstream& ifs, std::vector<std::string>& var);
+template void Input::read_value2stdvector(std::ifstream& ifs,
+                                          std::vector<int>& var);
+template void Input::read_value2stdvector(std::ifstream& ifs,
+                                          std::vector<double>& var);
+template void Input::read_value2stdvector(std::ifstream& ifs,
+                                          std::vector<std::string>& var);
 
 // Conut how many types of atoms are listed in STRU
-int Input::count_ntype(const std::string& fn)
-{
-    // Only RANK0 core can reach here, because this function is called during Input::Read.
+int Input::count_ntype(const std::string& fn) {
+    // Only RANK0 core can reach here, because this function is called during
+    // Input::Read.
     assert(GlobalV::MY_RANK == 0);
 
     std::ifstream ifa(fn.c_str(), std::ios::in);
-    if (!ifa)
-    {
+    if (!ifa) {
         GlobalV::ofs_warning << fn;
-        ModuleBase::WARNING_QUIT("Input::count_ntype", "Can not find the file containing atom positions.!");
+        ModuleBase::WARNING_QUIT(
+            "Input::count_ntype",
+            "Can not find the file containing atom positions.!");
     }
 
     int ntype_stru = 0;
     std::string temp;
-    if (ModuleBase::GlobalFunc::SCAN_BEGIN(ifa, "ATOMIC_SPECIES"))
-    {
-        while (true)
-        {
+    if (ModuleBase::GlobalFunc::SCAN_BEGIN(ifa, "ATOMIC_SPECIES")) {
+        while (true) {
             ModuleBase::GlobalFunc::READ_VALUE(ifa, temp);
-            if (temp == "LATTICE_CONSTANT" || temp == "NUMERICAL_ORBITAL" || temp == "NUMERICAL_DESCRIPTOR"
-                || temp == "PAW_FILES" || ifa.eof())
-            {
+            if (temp == "LATTICE_CONSTANT" || temp == "NUMERICAL_ORBITAL"
+                || temp == "NUMERICAL_DESCRIPTOR" || temp == "PAW_FILES"
+                || ifa.eof()) {
                 break;
-            }
-            else if (isalpha(temp[0]))
-            {
+            } else if (isalpha(temp[0])) {
                 ntype_stru += 1;
             }
         }

--- a/source/module_io/input.cpp
+++ b/source/module_io/input.cpp
@@ -4130,9 +4130,9 @@ void Input::Check(void)
     {
         ModuleBase::WARNING_QUIT("Input", "check 'calculation' !");
     }
-    if (init_chg != "atomic" && init_chg != "file")
+    if (init_chg != "atomic" && init_chg != "file" && init_chg != "auto")
     {
-        ModuleBase::WARNING_QUIT("Input", "wrong 'init_chg',not 'atomic', 'file',please check");
+        ModuleBase::WARNING_QUIT("Input", "wrong 'init_chg', not 'atomic', 'file', 'auto', please check");
     }
     if (gamma_only_local == 0)
     {

--- a/source/module_io/input.h
+++ b/source/module_io/input.h
@@ -1,15 +1,15 @@
 #ifndef INPUT_H
 #define INPUT_H
 
+#include "input_conv.h"
+#include "module_base/vector3.h"
+#include "module_md/md_para.h"
+
 #include <fstream>
 #include <sstream>
 #include <string>
-#include <vector>
 #include <type_traits>
-
-#include "module_base/vector3.h"
-#include "module_md/md_para.h"
-#include "input_conv.h"
+#include <vector>
 
 class Input
 {
@@ -19,9 +19,9 @@ class Input
         delete[] hubbard_u;
         delete[] orbital_corr;
     }
-    void Init(const std::string &fn);
+    void Init(const std::string& fn);
 
-    void Print(const std::string &fn) const;
+    void Print(const std::string& fn) const;
 
     void close_log(void) const;
 
@@ -29,53 +29,53 @@ class Input
     // directories of files
     //==========================================================
 
-    std::string suffix; // suffix of out put dir
-    std::string stru_file; // file contains atomic positions -- xiaohui modify 2015-02-01
-    std::string pseudo_dir; // directory of pseudopotential
-    std::string orbital_dir; // directory of orbital file
+    std::string suffix;        // suffix of out put dir
+    std::string stru_file;     // file contains atomic positions -- xiaohui modify 2015-02-01
+    std::string pseudo_dir;    // directory of pseudopotential
+    std::string orbital_dir;   // directory of orbital file
     std::string read_file_dir; // directory of files for reading
     // std::string pseudo_type; // the type of pseudopotential, mohan add 2013-05-20, ABACUS supports
     //                          // UPF format (default) and vwr format. (xiaohui add 2013-06-23)
-    std::string kpoint_file; // file contains k-points -- xiaohui modify 2015-02-01
+    std::string kpoint_file;  // file contains k-points -- xiaohui modify 2015-02-01
     std::string wannier_card; // input card for wannier functions.
-    std::string latname; // lattice name
+    std::string latname;      // lattice name
 
-    std::string calculation; // "scf" : self consistent calculation.
-                             // "nscf" : non-self consistent calculation.
-                             // "relax" : cell relaxations
-    std::string esolver_type;    // the energy solver: ksdft, sdft, ofdft, tddft, lj, dp
-    double pseudo_rcut; // cut-off radius for calculating msh
-    bool pseudo_mesh; // 0: use msh to normalize radial wave functions;  1: use mesh, which is used in QE.
-    int ntype; // number of atom types
-    int nbands; // number of bands
-    int nbands_istate; // number of bands around fermi level for get_pchg calculation.
+    std::string calculation;  // "scf" : self consistent calculation.
+                              // "nscf" : non-self consistent calculation.
+                              // "relax" : cell relaxations
+    std::string esolver_type; // the energy solver: ksdft, sdft, ofdft, tddft, lj, dp
+    double pseudo_rcut;       // cut-off radius for calculating msh
+    bool pseudo_mesh;         // 0: use msh to normalize radial wave functions;  1: use mesh, which is used in QE.
+    int ntype;                // number of atom types
+    int nbands;               // number of bands
+    int nbands_istate;        // number of bands around fermi level for get_pchg calculation.
 
     int pw_seed; // random seed for initializing wave functions qianrui 2021-8-12
 
-    bool init_vel;             // read velocity from STRU or not  liuyu 2021-07-14
-    double ref_cell_factor;    // construct a reference cell bigger than the initial cell  liuyu 2023-03-21
+    bool init_vel;          // read velocity from STRU or not  liuyu 2021-07-14
+    double ref_cell_factor; // construct a reference cell bigger than the initial cell  liuyu 2023-03-21
 
-    /* symmetry level: 
-      -1, no symmetry at all; 
-      0, only basic time reversal would be considered; 
+    /* symmetry level:
+      -1, no symmetry at all;
+      0, only basic time reversal would be considered;
       1, point group symmetry would be considered*/
-    std::string symmetry; 
-    double symmetry_prec; // LiuXh add 2021-08-12, accuracy for symmetry
+    std::string symmetry;
+    double symmetry_prec;    // LiuXh add 2021-08-12, accuracy for symmetry
     bool symmetry_autoclose; // whether to close symmetry automatically when error occurs in symmetry analysis
-    int kpar; // ecch pool is for one k point
+    int kpar;                // ecch pool is for one k point
 
     bool berry_phase; // berry phase calculation
-    int gdir; // berry phase calculation
+    int gdir;         // berry phase calculation
     double kspacing[3];
     double min_dist_coef;
     //==========================================================
     // Wannier functions
     //==========================================================
-    bool towannier90; // add by jingan for wannier90
-    std::string nnkpfile; // add by jingan for wannier90
+    bool towannier90;         // add by jingan for wannier90
+    std::string nnkpfile;     // add by jingan for wannier90
     std::string wannier_spin; // add by jingan for wannier90
-    int wannier_method; // different implementation methods under Lcao basis set
-    bool out_wannier_mmn;  // add by renxi for wannier90
+    int wannier_method;       // different implementation methods under Lcao basis set
+    bool out_wannier_mmn;     // add by renxi for wannier90
     bool out_wannier_amn;
     bool out_wannier_unk;
     bool out_wannier_eig;
@@ -84,36 +84,36 @@ class Input
     //==========================================================
     // Stochastic DFT
     //==========================================================
-    int nche_sto; // number of orders for Chebyshev expansion in stochastic DFT //qinarui 2021-2-5
-    int nbands_sto;			// number of stochastic bands //qianrui 2021-2-5
-    std::string nbndsto_str; // string parameter for stochastic bands
-    int seed_sto; // random seed for sDFT
+    int nche_sto;              // number of orders for Chebyshev expansion in stochastic DFT //qinarui 2021-2-5
+    int nbands_sto;            // number of stochastic bands //qianrui 2021-2-5
+    std::string nbndsto_str;   // string parameter for stochastic bands
+    int seed_sto;              // random seed for sDFT
     double initsto_ecut = 0.0; // maximum ecut to init stochastic bands
-    double emax_sto; // Emax & Emin to normalize H
+    double emax_sto;           // Emax & Emin to normalize H
     double emin_sto;
-    int bndpar; //parallel for stochastic/deterministic bands
-    int initsto_freq; //frequency to init stochastic orbitals when running md
-    int method_sto; //different methods for sdft, 1: slow, less memory  2: fast, more memory
-    int npart_sto; //for method_sto = 2, reduce memory
-    bool cal_cond; //calculate electronic conductivities
-    double cond_che_thr; //control the error of Chebyshev expansions for conductivities
-    int cond_smear; //smearing method for conductivities 1: Gaussian 2: Lorentzian
-    double cond_dw; //d\omega for conductivities
-    double cond_wcut; //cutoff \omega for conductivities
-    double cond_dt;  //dt to integrate conductivities
-    int cond_dtbatch; //exp(iH*dt*cond_dtbatch) is expanded with Chebyshev expansion.
-    double cond_fwhm; //FWHM for conductivities 
-    bool cond_nonlocal; //if calculate nonlocal effects
+    int bndpar;          // parallel for stochastic/deterministic bands
+    int initsto_freq;    // frequency to init stochastic orbitals when running md
+    int method_sto;      // different methods for sdft, 1: slow, less memory  2: fast, more memory
+    int npart_sto;       // for method_sto = 2, reduce memory
+    bool cal_cond;       // calculate electronic conductivities
+    double cond_che_thr; // control the error of Chebyshev expansions for conductivities
+    int cond_smear;      // smearing method for conductivities 1: Gaussian 2: Lorentzian
+    double cond_dw;      // d\omega for conductivities
+    double cond_wcut;    // cutoff \omega for conductivities
+    double cond_dt;      // dt to integrate conductivities
+    int cond_dtbatch;    // exp(iH*dt*cond_dtbatch) is expanded with Chebyshev expansion.
+    double cond_fwhm;    // FWHM for conductivities
+    bool cond_nonlocal;  // if calculate nonlocal effects
 
     //==========================================================
     // electrons / spin
     //==========================================================
     std::string dft_functional; // input DFT functional.
-    double xc_temperature; // only relevant if finite temperature functional is used
-    int nspin; // LDA ; LSDA ; non-linear spin
+    double xc_temperature;      // only relevant if finite temperature functional is used
+    int nspin;                  // LDA ; LSDA ; non-linear spin
     bool two_fermi = false;
     double nupdown = 0.0;
-    double nelec; // total number of electrons
+    double nelec;       // total number of electrons
     double nelec_delta; // change in the number of total electrons
     int lmaxmax;
 
@@ -121,13 +121,13 @@ class Input
     // LCAO parameters
     //==========================================================
     std::string basis_type; // xiaohui add 2013-09-01, for structural adjustment
-    std::string ks_solver; // xiaohui add 2013-09-01
+    std::string ks_solver;  // xiaohui add 2013-09-01
 
     //==========================================================
     // Forces
     //==========================================================
     bool cal_force;
-    double force_thr; // threshold of force in unit (Ry/Bohr)
+    double force_thr;     // threshold of force in unit (Ry/Bohr)
     double force_thr_ev2; // invalid force threshold, mohan add 2011-04-17
 
     //==========================================================
@@ -139,16 +139,16 @@ class Input
     double press3;
     bool cal_stress; // calculate the stress
     int nstream;
-    std::string fixed_axes; // which axes are fixed
-    bool fixed_ibrav; //whether to keep type of lattice; must be used along with latname
-    bool fixed_atoms; //whether to fix atoms during vc-relax
+    std::string fixed_axes;   // which axes are fixed
+    bool fixed_ibrav;         // whether to keep type of lattice; must be used along with latname
+    bool fixed_atoms;         // whether to fix atoms during vc-relax
     std::string relax_method; // methods to move_ion: sd, bfgs, cg...
 
-    //For now, this is only relevant if we choose to use
-    //CG relaxation method. If set to true, then the new
-    //implementation will be used; if set to false, then
-    //the original implementation will be used
-    //Default is true
+    // For now, this is only relevant if we choose to use
+    // CG relaxation method. If set to true, then the new
+    // implementation will be used; if set to false, then
+    // the original implementation will be used
+    // Default is true
     bool relax_new;
 
     double relax_cg_thr; // threshold when cg to bfgs, pengfei add 2011-08-15
@@ -165,9 +165,9 @@ class Input
     //==========================================================
     // Planewave
     //==========================================================
-    bool gamma_only; // for plane wave.
+    bool gamma_only;       // for plane wave.
     bool gamma_only_local; // for local orbitals.
-    int fft_mode = 0; // fftw mode 0: estimate, 1: measure, 2: patient, 3: exhaustive
+    int fft_mode = 0;      // fftw mode 0: estimate, 1: measure, 2: patient, 3: exhaustive
 
     double ecutwfc; // energy cutoff for wavefunctions
     double ecutrho; // energy cutoff for charge/potential
@@ -177,8 +177,8 @@ class Input
     double erf_sigma;  // the width of the energy step for reciprocal vectors
 
     int ncx, ncy, ncz; // three dimension of FFT charge/grid
-    int nx, ny, nz; // three dimension of FFT wavefunc
-    int bx, by, bz; // big mesh ball. mohan add 2011-04-21
+    int nx, ny, nz;    // three dimension of FFT wavefunc
+    int bx, by, bz;    // big mesh ball. mohan add 2011-04-21
     int ndx, ndy, ndz; // three dimension of FFT smooth charge density
 
     //==========================================================
@@ -193,32 +193,32 @@ class Input
 
     int nb2d; // matrix 2d division.
 
-    int nurse; // used for debug.
+    int nurse;    // used for debug.
     int nbspline; // the order of B-spline basis(>=0) if it is -1 (default), B-spline for Sturcture Factor isnot used.
 
     bool colour; // used for fun.
 
-    bool t_in_h; // calculate the T or not.
-    bool vl_in_h; // calculate the vloc or not.
+    bool t_in_h;   // calculate the T or not.
+    bool vl_in_h;  // calculate the vloc or not.
     bool vnl_in_h; // calculate the vnl or not.
 
-    bool vh_in_h; // calculate the hartree potential or not
+    bool vh_in_h;   // calculate the hartree potential or not
     bool vion_in_h; // calculate the local ionic potential or not
     // only relevant when vl_in_h = 1
 
-    bool test_force; // test the force.
+    bool test_force;  // test the force.
     bool test_stress; // test the stress.
 
     //==========================================================
     // iteration
     //==========================================================
-    double scf_thr; // \sum |rhog_out - rhog_in |^2
-    int scf_thr_type; // type of the criterion of scf_thr, 1: reci drho, 2: real drho
-    int scf_nmax; // number of max elec iter
-    int relax_nmax; // number of max ionic iter
-    bool out_stru; // outut stru file each ion step
+    double scf_thr;        // \sum |rhog_out - rhog_in |^2
+    int scf_thr_type;      // type of the criterion of scf_thr, 1: reci drho, 2: real drho
+    int scf_nmax;          // number of max elec iter
+    int relax_nmax;        // number of max ionic iter
+    bool out_stru;         // outut stru file each ion step
     std::string out_level; // control the output information.
-    bool out_md_control; // internal parameter , added by zhengdy 2019-04-07
+    bool out_md_control;   // internal parameter , added by zhengdy 2019-04-07
 
     //==========================================================
     // occupation
@@ -229,24 +229,24 @@ class Input
                                  // "mp","methfessel-paxton"
                                  // "mv","marzari-vanderbilt","cold"
                                  // "fd","fermi-dirac"
-    double smearing_sigma; //
+    double smearing_sigma;       //
 
     //==========================================================
     // charge mixing
     //==========================================================
     std::string mixing_mode; // "plain","broyden",...
-    double mixing_beta; // 0 : no_mixing
-    int mixing_ndim; // used in Broyden method
-    double mixing_restart; // mixing will restart once if drho is smaller than mixing_restart
-    double mixing_gg0; // used in kerker method
+    double mixing_beta;      // 0 : no_mixing
+    int mixing_ndim;         // used in Broyden method
+    double mixing_restart;   // mixing will restart once if drho is smaller than mixing_restart
+    double mixing_gg0;       // used in kerker method
     double mixing_beta_mag;
     double mixing_gg0_mag;
     double mixing_gg0_min;
     double mixing_angle;
 
-    bool mixing_tau; // whether to mix tau in mgga
-    bool mixing_dftu; //whether to mix locale in DFT+U
-    bool mixing_dmr; // whether to mix real space density matrix
+    bool mixing_tau;  // whether to mix tau in mgga
+    bool mixing_dftu; // whether to mix locale in DFT+U
+    bool mixing_dmr;  // whether to mix real space density matrix
 
     //==========================================================
     // potential / charge / wavefunction / energy
@@ -255,50 +255,53 @@ class Input
     std::string init_wfc; // "file","atomic","random"
     std::string init_chg; // "file","atomic", "auto"
     bool psi_initializer; // whether use psi_initializer to initialize wavefunctions
-    
+
     std::string chg_extrap; // xiaohui modify 2015-02-01
 
     int mem_saver; // 1: save psi when nscf calculation.
 
-    int printe; // mohan add 2011-03-16
-    int out_freq_elec;  // the frequency ( >= 0) of electronic iter to output charge density and wavefunction. 0: output only when converged
-    int out_freq_ion;  // the frequency ( >= 0 ) of ionic step to output charge density and wavefunction. 0: output only when ion steps are finished
-    int out_chg; // output charge density. 0: no; 1: yes
-    bool out_dm; // output density matrix.
+    int printe;        // mohan add 2011-03-16
+    int out_freq_elec; // the frequency ( >= 0) of electronic iter to output charge density and wavefunction. 0: output
+                       // only when converged
+    int out_freq_ion;  // the frequency ( >= 0 ) of ionic step to output charge density and wavefunction. 0: output only
+                       // when ion steps are finished
+    int out_chg;       // output charge density. 0: no; 1: yes
+    bool out_dm;       // output density matrix.
     bool out_dm1;
-    int out_pot; // yes or no
-    int out_wfc_pw; // 0: no; 1: txt; 2: dat
-    bool out_wfc_r; // 0: no; 1: yes
-    int out_dos; // dos calculation. mohan add 20090909
-    std::vector<int> out_band; // band calculation pengfei 2014-10-13
-    bool out_proj_band; // projected band structure calculation jiyy add 2022-05-11
+    int out_pot;                 // yes or no
+    int out_wfc_pw;              // 0: no; 1: txt; 2: dat
+    bool out_wfc_r;              // 0: no; 1: yes
+    int out_dos;                 // dos calculation. mohan add 20090909
+    std::vector<int> out_band;   // band calculation pengfei 2014-10-13
+    bool out_proj_band;          // projected band structure calculation jiyy add 2022-05-11
     std::vector<int> out_mat_hs; // output H matrix and S matrix in local basis.
-    bool out_mat_xc; // output exchange-correlation matrix in KS-orbital representation.
-    bool out_hr_npz;// output exchange-correlation matrix in KS-orbital representation.
+    bool out_mat_xc;             // output exchange-correlation matrix in KS-orbital representation.
+    bool out_hr_npz;             // output exchange-correlation matrix in KS-orbital representation.
     bool out_dm_npz;
     bool dm_to_rho;
-    bool cal_syns; // calculate asynchronous S matrix to output
-    double dmax; // maximum displacement of all atoms in one step (bohr)
+    bool cal_syns;    // calculate asynchronous S matrix to output
+    double dmax;      // maximum displacement of all atoms in one step (bohr)
     bool out_mat_hs2; // LiuXh add 2019-07-16, output H(R) matrix and S(R) matrix in local basis.
     bool out_mat_dh;
     int out_interval;
-    bool out_app_flag;    // whether output r(R), H(R), S(R), T(R), and dH(R) matrices in an append manner during MD  liuyu 2023-03-20
+    bool out_app_flag; // whether output r(R), H(R), S(R), T(R), and dH(R) matrices in an append manner during MD  liuyu
+                       // 2023-03-20
     int out_ndigits;
     bool out_mat_t;
-    bool out_mat_r; // jingan add 2019-8-14, output r(R) matrix.
-    int out_wfc_lcao; // output the wave functions in local basis.
-    bool out_alllog; // output all logs.
+    bool out_mat_r;        // jingan add 2019-8-14, output r(R) matrix.
+    int out_wfc_lcao;      // output the wave functions in local basis.
+    bool out_alllog;       // output all logs.
     bool out_element_info; // output infomation of all element
 
     bool out_bandgap; // QO added for bandgap printing
-    
+
     double dos_emin_ev;
     double dos_emax_ev;
     double dos_edelta_ev;
     double dos_scale;
-    int dos_nche; //orders of Chebyshev expansions for dos
-    bool dos_setemin = false; //true: emin is set
-    bool dos_setemax = false; //true: emax is set
+    int dos_nche;             // orders of Chebyshev expansions for dos
+    bool dos_setemin = false; // true: emin is set
+    bool dos_setemax = false; // true: emax is set
 
     double dos_sigma; //  pengfei 2014-10-13
 
@@ -306,12 +309,12 @@ class Input
     // two center integrals in LCAO
     // mohan add 2009-11-11
     //==========================================================
-    double lcao_ecut; // ecut of two center integral
-    double lcao_dk; // delta k used in two center integral
-    double lcao_dr; // dr used in two center integral
-    double lcao_rmax; // rmax(a.u.) to make table.
+    double lcao_ecut;     // ecut of two center integral
+    double lcao_dk;       // delta k used in two center integral
+    double lcao_dr;       // dr used in two center integral
+    double lcao_rmax;     // rmax(a.u.) to make table.
     double search_radius; // 11.1
-    bool search_pbc; // 11.2
+    bool search_pbc;      // 11.2
     double onsite_radius; // the radius of on-site orbitals
 
     //==========================================================
@@ -324,44 +327,44 @@ class Input
     // efield and dipole correction
     // Yu Liu add 2022-05-18
     //==========================================================
-    bool efield_flag;        // add electric field
-    bool dip_cor_flag;        // dipole correction
-    int efield_dir;           // the direction of the electric field or dipole correction
-    double efield_pos_max;     // position of the maximum of the saw-like potential along crystal axis efield_dir
-    double efield_pos_dec;      // zone in the unit cell where the saw-like potential decreases
-    double efield_amp ;        // amplitude of the electric field
+    bool efield_flag;      // add electric field
+    bool dip_cor_flag;     // dipole correction
+    int efield_dir;        // the direction of the electric field or dipole correction
+    double efield_pos_max; // position of the maximum of the saw-like potential along crystal axis efield_dir
+    double efield_pos_dec; // zone in the unit cell where the saw-like potential decreases
+    double efield_amp;     // amplitude of the electric field
 
     //==========================================================
     // gatefield (compensating charge)
     // Yu Liu add 2022-09-13
     //==========================================================
-    bool gate_flag;                 // compensating charge or not
-    double zgate;                   // position of charged plate
-    bool relax;                     // allow relaxation along the specific direction
-    bool block;                     // add a block potential or not
-    double block_down;              // low bound of the block
-    double block_up;                // high bound of the block
-    double block_height;            // height of the block
+    bool gate_flag;      // compensating charge or not
+    double zgate;        // position of charged plate
+    bool relax;          // allow relaxation along the specific direction
+    bool block;          // add a block potential or not
+    double block_down;   // low bound of the block
+    double block_up;     // high bound of the block
+    double block_height; // height of the block
 
     //==========================================================
     // vdw
     // Peize Lin add 2014-03-31, jiyy update 2019-08-01
     //==========================================================
-    std::string vdw_method; // the method of vdw calculation
-    std::string vdw_s6; // scale parameter
-    std::string vdw_s8; // scale parameter
-    std::string vdw_a1; // damping function parameter
-    std::string vdw_a2; // damping function parameter
-    double vdw_d; // damping function parameter d
-    bool vdw_abc; // third-order term?
+    std::string vdw_method;        // the method of vdw calculation
+    std::string vdw_s6;            // scale parameter
+    std::string vdw_s8;            // scale parameter
+    std::string vdw_a1;            // damping function parameter
+    std::string vdw_a2;            // damping function parameter
+    double vdw_d;                  // damping function parameter d
+    bool vdw_abc;                  // third-order term?
     std::string vdw_cutoff_radius; // cutoff radius for std::pair interactions
-    std::string vdw_radius_unit; //"Bohr" or "Angstrom"
-    double vdw_cn_thr; // cutoff radius for calculating the coordination number
-    std::string vdw_cn_thr_unit; //"Bohr" or "Angstrom"
+    std::string vdw_radius_unit;   //"Bohr" or "Angstrom"
+    double vdw_cn_thr;             // cutoff radius for calculating the coordination number
+    std::string vdw_cn_thr_unit;   //"Bohr" or "Angstrom"
     std::string vdw_C6_file;
     std::string vdw_C6_unit; //"Bohr" or "Angstrom"
     std::string vdw_R0_file;
-    std::string vdw_R0_unit; //"Bohr" or "Angstrom"
+    std::string vdw_R0_unit;     //"Bohr" or "Angstrom"
     std::string vdw_cutoff_type; //"period" or "radius"
     ModuleBase::Vector3<int> vdw_cutoff_period;
 
@@ -411,71 +414,71 @@ class Input
     // tddft
     // Fuxiang He add 2016-10-26
     //==========================================================
-    double td_force_dt; //"fs"
-    bool td_vext; // add extern potential or not
+    double td_force_dt;       //"fs"
+    bool td_vext;             // add extern potential or not
     std::string td_vext_dire; // vext direction
-    bool out_dipole; // output the dipole or not
-    bool out_efield; // output the efield or not
-    bool out_current; //output the current or not
-    bool out_vecpot; // output the vector potential or not
-    bool init_vecpot_file; // initialize the vector potential, though file or integral
+    bool out_dipole;          // output the dipole or not
+    bool out_efield;          // output the efield or not
+    bool out_current;         // output the current or not
+    bool out_vecpot;          // output the vector potential or not
+    bool init_vecpot_file;    // initialize the vector potential, though file or integral
 
     double td_print_eij; // threshold to output Eij elements
-    int td_edm; //0: new edm method   1: old edm method
+    int td_edm;          // 0: new edm method   1: old edm method
 
     int propagator; // method of propagator
 
-    int td_stype ; //type of space domain  0 : length gauge  1: velocity gauge
+    int td_stype; // type of space domain  0 : length gauge  1: velocity gauge
 
-    std::string td_ttype ; //type of time domain
+    std::string td_ttype; // type of time domain
     //  0  Gauss type function.
     //  1  trapezoid type function.
     //  2  Trigonometric functions, sin^2.
     //  3  heaviside function.
     //  4  HHG function.
 
-    int td_tstart ;
-    int td_tend ;
+    int td_tstart;
+    int td_tend;
 
     // space domain parameters
 
-    //length gauge
+    // length gauge
     double td_lcut1;
     double td_lcut2;
 
     // time domain parameters
 
     // Gauss
-    std::string td_gauss_freq ; // time(fs)^-1 
-    std::string td_gauss_phase ;
-    std::string td_gauss_sigma ; // time(fs)
-    std::string td_gauss_t0 ;
-    std::string td_gauss_amp ;  // V/A
+    std::string td_gauss_freq; // time(fs)^-1
+    std::string td_gauss_phase;
+    std::string td_gauss_sigma; // time(fs)
+    std::string td_gauss_t0;
+    std::string td_gauss_amp; // V/A
 
     // trapezoid
-    std::string td_trape_freq ; // time(fs)^-1 
-    std::string td_trape_phase ;
-    std::string td_trape_t1 ;
-    std::string td_trape_t2 ;
-    std::string td_trape_t3 ;
-    std::string td_trape_amp ; // V/A
+    std::string td_trape_freq; // time(fs)^-1
+    std::string td_trape_phase;
+    std::string td_trape_t1;
+    std::string td_trape_t2;
+    std::string td_trape_t3;
+    std::string td_trape_amp; // V/A
 
     // Trigonometric
-    std::string td_trigo_freq1 ; // time(fs)^-1 
-    std::string td_trigo_freq2 ; // time(fs)^-1 
-    std::string td_trigo_phase1 ;
-    std::string td_trigo_phase2 ;
-    std::string td_trigo_amp ; // V/A
+    std::string td_trigo_freq1; // time(fs)^-1
+    std::string td_trigo_freq2; // time(fs)^-1
+    std::string td_trigo_phase1;
+    std::string td_trigo_phase2;
+    std::string td_trigo_amp; // V/A
 
     // Heaviside
     std::string td_heavi_t0;
-    std::string td_heavi_amp ; // V/A
+    std::string td_heavi_amp; // V/A
 
     // HHG
     // std::string td_hhg_amp1; // V/A
     // std::string td_hhg_amp2; // V/A
-    // std::string td_hhg_freq1; // time(fs)^-1 
-    // std::string td_hhg_freq2; // time(fs)^-1 
+    // std::string td_hhg_freq1; // time(fs)^-1
+    // std::string td_hhg_freq2; // time(fs)^-1
     // std::string td_hhg_phase1;
     // std::string td_hhg_phase2;
     // std::string td_hhg_t0;
@@ -540,38 +543,42 @@ class Input
     std::string of_kinetic; // Kinetic energy functional, such as TF, VW, WT, TF+
     std::string of_method;  // optimization method, include cg1, cg2, tn (default), bfgs
     std::string of_conv;    // select the convergence criterion, potential, energy (default), or both
-    double of_tole;    // tolerance of the energy change (in Ry) for determining the convergence, default=2e-6 Ry
-    double of_tolp;    // tolerance of potential for determining the convergence, default=1e-5 in a.u.
-    double of_tf_weight;  // weight of TF KEDF
-    double of_vw_weight;  // weight of vW KEDF
-    double of_wt_alpha;   // parameter alpha of WT KEDF
-    double of_wt_beta;    // parameter beta of WT KEDF
-    double of_wt_rho0;    // set the average density of system, in Bohr^-3
-    bool of_hold_rho0;  // If set to 1, the rho0 will be fixed even if the volume of system has changed, it will be set to 1 automaticly if of_wt_rho0 is not zero.
+    double of_tole;         // tolerance of the energy change (in Ry) for determining the convergence, default=2e-6 Ry
+    double of_tolp;         // tolerance of potential for determining the convergence, default=1e-5 in a.u.
+    double of_tf_weight;    // weight of TF KEDF
+    double of_vw_weight;    // weight of vW KEDF
+    double of_wt_alpha;     // parameter alpha of WT KEDF
+    double of_wt_beta;      // parameter beta of WT KEDF
+    double of_wt_rho0;      // set the average density of system, in Bohr^-3
+    bool of_hold_rho0;  // If set to 1, the rho0 will be fixed even if the volume of system has changed, it will be set
+                        // to 1 automaticly if of_wt_rho0 is not zero.
     double of_lkt_a;    // parameter a of LKT KEDF
-    bool of_full_pw;    // If set to 1, ecut will be ignored while collecting planewaves, so that all planewaves will be used.
-    int of_full_pw_dim; // If of_full_pw = 1, the dimention of FFT will be testricted to be (0) either odd or even; (1) odd only; (2) even only.
-    bool of_read_kernel; // If set to 1, the kernel of WT KEDF will be filled from file of_kernel_file, not from formula. Only usable for WT KEDF.
+    bool of_full_pw;    // If set to 1, ecut will be ignored while collecting planewaves, so that all planewaves will be
+                        // used.
+    int of_full_pw_dim; // If of_full_pw = 1, the dimention of FFT will be testricted to be (0) either odd or even; (1)
+                        // odd only; (2) even only.
+    bool of_read_kernel;        // If set to 1, the kernel of WT KEDF will be filled from file of_kernel_file, not from
+                                // formula. Only usable for WT KEDF.
     std::string of_kernel_file; // The name of WT kernel file.
 
     //==========================================================
     // spherical bessel  Peize Lin added on 2022-12-15
     //==========================================================
     // the following are used when generating orb_matrix.dat
-		//int		bessel_nao_lmax;		// lmax used in descriptor
-	bool	bessel_nao_smooth;		// spherical bessel smooth or not
-	double	bessel_nao_sigma;		// spherical bessel smearing_sigma
-	std::string	bessel_nao_ecut;		// energy cutoff for spherical bessel functions(Ry)
-	double	bessel_nao_rcut;		// radial cutoff for spherical bessel functions(a.u.)
+    // int		bessel_nao_lmax;		// lmax used in descriptor
+    bool bessel_nao_smooth;      // spherical bessel smooth or not
+    double bessel_nao_sigma;     // spherical bessel smearing_sigma
+    std::string bessel_nao_ecut; // energy cutoff for spherical bessel functions(Ry)
+    double bessel_nao_rcut;      // radial cutoff for spherical bessel functions(a.u.)
     std::vector<double> bessel_nao_rcuts;
-	double	bessel_nao_tolerence;	// tolerence for spherical bessel root
-    // the following are used when generating jle.orb
-	int		bessel_descriptor_lmax;			// lmax used in descriptor
-	bool	bessel_descriptor_smooth;		// spherical bessel smooth or not
-	double	bessel_descriptor_sigma;		// spherical bessel smearing_sigma
-	std::string	bessel_descriptor_ecut;			// energy cutoff for spherical bessel functions(Ry)
-	double	bessel_descriptor_rcut;			// radial cutoff for spherical bessel functions(a.u.)
-	double	bessel_descriptor_tolerence;	// tolerence for spherical bessel root
+    double bessel_nao_tolerence;        // tolerence for spherical bessel root
+                                        // the following are used when generating jle.orb
+    int bessel_descriptor_lmax;         // lmax used in descriptor
+    bool bessel_descriptor_smooth;      // spherical bessel smooth or not
+    double bessel_descriptor_sigma;     // spherical bessel smearing_sigma
+    std::string bessel_descriptor_ecut; // energy cutoff for spherical bessel functions(Ry)
+    double bessel_descriptor_rcut;      // radial cutoff for spherical bessel functions(a.u.)
+    double bessel_descriptor_tolerence; // tolerence for spherical bessel root
 
     //==========================================================
     //    device control denghui added on 2022-11-15
@@ -594,15 +601,17 @@ class Input
      * 0: none spin-constrained DFT;
      * 1: constrain atomic spin;
      */
-    bool sc_mag_switch; // the switch to open the DeltaSpin function, 0: no spin-constrained DFT; 1: constrain atomic magnetization
-    bool decay_grad_switch;// the switch to use the local approximation of gradient decay, 0: no local approximation; 1: apply the method
-    double sc_thr; // threshold for spin-constrained DFT in uB
-    int nsc; // maximum number of inner lambda loop
-    int nsc_min; // minimum number of inner lambda loop
-    int sc_scf_nmin; // minimum number of outer scf loop before initial lambda loop
-    double alpha_trial; // initial trial step size for lambda in eV/uB^2
-    double sccut; // restriction of step size in eV/uB
-    std::string sc_file; // file name for Deltaspin (json format)
+    bool sc_mag_switch; // the switch to open the DeltaSpin function, 0: no spin-constrained DFT; 1: constrain atomic
+                        // magnetization
+    bool decay_grad_switch; // the switch to use the local approximation of gradient decay, 0: no local approximation;
+                            // 1: apply the method
+    double sc_thr;          // threshold for spin-constrained DFT in uB
+    int nsc;                // maximum number of inner lambda loop
+    int nsc_min;            // minimum number of inner lambda loop
+    int sc_scf_nmin;        // minimum number of outer scf loop before initial lambda loop
+    double alpha_trial;     // initial trial step size for lambda in eV/uB^2
+    double sccut;           // restriction of step size in eV/uB
+    std::string sc_file;    // file name for Deltaspin (json format)
     //==========================================================
     // variables for PAW
     //==========================================================
@@ -646,10 +655,10 @@ class Input
     //==========================================================
     // variables for elpa
     //==========================================================
-    int elpa_num_thread=-1;
+    int elpa_num_thread = -1;
 
     bool check_input = false;
-    
+
     std::time_t get_start_time(void) const
     {
         return start_time;
@@ -668,7 +677,7 @@ class Input
 
     // start time
     std::time_t start_time;
-    bool Read(const std::string &fn);
+    bool Read(const std::string& fn);
 
     void Default(void);
 
@@ -680,19 +689,21 @@ class Input
     void Bcast(void);
 #endif
 
-    int count_ntype(const std::string &fn); // sunliang add 2022-12-06
+    int count_ntype(const std::string& fn); // sunliang add 2022-12-06
 
-    std::string bands_to_print_; // specify the bands to be calculated in the get_pchg calculation, formalism similar to ocp_set.
+    std::string bands_to_print_; // specify the bands to be calculated in the get_pchg calculation, formalism similar to
+                                 // ocp_set.
 
   public:
-    template <class T> static void read_value(std::ifstream &ifs, T &var)
+    template <class T>
+    static void read_value(std::ifstream& ifs, T& var)
     {
         ifs >> var;
         std::string line;
         getline(ifs, line); // read the rest of the line, directly discard it.
         return;
     }
-    void read_kspacing(std::ifstream &ifs)
+    void read_kspacing(std::ifstream& ifs)
     {
         std::string s;
         std::getline(ifs, s);
@@ -724,7 +735,10 @@ class Input
     template <typename T>
     void read_value2stdvector(std::ifstream& ifs, std::vector<T>& var);
     template <typename T>
-    typename std::enable_if<std::is_same<T, double>::value, T>::type cast_string(const std::string& str) { return std::stod(str); }
+    typename std::enable_if<std::is_same<T, double>::value, T>::type cast_string(const std::string& str)
+    {
+        return std::stod(str);
+    }
     template <typename T>
     typename std::enable_if<std::is_same<T, int>::value, T>::type cast_string(const std::string& str)
     {
@@ -736,11 +750,17 @@ class Input
             return std::stoi(str);
     }
     template <typename T>
-    typename std::enable_if<std::is_same<T, bool>::value, T>::type cast_string(const std::string& str) { return (str == "true" || str == "1"); }
+    typename std::enable_if<std::is_same<T, bool>::value, T>::type cast_string(const std::string& str)
+    {
+        return (str == "true" || str == "1");
+    }
     template <typename T>
-    typename std::enable_if<std::is_same<T, std::string>::value, T>::type cast_string(const std::string& str) { return str; }
-    void strtolower(char *sa, char *sb);
-    void read_bool(std::ifstream &ifs, bool &var);
+    typename std::enable_if<std::is_same<T, std::string>::value, T>::type cast_string(const std::string& str)
+    {
+        return str;
+    }
+    void strtolower(char* sa, char* sb);
+    void read_bool(std::ifstream& ifs, bool& var);
 
     // Return the const string pointer of private member bands_to_print_
     // Not recommended to use this function directly, use get_out_band_kb() instead

--- a/source/module_io/input.h
+++ b/source/module_io/input.h
@@ -11,11 +11,9 @@
 #include <type_traits>
 #include <vector>
 
-class Input
-{
+class Input {
   public:
-    ~Input()
-    {
+    ~Input() {
         delete[] hubbard_u;
         delete[] orbital_corr;
     }
@@ -29,31 +27,40 @@ class Input
     // directories of files
     //==========================================================
 
-    std::string suffix;        // suffix of out put dir
-    std::string stru_file;     // file contains atomic positions -- xiaohui modify 2015-02-01
-    std::string pseudo_dir;    // directory of pseudopotential
-    std::string orbital_dir;   // directory of orbital file
+    std::string suffix;      // suffix of out put dir
+    std::string stru_file;   // file contains atomic positions -- xiaohui modify
+                             // 2015-02-01
+    std::string pseudo_dir;  // directory of pseudopotential
+    std::string orbital_dir; // directory of orbital file
     std::string read_file_dir; // directory of files for reading
-    // std::string pseudo_type; // the type of pseudopotential, mohan add 2013-05-20, ABACUS supports
-    //                          // UPF format (default) and vwr format. (xiaohui add 2013-06-23)
-    std::string kpoint_file;  // file contains k-points -- xiaohui modify 2015-02-01
+    // std::string pseudo_type; // the type of pseudopotential, mohan add
+    // 2013-05-20, ABACUS supports
+    //                          // UPF format (default) and vwr format. (xiaohui
+    //                          add 2013-06-23)
+    std::string
+        kpoint_file; // file contains k-points -- xiaohui modify 2015-02-01
     std::string wannier_card; // input card for wannier functions.
     std::string latname;      // lattice name
 
-    std::string calculation;  // "scf" : self consistent calculation.
-                              // "nscf" : non-self consistent calculation.
-                              // "relax" : cell relaxations
-    std::string esolver_type; // the energy solver: ksdft, sdft, ofdft, tddft, lj, dp
-    double pseudo_rcut;       // cut-off radius for calculating msh
-    bool pseudo_mesh;         // 0: use msh to normalize radial wave functions;  1: use mesh, which is used in QE.
-    int ntype;                // number of atom types
-    int nbands;               // number of bands
-    int nbands_istate;        // number of bands around fermi level for get_pchg calculation.
+    std::string calculation; // "scf" : self consistent calculation.
+                             // "nscf" : non-self consistent calculation.
+                             // "relax" : cell relaxations
+    std::string
+        esolver_type;   // the energy solver: ksdft, sdft, ofdft, tddft, lj, dp
+    double pseudo_rcut; // cut-off radius for calculating msh
+    bool pseudo_mesh;  // 0: use msh to normalize radial wave functions;  1: use
+                       // mesh, which is used in QE.
+    int ntype;         // number of atom types
+    int nbands;        // number of bands
+    int nbands_istate; // number of bands around fermi level for get_pchg
+                       // calculation.
 
-    int pw_seed; // random seed for initializing wave functions qianrui 2021-8-12
+    int pw_seed; // random seed for initializing wave functions qianrui
+                 // 2021-8-12
 
     bool init_vel;          // read velocity from STRU or not  liuyu 2021-07-14
-    double ref_cell_factor; // construct a reference cell bigger than the initial cell  liuyu 2023-03-21
+    double ref_cell_factor; // construct a reference cell bigger than the
+                            // initial cell  liuyu 2023-03-21
 
     /* symmetry level:
       -1, no symmetry at all;
@@ -61,7 +68,8 @@ class Input
       1, point group symmetry would be considered*/
     std::string symmetry;
     double symmetry_prec;    // LiuXh add 2021-08-12, accuracy for symmetry
-    bool symmetry_autoclose; // whether to close symmetry automatically when error occurs in symmetry analysis
+    bool symmetry_autoclose; // whether to close symmetry automatically when
+                             // error occurs in symmetry analysis
     int kpar;                // ecch pool is for one k point
 
     bool berry_phase; // berry phase calculation
@@ -74,8 +82,8 @@ class Input
     bool towannier90;         // add by jingan for wannier90
     std::string nnkpfile;     // add by jingan for wannier90
     std::string wannier_spin; // add by jingan for wannier90
-    int wannier_method;       // different implementation methods under Lcao basis set
-    bool out_wannier_mmn;     // add by renxi for wannier90
+    int wannier_method; // different implementation methods under Lcao basis set
+    bool out_wannier_mmn; // add by renxi for wannier90
     bool out_wannier_amn;
     bool out_wannier_unk;
     bool out_wannier_eig;
@@ -84,24 +92,29 @@ class Input
     //==========================================================
     // Stochastic DFT
     //==========================================================
-    int nche_sto;              // number of orders for Chebyshev expansion in stochastic DFT //qinarui 2021-2-5
+    int nche_sto; // number of orders for Chebyshev expansion in stochastic DFT
+                  // //qinarui 2021-2-5
     int nbands_sto;            // number of stochastic bands //qianrui 2021-2-5
     std::string nbndsto_str;   // string parameter for stochastic bands
     int seed_sto;              // random seed for sDFT
     double initsto_ecut = 0.0; // maximum ecut to init stochastic bands
     double emax_sto;           // Emax & Emin to normalize H
     double emin_sto;
-    int bndpar;          // parallel for stochastic/deterministic bands
-    int initsto_freq;    // frequency to init stochastic orbitals when running md
-    int method_sto;      // different methods for sdft, 1: slow, less memory  2: fast, more memory
-    int npart_sto;       // for method_sto = 2, reduce memory
-    bool cal_cond;       // calculate electronic conductivities
-    double cond_che_thr; // control the error of Chebyshev expansions for conductivities
-    int cond_smear;      // smearing method for conductivities 1: Gaussian 2: Lorentzian
+    int bndpar;       // parallel for stochastic/deterministic bands
+    int initsto_freq; // frequency to init stochastic orbitals when running md
+    int method_sto;   // different methods for sdft, 1: slow, less memory  2:
+                      // fast, more memory
+    int npart_sto;    // for method_sto = 2, reduce memory
+    bool cal_cond;    // calculate electronic conductivities
+    double cond_che_thr; // control the error of Chebyshev expansions for
+                         // conductivities
+    int cond_smear;      // smearing method for conductivities 1: Gaussian 2:
+                         // Lorentzian
     double cond_dw;      // d\omega for conductivities
     double cond_wcut;    // cutoff \omega for conductivities
     double cond_dt;      // dt to integrate conductivities
-    int cond_dtbatch;    // exp(iH*dt*cond_dtbatch) is expanded with Chebyshev expansion.
+    int cond_dtbatch;    // exp(iH*dt*cond_dtbatch) is expanded with Chebyshev
+                         // expansion.
     double cond_fwhm;    // FWHM for conductivities
     bool cond_nonlocal;  // if calculate nonlocal effects
 
@@ -109,8 +122,9 @@ class Input
     // electrons / spin
     //==========================================================
     std::string dft_functional; // input DFT functional.
-    double xc_temperature;      // only relevant if finite temperature functional is used
-    int nspin;                  // LDA ; LSDA ; non-linear spin
+    double xc_temperature; // only relevant if finite temperature functional is
+                           // used
+    int nspin;             // LDA ; LSDA ; non-linear spin
     bool two_fermi = false;
     double nupdown = 0.0;
     double nelec;       // total number of electrons
@@ -139,9 +153,10 @@ class Input
     double press3;
     bool cal_stress; // calculate the stress
     int nstream;
-    std::string fixed_axes;   // which axes are fixed
-    bool fixed_ibrav;         // whether to keep type of lattice; must be used along with latname
-    bool fixed_atoms;         // whether to fix atoms during vc-relax
+    std::string fixed_axes; // which axes are fixed
+    bool fixed_ibrav; // whether to keep type of lattice; must be used along
+                      // with latname
+    bool fixed_atoms; // whether to fix atoms during vc-relax
     std::string relax_method; // methods to move_ion: sd, bfgs, cg...
 
     // For now, this is only relevant if we choose to use
@@ -167,7 +182,8 @@ class Input
     //==========================================================
     bool gamma_only;       // for plane wave.
     bool gamma_only_local; // for local orbitals.
-    int fft_mode = 0;      // fftw mode 0: estimate, 1: measure, 2: patient, 3: exhaustive
+    int fft_mode
+        = 0; // fftw mode 0: estimate, 1: measure, 2: patient, 3: exhaustive
 
     double ecutwfc; // energy cutoff for wavefunctions
     double ecutrho; // energy cutoff for charge/potential
@@ -194,7 +210,8 @@ class Input
     int nb2d; // matrix 2d division.
 
     int nurse;    // used for debug.
-    int nbspline; // the order of B-spline basis(>=0) if it is -1 (default), B-spline for Sturcture Factor isnot used.
+    int nbspline; // the order of B-spline basis(>=0) if it is -1 (default),
+                  // B-spline for Sturcture Factor isnot used.
 
     bool colour; // used for fun.
 
@@ -212,11 +229,12 @@ class Input
     //==========================================================
     // iteration
     //==========================================================
-    double scf_thr;        // \sum |rhog_out - rhog_in |^2
-    int scf_thr_type;      // type of the criterion of scf_thr, 1: reci drho, 2: real drho
-    int scf_nmax;          // number of max elec iter
-    int relax_nmax;        // number of max ionic iter
-    bool out_stru;         // outut stru file each ion step
+    double scf_thr;   // \sum |rhog_out - rhog_in |^2
+    int scf_thr_type; // type of the criterion of scf_thr, 1: reci drho, 2: real
+                      // drho
+    int scf_nmax;     // number of max elec iter
+    int relax_nmax;   // number of max ionic iter
+    bool out_stru;    // outut stru file each ion step
     std::string out_level; // control the output information.
     bool out_md_control;   // internal parameter , added by zhengdy 2019-04-07
 
@@ -237,7 +255,8 @@ class Input
     std::string mixing_mode; // "plain","broyden",...
     double mixing_beta;      // 0 : no_mixing
     int mixing_ndim;         // used in Broyden method
-    double mixing_restart;   // mixing will restart once if drho is smaller than mixing_restart
+    double mixing_restart;   // mixing will restart once if drho is smaller than
+                             // mixing_restart
     double mixing_gg0;       // used in kerker method
     double mixing_beta_mag;
     double mixing_gg0_mag;
@@ -254,37 +273,45 @@ class Input
 
     std::string init_wfc; // "file","atomic","random"
     std::string init_chg; // "file","atomic", "auto"
-    bool psi_initializer; // whether use psi_initializer to initialize wavefunctions
+    bool psi_initializer; // whether use psi_initializer to initialize
+                          // wavefunctions
 
     std::string chg_extrap; // xiaohui modify 2015-02-01
 
     int mem_saver; // 1: save psi when nscf calculation.
 
     int printe;        // mohan add 2011-03-16
-    int out_freq_elec; // the frequency ( >= 0) of electronic iter to output charge density and wavefunction. 0: output
-                       // only when converged
-    int out_freq_ion;  // the frequency ( >= 0 ) of ionic step to output charge density and wavefunction. 0: output only
-                       // when ion steps are finished
-    int out_chg;       // output charge density. 0: no; 1: yes
-    bool out_dm;       // output density matrix.
+    int out_freq_elec; // the frequency ( >= 0) of electronic iter to output
+                       // charge density and wavefunction. 0: output only when
+                       // converged
+    int out_freq_ion; // the frequency ( >= 0 ) of ionic step to output charge
+                      // density and wavefunction. 0: output only when ion steps
+                      // are finished
+    int out_chg; // output charge density. 0: no; 1: yes
+    bool out_dm; // output density matrix.
     bool out_dm1;
-    int out_pot;                 // yes or no
-    int out_wfc_pw;              // 0: no; 1: txt; 2: dat
-    bool out_wfc_r;              // 0: no; 1: yes
-    int out_dos;                 // dos calculation. mohan add 20090909
-    std::vector<int> out_band;   // band calculation pengfei 2014-10-13
-    bool out_proj_band;          // projected band structure calculation jiyy add 2022-05-11
+    int out_pot;               // yes or no
+    int out_wfc_pw;            // 0: no; 1: txt; 2: dat
+    bool out_wfc_r;            // 0: no; 1: yes
+    int out_dos;               // dos calculation. mohan add 20090909
+    std::vector<int> out_band; // band calculation pengfei 2014-10-13
+    bool out_proj_band;        // projected band structure calculation jiyy add
+                               // 2022-05-11
     std::vector<int> out_mat_hs; // output H matrix and S matrix in local basis.
-    bool out_mat_xc;             // output exchange-correlation matrix in KS-orbital representation.
-    bool out_hr_npz;             // output exchange-correlation matrix in KS-orbital representation.
+    bool out_mat_xc; // output exchange-correlation matrix in KS-orbital
+                     // representation.
+    bool out_hr_npz; // output exchange-correlation matrix in KS-orbital
+                     // representation.
     bool out_dm_npz;
     bool dm_to_rho;
     bool cal_syns;    // calculate asynchronous S matrix to output
     double dmax;      // maximum displacement of all atoms in one step (bohr)
-    bool out_mat_hs2; // LiuXh add 2019-07-16, output H(R) matrix and S(R) matrix in local basis.
+    bool out_mat_hs2; // LiuXh add 2019-07-16, output H(R) matrix and S(R)
+                      // matrix in local basis.
     bool out_mat_dh;
     int out_interval;
-    bool out_app_flag; // whether output r(R), H(R), S(R), T(R), and dH(R) matrices in an append manner during MD  liuyu
+    bool out_app_flag; // whether output r(R), H(R), S(R), T(R), and dH(R)
+                       // matrices in an append manner during MD  liuyu
                        // 2023-03-20
     int out_ndigits;
     bool out_mat_t;
@@ -327,11 +354,13 @@ class Input
     // efield and dipole correction
     // Yu Liu add 2022-05-18
     //==========================================================
-    bool efield_flag;      // add electric field
-    bool dip_cor_flag;     // dipole correction
-    int efield_dir;        // the direction of the electric field or dipole correction
-    double efield_pos_max; // position of the maximum of the saw-like potential along crystal axis efield_dir
-    double efield_pos_dec; // zone in the unit cell where the saw-like potential decreases
+    bool efield_flag;  // add electric field
+    bool dip_cor_flag; // dipole correction
+    int efield_dir; // the direction of the electric field or dipole correction
+    double efield_pos_max; // position of the maximum of the saw-like potential
+                           // along crystal axis efield_dir
+    double efield_pos_dec; // zone in the unit cell where the saw-like potential
+                           // decreases
     double efield_amp;     // amplitude of the electric field
 
     //==========================================================
@@ -359,8 +388,8 @@ class Input
     bool vdw_abc;                  // third-order term?
     std::string vdw_cutoff_radius; // cutoff radius for std::pair interactions
     std::string vdw_radius_unit;   //"Bohr" or "Angstrom"
-    double vdw_cn_thr;             // cutoff radius for calculating the coordination number
-    std::string vdw_cn_thr_unit;   //"Bohr" or "Angstrom"
+    double vdw_cn_thr; // cutoff radius for calculating the coordination number
+    std::string vdw_cn_thr_unit; //"Bohr" or "Angstrom"
     std::string vdw_C6_file;
     std::string vdw_C6_unit; //"Bohr" or "Angstrom"
     std::string vdw_R0_file;
@@ -421,7 +450,8 @@ class Input
     bool out_efield;          // output the efield or not
     bool out_current;         // output the current or not
     bool out_vecpot;          // output the vector potential or not
-    bool init_vecpot_file;    // initialize the vector potential, though file or integral
+    bool init_vecpot_file;    // initialize the vector potential, though file or
+                              // integral
 
     double td_print_eij; // threshold to output Eij elements
     int td_edm;          // 0: new edm method   1: old edm method
@@ -497,18 +527,23 @@ class Input
     //==========================================================
     //    DFT+U       Xin Qu added on 2020-10-29
     //==========================================================
-    int dft_plus_u;              ///< 1:DFT+U correction; 2:old DFT+U method; 0:standard DFT calculation(default)
-    int* orbital_corr = nullptr; ///< which correlated orbitals need corrected ; d:2 ,f:3, do not need correction:-1
-    double* hubbard_u = nullptr; ///< Hubbard Coulomb interaction parameter U(ev)
-    int omc;                     ///< whether turn on occupation matrix control method or not
-    bool yukawa_potential;       ///< default:false
-    double yukawa_lambda;        ///< default:-1.0, which means we calculate lambda
-    double uramping;             ///< default:-1.0, which means we do not use U-Ramping method
+    int dft_plus_u; ///< 1:DFT+U correction; 2:old DFT+U method; 0:standard DFT
+                    ///< calculation(default)
+    int* orbital_corr = nullptr; ///< which correlated orbitals need corrected ;
+                                 ///< d:2 ,f:3, do not need correction:-1
+    double* hubbard_u
+        = nullptr; ///< Hubbard Coulomb interaction parameter U(ev)
+    int omc;       ///< whether turn on occupation matrix control method or not
+    bool yukawa_potential; ///< default:false
+    double yukawa_lambda;  ///< default:-1.0, which means we calculate lambda
+    double
+        uramping; ///< default:-1.0, which means we do not use U-Ramping method
 
     //==========================================================
     //    DFT+DMFT       Xin Qu added on 2021-08
     //==========================================================
-    bool dft_plus_dmft; // true:DFT+DMFT; false: standard DFT calcullation(default)
+    bool dft_plus_dmft; // true:DFT+DMFT; false: standard DFT
+                        // calcullation(default)
 
     //==========================================================
     //    RPA           Rong Shi added on 2022-04
@@ -519,19 +554,22 @@ class Input
     //==========================================================
     // DeepKS -- added by caoyu and mohan
     //==========================================================
-    bool deepks_out_labels; // (need libnpy) prints energy and force labels and descriptors for training, wenfei
-                            // 2022-1-12
-    bool deepks_scf; //(need libnpy and libtorch) if set 1, a trained model would be needed to cal V_delta and F_delta
+    bool deepks_out_labels; // (need libnpy) prints energy and force labels and
+                            // descriptors for training, wenfei 2022-1-12
+    bool deepks_scf;     //(need libnpy and libtorch) if set 1, a trained model
+                         //would be needed to cal V_delta and F_delta
     bool deepks_bandgap; // for bandgap label. QO added 2021-12-15
     bool deepks_equiv;
-    bool deepks_out_unittest; // if set 1, prints intermediate quantities that shall be used for making unit test
+    bool deepks_out_unittest; // if set 1, prints intermediate quantities that
+                              // shall be used for making unit test
 
     std::string deepks_model; // needed when deepks_scf=1
 
     //==========================================================
     //    implicit solvation model       Menglin Sun added on 2022-04-04
     //==========================================================
-    bool imp_sol; // true:implicit solvation correction; false: vacuum calculation(default)
+    bool imp_sol; // true:implicit solvation correction; false: vacuum
+                  // calculation(default)
     double eb_k;
     double tau;
     double sigma_k;
@@ -540,25 +578,33 @@ class Input
     //==========================================================
     // OFDFT  sunliang added on 2022-05-05
     //==========================================================
-    std::string of_kinetic; // Kinetic energy functional, such as TF, VW, WT, TF+
-    std::string of_method;  // optimization method, include cg1, cg2, tn (default), bfgs
-    std::string of_conv;    // select the convergence criterion, potential, energy (default), or both
-    double of_tole;         // tolerance of the energy change (in Ry) for determining the convergence, default=2e-6 Ry
-    double of_tolp;         // tolerance of potential for determining the convergence, default=1e-5 in a.u.
-    double of_tf_weight;    // weight of TF KEDF
-    double of_vw_weight;    // weight of vW KEDF
-    double of_wt_alpha;     // parameter alpha of WT KEDF
-    double of_wt_beta;      // parameter beta of WT KEDF
-    double of_wt_rho0;      // set the average density of system, in Bohr^-3
-    bool of_hold_rho0;  // If set to 1, the rho0 will be fixed even if the volume of system has changed, it will be set
-                        // to 1 automaticly if of_wt_rho0 is not zero.
-    double of_lkt_a;    // parameter a of LKT KEDF
-    bool of_full_pw;    // If set to 1, ecut will be ignored while collecting planewaves, so that all planewaves will be
-                        // used.
-    int of_full_pw_dim; // If of_full_pw = 1, the dimention of FFT will be testricted to be (0) either odd or even; (1)
-                        // odd only; (2) even only.
-    bool of_read_kernel;        // If set to 1, the kernel of WT KEDF will be filled from file of_kernel_file, not from
-                                // formula. Only usable for WT KEDF.
+    std::string
+        of_kinetic; // Kinetic energy functional, such as TF, VW, WT, TF+
+    std::string
+        of_method; // optimization method, include cg1, cg2, tn (default), bfgs
+    std::string of_conv; // select the convergence criterion, potential, energy
+                         // (default), or both
+    double of_tole; // tolerance of the energy change (in Ry) for determining
+                    // the convergence, default=2e-6 Ry
+    double of_tolp; // tolerance of potential for determining the convergence,
+                    // default=1e-5 in a.u.
+    double of_tf_weight; // weight of TF KEDF
+    double of_vw_weight; // weight of vW KEDF
+    double of_wt_alpha;  // parameter alpha of WT KEDF
+    double of_wt_beta;   // parameter beta of WT KEDF
+    double of_wt_rho0;   // set the average density of system, in Bohr^-3
+    bool of_hold_rho0; // If set to 1, the rho0 will be fixed even if the volume
+                       // of system has changed, it will be set to 1 automaticly
+                       // if of_wt_rho0 is not zero.
+    double of_lkt_a; // parameter a of LKT KEDF
+    bool of_full_pw; // If set to 1, ecut will be ignored while collecting
+                     // planewaves, so that all planewaves will be used.
+    int of_full_pw_dim; // If of_full_pw = 1, the dimention of FFT will be
+                        // testricted to be (0) either odd or even; (1) odd
+                        // only; (2) even only.
+    bool of_read_kernel; // If set to 1, the kernel of WT KEDF will be filled
+                         // from file of_kernel_file, not from formula. Only
+                         // usable for WT KEDF.
     std::string of_kernel_file; // The name of WT kernel file.
 
     //==========================================================
@@ -566,18 +612,23 @@ class Input
     //==========================================================
     // the following are used when generating orb_matrix.dat
     // int		bessel_nao_lmax;		// lmax used in descriptor
-    bool bessel_nao_smooth;      // spherical bessel smooth or not
-    double bessel_nao_sigma;     // spherical bessel smearing_sigma
-    std::string bessel_nao_ecut; // energy cutoff for spherical bessel functions(Ry)
-    double bessel_nao_rcut;      // radial cutoff for spherical bessel functions(a.u.)
+    bool bessel_nao_smooth;  // spherical bessel smooth or not
+    double bessel_nao_sigma; // spherical bessel smearing_sigma
+    std::string
+        bessel_nao_ecut; // energy cutoff for spherical bessel functions(Ry)
+    double
+        bessel_nao_rcut; // radial cutoff for spherical bessel functions(a.u.)
     std::vector<double> bessel_nao_rcuts;
-    double bessel_nao_tolerence;        // tolerence for spherical bessel root
-                                        // the following are used when generating jle.orb
+    double
+        bessel_nao_tolerence; // tolerence for spherical bessel root
+                              // the following are used when generating jle.orb
     int bessel_descriptor_lmax;         // lmax used in descriptor
     bool bessel_descriptor_smooth;      // spherical bessel smooth or not
     double bessel_descriptor_sigma;     // spherical bessel smearing_sigma
-    std::string bessel_descriptor_ecut; // energy cutoff for spherical bessel functions(Ry)
-    double bessel_descriptor_rcut;      // radial cutoff for spherical bessel functions(a.u.)
+    std::string bessel_descriptor_ecut; // energy cutoff for spherical bessel
+                                        // functions(Ry)
+    double bessel_descriptor_rcut;      // radial cutoff for spherical bessel
+                                        // functions(a.u.)
     double bessel_descriptor_tolerence; // tolerence for spherical bessel root
 
     //==========================================================
@@ -601,17 +652,20 @@ class Input
      * 0: none spin-constrained DFT;
      * 1: constrain atomic spin;
      */
-    bool sc_mag_switch; // the switch to open the DeltaSpin function, 0: no spin-constrained DFT; 1: constrain atomic
-                        // magnetization
-    bool decay_grad_switch; // the switch to use the local approximation of gradient decay, 0: no local approximation;
-                            // 1: apply the method
-    double sc_thr;          // threshold for spin-constrained DFT in uB
-    int nsc;                // maximum number of inner lambda loop
-    int nsc_min;            // minimum number of inner lambda loop
-    int sc_scf_nmin;        // minimum number of outer scf loop before initial lambda loop
-    double alpha_trial;     // initial trial step size for lambda in eV/uB^2
-    double sccut;           // restriction of step size in eV/uB
-    std::string sc_file;    // file name for Deltaspin (json format)
+    bool sc_mag_switch;     // the switch to open the DeltaSpin function, 0: no
+                            // spin-constrained DFT; 1: constrain atomic
+                            // magnetization
+    bool decay_grad_switch; // the switch to use the local approximation of
+                            // gradient decay, 0: no local approximation; 1:
+                            // apply the method
+    double sc_thr;   // threshold for spin-constrained DFT in uB
+    int nsc;         // maximum number of inner lambda loop
+    int nsc_min;     // minimum number of inner lambda loop
+    int sc_scf_nmin; // minimum number of outer scf loop before initial lambda
+                     // loop
+    double alpha_trial;  // initial trial step size for lambda in eV/uB^2
+    double sccut;        // restriction of step size in eV/uB
+    std::string sc_file; // file name for Deltaspin (json format)
     //==========================================================
     // variables for PAW
     //==========================================================
@@ -659,10 +713,7 @@ class Input
 
     bool check_input = false;
 
-    std::time_t get_start_time(void) const
-    {
-        return start_time;
-    }
+    std::time_t get_start_time(void) const { return start_time; }
 
   private:
     //==========================================================
@@ -691,42 +742,40 @@ class Input
 
     int count_ntype(const std::string& fn); // sunliang add 2022-12-06
 
-    std::string bands_to_print_; // specify the bands to be calculated in the get_pchg calculation, formalism similar to
-                                 // ocp_set.
+    std::string
+        bands_to_print_; // specify the bands to be calculated in the get_pchg
+                         // calculation, formalism similar to ocp_set.
 
   public:
     template <class T>
-    static void read_value(std::ifstream& ifs, T& var)
-    {
+    static void read_value(std::ifstream& ifs, T& var) {
         ifs >> var;
         std::string line;
         getline(ifs, line); // read the rest of the line, directly discard it.
         return;
     }
-    void read_kspacing(std::ifstream& ifs)
-    {
+    void read_kspacing(std::ifstream& ifs) {
         std::string s;
         std::getline(ifs, s);
         std::stringstream ss(s);
         // read 3 values
         int count = 0;
-        while ((ss >> kspacing[count]) && count < 3)
-        {
+        while ((ss >> kspacing[count]) && count < 3) {
             count++;
         }
         // if not read even one value, or read two values, the input is invalid.
-        if (count == 0 || count == 2)
-        {
-            std::cout << "kspacing can only accept one or three double values." << std::endl;
+        if (count == 0 || count == 2) {
+            std::cout << "kspacing can only accept one or three double values."
+                      << std::endl;
             ifs.setstate(std::ios::failbit);
         }
         // if only read one value, set all to kspacing[0]
-        if (count == 1)
-        {
+        if (count == 1) {
             kspacing[1] = kspacing[0];
             kspacing[2] = kspacing[0];
         }
-        // std::cout << "count: " << count << " kspacing: " << kspacing[0] << " " << kspacing[1] << " " << kspacing[2]
+        // std::cout << "count: " << count << " kspacing: " << kspacing[0] << "
+        // " << kspacing[1] << " " << kspacing[2]
         // << std::endl;
     };
 
@@ -735,13 +784,13 @@ class Input
     template <typename T>
     void read_value2stdvector(std::ifstream& ifs, std::vector<T>& var);
     template <typename T>
-    typename std::enable_if<std::is_same<T, double>::value, T>::type cast_string(const std::string& str)
-    {
+    typename std::enable_if<std::is_same<T, double>::value, T>::type
+        cast_string(const std::string& str) {
         return std::stod(str);
     }
     template <typename T>
-    typename std::enable_if<std::is_same<T, int>::value, T>::type cast_string(const std::string& str)
-    {
+    typename std::enable_if<std::is_same<T, int>::value, T>::type
+        cast_string(const std::string& str) {
         if (str == "true" || str == "1")
             return 1;
         else if (str == "false" || str == "0")
@@ -750,27 +799,24 @@ class Input
             return std::stoi(str);
     }
     template <typename T>
-    typename std::enable_if<std::is_same<T, bool>::value, T>::type cast_string(const std::string& str)
-    {
+    typename std::enable_if<std::is_same<T, bool>::value, T>::type
+        cast_string(const std::string& str) {
         return (str == "true" || str == "1");
     }
     template <typename T>
-    typename std::enable_if<std::is_same<T, std::string>::value, T>::type cast_string(const std::string& str)
-    {
+    typename std::enable_if<std::is_same<T, std::string>::value, T>::type
+        cast_string(const std::string& str) {
         return str;
     }
     void strtolower(char* sa, char* sb);
     void read_bool(std::ifstream& ifs, bool& var);
 
     // Return the const string pointer of private member bands_to_print_
-    // Not recommended to use this function directly, use get_out_band_kb() instead
-    const std::string* get_bands_to_print() const
-    {
-        return &bands_to_print_;
-    }
+    // Not recommended to use this function directly, use get_out_band_kb()
+    // instead
+    const std::string* get_bands_to_print() const { return &bands_to_print_; }
     // Return parsed bands_to_print_ as a vector of integers
-    std::vector<int> get_out_band_kb() const
-    {
+    std::vector<int> get_out_band_kb() const {
         std::vector<int> out_band_kb;
         Input_Conv::parse_expression(bands_to_print_, out_band_kb);
         return out_band_kb;

--- a/source/module_io/input.h
+++ b/source/module_io/input.h
@@ -253,7 +253,7 @@ class Input
     //==========================================================
 
     std::string init_wfc; // "file","atomic","random"
-    std::string init_chg; // "file","atomic"
+    std::string init_chg; // "file","atomic", "auto"
     bool psi_initializer; // whether use psi_initializer to initialize wavefunctions
     
     std::string chg_extrap; // xiaohui modify 2015-02-01

--- a/source/module_io/test/input_test.cpp
+++ b/source/module_io/test/input_test.cpp
@@ -18,14 +18,12 @@
 #define private public
 #include "module_io/input.h"
 
-class InputTest : public testing::Test
-{
+class InputTest : public testing::Test {
   protected:
     std::string output;
 };
 
-TEST_F(InputTest, Default)
-{
+TEST_F(InputTest, Default) {
     INPUT.Default();
     EXPECT_EQ(INPUT.suffix, "ABACUS");
     EXPECT_EQ(INPUT.stru_file, "");
@@ -390,8 +388,7 @@ TEST_F(InputTest, Default)
     EXPECT_EQ(INPUT.sc_file, "none");
 }
 
-TEST_F(InputTest, Read)
-{
+TEST_F(InputTest, Read) {
     std::string input_file = "./support/INPUT";
     INPUT.Read(input_file);
     EXPECT_EQ(INPUT.suffix, "autotest");
@@ -760,8 +757,7 @@ TEST_F(InputTest, Read)
     EXPECT_EQ(INPUT.sc_file, "sc.json");
 }
 
-TEST_F(InputTest, Default_2)
-{
+TEST_F(InputTest, Default_2) {
     //==================================================
     // prepare default parameters for the 1st calling
     EXPECT_EQ(INPUT.vdw_method, "d2");
@@ -1037,8 +1033,7 @@ TEST_F(InputTest, Default_2)
     remove("STRU");
 }
 
-TEST_F(InputTest, Check)
-{
+TEST_F(InputTest, Check) {
     INPUT.ecutwfc = 20.0;
     INPUT.ecutrho = 10;
     testing::internal::CaptureStdout();
@@ -1051,7 +1046,8 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("smooth grids is denser than dense grids"));
+    EXPECT_THAT(output,
+                testing::HasSubstr("smooth grids is denser than dense grids"));
     INPUT.ndx = INPUT.ndy = INPUT.ndz = 11;
     //
     INPUT.nbands = -1;
@@ -1080,7 +1076,9 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("please don't set diago_proc with lcao base"));
+    EXPECT_THAT(
+        output,
+        testing::HasSubstr("please don't set diago_proc with lcao base"));
     INPUT.diago_proc = 1;
     //
     INPUT.kspacing[0] = -1;
@@ -1102,7 +1100,9 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("dipole correction is not active if efield_flag=false !"));
+    EXPECT_THAT(output,
+                testing::HasSubstr(
+                    "dipole correction is not active if efield_flag=false !"));
     INPUT.dip_cor_flag = false;
     //
     INPUT.efield_flag = true;
@@ -1111,7 +1111,10 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("gate field cannot be used with efield if dip_cor_flag=false !"));
+    EXPECT_THAT(
+        output,
+        testing::HasSubstr(
+            "gate field cannot be used with efield if dip_cor_flag=false !"));
     INPUT.gate_flag = false;
     //
     INPUT.calculation = "nscf";
@@ -1120,7 +1123,10 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("symmetry can't be used for out_dos==3(Fermi Surface Plotting) by now."));
+    EXPECT_THAT(
+        output,
+        testing::HasSubstr("symmetry can't be used for out_dos==3(Fermi "
+                           "Surface Plotting) by now."));
     INPUT.symmetry = "0";
     INPUT.out_dos = 0;
     //
@@ -1129,7 +1135,9 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("calculate = get_pchg is only availble for LCAO"));
+    EXPECT_THAT(
+        output,
+        testing::HasSubstr("calculate = get_pchg is only availble for LCAO"));
     INPUT.basis_type = "lcao";
     //
     INPUT.calculation = "get_wf";
@@ -1137,7 +1145,9 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("calculate = get_wf is only availble for LCAO"));
+    EXPECT_THAT(
+        output,
+        testing::HasSubstr("calculate = get_wf is only availble for LCAO"));
     INPUT.basis_type = "lcao";
     //
     INPUT.calculation = "md";
@@ -1145,7 +1155,9 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("time interval of MD calculation should be set!"));
+    EXPECT_THAT(
+        output,
+        testing::HasSubstr("time interval of MD calculation should be set!"));
     INPUT.mdp.md_dt = 1.0;
     //
     INPUT.mdp.md_type = "msst";
@@ -1153,7 +1165,8 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("msst_qmass must be greater than 0!"));
+    EXPECT_THAT(output,
+                testing::HasSubstr("msst_qmass must be greater than 0!"));
     INPUT.mdp.msst_qmass = 1.0;
     //
     INPUT.esolver_type = "dp";
@@ -1169,7 +1182,9 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("to generate descriptors, please use pw basis"));
+    EXPECT_THAT(
+        output,
+        testing::HasSubstr("to generate descriptors, please use pw basis"));
     INPUT.basis_type = "pw";
     //
     INPUT.calculation = "arbitrary";
@@ -1183,7 +1198,10 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("wrong 'init_chg', not 'atomic', 'file', 'auto', please check"));
+    EXPECT_THAT(
+        output,
+        testing::HasSubstr(
+            "wrong 'init_chg', not 'atomic', 'file', 'auto', please check"));
     INPUT.init_chg = "atomic";
     //
     INPUT.gamma_only_local = false;
@@ -1191,7 +1209,9 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("out_dm with k-point algorithm is not implemented yet."));
+    EXPECT_THAT(output,
+                testing::HasSubstr(
+                    "out_dm with k-point algorithm is not implemented yet."));
     INPUT.out_dm = false;
     //
     INPUT.gamma_only_local = true;
@@ -1214,14 +1234,16 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("nelec > 2*nbnd , bands not enough!"));
+    EXPECT_THAT(output,
+                testing::HasSubstr("nelec > 2*nbnd , bands not enough!"));
     INPUT.nelec = INPUT.nbands;
     //
     INPUT.nspin = 3;
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("nspin does not equal to 1, 2, or 4!"));
+    EXPECT_THAT(output,
+                testing::HasSubstr("nspin does not equal to 1, 2, or 4!"));
     INPUT.nspin = 1;
     //
     INPUT.basis_type = "pw";
@@ -1229,28 +1251,35 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("genelpa can not be used with plane wave basis."));
+    EXPECT_THAT(
+        output,
+        testing::HasSubstr("genelpa can not be used with plane wave basis."));
     //
     INPUT.basis_type = "pw";
     INPUT.ks_solver = "scalapack_gvx";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("scalapack_gvx can not be used with plane wave basis."));
+    EXPECT_THAT(output,
+                testing::HasSubstr(
+                    "scalapack_gvx can not be used with plane wave basis."));
     //
     INPUT.basis_type = "pw";
     INPUT.ks_solver = "lapack";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("lapack can not be used with plane wave basis."));
+    EXPECT_THAT(
+        output,
+        testing::HasSubstr("lapack can not be used with plane wave basis."));
     //
     INPUT.basis_type = "pw";
     INPUT.ks_solver = "arbitrary";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("please check the ks_solver parameter!"));
+    EXPECT_THAT(output,
+                testing::HasSubstr("please check the ks_solver parameter!"));
     INPUT.ks_solver = "cg";
     //
     INPUT.basis_type = "pw";
@@ -1258,7 +1287,9 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("gamma_only not implemented for plane wave now."));
+    EXPECT_THAT(
+        output,
+        testing::HasSubstr("gamma_only not implemented for plane wave now."));
     INPUT.gamma_only = false;
     //
     INPUT.basis_type = "pw";
@@ -1266,7 +1297,9 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("out_proj_band not implemented for plane wave now."));
+    EXPECT_THAT(output,
+                testing::HasSubstr(
+                    "out_proj_band not implemented for plane wave now."));
     INPUT.out_proj_band = false;
     //
     INPUT.basis_type = "pw";
@@ -1274,7 +1307,10 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("Fermi Surface Plotting not implemented for plane wave now."));
+    EXPECT_THAT(
+        output,
+        testing::HasSubstr(
+            "Fermi Surface Plotting not implemented for plane wave now."));
     INPUT.out_dos = 0;
     //
     INPUT.basis_type = "pw";
@@ -1282,7 +1318,9 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("Non-colliner Spin-constrained DFT not implemented for plane wave now."));
+    EXPECT_THAT(output,
+                testing::HasSubstr("Non-colliner Spin-constrained DFT not "
+                                   "implemented for plane wave now."));
     INPUT.sc_mag_switch = false;
     //
     INPUT.basis_type = "lcao";
@@ -1290,7 +1328,8 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("not ready for cg method in lcao ."));
+    EXPECT_THAT(output,
+                testing::HasSubstr("not ready for cg method in lcao ."));
     //
     INPUT.basis_type = "lcao";
     INPUT.ks_solver = "genelpa";
@@ -1298,7 +1337,9 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("genelpa can not be used for series version."));
+    EXPECT_THAT(
+        output,
+        testing::HasSubstr("genelpa can not be used for series version."));
 #endif
 #ifndef __ELPA
     testing::internal::CaptureStdout();
@@ -1306,8 +1347,8 @@ TEST_F(InputTest, Check)
     output = testing::internal::GetCapturedStdout();
     EXPECT_THAT(
         output,
-        testing::HasSubstr(
-            "Can not use genelpa if abacus is not compiled with ELPA. Please change ks_solver to scalapack_gvx."));
+        testing::HasSubstr("Can not use genelpa if abacus is not compiled with "
+                           "ELPA. Please change ks_solver to scalapack_gvx."));
 #endif
     //
     INPUT.basis_type = "lcao";
@@ -1316,7 +1357,9 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("scalapack_gvx can not be used for series version."));
+    EXPECT_THAT(output,
+                testing::HasSubstr(
+                    "scalapack_gvx can not be used for series version."));
 #endif
     //
     INPUT.basis_type = "lcao";
@@ -1326,7 +1369,8 @@ TEST_F(InputTest, Check)
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
     EXPECT_THAT(output,
-                testing::HasSubstr("ks_solver=lapack is not an option for parallel version of ABACUS (try genelpa)"));
+                testing::HasSubstr("ks_solver=lapack is not an option for "
+                                   "parallel version of ABACUS (try genelpa)"));
 #endif
     //
     INPUT.basis_type = "lcao";
@@ -1335,7 +1379,9 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("Cusolver can not be used for series version."));
+    EXPECT_THAT(
+        output,
+        testing::HasSubstr("Cusolver can not be used for series version."));
 #endif
     //
     INPUT.basis_type = "lcao";
@@ -1343,7 +1389,8 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("please check the ks_solver parameter!"));
+    EXPECT_THAT(output,
+                testing::HasSubstr("please check the ks_solver parameter!"));
     INPUT.ks_solver = "genelpa";
     //
     INPUT.basis_type = "lcao";
@@ -1351,7 +1398,9 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("kpar > 1 has not been supported for lcao calculation."));
+    EXPECT_THAT(output,
+                testing::HasSubstr(
+                    "kpar > 1 has not been supported for lcao calculation."));
     INPUT.kpar = 1;
     //
     INPUT.basis_type = "lcao";
@@ -1367,21 +1416,26 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("LCAO in plane wave can only done with lapack."));
+    EXPECT_THAT(
+        output,
+        testing::HasSubstr("LCAO in plane wave can only done with lapack."));
     INPUT.ks_solver = "default";
     //
     INPUT.basis_type = "arbitrary";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("please check the basis_type parameter!"));
+    EXPECT_THAT(output,
+                testing::HasSubstr("please check the basis_type parameter!"));
     INPUT.basis_type = "pw";
     //
     INPUT.relax_method = "arbitrary";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("relax_method can only be sd, cg, bfgs or cg_bfgs."));
+    EXPECT_THAT(output,
+                testing::HasSubstr(
+                    "relax_method can only be sd, cg, bfgs or cg_bfgs."));
     INPUT.relax_method = "cg";
     //
     INPUT.bx = 11;
@@ -1390,7 +1444,8 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("bx, or by, or bz is larger than 10!"));
+    EXPECT_THAT(output,
+                testing::HasSubstr("bx, or by, or bz is larger than 10!"));
     INPUT.bx = 1;
     //
     INPUT.vdw_method = "d2";
@@ -1398,7 +1453,8 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("vdw_C6_unit must be Jnm6/mol or eVA6"));
+    EXPECT_THAT(output,
+                testing::HasSubstr("vdw_C6_unit must be Jnm6/mol or eVA6"));
     INPUT.vdw_C6_unit = "eVA6";
     //
     INPUT.vdw_R0_unit = "arbitrary";
@@ -1412,28 +1468,32 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("vdw_cutoff_type must be radius or period"));
+    EXPECT_THAT(output,
+                testing::HasSubstr("vdw_cutoff_type must be radius or period"));
     INPUT.vdw_cutoff_type = "radius";
     //
     INPUT.vdw_cutoff_period.x = 0;
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("vdw_cutoff_period <= 0 is not allowd"));
+    EXPECT_THAT(output,
+                testing::HasSubstr("vdw_cutoff_period <= 0 is not allowd"));
     INPUT.vdw_cutoff_period.x = 3;
     //
     INPUT.vdw_cutoff_radius = "0";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("vdw_cutoff_radius <= 0 is not allowd"));
+    EXPECT_THAT(output,
+                testing::HasSubstr("vdw_cutoff_radius <= 0 is not allowd"));
     INPUT.vdw_cutoff_radius = "1.0";
     //
     INPUT.vdw_radius_unit = "arbitrary";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("vdw_radius_unit must be A or Bohr"));
+    EXPECT_THAT(output,
+                testing::HasSubstr("vdw_radius_unit must be A or Bohr"));
     INPUT.vdw_radius_unit = "A";
     //
     INPUT.vdw_cn_thr = 0;
@@ -1447,7 +1507,8 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("vdw_cn_thr_unit must be A or Bohr"));
+    EXPECT_THAT(output,
+                testing::HasSubstr("vdw_cn_thr_unit must be A or Bohr"));
     INPUT.vdw_cn_thr_unit = "A";
     //
     INPUT.dft_functional = "scan0";
@@ -1484,7 +1545,9 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("exx_distribute_type must be htime or kmeans2 or kmeans1"));
+    EXPECT_THAT(output,
+                testing::HasSubstr(
+                    "exx_distribute_type must be htime or kmeans2 or kmeans1"));
     INPUT.exx_distribute_type = "htime";
     //
     INPUT.dft_functional = "opt_orb";
@@ -1515,7 +1578,10 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("calculate berry phase, please set basis_type = pw or lcao"));
+    EXPECT_THAT(
+        output,
+        testing::HasSubstr(
+            "calculate berry phase, please set basis_type = pw or lcao"));
     INPUT.basis_type = "pw";
     INPUT.ks_solver = "cg";
     //
@@ -1523,25 +1589,29 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("calculate berry phase, please set calculation = nscf"));
+    EXPECT_THAT(output,
+                testing::HasSubstr(
+                    "calculate berry phase, please set calculation = nscf"));
     INPUT.calculation = "nscf";
     //
     INPUT.gdir = 4;
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("calculate berry phase, please set gdir = 1 or 2 or 3"));
+    EXPECT_THAT(output,
+                testing::HasSubstr(
+                    "calculate berry phase, please set gdir = 1 or 2 or 3"));
     INPUT.gdir = 3;
     INPUT.berry_phase = false;
     //
     INPUT.towannier90 = true;
-    // due to the repair of lcao_in_pw, original warning has been deprecated, 2023/12/23, ykhuang
-    // INPUT.basis_type = "lcao_in_pw";
-    // INPUT.ks_solver = "lapack";
-    // testing::internal::CaptureStdout();
+    // due to the repair of lcao_in_pw, original warning has been deprecated,
+    // 2023/12/23, ykhuang INPUT.basis_type = "lcao_in_pw"; INPUT.ks_solver =
+    // "lapack"; testing::internal::CaptureStdout();
     // EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
     // output = testing::internal::GetCapturedStdout();
-    // EXPECT_THAT(output,testing::HasSubstr("to use towannier90, please set basis_type = pw or lcao"));
+    // EXPECT_THAT(output,testing::HasSubstr("to use towannier90, please set
+    // basis_type = pw or lcao"));
     INPUT.basis_type = "pw";
     INPUT.ks_solver = "cg";
     //
@@ -1549,7 +1619,9 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("to use towannier90, please set calculation = nscf"));
+    EXPECT_THAT(output,
+                testing::HasSubstr(
+                    "to use towannier90, please set calculation = nscf"));
     INPUT.calculation = "nscf";
     //
     INPUT.nspin = 2;
@@ -1557,7 +1629,10 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("to use towannier90, please set wannier_spin = up or down"));
+    EXPECT_THAT(
+        output,
+        testing::HasSubstr(
+            "to use towannier90, please set wannier_spin = up or down"));
     INPUT.wannier_spin = "up";
     INPUT.towannier90 = false;
     //
@@ -1565,7 +1640,9 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("please set right files directory for reading in."));
+    EXPECT_THAT(
+        output,
+        testing::HasSubstr("please set right files directory for reading in."));
     INPUT.read_file_dir = "auto";
     /*
     // Start to check deltaspin parameters
@@ -1577,7 +1654,8 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output,testing::HasSubstr("sc_file (json format) must be set when sc_mag_switch > 0"));
+    EXPECT_THAT(output,testing::HasSubstr("sc_file (json format) must be set
+    when sc_mag_switch > 0"));
     // warning 2 of Deltaspin
     INPUT.sc_file = "sc.json";
     testing::internal::CaptureStdout();
@@ -1590,15 +1668,15 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output,testing::HasSubstr("nspin must be 2 or 4 when sc_mag_switch > 0"));
-    INPUT.nspin = 4;
+    EXPECT_THAT(output,testing::HasSubstr("nspin must be 2 or 4 when
+    sc_mag_switch > 0")); INPUT.nspin = 4;
     // warning 4 of Deltaspin
     INPUT.calculation = "nscf";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output,testing::HasSubstr("calculation must be scf when sc_mag_switch > 0"));
-    INPUT.calculation = "scf";
+    EXPECT_THAT(output,testing::HasSubstr("calculation must be scf when
+    sc_mag_switch > 0")); INPUT.calculation = "scf";
     // warning 5 of Deltaspin
     INPUT.sc_thr = -1;
         testing::internal::CaptureStdout();
@@ -1646,8 +1724,8 @@ TEST_F(InputTest, Check)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output,testing::HasSubstr("nupdown should not be set when sc_mag_switch > 0"));
-    INPUT.nupdown = 0;
+    EXPECT_THAT(output,testing::HasSubstr("nupdown should not be set when
+    sc_mag_switch > 0")); INPUT.nupdown = 0;
     // restore to default values
     INPUT.nspin = 1;
     INPUT.sc_file = "none";
@@ -1665,69 +1743,59 @@ TEST_F(InputTest, Check)
     */
 }
 
-bool strcmp_inbuilt(const std::string& str1, const std::string& str2)
-{
+bool strcmp_inbuilt(const std::string& str1, const std::string& str2) {
     if (str1.size() != str2.size())
         return false;
-    for (int i = 0; i < str1.size(); i++)
-    {
+    for (int i = 0; i < str1.size(); i++) {
         if (str1[i] != str2[i])
             return false;
     }
     return true;
 }
 
-TEST_F(InputTest, ReadValue2stdvector)
-{
+TEST_F(InputTest, ReadValue2stdvector) {
     std::string input_file = "./support/INPUT_list";
     std::ifstream ifs(input_file);
     std::string word;
     std::vector<int> value;
-    while (!ifs.eof())
-    {
+    while (!ifs.eof()) {
         ifs >> word;
-        if (strcmp_inbuilt(word, "bessel_nao_rcut_case0"))
-        {
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case0")) {
             value.clear();
             value.shrink_to_fit();
             INPUT.read_value2stdvector(ifs, value);
             EXPECT_EQ(value.size(), 1);
             EXPECT_EQ(value[0], 7);
         }
-        if (strcmp_inbuilt(word, "bessel_nao_rcut_case1"))
-        {
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case1")) {
             value.clear();
             value.shrink_to_fit();
             INPUT.read_value2stdvector(ifs, value);
             EXPECT_EQ(value.size(), 1);
             EXPECT_EQ(value[0], 7);
         }
-        if (strcmp_inbuilt(word, "bessel_nao_rcut_case2"))
-        {
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case2")) {
             value.clear();
             value.shrink_to_fit();
             INPUT.read_value2stdvector(ifs, value);
             EXPECT_EQ(value.size(), 1);
             EXPECT_EQ(value[0], 7);
         }
-        if (strcmp_inbuilt(word, "bessel_nao_rcut_case3"))
-        {
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case3")) {
             value.clear();
             value.shrink_to_fit();
             INPUT.read_value2stdvector(ifs, value);
             EXPECT_EQ(value.size(), 1);
             EXPECT_EQ(value[0], 7);
         }
-        if (strcmp_inbuilt(word, "bessel_nao_rcut_case4"))
-        {
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case4")) {
             value.clear();
             value.shrink_to_fit();
             INPUT.read_value2stdvector(ifs, value);
             EXPECT_EQ(value.size(), 1);
             EXPECT_EQ(value[0], 7);
         }
-        if (strcmp_inbuilt(word, "bessel_nao_rcut_case5"))
-        {
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case5")) {
             value.clear();
             value.shrink_to_fit();
             INPUT.read_value2stdvector(ifs, value);
@@ -1737,8 +1805,7 @@ TEST_F(InputTest, ReadValue2stdvector)
             EXPECT_EQ(value[2], 9);
             EXPECT_EQ(value[3], 10);
         }
-        if (strcmp_inbuilt(word, "bessel_nao_rcut_case6"))
-        {
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case6")) {
             value.clear();
             value.shrink_to_fit();
             INPUT.read_value2stdvector(ifs, value);
@@ -1748,8 +1815,7 @@ TEST_F(InputTest, ReadValue2stdvector)
             EXPECT_EQ(value[2], 9);
             EXPECT_EQ(value[3], 10);
         }
-        if (strcmp_inbuilt(word, "bessel_nao_rcut_case7"))
-        {
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case7")) {
             value.clear();
             value.shrink_to_fit();
             INPUT.read_value2stdvector(ifs, value);
@@ -1759,8 +1825,7 @@ TEST_F(InputTest, ReadValue2stdvector)
             EXPECT_EQ(value[2], 9);
             EXPECT_EQ(value[3], 10);
         }
-        if (strcmp_inbuilt(word, "bessel_nao_rcut_case8"))
-        {
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case8")) {
             value.clear();
             value.shrink_to_fit();
             INPUT.read_value2stdvector(ifs, value);
@@ -1771,16 +1836,14 @@ TEST_F(InputTest, ReadValue2stdvector)
             EXPECT_EQ(value[3], 10);
         }
         std::vector<std::string> str_value;
-        if (strcmp_inbuilt(word, "bessel_nao_rcut_case9"))
-        {
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case9")) {
             str_value.clear();
             str_value.shrink_to_fit();
             INPUT.read_value2stdvector(ifs, str_value);
             EXPECT_EQ(str_value.size(), 1);
             EXPECT_EQ(str_value[0], "string1");
         }
-        if (strcmp_inbuilt(word, "bessel_nao_rcut_case10"))
-        {
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case10")) {
             str_value.clear();
             str_value.shrink_to_fit();
             INPUT.read_value2stdvector(ifs, str_value);
@@ -1791,16 +1854,14 @@ TEST_F(InputTest, ReadValue2stdvector)
             EXPECT_EQ(str_value[3], "string4");
         }
         std::vector<double> double_value;
-        if (strcmp_inbuilt(word, "bessel_nao_rcut_case11"))
-        {
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case11")) {
             double_value.clear();
             double_value.shrink_to_fit();
             INPUT.read_value2stdvector(ifs, double_value);
             EXPECT_EQ(double_value.size(), 1);
             EXPECT_EQ(double_value[0], 1.23456789);
         }
-        if (strcmp_inbuilt(word, "bessel_nao_rcut_case12"))
-        {
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case12")) {
             double_value.clear();
             double_value.shrink_to_fit();
             INPUT.read_value2stdvector(ifs, double_value);
@@ -1814,11 +1875,9 @@ TEST_F(InputTest, ReadValue2stdvector)
 }
 #undef private
 
-class ReadKSpacingTest : public ::testing::Test
-{
+class ReadKSpacingTest : public ::testing::Test {
   protected:
-    void SetUp() override
-    {
+    void SetUp() override {
         // create a temporary file for testing
         char tmpname[] = "tmpfile.tmp";
         int fd = mkstemp(tmpname);
@@ -1828,8 +1887,7 @@ class ReadKSpacingTest : public ::testing::Test
         ofs.close();
     }
 
-    void TearDown() override
-    {
+    void TearDown() override {
         close(fd);
         unlink(tmpfile.c_str());
     }
@@ -1838,8 +1896,7 @@ class ReadKSpacingTest : public ::testing::Test
     int fd;
 };
 
-TEST_F(ReadKSpacingTest, ValidInputOneValue)
-{
+TEST_F(ReadKSpacingTest, ValidInputOneValue) {
     std::ifstream ifs(tmpfile);
     EXPECT_NO_THROW(INPUT.read_kspacing(ifs));
     EXPECT_EQ(INPUT.kspacing[0], 1.0);
@@ -1847,8 +1904,7 @@ TEST_F(ReadKSpacingTest, ValidInputOneValue)
     EXPECT_EQ(INPUT.kspacing[2], 1.0);
 }
 
-TEST_F(ReadKSpacingTest, ValidInputThreeValue)
-{
+TEST_F(ReadKSpacingTest, ValidInputThreeValue) {
     std::ofstream ofs(tmpfile);
     ofs << "1.0 2.0 3.0"; // invalid input
     ofs.close();
@@ -1860,8 +1916,7 @@ TEST_F(ReadKSpacingTest, ValidInputThreeValue)
     EXPECT_EQ(INPUT.kspacing[2], 3.0);
 }
 
-TEST_F(ReadKSpacingTest, InvalidInput)
-{
+TEST_F(ReadKSpacingTest, InvalidInput) {
     std::ofstream ofs(tmpfile);
     ofs << "1.0 2.0"; // invalid input
     ofs.close();

--- a/source/module_io/test/input_test.cpp
+++ b/source/module_io/test/input_test.cpp
@@ -1182,7 +1182,7 @@ TEST_F(InputTest, Check)
 	testing::internal::CaptureStdout();
 	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
 	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("wrong 'init_chg',not 'atomic', 'file',please check"));
+	EXPECT_THAT(output,testing::HasSubstr("wrong 'init_chg', not 'atomic', 'file', 'auto', please check"));
 	INPUT.init_chg = "atomic";
 	//
 	INPUT.gamma_only_local = 0;

--- a/source/module_io/test/input_test.cpp
+++ b/source/module_io/test/input_test.cpp
@@ -1,7 +1,8 @@
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
 #include "module_base/global_variable.h"
 #include "module_base/tool_quit.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 /************************************************
  *  unit test of input.cpp
  ***********************************************/
@@ -19,371 +20,371 @@
 
 class InputTest : public testing::Test
 {
-protected:
-	std::string output;
+  protected:
+    std::string output;
 };
 
 TEST_F(InputTest, Default)
 {
-	INPUT.Default();
-	EXPECT_EQ(INPUT.suffix,"ABACUS");
-	EXPECT_EQ(INPUT.stru_file,"");
-	EXPECT_EQ(INPUT.kpoint_file,"");
-	EXPECT_EQ(INPUT.pseudo_dir,"");
-	EXPECT_EQ(INPUT.orbital_dir,"");
-	EXPECT_EQ(INPUT.read_file_dir,"auto");
-	EXPECT_EQ(INPUT.wannier_card,"none");
-	EXPECT_EQ(INPUT.latname,"none");
-	EXPECT_EQ(INPUT.calculation,"scf");
-	EXPECT_EQ(INPUT.esolver_type,"ksdft");
-	EXPECT_DOUBLE_EQ(INPUT.pseudo_rcut,15.0);
-	EXPECT_FALSE(INPUT.pseudo_mesh);
-	EXPECT_EQ(INPUT.ntype,0);
-	EXPECT_EQ(INPUT.nbands,0);
-	EXPECT_EQ(INPUT.nbands_sto,256);
-	EXPECT_EQ(INPUT.nbands_istate,5);
-	EXPECT_EQ(INPUT.pw_seed,1);
-	EXPECT_EQ(INPUT.emin_sto,0.0);
-	EXPECT_EQ(INPUT.emax_sto,0.0);
-	EXPECT_EQ(INPUT.nche_sto,100);
-        EXPECT_EQ(INPUT.seed_sto,0);
-		EXPECT_EQ(INPUT.initsto_ecut,0.0);
-        EXPECT_EQ(INPUT.bndpar,1);
-        EXPECT_EQ(INPUT.kpar,1);
-        EXPECT_EQ(INPUT.initsto_freq,0);
-        EXPECT_EQ(INPUT.method_sto,2);
-        EXPECT_EQ(INPUT.npart_sto,1);
-        EXPECT_FALSE(INPUT.cal_cond);
-        EXPECT_EQ(INPUT.dos_nche,100);
-        EXPECT_DOUBLE_EQ(INPUT.cond_che_thr,1e-8);
-        EXPECT_DOUBLE_EQ(INPUT.cond_dw,0.1);
-        EXPECT_DOUBLE_EQ(INPUT.cond_wcut,10);
-        EXPECT_EQ(INPUT.cond_dt,0.02);
-		EXPECT_EQ(INPUT.cond_dtbatch,0);
-		EXPECT_EQ(INPUT.cond_smear,1);
-        EXPECT_DOUBLE_EQ(INPUT.cond_fwhm,0.4);
-        EXPECT_TRUE(INPUT.cond_nonlocal);
-        EXPECT_FALSE(INPUT.berry_phase);
-        EXPECT_EQ(INPUT.gdir,3);
-        EXPECT_FALSE(INPUT.towannier90);
-        EXPECT_EQ(INPUT.nnkpfile,"seedname.nnkp");
-        EXPECT_EQ(INPUT.wannier_spin,"up");
-        EXPECT_EQ(INPUT.wannier_method,1);
-		EXPECT_TRUE(INPUT.out_wannier_amn);
-		EXPECT_TRUE(INPUT.out_wannier_mmn);
-		EXPECT_FALSE(INPUT.out_wannier_unk);
-		EXPECT_TRUE(INPUT.out_wannier_eig);
-        EXPECT_TRUE(INPUT.out_wannier_wvfn_formatted);
-        EXPECT_DOUBLE_EQ(INPUT.kspacing[0], 0.0);
-        EXPECT_DOUBLE_EQ(INPUT.kspacing[1],0.0);
-        EXPECT_DOUBLE_EQ(INPUT.kspacing[2],0.0);
-        EXPECT_DOUBLE_EQ(INPUT.min_dist_coef,0.2);
-        EXPECT_EQ(INPUT.dft_functional,"default");
-        EXPECT_DOUBLE_EQ(INPUT.xc_temperature,0.0);
-        EXPECT_EQ(INPUT.nspin,1);
-        EXPECT_DOUBLE_EQ(INPUT.nelec,0.0);
-        EXPECT_EQ(INPUT.lmaxmax,2);
-        EXPECT_EQ(INPUT.basis_type,"pw");
-        EXPECT_EQ(INPUT.ks_solver,"default");
-        EXPECT_DOUBLE_EQ(INPUT.search_radius,-1.0);
-        EXPECT_TRUE(INPUT.search_pbc);
-        EXPECT_EQ(INPUT.symmetry,"default");
-        EXPECT_FALSE(INPUT.init_vel);
-        EXPECT_DOUBLE_EQ(INPUT.ref_cell_factor,1.0);
-        EXPECT_DOUBLE_EQ(INPUT.symmetry_prec, 1.0e-6);
-        EXPECT_TRUE(INPUT.symmetry_autoclose);
-        EXPECT_EQ(INPUT.cal_force, 0);
-        EXPECT_DOUBLE_EQ(INPUT.force_thr,1.0e-3);
-        EXPECT_DOUBLE_EQ(INPUT.force_thr_ev2,0);
-        EXPECT_DOUBLE_EQ(INPUT.stress_thr, 0.5);
-        EXPECT_DOUBLE_EQ(INPUT.press1,0.0);
-        EXPECT_DOUBLE_EQ(INPUT.press2,0.0);
-        EXPECT_DOUBLE_EQ(INPUT.press3,0.0);
-        EXPECT_FALSE(INPUT.cal_stress);
-        EXPECT_EQ(INPUT.fixed_axes,"None");
-        EXPECT_FALSE(INPUT.fixed_ibrav);
-        EXPECT_FALSE(INPUT.fixed_atoms);
-        EXPECT_EQ(INPUT.relax_method,"cg");
-        EXPECT_DOUBLE_EQ(INPUT.relax_cg_thr,0.5);
-        EXPECT_EQ(INPUT.out_level,"ie");
-        EXPECT_FALSE(INPUT.out_md_control);
-        EXPECT_TRUE(INPUT.relax_new);
-        EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_w1,0.01);
-        EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_w2,0.5);
-        EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_rmax,0.8);
-        EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_rmin,1e-5);
-        EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_init,0.5);
-        EXPECT_DOUBLE_EQ(INPUT.relax_scale_force,0.5);
-        EXPECT_EQ(INPUT.nbspline,-1);
-        EXPECT_FALSE(INPUT.gamma_only);
-        EXPECT_FALSE(INPUT.gamma_only_local);
-        EXPECT_DOUBLE_EQ(INPUT.ecutwfc,50.0);
-        EXPECT_DOUBLE_EQ(INPUT.erf_ecut, 0.0);
-        EXPECT_DOUBLE_EQ(INPUT.erf_height, 0.0);
-        EXPECT_DOUBLE_EQ(INPUT.erf_sigma, 0.1);
-		EXPECT_EQ(INPUT.fft_mode,0);
-        EXPECT_EQ(INPUT.nx,0);
-        EXPECT_EQ(INPUT.ny,0);
-        EXPECT_EQ(INPUT.nz,0);
-        EXPECT_EQ(INPUT.bx,0);
-        EXPECT_EQ(INPUT.by,0);
-        EXPECT_EQ(INPUT.bz,0);
-        EXPECT_EQ(INPUT.ndx, 0);
-        EXPECT_EQ(INPUT.ndy, 0);
-        EXPECT_EQ(INPUT.ndz, 0);
-        EXPECT_EQ(INPUT.diago_proc,0);
-        EXPECT_EQ(INPUT.pw_diag_nmax,50);
-        EXPECT_EQ(INPUT.diago_cg_prec,1);
-        EXPECT_EQ(INPUT.pw_diag_ndim,4);
-        EXPECT_DOUBLE_EQ(INPUT.pw_diag_thr,1.0e-2);
-        EXPECT_EQ(INPUT.nb2d,0);
-        EXPECT_EQ(INPUT.nurse,0);
-        EXPECT_EQ(INPUT.colour,0);
-        EXPECT_EQ(INPUT.t_in_h,1);
-        EXPECT_EQ(INPUT.vl_in_h,1);
-        EXPECT_EQ(INPUT.vnl_in_h,1);
-        EXPECT_EQ(INPUT.vh_in_h,1);
-        EXPECT_EQ(INPUT.vion_in_h,1);
-        EXPECT_EQ(INPUT.test_force,0);
-        EXPECT_EQ(INPUT.test_stress,0);
-        EXPECT_DOUBLE_EQ(INPUT.scf_thr,-1.0);
-        EXPECT_EQ(INPUT.scf_thr_type,-1);
-        EXPECT_EQ(INPUT.scf_nmax,100);
-        EXPECT_EQ(INPUT.relax_nmax,0);
-        EXPECT_EQ(INPUT.out_stru,0);
-        EXPECT_EQ(INPUT.occupations,"smearing");
-        EXPECT_EQ(INPUT.smearing_method,"gauss");
-        EXPECT_DOUBLE_EQ(INPUT.smearing_sigma,0.015);
-        EXPECT_EQ(INPUT.mixing_mode,"broyden");
-        EXPECT_DOUBLE_EQ(INPUT.mixing_beta,-10.0);
-        EXPECT_EQ(INPUT.mixing_ndim,8);
-        EXPECT_DOUBLE_EQ(INPUT.mixing_gg0,1.00);
-        EXPECT_EQ(INPUT.init_wfc,"atomic");
-        EXPECT_EQ(INPUT.mem_saver,0);
-        EXPECT_EQ(INPUT.printe,100);
-        EXPECT_EQ(INPUT.init_chg,"atomic");
-        EXPECT_EQ(INPUT.chg_extrap, "default");
-        EXPECT_EQ(INPUT.out_freq_elec,0);
-        EXPECT_EQ(INPUT.out_freq_ion,0);
-        EXPECT_EQ(INPUT.out_chg,0);
-        EXPECT_EQ(INPUT.out_dm,0);
-        EXPECT_EQ(INPUT.out_dm1,0);
-        EXPECT_EQ(INPUT.deepks_out_labels,0);
-        EXPECT_EQ(INPUT.deepks_scf,0);
-		EXPECT_EQ(INPUT.deepks_equiv,0);
-        EXPECT_EQ(INPUT.deepks_bandgap,0);
-        EXPECT_EQ(INPUT.deepks_out_unittest,0);
-        EXPECT_EQ(INPUT.out_pot,0);
-        EXPECT_EQ(INPUT.out_wfc_pw,0);
-        EXPECT_EQ(INPUT.out_wfc_r,0);
-        EXPECT_EQ(INPUT.out_dos,0);
-        EXPECT_EQ(INPUT.out_band[0],0);
-		EXPECT_EQ(INPUT.out_band[1],8);
-        EXPECT_EQ(INPUT.out_proj_band,0);
-        EXPECT_EQ(INPUT.out_mat_hs[0],0);
-		EXPECT_EQ(INPUT.out_mat_hs[1],8);
-        EXPECT_EQ(INPUT.out_mat_hs2,0);
-        EXPECT_EQ(INPUT.out_mat_xc, 0);
-        EXPECT_EQ(INPUT.out_interval,1);
-        EXPECT_EQ(INPUT.out_app_flag,1);
-        EXPECT_EQ(INPUT.out_mat_r,0);
-        EXPECT_EQ(INPUT.out_wfc_lcao,0);
-        EXPECT_FALSE(INPUT.out_alllog);
-        EXPECT_DOUBLE_EQ(INPUT.dos_emin_ev,-15);
-        EXPECT_DOUBLE_EQ(INPUT.dos_emax_ev,15);
-        EXPECT_DOUBLE_EQ(INPUT.dos_edelta_ev,0.01);
-        EXPECT_DOUBLE_EQ(INPUT.dos_scale,0.01);
-        EXPECT_DOUBLE_EQ(INPUT.dos_sigma,0.07);
-        EXPECT_FALSE(INPUT.out_element_info);
-        EXPECT_DOUBLE_EQ(INPUT.lcao_ecut,0);
-        EXPECT_DOUBLE_EQ(INPUT.lcao_dk,0.01);
-        EXPECT_DOUBLE_EQ(INPUT.lcao_dr,0.01);
-        EXPECT_DOUBLE_EQ(INPUT.lcao_rmax,30);
-		EXPECT_TRUE(INPUT.bessel_nao_smooth);
-		EXPECT_DOUBLE_EQ(INPUT.bessel_nao_sigma, 0.1);
-		EXPECT_EQ(INPUT.bessel_nao_ecut, "default");
-		EXPECT_DOUBLE_EQ(INPUT.bessel_nao_rcut, 6.0);
-		EXPECT_DOUBLE_EQ(INPUT.bessel_nao_tolerence, 1E-12);
-		EXPECT_EQ(INPUT.bessel_descriptor_lmax, 2);
-		EXPECT_TRUE(INPUT.bessel_descriptor_smooth);
-		EXPECT_DOUBLE_EQ(INPUT.bessel_descriptor_sigma, 0.1);
-		EXPECT_EQ(INPUT.bessel_descriptor_ecut, "default");
-		EXPECT_DOUBLE_EQ(INPUT.bessel_descriptor_rcut, 6.0);
-		EXPECT_DOUBLE_EQ(INPUT.bessel_descriptor_tolerence, 1E-12);
+    INPUT.Default();
+    EXPECT_EQ(INPUT.suffix, "ABACUS");
+    EXPECT_EQ(INPUT.stru_file, "");
+    EXPECT_EQ(INPUT.kpoint_file, "");
+    EXPECT_EQ(INPUT.pseudo_dir, "");
+    EXPECT_EQ(INPUT.orbital_dir, "");
+    EXPECT_EQ(INPUT.read_file_dir, "auto");
+    EXPECT_EQ(INPUT.wannier_card, "none");
+    EXPECT_EQ(INPUT.latname, "none");
+    EXPECT_EQ(INPUT.calculation, "scf");
+    EXPECT_EQ(INPUT.esolver_type, "ksdft");
+    EXPECT_DOUBLE_EQ(INPUT.pseudo_rcut, 15.0);
+    EXPECT_FALSE(INPUT.pseudo_mesh);
+    EXPECT_EQ(INPUT.ntype, 0);
+    EXPECT_EQ(INPUT.nbands, 0);
+    EXPECT_EQ(INPUT.nbands_sto, 256);
+    EXPECT_EQ(INPUT.nbands_istate, 5);
+    EXPECT_EQ(INPUT.pw_seed, 1);
+    EXPECT_EQ(INPUT.emin_sto, 0.0);
+    EXPECT_EQ(INPUT.emax_sto, 0.0);
+    EXPECT_EQ(INPUT.nche_sto, 100);
+    EXPECT_EQ(INPUT.seed_sto, 0);
+    EXPECT_EQ(INPUT.initsto_ecut, 0.0);
+    EXPECT_EQ(INPUT.bndpar, 1);
+    EXPECT_EQ(INPUT.kpar, 1);
+    EXPECT_EQ(INPUT.initsto_freq, 0);
+    EXPECT_EQ(INPUT.method_sto, 2);
+    EXPECT_EQ(INPUT.npart_sto, 1);
+    EXPECT_FALSE(INPUT.cal_cond);
+    EXPECT_EQ(INPUT.dos_nche, 100);
+    EXPECT_DOUBLE_EQ(INPUT.cond_che_thr, 1e-8);
+    EXPECT_DOUBLE_EQ(INPUT.cond_dw, 0.1);
+    EXPECT_DOUBLE_EQ(INPUT.cond_wcut, 10);
+    EXPECT_EQ(INPUT.cond_dt, 0.02);
+    EXPECT_EQ(INPUT.cond_dtbatch, 0);
+    EXPECT_EQ(INPUT.cond_smear, 1);
+    EXPECT_DOUBLE_EQ(INPUT.cond_fwhm, 0.4);
+    EXPECT_TRUE(INPUT.cond_nonlocal);
+    EXPECT_FALSE(INPUT.berry_phase);
+    EXPECT_EQ(INPUT.gdir, 3);
+    EXPECT_FALSE(INPUT.towannier90);
+    EXPECT_EQ(INPUT.nnkpfile, "seedname.nnkp");
+    EXPECT_EQ(INPUT.wannier_spin, "up");
+    EXPECT_EQ(INPUT.wannier_method, 1);
+    EXPECT_TRUE(INPUT.out_wannier_amn);
+    EXPECT_TRUE(INPUT.out_wannier_mmn);
+    EXPECT_FALSE(INPUT.out_wannier_unk);
+    EXPECT_TRUE(INPUT.out_wannier_eig);
+    EXPECT_TRUE(INPUT.out_wannier_wvfn_formatted);
+    EXPECT_DOUBLE_EQ(INPUT.kspacing[0], 0.0);
+    EXPECT_DOUBLE_EQ(INPUT.kspacing[1], 0.0);
+    EXPECT_DOUBLE_EQ(INPUT.kspacing[2], 0.0);
+    EXPECT_DOUBLE_EQ(INPUT.min_dist_coef, 0.2);
+    EXPECT_EQ(INPUT.dft_functional, "default");
+    EXPECT_DOUBLE_EQ(INPUT.xc_temperature, 0.0);
+    EXPECT_EQ(INPUT.nspin, 1);
+    EXPECT_DOUBLE_EQ(INPUT.nelec, 0.0);
+    EXPECT_EQ(INPUT.lmaxmax, 2);
+    EXPECT_EQ(INPUT.basis_type, "pw");
+    EXPECT_EQ(INPUT.ks_solver, "default");
+    EXPECT_DOUBLE_EQ(INPUT.search_radius, -1.0);
+    EXPECT_TRUE(INPUT.search_pbc);
+    EXPECT_EQ(INPUT.symmetry, "default");
+    EXPECT_FALSE(INPUT.init_vel);
+    EXPECT_DOUBLE_EQ(INPUT.ref_cell_factor, 1.0);
+    EXPECT_DOUBLE_EQ(INPUT.symmetry_prec, 1.0e-6);
+    EXPECT_TRUE(INPUT.symmetry_autoclose);
+    EXPECT_EQ(INPUT.cal_force, 0);
+    EXPECT_DOUBLE_EQ(INPUT.force_thr, 1.0e-3);
+    EXPECT_DOUBLE_EQ(INPUT.force_thr_ev2, 0);
+    EXPECT_DOUBLE_EQ(INPUT.stress_thr, 0.5);
+    EXPECT_DOUBLE_EQ(INPUT.press1, 0.0);
+    EXPECT_DOUBLE_EQ(INPUT.press2, 0.0);
+    EXPECT_DOUBLE_EQ(INPUT.press3, 0.0);
+    EXPECT_FALSE(INPUT.cal_stress);
+    EXPECT_EQ(INPUT.fixed_axes, "None");
+    EXPECT_FALSE(INPUT.fixed_ibrav);
+    EXPECT_FALSE(INPUT.fixed_atoms);
+    EXPECT_EQ(INPUT.relax_method, "cg");
+    EXPECT_DOUBLE_EQ(INPUT.relax_cg_thr, 0.5);
+    EXPECT_EQ(INPUT.out_level, "ie");
+    EXPECT_FALSE(INPUT.out_md_control);
+    EXPECT_TRUE(INPUT.relax_new);
+    EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_w1, 0.01);
+    EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_w2, 0.5);
+    EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_rmax, 0.8);
+    EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_rmin, 1e-5);
+    EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_init, 0.5);
+    EXPECT_DOUBLE_EQ(INPUT.relax_scale_force, 0.5);
+    EXPECT_EQ(INPUT.nbspline, -1);
+    EXPECT_FALSE(INPUT.gamma_only);
+    EXPECT_FALSE(INPUT.gamma_only_local);
+    EXPECT_DOUBLE_EQ(INPUT.ecutwfc, 50.0);
+    EXPECT_DOUBLE_EQ(INPUT.erf_ecut, 0.0);
+    EXPECT_DOUBLE_EQ(INPUT.erf_height, 0.0);
+    EXPECT_DOUBLE_EQ(INPUT.erf_sigma, 0.1);
+    EXPECT_EQ(INPUT.fft_mode, 0);
+    EXPECT_EQ(INPUT.nx, 0);
+    EXPECT_EQ(INPUT.ny, 0);
+    EXPECT_EQ(INPUT.nz, 0);
+    EXPECT_EQ(INPUT.bx, 0);
+    EXPECT_EQ(INPUT.by, 0);
+    EXPECT_EQ(INPUT.bz, 0);
+    EXPECT_EQ(INPUT.ndx, 0);
+    EXPECT_EQ(INPUT.ndy, 0);
+    EXPECT_EQ(INPUT.ndz, 0);
+    EXPECT_EQ(INPUT.diago_proc, 0);
+    EXPECT_EQ(INPUT.pw_diag_nmax, 50);
+    EXPECT_EQ(INPUT.diago_cg_prec, 1);
+    EXPECT_EQ(INPUT.pw_diag_ndim, 4);
+    EXPECT_DOUBLE_EQ(INPUT.pw_diag_thr, 1.0e-2);
+    EXPECT_EQ(INPUT.nb2d, 0);
+    EXPECT_EQ(INPUT.nurse, 0);
+    EXPECT_EQ(INPUT.colour, 0);
+    EXPECT_EQ(INPUT.t_in_h, 1);
+    EXPECT_EQ(INPUT.vl_in_h, 1);
+    EXPECT_EQ(INPUT.vnl_in_h, 1);
+    EXPECT_EQ(INPUT.vh_in_h, 1);
+    EXPECT_EQ(INPUT.vion_in_h, 1);
+    EXPECT_EQ(INPUT.test_force, 0);
+    EXPECT_EQ(INPUT.test_stress, 0);
+    EXPECT_DOUBLE_EQ(INPUT.scf_thr, -1.0);
+    EXPECT_EQ(INPUT.scf_thr_type, -1);
+    EXPECT_EQ(INPUT.scf_nmax, 100);
+    EXPECT_EQ(INPUT.relax_nmax, 0);
+    EXPECT_EQ(INPUT.out_stru, 0);
+    EXPECT_EQ(INPUT.occupations, "smearing");
+    EXPECT_EQ(INPUT.smearing_method, "gauss");
+    EXPECT_DOUBLE_EQ(INPUT.smearing_sigma, 0.015);
+    EXPECT_EQ(INPUT.mixing_mode, "broyden");
+    EXPECT_DOUBLE_EQ(INPUT.mixing_beta, -10.0);
+    EXPECT_EQ(INPUT.mixing_ndim, 8);
+    EXPECT_DOUBLE_EQ(INPUT.mixing_gg0, 1.00);
+    EXPECT_EQ(INPUT.init_wfc, "atomic");
+    EXPECT_EQ(INPUT.mem_saver, 0);
+    EXPECT_EQ(INPUT.printe, 100);
+    EXPECT_EQ(INPUT.init_chg, "atomic");
+    EXPECT_EQ(INPUT.chg_extrap, "default");
+    EXPECT_EQ(INPUT.out_freq_elec, 0);
+    EXPECT_EQ(INPUT.out_freq_ion, 0);
+    EXPECT_EQ(INPUT.out_chg, 0);
+    EXPECT_EQ(INPUT.out_dm, 0);
+    EXPECT_EQ(INPUT.out_dm1, 0);
+    EXPECT_EQ(INPUT.deepks_out_labels, 0);
+    EXPECT_EQ(INPUT.deepks_scf, 0);
+    EXPECT_EQ(INPUT.deepks_equiv, 0);
+    EXPECT_EQ(INPUT.deepks_bandgap, 0);
+    EXPECT_EQ(INPUT.deepks_out_unittest, 0);
+    EXPECT_EQ(INPUT.out_pot, 0);
+    EXPECT_EQ(INPUT.out_wfc_pw, 0);
+    EXPECT_EQ(INPUT.out_wfc_r, 0);
+    EXPECT_EQ(INPUT.out_dos, 0);
+    EXPECT_EQ(INPUT.out_band[0], 0);
+    EXPECT_EQ(INPUT.out_band[1], 8);
+    EXPECT_EQ(INPUT.out_proj_band, 0);
+    EXPECT_EQ(INPUT.out_mat_hs[0], 0);
+    EXPECT_EQ(INPUT.out_mat_hs[1], 8);
+    EXPECT_EQ(INPUT.out_mat_hs2, 0);
+    EXPECT_EQ(INPUT.out_mat_xc, 0);
+    EXPECT_EQ(INPUT.out_interval, 1);
+    EXPECT_EQ(INPUT.out_app_flag, 1);
+    EXPECT_EQ(INPUT.out_mat_r, 0);
+    EXPECT_EQ(INPUT.out_wfc_lcao, 0);
+    EXPECT_FALSE(INPUT.out_alllog);
+    EXPECT_DOUBLE_EQ(INPUT.dos_emin_ev, -15);
+    EXPECT_DOUBLE_EQ(INPUT.dos_emax_ev, 15);
+    EXPECT_DOUBLE_EQ(INPUT.dos_edelta_ev, 0.01);
+    EXPECT_DOUBLE_EQ(INPUT.dos_scale, 0.01);
+    EXPECT_DOUBLE_EQ(INPUT.dos_sigma, 0.07);
+    EXPECT_FALSE(INPUT.out_element_info);
+    EXPECT_DOUBLE_EQ(INPUT.lcao_ecut, 0);
+    EXPECT_DOUBLE_EQ(INPUT.lcao_dk, 0.01);
+    EXPECT_DOUBLE_EQ(INPUT.lcao_dr, 0.01);
+    EXPECT_DOUBLE_EQ(INPUT.lcao_rmax, 30);
+    EXPECT_TRUE(INPUT.bessel_nao_smooth);
+    EXPECT_DOUBLE_EQ(INPUT.bessel_nao_sigma, 0.1);
+    EXPECT_EQ(INPUT.bessel_nao_ecut, "default");
+    EXPECT_DOUBLE_EQ(INPUT.bessel_nao_rcut, 6.0);
+    EXPECT_DOUBLE_EQ(INPUT.bessel_nao_tolerence, 1E-12);
+    EXPECT_EQ(INPUT.bessel_descriptor_lmax, 2);
+    EXPECT_TRUE(INPUT.bessel_descriptor_smooth);
+    EXPECT_DOUBLE_EQ(INPUT.bessel_descriptor_sigma, 0.1);
+    EXPECT_EQ(INPUT.bessel_descriptor_ecut, "default");
+    EXPECT_DOUBLE_EQ(INPUT.bessel_descriptor_rcut, 6.0);
+    EXPECT_DOUBLE_EQ(INPUT.bessel_descriptor_tolerence, 1E-12);
 
-        EXPECT_FALSE(INPUT.efield_flag);
-        EXPECT_FALSE(INPUT.dip_cor_flag);
-        EXPECT_EQ(INPUT.efield_dir,2);
-        EXPECT_DOUBLE_EQ(INPUT.efield_pos_max, -1.0);
-        EXPECT_DOUBLE_EQ(INPUT.efield_pos_dec, -1.0);
-        EXPECT_DOUBLE_EQ(INPUT.efield_amp ,0.0);
-        EXPECT_FALSE(INPUT.gate_flag);
-        EXPECT_DOUBLE_EQ(INPUT.zgate,0.5);
-        EXPECT_FALSE(INPUT.relax);
-        EXPECT_FALSE(INPUT.block);
-        EXPECT_DOUBLE_EQ(INPUT.block_down,0.45);
-        EXPECT_DOUBLE_EQ(INPUT.block_up,0.55);
-        EXPECT_DOUBLE_EQ(INPUT.block_height,0.1);
-        EXPECT_EQ(INPUT.vdw_method,"none");
-        EXPECT_EQ(INPUT.vdw_s6,"default");
-        EXPECT_EQ(INPUT.vdw_s8,"default");
-        EXPECT_EQ(INPUT.vdw_a1,"default");
-        EXPECT_EQ(INPUT.vdw_a2,"default");
-        EXPECT_DOUBLE_EQ(INPUT.vdw_d,20);
-        EXPECT_FALSE(INPUT.vdw_abc);
-        EXPECT_EQ(INPUT.vdw_cutoff_radius,"default");
-        EXPECT_EQ(INPUT.vdw_radius_unit,"Bohr");
-        EXPECT_DOUBLE_EQ(INPUT.vdw_cn_thr,40.0);
-        EXPECT_EQ(INPUT.vdw_cn_thr_unit,"Bohr");
-        EXPECT_EQ(INPUT.vdw_C6_file,"default");
-        EXPECT_EQ(INPUT.vdw_C6_unit,"Jnm6/mol");
-        EXPECT_EQ(INPUT.vdw_R0_file,"default");
-        EXPECT_EQ(INPUT.vdw_R0_unit,"A");
-        EXPECT_EQ(INPUT.vdw_cutoff_type,"radius");
-        EXPECT_EQ(INPUT.vdw_cutoff_period[0],3);
-        EXPECT_EQ(INPUT.vdw_cutoff_period[1],3);
-        EXPECT_EQ(INPUT.vdw_cutoff_period[2],3);
-        EXPECT_EQ(INPUT.exx_hybrid_alpha,"default");
-        EXPECT_EQ(INPUT.exx_real_number,"default");
-        EXPECT_DOUBLE_EQ(INPUT.exx_hse_omega,0.11);
-        EXPECT_TRUE(INPUT.exx_separate_loop);
-        EXPECT_EQ(INPUT.exx_hybrid_step,100);
-        EXPECT_DOUBLE_EQ(INPUT.exx_lambda,0.3);
-		EXPECT_DOUBLE_EQ(INPUT.exx_mixing_beta,1.0);
-        EXPECT_DOUBLE_EQ(INPUT.exx_pca_threshold,1E-4);
-        EXPECT_DOUBLE_EQ(INPUT.exx_c_threshold,1E-4);
-        EXPECT_DOUBLE_EQ(INPUT.exx_v_threshold,1E-1);
-        EXPECT_DOUBLE_EQ(INPUT.exx_dm_threshold,1E-4);
-        EXPECT_DOUBLE_EQ(INPUT.exx_schwarz_threshold,0);
-        EXPECT_DOUBLE_EQ(INPUT.exx_cauchy_threshold,1E-7);
-        EXPECT_DOUBLE_EQ(INPUT.exx_c_grad_threshold,1E-4);
-        EXPECT_DOUBLE_EQ(INPUT.exx_v_grad_threshold,1E-1);
-        EXPECT_DOUBLE_EQ(INPUT.exx_cauchy_force_threshold,1E-7);
-        EXPECT_DOUBLE_EQ(INPUT.exx_cauchy_stress_threshold,1E-7);
-        EXPECT_DOUBLE_EQ(INPUT.exx_ccp_threshold,1E-8);
-        EXPECT_EQ(INPUT.exx_ccp_rmesh_times, "default");
-        EXPECT_DOUBLE_EQ(INPUT.rpa_ccp_rmesh_times, 10.0);
-        EXPECT_EQ(INPUT.exx_distribute_type, "htime");
-        EXPECT_EQ(INPUT.exx_opt_orb_lmax,0);
-        EXPECT_DOUBLE_EQ(INPUT.exx_opt_orb_ecut,0.0);
-        EXPECT_DOUBLE_EQ(INPUT.exx_opt_orb_tolerence,0.0);
-        EXPECT_FALSE(INPUT.noncolin);
-        EXPECT_FALSE(INPUT.lspinorb);
-        EXPECT_DOUBLE_EQ(INPUT.soc_lambda,1.0);
-        EXPECT_EQ(INPUT.input_error,0);
-        EXPECT_DOUBLE_EQ(INPUT.td_force_dt,0.02);
-        EXPECT_FALSE(INPUT.td_vext);
-        EXPECT_EQ(INPUT.td_vext_dire,"1");
-		EXPECT_EQ(INPUT.propagator,0);
-		EXPECT_EQ(INPUT.td_stype,0);
-		EXPECT_EQ(INPUT.td_ttype,"0");
-		EXPECT_EQ(INPUT.td_tstart,1);
-		EXPECT_EQ(INPUT.td_tend,1000);
-		EXPECT_EQ(INPUT.td_lcut1,0.05);
-		EXPECT_EQ(INPUT.td_lcut2,0.95);
-		EXPECT_EQ(INPUT.td_gauss_amp,"0.25");
-		EXPECT_EQ(INPUT.td_gauss_freq,"22.13");
-		EXPECT_EQ(INPUT.td_gauss_phase,"0.0");
-		EXPECT_EQ(INPUT.td_gauss_t0,"100.0");
-		EXPECT_EQ(INPUT.td_gauss_sigma,"30.0");
-		EXPECT_EQ(INPUT.td_trape_amp,"2.74");
-		EXPECT_EQ(INPUT.td_trape_freq,"1.60");
-		EXPECT_EQ(INPUT.td_trape_phase,"0.0");
-		EXPECT_EQ(INPUT.td_trape_t1,"1875");
-		EXPECT_EQ(INPUT.td_trape_t2,"5625");
-		EXPECT_EQ(INPUT.td_trape_t3,"7500");
-		EXPECT_EQ(INPUT.td_trigo_freq1,"1.164656");
-		EXPECT_EQ(INPUT.td_trigo_freq2,"0.029116");
-		EXPECT_EQ(INPUT.td_trigo_phase1,"0.0");
-		EXPECT_EQ(INPUT.td_trigo_phase2,"0.0");
-		EXPECT_EQ(INPUT.td_trigo_amp,"2.74");
-		EXPECT_EQ(INPUT.td_heavi_t0,"100");	
-		EXPECT_EQ(INPUT.td_heavi_amp,"1.0");					
-        EXPECT_EQ(INPUT.out_dipole,0);
-		EXPECT_EQ(INPUT.out_efield,0);
-		EXPECT_EQ(INPUT.td_print_eij,-1.0);
-		EXPECT_EQ(INPUT.td_edm,0);
-        EXPECT_DOUBLE_EQ(INPUT.cell_factor,1.2);
-        EXPECT_EQ(INPUT.out_mul,0);
-        EXPECT_FALSE(INPUT.restart_save);
-        EXPECT_FALSE(INPUT.restart_load);
-        EXPECT_FALSE(INPUT.test_skip_ewald);
-        EXPECT_EQ(INPUT.dft_plus_u, 0);
-        EXPECT_FALSE(INPUT.yukawa_potential);
-        EXPECT_DOUBLE_EQ(INPUT.yukawa_lambda,-1.0);
-		EXPECT_EQ(INPUT.onsite_radius, 0.0);
-        EXPECT_EQ(INPUT.omc,0);
-        EXPECT_FALSE(INPUT.dft_plus_dmft);
-        EXPECT_FALSE(INPUT.rpa);
-        EXPECT_EQ(INPUT.coulomb_type,"full");
-        EXPECT_EQ(INPUT.imp_sol,0);
-        EXPECT_DOUBLE_EQ(INPUT.eb_k,80.0);
-        EXPECT_DOUBLE_EQ(INPUT.tau,1.0798 * 1e-5);
-        EXPECT_DOUBLE_EQ(INPUT.sigma_k,0.6);
-        EXPECT_DOUBLE_EQ(INPUT.nc_k,0.00037);
-        EXPECT_EQ(INPUT.of_kinetic,"wt");
-        EXPECT_EQ(INPUT.of_method,"tn");
-        EXPECT_EQ(INPUT.of_conv,"energy");
-        EXPECT_DOUBLE_EQ(INPUT.of_tole,1e-6);
-        EXPECT_DOUBLE_EQ(INPUT.of_tolp,1e-5);
-        EXPECT_DOUBLE_EQ(INPUT.of_tf_weight,1.);
-        EXPECT_DOUBLE_EQ(INPUT.of_vw_weight,1.);
-        EXPECT_DOUBLE_EQ(INPUT.of_wt_alpha,5./6.);
-        EXPECT_DOUBLE_EQ(INPUT.of_wt_beta,5./6.);
-        EXPECT_DOUBLE_EQ(INPUT.of_wt_rho0,0.);
-        EXPECT_FALSE(INPUT.of_hold_rho0);
-        EXPECT_DOUBLE_EQ(INPUT.of_lkt_a,1.3);
-        EXPECT_TRUE(INPUT.of_full_pw);
-        EXPECT_EQ(INPUT.of_full_pw_dim,0);
-        EXPECT_FALSE(INPUT.of_read_kernel);
-        EXPECT_EQ(INPUT.of_kernel_file,"WTkernel.txt");
-        EXPECT_EQ(INPUT.device,"cpu");
-        EXPECT_DOUBLE_EQ(INPUT.ecutrho,0.0);
-        EXPECT_EQ(INPUT.ncx,0);
-        EXPECT_EQ(INPUT.ncy,0);
-        EXPECT_EQ(INPUT.ncz,0);
-	EXPECT_NEAR(INPUT.mdp.lj_epsilon,0.01032,1e-7);
-	EXPECT_NEAR(INPUT.mdp.lj_rcut,8.5,1e-7);
-	EXPECT_NEAR(INPUT.mdp.lj_sigma,3.405,1e-7);
-	EXPECT_EQ(INPUT.mdp.md_damp,1);
-	EXPECT_EQ(INPUT.mdp.md_dt,1);
-	EXPECT_EQ(INPUT.mdp.md_dumpfreq,1);
-	EXPECT_EQ(INPUT.mdp.md_nraise,1);
-	EXPECT_EQ(INPUT.cal_syns,0);
-	EXPECT_EQ(INPUT.dmax,0.01);
-	EXPECT_EQ(INPUT.mdp.md_nstep,10);
-	EXPECT_EQ(INPUT.mdp.md_pchain,1);
-	EXPECT_EQ(INPUT.mdp.md_pcouple,"none");
-	EXPECT_DOUBLE_EQ(INPUT.mdp.md_pfirst,-1);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.md_pfreq,0);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.md_plast,-1);
-	EXPECT_EQ(INPUT.mdp.md_pmode,"iso");
-	EXPECT_EQ(INPUT.mdp.md_restart,0);
-	EXPECT_EQ(INPUT.mdp.md_restartfreq,5);
-	EXPECT_EQ(INPUT.mdp.md_seed,-1);
-    EXPECT_EQ(INPUT.mdp.md_prec_level,0);
-	EXPECT_EQ(INPUT.mdp.md_tchain,1);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.md_tfirst,-1);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.md_tfreq,0);
-	EXPECT_EQ(INPUT.mdp.md_thermostat,"nhc");
-	EXPECT_DOUBLE_EQ(INPUT.mdp.md_tlast,-1);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.md_tolerance,100);
-	EXPECT_EQ(INPUT.mdp.md_type,"nvt");
-	EXPECT_EQ(INPUT.mdp.msst_direction,2);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.msst_qmass,-1);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.msst_tscale,0.01);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.msst_vel,0);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.msst_vis,0);
-	EXPECT_EQ(INPUT.mdp.pot_file,"graph.pb");
+    EXPECT_FALSE(INPUT.efield_flag);
+    EXPECT_FALSE(INPUT.dip_cor_flag);
+    EXPECT_EQ(INPUT.efield_dir, 2);
+    EXPECT_DOUBLE_EQ(INPUT.efield_pos_max, -1.0);
+    EXPECT_DOUBLE_EQ(INPUT.efield_pos_dec, -1.0);
+    EXPECT_DOUBLE_EQ(INPUT.efield_amp, 0.0);
+    EXPECT_FALSE(INPUT.gate_flag);
+    EXPECT_DOUBLE_EQ(INPUT.zgate, 0.5);
+    EXPECT_FALSE(INPUT.relax);
+    EXPECT_FALSE(INPUT.block);
+    EXPECT_DOUBLE_EQ(INPUT.block_down, 0.45);
+    EXPECT_DOUBLE_EQ(INPUT.block_up, 0.55);
+    EXPECT_DOUBLE_EQ(INPUT.block_height, 0.1);
+    EXPECT_EQ(INPUT.vdw_method, "none");
+    EXPECT_EQ(INPUT.vdw_s6, "default");
+    EXPECT_EQ(INPUT.vdw_s8, "default");
+    EXPECT_EQ(INPUT.vdw_a1, "default");
+    EXPECT_EQ(INPUT.vdw_a2, "default");
+    EXPECT_DOUBLE_EQ(INPUT.vdw_d, 20);
+    EXPECT_FALSE(INPUT.vdw_abc);
+    EXPECT_EQ(INPUT.vdw_cutoff_radius, "default");
+    EXPECT_EQ(INPUT.vdw_radius_unit, "Bohr");
+    EXPECT_DOUBLE_EQ(INPUT.vdw_cn_thr, 40.0);
+    EXPECT_EQ(INPUT.vdw_cn_thr_unit, "Bohr");
+    EXPECT_EQ(INPUT.vdw_C6_file, "default");
+    EXPECT_EQ(INPUT.vdw_C6_unit, "Jnm6/mol");
+    EXPECT_EQ(INPUT.vdw_R0_file, "default");
+    EXPECT_EQ(INPUT.vdw_R0_unit, "A");
+    EXPECT_EQ(INPUT.vdw_cutoff_type, "radius");
+    EXPECT_EQ(INPUT.vdw_cutoff_period[0], 3);
+    EXPECT_EQ(INPUT.vdw_cutoff_period[1], 3);
+    EXPECT_EQ(INPUT.vdw_cutoff_period[2], 3);
+    EXPECT_EQ(INPUT.exx_hybrid_alpha, "default");
+    EXPECT_EQ(INPUT.exx_real_number, "default");
+    EXPECT_DOUBLE_EQ(INPUT.exx_hse_omega, 0.11);
+    EXPECT_TRUE(INPUT.exx_separate_loop);
+    EXPECT_EQ(INPUT.exx_hybrid_step, 100);
+    EXPECT_DOUBLE_EQ(INPUT.exx_lambda, 0.3);
+    EXPECT_DOUBLE_EQ(INPUT.exx_mixing_beta, 1.0);
+    EXPECT_DOUBLE_EQ(INPUT.exx_pca_threshold, 1E-4);
+    EXPECT_DOUBLE_EQ(INPUT.exx_c_threshold, 1E-4);
+    EXPECT_DOUBLE_EQ(INPUT.exx_v_threshold, 1E-1);
+    EXPECT_DOUBLE_EQ(INPUT.exx_dm_threshold, 1E-4);
+    EXPECT_DOUBLE_EQ(INPUT.exx_schwarz_threshold, 0);
+    EXPECT_DOUBLE_EQ(INPUT.exx_cauchy_threshold, 1E-7);
+    EXPECT_DOUBLE_EQ(INPUT.exx_c_grad_threshold, 1E-4);
+    EXPECT_DOUBLE_EQ(INPUT.exx_v_grad_threshold, 1E-1);
+    EXPECT_DOUBLE_EQ(INPUT.exx_cauchy_force_threshold, 1E-7);
+    EXPECT_DOUBLE_EQ(INPUT.exx_cauchy_stress_threshold, 1E-7);
+    EXPECT_DOUBLE_EQ(INPUT.exx_ccp_threshold, 1E-8);
+    EXPECT_EQ(INPUT.exx_ccp_rmesh_times, "default");
+    EXPECT_DOUBLE_EQ(INPUT.rpa_ccp_rmesh_times, 10.0);
+    EXPECT_EQ(INPUT.exx_distribute_type, "htime");
+    EXPECT_EQ(INPUT.exx_opt_orb_lmax, 0);
+    EXPECT_DOUBLE_EQ(INPUT.exx_opt_orb_ecut, 0.0);
+    EXPECT_DOUBLE_EQ(INPUT.exx_opt_orb_tolerence, 0.0);
+    EXPECT_FALSE(INPUT.noncolin);
+    EXPECT_FALSE(INPUT.lspinorb);
+    EXPECT_DOUBLE_EQ(INPUT.soc_lambda, 1.0);
+    EXPECT_EQ(INPUT.input_error, 0);
+    EXPECT_DOUBLE_EQ(INPUT.td_force_dt, 0.02);
+    EXPECT_FALSE(INPUT.td_vext);
+    EXPECT_EQ(INPUT.td_vext_dire, "1");
+    EXPECT_EQ(INPUT.propagator, 0);
+    EXPECT_EQ(INPUT.td_stype, 0);
+    EXPECT_EQ(INPUT.td_ttype, "0");
+    EXPECT_EQ(INPUT.td_tstart, 1);
+    EXPECT_EQ(INPUT.td_tend, 1000);
+    EXPECT_EQ(INPUT.td_lcut1, 0.05);
+    EXPECT_EQ(INPUT.td_lcut2, 0.95);
+    EXPECT_EQ(INPUT.td_gauss_amp, "0.25");
+    EXPECT_EQ(INPUT.td_gauss_freq, "22.13");
+    EXPECT_EQ(INPUT.td_gauss_phase, "0.0");
+    EXPECT_EQ(INPUT.td_gauss_t0, "100.0");
+    EXPECT_EQ(INPUT.td_gauss_sigma, "30.0");
+    EXPECT_EQ(INPUT.td_trape_amp, "2.74");
+    EXPECT_EQ(INPUT.td_trape_freq, "1.60");
+    EXPECT_EQ(INPUT.td_trape_phase, "0.0");
+    EXPECT_EQ(INPUT.td_trape_t1, "1875");
+    EXPECT_EQ(INPUT.td_trape_t2, "5625");
+    EXPECT_EQ(INPUT.td_trape_t3, "7500");
+    EXPECT_EQ(INPUT.td_trigo_freq1, "1.164656");
+    EXPECT_EQ(INPUT.td_trigo_freq2, "0.029116");
+    EXPECT_EQ(INPUT.td_trigo_phase1, "0.0");
+    EXPECT_EQ(INPUT.td_trigo_phase2, "0.0");
+    EXPECT_EQ(INPUT.td_trigo_amp, "2.74");
+    EXPECT_EQ(INPUT.td_heavi_t0, "100");
+    EXPECT_EQ(INPUT.td_heavi_amp, "1.0");
+    EXPECT_EQ(INPUT.out_dipole, 0);
+    EXPECT_EQ(INPUT.out_efield, 0);
+    EXPECT_EQ(INPUT.td_print_eij, -1.0);
+    EXPECT_EQ(INPUT.td_edm, 0);
+    EXPECT_DOUBLE_EQ(INPUT.cell_factor, 1.2);
+    EXPECT_EQ(INPUT.out_mul, 0);
+    EXPECT_FALSE(INPUT.restart_save);
+    EXPECT_FALSE(INPUT.restart_load);
+    EXPECT_FALSE(INPUT.test_skip_ewald);
+    EXPECT_EQ(INPUT.dft_plus_u, 0);
+    EXPECT_FALSE(INPUT.yukawa_potential);
+    EXPECT_DOUBLE_EQ(INPUT.yukawa_lambda, -1.0);
+    EXPECT_EQ(INPUT.onsite_radius, 0.0);
+    EXPECT_EQ(INPUT.omc, 0);
+    EXPECT_FALSE(INPUT.dft_plus_dmft);
+    EXPECT_FALSE(INPUT.rpa);
+    EXPECT_EQ(INPUT.coulomb_type, "full");
+    EXPECT_EQ(INPUT.imp_sol, 0);
+    EXPECT_DOUBLE_EQ(INPUT.eb_k, 80.0);
+    EXPECT_DOUBLE_EQ(INPUT.tau, 1.0798 * 1e-5);
+    EXPECT_DOUBLE_EQ(INPUT.sigma_k, 0.6);
+    EXPECT_DOUBLE_EQ(INPUT.nc_k, 0.00037);
+    EXPECT_EQ(INPUT.of_kinetic, "wt");
+    EXPECT_EQ(INPUT.of_method, "tn");
+    EXPECT_EQ(INPUT.of_conv, "energy");
+    EXPECT_DOUBLE_EQ(INPUT.of_tole, 1e-6);
+    EXPECT_DOUBLE_EQ(INPUT.of_tolp, 1e-5);
+    EXPECT_DOUBLE_EQ(INPUT.of_tf_weight, 1.);
+    EXPECT_DOUBLE_EQ(INPUT.of_vw_weight, 1.);
+    EXPECT_DOUBLE_EQ(INPUT.of_wt_alpha, 5. / 6.);
+    EXPECT_DOUBLE_EQ(INPUT.of_wt_beta, 5. / 6.);
+    EXPECT_DOUBLE_EQ(INPUT.of_wt_rho0, 0.);
+    EXPECT_FALSE(INPUT.of_hold_rho0);
+    EXPECT_DOUBLE_EQ(INPUT.of_lkt_a, 1.3);
+    EXPECT_TRUE(INPUT.of_full_pw);
+    EXPECT_EQ(INPUT.of_full_pw_dim, 0);
+    EXPECT_FALSE(INPUT.of_read_kernel);
+    EXPECT_EQ(INPUT.of_kernel_file, "WTkernel.txt");
+    EXPECT_EQ(INPUT.device, "cpu");
+    EXPECT_DOUBLE_EQ(INPUT.ecutrho, 0.0);
+    EXPECT_EQ(INPUT.ncx, 0);
+    EXPECT_EQ(INPUT.ncy, 0);
+    EXPECT_EQ(INPUT.ncz, 0);
+    EXPECT_NEAR(INPUT.mdp.lj_epsilon, 0.01032, 1e-7);
+    EXPECT_NEAR(INPUT.mdp.lj_rcut, 8.5, 1e-7);
+    EXPECT_NEAR(INPUT.mdp.lj_sigma, 3.405, 1e-7);
+    EXPECT_EQ(INPUT.mdp.md_damp, 1);
+    EXPECT_EQ(INPUT.mdp.md_dt, 1);
+    EXPECT_EQ(INPUT.mdp.md_dumpfreq, 1);
+    EXPECT_EQ(INPUT.mdp.md_nraise, 1);
+    EXPECT_EQ(INPUT.cal_syns, 0);
+    EXPECT_EQ(INPUT.dmax, 0.01);
+    EXPECT_EQ(INPUT.mdp.md_nstep, 10);
+    EXPECT_EQ(INPUT.mdp.md_pchain, 1);
+    EXPECT_EQ(INPUT.mdp.md_pcouple, "none");
+    EXPECT_DOUBLE_EQ(INPUT.mdp.md_pfirst, -1);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.md_pfreq, 0);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.md_plast, -1);
+    EXPECT_EQ(INPUT.mdp.md_pmode, "iso");
+    EXPECT_EQ(INPUT.mdp.md_restart, 0);
+    EXPECT_EQ(INPUT.mdp.md_restartfreq, 5);
+    EXPECT_EQ(INPUT.mdp.md_seed, -1);
+    EXPECT_EQ(INPUT.mdp.md_prec_level, 0);
+    EXPECT_EQ(INPUT.mdp.md_tchain, 1);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.md_tfirst, -1);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.md_tfreq, 0);
+    EXPECT_EQ(INPUT.mdp.md_thermostat, "nhc");
+    EXPECT_DOUBLE_EQ(INPUT.mdp.md_tlast, -1);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.md_tolerance, 100);
+    EXPECT_EQ(INPUT.mdp.md_type, "nvt");
+    EXPECT_EQ(INPUT.mdp.msst_direction, 2);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.msst_qmass, -1);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.msst_tscale, 0.01);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.msst_vel, 0);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.msst_vis, 0);
+    EXPECT_EQ(INPUT.mdp.pot_file, "graph.pb");
     EXPECT_TRUE(INPUT.mdp.dump_force);
     EXPECT_TRUE(INPUT.mdp.dump_vel);
     EXPECT_TRUE(INPUT.mdp.dump_virial);
-    EXPECT_EQ(INPUT.sc_mag_switch,0);
+    EXPECT_EQ(INPUT.sc_mag_switch, 0);
     EXPECT_FALSE(INPUT.decay_grad_switch);
     EXPECT_DOUBLE_EQ(INPUT.sc_thr, 1e-6);
     EXPECT_EQ(INPUT.nsc, 100);
     EXPECT_EQ(INPUT.nsc_min, 2);
-	EXPECT_EQ(INPUT.sc_scf_nmin, 2);
+    EXPECT_EQ(INPUT.sc_scf_nmin, 2);
     EXPECT_DOUBLE_EQ(INPUT.alpha_trial, 0.01);
     EXPECT_DOUBLE_EQ(INPUT.sccut, 3.0);
     EXPECT_EQ(INPUT.sc_file, "none");
@@ -391,360 +392,360 @@ TEST_F(InputTest, Default)
 
 TEST_F(InputTest, Read)
 {
-	std::string input_file = "./support/INPUT";
-	INPUT.Read(input_file);
-	EXPECT_EQ(INPUT.suffix,"autotest");
-	EXPECT_EQ(INPUT.stru_file,"./support/STRU");
-	EXPECT_EQ(INPUT.kpoint_file,"KPT");
-	EXPECT_EQ(INPUT.pseudo_dir,"../../PP_ORB/");
-	EXPECT_EQ(INPUT.orbital_dir,"../../PP_ORB/");
-	EXPECT_EQ(INPUT.read_file_dir,"auto");
-	EXPECT_EQ(INPUT.wannier_card,"none");
-	EXPECT_EQ(INPUT.latname,"none");
-	EXPECT_EQ(INPUT.calculation,"scf");
-	EXPECT_EQ(INPUT.esolver_type,"ksdft");
-	EXPECT_DOUBLE_EQ(INPUT.pseudo_rcut,15.0);
-	EXPECT_FALSE(INPUT.pseudo_mesh);
-	EXPECT_EQ(INPUT.ntype,1);
-	EXPECT_EQ(INPUT.nbands,8);
-	EXPECT_EQ(INPUT.nbands_sto,256);
-	EXPECT_EQ(INPUT.nbands_istate,5);
-	EXPECT_EQ(INPUT.pw_seed,1);
-	EXPECT_EQ(INPUT.emin_sto,0.0);
-	EXPECT_EQ(INPUT.emax_sto,0.0);
-	EXPECT_EQ(INPUT.nche_sto,100);
-        EXPECT_EQ(INPUT.seed_sto,0);
-		EXPECT_EQ(INPUT.initsto_ecut,0.0);
-        EXPECT_EQ(INPUT.bndpar,1);
-        EXPECT_EQ(INPUT.kpar,1);
-        EXPECT_EQ(INPUT.initsto_freq,0);
-        EXPECT_EQ(INPUT.method_sto,3);
-        EXPECT_EQ(INPUT.npart_sto,1);
-        EXPECT_FALSE(INPUT.cal_cond);
-        EXPECT_EQ(INPUT.dos_nche,100);
-        EXPECT_DOUBLE_EQ(INPUT.cond_che_thr,1e-8);
-        EXPECT_DOUBLE_EQ(INPUT.cond_dw,0.1);
-        EXPECT_DOUBLE_EQ(INPUT.cond_wcut,10);
-        EXPECT_EQ(INPUT.cond_dt,0.07);
-		EXPECT_EQ(INPUT.cond_dtbatch,2);
-        EXPECT_DOUBLE_EQ(INPUT.cond_fwhm,0.3);
-        EXPECT_TRUE(INPUT.cond_nonlocal);
-        EXPECT_FALSE(INPUT.berry_phase);
-        EXPECT_EQ(INPUT.gdir,3);
-        EXPECT_FALSE(INPUT.towannier90);
-        EXPECT_EQ(INPUT.nnkpfile,"seedname.nnkp");
-        EXPECT_EQ(INPUT.wannier_spin,"up");
-        EXPECT_EQ(INPUT.wannier_method,1);
-		EXPECT_TRUE(INPUT.out_wannier_amn);
-		EXPECT_TRUE(INPUT.out_wannier_mmn);
-		EXPECT_TRUE(INPUT.out_wannier_unk);
-		EXPECT_TRUE(INPUT.out_wannier_eig);
-        EXPECT_TRUE(INPUT.out_wannier_wvfn_formatted);
-        EXPECT_DOUBLE_EQ(INPUT.kspacing[0], 0.0);
-        EXPECT_DOUBLE_EQ(INPUT.kspacing[1],0.0);
-        EXPECT_DOUBLE_EQ(INPUT.kspacing[2],0.0);
-        EXPECT_DOUBLE_EQ(INPUT.min_dist_coef,0.2);
-        EXPECT_EQ(INPUT.dft_functional,"hse");
-        EXPECT_DOUBLE_EQ(INPUT.xc_temperature,0.0);
-        EXPECT_EQ(INPUT.nspin,1);
-        EXPECT_DOUBLE_EQ(INPUT.nelec,0.0);
-        EXPECT_EQ(INPUT.lmaxmax,2);
-        EXPECT_EQ(INPUT.basis_type,"lcao");
-        EXPECT_EQ(INPUT.ks_solver,"genelpa");
-        EXPECT_DOUBLE_EQ(INPUT.search_radius,-1.0);
-        EXPECT_TRUE(INPUT.search_pbc);
-        EXPECT_EQ(INPUT.symmetry,"1");
-        EXPECT_FALSE(INPUT.init_vel);
-        EXPECT_DOUBLE_EQ(INPUT.symmetry_prec, 1.0e-6);
-        EXPECT_TRUE(INPUT.symmetry_autoclose);
-        EXPECT_EQ(INPUT.cal_force, 0);
-        EXPECT_NEAR(INPUT.force_thr,1.0e-3,1.0e-7);
-        EXPECT_DOUBLE_EQ(INPUT.force_thr_ev2,0);
-        EXPECT_DOUBLE_EQ(INPUT.stress_thr,1.0e-2);
-        EXPECT_DOUBLE_EQ(INPUT.press1,0.0);
-        EXPECT_DOUBLE_EQ(INPUT.press2,0.0);
-        EXPECT_DOUBLE_EQ(INPUT.press3,0.0);
-        EXPECT_FALSE(INPUT.cal_stress);
-        EXPECT_EQ(INPUT.fixed_axes,"None");
-        EXPECT_FALSE(INPUT.fixed_ibrav);
-        EXPECT_FALSE(INPUT.fixed_atoms);
-        EXPECT_EQ(INPUT.relax_method,"cg");
-        EXPECT_DOUBLE_EQ(INPUT.relax_cg_thr,0.5);
-        EXPECT_EQ(INPUT.out_level,"ie");
-        EXPECT_TRUE(INPUT.out_md_control);
-        EXPECT_TRUE(INPUT.relax_new);
-        EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_w1,0.01);
-        EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_w2,0.5);
-        EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_rmax,0.8);
-        EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_rmin,1e-5);
-        EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_init,0.5);
-        EXPECT_DOUBLE_EQ(INPUT.relax_scale_force,0.5);
-        EXPECT_EQ(INPUT.nbspline,-1);
-        EXPECT_TRUE(INPUT.gamma_only);
-        EXPECT_TRUE(INPUT.gamma_only_local);
-        EXPECT_DOUBLE_EQ(INPUT.ecutwfc,20.0);
-        EXPECT_DOUBLE_EQ(INPUT.erf_ecut, 20.0);
-        EXPECT_DOUBLE_EQ(INPUT.erf_height, 20.0);
-        EXPECT_DOUBLE_EQ(INPUT.erf_sigma, 4.0);
-        EXPECT_DOUBLE_EQ(INPUT.ecutrho, 0.0);
-		EXPECT_EQ(INPUT.fft_mode,0);
-        EXPECT_EQ(INPUT.ncx,0);
-        EXPECT_EQ(INPUT.ncy,0);
-        EXPECT_EQ(INPUT.ncz,0);
-        EXPECT_EQ(INPUT.nx,0);
-        EXPECT_EQ(INPUT.ny,0);
-        EXPECT_EQ(INPUT.nz,0);
-        EXPECT_EQ(INPUT.bx,2);
-        EXPECT_EQ(INPUT.by,2);
-        EXPECT_EQ(INPUT.bz,2);
-        EXPECT_EQ(INPUT.ndx, 0);
-        EXPECT_EQ(INPUT.ndy, 0);
-        EXPECT_EQ(INPUT.ndz, 0);
-        EXPECT_EQ(INPUT.diago_proc,4);
-        EXPECT_EQ(INPUT.pw_diag_nmax,50);
-        EXPECT_EQ(INPUT.diago_cg_prec,1);
-        EXPECT_EQ(INPUT.pw_diag_ndim,4);
-        EXPECT_DOUBLE_EQ(INPUT.pw_diag_thr,1.0e-2);
-        EXPECT_EQ(INPUT.nb2d,0);
-        EXPECT_EQ(INPUT.nurse,0);
-        EXPECT_EQ(INPUT.colour,0);
-        EXPECT_EQ(INPUT.t_in_h,1);
-        EXPECT_EQ(INPUT.vl_in_h,1);
-        EXPECT_EQ(INPUT.vnl_in_h,1);
-        EXPECT_EQ(INPUT.vh_in_h,1);
-        EXPECT_EQ(INPUT.vion_in_h,1);
-        EXPECT_EQ(INPUT.test_force,0);
-        EXPECT_EQ(INPUT.test_stress,0);
-        EXPECT_NEAR(INPUT.scf_thr,1.0e-8,1.0e-15);
-        EXPECT_EQ(INPUT.scf_nmax,50);
-        EXPECT_EQ(INPUT.relax_nmax,1);
-        EXPECT_EQ(INPUT.out_stru,0);
-        EXPECT_EQ(INPUT.occupations,"smearing");
-        EXPECT_EQ(INPUT.smearing_method,"gauss");
-        EXPECT_DOUBLE_EQ(INPUT.smearing_sigma,0.002);
-        EXPECT_EQ(INPUT.mixing_mode,"broyden");
-        EXPECT_DOUBLE_EQ(INPUT.mixing_beta,0.7);
-        EXPECT_EQ(INPUT.mixing_ndim,8);
-        EXPECT_DOUBLE_EQ(INPUT.mixing_gg0,0.00);
-        EXPECT_EQ(INPUT.init_wfc,"atomic");
-        EXPECT_EQ(INPUT.mem_saver,0);
-        EXPECT_EQ(INPUT.printe,100);
-        EXPECT_EQ(INPUT.init_chg,"atomic");
-        EXPECT_EQ(INPUT.chg_extrap,"atomic");
-        EXPECT_EQ(INPUT.out_freq_elec,0);
-        EXPECT_EQ(INPUT.out_freq_ion,0);
-        EXPECT_EQ(INPUT.out_chg,0);
-        EXPECT_EQ(INPUT.out_dm,0);
-        EXPECT_EQ(INPUT.out_dm1,0);
-        EXPECT_EQ(INPUT.deepks_out_labels,0);
-        EXPECT_EQ(INPUT.deepks_scf,0);
-		EXPECT_EQ(INPUT.deepks_equiv,0);
-        EXPECT_EQ(INPUT.deepks_bandgap,0);
-        EXPECT_EQ(INPUT.deepks_out_unittest,0);
-        EXPECT_EQ(INPUT.out_pot,2);
-        EXPECT_EQ(INPUT.out_wfc_pw,0);
-        EXPECT_EQ(INPUT.out_wfc_r,0);
-        EXPECT_EQ(INPUT.out_dos,0);
-        EXPECT_EQ(INPUT.out_band[0],0);
-		EXPECT_EQ(INPUT.out_band[1],8);
-        EXPECT_EQ(INPUT.out_proj_band,0);
-        EXPECT_EQ(INPUT.out_mat_hs[0],0);
-		EXPECT_EQ(INPUT.out_mat_hs[1],8);
-        EXPECT_EQ(INPUT.out_mat_hs2,0);
-        EXPECT_EQ(INPUT.out_mat_xc, 0);
-        EXPECT_EQ(INPUT.out_interval,1);
-        EXPECT_EQ(INPUT.out_app_flag,0);
-        EXPECT_EQ(INPUT.out_mat_r,0);
-        EXPECT_FALSE(INPUT.out_wfc_lcao);
-        EXPECT_FALSE(INPUT.out_alllog);
-        EXPECT_DOUBLE_EQ(INPUT.dos_emin_ev,-15);
-        EXPECT_DOUBLE_EQ(INPUT.dos_emax_ev,15);
-        EXPECT_DOUBLE_EQ(INPUT.dos_edelta_ev,0.01);
-        EXPECT_DOUBLE_EQ(INPUT.dos_scale,0.01);
-        EXPECT_DOUBLE_EQ(INPUT.dos_sigma,0.07);
-        EXPECT_FALSE(INPUT.out_element_info);
-        EXPECT_DOUBLE_EQ(INPUT.lcao_ecut,20);
-        EXPECT_DOUBLE_EQ(INPUT.lcao_dk,0.01);
-        EXPECT_DOUBLE_EQ(INPUT.lcao_dr,0.01);
-        EXPECT_DOUBLE_EQ(INPUT.lcao_rmax,30);
-		EXPECT_TRUE(INPUT.bessel_nao_smooth);
-		EXPECT_DOUBLE_EQ(INPUT.bessel_nao_sigma, 0.1);
-		EXPECT_EQ(INPUT.bessel_nao_ecut, "default");
-		EXPECT_DOUBLE_EQ(INPUT.bessel_nao_rcut, 6.0);
-		EXPECT_DOUBLE_EQ(INPUT.bessel_nao_tolerence, 1E-12);
-		EXPECT_EQ(INPUT.bessel_descriptor_lmax, 2);
-		EXPECT_TRUE(INPUT.bessel_descriptor_smooth);
-		EXPECT_DOUBLE_EQ(INPUT.bessel_descriptor_sigma, 0.1);
-		EXPECT_EQ(INPUT.bessel_descriptor_ecut, "default");
-		EXPECT_DOUBLE_EQ(INPUT.bessel_descriptor_rcut, 6.0);
-		EXPECT_DOUBLE_EQ(INPUT.bessel_descriptor_tolerence, 1E-12);
-        EXPECT_FALSE(INPUT.efield_flag);
-        EXPECT_FALSE(INPUT.dip_cor_flag);
-        EXPECT_EQ(INPUT.efield_dir,2);
-        EXPECT_DOUBLE_EQ(INPUT.efield_pos_max,0.5);
-        EXPECT_DOUBLE_EQ(INPUT.efield_pos_dec,0.1);
-        EXPECT_DOUBLE_EQ(INPUT.efield_amp ,0.0);
-        EXPECT_FALSE(INPUT.gate_flag);
-        EXPECT_DOUBLE_EQ(INPUT.zgate,0.5);
-        EXPECT_FALSE(INPUT.relax);
-        EXPECT_FALSE(INPUT.block);
-        EXPECT_DOUBLE_EQ(INPUT.block_down,0.45);
-        EXPECT_DOUBLE_EQ(INPUT.block_up,0.55);
-        EXPECT_DOUBLE_EQ(INPUT.block_height,0.1);
-        EXPECT_EQ(INPUT.vdw_method,"d2");
-        EXPECT_EQ(INPUT.vdw_s6,"default");
-        EXPECT_EQ(INPUT.vdw_s8,"default");
-        EXPECT_EQ(INPUT.vdw_a1,"default");
-        EXPECT_EQ(INPUT.vdw_a2,"default");
-        EXPECT_DOUBLE_EQ(INPUT.vdw_d,20);
-        EXPECT_FALSE(INPUT.vdw_abc);
-        EXPECT_EQ(INPUT.vdw_cutoff_radius,"default");
-        EXPECT_EQ(INPUT.vdw_radius_unit,"Bohr");
-        EXPECT_DOUBLE_EQ(INPUT.vdw_cn_thr,40.0);
-        EXPECT_EQ(INPUT.vdw_cn_thr_unit,"Bohr");
-        EXPECT_EQ(INPUT.vdw_C6_file,"default");
-        EXPECT_EQ(INPUT.vdw_C6_unit,"Jnm6/mol");
-        EXPECT_EQ(INPUT.vdw_R0_file,"default");
-        EXPECT_EQ(INPUT.vdw_R0_unit,"A");
-        EXPECT_EQ(INPUT.vdw_cutoff_type,"radius");
-        EXPECT_EQ(INPUT.vdw_cutoff_period[0],3);
-        EXPECT_EQ(INPUT.vdw_cutoff_period[1],3);
-        EXPECT_EQ(INPUT.vdw_cutoff_period[2],3);
-        EXPECT_EQ(INPUT.exx_hybrid_alpha,"default");
-        EXPECT_EQ(INPUT.exx_real_number,"default");
-        EXPECT_DOUBLE_EQ(INPUT.exx_hse_omega,0.11);
-        EXPECT_TRUE(INPUT.exx_separate_loop);
-        EXPECT_EQ(INPUT.exx_hybrid_step,100);
-        EXPECT_DOUBLE_EQ(INPUT.exx_lambda,0.3);
-		EXPECT_DOUBLE_EQ(INPUT.exx_mixing_beta,1.0);
-        EXPECT_DOUBLE_EQ(INPUT.exx_pca_threshold,0);
-        EXPECT_DOUBLE_EQ(INPUT.exx_c_threshold,0);
-        EXPECT_DOUBLE_EQ(INPUT.exx_v_threshold,0);
-        EXPECT_DOUBLE_EQ(INPUT.exx_dm_threshold,0);
-        EXPECT_DOUBLE_EQ(INPUT.exx_schwarz_threshold,0);
-        EXPECT_DOUBLE_EQ(INPUT.exx_cauchy_threshold,0);
-        EXPECT_DOUBLE_EQ(INPUT.exx_c_grad_threshold,0);
-        EXPECT_DOUBLE_EQ(INPUT.exx_v_grad_threshold,0);
-        EXPECT_DOUBLE_EQ(INPUT.exx_cauchy_force_threshold,0);
-        EXPECT_DOUBLE_EQ(INPUT.exx_cauchy_stress_threshold,0);
-        EXPECT_DOUBLE_EQ(INPUT.exx_ccp_threshold,1E-8);
-        EXPECT_EQ(INPUT.exx_ccp_rmesh_times, "default");
-        EXPECT_DOUBLE_EQ(INPUT.rpa_ccp_rmesh_times, 10.0);
-        EXPECT_EQ(INPUT.exx_distribute_type, "htime");
-        EXPECT_EQ(INPUT.exx_opt_orb_lmax,0);
-        EXPECT_DOUBLE_EQ(INPUT.exx_opt_orb_ecut,0.0);
-        EXPECT_DOUBLE_EQ(INPUT.exx_opt_orb_tolerence,0.0);
-        EXPECT_FALSE(INPUT.noncolin);
-        EXPECT_FALSE(INPUT.lspinorb);
-        EXPECT_DOUBLE_EQ(INPUT.soc_lambda,1.0);
-        EXPECT_EQ(INPUT.input_error,0);
-        EXPECT_DOUBLE_EQ(INPUT.td_force_dt,0.02);
-        EXPECT_EQ(INPUT.td_vext,0);
-        // EXPECT_EQ(INPUT.td_vext_dire,"1");
-		EXPECT_EQ(INPUT.propagator,0);
-		EXPECT_EQ(INPUT.td_stype,0);
-		// EXPECT_EQ(INPUT.td_ttype,"0");
-		EXPECT_EQ(INPUT.td_tstart,1);
-		EXPECT_EQ(INPUT.td_tend,1000);
-		EXPECT_EQ(INPUT.td_lcut1,0.05);
-		EXPECT_EQ(INPUT.td_lcut2,0.95);
-		// EXPECT_EQ(INPUT.td_gauss_amp,"0.25");
-		// EXPECT_EQ(INPUT.td_gauss_freq,"22.13");
-		// EXPECT_EQ(INPUT.td_gauss_phase,"0.0");
-		// EXPECT_EQ(INPUT.td_gauss_t0,"100.0");
-		// EXPECT_EQ(INPUT.td_gauss_sigma,"30.0");
-		// EXPECT_EQ(INPUT.td_trape_amp,"2.74");
-		// EXPECT_EQ(INPUT.td_trape_freq,"1.60");
-		// EXPECT_EQ(INPUT.td_trape_phase,"0.0");
-		// EXPECT_EQ(INPUT.td_trape_t1,"1875");
-		// EXPECT_EQ(INPUT.td_trape_t2,"5625");
-		// EXPECT_EQ(INPUT.td_trape_t3,"7500");
-		// EXPECT_EQ(INPUT.td_trigo_freq1,"1.164656");
-		// EXPECT_EQ(INPUT.td_trigo_freq2,"0.029116");
-		// EXPECT_EQ(INPUT.td_trigo_phase1,"0.0");
-		// EXPECT_EQ(INPUT.td_trigo_phase2,"0.0");
-		// EXPECT_EQ(INPUT.td_trigo_amp,"2.74");
-		// EXPECT_EQ(INPUT.td_heavi_t0,"100");	
-		// EXPECT_EQ(INPUT.td_heavi_amp,"1.0");		
-        EXPECT_EQ(INPUT.out_dipole,0);
-		EXPECT_EQ(INPUT.out_efield,0);
-		EXPECT_EQ(INPUT.td_print_eij,-1.0);
-		EXPECT_EQ(INPUT.td_edm,0);
-        EXPECT_DOUBLE_EQ(INPUT.cell_factor,1.2);
-        EXPECT_EQ(INPUT.out_mul,0);
-        EXPECT_FALSE(INPUT.restart_save);
-        EXPECT_FALSE(INPUT.restart_load);
-        EXPECT_FALSE(INPUT.test_skip_ewald);
-        EXPECT_EQ(INPUT.dft_plus_u, 0);
-        EXPECT_FALSE(INPUT.yukawa_potential);
-        EXPECT_DOUBLE_EQ(INPUT.yukawa_lambda,-1.0);
-		EXPECT_EQ(INPUT.onsite_radius, 0.0);
-        EXPECT_EQ(INPUT.omc,0);
-        EXPECT_FALSE(INPUT.dft_plus_dmft);
-        EXPECT_FALSE(INPUT.rpa);
-        EXPECT_EQ(INPUT.coulomb_type,"full");
-        EXPECT_EQ(INPUT.imp_sol,0);
-        EXPECT_DOUBLE_EQ(INPUT.eb_k,80.0);
-        EXPECT_DOUBLE_EQ(INPUT.tau,1.0798 * 1e-5);
-        EXPECT_DOUBLE_EQ(INPUT.sigma_k,0.6);
-        EXPECT_DOUBLE_EQ(INPUT.nc_k,0.00037);
-        EXPECT_EQ(INPUT.of_kinetic,"vw");
-        EXPECT_EQ(INPUT.of_method,"tn");
-        EXPECT_EQ(INPUT.of_conv,"energy");
-        EXPECT_DOUBLE_EQ(INPUT.of_tole,1e-6);
-        EXPECT_DOUBLE_EQ(INPUT.of_tolp,1e-5);
-        EXPECT_DOUBLE_EQ(INPUT.of_tf_weight,1.);
-        EXPECT_DOUBLE_EQ(INPUT.of_vw_weight,1.);
-        EXPECT_DOUBLE_EQ(INPUT.of_wt_alpha,0.833333);
-        EXPECT_DOUBLE_EQ(INPUT.of_wt_beta,0.833333);
-        EXPECT_DOUBLE_EQ(INPUT.of_wt_rho0,1.);
-        EXPECT_FALSE(INPUT.of_hold_rho0);
-        EXPECT_DOUBLE_EQ(INPUT.of_lkt_a, 1.3);
-        EXPECT_FALSE(INPUT.of_full_pw);
-        EXPECT_EQ(INPUT.of_full_pw_dim,0);
-        EXPECT_FALSE(INPUT.of_read_kernel);
-        EXPECT_EQ(INPUT.of_kernel_file,"WTkernel.txt");
-        EXPECT_EQ(INPUT.device, "cpu");
-        EXPECT_EQ(INPUT.ncx,0);
-        EXPECT_EQ(INPUT.ncy,0);
-        EXPECT_EQ(INPUT.ncz,0);
-        //EXPECT_NEAR(INPUT.force_thr_ev,0.0257112,1e-8);
-        EXPECT_DOUBLE_EQ(INPUT.hubbard_u[0],0);
-	EXPECT_EQ(INPUT.orbital_corr[0],-1);
-	EXPECT_NEAR(INPUT.mdp.lj_epsilon,0.01032,1e-7);
-	EXPECT_NEAR(INPUT.mdp.lj_rcut,8.5,1e-7);
-	EXPECT_NEAR(INPUT.mdp.lj_sigma,3.405,1e-7);
-	EXPECT_EQ(INPUT.mdp.md_damp,1);
-	EXPECT_EQ(INPUT.mdp.md_dt,1);
-	EXPECT_EQ(INPUT.mdp.md_dumpfreq,1);
-	EXPECT_EQ(INPUT.mdp.md_nraise,1);
-	EXPECT_EQ(INPUT.cal_syns,0);
-	EXPECT_EQ(INPUT.dmax,0.01);
-	EXPECT_EQ(INPUT.mdp.md_nstep,10);
-	EXPECT_EQ(INPUT.mdp.md_pchain,1);
-	EXPECT_EQ(INPUT.mdp.md_pcouple,"none");
-	EXPECT_DOUBLE_EQ(INPUT.mdp.md_pfirst,-1);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.md_pfreq,0);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.md_plast,-1);
-	EXPECT_EQ(INPUT.mdp.md_pmode,"iso");
-	EXPECT_EQ(INPUT.mdp.md_restart,0);
-	EXPECT_EQ(INPUT.mdp.md_restartfreq,5);
-	EXPECT_EQ(INPUT.mdp.md_seed,-1);
+    std::string input_file = "./support/INPUT";
+    INPUT.Read(input_file);
+    EXPECT_EQ(INPUT.suffix, "autotest");
+    EXPECT_EQ(INPUT.stru_file, "./support/STRU");
+    EXPECT_EQ(INPUT.kpoint_file, "KPT");
+    EXPECT_EQ(INPUT.pseudo_dir, "../../PP_ORB/");
+    EXPECT_EQ(INPUT.orbital_dir, "../../PP_ORB/");
+    EXPECT_EQ(INPUT.read_file_dir, "auto");
+    EXPECT_EQ(INPUT.wannier_card, "none");
+    EXPECT_EQ(INPUT.latname, "none");
+    EXPECT_EQ(INPUT.calculation, "scf");
+    EXPECT_EQ(INPUT.esolver_type, "ksdft");
+    EXPECT_DOUBLE_EQ(INPUT.pseudo_rcut, 15.0);
+    EXPECT_FALSE(INPUT.pseudo_mesh);
+    EXPECT_EQ(INPUT.ntype, 1);
+    EXPECT_EQ(INPUT.nbands, 8);
+    EXPECT_EQ(INPUT.nbands_sto, 256);
+    EXPECT_EQ(INPUT.nbands_istate, 5);
+    EXPECT_EQ(INPUT.pw_seed, 1);
+    EXPECT_EQ(INPUT.emin_sto, 0.0);
+    EXPECT_EQ(INPUT.emax_sto, 0.0);
+    EXPECT_EQ(INPUT.nche_sto, 100);
+    EXPECT_EQ(INPUT.seed_sto, 0);
+    EXPECT_EQ(INPUT.initsto_ecut, 0.0);
+    EXPECT_EQ(INPUT.bndpar, 1);
+    EXPECT_EQ(INPUT.kpar, 1);
+    EXPECT_EQ(INPUT.initsto_freq, 0);
+    EXPECT_EQ(INPUT.method_sto, 3);
+    EXPECT_EQ(INPUT.npart_sto, 1);
+    EXPECT_FALSE(INPUT.cal_cond);
+    EXPECT_EQ(INPUT.dos_nche, 100);
+    EXPECT_DOUBLE_EQ(INPUT.cond_che_thr, 1e-8);
+    EXPECT_DOUBLE_EQ(INPUT.cond_dw, 0.1);
+    EXPECT_DOUBLE_EQ(INPUT.cond_wcut, 10);
+    EXPECT_EQ(INPUT.cond_dt, 0.07);
+    EXPECT_EQ(INPUT.cond_dtbatch, 2);
+    EXPECT_DOUBLE_EQ(INPUT.cond_fwhm, 0.3);
+    EXPECT_TRUE(INPUT.cond_nonlocal);
+    EXPECT_FALSE(INPUT.berry_phase);
+    EXPECT_EQ(INPUT.gdir, 3);
+    EXPECT_FALSE(INPUT.towannier90);
+    EXPECT_EQ(INPUT.nnkpfile, "seedname.nnkp");
+    EXPECT_EQ(INPUT.wannier_spin, "up");
+    EXPECT_EQ(INPUT.wannier_method, 1);
+    EXPECT_TRUE(INPUT.out_wannier_amn);
+    EXPECT_TRUE(INPUT.out_wannier_mmn);
+    EXPECT_TRUE(INPUT.out_wannier_unk);
+    EXPECT_TRUE(INPUT.out_wannier_eig);
+    EXPECT_TRUE(INPUT.out_wannier_wvfn_formatted);
+    EXPECT_DOUBLE_EQ(INPUT.kspacing[0], 0.0);
+    EXPECT_DOUBLE_EQ(INPUT.kspacing[1], 0.0);
+    EXPECT_DOUBLE_EQ(INPUT.kspacing[2], 0.0);
+    EXPECT_DOUBLE_EQ(INPUT.min_dist_coef, 0.2);
+    EXPECT_EQ(INPUT.dft_functional, "hse");
+    EXPECT_DOUBLE_EQ(INPUT.xc_temperature, 0.0);
+    EXPECT_EQ(INPUT.nspin, 1);
+    EXPECT_DOUBLE_EQ(INPUT.nelec, 0.0);
+    EXPECT_EQ(INPUT.lmaxmax, 2);
+    EXPECT_EQ(INPUT.basis_type, "lcao");
+    EXPECT_EQ(INPUT.ks_solver, "genelpa");
+    EXPECT_DOUBLE_EQ(INPUT.search_radius, -1.0);
+    EXPECT_TRUE(INPUT.search_pbc);
+    EXPECT_EQ(INPUT.symmetry, "1");
+    EXPECT_FALSE(INPUT.init_vel);
+    EXPECT_DOUBLE_EQ(INPUT.symmetry_prec, 1.0e-6);
+    EXPECT_TRUE(INPUT.symmetry_autoclose);
+    EXPECT_EQ(INPUT.cal_force, 0);
+    EXPECT_NEAR(INPUT.force_thr, 1.0e-3, 1.0e-7);
+    EXPECT_DOUBLE_EQ(INPUT.force_thr_ev2, 0);
+    EXPECT_DOUBLE_EQ(INPUT.stress_thr, 1.0e-2);
+    EXPECT_DOUBLE_EQ(INPUT.press1, 0.0);
+    EXPECT_DOUBLE_EQ(INPUT.press2, 0.0);
+    EXPECT_DOUBLE_EQ(INPUT.press3, 0.0);
+    EXPECT_FALSE(INPUT.cal_stress);
+    EXPECT_EQ(INPUT.fixed_axes, "None");
+    EXPECT_FALSE(INPUT.fixed_ibrav);
+    EXPECT_FALSE(INPUT.fixed_atoms);
+    EXPECT_EQ(INPUT.relax_method, "cg");
+    EXPECT_DOUBLE_EQ(INPUT.relax_cg_thr, 0.5);
+    EXPECT_EQ(INPUT.out_level, "ie");
+    EXPECT_TRUE(INPUT.out_md_control);
+    EXPECT_TRUE(INPUT.relax_new);
+    EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_w1, 0.01);
+    EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_w2, 0.5);
+    EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_rmax, 0.8);
+    EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_rmin, 1e-5);
+    EXPECT_DOUBLE_EQ(INPUT.relax_bfgs_init, 0.5);
+    EXPECT_DOUBLE_EQ(INPUT.relax_scale_force, 0.5);
+    EXPECT_EQ(INPUT.nbspline, -1);
+    EXPECT_TRUE(INPUT.gamma_only);
+    EXPECT_TRUE(INPUT.gamma_only_local);
+    EXPECT_DOUBLE_EQ(INPUT.ecutwfc, 20.0);
+    EXPECT_DOUBLE_EQ(INPUT.erf_ecut, 20.0);
+    EXPECT_DOUBLE_EQ(INPUT.erf_height, 20.0);
+    EXPECT_DOUBLE_EQ(INPUT.erf_sigma, 4.0);
+    EXPECT_DOUBLE_EQ(INPUT.ecutrho, 0.0);
+    EXPECT_EQ(INPUT.fft_mode, 0);
+    EXPECT_EQ(INPUT.ncx, 0);
+    EXPECT_EQ(INPUT.ncy, 0);
+    EXPECT_EQ(INPUT.ncz, 0);
+    EXPECT_EQ(INPUT.nx, 0);
+    EXPECT_EQ(INPUT.ny, 0);
+    EXPECT_EQ(INPUT.nz, 0);
+    EXPECT_EQ(INPUT.bx, 2);
+    EXPECT_EQ(INPUT.by, 2);
+    EXPECT_EQ(INPUT.bz, 2);
+    EXPECT_EQ(INPUT.ndx, 0);
+    EXPECT_EQ(INPUT.ndy, 0);
+    EXPECT_EQ(INPUT.ndz, 0);
+    EXPECT_EQ(INPUT.diago_proc, 4);
+    EXPECT_EQ(INPUT.pw_diag_nmax, 50);
+    EXPECT_EQ(INPUT.diago_cg_prec, 1);
+    EXPECT_EQ(INPUT.pw_diag_ndim, 4);
+    EXPECT_DOUBLE_EQ(INPUT.pw_diag_thr, 1.0e-2);
+    EXPECT_EQ(INPUT.nb2d, 0);
+    EXPECT_EQ(INPUT.nurse, 0);
+    EXPECT_EQ(INPUT.colour, 0);
+    EXPECT_EQ(INPUT.t_in_h, 1);
+    EXPECT_EQ(INPUT.vl_in_h, 1);
+    EXPECT_EQ(INPUT.vnl_in_h, 1);
+    EXPECT_EQ(INPUT.vh_in_h, 1);
+    EXPECT_EQ(INPUT.vion_in_h, 1);
+    EXPECT_EQ(INPUT.test_force, 0);
+    EXPECT_EQ(INPUT.test_stress, 0);
+    EXPECT_NEAR(INPUT.scf_thr, 1.0e-8, 1.0e-15);
+    EXPECT_EQ(INPUT.scf_nmax, 50);
+    EXPECT_EQ(INPUT.relax_nmax, 1);
+    EXPECT_EQ(INPUT.out_stru, 0);
+    EXPECT_EQ(INPUT.occupations, "smearing");
+    EXPECT_EQ(INPUT.smearing_method, "gauss");
+    EXPECT_DOUBLE_EQ(INPUT.smearing_sigma, 0.002);
+    EXPECT_EQ(INPUT.mixing_mode, "broyden");
+    EXPECT_DOUBLE_EQ(INPUT.mixing_beta, 0.7);
+    EXPECT_EQ(INPUT.mixing_ndim, 8);
+    EXPECT_DOUBLE_EQ(INPUT.mixing_gg0, 0.00);
+    EXPECT_EQ(INPUT.init_wfc, "atomic");
+    EXPECT_EQ(INPUT.mem_saver, 0);
+    EXPECT_EQ(INPUT.printe, 100);
+    EXPECT_EQ(INPUT.init_chg, "atomic");
+    EXPECT_EQ(INPUT.chg_extrap, "atomic");
+    EXPECT_EQ(INPUT.out_freq_elec, 0);
+    EXPECT_EQ(INPUT.out_freq_ion, 0);
+    EXPECT_EQ(INPUT.out_chg, 0);
+    EXPECT_EQ(INPUT.out_dm, 0);
+    EXPECT_EQ(INPUT.out_dm1, 0);
+    EXPECT_EQ(INPUT.deepks_out_labels, 0);
+    EXPECT_EQ(INPUT.deepks_scf, 0);
+    EXPECT_EQ(INPUT.deepks_equiv, 0);
+    EXPECT_EQ(INPUT.deepks_bandgap, 0);
+    EXPECT_EQ(INPUT.deepks_out_unittest, 0);
+    EXPECT_EQ(INPUT.out_pot, 2);
+    EXPECT_EQ(INPUT.out_wfc_pw, 0);
+    EXPECT_EQ(INPUT.out_wfc_r, 0);
+    EXPECT_EQ(INPUT.out_dos, 0);
+    EXPECT_EQ(INPUT.out_band[0], 0);
+    EXPECT_EQ(INPUT.out_band[1], 8);
+    EXPECT_EQ(INPUT.out_proj_band, 0);
+    EXPECT_EQ(INPUT.out_mat_hs[0], 0);
+    EXPECT_EQ(INPUT.out_mat_hs[1], 8);
+    EXPECT_EQ(INPUT.out_mat_hs2, 0);
+    EXPECT_EQ(INPUT.out_mat_xc, 0);
+    EXPECT_EQ(INPUT.out_interval, 1);
+    EXPECT_EQ(INPUT.out_app_flag, 0);
+    EXPECT_EQ(INPUT.out_mat_r, 0);
+    EXPECT_FALSE(INPUT.out_wfc_lcao);
+    EXPECT_FALSE(INPUT.out_alllog);
+    EXPECT_DOUBLE_EQ(INPUT.dos_emin_ev, -15);
+    EXPECT_DOUBLE_EQ(INPUT.dos_emax_ev, 15);
+    EXPECT_DOUBLE_EQ(INPUT.dos_edelta_ev, 0.01);
+    EXPECT_DOUBLE_EQ(INPUT.dos_scale, 0.01);
+    EXPECT_DOUBLE_EQ(INPUT.dos_sigma, 0.07);
+    EXPECT_FALSE(INPUT.out_element_info);
+    EXPECT_DOUBLE_EQ(INPUT.lcao_ecut, 20);
+    EXPECT_DOUBLE_EQ(INPUT.lcao_dk, 0.01);
+    EXPECT_DOUBLE_EQ(INPUT.lcao_dr, 0.01);
+    EXPECT_DOUBLE_EQ(INPUT.lcao_rmax, 30);
+    EXPECT_TRUE(INPUT.bessel_nao_smooth);
+    EXPECT_DOUBLE_EQ(INPUT.bessel_nao_sigma, 0.1);
+    EXPECT_EQ(INPUT.bessel_nao_ecut, "default");
+    EXPECT_DOUBLE_EQ(INPUT.bessel_nao_rcut, 6.0);
+    EXPECT_DOUBLE_EQ(INPUT.bessel_nao_tolerence, 1E-12);
+    EXPECT_EQ(INPUT.bessel_descriptor_lmax, 2);
+    EXPECT_TRUE(INPUT.bessel_descriptor_smooth);
+    EXPECT_DOUBLE_EQ(INPUT.bessel_descriptor_sigma, 0.1);
+    EXPECT_EQ(INPUT.bessel_descriptor_ecut, "default");
+    EXPECT_DOUBLE_EQ(INPUT.bessel_descriptor_rcut, 6.0);
+    EXPECT_DOUBLE_EQ(INPUT.bessel_descriptor_tolerence, 1E-12);
+    EXPECT_FALSE(INPUT.efield_flag);
+    EXPECT_FALSE(INPUT.dip_cor_flag);
+    EXPECT_EQ(INPUT.efield_dir, 2);
+    EXPECT_DOUBLE_EQ(INPUT.efield_pos_max, 0.5);
+    EXPECT_DOUBLE_EQ(INPUT.efield_pos_dec, 0.1);
+    EXPECT_DOUBLE_EQ(INPUT.efield_amp, 0.0);
+    EXPECT_FALSE(INPUT.gate_flag);
+    EXPECT_DOUBLE_EQ(INPUT.zgate, 0.5);
+    EXPECT_FALSE(INPUT.relax);
+    EXPECT_FALSE(INPUT.block);
+    EXPECT_DOUBLE_EQ(INPUT.block_down, 0.45);
+    EXPECT_DOUBLE_EQ(INPUT.block_up, 0.55);
+    EXPECT_DOUBLE_EQ(INPUT.block_height, 0.1);
+    EXPECT_EQ(INPUT.vdw_method, "d2");
+    EXPECT_EQ(INPUT.vdw_s6, "default");
+    EXPECT_EQ(INPUT.vdw_s8, "default");
+    EXPECT_EQ(INPUT.vdw_a1, "default");
+    EXPECT_EQ(INPUT.vdw_a2, "default");
+    EXPECT_DOUBLE_EQ(INPUT.vdw_d, 20);
+    EXPECT_FALSE(INPUT.vdw_abc);
+    EXPECT_EQ(INPUT.vdw_cutoff_radius, "default");
+    EXPECT_EQ(INPUT.vdw_radius_unit, "Bohr");
+    EXPECT_DOUBLE_EQ(INPUT.vdw_cn_thr, 40.0);
+    EXPECT_EQ(INPUT.vdw_cn_thr_unit, "Bohr");
+    EXPECT_EQ(INPUT.vdw_C6_file, "default");
+    EXPECT_EQ(INPUT.vdw_C6_unit, "Jnm6/mol");
+    EXPECT_EQ(INPUT.vdw_R0_file, "default");
+    EXPECT_EQ(INPUT.vdw_R0_unit, "A");
+    EXPECT_EQ(INPUT.vdw_cutoff_type, "radius");
+    EXPECT_EQ(INPUT.vdw_cutoff_period[0], 3);
+    EXPECT_EQ(INPUT.vdw_cutoff_period[1], 3);
+    EXPECT_EQ(INPUT.vdw_cutoff_period[2], 3);
+    EXPECT_EQ(INPUT.exx_hybrid_alpha, "default");
+    EXPECT_EQ(INPUT.exx_real_number, "default");
+    EXPECT_DOUBLE_EQ(INPUT.exx_hse_omega, 0.11);
+    EXPECT_TRUE(INPUT.exx_separate_loop);
+    EXPECT_EQ(INPUT.exx_hybrid_step, 100);
+    EXPECT_DOUBLE_EQ(INPUT.exx_lambda, 0.3);
+    EXPECT_DOUBLE_EQ(INPUT.exx_mixing_beta, 1.0);
+    EXPECT_DOUBLE_EQ(INPUT.exx_pca_threshold, 0);
+    EXPECT_DOUBLE_EQ(INPUT.exx_c_threshold, 0);
+    EXPECT_DOUBLE_EQ(INPUT.exx_v_threshold, 0);
+    EXPECT_DOUBLE_EQ(INPUT.exx_dm_threshold, 0);
+    EXPECT_DOUBLE_EQ(INPUT.exx_schwarz_threshold, 0);
+    EXPECT_DOUBLE_EQ(INPUT.exx_cauchy_threshold, 0);
+    EXPECT_DOUBLE_EQ(INPUT.exx_c_grad_threshold, 0);
+    EXPECT_DOUBLE_EQ(INPUT.exx_v_grad_threshold, 0);
+    EXPECT_DOUBLE_EQ(INPUT.exx_cauchy_force_threshold, 0);
+    EXPECT_DOUBLE_EQ(INPUT.exx_cauchy_stress_threshold, 0);
+    EXPECT_DOUBLE_EQ(INPUT.exx_ccp_threshold, 1E-8);
+    EXPECT_EQ(INPUT.exx_ccp_rmesh_times, "default");
+    EXPECT_DOUBLE_EQ(INPUT.rpa_ccp_rmesh_times, 10.0);
+    EXPECT_EQ(INPUT.exx_distribute_type, "htime");
+    EXPECT_EQ(INPUT.exx_opt_orb_lmax, 0);
+    EXPECT_DOUBLE_EQ(INPUT.exx_opt_orb_ecut, 0.0);
+    EXPECT_DOUBLE_EQ(INPUT.exx_opt_orb_tolerence, 0.0);
+    EXPECT_FALSE(INPUT.noncolin);
+    EXPECT_FALSE(INPUT.lspinorb);
+    EXPECT_DOUBLE_EQ(INPUT.soc_lambda, 1.0);
+    EXPECT_EQ(INPUT.input_error, 0);
+    EXPECT_DOUBLE_EQ(INPUT.td_force_dt, 0.02);
+    EXPECT_EQ(INPUT.td_vext, 0);
+    // EXPECT_EQ(INPUT.td_vext_dire,"1");
+    EXPECT_EQ(INPUT.propagator, 0);
+    EXPECT_EQ(INPUT.td_stype, 0);
+    // EXPECT_EQ(INPUT.td_ttype,"0");
+    EXPECT_EQ(INPUT.td_tstart, 1);
+    EXPECT_EQ(INPUT.td_tend, 1000);
+    EXPECT_EQ(INPUT.td_lcut1, 0.05);
+    EXPECT_EQ(INPUT.td_lcut2, 0.95);
+    // EXPECT_EQ(INPUT.td_gauss_amp,"0.25");
+    // EXPECT_EQ(INPUT.td_gauss_freq,"22.13");
+    // EXPECT_EQ(INPUT.td_gauss_phase,"0.0");
+    // EXPECT_EQ(INPUT.td_gauss_t0,"100.0");
+    // EXPECT_EQ(INPUT.td_gauss_sigma,"30.0");
+    // EXPECT_EQ(INPUT.td_trape_amp,"2.74");
+    // EXPECT_EQ(INPUT.td_trape_freq,"1.60");
+    // EXPECT_EQ(INPUT.td_trape_phase,"0.0");
+    // EXPECT_EQ(INPUT.td_trape_t1,"1875");
+    // EXPECT_EQ(INPUT.td_trape_t2,"5625");
+    // EXPECT_EQ(INPUT.td_trape_t3,"7500");
+    // EXPECT_EQ(INPUT.td_trigo_freq1,"1.164656");
+    // EXPECT_EQ(INPUT.td_trigo_freq2,"0.029116");
+    // EXPECT_EQ(INPUT.td_trigo_phase1,"0.0");
+    // EXPECT_EQ(INPUT.td_trigo_phase2,"0.0");
+    // EXPECT_EQ(INPUT.td_trigo_amp,"2.74");
+    // EXPECT_EQ(INPUT.td_heavi_t0,"100");
+    // EXPECT_EQ(INPUT.td_heavi_amp,"1.0");
+    EXPECT_EQ(INPUT.out_dipole, 0);
+    EXPECT_EQ(INPUT.out_efield, 0);
+    EXPECT_EQ(INPUT.td_print_eij, -1.0);
+    EXPECT_EQ(INPUT.td_edm, 0);
+    EXPECT_DOUBLE_EQ(INPUT.cell_factor, 1.2);
+    EXPECT_EQ(INPUT.out_mul, 0);
+    EXPECT_FALSE(INPUT.restart_save);
+    EXPECT_FALSE(INPUT.restart_load);
+    EXPECT_FALSE(INPUT.test_skip_ewald);
+    EXPECT_EQ(INPUT.dft_plus_u, 0);
+    EXPECT_FALSE(INPUT.yukawa_potential);
+    EXPECT_DOUBLE_EQ(INPUT.yukawa_lambda, -1.0);
+    EXPECT_EQ(INPUT.onsite_radius, 0.0);
+    EXPECT_EQ(INPUT.omc, 0);
+    EXPECT_FALSE(INPUT.dft_plus_dmft);
+    EXPECT_FALSE(INPUT.rpa);
+    EXPECT_EQ(INPUT.coulomb_type, "full");
+    EXPECT_EQ(INPUT.imp_sol, 0);
+    EXPECT_DOUBLE_EQ(INPUT.eb_k, 80.0);
+    EXPECT_DOUBLE_EQ(INPUT.tau, 1.0798 * 1e-5);
+    EXPECT_DOUBLE_EQ(INPUT.sigma_k, 0.6);
+    EXPECT_DOUBLE_EQ(INPUT.nc_k, 0.00037);
+    EXPECT_EQ(INPUT.of_kinetic, "vw");
+    EXPECT_EQ(INPUT.of_method, "tn");
+    EXPECT_EQ(INPUT.of_conv, "energy");
+    EXPECT_DOUBLE_EQ(INPUT.of_tole, 1e-6);
+    EXPECT_DOUBLE_EQ(INPUT.of_tolp, 1e-5);
+    EXPECT_DOUBLE_EQ(INPUT.of_tf_weight, 1.);
+    EXPECT_DOUBLE_EQ(INPUT.of_vw_weight, 1.);
+    EXPECT_DOUBLE_EQ(INPUT.of_wt_alpha, 0.833333);
+    EXPECT_DOUBLE_EQ(INPUT.of_wt_beta, 0.833333);
+    EXPECT_DOUBLE_EQ(INPUT.of_wt_rho0, 1.);
+    EXPECT_FALSE(INPUT.of_hold_rho0);
+    EXPECT_DOUBLE_EQ(INPUT.of_lkt_a, 1.3);
+    EXPECT_FALSE(INPUT.of_full_pw);
+    EXPECT_EQ(INPUT.of_full_pw_dim, 0);
+    EXPECT_FALSE(INPUT.of_read_kernel);
+    EXPECT_EQ(INPUT.of_kernel_file, "WTkernel.txt");
+    EXPECT_EQ(INPUT.device, "cpu");
+    EXPECT_EQ(INPUT.ncx, 0);
+    EXPECT_EQ(INPUT.ncy, 0);
+    EXPECT_EQ(INPUT.ncz, 0);
+    // EXPECT_NEAR(INPUT.force_thr_ev,0.0257112,1e-8);
+    EXPECT_DOUBLE_EQ(INPUT.hubbard_u[0], 0);
+    EXPECT_EQ(INPUT.orbital_corr[0], -1);
+    EXPECT_NEAR(INPUT.mdp.lj_epsilon, 0.01032, 1e-7);
+    EXPECT_NEAR(INPUT.mdp.lj_rcut, 8.5, 1e-7);
+    EXPECT_NEAR(INPUT.mdp.lj_sigma, 3.405, 1e-7);
+    EXPECT_EQ(INPUT.mdp.md_damp, 1);
+    EXPECT_EQ(INPUT.mdp.md_dt, 1);
+    EXPECT_EQ(INPUT.mdp.md_dumpfreq, 1);
+    EXPECT_EQ(INPUT.mdp.md_nraise, 1);
+    EXPECT_EQ(INPUT.cal_syns, 0);
+    EXPECT_EQ(INPUT.dmax, 0.01);
+    EXPECT_EQ(INPUT.mdp.md_nstep, 10);
+    EXPECT_EQ(INPUT.mdp.md_pchain, 1);
+    EXPECT_EQ(INPUT.mdp.md_pcouple, "none");
+    EXPECT_DOUBLE_EQ(INPUT.mdp.md_pfirst, -1);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.md_pfreq, 0);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.md_plast, -1);
+    EXPECT_EQ(INPUT.mdp.md_pmode, "iso");
+    EXPECT_EQ(INPUT.mdp.md_restart, 0);
+    EXPECT_EQ(INPUT.mdp.md_restartfreq, 5);
+    EXPECT_EQ(INPUT.mdp.md_seed, -1);
     EXPECT_EQ(INPUT.mdp.md_prec_level, 2);
-    EXPECT_DOUBLE_EQ(INPUT.ref_cell_factor,1.2);
-	EXPECT_EQ(INPUT.mdp.md_tchain,1);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.md_tfirst,-1);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.md_tfreq,0);
-	EXPECT_EQ(INPUT.mdp.md_thermostat,"nhc");
-	EXPECT_DOUBLE_EQ(INPUT.mdp.md_tlast,-1);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.md_tolerance,100);
-	EXPECT_EQ(INPUT.mdp.md_type,"nvt");
-	EXPECT_EQ(INPUT.mdp.msst_direction,2);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.msst_qmass,-1);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.msst_tscale,0.01);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.msst_vel,0);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.msst_vis,0);
-	EXPECT_EQ(INPUT.mdp.pot_file,"graph.pb");
+    EXPECT_DOUBLE_EQ(INPUT.ref_cell_factor, 1.2);
+    EXPECT_EQ(INPUT.mdp.md_tchain, 1);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.md_tfirst, -1);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.md_tfreq, 0);
+    EXPECT_EQ(INPUT.mdp.md_thermostat, "nhc");
+    EXPECT_DOUBLE_EQ(INPUT.mdp.md_tlast, -1);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.md_tolerance, 100);
+    EXPECT_EQ(INPUT.mdp.md_type, "nvt");
+    EXPECT_EQ(INPUT.mdp.msst_direction, 2);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.msst_qmass, -1);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.msst_tscale, 0.01);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.msst_vel, 0);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.msst_vis, 0);
+    EXPECT_EQ(INPUT.mdp.pot_file, "graph.pb");
     EXPECT_FALSE(INPUT.mdp.dump_force);
     EXPECT_FALSE(INPUT.mdp.dump_vel);
     EXPECT_FALSE(INPUT.mdp.dump_virial);
@@ -752,40 +753,40 @@ TEST_F(InputTest, Read)
     EXPECT_TRUE(INPUT.decay_grad_switch);
     EXPECT_DOUBLE_EQ(INPUT.sc_thr, 1e-4);
     EXPECT_EQ(INPUT.nsc, 50);
-	EXPECT_EQ(INPUT.nsc_min, 4);
-	EXPECT_EQ(INPUT.sc_scf_nmin, 4);
+    EXPECT_EQ(INPUT.nsc_min, 4);
+    EXPECT_EQ(INPUT.sc_scf_nmin, 4);
     EXPECT_DOUBLE_EQ(INPUT.alpha_trial, 0.02);
-	EXPECT_DOUBLE_EQ(INPUT.sccut, 4.0);
+    EXPECT_DOUBLE_EQ(INPUT.sccut, 4.0);
     EXPECT_EQ(INPUT.sc_file, "sc.json");
 }
 
 TEST_F(InputTest, Default_2)
 {
-	//==================================================
-	// prepare default parameters for the 1st calling
-	EXPECT_EQ(INPUT.vdw_method,"d2");
-	EXPECT_EQ(INPUT.vdw_s6,"default");
-        EXPECT_EQ(INPUT.vdw_s8,"default");
-        EXPECT_EQ(INPUT.vdw_a1,"default");
-        EXPECT_EQ(INPUT.vdw_a2,"default");
-        EXPECT_EQ(INPUT.vdw_cutoff_radius,"default");
-	EXPECT_NE(INPUT.esolver_type,"sdft");
-	EXPECT_NE(INPUT.method_sto,1);
-	EXPECT_NE(INPUT.method_sto,2);
-	EXPECT_NE(INPUT.of_wt_rho0,0.0);
-	EXPECT_EQ(INPUT.exx_hybrid_alpha,"default");
-	EXPECT_EQ(INPUT.dft_functional,"hse");
-	EXPECT_EQ(INPUT.exx_real_number,"default");
-	EXPECT_TRUE(INPUT.gamma_only);
-        EXPECT_EQ(INPUT.exx_ccp_rmesh_times,"default");
-	EXPECT_EQ(INPUT.diago_proc,4);
-	EXPECT_EQ(GlobalV::NPROC,1);
-	EXPECT_EQ(INPUT.calculation,"scf");
-	EXPECT_EQ(INPUT.basis_type,"lcao");
-	INPUT.ks_solver = "default";
-	INPUT.lcao_ecut = 0;
-	INPUT.scf_thr = -1.0;
-	INPUT.scf_thr_type = -1;
+    //==================================================
+    // prepare default parameters for the 1st calling
+    EXPECT_EQ(INPUT.vdw_method, "d2");
+    EXPECT_EQ(INPUT.vdw_s6, "default");
+    EXPECT_EQ(INPUT.vdw_s8, "default");
+    EXPECT_EQ(INPUT.vdw_a1, "default");
+    EXPECT_EQ(INPUT.vdw_a2, "default");
+    EXPECT_EQ(INPUT.vdw_cutoff_radius, "default");
+    EXPECT_NE(INPUT.esolver_type, "sdft");
+    EXPECT_NE(INPUT.method_sto, 1);
+    EXPECT_NE(INPUT.method_sto, 2);
+    EXPECT_NE(INPUT.of_wt_rho0, 0.0);
+    EXPECT_EQ(INPUT.exx_hybrid_alpha, "default");
+    EXPECT_EQ(INPUT.dft_functional, "hse");
+    EXPECT_EQ(INPUT.exx_real_number, "default");
+    EXPECT_TRUE(INPUT.gamma_only);
+    EXPECT_EQ(INPUT.exx_ccp_rmesh_times, "default");
+    EXPECT_EQ(INPUT.diago_proc, 4);
+    EXPECT_EQ(GlobalV::NPROC, 1);
+    EXPECT_EQ(INPUT.calculation, "scf");
+    EXPECT_EQ(INPUT.basis_type, "lcao");
+    INPUT.ks_solver = "default";
+    INPUT.lcao_ecut = 0;
+    INPUT.scf_thr = -1.0;
+    INPUT.scf_thr_type = -1;
     EXPECT_DOUBLE_EQ(INPUT.ecutwfc, 20.0);
     EXPECT_DOUBLE_EQ(INPUT.erf_ecut, 20.0);
     EXPECT_DOUBLE_EQ(INPUT.erf_height, 20.0);
@@ -803,54 +804,54 @@ TEST_F(InputTest, Default_2)
     EXPECT_DOUBLE_EQ(INPUT.ecutrho, 80.0);
     EXPECT_EQ(INPUT.vdw_s6, "0.75");
     EXPECT_EQ(INPUT.vdw_cutoff_radius, "56.6918");
-    EXPECT_EQ(INPUT.bndpar,1);
-	EXPECT_EQ(INPUT.method_sto,2);
-	EXPECT_TRUE(INPUT.of_hold_rho0);
-        EXPECT_EQ(INPUT.of_full_pw_dim,0);
-	EXPECT_EQ(INPUT.exx_hybrid_alpha,"0.25");
-	EXPECT_EQ(INPUT.exx_real_number,"1");
-        EXPECT_EQ(INPUT.exx_ccp_rmesh_times,"1.5");
-	EXPECT_EQ(INPUT.diago_proc,1);
-	EXPECT_EQ(INPUT.mem_saver,0);
-	EXPECT_EQ(INPUT.relax_nmax,1);
-	EXPECT_DOUBLE_EQ(INPUT.scf_thr,1.0e-7);
-	EXPECT_EQ(INPUT.scf_thr_type,2);
+    EXPECT_EQ(INPUT.bndpar, 1);
+    EXPECT_EQ(INPUT.method_sto, 2);
+    EXPECT_TRUE(INPUT.of_hold_rho0);
+    EXPECT_EQ(INPUT.of_full_pw_dim, 0);
+    EXPECT_EQ(INPUT.exx_hybrid_alpha, "0.25");
+    EXPECT_EQ(INPUT.exx_real_number, "1");
+    EXPECT_EQ(INPUT.exx_ccp_rmesh_times, "1.5");
+    EXPECT_EQ(INPUT.diago_proc, 1);
+    EXPECT_EQ(INPUT.mem_saver, 0);
+    EXPECT_EQ(INPUT.relax_nmax, 1);
+    EXPECT_DOUBLE_EQ(INPUT.scf_thr, 1.0e-7);
+    EXPECT_EQ(INPUT.scf_thr_type, 2);
 #ifdef __ELPA
-	EXPECT_EQ(INPUT.ks_solver,"genelpa");
+    EXPECT_EQ(INPUT.ks_solver, "genelpa");
 #else
-	EXPECT_EQ(INPUT.ks_solver,"scalapack_gvx");
+    EXPECT_EQ(INPUT.ks_solver, "scalapack_gvx");
 #endif
-        EXPECT_DOUBLE_EQ(INPUT.lcao_ecut,20.0);
-	EXPECT_EQ(INPUT.nbands_sto, 0);
-	//==================================================
-	// prepare default parameters for the 2nd calling
-	INPUT.vdw_method = "d3_0";
-	INPUT.vdw_s6 = "default";
-	INPUT.vdw_s8 = "default";
-	INPUT.vdw_a1 = "default";
-	INPUT.vdw_a2 = "default";
-	INPUT.vdw_cutoff_radius = "default";
-	INPUT.exx_hybrid_alpha = "default";
-	INPUT.dft_functional = "hf";
-	INPUT.exx_real_number = "default";
-	INPUT.gamma_only = 0;
-        INPUT.exx_ccp_rmesh_times = "default";
-	INPUT.diago_proc = 0;
-	INPUT.calculation = "relax";
+    EXPECT_DOUBLE_EQ(INPUT.lcao_ecut, 20.0);
+    EXPECT_EQ(INPUT.nbands_sto, 0);
+    //==================================================
+    // prepare default parameters for the 2nd calling
+    INPUT.vdw_method = "d3_0";
+    INPUT.vdw_s6 = "default";
+    INPUT.vdw_s8 = "default";
+    INPUT.vdw_a1 = "default";
+    INPUT.vdw_a2 = "default";
+    INPUT.vdw_cutoff_radius = "default";
+    INPUT.exx_hybrid_alpha = "default";
+    INPUT.dft_functional = "hf";
+    INPUT.exx_real_number = "default";
+    INPUT.gamma_only = false;
+    INPUT.exx_ccp_rmesh_times = "default";
+    INPUT.diago_proc = 0;
+    INPUT.calculation = "relax";
     INPUT.chg_extrap = "default";
     INPUT.relax_nmax = 0;
     INPUT.basis_type = "pw";
     INPUT.ks_solver = "default";
-    INPUT.gamma_only_local = 1;
-	INPUT.scf_thr = -1.0;
-	INPUT.scf_thr_type = -1;
+    INPUT.gamma_only_local = true;
+    INPUT.scf_thr = -1.0;
+    INPUT.scf_thr_type = -1;
     INPUT.nbndsto_str = "0";
     INPUT.esolver_type = "sdft";
     INPUT.nx = INPUT.ny = INPUT.nz = 0;
     INPUT.ndx = INPUT.ndy = INPUT.ndz = 4;
     // the 2nd calling
-	INPUT.Default_2();
-	// ^^^^^^^^^^^^^^
+    INPUT.Default_2();
+    // ^^^^^^^^^^^^^^
     EXPECT_EQ(INPUT.nx, 4);
     EXPECT_EQ(INPUT.ny, 4);
     EXPECT_EQ(INPUT.nz, 4);
@@ -859,41 +860,41 @@ TEST_F(InputTest, Default_2)
     EXPECT_EQ(INPUT.vdw_s6, "1.0");
     EXPECT_EQ(INPUT.vdw_s8, "0.722");
     EXPECT_EQ(INPUT.vdw_a1, "1.217");
-    EXPECT_EQ(INPUT.vdw_a2,"1.0");
-	EXPECT_EQ(INPUT.vdw_cutoff_radius,"95");
-	EXPECT_EQ(INPUT.exx_hybrid_alpha,"1");
-	EXPECT_EQ(INPUT.exx_real_number,"0");
-        EXPECT_EQ(INPUT.exx_ccp_rmesh_times,"5");
-	EXPECT_EQ(INPUT.diago_proc,1);
-	EXPECT_EQ(INPUT.mem_saver,0);
-	EXPECT_EQ(INPUT.cal_force,1);
-	EXPECT_EQ(INPUT.relax_nmax,50);
-	EXPECT_EQ(INPUT.ks_solver,"cg");
-	EXPECT_EQ(INPUT.gamma_only_local,0);
-	EXPECT_EQ(INPUT.bx,1);
-	EXPECT_EQ(INPUT.by,1);
-	EXPECT_EQ(INPUT.bz,1);
-	EXPECT_DOUBLE_EQ(INPUT.scf_thr,1.0e-9);
-	EXPECT_EQ(INPUT.scf_thr_type,1);
-	EXPECT_EQ(INPUT.esolver_type, "ksdft");
-	//==================================================
-	// prepare default parameters for the 3rd calling
-	INPUT.vdw_method = "d3_bj";
-	INPUT.vdw_s6 = "default";
-	INPUT.vdw_s8 = "default";
-	INPUT.vdw_a1 = "default";
-	INPUT.vdw_a2 = "default";
-	INPUT.vdw_cutoff_radius = "default";
-	INPUT.calculation = "get_S";
+    EXPECT_EQ(INPUT.vdw_a2, "1.0");
+    EXPECT_EQ(INPUT.vdw_cutoff_radius, "95");
+    EXPECT_EQ(INPUT.exx_hybrid_alpha, "1");
+    EXPECT_EQ(INPUT.exx_real_number, "0");
+    EXPECT_EQ(INPUT.exx_ccp_rmesh_times, "5");
+    EXPECT_EQ(INPUT.diago_proc, 1);
+    EXPECT_EQ(INPUT.mem_saver, 0);
+    EXPECT_EQ(INPUT.cal_force, 1);
+    EXPECT_EQ(INPUT.relax_nmax, 50);
+    EXPECT_EQ(INPUT.ks_solver, "cg");
+    EXPECT_EQ(INPUT.gamma_only_local, 0);
+    EXPECT_EQ(INPUT.bx, 1);
+    EXPECT_EQ(INPUT.by, 1);
+    EXPECT_EQ(INPUT.bz, 1);
+    EXPECT_DOUBLE_EQ(INPUT.scf_thr, 1.0e-9);
+    EXPECT_EQ(INPUT.scf_thr_type, 1);
+    EXPECT_EQ(INPUT.esolver_type, "ksdft");
+    //==================================================
+    // prepare default parameters for the 3rd calling
+    INPUT.vdw_method = "d3_bj";
+    INPUT.vdw_s6 = "default";
+    INPUT.vdw_s8 = "default";
+    INPUT.vdw_a1 = "default";
+    INPUT.vdw_a2 = "default";
+    INPUT.vdw_cutoff_radius = "default";
+    INPUT.calculation = "get_S";
     INPUT.chg_extrap = "default";
     INPUT.basis_type = "pw";
     INPUT.pw_diag_thr = 1.0e-2;
-    INPUT.cal_force = 1;
-	INPUT.init_chg = "atomic";
-	INPUT.basis_type = "pw";
-	INPUT.ks_solver = "cg";
-	GlobalV::NPROC = 8;
-	INPUT.diago_proc = 1;
+    INPUT.cal_force = true;
+    INPUT.init_chg = "atomic";
+    INPUT.basis_type = "pw";
+    INPUT.ks_solver = "cg";
+    GlobalV::NPROC = 8;
+    INPUT.diago_proc = 1;
     INPUT.nx = INPUT.ny = INPUT.nz = 4;
     INPUT.ndx = INPUT.ndy = INPUT.ndz = 6;
     // the 3rd calling
@@ -903,19 +904,19 @@ TEST_F(InputTest, Default_2)
     EXPECT_EQ(INPUT.chg_extrap, "atomic");
     EXPECT_EQ(INPUT.vdw_s6, "1.0");
     EXPECT_EQ(INPUT.vdw_s8, "0.7875");
-    EXPECT_EQ(INPUT.vdw_a1,"0.4289");
-	EXPECT_EQ(INPUT.vdw_a2,"4.4407");
-	EXPECT_EQ(INPUT.vdw_cutoff_radius,"95");
-	EXPECT_EQ(GlobalV::CALCULATION,"nscf");
-	EXPECT_EQ(INPUT.relax_nmax,1);
-	EXPECT_EQ(INPUT.out_stru,0);
-	EXPECT_DOUBLE_EQ(INPUT.pw_diag_thr,1.0e-5);
-	EXPECT_FALSE(INPUT.cal_force);
-	EXPECT_EQ(INPUT.init_chg,"file");
-	EXPECT_EQ(INPUT.diago_proc,8);
-	//==================================================
-	// prepare default parameters for the 4th calling
-	INPUT.calculation = "get_pchg";
+    EXPECT_EQ(INPUT.vdw_a1, "0.4289");
+    EXPECT_EQ(INPUT.vdw_a2, "4.4407");
+    EXPECT_EQ(INPUT.vdw_cutoff_radius, "95");
+    EXPECT_EQ(GlobalV::CALCULATION, "nscf");
+    EXPECT_EQ(INPUT.relax_nmax, 1);
+    EXPECT_EQ(INPUT.out_stru, 0);
+    EXPECT_DOUBLE_EQ(INPUT.pw_diag_thr, 1.0e-5);
+    EXPECT_FALSE(INPUT.cal_force);
+    EXPECT_EQ(INPUT.init_chg, "file");
+    EXPECT_EQ(INPUT.diago_proc, 8);
+    //==================================================
+    // prepare default parameters for the 4th calling
+    INPUT.calculation = "get_pchg";
     INPUT.chg_extrap = "default";
     INPUT.symmetry = "default";
     INPUT.ecutwfc = 10;
@@ -931,109 +932,109 @@ TEST_F(InputTest, Default_2)
     EXPECT_EQ(INPUT.relax_nmax, 1);
     EXPECT_EQ(INPUT.out_stru, 0);
     EXPECT_EQ(INPUT.symmetry, "0");
-	EXPECT_EQ(INPUT.out_band[0],0);
-	EXPECT_EQ(INPUT.out_band[1],8);
-	EXPECT_EQ(INPUT.out_proj_band,0);
-	EXPECT_EQ(INPUT.cal_force,0);
-	EXPECT_EQ(INPUT.init_wfc,"file");
-	EXPECT_EQ(INPUT.init_chg,"atomic");
-	EXPECT_EQ(INPUT.chg_extrap,"atomic");
-	EXPECT_EQ(INPUT.out_chg,1);
-	EXPECT_EQ(INPUT.out_dm,0);
-	EXPECT_EQ(INPUT.out_dm1,0);
-	EXPECT_EQ(INPUT.out_pot,0);
-	//==================================================
-	// prepare default parameters for the 5th calling
-	INPUT.calculation = "get_wf";
+    EXPECT_EQ(INPUT.out_band[0], 0);
+    EXPECT_EQ(INPUT.out_band[1], 8);
+    EXPECT_EQ(INPUT.out_proj_band, 0);
+    EXPECT_EQ(INPUT.cal_force, 0);
+    EXPECT_EQ(INPUT.init_wfc, "file");
+    EXPECT_EQ(INPUT.init_chg, "atomic");
+    EXPECT_EQ(INPUT.chg_extrap, "atomic");
+    EXPECT_EQ(INPUT.out_chg, 1);
+    EXPECT_EQ(INPUT.out_dm, 0);
+    EXPECT_EQ(INPUT.out_dm1, 0);
+    EXPECT_EQ(INPUT.out_pot, 0);
+    //==================================================
+    // prepare default parameters for the 5th calling
+    INPUT.calculation = "get_wf";
     INPUT.symmetry = "default";
     INPUT.chg_extrap = "default";
     // the 5th calling
     INPUT.Default_2();
     // ^^^^^^^^^^^^^^
-	EXPECT_EQ(GlobalV::CALCULATION,"get_wf");
+    EXPECT_EQ(GlobalV::CALCULATION, "get_wf");
     EXPECT_EQ(INPUT.relax_nmax, 1);
     EXPECT_EQ(INPUT.symmetry, "0");
     EXPECT_EQ(INPUT.out_stru, 0);
-	EXPECT_EQ(INPUT.out_band[0],0);
-	EXPECT_EQ(INPUT.out_band[1],8);
-	EXPECT_EQ(INPUT.out_proj_band,0);
-	EXPECT_EQ(INPUT.cal_force,0);
-	EXPECT_EQ(INPUT.init_wfc,"file");
-	EXPECT_EQ(INPUT.init_chg,"atomic");
-	EXPECT_EQ(INPUT.chg_extrap,"atomic");
-	EXPECT_EQ(INPUT.out_chg,1);
-	EXPECT_EQ(INPUT.out_dm,0);
-	EXPECT_EQ(INPUT.out_dm1,0);
-	EXPECT_EQ(INPUT.out_pot,0);
-	//==================================================
-	// prepare default parameters for the 6th calling
-	INPUT.calculation = "md";
+    EXPECT_EQ(INPUT.out_band[0], 0);
+    EXPECT_EQ(INPUT.out_band[1], 8);
+    EXPECT_EQ(INPUT.out_proj_band, 0);
+    EXPECT_EQ(INPUT.cal_force, 0);
+    EXPECT_EQ(INPUT.init_wfc, "file");
+    EXPECT_EQ(INPUT.init_chg, "atomic");
+    EXPECT_EQ(INPUT.chg_extrap, "atomic");
+    EXPECT_EQ(INPUT.out_chg, 1);
+    EXPECT_EQ(INPUT.out_dm, 0);
+    EXPECT_EQ(INPUT.out_dm1, 0);
+    EXPECT_EQ(INPUT.out_pot, 0);
+    //==================================================
+    // prepare default parameters for the 6th calling
+    INPUT.calculation = "md";
     INPUT.chg_extrap = "default";
     INPUT.mdp.md_nstep = 0;
-	INPUT.out_md_control = 0;
-	INPUT.mdp.md_tlast = -1.0;
-	INPUT.mdp.md_plast = -1.0;
-	INPUT.mdp.md_tfreq = 0;
-	INPUT.mdp.md_pfreq = 0;
-	INPUT.mdp.md_restart = 1;
-	INPUT.mdp.md_type = "npt";
-	INPUT.mdp.md_pmode = "iso";
-	// the 6th calling
-	INPUT.Default_2();
-	// ^^^^^^^^^^^^^^
-	EXPECT_EQ(GlobalV::CALCULATION,"md");
+    INPUT.out_md_control = false;
+    INPUT.mdp.md_tlast = -1.0;
+    INPUT.mdp.md_plast = -1.0;
+    INPUT.mdp.md_tfreq = 0;
+    INPUT.mdp.md_pfreq = 0;
+    INPUT.mdp.md_restart = true;
+    INPUT.mdp.md_type = "npt";
+    INPUT.mdp.md_pmode = "iso";
+    // the 6th calling
+    INPUT.Default_2();
+    // ^^^^^^^^^^^^^^
+    EXPECT_EQ(GlobalV::CALCULATION, "md");
     EXPECT_EQ(INPUT.chg_extrap, "second-order");
     EXPECT_EQ(INPUT.symmetry, "0");
     EXPECT_EQ(INPUT.cal_force, 1);
-    EXPECT_EQ(INPUT.mdp.md_nstep,50);
+    EXPECT_EQ(INPUT.mdp.md_nstep, 50);
     EXPECT_EQ(INPUT.out_level, "m");
     EXPECT_DOUBLE_EQ(INPUT.mdp.md_plast, INPUT.mdp.md_pfirst);
-    EXPECT_DOUBLE_EQ(INPUT.mdp.md_tfreq,1.0/40/INPUT.mdp.md_dt);
-	EXPECT_DOUBLE_EQ(INPUT.mdp.md_pfreq,1.0/400/INPUT.mdp.md_dt);
-	EXPECT_EQ(INPUT.init_vel,1);
-	EXPECT_EQ(INPUT.cal_stress,1);
-	//==================================================
-	// prepare default parameters for the 7th calling
-	INPUT.calculation = "cell-relax";
+    EXPECT_DOUBLE_EQ(INPUT.mdp.md_tfreq, 1.0 / 40 / INPUT.mdp.md_dt);
+    EXPECT_DOUBLE_EQ(INPUT.mdp.md_pfreq, 1.0 / 400 / INPUT.mdp.md_dt);
+    EXPECT_EQ(INPUT.init_vel, 1);
+    EXPECT_EQ(INPUT.cal_stress, 1);
+    //==================================================
+    // prepare default parameters for the 7th calling
+    INPUT.calculation = "cell-relax";
     INPUT.chg_extrap = "default";
     INPUT.relax_nmax = 0;
     // the 7th calling
-	INPUT.Default_2();
-	// ^^^^^^^^^^^^^^
+    INPUT.Default_2();
+    // ^^^^^^^^^^^^^^
     EXPECT_EQ(INPUT.chg_extrap, "first-order");
     EXPECT_EQ(INPUT.cal_force, 1);
-    EXPECT_EQ(INPUT.cal_stress,1);
-	EXPECT_EQ(INPUT.relax_nmax,50);
-	//==================================================
-	// prepare default parameters for the 8th calling
-	INPUT.calculation = "test_memory";
+    EXPECT_EQ(INPUT.cal_stress, 1);
+    EXPECT_EQ(INPUT.relax_nmax, 50);
+    //==================================================
+    // prepare default parameters for the 8th calling
+    INPUT.calculation = "test_memory";
     INPUT.chg_extrap = "default";
     // the 8th calling
-	INPUT.Default_2();
-	// ^^^^^^^^^^^^^^
+    INPUT.Default_2();
+    // ^^^^^^^^^^^^^^
     EXPECT_EQ(INPUT.chg_extrap, "atomic");
-    EXPECT_EQ(INPUT.relax_nmax,1);
-	//==================================================
-	// prepare default parameters for the 9th calling
-	INPUT.calculation = "test_neighbour";
+    EXPECT_EQ(INPUT.relax_nmax, 1);
+    //==================================================
+    // prepare default parameters for the 9th calling
+    INPUT.calculation = "test_neighbour";
     INPUT.chg_extrap = "default";
     // the 9th calling
-	INPUT.Default_2();
-	// ^^^^^^^^^^^^^^
+    INPUT.Default_2();
+    // ^^^^^^^^^^^^^^
     EXPECT_EQ(INPUT.chg_extrap, "atomic");
-    EXPECT_EQ(INPUT.relax_nmax,1);
-	//==================================================
-	// prepare default parameters for the 10th calling
-	INPUT.calculation = "gen_bessel";
+    EXPECT_EQ(INPUT.relax_nmax, 1);
+    //==================================================
+    // prepare default parameters for the 10th calling
+    INPUT.calculation = "gen_bessel";
     INPUT.chg_extrap = "default";
     // the 10th calling
-	INPUT.Default_2();
-	// ^^^^^^^^^^^^^^
+    INPUT.Default_2();
+    // ^^^^^^^^^^^^^^
     EXPECT_EQ(INPUT.chg_extrap, "atomic");
-    EXPECT_EQ(INPUT.relax_nmax,1);
-	//==================================================
-	remove("INPUT");
-	remove("STRU");
+    EXPECT_EQ(INPUT.relax_nmax, 1);
+    //==================================================
+    remove("INPUT");
+    remove("STRU");
 }
 
 TEST_F(InputTest, Check)
@@ -1055,415 +1056,421 @@ TEST_F(InputTest, Check)
     //
     INPUT.nbands = -1;
     testing::internal::CaptureStdout();
-    EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("NBANDS must >= 0"));
-	INPUT.nbands = 2;
-	//
-	INPUT.nb2d = -1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("nb2d must > 0"));
-	INPUT.nb2d = 1;
-	//
-	INPUT.ntype = -1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("ntype must > 0"));
-	INPUT.ntype = 1;
-	//
-	INPUT.basis_type = "lcao";
-	INPUT.diago_proc = 2;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("please don't set diago_proc with lcao base"));
-	INPUT.diago_proc = 1;
-	//
-	INPUT.kspacing[0] = -1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("kspacing must > 0"));
-	INPUT.kspacing[0] = INPUT.kspacing[1] = INPUT.kspacing[2] = 0.8;
-	//
-	INPUT.nelec = -1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("nelec < 0 is not allowed !"));
-	INPUT.nelec = 100;
-	//
-	INPUT.efield_flag = 0;
-	INPUT.dip_cor_flag = 1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("dipole correction is not active if efield_flag=false !"));
-	INPUT.dip_cor_flag = 0;
-	//
-	INPUT.efield_flag = 1;
-	INPUT.gate_flag = 1;
-	INPUT.dip_cor_flag = 0;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("gate field cannot be used with efield if dip_cor_flag=false !"));
-	INPUT.gate_flag = 0;
-	//
-	INPUT.calculation = "nscf";
-	INPUT.out_dos = 3;
-	INPUT.symmetry = "1";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("symmetry can't be used for out_dos==3(Fermi Surface Plotting) by now."));
-	INPUT.symmetry = "0";
-	INPUT.out_dos = 0;
-	//
-	INPUT.calculation = "get_pchg";
-	INPUT.basis_type = "pw";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("calculate = get_pchg is only availble for LCAO"));
-	INPUT.basis_type = "lcao";
-	//
-	INPUT.calculation = "get_wf";
-	INPUT.basis_type = "pw";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("calculate = get_wf is only availble for LCAO"));
-	INPUT.basis_type = "lcao";
-	//
-	INPUT.calculation = "md";
-	INPUT.mdp.md_dt = -1.0;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("time interval of MD calculation should be set!"));
-	INPUT.mdp.md_dt = 1.0;
-	//
-	INPUT.mdp.md_type = "msst";
-	INPUT.mdp.msst_qmass = -1.0;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("msst_qmass must be greater than 0!"));
-	INPUT.mdp.msst_qmass = 1.0;
-	//
-	INPUT.esolver_type = "dp";
-	INPUT.mdp.pot_file = "graph.pb";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("Can not find DP model !"));
-	INPUT.esolver_type = "ksdft";
-	//
-	INPUT.calculation = "gen_bessel";
-	INPUT.basis_type = "lcao";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("to generate descriptors, please use pw basis"));
-	INPUT.basis_type = "pw";
-	//
-	INPUT.calculation = "arbitrary";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("check 'calculation' !"));
-	INPUT.calculation = "scf";
-	//
-	INPUT.init_chg = "arbitrary";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("wrong 'init_chg', not 'atomic', 'file', 'auto', please check"));
-	INPUT.init_chg = "atomic";
-	//
-	INPUT.gamma_only_local = 0;
-	INPUT.out_dm = 1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("out_dm with k-point algorithm is not implemented yet."));
-	INPUT.out_dm = 0;
-	//
-	INPUT.gamma_only_local = 1;
-	INPUT.out_dm1 = 1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("out_dm1 is only for multi-k"));
-	INPUT.gamma_only_local = 0;
-	INPUT.out_dm1 = 0;
-	//
-	INPUT.nbands = 100001;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("nbnd >100000, out of range"));
-	INPUT.nbands = 100;
-	//
-	INPUT.nelec = 2*INPUT.nbands + 1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("nelec > 2*nbnd , bands not enough!"));
-	INPUT.nelec = INPUT.nbands;
-	//
-	INPUT.nspin = 3;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("nspin does not equal to 1, 2, or 4!"));
-	INPUT.nspin = 1;
-	//
-	INPUT.basis_type = "pw";
-	INPUT.ks_solver = "genelpa";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("genelpa can not be used with plane wave basis."));
-	//
-	INPUT.basis_type = "pw";
-	INPUT.ks_solver = "scalapack_gvx";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("scalapack_gvx can not be used with plane wave basis."));
-	//
-	INPUT.basis_type = "pw";
-	INPUT.ks_solver = "lapack";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("lapack can not be used with plane wave basis."));
-	//
-	INPUT.basis_type = "pw";
-	INPUT.ks_solver = "arbitrary";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("please check the ks_solver parameter!"));
-	INPUT.ks_solver = "cg";
-	//
-	INPUT.basis_type = "pw";
-	INPUT.gamma_only = 1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("gamma_only not implemented for plane wave now."));
-	INPUT.gamma_only = 0;
-	//
-	INPUT.basis_type = "pw";
-	INPUT.out_proj_band = 1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("out_proj_band not implemented for plane wave now."));
-	INPUT.out_proj_band = 0;
-	//
-	INPUT.basis_type = "pw";
-	INPUT.out_dos = 3;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("Fermi Surface Plotting not implemented for plane wave now."));
-	INPUT.out_dos = 0;
-	//
-	INPUT.basis_type = "pw";
-	INPUT.sc_mag_switch = 3;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("Non-colliner Spin-constrained DFT not implemented for plane wave now."));
-	INPUT.sc_mag_switch = 0;
-	//
-	INPUT.basis_type = "lcao";
-	INPUT.ks_solver = "cg";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("not ready for cg method in lcao ."));
-	//
-	INPUT.basis_type = "lcao";
-	INPUT.ks_solver = "genelpa";
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("NBANDS must >= 0"));
+    INPUT.nbands = 2;
+    //
+    INPUT.nb2d = -1;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("nb2d must > 0"));
+    INPUT.nb2d = 1;
+    //
+    INPUT.ntype = -1;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("ntype must > 0"));
+    INPUT.ntype = 1;
+    //
+    INPUT.basis_type = "lcao";
+    INPUT.diago_proc = 2;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("please don't set diago_proc with lcao base"));
+    INPUT.diago_proc = 1;
+    //
+    INPUT.kspacing[0] = -1;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("kspacing must > 0"));
+    INPUT.kspacing[0] = INPUT.kspacing[1] = INPUT.kspacing[2] = 0.8;
+    //
+    INPUT.nelec = -1;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("nelec < 0 is not allowed !"));
+    INPUT.nelec = 100;
+    //
+    INPUT.efield_flag = false;
+    INPUT.dip_cor_flag = true;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("dipole correction is not active if efield_flag=false !"));
+    INPUT.dip_cor_flag = false;
+    //
+    INPUT.efield_flag = true;
+    INPUT.gate_flag = true;
+    INPUT.dip_cor_flag = false;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("gate field cannot be used with efield if dip_cor_flag=false !"));
+    INPUT.gate_flag = false;
+    //
+    INPUT.calculation = "nscf";
+    INPUT.out_dos = 3;
+    INPUT.symmetry = "1";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("symmetry can't be used for out_dos==3(Fermi Surface Plotting) by now."));
+    INPUT.symmetry = "0";
+    INPUT.out_dos = 0;
+    //
+    INPUT.calculation = "get_pchg";
+    INPUT.basis_type = "pw";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("calculate = get_pchg is only availble for LCAO"));
+    INPUT.basis_type = "lcao";
+    //
+    INPUT.calculation = "get_wf";
+    INPUT.basis_type = "pw";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("calculate = get_wf is only availble for LCAO"));
+    INPUT.basis_type = "lcao";
+    //
+    INPUT.calculation = "md";
+    INPUT.mdp.md_dt = -1.0;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("time interval of MD calculation should be set!"));
+    INPUT.mdp.md_dt = 1.0;
+    //
+    INPUT.mdp.md_type = "msst";
+    INPUT.mdp.msst_qmass = -1.0;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("msst_qmass must be greater than 0!"));
+    INPUT.mdp.msst_qmass = 1.0;
+    //
+    INPUT.esolver_type = "dp";
+    INPUT.mdp.pot_file = "graph.pb";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("Can not find DP model !"));
+    INPUT.esolver_type = "ksdft";
+    //
+    INPUT.calculation = "gen_bessel";
+    INPUT.basis_type = "lcao";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("to generate descriptors, please use pw basis"));
+    INPUT.basis_type = "pw";
+    //
+    INPUT.calculation = "arbitrary";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("check 'calculation' !"));
+    INPUT.calculation = "scf";
+    //
+    INPUT.init_chg = "arbitrary";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("wrong 'init_chg', not 'atomic', 'file', 'auto', please check"));
+    INPUT.init_chg = "atomic";
+    //
+    INPUT.gamma_only_local = false;
+    INPUT.out_dm = true;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("out_dm with k-point algorithm is not implemented yet."));
+    INPUT.out_dm = false;
+    //
+    INPUT.gamma_only_local = true;
+    INPUT.out_dm1 = true;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("out_dm1 is only for multi-k"));
+    INPUT.gamma_only_local = false;
+    INPUT.out_dm1 = false;
+    //
+    INPUT.nbands = 100001;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("nbnd >100000, out of range"));
+    INPUT.nbands = 100;
+    //
+    INPUT.nelec = 2 * INPUT.nbands + 1;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("nelec > 2*nbnd , bands not enough!"));
+    INPUT.nelec = INPUT.nbands;
+    //
+    INPUT.nspin = 3;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("nspin does not equal to 1, 2, or 4!"));
+    INPUT.nspin = 1;
+    //
+    INPUT.basis_type = "pw";
+    INPUT.ks_solver = "genelpa";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("genelpa can not be used with plane wave basis."));
+    //
+    INPUT.basis_type = "pw";
+    INPUT.ks_solver = "scalapack_gvx";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("scalapack_gvx can not be used with plane wave basis."));
+    //
+    INPUT.basis_type = "pw";
+    INPUT.ks_solver = "lapack";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("lapack can not be used with plane wave basis."));
+    //
+    INPUT.basis_type = "pw";
+    INPUT.ks_solver = "arbitrary";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("please check the ks_solver parameter!"));
+    INPUT.ks_solver = "cg";
+    //
+    INPUT.basis_type = "pw";
+    INPUT.gamma_only = true;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("gamma_only not implemented for plane wave now."));
+    INPUT.gamma_only = false;
+    //
+    INPUT.basis_type = "pw";
+    INPUT.out_proj_band = true;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("out_proj_band not implemented for plane wave now."));
+    INPUT.out_proj_band = false;
+    //
+    INPUT.basis_type = "pw";
+    INPUT.out_dos = 3;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("Fermi Surface Plotting not implemented for plane wave now."));
+    INPUT.out_dos = 0;
+    //
+    INPUT.basis_type = "pw";
+    INPUT.sc_mag_switch = true;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("Non-colliner Spin-constrained DFT not implemented for plane wave now."));
+    INPUT.sc_mag_switch = false;
+    //
+    INPUT.basis_type = "lcao";
+    INPUT.ks_solver = "cg";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("not ready for cg method in lcao ."));
+    //
+    INPUT.basis_type = "lcao";
+    INPUT.ks_solver = "genelpa";
 #ifndef __MPI
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("genelpa can not be used for series version."));
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("genelpa can not be used for series version."));
 #endif
 #ifndef __ELPA
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("Can not use genelpa if abacus is not compiled with ELPA. Please change ks_solver to scalapack_gvx."));
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(
+        output,
+        testing::HasSubstr(
+            "Can not use genelpa if abacus is not compiled with ELPA. Please change ks_solver to scalapack_gvx."));
 #endif
-	//
-	INPUT.basis_type = "lcao";
-	INPUT.ks_solver = "scalapack_gvx";
+    //
+    INPUT.basis_type = "lcao";
+    INPUT.ks_solver = "scalapack_gvx";
 #ifndef __MPI
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("scalapack_gvx can not be used for series version."));
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("scalapack_gvx can not be used for series version."));
 #endif
-	//
-	INPUT.basis_type = "lcao";
-	INPUT.ks_solver = "lapack";
+    //
+    INPUT.basis_type = "lcao";
+    INPUT.ks_solver = "lapack";
 #ifdef __MPI
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("ks_solver=lapack is not an option for parallel version of ABACUS (try genelpa)"));
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output,
+                testing::HasSubstr("ks_solver=lapack is not an option for parallel version of ABACUS (try genelpa)"));
 #endif
-	//
-	INPUT.basis_type = "lcao";
-	INPUT.ks_solver = "cusolver";
+    //
+    INPUT.basis_type = "lcao";
+    INPUT.ks_solver = "cusolver";
 #ifndef __MPI
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("Cusolver can not be used for series version."));
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("Cusolver can not be used for series version."));
 #endif
-	//
-	INPUT.basis_type = "lcao";
-	INPUT.ks_solver = "arbitrary";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("please check the ks_solver parameter!"));
-	INPUT.ks_solver = "genelpa";
-	//
-	INPUT.basis_type = "lcao";
-	INPUT.kpar = 2;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("kpar > 1 has not been supported for lcao calculation."));
-	INPUT.kpar = 1;
-	//
-	INPUT.basis_type = "lcao";
-	INPUT.out_wfc_lcao = 3;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("out_wfc_lcao must be 0, 1, or 2"));
-	INPUT.out_wfc_lcao = 0;
-	//
-	INPUT.basis_type = "lcao_in_pw";
-	INPUT.ks_solver = "arbitrary";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("LCAO in plane wave can only done with lapack."));
-	INPUT.ks_solver = "default";
-	//
-	INPUT.basis_type = "arbitrary";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("please check the basis_type parameter!"));
-	INPUT.basis_type = "pw";
-	//
-	INPUT.relax_method = "arbitrary";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("relax_method can only be sd, cg, bfgs or cg_bfgs."));
-	INPUT.relax_method = "cg";
-	//
-	INPUT.bx = 11; INPUT.by = 1; INPUT.bz = 1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("bx, or by, or bz is larger than 10!"));
-	INPUT.bx = 1;
-	//
-	INPUT.vdw_method = "d2";
-	INPUT.vdw_C6_unit = "arbitrary";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("vdw_C6_unit must be Jnm6/mol or eVA6"));
-	INPUT.vdw_C6_unit = "eVA6";
-	//
-	INPUT.vdw_R0_unit = "arbitrary";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("vdw_R0_unit must be A or Bohr"));
-	INPUT.vdw_R0_unit = "A";
-	//
-	INPUT.vdw_cutoff_type = "arbitrary";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("vdw_cutoff_type must be radius or period"));
-	INPUT.vdw_cutoff_type = "radius";
-	//
-	INPUT.vdw_cutoff_period.x = 0;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("vdw_cutoff_period <= 0 is not allowd"));
-	INPUT.vdw_cutoff_period.x = 3;
-	//
-	INPUT.vdw_cutoff_radius = "0";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("vdw_cutoff_radius <= 0 is not allowd"));
-	INPUT.vdw_cutoff_radius = "1.0";
-	//
-	INPUT.vdw_radius_unit = "arbitrary";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("vdw_radius_unit must be A or Bohr"));
-	INPUT.vdw_radius_unit = "A";
-	//
-	INPUT.vdw_cn_thr = 0;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("vdw_cn_thr <= 0 is not allowd"));
-	INPUT.vdw_cn_thr = 1.0;
-	//
-	INPUT.vdw_cn_thr_unit = "arbitrary";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("vdw_cn_thr_unit must be A or Bohr"));
-	INPUT.vdw_cn_thr_unit = "A";
-	//
-	INPUT.dft_functional = "scan0";
-	INPUT.exx_hybrid_alpha = "1.25";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("must 0 <= exx_hybrid_alpha <= 1"));
-	INPUT.exx_hybrid_alpha = "0.25";
-	//
-	INPUT.exx_hybrid_step = 0;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("must exx_hybrid_step > 0"));
-	INPUT.exx_hybrid_step = 1;
-	//
-	INPUT.exx_ccp_rmesh_times = "-1";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("must exx_ccp_rmesh_times >= 1"));
-	INPUT.exx_ccp_rmesh_times = "1.5";
+    //
+    INPUT.basis_type = "lcao";
+    INPUT.ks_solver = "arbitrary";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("please check the ks_solver parameter!"));
+    INPUT.ks_solver = "genelpa";
+    //
+    INPUT.basis_type = "lcao";
+    INPUT.kpar = 2;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("kpar > 1 has not been supported for lcao calculation."));
+    INPUT.kpar = 1;
+    //
+    INPUT.basis_type = "lcao";
+    INPUT.out_wfc_lcao = 3;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("out_wfc_lcao must be 0, 1, or 2"));
+    INPUT.out_wfc_lcao = 0;
+    //
+    INPUT.basis_type = "lcao_in_pw";
+    INPUT.ks_solver = "arbitrary";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("LCAO in plane wave can only done with lapack."));
+    INPUT.ks_solver = "default";
+    //
+    INPUT.basis_type = "arbitrary";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("please check the basis_type parameter!"));
+    INPUT.basis_type = "pw";
+    //
+    INPUT.relax_method = "arbitrary";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("relax_method can only be sd, cg, bfgs or cg_bfgs."));
+    INPUT.relax_method = "cg";
+    //
+    INPUT.bx = 11;
+    INPUT.by = 1;
+    INPUT.bz = 1;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("bx, or by, or bz is larger than 10!"));
+    INPUT.bx = 1;
+    //
+    INPUT.vdw_method = "d2";
+    INPUT.vdw_C6_unit = "arbitrary";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("vdw_C6_unit must be Jnm6/mol or eVA6"));
+    INPUT.vdw_C6_unit = "eVA6";
+    //
+    INPUT.vdw_R0_unit = "arbitrary";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("vdw_R0_unit must be A or Bohr"));
+    INPUT.vdw_R0_unit = "A";
+    //
+    INPUT.vdw_cutoff_type = "arbitrary";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("vdw_cutoff_type must be radius or period"));
+    INPUT.vdw_cutoff_type = "radius";
+    //
+    INPUT.vdw_cutoff_period.x = 0;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("vdw_cutoff_period <= 0 is not allowd"));
+    INPUT.vdw_cutoff_period.x = 3;
+    //
+    INPUT.vdw_cutoff_radius = "0";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("vdw_cutoff_radius <= 0 is not allowd"));
+    INPUT.vdw_cutoff_radius = "1.0";
+    //
+    INPUT.vdw_radius_unit = "arbitrary";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("vdw_radius_unit must be A or Bohr"));
+    INPUT.vdw_radius_unit = "A";
+    //
+    INPUT.vdw_cn_thr = 0;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("vdw_cn_thr <= 0 is not allowd"));
+    INPUT.vdw_cn_thr = 1.0;
+    //
+    INPUT.vdw_cn_thr_unit = "arbitrary";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("vdw_cn_thr_unit must be A or Bohr"));
+    INPUT.vdw_cn_thr_unit = "A";
+    //
+    INPUT.dft_functional = "scan0";
+    INPUT.exx_hybrid_alpha = "1.25";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("must 0 <= exx_hybrid_alpha <= 1"));
+    INPUT.exx_hybrid_alpha = "0.25";
+    //
+    INPUT.exx_hybrid_step = 0;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("must exx_hybrid_step > 0"));
+    INPUT.exx_hybrid_step = 1;
+    //
+    INPUT.exx_ccp_rmesh_times = "-1";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("must exx_ccp_rmesh_times >= 1"));
+    INPUT.exx_ccp_rmesh_times = "1.5";
     //
     INPUT.rpa = true;
     INPUT.rpa_ccp_rmesh_times = -1;
@@ -1472,333 +1479,346 @@ TEST_F(InputTest, Check)
     output = testing::internal::GetCapturedStdout();
     EXPECT_THAT(output, testing::HasSubstr("must rpa_ccp_rmesh_times >= 1"));
     INPUT.rpa_ccp_rmesh_times = 10.0;
-	//
-	INPUT.exx_distribute_type = "arbitrary";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("exx_distribute_type must be htime or kmeans2 or kmeans1"));
-	INPUT.exx_distribute_type = "htime";
-	//
-	INPUT.dft_functional = "opt_orb";
-	INPUT.exx_opt_orb_lmax = -1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("exx_opt_orb_lmax must >=0"));
-	INPUT.exx_opt_orb_lmax = 0;
-	//
-	INPUT.exx_opt_orb_ecut = -1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("exx_opt_orb_ecut must >=0"));
-	INPUT.exx_opt_orb_ecut = 0;
-	//
-	INPUT.exx_opt_orb_tolerence = -1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("exx_opt_orb_tolerence must >=0"));
-	INPUT.exx_opt_orb_tolerence = 0;
-	//
-	INPUT.berry_phase = 1;
-	INPUT.basis_type = "lcao_in_pw";
-	INPUT.ks_solver = "lapack";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("calculate berry phase, please set basis_type = pw or lcao"));
-	INPUT.basis_type = "pw";
-	INPUT.ks_solver = "cg";
-	//
-	INPUT.calculation = "scf";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("calculate berry phase, please set calculation = nscf"));
-	INPUT.calculation = "nscf";
-	//
-	INPUT.gdir = 4;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("calculate berry phase, please set gdir = 1 or 2 or 3"));
-	INPUT.gdir = 3;
-	INPUT.berry_phase = 0;
-	//
-	INPUT.towannier90 = 1;
-	// due to the repair of lcao_in_pw, original warning has been deprecated, 2023/12/23, ykhuang
-	// INPUT.basis_type = "lcao_in_pw";
-	// INPUT.ks_solver = "lapack";
-	// testing::internal::CaptureStdout();
-	// EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	// output = testing::internal::GetCapturedStdout();
-	// EXPECT_THAT(output,testing::HasSubstr("to use towannier90, please set basis_type = pw or lcao"));
-	INPUT.basis_type = "pw";
-	INPUT.ks_solver = "cg";
-	//
-	INPUT.calculation = "scf";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("to use towannier90, please set calculation = nscf"));
-	INPUT.calculation = "nscf";
-	//
-	INPUT.nspin = 2;
-	INPUT.wannier_spin = "arbitrary";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("to use towannier90, please set wannier_spin = up or down"));
-	INPUT.wannier_spin = "up";
-	INPUT.towannier90 = 0;
-	//
-	INPUT.read_file_dir = "arbitrary";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("please set right files directory for reading in."));
-	INPUT.read_file_dir = "auto";
-	/*
-	// Start to check deltaspin parameters
-	INPUT.sc_mag_switch = 1;
-	INPUT.sc_file = "none";
-	INPUT.basis_type = "lcao";
-	INPUT.ks_solver = "genelpa";
-	// warning 1 of Deltaspin
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("sc_file (json format) must be set when sc_mag_switch > 0"));
-	// warning 2 of Deltaspin
-	INPUT.sc_file = "sc.json";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("sc_file does not exist"));
-	INPUT.sc_file = "./support/sc.json";
-	// warning 3 of Deltaspin
-	INPUT.nspin = 1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("nspin must be 2 or 4 when sc_mag_switch > 0"));
-	INPUT.nspin = 4;
-	// warning 4 of Deltaspin
-	INPUT.calculation = "nscf";
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("calculation must be scf when sc_mag_switch > 0"));
-	INPUT.calculation = "scf";
-	// warning 5 of Deltaspin
-	INPUT.sc_thr = -1;
-		testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("sc_thr must > 0"));
-	INPUT.sc_thr = 1e-6;
-	// warning 6 of Deltaspin
-	INPUT.nsc = -1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("nsc must > 0"));
-	INPUT.nsc = 100;
-	// warning 7 of Deltaspin
-	INPUT.nsc_min = -1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("nsc_min must > 0"));
-	INPUT.nsc_min = 2;
-	// warning 8 of Deltapsin
+    //
+    INPUT.exx_distribute_type = "arbitrary";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("exx_distribute_type must be htime or kmeans2 or kmeans1"));
+    INPUT.exx_distribute_type = "htime";
+    //
+    INPUT.dft_functional = "opt_orb";
+    INPUT.exx_opt_orb_lmax = -1;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("exx_opt_orb_lmax must >=0"));
+    INPUT.exx_opt_orb_lmax = 0;
+    //
+    INPUT.exx_opt_orb_ecut = -1;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("exx_opt_orb_ecut must >=0"));
+    INPUT.exx_opt_orb_ecut = 0;
+    //
+    INPUT.exx_opt_orb_tolerence = -1;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("exx_opt_orb_tolerence must >=0"));
+    INPUT.exx_opt_orb_tolerence = 0;
+    //
+    INPUT.berry_phase = true;
+    INPUT.basis_type = "lcao_in_pw";
+    INPUT.ks_solver = "lapack";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("calculate berry phase, please set basis_type = pw or lcao"));
+    INPUT.basis_type = "pw";
+    INPUT.ks_solver = "cg";
+    //
+    INPUT.calculation = "scf";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("calculate berry phase, please set calculation = nscf"));
+    INPUT.calculation = "nscf";
+    //
+    INPUT.gdir = 4;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("calculate berry phase, please set gdir = 1 or 2 or 3"));
+    INPUT.gdir = 3;
+    INPUT.berry_phase = false;
+    //
+    INPUT.towannier90 = true;
+    // due to the repair of lcao_in_pw, original warning has been deprecated, 2023/12/23, ykhuang
+    // INPUT.basis_type = "lcao_in_pw";
+    // INPUT.ks_solver = "lapack";
+    // testing::internal::CaptureStdout();
+    // EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
+    // output = testing::internal::GetCapturedStdout();
+    // EXPECT_THAT(output,testing::HasSubstr("to use towannier90, please set basis_type = pw or lcao"));
+    INPUT.basis_type = "pw";
+    INPUT.ks_solver = "cg";
+    //
+    INPUT.calculation = "scf";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("to use towannier90, please set calculation = nscf"));
+    INPUT.calculation = "nscf";
+    //
+    INPUT.nspin = 2;
+    INPUT.wannier_spin = "arbitrary";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("to use towannier90, please set wannier_spin = up or down"));
+    INPUT.wannier_spin = "up";
+    INPUT.towannier90 = false;
+    //
+    INPUT.read_file_dir = "arbitrary";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(), ::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("please set right files directory for reading in."));
+    INPUT.read_file_dir = "auto";
+    /*
+    // Start to check deltaspin parameters
+    INPUT.sc_mag_switch = 1;
+    INPUT.sc_file = "none";
+    INPUT.basis_type = "lcao";
+    INPUT.ks_solver = "genelpa";
+    // warning 1 of Deltaspin
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output,testing::HasSubstr("sc_file (json format) must be set when sc_mag_switch > 0"));
+    // warning 2 of Deltaspin
+    INPUT.sc_file = "sc.json";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output,testing::HasSubstr("sc_file does not exist"));
+    INPUT.sc_file = "./support/sc.json";
+    // warning 3 of Deltaspin
+    INPUT.nspin = 1;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output,testing::HasSubstr("nspin must be 2 or 4 when sc_mag_switch > 0"));
+    INPUT.nspin = 4;
+    // warning 4 of Deltaspin
+    INPUT.calculation = "nscf";
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output,testing::HasSubstr("calculation must be scf when sc_mag_switch > 0"));
+    INPUT.calculation = "scf";
+    // warning 5 of Deltaspin
+    INPUT.sc_thr = -1;
+        testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output,testing::HasSubstr("sc_thr must > 0"));
+    INPUT.sc_thr = 1e-6;
+    // warning 6 of Deltaspin
+    INPUT.nsc = -1;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output,testing::HasSubstr("nsc must > 0"));
+    INPUT.nsc = 100;
+    // warning 7 of Deltaspin
+    INPUT.nsc_min = -1;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output,testing::HasSubstr("nsc_min must > 0"));
+    INPUT.nsc_min = 2;
+    // warning 8 of Deltapsin
     INPUT.alpha_trial = -1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("alpha_trial must > 0"));
-	INPUT.alpha_trial = 0.01;
-	// warning 9 of Deltapsin
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output,testing::HasSubstr("alpha_trial must > 0"));
+    INPUT.alpha_trial = 0.01;
+    // warning 9 of Deltapsin
     INPUT.sccut = -1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("sccut must > 0"));
-	INPUT.sccut = 3.0;
-	// warning 10 of Deltaspin
-	INPUT.sc_scf_nmin = -1;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("sc_scf_nmin must >= 2"));
-	INPUT.sc_scf_nmin = 2;
-	// warning 10 of Deltaspin
-	INPUT.nupdown = 4;
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("nupdown should not be set when sc_mag_switch > 0"));
-	INPUT.nupdown = 0;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output,testing::HasSubstr("sccut must > 0"));
+    INPUT.sccut = 3.0;
+    // warning 10 of Deltaspin
+    INPUT.sc_scf_nmin = -1;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output,testing::HasSubstr("sc_scf_nmin must >= 2"));
+    INPUT.sc_scf_nmin = 2;
+    // warning 10 of Deltaspin
+    INPUT.nupdown = 4;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output,testing::HasSubstr("nupdown should not be set when sc_mag_switch > 0"));
+    INPUT.nupdown = 0;
     // restore to default values
     INPUT.nspin = 1;
-	INPUT.sc_file = "none";
-	INPUT.sc_mag_switch = 0;
-	INPUT.ks_solver = "default";
-	INPUT.basis_type = "pw";
-	// End of checking Deltaspin parameters
-	*/
+    INPUT.sc_file = "none";
+    INPUT.sc_mag_switch = 0;
+    INPUT.ks_solver = "default";
+    INPUT.basis_type = "pw";
+    // End of checking Deltaspin parameters
+    */
 
-	/*
-	testing::internal::CaptureStdout();
-	EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
-	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr(""));
-	*/
+    /*
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(INPUT.Check(),::testing::ExitedWithCode(0), "");
+    output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output,testing::HasSubstr(""));
+    */
 }
 
 bool strcmp_inbuilt(const std::string& str1, const std::string& str2)
 {
-	if(str1.size() != str2.size())
-		return false;
-	for(int i=0; i<str1.size(); i++)
-	{
-		if(str1[i] != str2[i])
-			return false;
-	}
-	return true;
+    if (str1.size() != str2.size())
+        return false;
+    for (int i = 0; i < str1.size(); i++)
+    {
+        if (str1[i] != str2[i])
+            return false;
+    }
+    return true;
 }
 
 TEST_F(InputTest, ReadValue2stdvector)
 {
-	std::string input_file = "./support/INPUT_list";
-	std::ifstream ifs(input_file);
-	std::string word;
-	std::vector<int> value;
-	while(!ifs.eof())
-	{
-		ifs >> word;
-		if(strcmp_inbuilt(word, "bessel_nao_rcut_case0"))
-		{
-			value.clear(); value.shrink_to_fit();
-			INPUT.read_value2stdvector(ifs, value);
-			EXPECT_EQ(value.size(), 1);
-			EXPECT_EQ(value[0], 7);
-		}
-		if(strcmp_inbuilt(word, "bessel_nao_rcut_case1"))
-		{
-			value.clear(); value.shrink_to_fit();
-			INPUT.read_value2stdvector(ifs, value);
-			EXPECT_EQ(value.size(), 1);
-			EXPECT_EQ(value[0], 7);
-		}
-		if(strcmp_inbuilt(word, "bessel_nao_rcut_case2"))
-		{
-			value.clear(); value.shrink_to_fit();
-			INPUT.read_value2stdvector(ifs, value);
-			EXPECT_EQ(value.size(), 1);
-			EXPECT_EQ(value[0], 7);
-		}
-		if(strcmp_inbuilt(word, "bessel_nao_rcut_case3"))
-		{
-			value.clear(); value.shrink_to_fit();
-			INPUT.read_value2stdvector(ifs, value);
-			EXPECT_EQ(value.size(), 1);
-			EXPECT_EQ(value[0], 7);
-		}
-		if(strcmp_inbuilt(word, "bessel_nao_rcut_case4"))
-		{
-			value.clear(); value.shrink_to_fit();
-			INPUT.read_value2stdvector(ifs, value);
-			EXPECT_EQ(value.size(), 1);
-			EXPECT_EQ(value[0], 7);
-		}
-		if(strcmp_inbuilt(word, "bessel_nao_rcut_case5"))
-		{
-			value.clear(); value.shrink_to_fit();
-			INPUT.read_value2stdvector(ifs, value);
-			EXPECT_EQ(value.size(), 4);
-			EXPECT_EQ(value[0], 7);
-			EXPECT_EQ(value[1], 8);
-			EXPECT_EQ(value[2], 9);
-			EXPECT_EQ(value[3], 10);
-		}
-		if(strcmp_inbuilt(word, "bessel_nao_rcut_case6"))
-		{
-			value.clear(); value.shrink_to_fit();
-			INPUT.read_value2stdvector(ifs, value);
-			EXPECT_EQ(value.size(), 4);
-			EXPECT_EQ(value[0], 7);
-			EXPECT_EQ(value[1], 8);
-			EXPECT_EQ(value[2], 9);
-			EXPECT_EQ(value[3], 10);
-		}
-		if(strcmp_inbuilt(word, "bessel_nao_rcut_case7"))
-		{
-			value.clear(); value.shrink_to_fit();
-			INPUT.read_value2stdvector(ifs, value);
-			EXPECT_EQ(value.size(), 4);
-			EXPECT_EQ(value[0], 7);
-			EXPECT_EQ(value[1], 8);
-			EXPECT_EQ(value[2], 9);
-			EXPECT_EQ(value[3], 10);
-		}
-		if(strcmp_inbuilt(word, "bessel_nao_rcut_case8"))
-		{
-			value.clear(); value.shrink_to_fit();
-			INPUT.read_value2stdvector(ifs, value);
-			EXPECT_EQ(value.size(), 4);
-			EXPECT_EQ(value[0], 7);
-			EXPECT_EQ(value[1], 8);
-			EXPECT_EQ(value[2], 9);
-			EXPECT_EQ(value[3], 10);
-		}
-		std::vector<std::string> str_value;
-		if(strcmp_inbuilt(word, "bessel_nao_rcut_case9"))
-		{
-			str_value.clear(); str_value.shrink_to_fit();
-			INPUT.read_value2stdvector(ifs, str_value);
-			EXPECT_EQ(str_value.size(), 1);
-			EXPECT_EQ(str_value[0], "string1");
-		}
-		if(strcmp_inbuilt(word, "bessel_nao_rcut_case10"))
-		{
-			str_value.clear(); str_value.shrink_to_fit();
-			INPUT.read_value2stdvector(ifs, str_value);
-			EXPECT_EQ(str_value.size(), 4);
-			EXPECT_EQ(str_value[0], "string1");
-			EXPECT_EQ(str_value[1], "string2");
-			EXPECT_EQ(str_value[2], "string3");
-			EXPECT_EQ(str_value[3], "string4");
-		}
-		std::vector<double> double_value;
-		if(strcmp_inbuilt(word, "bessel_nao_rcut_case11"))
-		{
-			double_value.clear(); double_value.shrink_to_fit();
-			INPUT.read_value2stdvector(ifs, double_value);
-			EXPECT_EQ(double_value.size(), 1);
-			EXPECT_EQ(double_value[0], 1.23456789);
-		}
-		if(strcmp_inbuilt(word, "bessel_nao_rcut_case12"))
-		{
-			double_value.clear(); double_value.shrink_to_fit();
-			INPUT.read_value2stdvector(ifs, double_value);
-			EXPECT_EQ(double_value.size(), 4);
-			EXPECT_EQ(double_value[0], -1.23456789);
-			EXPECT_EQ(double_value[1], 2.3456789);
-			EXPECT_EQ(double_value[2], -3.456789);
-			EXPECT_EQ(double_value[3], 4.56789);
-		}
-	}
+    std::string input_file = "./support/INPUT_list";
+    std::ifstream ifs(input_file);
+    std::string word;
+    std::vector<int> value;
+    while (!ifs.eof())
+    {
+        ifs >> word;
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case0"))
+        {
+            value.clear();
+            value.shrink_to_fit();
+            INPUT.read_value2stdvector(ifs, value);
+            EXPECT_EQ(value.size(), 1);
+            EXPECT_EQ(value[0], 7);
+        }
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case1"))
+        {
+            value.clear();
+            value.shrink_to_fit();
+            INPUT.read_value2stdvector(ifs, value);
+            EXPECT_EQ(value.size(), 1);
+            EXPECT_EQ(value[0], 7);
+        }
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case2"))
+        {
+            value.clear();
+            value.shrink_to_fit();
+            INPUT.read_value2stdvector(ifs, value);
+            EXPECT_EQ(value.size(), 1);
+            EXPECT_EQ(value[0], 7);
+        }
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case3"))
+        {
+            value.clear();
+            value.shrink_to_fit();
+            INPUT.read_value2stdvector(ifs, value);
+            EXPECT_EQ(value.size(), 1);
+            EXPECT_EQ(value[0], 7);
+        }
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case4"))
+        {
+            value.clear();
+            value.shrink_to_fit();
+            INPUT.read_value2stdvector(ifs, value);
+            EXPECT_EQ(value.size(), 1);
+            EXPECT_EQ(value[0], 7);
+        }
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case5"))
+        {
+            value.clear();
+            value.shrink_to_fit();
+            INPUT.read_value2stdvector(ifs, value);
+            EXPECT_EQ(value.size(), 4);
+            EXPECT_EQ(value[0], 7);
+            EXPECT_EQ(value[1], 8);
+            EXPECT_EQ(value[2], 9);
+            EXPECT_EQ(value[3], 10);
+        }
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case6"))
+        {
+            value.clear();
+            value.shrink_to_fit();
+            INPUT.read_value2stdvector(ifs, value);
+            EXPECT_EQ(value.size(), 4);
+            EXPECT_EQ(value[0], 7);
+            EXPECT_EQ(value[1], 8);
+            EXPECT_EQ(value[2], 9);
+            EXPECT_EQ(value[3], 10);
+        }
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case7"))
+        {
+            value.clear();
+            value.shrink_to_fit();
+            INPUT.read_value2stdvector(ifs, value);
+            EXPECT_EQ(value.size(), 4);
+            EXPECT_EQ(value[0], 7);
+            EXPECT_EQ(value[1], 8);
+            EXPECT_EQ(value[2], 9);
+            EXPECT_EQ(value[3], 10);
+        }
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case8"))
+        {
+            value.clear();
+            value.shrink_to_fit();
+            INPUT.read_value2stdvector(ifs, value);
+            EXPECT_EQ(value.size(), 4);
+            EXPECT_EQ(value[0], 7);
+            EXPECT_EQ(value[1], 8);
+            EXPECT_EQ(value[2], 9);
+            EXPECT_EQ(value[3], 10);
+        }
+        std::vector<std::string> str_value;
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case9"))
+        {
+            str_value.clear();
+            str_value.shrink_to_fit();
+            INPUT.read_value2stdvector(ifs, str_value);
+            EXPECT_EQ(str_value.size(), 1);
+            EXPECT_EQ(str_value[0], "string1");
+        }
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case10"))
+        {
+            str_value.clear();
+            str_value.shrink_to_fit();
+            INPUT.read_value2stdvector(ifs, str_value);
+            EXPECT_EQ(str_value.size(), 4);
+            EXPECT_EQ(str_value[0], "string1");
+            EXPECT_EQ(str_value[1], "string2");
+            EXPECT_EQ(str_value[2], "string3");
+            EXPECT_EQ(str_value[3], "string4");
+        }
+        std::vector<double> double_value;
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case11"))
+        {
+            double_value.clear();
+            double_value.shrink_to_fit();
+            INPUT.read_value2stdvector(ifs, double_value);
+            EXPECT_EQ(double_value.size(), 1);
+            EXPECT_EQ(double_value[0], 1.23456789);
+        }
+        if (strcmp_inbuilt(word, "bessel_nao_rcut_case12"))
+        {
+            double_value.clear();
+            double_value.shrink_to_fit();
+            INPUT.read_value2stdvector(ifs, double_value);
+            EXPECT_EQ(double_value.size(), 4);
+            EXPECT_EQ(double_value[0], -1.23456789);
+            EXPECT_EQ(double_value[1], 2.3456789);
+            EXPECT_EQ(double_value[2], -3.456789);
+            EXPECT_EQ(double_value[3], 4.56789);
+        }
+    }
 }
 #undef private
 
-
-class ReadKSpacingTest : public ::testing::Test {
-protected:
-    void SetUp() override 
-	{
+class ReadKSpacingTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
         // create a temporary file for testing
         char tmpname[] = "tmpfile.tmp";
         int fd = mkstemp(tmpname);
@@ -1808,7 +1828,8 @@ protected:
         ofs.close();
     }
 
-    void TearDown() override {
+    void TearDown() override
+    {
         close(fd);
         unlink(tmpfile.c_str());
     }
@@ -1817,7 +1838,8 @@ protected:
     int fd;
 };
 
-TEST_F(ReadKSpacingTest, ValidInputOneValue) {
+TEST_F(ReadKSpacingTest, ValidInputOneValue)
+{
     std::ifstream ifs(tmpfile);
     EXPECT_NO_THROW(INPUT.read_kspacing(ifs));
     EXPECT_EQ(INPUT.kspacing[0], 1.0);
@@ -1825,8 +1847,9 @@ TEST_F(ReadKSpacingTest, ValidInputOneValue) {
     EXPECT_EQ(INPUT.kspacing[2], 1.0);
 }
 
-TEST_F(ReadKSpacingTest, ValidInputThreeValue) {
-	std::ofstream ofs(tmpfile);
+TEST_F(ReadKSpacingTest, ValidInputThreeValue)
+{
+    std::ofstream ofs(tmpfile);
     ofs << "1.0 2.0 3.0"; // invalid input
     ofs.close();
 
@@ -1837,15 +1860,16 @@ TEST_F(ReadKSpacingTest, ValidInputThreeValue) {
     EXPECT_EQ(INPUT.kspacing[2], 3.0);
 }
 
-TEST_F(ReadKSpacingTest, InvalidInput) {
+TEST_F(ReadKSpacingTest, InvalidInput)
+{
     std::ofstream ofs(tmpfile);
     ofs << "1.0 2.0"; // invalid input
     ofs.close();
 
     std::ifstream ifs(tmpfile);
-	testing::internal::CaptureStdout();
-	INPUT.read_kspacing(ifs);
-	std::string output;
-	output = testing::internal::GetCapturedStdout();
+    testing::internal::CaptureStdout();
+    INPUT.read_kspacing(ifs);
+    std::string output;
+    output = testing::internal::GetCapturedStdout();
     EXPECT_TRUE(ifs.fail());
 }

--- a/source/module_io/write_input.cpp
+++ b/source/module_io/write_input.cpp
@@ -187,7 +187,7 @@ void Input::Print(const std::string& fn) const
                                  "init_wfc",
                                  init_wfc,
                                  "start wave functions are from 'atomic', 'atomic+random', 'random' or 'file'");
-    ModuleBase::GlobalFunc::OUTP(ofs, "init_chg", init_chg, "start charge is from 'atomic' or file");
+    ModuleBase::GlobalFunc::OUTP(ofs, "init_chg", init_chg, "start charge is from 'atomic' or file, or auto means fistly read from file and use atomic charge if file is not found");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "chg_extrap",
                                  chg_extrap,

--- a/source/module_io/write_input.cpp
+++ b/source/module_io/write_input.cpp
@@ -187,7 +187,11 @@ void Input::Print(const std::string& fn) const
                                  "init_wfc",
                                  init_wfc,
                                  "start wave functions are from 'atomic', 'atomic+random', 'random' or 'file'");
-    ModuleBase::GlobalFunc::OUTP(ofs, "init_chg", init_chg, "start charge is from 'atomic' or file, or auto means fistly read from file and use atomic charge if file is not found");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "init_chg",
+                                 init_chg,
+                                 "start charge is from 'atomic' or file, or auto means fistly read from file and use "
+                                 "atomic charge if file is not found");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "chg_extrap",
                                  chg_extrap,

--- a/source/module_io/write_input.cpp
+++ b/source/module_io/write_input.cpp
@@ -3,8 +3,7 @@
 #include "module_base/global_variable.h"
 #include "module_io/input.h"
 
-void Input::Print(const std::string& fn) const
-{
+void Input::Print(const std::string& fn) const {
     if (GlobalV::MY_RANK != 0)
         return;
 
@@ -19,12 +18,19 @@ void Input::Print(const std::string& fn) const
     ofs << std::setiosflags(std::ios::left);
 
     ofs << "#Parameters (1.General)" << std::endl;
-    ModuleBase::GlobalFunc::OUTP(ofs, "suffix", suffix, "the name of main output directory");
-    ModuleBase::GlobalFunc::OUTP(ofs, "latname", latname, "the name of lattice name");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "stru_file",
-                                 GlobalV::stru_file,
-                                 "the filename of file containing atom positions");
+                                 "suffix",
+                                 suffix,
+                                 "the name of main output directory");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "latname",
+                                 latname,
+                                 "the name of lattice name");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "stru_file",
+        GlobalV::stru_file,
+        "the filename of file containing atom positions");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "kpoint_file",
                                  GlobalV::global_kpoint_card,
@@ -37,550 +43,1189 @@ void Input::Print(const std::string& fn) const
                                  "orbital_dir",
                                  GlobalV::global_orbital_dir,
                                  "the directory containing orbital files");
-    // ModuleBase::GlobalFunc::OUTP(ofs, "pseudo_type", GlobalV::global_pseudo_type, "the type pseudo files");
-    ModuleBase::GlobalFunc::OUTP(ofs, "pseudo_rcut", pseudo_rcut, "cut-off radius for radial integration");
+    // ModuleBase::GlobalFunc::OUTP(ofs, "pseudo_type",
+    // GlobalV::global_pseudo_type, "the type pseudo files");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "pseudo_rcut",
+                                 pseudo_rcut,
+                                 "cut-off radius for radial integration");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "pseudo_mesh",
                                  pseudo_mesh,
-                                 "0: use our own mesh to do radial renormalization; 1: use mesh as in QE");
-    ModuleBase::GlobalFunc::OUTP(ofs, "lmaxmax", lmaxmax, "maximum of l channels used");
-    ModuleBase::GlobalFunc::OUTP(ofs, "dft_functional", dft_functional, "exchange correlation functional");
+                                 "0: use our own mesh to do radial "
+                                 "renormalization; 1: use mesh as in QE");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "xc_temperature",
-                                 xc_temperature,
-                                 "temperature for finite temperature functionals");
-    ModuleBase::GlobalFunc::OUTP(ofs, "calculation", calculation, "test; scf; relax; nscf; get_wf; get_pchg");
+                                 "lmaxmax",
+                                 lmaxmax,
+                                 "maximum of l channels used");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "esolver_type",
-                                 esolver_type,
-                                 "the energy solver: ksdft, sdft, ofdft, tddft, lj, dp");
+                                 "dft_functional",
+                                 dft_functional,
+                                 "exchange correlation functional");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "xc_temperature",
+        xc_temperature,
+        "temperature for finite temperature functionals");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "calculation",
+                                 calculation,
+                                 "test; scf; relax; nscf; get_wf; get_pchg");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "esolver_type",
+        esolver_type,
+        "the energy solver: ksdft, sdft, ofdft, tddft, lj, dp");
     ModuleBase::GlobalFunc::OUTP(ofs, "ntype", ntype, "atom species number");
-    ModuleBase::GlobalFunc::OUTP(ofs, "nspin", nspin, "1: single spin; 2: up and down spin; 4: noncollinear spin");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "nspin",
+        nspin,
+        "1: single spin; 2: up and down spin; 4: noncollinear spin");
     std::stringstream kspacing_ss;
-    for (int i = 0; i < 3; i++)
-    {
+    for (int i = 0; i < 3; i++) {
         kspacing_ss << kspacing[i] << " ";
     }
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "kspacing",
                                  kspacing_ss.str(),
-                                 "unit in 1/bohr, should be > 0, default is 0 which means read KPT file");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "min_dist_coef",
-                                 min_dist_coef,
-                                 "factor related to the allowed minimum distance between two atoms");
+                                 "unit in 1/bohr, should be > 0, default is 0 "
+                                 "which means read KPT file");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "min_dist_coef",
+        min_dist_coef,
+        "factor related to the allowed minimum distance between two atoms");
     ModuleBase::GlobalFunc::OUTP(ofs, "nbands", nbands, "number of bands");
-    ModuleBase::GlobalFunc::OUTP(ofs, "nbands_sto", nbands_sto, "number of stochastic bands");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "nbands_istate",
-                                 nbands_istate,
-                                 "number of bands around Fermi level for get_pchg calulation");
+                                 "nbands_sto",
+                                 nbands_sto,
+                                 "number of stochastic bands");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "nbands_istate",
+        nbands_istate,
+        "number of bands around Fermi level for get_pchg calulation");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "bands_to_print",
+        bands_to_print_,
+        "specify the bands to be calculated in the get_pchg calculation");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "bands_to_print",
-                                 bands_to_print_,
-                                 "specify the bands to be calculated in the get_pchg calculation");
-    ModuleBase::GlobalFunc::OUTP(ofs, "symmetry", symmetry, "the control of symmetry");
-    ModuleBase::GlobalFunc::OUTP(ofs, "init_vel", init_vel, "read velocity from STRU or not");
+                                 "symmetry",
+                                 symmetry,
+                                 "the control of symmetry");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "symmetry_prec",
-                                 symmetry_prec,
-                                 "accuracy for symmetry"); // LiuXh add 2021-08-12, accuracy for symmetry
+                                 "init_vel",
+                                 init_vel,
+                                 "read velocity from STRU or not");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "symmetry_prec",
+        symmetry_prec,
+        "accuracy for symmetry"); // LiuXh add 2021-08-12, accuracy for symmetry
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "symmetry_autoclose",
                                  symmetry_autoclose,
-                                 "whether to close symmetry automatically when error occurs in symmetry analysis");
-    ModuleBase::GlobalFunc::OUTP(ofs, "nelec", nelec, "input number of electrons");
-    ModuleBase::GlobalFunc::OUTP(ofs, "nelec_delta", nelec_delta, "change in the number of total electrons");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_mul", GlobalV::out_mul, " mulliken  charge or not"); // qifeng add 2019/9/10
-    ModuleBase::GlobalFunc::OUTP(ofs, "noncolin", noncolin, "using non-collinear-spin");
-    ModuleBase::GlobalFunc::OUTP(ofs, "lspinorb", lspinorb, "consider the spin-orbit interaction");
+                                 "whether to close symmetry automatically when "
+                                 "error occurs in symmetry analysis");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "nelec",
+                                 nelec,
+                                 "input number of electrons");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "nelec_delta",
+                                 nelec_delta,
+                                 "change in the number of total electrons");
     ModuleBase::GlobalFunc::OUTP(
         ofs,
-        "kpar",
-        kpar,
-        "devide all processors into kpar groups and k points will be distributed among each group");
-    ModuleBase::GlobalFunc::OUTP(
-        ofs,
-        "bndpar",
-        bndpar,
-        "devide all processors into bndpar groups and bands will be distributed among each group");
+        "out_mul",
+        GlobalV::out_mul,
+        " mulliken  charge or not"); // qifeng add 2019/9/10
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "noncolin",
+                                 noncolin,
+                                 "using non-collinear-spin");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "lspinorb",
+                                 lspinorb,
+                                 "consider the spin-orbit interaction");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "kpar",
+                                 kpar,
+                                 "devide all processors into kpar groups and k "
+                                 "points will be distributed among each group");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "bndpar",
+                                 bndpar,
+                                 "devide all processors into bndpar groups and "
+                                 "bands will be distributed among each group");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "out_freq_elec",
                                  out_freq_elec,
-                                 "the frequency ( >= 0) of electronic iter to output charge density and wavefunction. "
+                                 "the frequency ( >= 0) of electronic iter to "
+                                 "output charge density and wavefunction. "
                                  "0: output only when converged");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "dft_plus_dmft",
-                                 dft_plus_dmft,
-                                 "true:DFT+DMFT; false: standard DFT calcullation(default)");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "rpa",
-                                 rpa,
-                                 "true:generate output files used in rpa calculation; false:(default)");
-    ModuleBase::GlobalFunc::OUTP(ofs, "printe", printe, "Print out energy for each band for every printe steps");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "dft_plus_dmft",
+        dft_plus_dmft,
+        "true:DFT+DMFT; false: standard DFT calcullation(default)");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "rpa",
+        rpa,
+        "true:generate output files used in rpa calculation; false:(default)");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "printe",
+        printe,
+        "Print out energy for each band for every printe steps");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "mem_saver",
                                  mem_saver,
-                                 "Only for nscf calculations. if set to 1, then a memory saving technique will be used "
+                                 "Only for nscf calculations. if set to 1, "
+                                 "then a memory saving technique will be used "
                                  "for many k point calculations.");
-    ModuleBase::GlobalFunc::OUTP(ofs, "diago_proc", diago_proc, "the number of procs used to do diagonalization");
-    ModuleBase::GlobalFunc::OUTP(ofs, "nbspline", nbspline, "the order of B-spline basis");
-    ModuleBase::GlobalFunc::OUTP(ofs, "wannier_card", wannier_card, "input card for wannier functions");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "diago_proc",
+        diago_proc,
+        "the number of procs used to do diagonalization");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "nbspline",
+                                 nbspline,
+                                 "the order of B-spline basis");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "wannier_card",
+                                 wannier_card,
+                                 "input card for wannier functions");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "soc_lambda",
                                  soc_lambda,
-                                 "The fraction of averaged SOC pseudopotential is given by (1-soc_lambda)");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "cal_force",
-                                 cal_force,
-                                 "if calculate the force at the end of the electronic iteration");
+                                 "The fraction of averaged SOC pseudopotential "
+                                 "is given by (1-soc_lambda)");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "cal_force",
+        cal_force,
+        "if calculate the force at the end of the electronic iteration");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "out_freq_ion",
                                  out_freq_ion,
-                                 "the frequency ( >= 0 ) of ionic step to output charge density and wavefunction. 0: "
+                                 "the frequency ( >= 0 ) of ionic step to "
+                                 "output charge density and wavefunction. 0: "
                                  "output only when ion steps are finished");
-    ModuleBase::GlobalFunc::OUTP(ofs, "elpa_num_thread", elpa_num_thread, "Number of threads need to use in elpa");
-    ModuleBase::GlobalFunc::OUTP(ofs, "device", device, "the computing device for ABACUS");
-    ModuleBase::GlobalFunc::OUTP(ofs, "precision", precision, "the computing precision for ABACUS");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "elpa_num_thread",
+                                 elpa_num_thread,
+                                 "Number of threads need to use in elpa");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "device",
+                                 device,
+                                 "the computing device for ABACUS");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "precision",
+                                 precision,
+                                 "the computing precision for ABACUS");
 
     ofs << "\n#Parameters (2.PW)" << std::endl;
-    ModuleBase::GlobalFunc::OUTP(ofs, "ecutwfc", ecutwfc, "#energy cutoff for wave functions");
-    ModuleBase::GlobalFunc::OUTP(ofs, "ecutrho", ecutrho, "#energy cutoff for charge density and potential");
-    ModuleBase::GlobalFunc::OUTP(ofs, "erf_ecut", erf_ecut, "#the value of the constant energy cutoff");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "erf_height",
-                                 erf_height,
-                                 "#the height of the energy step for reciprocal vectors");
-    ModuleBase::GlobalFunc::OUTP(ofs, "erf_sigma", erf_sigma, "#the width of the energy step for reciprocal vectors");
+                                 "ecutwfc",
+                                 ecutwfc,
+                                 "#energy cutoff for wave functions");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "ecutrho",
+        ecutrho,
+        "#energy cutoff for charge density and potential");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "erf_ecut",
+                                 erf_ecut,
+                                 "#the value of the constant energy cutoff");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "erf_height",
+        erf_height,
+        "#the height of the energy step for reciprocal vectors");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "erf_sigma",
+        erf_sigma,
+        "#the width of the energy step for reciprocal vectors");
     ModuleBase::GlobalFunc::OUTP(ofs, "fft_mode", fft_mode, "#mode of FFTW");
-    if (ks_solver == "cg")
-    {
-        ModuleBase::GlobalFunc::OUTP(ofs, "pw_diag_nmax", pw_diag_nmax, "max iteration number for cg");
-        ModuleBase::GlobalFunc::OUTP(ofs, "diago_cg_prec", diago_cg_prec, "diago_cg_prec");
-    }
-    else if (ks_solver == "dav")
-    {
-        ModuleBase::GlobalFunc::OUTP(ofs, "pw_diag_ndim", pw_diag_ndim, "max dimension for davidson");
-    }
-    else if (ks_solver == "dav_subspace")
-    {
+    if (ks_solver == "cg") {
+        ModuleBase::GlobalFunc::OUTP(ofs,
+                                     "pw_diag_nmax",
+                                     pw_diag_nmax,
+                                     "max iteration number for cg");
+        ModuleBase::GlobalFunc::OUTP(ofs,
+                                     "diago_cg_prec",
+                                     diago_cg_prec,
+                                     "diago_cg_prec");
+    } else if (ks_solver == "dav") {
         ModuleBase::GlobalFunc::OUTP(ofs,
                                      "pw_diag_ndim",
                                      pw_diag_ndim,
-                                     "dimension of workspace (number of wavefunction packets, at least 2 needed)");
+                                     "max dimension for davidson");
+    } else if (ks_solver == "dav_subspace") {
+        ModuleBase::GlobalFunc::OUTP(
+            ofs,
+            "pw_diag_ndim",
+            pw_diag_ndim,
+            "dimension of workspace (number of wavefunction packets, at least "
+            "2 needed)");
         ModuleBase::GlobalFunc::OUTP(
             ofs,
             "diago_full_acc",
             pw_diag_ndim,
-            "if all the empty states are diagonalized at the same level of accuracy of the occupied ones.");
+            "if all the empty states are diagonalized at the same level of "
+            "accuracy of the occupied ones.");
     }
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "pw_diag_thr",
+        pw_diag_thr,
+        "threshold for eigenvalues is cg electron iterations");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "pw_diag_thr",
-                                 pw_diag_thr,
-                                 "threshold for eigenvalues is cg electron iterations");
-    ModuleBase::GlobalFunc::OUTP(ofs, "scf_thr", scf_thr, "charge density error");
+                                 "scf_thr",
+                                 scf_thr,
+                                 "charge density error");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "scf_thr_type",
                                  scf_thr_type,
-                                 "type of the criterion of scf_thr, 1: reci drho for pw, 2: real drho for lcao");
+                                 "type of the criterion of scf_thr, 1: reci "
+                                 "drho for pw, 2: real drho for lcao");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "init_wfc",
                                  init_wfc,
-                                 "start wave functions are from 'atomic', 'atomic+random', 'random' or 'file'");
+                                 "start wave functions are from 'atomic', "
+                                 "'atomic+random', 'random' or 'file'");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "init_chg",
                                  init_chg,
-                                 "start charge is from 'atomic' or file, or auto means fistly read from file and use "
+                                 "start charge is from 'atomic' or file, or "
+                                 "auto means fistly read from file and use "
                                  "atomic charge if file is not found");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "chg_extrap",
+        chg_extrap,
+        "atomic; first-order; second-order; dm:coefficients of SIA");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "out_chg",
+        out_chg,
+        ">0 output charge density for selected electron steps");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "chg_extrap",
-                                 chg_extrap,
-                                 "atomic; first-order; second-order; dm:coefficients of SIA");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_chg", out_chg, ">0 output charge density for selected electron steps");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_pot", out_pot, "output realspace potential");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_wfc_pw", out_wfc_pw, "output wave functions");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_wfc_r", out_wfc_r, "output wave functions in realspace");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_dos", out_dos, "output energy and dos");
+                                 "out_pot",
+                                 out_pot,
+                                 "output realspace potential");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "out_band",
-                                 out_band[0],
-                                 "output energy and band structure (with precision " + std::to_string(out_band[1])
-                                     + ")");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_proj_band", out_proj_band, "output projected band structure");
-    ModuleBase::GlobalFunc::OUTP(ofs, "restart_save", restart_save, "print to disk every step for restart");
-    ModuleBase::GlobalFunc::OUTP(ofs, "restart_load", restart_load, "restart from disk");
-    ModuleBase::GlobalFunc::OUTP(ofs, "read_file_dir", read_file_dir, "directory of files for reading");
-    ModuleBase::GlobalFunc::OUTP(ofs, "nx", nx, "number of points along x axis for FFT grid");
-    ModuleBase::GlobalFunc::OUTP(ofs, "ny", ny, "number of points along y axis for FFT grid");
-    ModuleBase::GlobalFunc::OUTP(ofs, "nz", nz, "number of points along z axis for FFT grid");
-    ModuleBase::GlobalFunc::OUTP(ofs, "ndx", ndx, "number of points along x axis for FFT smooth grid");
-    ModuleBase::GlobalFunc::OUTP(ofs, "ndy", ndy, "number of points along y axis for FFT smooth grid");
-    ModuleBase::GlobalFunc::OUTP(ofs, "ndz", ndz, "number of points along z axis for FFT smooth grid");
+                                 "out_wfc_pw",
+                                 out_wfc_pw,
+                                 "output wave functions");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "cell_factor",
-                                 cell_factor,
-                                 "used in the construction of the pseudopotential tables");
-    ModuleBase::GlobalFunc::OUTP(ofs, "pw_seed", pw_seed, "random seed for initializing wave functions");
+                                 "out_wfc_r",
+                                 out_wfc_r,
+                                 "output wave functions in realspace");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "out_dos",
+                                 out_dos,
+                                 "output energy and dos");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "out_band",
+        out_band[0],
+        "output energy and band structure (with precision "
+            + std::to_string(out_band[1]) + ")");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "out_proj_band",
+                                 out_proj_band,
+                                 "output projected band structure");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "restart_save",
+                                 restart_save,
+                                 "print to disk every step for restart");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "restart_load",
+                                 restart_load,
+                                 "restart from disk");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "read_file_dir",
+                                 read_file_dir,
+                                 "directory of files for reading");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "nx",
+                                 nx,
+                                 "number of points along x axis for FFT grid");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "ny",
+                                 ny,
+                                 "number of points along y axis for FFT grid");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "nz",
+                                 nz,
+                                 "number of points along z axis for FFT grid");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "ndx",
+        ndx,
+        "number of points along x axis for FFT smooth grid");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "ndy",
+        ndy,
+        "number of points along y axis for FFT smooth grid");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "ndz",
+        ndz,
+        "number of points along z axis for FFT smooth grid");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "cell_factor",
+        cell_factor,
+        "used in the construction of the pseudopotential tables");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "pw_seed",
+                                 pw_seed,
+                                 "random seed for initializing wave functions");
 
     ofs << "\n#Parameters (3.Stochastic DFT)" << std::endl;
-    ModuleBase::GlobalFunc::OUTP(ofs, "method_sto", method_sto, "1: slow and save memory, 2: fast and waste memory");
-    ModuleBase::GlobalFunc::OUTP(ofs, "npart_sto", npart_sto, "Reduce memory when calculating Stochastic DOS");
-    ModuleBase::GlobalFunc::OUTP(ofs, "nbands_sto", nbands_sto, "number of stochstic orbitals");
-    ModuleBase::GlobalFunc::OUTP(ofs, "nche_sto", nche_sto, "Chebyshev expansion orders");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "method_sto",
+        method_sto,
+        "1: slow and save memory, 2: fast and waste memory");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "npart_sto",
+        npart_sto,
+        "Reduce memory when calculating Stochastic DOS");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "nbands_sto",
+                                 nbands_sto,
+                                 "number of stochstic orbitals");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "nche_sto",
+                                 nche_sto,
+                                 "Chebyshev expansion orders");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "emin_sto",
                                  emin_sto,
-                                 "trial energy to guess the lower bound of eigen energies of the Hamitonian operator");
+                                 "trial energy to guess the lower bound of "
+                                 "eigen energies of the Hamitonian operator");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "emax_sto",
                                  emax_sto,
-                                 "trial energy to guess the upper bound of eigen energies of the Hamitonian operator");
-    ModuleBase::GlobalFunc::OUTP(ofs, "seed_sto", seed_sto, "the random seed to generate stochastic orbitals");
-    ModuleBase::GlobalFunc::OUTP(ofs, "initsto_ecut", initsto_ecut, "maximum ecut to init stochastic bands");
+                                 "trial energy to guess the upper bound of "
+                                 "eigen energies of the Hamitonian operator");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "seed_sto",
+        seed_sto,
+        "the random seed to generate stochastic orbitals");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "initsto_freq",
-                                 initsto_freq,
-                                 "frequency to generate new stochastic orbitals when running md");
-    ModuleBase::GlobalFunc::OUTP(ofs, "cal_cond", cal_cond, "calculate electronic conductivities");
+                                 "initsto_ecut",
+                                 initsto_ecut,
+                                 "maximum ecut to init stochastic bands");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "initsto_freq",
+        initsto_freq,
+        "frequency to generate new stochastic orbitals when running md");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "cond_che_thr",
-                                 cond_che_thr,
-                                 "control the error of Chebyshev expansions for conductivities");
-    ModuleBase::GlobalFunc::OUTP(ofs, "cond_dw", cond_dw, "frequency interval for conductivities");
-    ModuleBase::GlobalFunc::OUTP(ofs, "cond_wcut", cond_wcut, "cutoff frequency (omega) for conductivities");
-    ModuleBase::GlobalFunc::OUTP(ofs, "cond_dt", cond_dt, "t interval to integrate Onsager coefficiencies");
+                                 "cal_cond",
+                                 cal_cond,
+                                 "calculate electronic conductivities");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "cond_che_thr",
+        cond_che_thr,
+        "control the error of Chebyshev expansions for conductivities");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "cond_dtbatch",
-                                 cond_dtbatch,
-                                 "exp(iH*dt*cond_dtbatch) is expanded with Chebyshev expansion.");
-    ModuleBase::GlobalFunc::OUTP(ofs, "cond_smear", cond_smear, "Smearing method for conductivities");
-    ModuleBase::GlobalFunc::OUTP(ofs, "cond_fwhm", cond_fwhm, "FWHM for conductivities");
-    ModuleBase::GlobalFunc::OUTP(ofs, "cond_nonlocal", cond_nonlocal, "Nonlocal effects for conductivities");
+                                 "cond_dw",
+                                 cond_dw,
+                                 "frequency interval for conductivities");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "cond_wcut",
+                                 cond_wcut,
+                                 "cutoff frequency (omega) for conductivities");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "cond_dt",
+        cond_dt,
+        "t interval to integrate Onsager coefficiencies");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "cond_dtbatch",
+        cond_dtbatch,
+        "exp(iH*dt*cond_dtbatch) is expanded with Chebyshev expansion.");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "cond_smear",
+                                 cond_smear,
+                                 "Smearing method for conductivities");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "cond_fwhm",
+                                 cond_fwhm,
+                                 "FWHM for conductivities");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "cond_nonlocal",
+                                 cond_nonlocal,
+                                 "Nonlocal effects for conductivities");
 
     ofs << "\n#Parameters (4.Relaxation)" << std::endl;
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "ks_solver",
+        GlobalV::KS_SOLVER,
+        "cg; dav; lapack; genelpa; scalapack_gvx; cusolver");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "ks_solver",
-                                 GlobalV::KS_SOLVER,
-                                 "cg; dav; lapack; genelpa; scalapack_gvx; cusolver");
-    ModuleBase::GlobalFunc::OUTP(ofs, "scf_nmax", scf_nmax, "#number of electron iterations");
-    ModuleBase::GlobalFunc::OUTP(ofs, "relax_nmax", relax_nmax, "number of ion iteration steps");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_stru", out_stru, "output the structure files after each ion step");
-    ModuleBase::GlobalFunc::OUTP(ofs, "force_thr", force_thr, "force threshold, unit: Ry/Bohr");
+                                 "scf_nmax",
+                                 scf_nmax,
+                                 "#number of electron iterations");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "relax_nmax",
+                                 relax_nmax,
+                                 "number of ion iteration steps");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "out_stru",
+        out_stru,
+        "output the structure files after each ion step");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "force_thr",
+                                 force_thr,
+                                 "force threshold, unit: Ry/Bohr");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "force_thr_ev",
                                  force_thr * 13.6058 / 0.529177,
                                  "force threshold, unit: eV/Angstrom");
-    ModuleBase::GlobalFunc::OUTP(ofs, "force_thr_ev2", force_thr_ev2, "force invalid threshold, unit: eV/Angstrom");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "relax_cg_thr",
-                                 relax_cg_thr,
-                                 "threshold for switching from cg to bfgs, unit: eV/Angstrom");
-    ModuleBase::GlobalFunc::OUTP(ofs, "stress_thr", stress_thr, "stress threshold");
-    ModuleBase::GlobalFunc::OUTP(ofs, "press1", press1, "target pressure, unit: KBar");
-    ModuleBase::GlobalFunc::OUTP(ofs, "press2", press2, "target pressure, unit: KBar");
-    ModuleBase::GlobalFunc::OUTP(ofs, "press3", press3, "target pressure, unit: KBar");
-    ModuleBase::GlobalFunc::OUTP(ofs, "relax_bfgs_w1", relax_bfgs_w1, "wolfe condition 1 for bfgs");
-    ModuleBase::GlobalFunc::OUTP(ofs, "relax_bfgs_w2", relax_bfgs_w2, "wolfe condition 2 for bfgs");
-    ModuleBase::GlobalFunc::OUTP(ofs, "relax_bfgs_rmax", relax_bfgs_rmax, "maximal trust radius, unit: Bohr");
-    ModuleBase::GlobalFunc::OUTP(ofs, "relax_bfgs_rmin", relax_bfgs_rmin, "minimal trust radius, unit: Bohr");
-    ModuleBase::GlobalFunc::OUTP(ofs, "relax_bfgs_init", relax_bfgs_init, "initial trust radius, unit: Bohr");
-    ModuleBase::GlobalFunc::OUTP(ofs, "cal_stress", cal_stress, "calculate the stress or not");
-    ModuleBase::GlobalFunc::OUTP(ofs, "fixed_axes", fixed_axes, "which axes are fixed");
-    ModuleBase::GlobalFunc::OUTP(ofs, "fixed_ibrav", fixed_ibrav, "whether to preseve lattice type during relaxation");
+                                 "force_thr_ev2",
+                                 force_thr_ev2,
+                                 "force invalid threshold, unit: eV/Angstrom");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "relax_cg_thr",
+        relax_cg_thr,
+        "threshold for switching from cg to bfgs, unit: eV/Angstrom");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "fixed_atoms",
-                                 fixed_atoms,
-                                 "whether to preseve direct coordinates of atoms during relaxation");
-    ModuleBase::GlobalFunc::OUTP(ofs, "relax_method", relax_method, "bfgs; sd; cg; cg_bfgs;"); // pengfei add 2013-08-15
-    ModuleBase::GlobalFunc::OUTP(ofs, "relax_new", relax_new, "whether to use the new relaxation method");
+                                 "stress_thr",
+                                 stress_thr,
+                                 "stress threshold");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "relax_scale_force",
-                                 relax_scale_force,
-                                 "controls the size of the first CG step if relax_new is true");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_level", out_level, "ie(for electrons); i(for ions);");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_dm", out_dm, ">0 output density matrix");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_bandgap", out_bandgap, "if true, print out bandgap");
+                                 "press1",
+                                 press1,
+                                 "target pressure, unit: KBar");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "press2",
+                                 press2,
+                                 "target pressure, unit: KBar");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "press3",
+                                 press3,
+                                 "target pressure, unit: KBar");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "relax_bfgs_w1",
+                                 relax_bfgs_w1,
+                                 "wolfe condition 1 for bfgs");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "relax_bfgs_w2",
+                                 relax_bfgs_w2,
+                                 "wolfe condition 2 for bfgs");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "relax_bfgs_rmax",
+                                 relax_bfgs_rmax,
+                                 "maximal trust radius, unit: Bohr");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "relax_bfgs_rmin",
+                                 relax_bfgs_rmin,
+                                 "minimal trust radius, unit: Bohr");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "relax_bfgs_init",
+                                 relax_bfgs_init,
+                                 "initial trust radius, unit: Bohr");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "cal_stress",
+                                 cal_stress,
+                                 "calculate the stress or not");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "fixed_axes",
+                                 fixed_axes,
+                                 "which axes are fixed");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "fixed_ibrav",
+        fixed_ibrav,
+        "whether to preseve lattice type during relaxation");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "fixed_atoms",
+        fixed_atoms,
+        "whether to preseve direct coordinates of atoms during relaxation");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "relax_method",
+        relax_method,
+        "bfgs; sd; cg; cg_bfgs;"); // pengfei add 2013-08-15
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "relax_new",
+                                 relax_new,
+                                 "whether to use the new relaxation method");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "relax_scale_force",
+        relax_scale_force,
+        "controls the size of the first CG step if relax_new is true");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "out_level",
+                                 out_level,
+                                 "ie(for electrons); i(for ions);");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "out_dm",
+                                 out_dm,
+                                 ">0 output density matrix");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "out_bandgap",
+                                 out_bandgap,
+                                 "if true, print out bandgap");
 
-    ModuleBase::GlobalFunc::OUTP(ofs, "use_paw", use_paw, "whether to use PAW in pw calculation");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "use_paw",
+                                 use_paw,
+                                 "whether to use PAW in pw calculation");
 
     // for deepks
-    ModuleBase::GlobalFunc::OUTP(ofs, "deepks_out_labels", deepks_out_labels, ">0 compute descriptor for deepks");
-    ModuleBase::GlobalFunc::OUTP(ofs, "deepks_scf", deepks_scf, ">0 add V_delta to Hamiltonian");
-    ModuleBase::GlobalFunc::OUTP(ofs, "deepks_equiv", deepks_equiv, "whether to use equivariant version of DeePKS");
-    ModuleBase::GlobalFunc::OUTP(ofs, "deepks_bandgap", deepks_bandgap, ">0 for bandgap label");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "deepks_out_labels",
+                                 deepks_out_labels,
+                                 ">0 compute descriptor for deepks");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "deepks_scf",
+                                 deepks_scf,
+                                 ">0 add V_delta to Hamiltonian");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "deepks_equiv",
+        deepks_equiv,
+        "whether to use equivariant version of DeePKS");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "deepks_bandgap",
+                                 deepks_bandgap,
+                                 ">0 for bandgap label");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "deepks_out_unittest",
                                  deepks_out_unittest,
-                                 "if set 1, prints intermediate quantities that shall be used for making unit test");
-    ModuleBase::GlobalFunc::OUTP(ofs, "deepks_model", deepks_model, "file dir of traced pytorch model: 'model.ptg");
+                                 "if set 1, prints intermediate quantities "
+                                 "that shall be used for making unit test");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "deepks_model",
+        deepks_model,
+        "file dir of traced pytorch model: 'model.ptg");
 
     ofs << "\n#Parameters (5.LCAO)" << std::endl;
-    ModuleBase::GlobalFunc::OUTP(ofs, "basis_type", basis_type, "PW; LCAO in pw; LCAO");
-    if (ks_solver == "HPSEPS" || ks_solver == "genelpa" || ks_solver == "scalapack_gvx" || ks_solver == "cusolver"
-        || ks_solver == "cusolvermp" || ks_solver == "pexsi")
-    {
-        ModuleBase::GlobalFunc::OUTP(ofs, "nb2d", nb2d, "2d distribution of atoms");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "basis_type",
+                                 basis_type,
+                                 "PW; LCAO in pw; LCAO");
+    if (ks_solver == "HPSEPS" || ks_solver == "genelpa"
+        || ks_solver == "scalapack_gvx" || ks_solver == "cusolver"
+        || ks_solver == "cusolvermp" || ks_solver == "pexsi") {
+        ModuleBase::GlobalFunc::OUTP(ofs,
+                                     "nb2d",
+                                     nb2d,
+                                     "2d distribution of atoms");
     }
     ModuleBase::GlobalFunc::OUTP(
         ofs,
         "gamma_only",
         gamma_only,
-        "Only for localized orbitals set and gamma point. If set to 1, a fast algorithm is used");
-    ModuleBase::GlobalFunc::OUTP(ofs, "search_radius", search_radius, "input search radius (Bohr)");
-    ModuleBase::GlobalFunc::OUTP(ofs, "search_pbc", search_pbc, "input periodic boundary condition");
-    ModuleBase::GlobalFunc::OUTP(ofs, "lcao_ecut", lcao_ecut, "energy cutoff for LCAO");
-    ModuleBase::GlobalFunc::OUTP(ofs, "lcao_dk", lcao_dk, "delta k for 1D integration in LCAO");
-    ModuleBase::GlobalFunc::OUTP(ofs, "lcao_dr", lcao_dr, "delta r for 1D integration in LCAO");
-    ModuleBase::GlobalFunc::OUTP(ofs, "lcao_rmax", lcao_rmax, "max R for 1D two-center integration table");
+        "Only for localized orbitals set and gamma point. If set to 1, a fast "
+        "algorithm is used");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "search_radius",
+                                 search_radius,
+                                 "input search radius (Bohr)");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "search_pbc",
+                                 search_pbc,
+                                 "input periodic boundary condition");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "lcao_ecut",
+                                 lcao_ecut,
+                                 "energy cutoff for LCAO");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "lcao_dk",
+                                 lcao_dk,
+                                 "delta k for 1D integration in LCAO");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "lcao_dr",
+                                 lcao_dr,
+                                 "delta r for 1D integration in LCAO");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "lcao_rmax",
+                                 lcao_rmax,
+                                 "max R for 1D two-center integration table");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "out_mat_hs",
                                  out_mat_hs[0],
-                                 "output H and S matrix (with precision " + std::to_string(out_mat_hs[1]) + ")");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_mat_hs2", out_mat_hs2, "output H(R) and S(R) matrix");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_mat_dh", out_mat_dh, "output of derivative of H(R) matrix");
+                                 "output H and S matrix (with precision "
+                                     + std::to_string(out_mat_hs[1]) + ")");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "out_mat_xc",
-                                 out_mat_xc,
-                                 "output exchange-correlation matrix in KS-orbital representation");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_hr_npz", out_hr_npz, "output hr(I0,JR) submatrices in npz format");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_dm_npz", out_dm_npz, "output dmr(I0,JR) submatrices in npz format");
+                                 "out_mat_hs2",
+                                 out_mat_hs2,
+                                 "output H(R) and S(R) matrix");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "dm_to_rho",
-                                 dm_to_rho,
-                                 "reads dmr in npz format and calculates electron density");
+                                 "out_mat_dh",
+                                 out_mat_dh,
+                                 "output of derivative of H(R) matrix");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "out_mat_xc",
+        out_mat_xc,
+        "output exchange-correlation matrix in KS-orbital representation");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "out_interval",
-                                 out_interval,
-                                 "interval for printing H(R) and S(R) matrix during MD");
+                                 "out_hr_npz",
+                                 out_hr_npz,
+                                 "output hr(I0,JR) submatrices in npz format");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "out_dm_npz",
+                                 out_dm_npz,
+                                 "output dmr(I0,JR) submatrices in npz format");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "dm_to_rho",
+        dm_to_rho,
+        "reads dmr in npz format and calculates electron density");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "out_interval",
+        out_interval,
+        "interval for printing H(R) and S(R) matrix during MD");
     ModuleBase::GlobalFunc::OUTP(
         ofs,
         "out_app_flag",
         out_app_flag,
-        "whether output r(R), H(R), S(R), T(R), and dH(R) matrices in an append manner during MD");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_mat_t", out_mat_t, "output T(R) matrix");
+        "whether output r(R), H(R), S(R), T(R), and dH(R) matrices in an "
+        "append manner during MD");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "out_element_info",
-                                 out_element_info,
-                                 "output (projected) wavefunction of each element");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_mat_r", out_mat_r, "output r(R) matrix");
+                                 "out_mat_t",
+                                 out_mat_t,
+                                 "output T(R) matrix");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "out_element_info",
+        out_element_info,
+        "output (projected) wavefunction of each element");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "out_wfc_lcao",
-                                 out_wfc_lcao,
-                                 "ouput LCAO wave functions, 0, no output 1: text, 2: binary");
-    ModuleBase::GlobalFunc::OUTP(ofs, "bx", bx, "division of an element grid in FFT grid along x");
-    ModuleBase::GlobalFunc::OUTP(ofs, "by", by, "division of an element grid in FFT grid along y");
-    ModuleBase::GlobalFunc::OUTP(ofs, "bz", bz, "division of an element grid in FFT grid along z");
-    ModuleBase::GlobalFunc::OUTP(ofs, "num_stream", nstream, "the nstream in compute the LCAO with CUDA");
+                                 "out_mat_r",
+                                 out_mat_r,
+                                 "output r(R) matrix");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "out_wfc_lcao",
+        out_wfc_lcao,
+        "ouput LCAO wave functions, 0, no output 1: text, 2: binary");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "bx",
+        bx,
+        "division of an element grid in FFT grid along x");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "by",
+        by,
+        "division of an element grid in FFT grid along y");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "bz",
+        bz,
+        "division of an element grid in FFT grid along z");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "num_stream",
+                                 nstream,
+                                 "the nstream in compute the LCAO with CUDA");
 
     ofs << "\n#Parameters (6.Smearing)" << std::endl;
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "smearing_method",
+        smearing_method,
+        "type of smearing_method: gauss; fd; fixed; mp; mp2; mv");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "smearing_method",
-                                 smearing_method,
-                                 "type of smearing_method: gauss; fd; fixed; mp; mp2; mv");
-    ModuleBase::GlobalFunc::OUTP(ofs, "smearing_sigma", smearing_sigma, "energy range for smearing");
+                                 "smearing_sigma",
+                                 smearing_sigma,
+                                 "energy range for smearing");
 
     ofs << "\n#Parameters (7.Charge Mixing)" << std::endl;
-    ModuleBase::GlobalFunc::OUTP(ofs, "mixing_type", mixing_mode, "plain; pulay; broyden");
-    ModuleBase::GlobalFunc::OUTP(ofs, "mixing_beta", mixing_beta, "mixing parameter: 0 means no new charge");
-    ModuleBase::GlobalFunc::OUTP(ofs, "mixing_ndim", mixing_ndim, "mixing dimension in pulay or broyden");
-    ModuleBase::GlobalFunc::OUTP(ofs, "mixing_restart", mixing_restart, "threshold to restart mixing during SCF");
-    ModuleBase::GlobalFunc::OUTP(ofs, "mixing_gg0", mixing_gg0, "mixing parameter in kerker");
-    ModuleBase::GlobalFunc::OUTP(ofs, "mixing_beta_mag", mixing_beta_mag, "mixing parameter for magnetic density");
-    ModuleBase::GlobalFunc::OUTP(ofs, "mixing_gg0_mag", mixing_gg0_mag, "mixing parameter in kerker");
-    ModuleBase::GlobalFunc::OUTP(ofs, "mixing_gg0_min", mixing_gg0_min, "the minimum kerker coefficient");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "mixing_angle",
-                                 mixing_angle,
-                                 "angle mixing parameter for non-colinear calculations");
-    ModuleBase::GlobalFunc::OUTP(ofs, "mixing_tau", mixing_tau, "whether to mix tau in mGGA calculation");
-    ModuleBase::GlobalFunc::OUTP(ofs, "mixing_dftu", mixing_dftu, "whether to mix locale in DFT+U calculation");
-    ModuleBase::GlobalFunc::OUTP(ofs, "mixing_dmr", mixing_dmr, "whether to mix real-space density matrix");
+                                 "mixing_type",
+                                 mixing_mode,
+                                 "plain; pulay; broyden");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "mixing_beta",
+                                 mixing_beta,
+                                 "mixing parameter: 0 means no new charge");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "mixing_ndim",
+                                 mixing_ndim,
+                                 "mixing dimension in pulay or broyden");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "mixing_restart",
+                                 mixing_restart,
+                                 "threshold to restart mixing during SCF");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "mixing_gg0",
+                                 mixing_gg0,
+                                 "mixing parameter in kerker");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "mixing_beta_mag",
+                                 mixing_beta_mag,
+                                 "mixing parameter for magnetic density");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "mixing_gg0_mag",
+                                 mixing_gg0_mag,
+                                 "mixing parameter in kerker");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "mixing_gg0_min",
+                                 mixing_gg0_min,
+                                 "the minimum kerker coefficient");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "mixing_angle",
+        mixing_angle,
+        "angle mixing parameter for non-colinear calculations");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "mixing_tau",
+                                 mixing_tau,
+                                 "whether to mix tau in mGGA calculation");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "mixing_dftu",
+                                 mixing_dftu,
+                                 "whether to mix locale in DFT+U calculation");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "mixing_dmr",
+                                 mixing_dmr,
+                                 "whether to mix real-space density matrix");
 
     ofs << "\n#Parameters (8.DOS)" << std::endl;
-    ModuleBase::GlobalFunc::OUTP(ofs, "dos_emin_ev", dos_emin_ev, "minimal range for dos");
-    ModuleBase::GlobalFunc::OUTP(ofs, "dos_emax_ev", dos_emax_ev, "maximal range for dos");
-    ModuleBase::GlobalFunc::OUTP(ofs, "dos_edelta_ev", dos_edelta_ev, "delta energy for dos");
-    ModuleBase::GlobalFunc::OUTP(ofs, "dos_scale", dos_scale, "scale dos range by");
-    ModuleBase::GlobalFunc::OUTP(ofs, "dos_sigma", dos_sigma, "gauss b coefficeinet(default=0.07)");
-    ModuleBase::GlobalFunc::OUTP(ofs, "dos_nche", dos_nche, "orders of Chebyshev expansions for dos");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "dos_emin_ev",
+                                 dos_emin_ev,
+                                 "minimal range for dos");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "dos_emax_ev",
+                                 dos_emax_ev,
+                                 "maximal range for dos");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "dos_edelta_ev",
+                                 dos_edelta_ev,
+                                 "delta energy for dos");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "dos_scale",
+                                 dos_scale,
+                                 "scale dos range by");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "dos_sigma",
+                                 dos_sigma,
+                                 "gauss b coefficeinet(default=0.07)");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "dos_nche",
+                                 dos_nche,
+                                 "orders of Chebyshev expansions for dos");
 
     ofs << "\n#Parameters (9.Molecular dynamics)" << std::endl;
-    ModuleBase::GlobalFunc::OUTP(ofs, "md_type", mdp.md_type, "choose ensemble");
-    ModuleBase::GlobalFunc::OUTP(ofs, "md_thermostat", mdp.md_thermostat, "choose thermostat");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "md_type",
+                                 mdp.md_type,
+                                 "choose ensemble");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "md_thermostat",
+                                 mdp.md_thermostat,
+                                 "choose thermostat");
     ModuleBase::GlobalFunc::OUTP(ofs, "md_nstep", mdp.md_nstep, "md steps");
     ModuleBase::GlobalFunc::OUTP(ofs, "md_dt", mdp.md_dt, "time step");
-    ModuleBase::GlobalFunc::OUTP(ofs, "md_tchain", mdp.md_tchain, "number of Nose-Hoover chains");
-    ModuleBase::GlobalFunc::OUTP(ofs, "md_tfirst", mdp.md_tfirst, "temperature first");
-    ModuleBase::GlobalFunc::OUTP(ofs, "md_tlast", mdp.md_tlast, "temperature last");
-    ModuleBase::GlobalFunc::OUTP(ofs, "md_dumpfreq", mdp.md_dumpfreq, "The period to dump MD information");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "md_tchain",
+                                 mdp.md_tchain,
+                                 "number of Nose-Hoover chains");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "md_tfirst",
+                                 mdp.md_tfirst,
+                                 "temperature first");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "md_tlast",
+                                 mdp.md_tlast,
+                                 "temperature last");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "md_dumpfreq",
+                                 mdp.md_dumpfreq,
+                                 "The period to dump MD information");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "md_restartfreq",
                                  mdp.md_restartfreq,
                                  "The period to output MD restart information");
-    ModuleBase::GlobalFunc::OUTP(ofs, "md_seed", mdp.md_seed, "random seed for MD");
-    ModuleBase::GlobalFunc::OUTP(ofs, "md_prec_level", mdp.md_prec_level, "precision level for vc-md");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "ref_cell_factor",
-                                 ref_cell_factor,
-                                 "construct a reference cell bigger than the initial cell");
-    ModuleBase::GlobalFunc::OUTP(ofs, "md_restart", mdp.md_restart, "whether restart");
-    ModuleBase::GlobalFunc::OUTP(ofs, "lj_rcut", mdp.lj_rcut, "cutoff radius of LJ potential");
-    ModuleBase::GlobalFunc::OUTP(ofs, "lj_epsilon", mdp.lj_epsilon, "the value of epsilon for LJ potential");
-    ModuleBase::GlobalFunc::OUTP(ofs, "lj_sigma", mdp.lj_sigma, "the value of sigma for LJ potential");
-    ModuleBase::GlobalFunc::OUTP(ofs, "pot_file", mdp.pot_file, "the filename of potential files for CMD such as DP");
-    ModuleBase::GlobalFunc::OUTP(ofs, "msst_direction", mdp.msst_direction, "the direction of shock wave");
-    ModuleBase::GlobalFunc::OUTP(ofs, "msst_vel", mdp.msst_vel, "the velocity of shock wave");
-    ModuleBase::GlobalFunc::OUTP(ofs, "msst_vis", mdp.msst_vis, "artificial viscosity");
-    ModuleBase::GlobalFunc::OUTP(ofs, "msst_tscale", mdp.msst_tscale, "reduction in initial temperature");
-    ModuleBase::GlobalFunc::OUTP(ofs, "msst_qmass", mdp.msst_qmass, "mass of thermostat");
+                                 "md_seed",
+                                 mdp.md_seed,
+                                 "random seed for MD");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "md_tfreq",
-                                 mdp.md_tfreq,
-                                 "oscillation frequency, used to determine qmass of NHC");
+                                 "md_prec_level",
+                                 mdp.md_prec_level,
+                                 "precision level for vc-md");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "ref_cell_factor",
+        ref_cell_factor,
+        "construct a reference cell bigger than the initial cell");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "md_damp",
-                                 mdp.md_damp,
-                                 "damping parameter (time units) used to add force in Langevin method");
-    ModuleBase::GlobalFunc::OUTP(ofs, "md_nraise", mdp.md_nraise, "parameters used when md_type=nvt");
+                                 "md_restart",
+                                 mdp.md_restart,
+                                 "whether restart");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "cal_syns",
-                                 cal_syns,
-                                 "calculate asynchronous overlap matrix to output for Hefei-NAMD");
-    ModuleBase::GlobalFunc::OUTP(ofs, "dmax", dmax, "maximum displacement of all atoms in one step (bohr)");
-    ModuleBase::GlobalFunc::OUTP(ofs, "md_tolerance", mdp.md_tolerance, "tolerance for velocity rescaling (K)");
-    ModuleBase::GlobalFunc::OUTP(ofs, "md_pmode", mdp.md_pmode, "NPT ensemble mode: iso, aniso, tri");
+                                 "lj_rcut",
+                                 mdp.lj_rcut,
+                                 "cutoff radius of LJ potential");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "md_pcouple",
-                                 mdp.md_pcouple,
-                                 "whether couple different components: xyz, xy, yz, xz, none");
-    ModuleBase::GlobalFunc::OUTP(ofs, "md_pchain", mdp.md_pchain, "num of thermostats coupled with barostat");
-    ModuleBase::GlobalFunc::OUTP(ofs, "md_pfirst", mdp.md_pfirst, "initial target pressure");
-    ModuleBase::GlobalFunc::OUTP(ofs, "md_plast", mdp.md_plast, "final target pressure");
+                                 "lj_epsilon",
+                                 mdp.lj_epsilon,
+                                 "the value of epsilon for LJ potential");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "lj_sigma",
+                                 mdp.lj_sigma,
+                                 "the value of sigma for LJ potential");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "pot_file",
+        mdp.pot_file,
+        "the filename of potential files for CMD such as DP");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "msst_direction",
+                                 mdp.msst_direction,
+                                 "the direction of shock wave");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "msst_vel",
+                                 mdp.msst_vel,
+                                 "the velocity of shock wave");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "msst_vis",
+                                 mdp.msst_vis,
+                                 "artificial viscosity");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "msst_tscale",
+                                 mdp.msst_tscale,
+                                 "reduction in initial temperature");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "msst_qmass",
+                                 mdp.msst_qmass,
+                                 "mass of thermostat");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "md_tfreq",
+        mdp.md_tfreq,
+        "oscillation frequency, used to determine qmass of NHC");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "md_damp",
+        mdp.md_damp,
+        "damping parameter (time units) used to add force in Langevin method");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "md_nraise",
+                                 mdp.md_nraise,
+                                 "parameters used when md_type=nvt");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "cal_syns",
+        cal_syns,
+        "calculate asynchronous overlap matrix to output for Hefei-NAMD");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "dmax",
+        dmax,
+        "maximum displacement of all atoms in one step (bohr)");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "md_tolerance",
+                                 mdp.md_tolerance,
+                                 "tolerance for velocity rescaling (K)");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "md_pmode",
+                                 mdp.md_pmode,
+                                 "NPT ensemble mode: iso, aniso, tri");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "md_pcouple",
+        mdp.md_pcouple,
+        "whether couple different components: xyz, xy, yz, xz, none");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "md_pchain",
+                                 mdp.md_pchain,
+                                 "num of thermostats coupled with barostat");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "md_pfirst",
+                                 mdp.md_pfirst,
+                                 "initial target pressure");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "md_plast",
+                                 mdp.md_plast,
+                                 "final target pressure");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "md_pfreq",
                                  mdp.md_pfreq,
-                                 "oscillation frequency, used to determine qmass of thermostats coupled with barostat");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "dump_force",
-                                 mdp.dump_force,
-                                 "output atomic forces into the file MD_dump or not");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "dump_vel",
-                                 mdp.dump_vel,
-                                 "output atomic velocities into the file MD_dump or not");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "dump_virial",
-                                 mdp.dump_virial,
-                                 "output lattice virial into the file MD_dump or not");
+                                 "oscillation frequency, used to determine "
+                                 "qmass of thermostats coupled with barostat");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "dump_force",
+        mdp.dump_force,
+        "output atomic forces into the file MD_dump or not");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "dump_vel",
+        mdp.dump_vel,
+        "output atomic velocities into the file MD_dump or not");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "dump_virial",
+        mdp.dump_virial,
+        "output lattice virial into the file MD_dump or not");
 
-    ofs << "\n#Parameters (10.Electric field and dipole correction)" << std::endl;
-    ModuleBase::GlobalFunc::OUTP(ofs, "efield_flag", efield_flag, "add electric field");
-    ModuleBase::GlobalFunc::OUTP(ofs, "dip_cor_flag", dip_cor_flag, "dipole correction");
+    ofs << "\n#Parameters (10.Electric field and dipole correction)"
+        << std::endl;
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "efield_dir",
-                                 efield_dir,
-                                 "the direction of the electric field or dipole correction");
+                                 "efield_flag",
+                                 efield_flag,
+                                 "add electric field");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "dip_cor_flag",
+                                 dip_cor_flag,
+                                 "dipole correction");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "efield_dir",
+        efield_dir,
+        "the direction of the electric field or dipole correction");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "efield_pos_max",
                                  efield_pos_max,
-                                 "position of the maximum of the saw-like potential along crystal axis efield_dir");
+                                 "position of the maximum of the saw-like "
+                                 "potential along crystal axis efield_dir");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "efield_pos_dec",
+        efield_pos_dec,
+        "zone in the unit cell where the saw-like potential decreases");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "efield_pos_dec",
-                                 efield_pos_dec,
-                                 "zone in the unit cell where the saw-like potential decreases");
-    ModuleBase::GlobalFunc::OUTP(ofs, "efield_amp ", efield_amp, "amplitude of the electric field");
+                                 "efield_amp ",
+                                 efield_amp,
+                                 "amplitude of the electric field");
 
     ofs << "\n#Parameters (11.Gate field)" << std::endl;
-    ModuleBase::GlobalFunc::OUTP(ofs, "gate_flag", gate_flag, "compensating charge or not");
-    ModuleBase::GlobalFunc::OUTP(ofs, "zgate", zgate, "position of charged plate");
-    ModuleBase::GlobalFunc::OUTP(ofs, "relax", relax, "allow relaxation along the specific direction");
-    ModuleBase::GlobalFunc::OUTP(ofs, "block", block, "add a block potential or not");
-    ModuleBase::GlobalFunc::OUTP(ofs, "block_down", block_down, "low bound of the block");
-    ModuleBase::GlobalFunc::OUTP(ofs, "block_up", block_up, "high bound of the block");
-    ModuleBase::GlobalFunc::OUTP(ofs, "block_height", block_height, "height of the block");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "gate_flag",
+                                 gate_flag,
+                                 "compensating charge or not");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "zgate",
+                                 zgate,
+                                 "position of charged plate");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "relax",
+        relax,
+        "allow relaxation along the specific direction");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "block",
+                                 block,
+                                 "add a block potential or not");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "block_down",
+                                 block_down,
+                                 "low bound of the block");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "block_up",
+                                 block_up,
+                                 "high bound of the block");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "block_height",
+                                 block_height,
+                                 "height of the block");
 
     ofs << "\n#Parameters (12.Test)" << std::endl;
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_alllog", out_alllog, "output information for each processor, when parallel");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "out_alllog",
+        out_alllog,
+        "output information for each processor, when parallel");
     ModuleBase::GlobalFunc::OUTP(ofs, "nurse", nurse, "for coders");
-    ModuleBase::GlobalFunc::OUTP(ofs, "colour", colour, "for coders, make their live colourful");
-    ModuleBase::GlobalFunc::OUTP(ofs, "t_in_h", t_in_h, "calculate the kinetic energy or not");
-    ModuleBase::GlobalFunc::OUTP(ofs, "vl_in_h", vl_in_h, "calculate the local potential or not");
-    ModuleBase::GlobalFunc::OUTP(ofs, "vnl_in_h", vnl_in_h, "calculate the nonlocal potential or not");
-    ModuleBase::GlobalFunc::OUTP(ofs, "vh_in_h", vh_in_h, "calculate the hartree potential or not");
-    ModuleBase::GlobalFunc::OUTP(ofs, "vion_in_h", vion_in_h, "calculate the local ionic potential or not");
-    ModuleBase::GlobalFunc::OUTP(ofs, "test_force", test_force, "test the force");
-    ModuleBase::GlobalFunc::OUTP(ofs, "test_stress", test_stress, "test the force");
-    ModuleBase::GlobalFunc::OUTP(ofs, "test_skip_ewald", test_skip_ewald, "skip ewald energy");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "colour",
+                                 colour,
+                                 "for coders, make their live colourful");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "t_in_h",
+                                 t_in_h,
+                                 "calculate the kinetic energy or not");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "vl_in_h",
+                                 vl_in_h,
+                                 "calculate the local potential or not");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "vnl_in_h",
+                                 vnl_in_h,
+                                 "calculate the nonlocal potential or not");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "vh_in_h",
+                                 vh_in_h,
+                                 "calculate the hartree potential or not");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "vion_in_h",
+                                 vion_in_h,
+                                 "calculate the local ionic potential or not");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "test_force",
+                                 test_force,
+                                 "test the force");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "test_stress",
+                                 test_stress,
+                                 "test the force");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "test_skip_ewald",
+                                 test_skip_ewald,
+                                 "skip ewald energy");
 
     ofs << "\n#Parameters (13.vdW Correction)" << std::endl;
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "vdw_method",
+        vdw_method,
+        "the method of calculating vdw (none ; d2 ; d3_0 ; d3_bj");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "vdw_method",
-                                 vdw_method,
-                                 "the method of calculating vdw (none ; d2 ; d3_0 ; d3_bj");
-    ModuleBase::GlobalFunc::OUTP(ofs, "vdw_s6", vdw_s6, "scale parameter of d2/d3_0/d3_bj");
-    ModuleBase::GlobalFunc::OUTP(ofs, "vdw_s8", vdw_s8, "scale parameter of d3_0/d3_bj");
-    ModuleBase::GlobalFunc::OUTP(ofs, "vdw_a1", vdw_a1, "damping parameter of d3_0/d3_bj");
-    ModuleBase::GlobalFunc::OUTP(ofs, "vdw_a2", vdw_a2, "damping parameter of d3_bj");
-    ModuleBase::GlobalFunc::OUTP(ofs, "vdw_d", vdw_d, "damping parameter of d2");
+                                 "vdw_s6",
+                                 vdw_s6,
+                                 "scale parameter of d2/d3_0/d3_bj");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "vdw_s8",
+                                 vdw_s8,
+                                 "scale parameter of d3_0/d3_bj");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "vdw_a1",
+                                 vdw_a1,
+                                 "damping parameter of d3_0/d3_bj");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "vdw_a2",
+                                 vdw_a2,
+                                 "damping parameter of d3_bj");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "vdw_d",
+                                 vdw_d,
+                                 "damping parameter of d2");
     ModuleBase::GlobalFunc::OUTP(ofs, "vdw_abc", vdw_abc, "third-order term?");
-    ModuleBase::GlobalFunc::OUTP(ofs, "vdw_C6_file", vdw_C6_file, "filename of C6");
-    ModuleBase::GlobalFunc::OUTP(ofs, "vdw_C6_unit", vdw_C6_unit, "unit of C6, Jnm6/mol or eVA6");
-    ModuleBase::GlobalFunc::OUTP(ofs, "vdw_R0_file", vdw_R0_file, "filename of R0");
-    ModuleBase::GlobalFunc::OUTP(ofs, "vdw_R0_unit", vdw_R0_unit, "unit of R0, A or Bohr");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "vdw_cutoff_type",
-                                 vdw_cutoff_type,
-                                 "expression model of periodic structure, radius or period");
-    ModuleBase::GlobalFunc::OUTP(ofs, "vdw_cutoff_radius", vdw_cutoff_radius, "radius cutoff for periodic structure");
+                                 "vdw_C6_file",
+                                 vdw_C6_file,
+                                 "filename of C6");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "vdw_radius_unit",
-                                 vdw_radius_unit,
-                                 "unit of radius cutoff for periodic structure");
-    ModuleBase::GlobalFunc::OUTP(ofs, "vdw_cn_thr", vdw_cn_thr, "radius cutoff for cn");
-    ModuleBase::GlobalFunc::OUTP(ofs, "vdw_cn_thr_unit", vdw_cn_thr_unit, "unit of cn_thr, Bohr or Angstrom");
-    ofs << std::setw(20) << "vdw_cutoff_period" << vdw_cutoff_period.x << " " << vdw_cutoff_period.y << " "
-        << vdw_cutoff_period.z << " #periods of periodic structure" << std::endl;
+                                 "vdw_C6_unit",
+                                 vdw_C6_unit,
+                                 "unit of C6, Jnm6/mol or eVA6");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "vdw_R0_file",
+                                 vdw_R0_file,
+                                 "filename of R0");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "vdw_R0_unit",
+                                 vdw_R0_unit,
+                                 "unit of R0, A or Bohr");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "vdw_cutoff_type",
+        vdw_cutoff_type,
+        "expression model of periodic structure, radius or period");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "vdw_cutoff_radius",
+                                 vdw_cutoff_radius,
+                                 "radius cutoff for periodic structure");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "vdw_radius_unit",
+        vdw_radius_unit,
+        "unit of radius cutoff for periodic structure");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "vdw_cn_thr",
+                                 vdw_cn_thr,
+                                 "radius cutoff for cn");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "vdw_cn_thr_unit",
+                                 vdw_cn_thr_unit,
+                                 "unit of cn_thr, Bohr or Angstrom");
+    ofs << std::setw(20) << "vdw_cutoff_period" << vdw_cutoff_period.x << " "
+        << vdw_cutoff_period.y << " " << vdw_cutoff_period.z
+        << " #periods of periodic structure" << std::endl;
 
     ofs << "\n#Parameters (14.exx)" << std::endl;
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "exx_hybrid_alpha",
-                                 exx_hybrid_alpha,
-                                 "fraction of Fock exchange in hybrid functionals");
-    ModuleBase::GlobalFunc::OUTP(ofs, "exx_hse_omega", exx_hse_omega, "range-separation parameter in HSE functional");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "exx_hybrid_alpha",
+        exx_hybrid_alpha,
+        "fraction of Fock exchange in hybrid functionals");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "exx_hse_omega",
+        exx_hse_omega,
+        "range-separation parameter in HSE functional");
     ModuleBase::GlobalFunc::OUTP(
         ofs,
         "exx_separate_loop",
         exx_separate_loop,
-        "if 1, a two-step method is employed, else it will start with a GGA-Loop, and then Hybrid-Loop");
+        "if 1, a two-step method is employed, else it will start with a "
+        "GGA-Loop, and then Hybrid-Loop");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "exx_hybrid_step",
                                  exx_hybrid_step,
-                                 "the maximal electronic iteration number in the evaluation of Fock exchange");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "exx_mixing_beta",
-                                 exx_mixing_beta,
-                                 "mixing_beta for outer-loop when exx_separate_loop=1");
+                                 "the maximal electronic iteration number in "
+                                 "the evaluation of Fock exchange");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "exx_mixing_beta",
+        exx_mixing_beta,
+        "mixing_beta for outer-loop when exx_separate_loop=1");
     ModuleBase::GlobalFunc::OUTP(
         ofs,
         "exx_lambda",
         exx_lambda,
-        "used to compensate for divergence points at G=0 in the evaluation of Fock exchange using lcao_in_pw method");
-    ModuleBase::GlobalFunc::OUTP(ofs, "exx_real_number", exx_real_number, "exx calculated in real or complex");
+        "used to compensate for divergence points at G=0 in the evaluation of "
+        "Fock exchange using lcao_in_pw method");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "exx_real_number",
+                                 exx_real_number,
+                                 "exx calculated in real or complex");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "exx_pca_threshold",
                                  exx_pca_threshold,
                                  "threshold to screen on-site ABFs in exx");
-    ModuleBase::GlobalFunc::OUTP(ofs, "exx_c_threshold", exx_c_threshold, "threshold to screen C matrix in exx");
-    ModuleBase::GlobalFunc::OUTP(ofs, "exx_v_threshold", exx_v_threshold, "threshold to screen C matrix in exx");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "exx_c_threshold",
+                                 exx_c_threshold,
+                                 "threshold to screen C matrix in exx");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "exx_v_threshold",
+                                 exx_v_threshold,
+                                 "threshold to screen C matrix in exx");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "exx_dm_threshold",
                                  exx_dm_threshold,
                                  "threshold to screen density matrix in exx");
-    // ModuleBase::GlobalFunc::OUTP(ofs, "exx_schwarz_threshold", exx_schwarz_threshold, "");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "exx_cauchy_threshold",
-                                 exx_cauchy_threshold,
-                                 "threshold to screen exx using Cauchy-Schwartz inequality");
+    // ModuleBase::GlobalFunc::OUTP(ofs, "exx_schwarz_threshold",
+    // exx_schwarz_threshold, "");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "exx_cauchy_threshold",
+        exx_cauchy_threshold,
+        "threshold to screen exx using Cauchy-Schwartz inequality");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "exx_c_grad_threshold",
                                  exx_c_grad_threshold,
@@ -589,186 +1234,321 @@ void Input::Print(const std::string& fn) const
                                  "exx_v_grad_threshold",
                                  exx_v_grad_threshold,
                                  "threshold to screen nabla V matrix in exx");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "exx_cauchy_force_threshold",
-                                 exx_cauchy_force_threshold,
-                                 "threshold to screen exx force using Cauchy-Schwartz inequality");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "exx_cauchy_stress_threshold",
-                                 exx_cauchy_stress_threshold,
-                                 "threshold to screen exx stress using Cauchy-Schwartz inequality");
-    // ModuleBase::GlobalFunc::OUTP(ofs, "exx_ccp_threshold", exx_ccp_threshold, "");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "exx_cauchy_force_threshold",
+        exx_cauchy_force_threshold,
+        "threshold to screen exx force using Cauchy-Schwartz inequality");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "exx_cauchy_stress_threshold",
+        exx_cauchy_stress_threshold,
+        "threshold to screen exx stress using Cauchy-Schwartz inequality");
+    // ModuleBase::GlobalFunc::OUTP(ofs, "exx_ccp_threshold", exx_ccp_threshold,
+    // "");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "exx_ccp_rmesh_times",
                                  exx_ccp_rmesh_times,
-                                 "how many times larger the radial mesh required for calculating Columb potential is "
+                                 "how many times larger the radial mesh "
+                                 "required for calculating Columb potential is "
                                  "to that of atomic orbitals");
-    // ModuleBase::GlobalFunc::OUTP(ofs, "exx_distribute_type", exx_distribute_type, "htime or kmeans1 or kmeans2");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "exx_opt_orb_lmax",
-                                 exx_opt_orb_lmax,
-                                 "the maximum l of the spherical Bessel functions for opt ABFs");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "exx_opt_orb_ecut",
-                                 exx_opt_orb_ecut,
-                                 "the cut-off of plane wave expansion for opt ABFs");
+    // ModuleBase::GlobalFunc::OUTP(ofs, "exx_distribute_type",
+    // exx_distribute_type, "htime or kmeans1 or kmeans2");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "exx_opt_orb_lmax",
+        exx_opt_orb_lmax,
+        "the maximum l of the spherical Bessel functions for opt ABFs");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "exx_opt_orb_ecut",
+        exx_opt_orb_ecut,
+        "the cut-off of plane wave expansion for opt ABFs");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "exx_opt_orb_tolerence",
                                  exx_opt_orb_tolerence,
-                                 "the threshold when solving for the zeros of spherical Bessel functions for opt ABFs");
+                                 "the threshold when solving for the zeros of "
+                                 "spherical Bessel functions for opt ABFs");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "rpa_ccp_rmesh_times",
                                  rpa_ccp_rmesh_times,
-                                 "how many times larger the radial mesh required for calculating Columb potential is "
+                                 "how many times larger the radial mesh "
+                                 "required for calculating Columb potential is "
                                  "to that of atomic orbitals");
 
     ofs << "\n#Parameters (16.tddft)" << std::endl;
-    ModuleBase::GlobalFunc::OUTP(ofs, "td_force_dt", td_force_dt, "time of force change");
-    ModuleBase::GlobalFunc::OUTP(ofs, "td_vext", td_vext, "add extern potential or not");
-    ModuleBase::GlobalFunc::OUTP(ofs, "td_vext_dire", td_vext_dire, "extern potential direction");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_dipole", out_dipole, "output dipole or not");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_efield", out_dipole, "output dipole or not");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_current", out_current, "output current or not");
-    ModuleBase::GlobalFunc::OUTP(ofs, "ocp", GlobalV::ocp, "change occupation or not");
-    ModuleBase::GlobalFunc::OUTP(ofs, "ocp_set", GlobalV::ocp_set, "set occupation");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "td_force_dt",
+                                 td_force_dt,
+                                 "time of force change");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "td_vext",
+                                 td_vext,
+                                 "add extern potential or not");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "td_vext_dire",
+                                 td_vext_dire,
+                                 "extern potential direction");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "out_dipole",
+                                 out_dipole,
+                                 "output dipole or not");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "out_efield",
+                                 out_dipole,
+                                 "output dipole or not");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "out_current",
+                                 out_current,
+                                 "output current or not");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "ocp",
+                                 GlobalV::ocp,
+                                 "change occupation or not");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "ocp_set",
+                                 GlobalV::ocp_set,
+                                 "set occupation");
 
     ofs << "\n#Parameters (17.berry_wannier)" << std::endl;
-    ModuleBase::GlobalFunc::OUTP(ofs, "berry_phase", berry_phase, "calculate berry phase or not");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "gdir",
-                                 gdir,
-                                 "calculate the polarization in the direction of the lattice vector");
-    ModuleBase::GlobalFunc::OUTP(ofs, "towannier90", towannier90, "use wannier90 code interface or not");
-    ModuleBase::GlobalFunc::OUTP(ofs, "nnkpfile", nnkpfile, "the wannier90 code nnkp file name");
-    ModuleBase::GlobalFunc::OUTP(ofs, "wannier_spin", wannier_spin, "calculate spin in wannier90 code interface");
+                                 "berry_phase",
+                                 berry_phase,
+                                 "calculate berry phase or not");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "gdir",
+        gdir,
+        "calculate the polarization in the direction of the lattice vector");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "wannier_method",
-                                 wannier_method,
-                                 "different implementation methods under Lcao basis set");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_wannier_mmn", out_wannier_mmn, "output .mmn file or not");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_wannier_amn", out_wannier_amn, "output .amn file or not");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_wannier_unk", out_wannier_unk, "output UNK. file or not");
-    ModuleBase::GlobalFunc::OUTP(ofs, "out_wannier_eig", out_wannier_eig, "output .eig file or not");
+                                 "towannier90",
+                                 towannier90,
+                                 "use wannier90 code interface or not");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "out_wannier_wvfn_formatted",
-                                 out_wannier_wvfn_formatted,
-                                 "output UNK. file in text format or in binary format");
+                                 "nnkpfile",
+                                 nnkpfile,
+                                 "the wannier90 code nnkp file name");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "wannier_spin",
+                                 wannier_spin,
+                                 "calculate spin in wannier90 code interface");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "wannier_method",
+        wannier_method,
+        "different implementation methods under Lcao basis set");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "out_wannier_mmn",
+                                 out_wannier_mmn,
+                                 "output .mmn file or not");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "out_wannier_amn",
+                                 out_wannier_amn,
+                                 "output .amn file or not");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "out_wannier_unk",
+                                 out_wannier_unk,
+                                 "output UNK. file or not");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "out_wannier_eig",
+                                 out_wannier_eig,
+                                 "output .eig file or not");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "out_wannier_wvfn_formatted",
+        out_wannier_wvfn_formatted,
+        "output UNK. file in text format or in binary format");
 
     ofs << "\n#Parameters (18.implicit_solvation)" << std::endl;
-    ModuleBase::GlobalFunc::OUTP(ofs, "imp_sol", imp_sol, "calculate implicit solvation correction or not");
-    ModuleBase::GlobalFunc::OUTP(ofs, "eb_k", eb_k, "the relative permittivity of the bulk solvent");
-    ModuleBase::GlobalFunc::OUTP(ofs, "tau", tau, "the effective surface tension parameter");
-    ModuleBase::GlobalFunc::OUTP(ofs, "sigma_k", sigma_k, " the width of the diffuse cavity");
-    ModuleBase::GlobalFunc::OUTP(ofs, "nc_k", nc_k, " the cut-off charge density");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "imp_sol",
+        imp_sol,
+        "calculate implicit solvation correction or not");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "eb_k",
+        eb_k,
+        "the relative permittivity of the bulk solvent");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "tau",
+                                 tau,
+                                 "the effective surface tension parameter");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "sigma_k",
+                                 sigma_k,
+                                 " the width of the diffuse cavity");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "nc_k",
+                                 nc_k,
+                                 " the cut-off charge density");
 
-    ofs << "\n#Parameters (19.orbital free density functional theory)" << std::endl;
-    ModuleBase::GlobalFunc::OUTP(ofs, "of_kinetic", of_kinetic, "kinetic energy functional, such as tf, vw, wt");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "of_method",
-                                 of_method,
-                                 "optimization method used in OFDFT, including cg1, cg2, tn (default)");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "of_conv",
-                                 of_conv,
-                                 "the convergence criterion, potential, energy (default), or both");
+    ofs << "\n#Parameters (19.orbital free density functional theory)"
+        << std::endl;
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "of_kinetic",
+        of_kinetic,
+        "kinetic energy functional, such as tf, vw, wt");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "of_method",
+        of_method,
+        "optimization method used in OFDFT, including cg1, cg2, tn (default)");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "of_conv",
+        of_conv,
+        "the convergence criterion, potential, energy (default), or both");
     ModuleBase::GlobalFunc::OUTP(
         ofs,
         "of_tole",
         of_tole,
-        "tolerance of the energy change (in Ry) for determining the convergence, default=2e-6 Ry");
+        "tolerance of the energy change (in Ry) for determining the "
+        "convergence, default=2e-6 Ry");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "of_tolp",
                                  of_tolp,
-                                 "tolerance of potential for determining the convergence, default=1e-5 in a.u.");
-    ModuleBase::GlobalFunc::OUTP(ofs, "of_tf_weight", of_tf_weight, "weight of TF KEDF");
-    ModuleBase::GlobalFunc::OUTP(ofs, "of_vw_weight", of_vw_weight, "weight of vW KEDF");
-    ModuleBase::GlobalFunc::OUTP(ofs, "of_wt_alpha", of_wt_alpha, "parameter alpha of WT KEDF");
-    ModuleBase::GlobalFunc::OUTP(ofs, "of_wt_beta", of_wt_beta, "parameter beta of WT KEDF");
+                                 "tolerance of potential for determining the "
+                                 "convergence, default=1e-5 in a.u.");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "of_wt_rho0",
-                                 of_wt_rho0,
-                                 "the average density of system, used in WT KEDF, in Bohr^-3");
+                                 "of_tf_weight",
+                                 of_tf_weight,
+                                 "weight of TF KEDF");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "of_hold_rho0",
-                                 of_hold_rho0,
-                                 "If set to 1, the rho0 will be fixed even if the volume of system has changed, it "
-                                 "will be set to 1 automaticly if of_wt_rho0 is not zero");
-    ModuleBase::GlobalFunc::OUTP(ofs, "of_lkt_a", of_lkt_a, "parameter a of LKT KEDF");
+                                 "of_vw_weight",
+                                 of_vw_weight,
+                                 "weight of vW KEDF");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "of_wt_alpha",
+                                 of_wt_alpha,
+                                 "parameter alpha of WT KEDF");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "of_wt_beta",
+                                 of_wt_beta,
+                                 "parameter beta of WT KEDF");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "of_wt_rho0",
+        of_wt_rho0,
+        "the average density of system, used in WT KEDF, in Bohr^-3");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "of_hold_rho0",
+        of_hold_rho0,
+        "If set to 1, the rho0 will be fixed even if the volume of system has "
+        "changed, it "
+        "will be set to 1 automaticly if of_wt_rho0 is not zero");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "of_lkt_a",
+                                 of_lkt_a,
+                                 "parameter a of LKT KEDF");
     ModuleBase::GlobalFunc::OUTP(
         ofs,
         "of_full_pw",
         of_full_pw,
-        "If set to 1, ecut will be ignored when collect planewaves, so that all planewaves will be used");
+        "If set to 1, ecut will be ignored when collect planewaves, so that "
+        "all planewaves will be used");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "of_full_pw_dim",
                                  of_full_pw_dim,
-                                 "If of_full_pw = true, dimention of FFT is testricted to be (0) either odd or even; "
+                                 "If of_full_pw = true, dimention of FFT is "
+                                 "testricted to be (0) either odd or even; "
                                  "(1) odd only; (2) even only");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "of_read_kernel",
                                  of_read_kernel,
-                                 "If set to 1, the kernel of WT KEDF will be filled from file of_kernel_file, not from "
+                                 "If set to 1, the kernel of WT KEDF will be "
+                                 "filled from file of_kernel_file, not from "
                                  "formula. Only usable for WT KEDF");
-    ModuleBase::GlobalFunc::OUTP(ofs, "of_kernel_file", of_kernel_file, "The name of WT kernel file.");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "of_kernel_file",
+                                 of_kernel_file,
+                                 "The name of WT kernel file.");
 
     ofs << "\n#Parameters (20.dft+u)" << std::endl;
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "dft_plus_u",
                                  dft_plus_u,
-                                 "1/2:new/old DFT+U correction method; 0: standard DFT calcullation(default)");
-    ModuleBase::GlobalFunc::OUTP(ofs, "yukawa_lambda", yukawa_lambda, "default:0.0");
-    ModuleBase::GlobalFunc::OUTP(ofs, "yukawa_potential", yukawa_potential, "default: false");
-    ModuleBase::GlobalFunc::OUTP(ofs, "uramping", uramping, "increasing U values during SCF");
-    ModuleBase::GlobalFunc::OUTP(ofs, "omc", omc, "the mode of occupation matrix control");
+                                 "1/2:new/old DFT+U correction method; 0: "
+                                 "standard DFT calcullation(default)");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "onsite_radius",
-                                 onsite_radius,
-                                 "radius of the sphere for onsite projection (Bohr)");
+                                 "yukawa_lambda",
+                                 yukawa_lambda,
+                                 "default:0.0");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "yukawa_potential",
+                                 yukawa_potential,
+                                 "default: false");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "uramping",
+                                 uramping,
+                                 "increasing U values during SCF");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "omc",
+                                 omc,
+                                 "the mode of occupation matrix control");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "onsite_radius",
+        onsite_radius,
+        "radius of the sphere for onsite projection (Bohr)");
     ofs << std::setw(20) << "hubbard_u ";
-    for (int i = 0; i < ntype; i++)
-    {
+    for (int i = 0; i < ntype; i++) {
         ofs << hubbard_u[i] * ModuleBase::Ry_to_eV << " ";
     }
     ofs << "#Hubbard Coulomb interaction parameter U(ev)" << std::endl;
     ofs << std::setw(20) << "orbital_corr ";
-    for (int i = 0; i < ntype; i++)
-    {
+    for (int i = 0; i < ntype; i++) {
         ofs << orbital_corr[i] << " ";
     }
-    ofs << "#which correlated orbitals need corrected ; d:2 ,f:3, do not need correction:-1" << std::endl;
+    ofs << "#which correlated orbitals need corrected ; d:2 ,f:3, do not need "
+           "correction:-1"
+        << std::endl;
 
     ofs << "\n#Parameters (21.spherical bessel)" << std::endl;
 
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "bessel_nao_ecut",
-                                 bessel_nao_ecut,
-                                 "energy cutoff for spherical bessel functions(Ry)");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "bessel_nao_ecut",
+        bessel_nao_ecut,
+        "energy cutoff for spherical bessel functions(Ry)");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "bessel_nao_tolerence",
                                  bessel_nao_tolerence,
                                  "tolerence for spherical bessel root");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "bessel_nao_rcut",
+        bessel_nao_rcut,
+        "radial cutoff for spherical bessel functions(a.u.)");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "bessel_nao_rcut",
-                                 bessel_nao_rcut,
-                                 "radial cutoff for spherical bessel functions(a.u.)");
-    ModuleBase::GlobalFunc::OUTP(ofs, "bessel_nao_smooth", bessel_nao_smooth, "spherical bessel smooth or not");
-    ModuleBase::GlobalFunc::OUTP(ofs, "bessel_nao_sigma", bessel_nao_sigma, "spherical bessel smearing_sigma");
+                                 "bessel_nao_smooth",
+                                 bessel_nao_smooth,
+                                 "spherical bessel smooth or not");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "bessel_descriptor_lmax",
-                                 bessel_descriptor_lmax,
-                                 "lmax used in generating spherical bessel functions");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "bessel_descriptor_ecut",
-                                 bessel_descriptor_ecut,
-                                 "energy cutoff for spherical bessel functions(Ry)");
+                                 "bessel_nao_sigma",
+                                 bessel_nao_sigma,
+                                 "spherical bessel smearing_sigma");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "bessel_descriptor_lmax",
+        bessel_descriptor_lmax,
+        "lmax used in generating spherical bessel functions");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "bessel_descriptor_ecut",
+        bessel_descriptor_ecut,
+        "energy cutoff for spherical bessel functions(Ry)");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "bessel_descriptor_tolerence",
                                  bessel_descriptor_tolerence,
                                  "tolerence for spherical bessel root");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "bessel_descriptor_rcut",
-                                 bessel_descriptor_rcut,
-                                 "radial cutoff for spherical bessel functions(a.u.)");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "bessel_descriptor_rcut",
+        bessel_descriptor_rcut,
+        "radial cutoff for spherical bessel functions(a.u.)");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "bessel_descriptor_smooth",
                                  bessel_descriptor_smooth,
@@ -779,106 +1559,177 @@ void Input::Print(const std::string& fn) const
                                  "spherical bessel smearing_sigma");
     /// deltaspin variables
     ofs << "\n#Parameters (22.non-collinear spin-constrained DFT)" << std::endl;
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "sc_mag_switch",
-                                 sc_mag_switch,
-                                 "0: no spin-constrained DFT; 1: constrain atomic magnetization");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "sc_mag_switch",
+        sc_mag_switch,
+        "0: no spin-constrained DFT; 1: constrain atomic magnetization");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "decay_grad_switch",
                                  decay_grad_switch,
                                  "switch to control gradient break condition");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "sc_thr",
+        sc_thr,
+        "Convergence criterion of spin-constrained iteration (RMS) in uB");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "nsc",
+        nsc,
+        "Maximal number of spin-constrained iteration");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "nsc_min",
+        nsc_min,
+        "Minimum number of spin-constrained iteration");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "sc_scf_nmin",
+        sc_scf_nmin,
+        "Minimum number of outer scf loop before initializing lambda loop");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "alpha_trial",
+        alpha_trial,
+        "Initial trial step size for lambda in eV/uB^2");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "sc_thr",
-                                 sc_thr,
-                                 "Convergence criterion of spin-constrained iteration (RMS) in uB");
-    ModuleBase::GlobalFunc::OUTP(ofs, "nsc", nsc, "Maximal number of spin-constrained iteration");
-    ModuleBase::GlobalFunc::OUTP(ofs, "nsc_min", nsc_min, "Minimum number of spin-constrained iteration");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "sc_scf_nmin",
-                                 sc_scf_nmin,
-                                 "Minimum number of outer scf loop before initializing lambda loop");
-    ModuleBase::GlobalFunc::OUTP(ofs, "alpha_trial", alpha_trial, "Initial trial step size for lambda in eV/uB^2");
-    ModuleBase::GlobalFunc::OUTP(ofs, "sccut", sccut, "Maximal step size for lambda in eV/uB");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "sc_file",
-                                 sc_file,
-                                 "file name for parameters used in non-collinear spin-constrained DFT (json format)");
+                                 "sccut",
+                                 sccut,
+                                 "Maximal step size for lambda in eV/uB");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "sc_file",
+        sc_file,
+        "file name for parameters used in non-collinear spin-constrained DFT "
+        "(json format)");
 
     ofs << "\n#Parameters (23.Quasiatomic Orbital analysis)" << std::endl;
-    ModuleBase::GlobalFunc::OUTP(ofs, "qo_switch", qo_switch, "0: no QO analysis; 1: QO analysis");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "qo_switch",
+                                 qo_switch,
+                                 "0: no QO analysis; 1: QO analysis");
     ModuleBase::GlobalFunc::OUTP(
         ofs,
         "qo_basis",
         qo_basis,
-        "type of QO basis function: hydrogen: hydrogen-like basis, pswfc: read basis from pseudopotential");
-    ModuleBase::GlobalFunc::OUTP(ofs, "qo_thr", qo_thr, "accuracy for evaluating cutoff radius of QO basis function");
+        "type of QO basis function: hydrogen: hydrogen-like basis, pswfc: read "
+        "basis from pseudopotential");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "qo_thr",
+        qo_thr,
+        "accuracy for evaluating cutoff radius of QO basis function");
 
     ofs << "\n#Parameters (24.PEXSI)" << std::endl;
-    ModuleBase::GlobalFunc::OUTP(ofs, "pexsi_npole", pexsi_npole, "Number of poles in expansion");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "pexsi_npole",
+                                 pexsi_npole,
+                                 "Number of poles in expansion");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "pexsi_inertia",
                                  pexsi_inertia,
-                                 "Whether inertia counting is used at the very beginning of PEXSI process");
+                                 "Whether inertia counting is used at the very "
+                                 "beginning of PEXSI process");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "pexsi_nmax",
                                  pexsi_nmax,
-                                 "Maximum number of PEXSI iterations after each inertia counting procedure.");
-    ModuleBase::GlobalFunc::OUTP(ofs, "pexsi_comm", pexsi_comm, "Whether to construct PSelInv communication pattern");
+                                 "Maximum number of PEXSI iterations after "
+                                 "each inertia counting procedure.");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "pexsi_comm",
+        pexsi_comm,
+        "Whether to construct PSelInv communication pattern");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "pexsi_storage",
                                  pexsi_storage,
-                                 "Storage space used by the Selected Inversion algorithm for symmetric matrices.");
-    ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "pexsi_ordering",
-                                 pexsi_ordering,
-                                 "Ordering strategy for factorization and selected inversion");
+                                 "Storage space used by the Selected Inversion "
+                                 "algorithm for symmetric matrices.");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "pexsi_ordering",
+        pexsi_ordering,
+        "Ordering strategy for factorization and selected inversion");
     ModuleBase::GlobalFunc::OUTP(
         ofs,
         "pexsi_row_ordering",
         pexsi_row_ordering,
-        "Row permutation strategy for factorization and selected inversion, 0: NoRowPerm, 1: LargeDiag");
-    ModuleBase::GlobalFunc::OUTP(ofs, "pexsi_nproc", pexsi_nproc, "Number of processors for parmetis");
-    ModuleBase::GlobalFunc::OUTP(ofs, "pexsi_symm", pexsi_symm, "Matrix symmetry");
-    ModuleBase::GlobalFunc::OUTP(ofs, "pexsi_trans", pexsi_trans, "Whether to transpose");
+        "Row permutation strategy for factorization and selected inversion, 0: "
+        "NoRowPerm, 1: LargeDiag");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "pexsi_nproc",
+                                 pexsi_nproc,
+                                 "Number of processors for parmetis");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "pexsi_symm",
+                                 pexsi_symm,
+                                 "Matrix symmetry");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "pexsi_trans",
+                                 pexsi_trans,
+                                 "Whether to transpose");
     ModuleBase::GlobalFunc::OUTP(ofs,
                                  "pexsi_method",
                                  pexsi_method,
-                                 "pole expansion method, 1: Cauchy Contour Integral, 2: Moussa optimized method");
-    ModuleBase::GlobalFunc::OUTP(ofs, "pexsi_nproc_pole", pexsi_nproc_pole, "Number of processes used by each pole");
-    ModuleBase::GlobalFunc::OUTP(ofs, "pexsi_temp", pexsi_temp, "Temperature, in the same unit as H");
-    ModuleBase::GlobalFunc::OUTP(ofs, "pexsi_gap", pexsi_gap, "Spectral gap");
+                                 "pole expansion method, 1: Cauchy Contour "
+                                 "Integral, 2: Moussa optimized method");
     ModuleBase::GlobalFunc::OUTP(ofs,
-                                 "pexsi_delta_e",
-                                 pexsi_delta_e,
-                                 "An upper bound for the spectral radius of \\f$S^{-1} H\\f$");
-    ModuleBase::GlobalFunc::OUTP(ofs, "pexsi_mu_lower", pexsi_mu_lower, "Initial guess of lower bound for mu");
-    ModuleBase::GlobalFunc::OUTP(ofs, "pexsi_mu_upper", pexsi_mu_upper, "Initial guess of upper bound for mu");
-    ModuleBase::GlobalFunc::OUTP(ofs, "pexsi_mu", pexsi_mu, "Initial guess for mu (for the solver)");
+                                 "pexsi_nproc_pole",
+                                 pexsi_nproc_pole,
+                                 "Number of processes used by each pole");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "pexsi_temp",
+                                 pexsi_temp,
+                                 "Temperature, in the same unit as H");
+    ModuleBase::GlobalFunc::OUTP(ofs, "pexsi_gap", pexsi_gap, "Spectral gap");
+    ModuleBase::GlobalFunc::OUTP(
+        ofs,
+        "pexsi_delta_e",
+        pexsi_delta_e,
+        "An upper bound for the spectral radius of \\f$S^{-1} H\\f$");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "pexsi_mu_lower",
+                                 pexsi_mu_lower,
+                                 "Initial guess of lower bound for mu");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "pexsi_mu_upper",
+                                 pexsi_mu_upper,
+                                 "Initial guess of upper bound for mu");
+    ModuleBase::GlobalFunc::OUTP(ofs,
+                                 "pexsi_mu",
+                                 pexsi_mu,
+                                 "Initial guess for mu (for the solver)");
     ModuleBase::GlobalFunc::OUTP(
         ofs,
         "pexsi_mu_thr",
         pexsi_mu_thr,
-        "Stopping criterion in terms of the chemical potential for the inertia counting procedure");
+        "Stopping criterion in terms of the chemical potential for the inertia "
+        "counting procedure");
     ModuleBase::GlobalFunc::OUTP(
         ofs,
         "pexsi_mu_expand",
         pexsi_mu_expand,
-        "If the chemical potential is not in the initial interval, the interval is expanded by muInertiaExpansion");
+        "If the chemical potential is not in the initial interval, the "
+        "interval is expanded by muInertiaExpansion");
     ModuleBase::GlobalFunc::OUTP(
         ofs,
         "pexsi_mu_guard",
         pexsi_mu_guard,
-        "Safe guard criterion in terms of the chemical potential to reinvoke the inertia counting procedure");
+        "Safe guard criterion in terms of the chemical potential to reinvoke "
+        "the inertia counting procedure");
     ModuleBase::GlobalFunc::OUTP(
         ofs,
         "pexsi_elec_thr",
         pexsi_elec_thr,
-        "Stopping criterion of the PEXSI iteration in terms of the number of electrons compared to numElectronExact");
+        "Stopping criterion of the PEXSI iteration in terms of the number of "
+        "electrons compared to numElectronExact");
     ModuleBase::GlobalFunc::OUTP(
         ofs,
         "pexsi_zero_thr",
         pexsi_zero_thr,
-        "if the absolute value of matrix element is less than ZERO_Limit, it will be considered as 0");
+        "if the absolute value of matrix element is less than ZERO_Limit, it "
+        "will be considered as 0");
 
     ofs.close();
     return;

--- a/source/module_ri/exx_lip.cpp
+++ b/source/module_ri/exx_lip.cpp
@@ -188,7 +188,7 @@ void Exx_Lip::init(const ModuleSymmetry::Symmetry& symm,
 		{
 			q_pack = k_pack;
 		}
-		else if(GlobalV::init_chg=="file")
+		else if(GlobalV::init_chg=="file" || GlobalV::init_chg=="auto")
 		{
             read_q_pack(symm, wfc_basis, sf);
         }

--- a/source/module_ri/exx_lip.cpp
+++ b/source/module_ri/exx_lip.cpp
@@ -17,9 +17,7 @@
 #include <limits>
 
 Exx_Lip::Exx_Lip(const Exx_Info::Exx_Info_Lip& info_in)
-    : init_finish(false), info(info_in), exx_matrix(NULL), exx_energy(0)
-{
-}
+    : init_finish(false), info(info_in), exx_matrix(NULL), exx_energy(0) {}
 
 // void Exx_Lip::cal_exx(const int& nks)
 // {
@@ -38,8 +36,8 @@ Exx_Lip::Exx_Lip(const Exx_Info::Exx_Info_Lip& info_in)
 
 // //timeval t;
 // //gettimeofday(&t, NULL);
-// //double t_phi_cal=0, t_qkg2_exp=0, t_b_cal=0, t_sum3_cal=0, t_b_sum=0, t_sum_all=0;
-// 	wf_wg_cal();
+// //double t_phi_cal=0, t_qkg2_exp=0, t_b_cal=0, t_sum3_cal=0, t_b_sum=0,
+// t_sum_all=0; 	wf_wg_cal();
 // //cout_t("wf_wg_cal",my_time(t));
 // 	psi_cal();
 // //cout_t("psi_cal",my_time(t));
@@ -51,8 +49,9 @@ Exx_Lip::Exx_Lip(const Exx_Info::Exx_Info_Lip& info_in)
 // 		judge_singularity(ik);
 // 		for( int iw_l=0; iw_l<GlobalV::NLOCAL; ++iw_l)
 // 			for( int iw_r=0; iw_r<GlobalV::NLOCAL; ++iw_r)
-// 				sum1[iw_l*GlobalV::NLOCAL+iw_r] = std::complex<double> (0.0,0.0);
-// 		if( Conv_Coulomb_Pot_K::Ccp_Type::Ccp==info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf==info.ccp_type )
+// 				sum1[iw_l*GlobalV::NLOCAL+iw_r] = std::complex<double>
+// (0.0,0.0); 		if( Conv_Coulomb_Pot_K::Ccp_Type::Ccp==info.ccp_type ||
+// Conv_Coulomb_Pot_K::Ccp_Type::Hf==info.ccp_type )
 // 		{
 // 			sum2_factor = 0.0;
 // 			if(gzero_rank_in_pool==GlobalV::RANK_IN_POOL)
@@ -61,18 +60,21 @@ Exx_Lip::Exx_Lip(const Exx_Info::Exx_Info_Lip& info_in)
 // 						sum3[iw_l][iw_r] = std::complex<double>(0.0, 0.0);
 // 		}
 
-// 		for( int iq_tmp=iq_vecik; iq_tmp<iq_vecik+q_pack->kv_ptr->get_nks()/GlobalV::NSPIN; ++iq_tmp)					// !!!
-// k_point parallel incompleted. need to loop iq in other pool
+// 		for( int iq_tmp=iq_vecik;
+// iq_tmp<iq_vecik+q_pack->kv_ptr->get_nks()/GlobalV::NSPIN; ++iq_tmp)					//
+// !!! k_point parallel incompleted. need to loop iq in other pool
 // 		{
-// 			int iq = (ik<(k_pack->kv_ptr->get_nks()/GlobalV::NSPIN)) ? (iq_tmp%(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN))
-// : (iq_tmp%(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN)+(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN));
+// 			int iq = (ik<(k_pack->kv_ptr->get_nks()/GlobalV::NSPIN)) ?
+// (iq_tmp%(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN)) :
+// (iq_tmp%(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN)+(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN));
 // qkg2_exp(ik, iq);
 // //t_qkg2_exp += my_time(t);
 // 			for( int ib=0; ib<GlobalV::NBANDS; ++ib)
 // 			{
 // 				b_cal(ik, iq, ib);
 // //t_b_cal += my_time(t);
-// 				if( Conv_Coulomb_Pot_K::Ccp_Type::Ccp==info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf==info.ccp_type
+// 				if( Conv_Coulomb_Pot_K::Ccp_Type::Ccp==info.ccp_type ||
+// Conv_Coulomb_Pot_K::Ccp_Type::Hf==info.ccp_type
 // ) 					if(iq==iq_vecik) 						sum3_cal(iq,ib);
 // //t_sum3_cal += my_time(t);
 // 				b_sum(iq, ib);
@@ -122,7 +124,8 @@ void Exx_Lip::cal_exx()
         for( int iw_l=0; iw_l<GlobalV::NLOCAL; ++iw_l)
             for( int iw_r=0; iw_r<GlobalV::NLOCAL; ++iw_r)
                 sum1[iw_l*GlobalV::NLOCAL+iw_r] = std::complex<double>(0.0,0.0);
-        if( Exx_Info::Hybrid_Type::HF==info.hybrid_type || Exx_Info::Hybrid_Type::PBE0==info.hybrid_type ||
+        if( Exx_Info::Hybrid_Type::HF==info.hybrid_type ||
+Exx_Info::Hybrid_Type::PBE0==info.hybrid_type ||
 Exx_Info::Hybrid_Type::SCAN0==info.hybrid_type )
         {
             sum2_factor = 0.0;
@@ -132,17 +135,20 @@ Exx_Info::Hybrid_Type::SCAN0==info.hybrid_type )
                         sum3[iw_l][iw_r] = std::complex<double>(0.0,0.0);
         }
 
-        for( int iq_tmp=iq_vecik; iq_tmp<iq_vecik+q_pack->kv_ptr->get_nks()/GlobalV::NSPIN; ++iq_tmp)
+        for( int iq_tmp=iq_vecik;
+iq_tmp<iq_vecik+q_pack->kv_ptr->get_nks()/GlobalV::NSPIN; ++iq_tmp)
 // !!! k_point parallel incompleted. need to loop iq in other pool
         {
             int iq = (ik<(k_pack->kv_ptr->get_nks()/GlobalV::NSPIN)) ?
 (iq_tmp%(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN)) :
-(iq_tmp%(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN)+(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN)); qkg2_exp(ik, iq); for(
-int ib=0; ib<GlobalV::NBANDS; ++ib)
+(iq_tmp%(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN)+(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN));
+qkg2_exp(ik, iq); for( int ib=0; ib<GlobalV::NBANDS; ++ib)
             {
                 b_cal(ik, iq, ib);
-                if( Exx_Info::Hybrid_Type::HF==info.hybrid_type || Exx_Info::Hybrid_Type::PBE0==info.hybrid_type ||
-Exx_Info::Hybrid_Type::SCAN0==info.hybrid_type ) if(iq==iq_vecik) sum3_cal(iq,ib); b_sum(iq, ib);
+                if( Exx_Info::Hybrid_Type::HF==info.hybrid_type ||
+Exx_Info::Hybrid_Type::PBE0==info.hybrid_type ||
+Exx_Info::Hybrid_Type::SCAN0==info.hybrid_type ) if(iq==iq_vecik)
+sum3_cal(iq,ib); b_sum(iq, ib);
             }
         }
         sum_all(ik);
@@ -158,11 +164,9 @@ void Exx_Lip::init(const ModuleSymmetry::Symmetry& symm,
                    const ModulePW::PW_Basis* rho_basis_in,
                    const Structure_Factor& sf,
                    const UnitCell* ucell_ptr_in,
-                   const elecstate::ElecState* pelec_in)
-{
+                   const elecstate::ElecState* pelec_in) {
     ModuleBase::TITLE("Exx_Lip", "init");
-    try
-    {
+    try {
         k_pack = new k_package;
         k_pack->kv_ptr = kv_ptr_in;
         k_pack->wf_ptr = wf_ptr_in;
@@ -172,42 +176,40 @@ void Exx_Lip::init(const ModuleSymmetry::Symmetry& symm,
         ucell_ptr = ucell_ptr_in;
 
         int gzero_judge(-1);
-        if (rho_basis->gg_uniq[0] < 1e-8)
-        {
+        if (rho_basis->gg_uniq[0] < 1e-8) {
             gzero_judge = GlobalV::RANK_IN_POOL;
         }
 #ifdef __MPI
-        MPI_Allreduce(&gzero_judge, &gzero_rank_in_pool, 1, MPI_INT, MPI_MAX, POOL_WORLD);
+        MPI_Allreduce(&gzero_judge,
+                      &gzero_rank_in_pool,
+                      1,
+                      MPI_INT,
+                      MPI_MAX,
+                      POOL_WORLD);
 #endif
         k_pack->wf_wg.create(k_pack->kv_ptr->get_nks(), GlobalV::NBANDS);
 
-        k_pack->hvec_array = new ModuleBase::ComplexMatrix[k_pack->kv_ptr->get_nks()];
-        for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik)
-        {
+        k_pack->hvec_array
+            = new ModuleBase::ComplexMatrix[k_pack->kv_ptr->get_nks()];
+        for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik) {
             k_pack->hvec_array[ik].create(GlobalV::NLOCAL, GlobalV::NBANDS);
         }
 
-        if (GlobalV::init_chg == "atomic")
-        {
+        if (GlobalV::init_chg == "atomic") {
             q_pack = k_pack;
-        }
-        else if (GlobalV::init_chg == "file" || GlobalV::init_chg == "auto")
-        {
+        } else if (GlobalV::init_chg == "file" || GlobalV::init_chg == "auto") {
             read_q_pack(symm, wfc_basis, sf);
         }
 
         phi = new std::complex<double>*[GlobalV::NLOCAL];
-        for (int iw = 0; iw < GlobalV::NLOCAL; ++iw)
-        {
+        for (int iw = 0; iw < GlobalV::NLOCAL; ++iw) {
             phi[iw] = new std::complex<double>[rho_basis->nrxx];
         }
 
         psi = new std::complex<double>**[q_pack->kv_ptr->get_nks()];
-        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-        {
+        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq) {
             psi[iq] = new std::complex<double>*[GlobalV::NBANDS];
-            for (int ib = 0; ib < GlobalV::NBANDS; ++ib)
-            {
+            for (int ib = 0; ib < GlobalV::NBANDS; ++ib) {
                 psi[iq][ib] = new std::complex<double>[rho_basis->nrxx];
             }
         }
@@ -218,62 +220,50 @@ void Exx_Lip::init(const ModuleSymmetry::Symmetry& symm,
 
         sum1 = new std::complex<double>[GlobalV::NLOCAL * GlobalV::NLOCAL];
 
-        if (Conv_Coulomb_Pot_K::Ccp_Type::Ccp == info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf == info.ccp_type)
-            if (gzero_rank_in_pool == GlobalV::RANK_IN_POOL)
-            {
+        if (Conv_Coulomb_Pot_K::Ccp_Type::Ccp == info.ccp_type
+            || Conv_Coulomb_Pot_K::Ccp_Type::Hf == info.ccp_type)
+            if (gzero_rank_in_pool == GlobalV::RANK_IN_POOL) {
                 b0 = new std::complex<double>[GlobalV::NLOCAL];
                 sum3 = new std::complex<double>*[GlobalV::NLOCAL];
-                for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l)
-                {
+                for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l) {
                     sum3[iw_l] = new std::complex<double>[GlobalV::NLOCAL];
                 }
-            }
-            else
-            {
+            } else {
                 b0 = NULL;
                 sum3 = NULL;
             }
-        else
-        {
+        else {
             b0 = NULL;
             sum3 = NULL;
         }
 
         exx_matrix = new std::complex<double>**[k_pack->kv_ptr->get_nks()];
-        for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik)
-        {
+        for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik) {
             exx_matrix[ik] = new std::complex<double>*[GlobalV::NLOCAL];
-            for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l)
-            {
-                exx_matrix[ik][iw_l] = new std::complex<double>[GlobalV::NLOCAL];
+            for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l) {
+                exx_matrix[ik][iw_l]
+                    = new std::complex<double>[GlobalV::NLOCAL];
             }
         }
-    }
-    catch (const std::bad_alloc& ex)
-    {
+    } catch (const std::bad_alloc& ex) {
         ModuleBase::WARNING_QUIT("exact_exchange", "Memory");
     }
 
     init_finish = true;
 }
 
-Exx_Lip::~Exx_Lip()
-{
+Exx_Lip::~Exx_Lip() {
     // ModuleBase::TITLE("Exx_Lip","~Exx_Lip");
-    if (init_finish)
-    {
-        for (int iw = 0; iw < GlobalV::NLOCAL; ++iw)
-        {
+    if (init_finish) {
+        for (int iw = 0; iw < GlobalV::NLOCAL; ++iw) {
             delete[] phi[iw];
             phi[iw] = NULL;
         }
         delete[] phi;
         phi = NULL;
 
-        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-        {
-            for (int ib = 0; ib < GlobalV::NBANDS; ++ib)
-            {
+        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq) {
+            for (int ib = 0; ib < GlobalV::NBANDS; ++ib) {
                 delete[] psi[iq][ib];
                 psi[iq][ib] = NULL;
             }
@@ -292,13 +282,12 @@ Exx_Lip::~Exx_Lip()
         delete[] sum1;
         sum1 = NULL;
 
-        if (Conv_Coulomb_Pot_K::Ccp_Type::Ccp == info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf == info.ccp_type)
-            if (gzero_rank_in_pool == GlobalV::RANK_IN_POOL)
-            {
+        if (Conv_Coulomb_Pot_K::Ccp_Type::Ccp == info.ccp_type
+            || Conv_Coulomb_Pot_K::Ccp_Type::Hf == info.ccp_type)
+            if (gzero_rank_in_pool == GlobalV::RANK_IN_POOL) {
                 delete[] b0;
                 b0 = NULL;
-                for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l)
-                {
+                for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l) {
                     delete[] sum3[iw_l];
                     sum3[iw_l] = NULL;
                 }
@@ -306,10 +295,8 @@ Exx_Lip::~Exx_Lip()
                 sum3 = NULL;
             }
 
-        for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik)
-        {
-            for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l)
-            {
+        for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik) {
+            for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l) {
                 delete[] exx_matrix[ik][iw_l];
                 exx_matrix[ik][iw_l] = NULL;
             }
@@ -323,12 +310,9 @@ Exx_Lip::~Exx_Lip()
         k_pack->hvec_array = NULL;
         delete k_pack;
 
-        if (GlobalV::init_chg == "atomic")
-        {
+        if (GlobalV::init_chg == "atomic") {
             q_pack = NULL;
-        }
-        else if (GlobalV::init_chg == "file")
-        {
+        } else if (GlobalV::init_chg == "file") {
             delete q_pack->kv_ptr;
             q_pack->kv_ptr = NULL;
             delete q_pack->wf_ptr;
@@ -341,8 +325,7 @@ Exx_Lip::~Exx_Lip()
     }
 }
 
-void Exx_Lip::wf_wg_cal()
-{
+void Exx_Lip::wf_wg_cal() {
     ModuleBase::TITLE("Exx_Lip", "wf_wg_cal");
     if (GlobalV::NSPIN == 1)
         for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik)
@@ -354,23 +337,26 @@ void Exx_Lip::wf_wg_cal()
                 k_pack->wf_wg(ik, ib) = k_pack->pelec->wg(ik, ib);
 }
 
-void Exx_Lip::phi_cal(k_package* kq_pack, int ikq)
-{
+void Exx_Lip::phi_cal(k_package* kq_pack, int ikq) {
     std::complex<double>* porter = new std::complex<double>[wfc_basis->nrxx];
-    for (int iw = 0; iw < GlobalV::NLOCAL; ++iw)
-    {
+    for (int iw = 0; iw < GlobalV::NLOCAL; ++iw) {
         wfc_basis->recip2real(&kq_pack->wf_ptr->wanf2[ikq](iw, 0), porter, ikq);
         int ir(0);
-        for (int ix = 0; ix < rho_basis->nx; ++ix)
-        {
-            const double phase_x = kq_pack->kv_ptr->kvec_d[ikq].x * ix / rho_basis->nx;
-            for (int iy = 0; iy < rho_basis->ny; ++iy)
-            {
-                const double phase_xy = phase_x + kq_pack->kv_ptr->kvec_d[ikq].y * iy / rho_basis->ny;
-                for (int iz = rho_basis->startz_current; iz < rho_basis->startz_current + rho_basis->nplane; ++iz)
-                {
-                    const double phase_xyz = phase_xy + kq_pack->kv_ptr->kvec_d[ikq].z * iz / rho_basis->nz;
-                    const std::complex<double> exp_tmp = exp(phase_xyz * ModuleBase::TWO_PI * ModuleBase::IMAG_UNIT);
+        for (int ix = 0; ix < rho_basis->nx; ++ix) {
+            const double phase_x
+                = kq_pack->kv_ptr->kvec_d[ikq].x * ix / rho_basis->nx;
+            for (int iy = 0; iy < rho_basis->ny; ++iy) {
+                const double phase_xy
+                    = phase_x
+                      + kq_pack->kv_ptr->kvec_d[ikq].y * iy / rho_basis->ny;
+                for (int iz = rho_basis->startz_current;
+                     iz < rho_basis->startz_current + rho_basis->nplane;
+                     ++iz) {
+                    const double phase_xyz
+                        = phase_xy
+                          + kq_pack->kv_ptr->kvec_d[ikq].z * iz / rho_basis->nz;
+                    const std::complex<double> exp_tmp = exp(
+                        phase_xyz * ModuleBase::TWO_PI * ModuleBase::IMAG_UNIT);
                     phi[iw][ir] = porter[ir] * exp_tmp;
                     ++ir;
                 }
@@ -385,26 +371,28 @@ void Exx_Lip::phi_cal(k_package* kq_pack, int ikq)
 // 	ModuleBase::TITLE("Exx_Lip","psi_cal");
 // 	if (GlobalV::init_chg=="atomic")
 // 	{
-// 		std::complex<double> *porter = new std::complex<double> [wfc_basis->nrxx];
-// 		for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
+// 		std::complex<double> *porter = new std::complex<double>
+// [wfc_basis->nrxx]; 		for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
 // 		{
 // 			for( int ib = 0; ib < GlobalV::NBANDS; ++ib)
 // 			{
-//                 wfc_basis->recip2real(&(q_pack->wf_ptr->psi->operator()(iq, ib, 0)), porter, iq);
+//                 wfc_basis->recip2real(&(q_pack->wf_ptr->psi->operator()(iq,
+//                 ib, 0)), porter, iq);
 
 //                 int ir(0);
 // 				for( int ix=0; ix<rho_basis->nx; ++ix)
 // 				{
-// 					const double phase_x = q_pack->kv_ptr->kvec_d[iq].x * ix / rho_basis->nx;
-// 					for( int iy=0; iy<rho_basis->ny; ++iy)
+// 					const double phase_x = q_pack->kv_ptr->kvec_d[iq].x * ix /
+// rho_basis->nx; 					for( int iy=0; iy<rho_basis->ny; ++iy)
 // 					{
-// 						const double phase_xy = phase_x + q_pack->kv_ptr->kvec_d[iq].y * iy / rho_basis->ny;
-// 						for( int iz=rho_basis->startz_current; iz<rho_basis->startz_current+rho_basis->nplane; ++iz)
+// 						const double phase_xy = phase_x + q_pack->kv_ptr->kvec_d[iq].y * iy /
+// rho_basis->ny; 						for( int iz=rho_basis->startz_current;
+// iz<rho_basis->startz_current+rho_basis->nplane; ++iz)
 // 						{
-// 							const double phase_xyz = phase_xy + q_pack->kv_ptr->kvec_d[iq].z * iz / rho_basis->nz;
-// 							const std::complex<double> exp_tmp =
-// exp(phase_xyz*ModuleBase::TWO_PI*ModuleBase::IMAG_UNIT); 							psi[iq][ib][ir] =
-// porter[ir]*exp_tmp;
+// 							const double phase_xyz = phase_xy + q_pack->kv_ptr->kvec_d[iq].z * iz
+// / rho_basis->nz; 							const std::complex<double> exp_tmp =
+// exp(phase_xyz*ModuleBase::TWO_PI*ModuleBase::IMAG_UNIT);
+// psi[iq][ib][ir] = porter[ir]*exp_tmp;
 // 							++ir;
 // 						}
 // 					}
@@ -425,7 +413,8 @@ void Exx_Lip::phi_cal(k_package* kq_pack, int ikq)
 // 				{
 // 					for( int ir=0; ir<rho_basis->nrxx; ++ir)
 // 					{
-// 						psi[iq][ib][ir] += q_pack->hvec_array[iq](iw,ib) * phi[iw][ir];
+// 						psi[iq][ib][ir] += q_pack->hvec_array[iq](iw,ib) *
+// phi[iw][ir];
 // 					}
 // 				}
 // 			}
@@ -436,20 +425,16 @@ void Exx_Lip::phi_cal(k_package* kq_pack, int ikq)
 // ///////////////////////////////////////////////////////////////////////////
 // }
 
-void Exx_Lip::judge_singularity(int ik)
-{
-    if (GlobalV::init_chg == "atomic")
-    {
+void Exx_Lip::judge_singularity(int ik) {
+    if (GlobalV::init_chg == "atomic") {
         iq_vecik = ik;
-    }
-    else if (GlobalV::init_chg == "file")
-    {
+    } else if (GlobalV::init_chg == "file") {
         double min_q_minus_k(std::numeric_limits<double>::max());
-        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-        {
-            const double q_minus_k((q_pack->kv_ptr->kvec_c[iq] - k_pack->kv_ptr->kvec_c[ik]).norm2());
-            if (q_minus_k < min_q_minus_k)
-            {
+        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq) {
+            const double q_minus_k(
+                (q_pack->kv_ptr->kvec_c[iq] - k_pack->kv_ptr->kvec_c[ik])
+                    .norm2());
+            if (q_minus_k < min_q_minus_k) {
                 min_q_minus_k = q_minus_k;
                 iq_vecik = iq;
             }
@@ -457,67 +442,70 @@ void Exx_Lip::judge_singularity(int ik)
     }
 }
 
-void Exx_Lip::qkg2_exp(int ik, int iq)
-{
-    for (int ig = 0; ig < rho_basis->npw; ++ig)
-    {
-        const double qkg2 = ((q_pack->kv_ptr->kvec_c[iq] - k_pack->kv_ptr->kvec_c[ik] + rho_basis->gcar[ig])
-                             * (ModuleBase::TWO_PI / ucell_ptr->lat0))
-                                .norm2();
-        if (Conv_Coulomb_Pot_K::Ccp_Type::Ccp == info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf == info.ccp_type)
-        {
+void Exx_Lip::qkg2_exp(int ik, int iq) {
+    for (int ig = 0; ig < rho_basis->npw; ++ig) {
+        const double qkg2
+            = ((q_pack->kv_ptr->kvec_c[iq] - k_pack->kv_ptr->kvec_c[ik]
+                + rho_basis->gcar[ig])
+               * (ModuleBase::TWO_PI / ucell_ptr->lat0))
+                  .norm2();
+        if (Conv_Coulomb_Pot_K::Ccp_Type::Ccp == info.ccp_type
+            || Conv_Coulomb_Pot_K::Ccp_Type::Hf == info.ccp_type) {
             if (std::abs(qkg2) < 1e-10)
                 recip_qkg2[ig] = 0.0; // 0 to ignore bb/qkg2 when qkg2==0
             else
                 recip_qkg2[ig] = 1.0 / qkg2;
             sum2_factor += recip_qkg2[ig] * exp(-info.lambda * qkg2);
             recip_qkg2[ig] = sqrt(recip_qkg2[ig]);
-        }
-        else if (Conv_Coulomb_Pot_K::Ccp_Type::Hse == info.ccp_type)
-        {
+        } else if (Conv_Coulomb_Pot_K::Ccp_Type::Hse == info.ccp_type) {
             if (std::abs(qkg2) < 1e-10)
                 recip_qkg2[ig] = 1.0 / (2 * info.hse_omega);
             else
-                recip_qkg2[ig] = sqrt((1 - exp(-qkg2 / (4 * info.hse_omega * info.hse_omega))) / qkg2);
+                recip_qkg2[ig] = sqrt(
+                    (1 - exp(-qkg2 / (4 * info.hse_omega * info.hse_omega)))
+                    / qkg2);
         }
     }
 }
 
-void Exx_Lip::b_cal(int ik, int iq, int ib)
-{
-    const ModuleBase::Vector3<double> q_minus_k = q_pack->kv_ptr->kvec_d[iq] - k_pack->kv_ptr->kvec_d[ik];
+void Exx_Lip::b_cal(int ik, int iq, int ib) {
+    const ModuleBase::Vector3<double> q_minus_k
+        = q_pack->kv_ptr->kvec_d[iq] - k_pack->kv_ptr->kvec_d[ik];
     std::vector<std::complex<double>> mul_tmp(rho_basis->nrxx);
-    for (size_t ir = 0, ix = 0; ix < rho_basis->nx; ++ix)
-    {
+    for (size_t ir = 0, ix = 0; ix < rho_basis->nx; ++ix) {
         const double phase_x = q_minus_k.x * ix / rho_basis->nx;
-        for (size_t iy = 0; iy < rho_basis->ny; ++iy)
-        {
+        for (size_t iy = 0; iy < rho_basis->ny; ++iy) {
             const double phase_xy = phase_x + q_minus_k.y * iy / rho_basis->ny;
-            for (size_t iz = rho_basis->startz_current; iz < rho_basis->startz_current + rho_basis->nplane; ++iz)
-            {
-                const double phase_xyz = phase_xy + q_minus_k.z * iz / rho_basis->nz;
-                mul_tmp[ir] = exp(-phase_xyz * ModuleBase::TWO_PI * ModuleBase::IMAG_UNIT);
+            for (size_t iz = rho_basis->startz_current;
+                 iz < rho_basis->startz_current + rho_basis->nplane;
+                 ++iz) {
+                const double phase_xyz
+                    = phase_xy + q_minus_k.z * iz / rho_basis->nz;
+                mul_tmp[ir] = exp(-phase_xyz * ModuleBase::TWO_PI
+                                  * ModuleBase::IMAG_UNIT);
                 mul_tmp[ir] *= psi[iq][ib][ir];
                 ++ir;
             }
         }
     }
 
-    std::complex<double>* const porter = new std::complex<double>[rho_basis->nrxx];
+    std::complex<double>* const porter
+        = new std::complex<double>[rho_basis->nrxx];
 
-    for (size_t iw = 0; iw < GlobalV::NLOCAL; ++iw)
-    {
+    for (size_t iw = 0; iw < GlobalV::NLOCAL; ++iw) {
         const std::complex<double>* const phi_w = phi[iw];
-        for (size_t ir = 0; ir < rho_basis->nrxx; ++ir)
-        {
+        for (size_t ir = 0; ir < rho_basis->nrxx; ++ir) {
             porter[ir] = conj(phi_w[ir]) * mul_tmp[ir];
             //			porter[ir] = phi_w[ir] * psi_q_b[ir] *exp_tmp[ir] ;
         }
         std::complex<double>* const b_w = b + iw * rho_basis->npw;
         rho_basis->real2recip(porter, b_w);
-        if (Conv_Coulomb_Pot_K::Ccp_Type::Ccp == info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf == info.ccp_type)
+        if (Conv_Coulomb_Pot_K::Ccp_Type::Ccp == info.ccp_type
+            || Conv_Coulomb_Pot_K::Ccp_Type::Hf == info.ccp_type)
             if ((iq == iq_vecik)
-                && (gzero_rank_in_pool == GlobalV::RANK_IN_POOL)) /// need to check while use k_point parallel
+                && (gzero_rank_in_pool
+                    == GlobalV::RANK_IN_POOL)) /// need to check while use
+                                               /// k_point parallel
                 b0[iw] = b_w[rho_basis->ig_gge0];
 
         for (size_t ig = 0; ig < rho_basis->npw; ++ig)
@@ -526,17 +514,18 @@ void Exx_Lip::b_cal(int ik, int iq, int ib)
     delete[] porter;
 }
 
-void Exx_Lip::sum3_cal(int iq, int ib)
-{
+void Exx_Lip::sum3_cal(int iq, int ib) {
     if (gzero_rank_in_pool == GlobalV::RANK_IN_POOL)
         for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l)
             for (int iw_r = 0; iw_r < GlobalV::NLOCAL; ++iw_r)
-                sum3[iw_l][iw_r] += b0[iw_l] * conj(b0[iw_r]) * q_pack->wf_wg(iq, ib);
+                sum3[iw_l][iw_r]
+                    += b0[iw_l] * conj(b0[iw_r]) * q_pack->wf_wg(iq, ib);
 }
 
 void Exx_Lip::b_sum(int iq, int ib) // Peize Lin change 2019-04-14
 {
-    // sum1[iw_l,iw_r] += \sum_{ig} b[iw_l,ig] * conj(b[iw_r,ig]) * q_pack->wf_wg(iq,ib)
+    // sum1[iw_l,iw_r] += \sum_{ig} b[iw_l,ig] * conj(b[iw_r,ig]) *
+    // q_pack->wf_wg(iq,ib)
     LapackConnector::zherk('U',
                            'N',
                            GlobalV::NLOCAL,
@@ -553,52 +542,59 @@ void Exx_Lip::b_sum(int iq, int ib) // Peize Lin change 2019-04-14
     //				1.0, static_cast<void*>(sum1), GlobalV::NLOCAL);
 }
 
-void Exx_Lip::sum_all(int ik)
-{
+void Exx_Lip::sum_all(int ik) {
     double sum2_factor_g(0.0);
 #ifdef __MPI
-    if (Conv_Coulomb_Pot_K::Ccp_Type::Ccp == info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf == info.ccp_type)
-        MPI_Reduce(&sum2_factor, &sum2_factor_g, 1, MPI_DOUBLE, MPI_SUM, gzero_rank_in_pool, POOL_WORLD);
+    if (Conv_Coulomb_Pot_K::Ccp_Type::Ccp == info.ccp_type
+        || Conv_Coulomb_Pot_K::Ccp_Type::Hf == info.ccp_type)
+        MPI_Reduce(&sum2_factor,
+                   &sum2_factor_g,
+                   1,
+                   MPI_DOUBLE,
+                   MPI_SUM,
+                   gzero_rank_in_pool,
+                   POOL_WORLD);
 #endif
     for (size_t iw_l = 1; iw_l < GlobalV::NLOCAL; ++iw_l)
         for (size_t iw_r = 0; iw_r < iw_l; ++iw_r)
             sum1[iw_l * GlobalV::NLOCAL + iw_r]
-                = conj(sum1[iw_r * GlobalV::NLOCAL + iw_l]); // Peize Lin add conj 2019-04-14
+                = conj(sum1[iw_r * GlobalV::NLOCAL
+                            + iw_l]); // Peize Lin add conj 2019-04-14
 
-    for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l)
-    {
-        for (int iw_r = 0; iw_r < GlobalV::NLOCAL; ++iw_r)
-        {
+    for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l) {
+        for (int iw_r = 0; iw_r < GlobalV::NLOCAL; ++iw_r) {
             exx_matrix[ik][iw_l][iw_r]
-                = 2.0 * (-4 * ModuleBase::PI / ucell_ptr->omega * sum1[iw_l * GlobalV::NLOCAL + iw_r]);
-            if (Conv_Coulomb_Pot_K::Ccp_Type::Ccp == info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf == info.ccp_type)
-                if (gzero_rank_in_pool == GlobalV::RANK_IN_POOL)
-                {
+                = 2.0
+                  * (-4 * ModuleBase::PI / ucell_ptr->omega
+                     * sum1[iw_l * GlobalV::NLOCAL + iw_r]);
+            if (Conv_Coulomb_Pot_K::Ccp_Type::Ccp == info.ccp_type
+                || Conv_Coulomb_Pot_K::Ccp_Type::Hf == info.ccp_type)
+                if (gzero_rank_in_pool == GlobalV::RANK_IN_POOL) {
                     exx_matrix[ik][iw_l][iw_r]
-                        += 2.0 * (4 * ModuleBase::PI / ucell_ptr->omega * sum3[iw_l][iw_r] * sum2_factor_g);
-                    exx_matrix[ik][iw_l][iw_r] += 2.0
-                                                  * (-1 / sqrt(info.lambda * ModuleBase::PI)
-                                                     * (q_pack->kv_ptr->get_nks() / GlobalV::NSPIN) * sum3[iw_l][iw_r]);
+                        += 2.0
+                           * (4 * ModuleBase::PI / ucell_ptr->omega
+                              * sum3[iw_l][iw_r] * sum2_factor_g);
+                    exx_matrix[ik][iw_l][iw_r]
+                        += 2.0
+                           * (-1 / sqrt(info.lambda * ModuleBase::PI)
+                              * (q_pack->kv_ptr->get_nks() / GlobalV::NSPIN)
+                              * sum3[iw_l][iw_r]);
                 }
         }
     }
 }
 
-void Exx_Lip::exx_energy_cal()
-{
+void Exx_Lip::exx_energy_cal() {
     ModuleBase::TITLE("Exx_Lip", "exx_energy_cal");
 
     double exx_energy_tmp = 0.0;
 
-    for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik)
-    {
-        for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l)
-        {
-            for (int iw_r = 0; iw_r < GlobalV::NLOCAL; ++iw_r)
-            {
-                for (int ib = 0; ib < GlobalV::NBANDS; ++ib)
-                {
-                    exx_energy_tmp += (exx_matrix[ik][iw_l][iw_r] * conj(k_pack->hvec_array[ik](iw_l, ib))
+    for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik) {
+        for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l) {
+            for (int iw_r = 0; iw_r < GlobalV::NLOCAL; ++iw_r) {
+                for (int ib = 0; ib < GlobalV::NBANDS; ++ib) {
+                    exx_energy_tmp += (exx_matrix[ik][iw_l][iw_r]
+                                       * conj(k_pack->hvec_array[ik](iw_l, ib))
                                        * k_pack->hvec_array[ik](iw_r, ib))
                                           .real()
                                       * k_pack->wf_wg(ik, ib);
@@ -613,7 +609,8 @@ void Exx_Lip::exx_energy_cal()
         1,
         MPI_DOUBLE,
         MPI_SUM,
-        MPI_COMM_WORLD); // !!! k_point parallel incompleted. different pools have different kv.set_nks(>) deadlock
+        MPI_COMM_WORLD); // !!! k_point parallel incompleted. different pools
+                         // have different kv.set_nks(>) deadlock
 #endif
     exx_energy *= (GlobalV::NSPIN == 1) ? 2 : 1;
     exx_energy /= 2; // ETOT = E_band - 1/2 E_exx
@@ -623,13 +620,10 @@ void Exx_Lip::exx_energy_cal()
         std::ofstream ofs("exx_matrix.dat", std::ofstream::app);
         static int istep = 0;
         ofs << "istep:\t" << istep++ << std::endl;
-        for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik)
-        {
+        for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik) {
             ofs << "ik:\t" << ik << std::endl;
-            for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l)
-            {
-                for (int iw_r = 0; iw_r < GlobalV::NLOCAL; ++iw_r)
-                {
+            for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l) {
+                for (int iw_r = 0; iw_r < GlobalV::NLOCAL; ++iw_r) {
                     ofs << exx_matrix[ik][iw_l][iw_r] << "\t";
                 }
                 ofs << std::endl;
@@ -642,16 +636,14 @@ void Exx_Lip::exx_energy_cal()
         std::ofstream ofs("DM.dat", std::ofstream::app);
         static int istep = 0;
         ofs << "istep:\t" << istep++ << std::endl;
-        for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik)
-        {
+        for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik) {
             ofs << "ik:\t" << ik << std::endl;
-            for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l)
-            {
-                for (int iw_r = 0; iw_r < GlobalV::NLOCAL; ++iw_r)
-                {
+            for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l) {
+                for (int iw_r = 0; iw_r < GlobalV::NLOCAL; ++iw_r) {
                     std::complex<double> DM = {0, 0};
                     for (int ib = 0; ib < GlobalV::NBANDS; ++ib)
-                        DM += conj(k_pack->hvec_array[ik](iw_l, ib)) * k_pack->hvec_array[ik](iw_r, ib)
+                        DM += conj(k_pack->hvec_array[ik](iw_l, ib))
+                              * k_pack->hvec_array[ik](iw_r, ib)
                               * k_pack->wf_wg(ik, ib);
                     ofs << DM << "\t";
                 }
@@ -668,33 +660,33 @@ void Exx_Lip::exx_energy_cal()
     return;
 }
 
-void Exx_Lip::write_q_pack() const
-{
+void Exx_Lip::write_q_pack() const {
     if (GlobalV::out_chg == 0)
         return;
 
-    if (!GlobalV::RANK_IN_POOL)
-    {
+    if (!GlobalV::RANK_IN_POOL) {
         const std::string exx_q_pack = "exx_q_pack/";
         int return_value = 0;
         const std::string command_mkdir
-            = "test -d " + GlobalV::global_out_dir + exx_q_pack + " || mkdir " + GlobalV::global_out_dir + exx_q_pack;
+            = "test -d " + GlobalV::global_out_dir + exx_q_pack + " || mkdir "
+              + GlobalV::global_out_dir + exx_q_pack;
         return_value = system(command_mkdir.c_str());
         assert(return_value == 0);
 
-        const std::string command_kpoint = "test -f " + GlobalV::global_out_dir + exx_q_pack
-                                           + GlobalV::global_kpoint_card + " || cp " + GlobalV::global_kpoint_card + " "
-                                           + GlobalV::global_out_dir + exx_q_pack + GlobalV::global_kpoint_card;
+        const std::string command_kpoint
+            = "test -f " + GlobalV::global_out_dir + exx_q_pack
+              + GlobalV::global_kpoint_card + " || cp "
+              + GlobalV::global_kpoint_card + " " + GlobalV::global_out_dir
+              + exx_q_pack + GlobalV::global_kpoint_card;
         return_value = system(command_kpoint.c_str());
         assert(return_value == 0);
 
         std::stringstream ss_wf_wg;
-        ss_wf_wg << GlobalV::global_out_dir << exx_q_pack << "wf_wg_" << GlobalV::MY_POOL;
+        ss_wf_wg << GlobalV::global_out_dir << exx_q_pack << "wf_wg_"
+                 << GlobalV::MY_POOL;
         std::ofstream ofs_wf_wg(ss_wf_wg.str().c_str());
-        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-        {
-            for (int ib = 0; ib < GlobalV::NBANDS; ++ib)
-            {
+        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq) {
+            for (int ib = 0; ib < GlobalV::NBANDS; ++ib) {
                 ofs_wf_wg << q_pack->wf_wg(iq, ib) << "\t";
             }
             ofs_wf_wg << std::endl;
@@ -702,16 +694,14 @@ void Exx_Lip::write_q_pack() const
         ofs_wf_wg.close();
 
         std::stringstream ss_hvec;
-        ss_hvec << GlobalV::global_out_dir << exx_q_pack << "hvec_" << GlobalV::MY_POOL;
+        ss_hvec << GlobalV::global_out_dir << exx_q_pack << "hvec_"
+                << GlobalV::MY_POOL;
         std::ofstream ofs_hvec(ss_hvec.str().c_str());
-        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-        {
-            for (int iw = 0; iw < GlobalV::NLOCAL; ++iw)
-            {
-                for (int ib = 0; ib < GlobalV::NBANDS; ++ib)
-                {
-                    ofs_hvec << q_pack->hvec_array[iq](iw, ib).real() << " " << q_pack->hvec_array[iq](iw, ib).imag()
-                             << " ";
+        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq) {
+            for (int iw = 0; iw < GlobalV::NLOCAL; ++iw) {
+                for (int ib = 0; ib < GlobalV::NBANDS; ++ib) {
+                    ofs_hvec << q_pack->hvec_array[iq](iw, ib).real() << " "
+                             << q_pack->hvec_array[iq](iw, ib).imag() << " ";
                 }
                 ofs_hvec << std::endl;
             }
@@ -723,15 +713,20 @@ void Exx_Lip::write_q_pack() const
 
 void Exx_Lip::read_q_pack(const ModuleSymmetry::Symmetry& symm,
                           const ModulePW::PW_Basis_K* wfc_basis,
-                          const Structure_Factor& sf)
-{
+                          const Structure_Factor& sf) {
     const std::string exx_q_pack = "exx_q_pack/";
 
     q_pack = new k_package();
 
     q_pack->kv_ptr = new K_Vectors();
-    const std::string exx_kpoint_card = GlobalV::global_out_dir + exx_q_pack + GlobalV::global_kpoint_card;
-    q_pack->kv_ptr->set(symm, exx_kpoint_card, GlobalV::NSPIN, ucell_ptr->G, ucell_ptr->latvec, GlobalV::ofs_running);
+    const std::string exx_kpoint_card
+        = GlobalV::global_out_dir + exx_q_pack + GlobalV::global_kpoint_card;
+    q_pack->kv_ptr->set(symm,
+                        exx_kpoint_card,
+                        GlobalV::NSPIN,
+                        ucell_ptr->G,
+                        ucell_ptr->latvec,
+                        GlobalV::ofs_running);
 
     q_pack->wf_ptr = new wavefunc();
     q_pack->wf_ptr->allocate(q_pack->kv_ptr->get_nkstot(),
@@ -739,59 +734,61 @@ void Exx_Lip::read_q_pack(const ModuleSymmetry::Symmetry& symm,
                              q_pack->kv_ptr->ngk.data(),
                              wfc_basis->npwk_max); // mohan update 2021-02-25
     //	q_pack->wf_ptr->init(q_pack->kv_ptr->get_nks(),q_pack->kv_ptr,ucell_ptr,old_pwptr,&ppcell,&GlobalC::ORB,&hm,&Pkpoints);
-    q_pack->wf_ptr->table_local.create(GlobalC::ucell.ntype, GlobalC::ucell.nmax_total, GlobalV::NQX);
-//	q_pack->wf_ptr->table_local.create(q_pack->wf_ptr->ucell_ptr->ntype, q_pack->wf_ptr->ucell_ptr->nmax_total,
-//GlobalV::NQX);
+    q_pack->wf_ptr->table_local.create(GlobalC::ucell.ntype,
+                                       GlobalC::ucell.nmax_total,
+                                       GlobalV::NQX);
+//	q_pack->wf_ptr->table_local.create(q_pack->wf_ptr->ucell_ptr->ntype,
+//q_pack->wf_ptr->ucell_ptr->nmax_total, GlobalV::NQX);
 #ifdef __LCAO
-    Wavefunc_in_pw::make_table_q(GlobalC::ORB.orbital_file, q_pack->wf_ptr->table_local);
-    //	Wavefunc_in_pw::make_table_q(q_pack->wf_ptr->ORB_ptr->orbital_file, q_pack->wf_ptr->table_local,
-    //q_pack->wf_ptr);
-    for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-    {
+    Wavefunc_in_pw::make_table_q(GlobalC::ORB.orbital_file,
+                                 q_pack->wf_ptr->table_local);
+    //	Wavefunc_in_pw::make_table_q(q_pack->wf_ptr->ORB_ptr->orbital_file,
+    //q_pack->wf_ptr->table_local, q_pack->wf_ptr);
+    for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq) {
         Wavefunc_in_pw::produce_local_basis_in_pw(iq,
                                                   wfc_basis,
                                                   sf,
                                                   q_pack->wf_ptr->wanf2[iq],
                                                   q_pack->wf_ptr->table_local);
-        //		Wavefunc_in_pw::produce_local_basis_in_pw(iq, q_pack->wf_ptr->wanf2[iq], q_pack->wf_ptr->table_local,
+        //		Wavefunc_in_pw::produce_local_basis_in_pw(iq,
+        //q_pack->wf_ptr->wanf2[iq], q_pack->wf_ptr->table_local,
         // q_pack->wf_ptr);
     }
 #endif
     q_pack->wf_wg.create(q_pack->kv_ptr->get_nks(), GlobalV::NBANDS);
-    if (!GlobalV::RANK_IN_POOL)
-    {
+    if (!GlobalV::RANK_IN_POOL) {
         std::stringstream ss_wf_wg;
-        ss_wf_wg << GlobalV::global_out_dir << exx_q_pack << "wf_wg_" << GlobalV::MY_POOL;
+        ss_wf_wg << GlobalV::global_out_dir << exx_q_pack << "wf_wg_"
+                 << GlobalV::MY_POOL;
         std::ifstream ifs_wf_wg(ss_wf_wg.str().c_str());
-        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-        {
-            for (int ib = 0; ib < GlobalV::NBANDS; ++ib)
-            {
+        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq) {
+            for (int ib = 0; ib < GlobalV::NBANDS; ++ib) {
                 ifs_wf_wg >> q_pack->wf_wg(iq, ib);
             }
         }
         ifs_wf_wg.close();
     }
 #ifdef __MPI
-    MPI_Bcast(q_pack->wf_wg.c, q_pack->kv_ptr->get_nks() * GlobalV::NBANDS, MPI_DOUBLE, 0, POOL_WORLD);
+    MPI_Bcast(q_pack->wf_wg.c,
+              q_pack->kv_ptr->get_nks() * GlobalV::NBANDS,
+              MPI_DOUBLE,
+              0,
+              POOL_WORLD);
 #endif
 
-    q_pack->hvec_array = new ModuleBase::ComplexMatrix[q_pack->kv_ptr->get_nks()];
-    for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-    {
+    q_pack->hvec_array
+        = new ModuleBase::ComplexMatrix[q_pack->kv_ptr->get_nks()];
+    for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq) {
         q_pack->hvec_array[iq].create(GlobalV::NLOCAL, GlobalV::NBANDS);
     }
-    if (!GlobalV::RANK_IN_POOL)
-    {
+    if (!GlobalV::RANK_IN_POOL) {
         std::stringstream ss_hvec;
-        ss_hvec << GlobalV::global_out_dir << exx_q_pack << "hvec_" << GlobalV::MY_POOL;
+        ss_hvec << GlobalV::global_out_dir << exx_q_pack << "hvec_"
+                << GlobalV::MY_POOL;
         std::ifstream ifs_hvec(ss_hvec.str().c_str());
-        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-        {
-            for (int iw = 0; iw < GlobalV::NLOCAL; ++iw)
-            {
-                for (int ib = 0; ib < GlobalV::NBANDS; ++ib)
-                {
+        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq) {
+            for (int iw = 0; iw < GlobalV::NLOCAL; ++iw) {
+                for (int ib = 0; ib < GlobalV::NBANDS; ++ib) {
                     double a, b;
                     ifs_hvec >> a >> b;
                     q_pack->hvec_array[iq](iw, ib) = {a, b};
@@ -801,9 +798,12 @@ void Exx_Lip::read_q_pack(const ModuleSymmetry::Symmetry& symm,
         ifs_hvec.close();
     }
 #ifdef __MPI
-    for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-    {
-        MPI_Bcast(q_pack->hvec_array[iq].c, GlobalV::NLOCAL * GlobalV::NBANDS, MPI_DOUBLE_COMPLEX, 0, POOL_WORLD);
+    for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq) {
+        MPI_Bcast(q_pack->hvec_array[iq].c,
+                  GlobalV::NLOCAL * GlobalV::NBANDS,
+                  MPI_DOUBLE_COMPLEX,
+                  0,
+                  POOL_WORLD);
     }
 #endif
 
@@ -821,7 +821,8 @@ void Exx_Lip::write_q_pack() const
         std::ofstream ofs(ssc.str().c_str());
         if (!ofs)
         {
-            ModuleBase::WARNING("Exx_Lip::write_q_pack","Can't create Exx_Lip File!");
+            ModuleBase::WARNING("Exx_Lip::write_q_pack","Can't create Exx_Lip
+File!");
         }
 
         ofs<<q_pack->kv_ptr->get_nks()<<std::endl;
@@ -832,8 +833,9 @@ void Exx_Lip::write_q_pack() const
         ofs<<std::endl;
         for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
         {
-            ofs<<q_pack.kvec_c[iq].x<<" "<<q_pack.kvec_c[iq].y<<" "<<q_pack.kvec_c[iq].z<<" "<<std::endl;
-            ofs<<q_pack.kvec_d[iq].x<<" "<<q_pack.kvec_d[iq].y<<" "<<q_pack.kvec_d[iq].z<<" "<<std::endl;
+            ofs<<q_pack.kvec_c[iq].x<<" "<<q_pack.kvec_c[iq].y<<"
+"<<q_pack.kvec_c[iq].z<<" "<<std::endl; ofs<<q_pack.kvec_d[iq].x<<"
+"<<q_pack.kvec_d[iq].y<<" "<<q_pack.kvec_d[iq].z<<" "<<std::endl;
         }
         ofs<<std::endl;
         for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
@@ -851,7 +853,8 @@ void Exx_Lip::write_q_pack() const
             {
                 for( int ib=0; ib<GlobalV::NBANDS; ++ib)
                 {
-                    ofs<<q_pack.hvec_array[iq](iw,ib).real()<<" "<<q_pack.hvec_array[iq](iw,ib).imag()<<" ";
+                    ofs<<q_pack.hvec_array[iq](iw,ib).real()<<"
+"<<q_pack.hvec_array[iq](iw,ib).imag()<<" ";
                 }
                 ofs<<std::endl;
             }
@@ -874,7 +877,8 @@ void Exx_Lip::read_q_pack()
         ifs.open(ssc.str().c_str());
         if (!ifs)
         {
-            ModuleBase::WARNING("Exx_Lip::write_q_pack","Can't read Exx_Lip File!");
+            ModuleBase::WARNING("Exx_Lip::write_q_pack","Can't read Exx_Lip
+File!");
         }
 
         ifs >> q_pack->kv_ptr->get_nks();
@@ -885,14 +889,14 @@ void Exx_Lip::read_q_pack()
     q_pack->kv_ptr->ngk = new int [q_pack->kv_ptr->get_nks()];
     q_pack.kvec_c = new ModuleBase::Vector3<double> [q_pack->kv_ptr->get_nks()];
     q_pack.kvec_d = new ModuleBase::Vector3<double> [q_pack->kv_ptr->get_nks()];
-    double *kvec_tmp = new double [q_pack->kv_ptr->get_nks()*6];				// just for MPI
-    q_pack.wf_wg = new double *[q_pack->kv_ptr->get_nks()];
-    for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
+    double *kvec_tmp = new double [q_pack->kv_ptr->get_nks()*6];
+// just for MPI q_pack.wf_wg = new double *[q_pack->kv_ptr->get_nks()]; for( int
+iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
     {
         q_pack.wf_wg[iq] = new double[GlobalV::NBANDS];
     }
-    q_pack.hvec_array = new ModuleBase::ComplexMatrix [q_pack->kv_ptr->get_nks()];
-    for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
+    q_pack.hvec_array = new ModuleBase::ComplexMatrix
+[q_pack->kv_ptr->get_nks()]; for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
     {
         q_pack.hvec_array[iq].create(GlobalV::NLOCAL,GlobalV::NBANDS);
     }
@@ -927,9 +931,9 @@ void Exx_Lip::read_q_pack()
         ifs.close();
     }
 
-    MPI_Bcast( q_pack->kv_ptr->ngk, q_pack->kv_ptr->get_nks(), MPI_INT, 0, POOL_WORLD);
-    MPI_Bcast( kvec_tmp, q_pack->kv_ptr->get_nks()*6, MPI_DOUBLE, 0, POOL_WORLD);
-    for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
+    MPI_Bcast( q_pack->kv_ptr->ngk, q_pack->kv_ptr->get_nks(), MPI_INT, 0,
+POOL_WORLD); MPI_Bcast( kvec_tmp, q_pack->kv_ptr->get_nks()*6, MPI_DOUBLE, 0,
+POOL_WORLD); for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
     {
         q_pack.kvec_c[iq].x = kvec_tmp[iq*6+0];
         q_pack.kvec_c[iq].y = kvec_tmp[iq*6+1];
@@ -941,11 +945,13 @@ void Exx_Lip::read_q_pack()
     delete[] kvec_tmp;
     for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
     {
-        MPI_Bcast( q_pack.wf_wg[iq], GlobalV::NBANDS, MPI_DOUBLE, 0, POOL_WORLD);
+        MPI_Bcast( q_pack.wf_wg[iq], GlobalV::NBANDS, MPI_DOUBLE, 0,
+POOL_WORLD);
     }
     for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
     {
-        MPI_Bcast( q_pack.hvec_array[iq].c, GlobalV::NLOCAL*GlobalV::NBANDS, MPI_DOUBLE_COMPLEX, 0, POOL_WORLD);
+        MPI_Bcast( q_pack.hvec_array[iq].c, GlobalV::NLOCAL*GlobalV::NBANDS,
+MPI_DOUBLE_COMPLEX, 0, POOL_WORLD);
     }
 
 
@@ -956,7 +962,8 @@ void Exx_Lip::read_q_pack()
         std::ofstream ofs(sss.str().c_str());
         if (!ofs)
         {
-            ModuleBase::WARNING("Exx_Lip::write_q_pack","Can't create Exx_Lip File!");
+            ModuleBase::WARNING("Exx_Lip::write_q_pack","Can't create Exx_Lip
+File!");
         }
 
         ofs<<q_pack->kv_ptr->get_nks()<<std::endl;
@@ -967,8 +974,9 @@ void Exx_Lip::read_q_pack()
         ofs<<std::endl;
         for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
         {
-            ofs<<q_pack.kvec_c[iq].x<<" "<<q_pack.kvec_c[iq].y<<" "<<q_pack.kvec_c[iq].z<<" "<<std::endl;
-            ofs<<q_pack.kvec_d[iq].x<<" "<<q_pack.kvec_d[iq].y<<" "<<q_pack.kvec_d[iq].z<<" "<<std::endl;
+            ofs<<q_pack.kvec_c[iq].x<<" "<<q_pack.kvec_c[iq].y<<"
+"<<q_pack.kvec_c[iq].z<<" "<<std::endl; ofs<<q_pack.kvec_d[iq].x<<"
+"<<q_pack.kvec_d[iq].y<<" "<<q_pack.kvec_d[iq].z<<" "<<std::endl;
         }
         ofs<<std::endl;
         for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
@@ -986,7 +994,8 @@ void Exx_Lip::read_q_pack()
             {
                 for( int ib=0; ib<GlobalV::NBANDS; ++ib)
                 {
-                    ofs<<q_pack.hvec_array[iq](iw,ib).real()<<" "<<q_pack.hvec_array[iq](iw,ib).imag()<<" ";
+                    ofs<<q_pack.hvec_array[iq](iw,ib).real()<<"
+"<<q_pack.hvec_array[iq](iw,ib).imag()<<" ";
                 }
                 ofs<<std::endl;
             }

--- a/source/module_ri/exx_lip.cpp
+++ b/source/module_ri/exx_lip.cpp
@@ -4,21 +4,22 @@
 //==========================================================
 
 #include "exx_lip.h"
-#include "module_base/global_function.h"
-#include "module_base/vector3.h"
-#include "module_hamilt_pw/hamilt_pwdft/global.h"
-#include "module_cell/klist.h"
-#include "module_hamilt_pw/hamilt_pwdft/wavefunc.h"
-#include "module_hamilt_lcao/hamilt_lcaodft/wavefunc_in_pw.h"
-#include "module_base/lapack_connector.h"
-#include <limits>
-#include "module_base/parallel_global.h"
 
-Exx_Lip::Exx_Lip( const Exx_Info::Exx_Info_Lip &info_in )
-	:init_finish(false),
-	 info(info_in),
-	 exx_matrix(NULL),
-	 exx_energy(0){}
+#include "module_base/global_function.h"
+#include "module_base/lapack_connector.h"
+#include "module_base/parallel_global.h"
+#include "module_base/vector3.h"
+#include "module_cell/klist.h"
+#include "module_hamilt_lcao/hamilt_lcaodft/wavefunc_in_pw.h"
+#include "module_hamilt_pw/hamilt_pwdft/global.h"
+#include "module_hamilt_pw/hamilt_pwdft/wavefunc.h"
+
+#include <limits>
+
+Exx_Lip::Exx_Lip(const Exx_Info::Exx_Info_Lip& info_in)
+    : init_finish(false), info(info_in), exx_matrix(NULL), exx_energy(0)
+{
+}
 
 // void Exx_Lip::cal_exx(const int& nks)
 // {
@@ -60,11 +61,12 @@ Exx_Lip::Exx_Lip( const Exx_Info::Exx_Info_Lip &info_in )
 // 						sum3[iw_l][iw_r] = std::complex<double>(0.0, 0.0);
 // 		}
 
-// 		for( int iq_tmp=iq_vecik; iq_tmp<iq_vecik+q_pack->kv_ptr->get_nks()/GlobalV::NSPIN; ++iq_tmp)					// !!! k_point
-// parallel incompleted. need to loop iq in other pool
+// 		for( int iq_tmp=iq_vecik; iq_tmp<iq_vecik+q_pack->kv_ptr->get_nks()/GlobalV::NSPIN; ++iq_tmp)					// !!!
+// k_point parallel incompleted. need to loop iq in other pool
 // 		{
-// 			int iq = (ik<(k_pack->kv_ptr->get_nks()/GlobalV::NSPIN)) ? (iq_tmp%(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN)) :
-// (iq_tmp%(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN)+(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN)); 			qkg2_exp(ik, iq);
+// 			int iq = (ik<(k_pack->kv_ptr->get_nks()/GlobalV::NSPIN)) ? (iq_tmp%(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN))
+// : (iq_tmp%(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN)+(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN));
+// qkg2_exp(ik, iq);
 // //t_qkg2_exp += my_time(t);
 // 			for( int ib=0; ib<GlobalV::NBANDS; ++ib)
 // 			{
@@ -109,42 +111,43 @@ Exx_Lip::Exx_Lip( const Exx_Info::Exx_Info_Lip &info_in )
 /*
 void Exx_Lip::cal_exx()
 {
-	ModuleBase::TITLE("Exx_Lip","cal_exx");
-	wf_wg_cal();
-	psi_cal();
-	for( int ik=0; ik<k_pack->kv_ptr->get_nks(); ++ik)
-	{
-		phi_cal(k_pack, ik);
+    ModuleBase::TITLE("Exx_Lip","cal_exx");
+    wf_wg_cal();
+    psi_cal();
+    for( int ik=0; ik<k_pack->kv_ptr->get_nks(); ++ik)
+    {
+        phi_cal(k_pack, ik);
 
-		judge_singularity(ik);
-		for( int iw_l=0; iw_l<GlobalV::NLOCAL; ++iw_l)
-			for( int iw_r=0; iw_r<GlobalV::NLOCAL; ++iw_r)
-				sum1[iw_l*GlobalV::NLOCAL+iw_r] = std::complex<double>(0.0,0.0);
-		if( Exx_Info::Hybrid_Type::HF==info.hybrid_type || Exx_Info::Hybrid_Type::PBE0==info.hybrid_type || Exx_Info::Hybrid_Type::SCAN0==info.hybrid_type )
-		{
-			sum2_factor = 0.0;
-			if(gzero_rank_in_pool==GlobalV::RANK_IN_POOL)
-				for( int iw_l=0; iw_l<GlobalV::NLOCAL; ++iw_l)
-					for( int iw_r=0; iw_r<GlobalV::NLOCAL; ++iw_r)
-						sum3[iw_l][iw_r] = std::complex<double>(0.0,0.0);
-		}
+        judge_singularity(ik);
+        for( int iw_l=0; iw_l<GlobalV::NLOCAL; ++iw_l)
+            for( int iw_r=0; iw_r<GlobalV::NLOCAL; ++iw_r)
+                sum1[iw_l*GlobalV::NLOCAL+iw_r] = std::complex<double>(0.0,0.0);
+        if( Exx_Info::Hybrid_Type::HF==info.hybrid_type || Exx_Info::Hybrid_Type::PBE0==info.hybrid_type ||
+Exx_Info::Hybrid_Type::SCAN0==info.hybrid_type )
+        {
+            sum2_factor = 0.0;
+            if(gzero_rank_in_pool==GlobalV::RANK_IN_POOL)
+                for( int iw_l=0; iw_l<GlobalV::NLOCAL; ++iw_l)
+                    for( int iw_r=0; iw_r<GlobalV::NLOCAL; ++iw_r)
+                        sum3[iw_l][iw_r] = std::complex<double>(0.0,0.0);
+        }
 
-		for( int iq_tmp=iq_vecik; iq_tmp<iq_vecik+q_pack->kv_ptr->get_nks()/GlobalV::NSPIN; ++iq_tmp)					// !!! k_point parallel incompleted. need to loop iq in other pool
-		{
-			int iq = (ik<(k_pack->kv_ptr->get_nks()/GlobalV::NSPIN)) ? (iq_tmp%(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN)) : (iq_tmp%(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN)+(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN));
-			qkg2_exp(ik, iq);
-			for( int ib=0; ib<GlobalV::NBANDS; ++ib)
-			{
-				b_cal(ik, iq, ib);
-				if( Exx_Info::Hybrid_Type::HF==info.hybrid_type || Exx_Info::Hybrid_Type::PBE0==info.hybrid_type || Exx_Info::Hybrid_Type::SCAN0==info.hybrid_type )
-					if(iq==iq_vecik)
-						sum3_cal(iq,ib);
-					b_sum(iq, ib);
-			}
-		}
-		sum_all(ik);
-	}
-	exx_energy_cal();
+        for( int iq_tmp=iq_vecik; iq_tmp<iq_vecik+q_pack->kv_ptr->get_nks()/GlobalV::NSPIN; ++iq_tmp)
+// !!! k_point parallel incompleted. need to loop iq in other pool
+        {
+            int iq = (ik<(k_pack->kv_ptr->get_nks()/GlobalV::NSPIN)) ?
+(iq_tmp%(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN)) :
+(iq_tmp%(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN)+(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN)); qkg2_exp(ik, iq); for(
+int ib=0; ib<GlobalV::NBANDS; ++ib)
+            {
+                b_cal(ik, iq, ib);
+                if( Exx_Info::Hybrid_Type::HF==info.hybrid_type || Exx_Info::Hybrid_Type::PBE0==info.hybrid_type ||
+Exx_Info::Hybrid_Type::SCAN0==info.hybrid_type ) if(iq==iq_vecik) sum3_cal(iq,ib); b_sum(iq, ib);
+            }
+        }
+        sum_all(ik);
+    }
+    exx_energy_cal();
 }
 */
 
@@ -157,13 +160,13 @@ void Exx_Lip::init(const ModuleSymmetry::Symmetry& symm,
                    const UnitCell* ucell_ptr_in,
                    const elecstate::ElecState* pelec_in)
 {
-	ModuleBase::TITLE("Exx_Lip","init");
-	try
-	{
-		k_pack = new k_package;
-		k_pack->kv_ptr = kv_ptr_in;
-		k_pack->wf_ptr = wf_ptr_in;
-		k_pack->pelec = pelec_in;
+    ModuleBase::TITLE("Exx_Lip", "init");
+    try
+    {
+        k_pack = new k_package;
+        k_pack->kv_ptr = kv_ptr_in;
+        k_pack->wf_ptr = wf_ptr_in;
+        k_pack->pelec = pelec_in;
         wfc_basis = wfc_basis_in;
         rho_basis = rho_basis_in;
         ucell_ptr = ucell_ptr_in;
@@ -175,21 +178,21 @@ void Exx_Lip::init(const ModuleSymmetry::Symmetry& symm,
         }
 #ifdef __MPI
         MPI_Allreduce(&gzero_judge, &gzero_rank_in_pool, 1, MPI_INT, MPI_MAX, POOL_WORLD);
-	#endif
-		k_pack->wf_wg.create(k_pack->kv_ptr->get_nks(),GlobalV::NBANDS);
+#endif
+        k_pack->wf_wg.create(k_pack->kv_ptr->get_nks(), GlobalV::NBANDS);
 
-		k_pack->hvec_array = new ModuleBase::ComplexMatrix [k_pack->kv_ptr->get_nks()];
-		for( int ik=0; ik<k_pack->kv_ptr->get_nks(); ++ik)
-		{
-			k_pack->hvec_array[ik].create(GlobalV::NLOCAL,GlobalV::NBANDS);
-		}
+        k_pack->hvec_array = new ModuleBase::ComplexMatrix[k_pack->kv_ptr->get_nks()];
+        for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik)
+        {
+            k_pack->hvec_array[ik].create(GlobalV::NLOCAL, GlobalV::NBANDS);
+        }
 
-		if (GlobalV::init_chg=="atomic")
-		{
-			q_pack = k_pack;
-		}
-		else if(GlobalV::init_chg=="file" || GlobalV::init_chg=="auto")
-		{
+        if (GlobalV::init_chg == "atomic")
+        {
+            q_pack = k_pack;
+        }
+        else if (GlobalV::init_chg == "file" || GlobalV::init_chg == "auto")
+        {
             read_q_pack(symm, wfc_basis, sf);
         }
 
@@ -202,160 +205,179 @@ void Exx_Lip::init(const ModuleSymmetry::Symmetry& symm,
         psi = new std::complex<double>**[q_pack->kv_ptr->get_nks()];
         for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
         {
-            psi[iq] = new std::complex<double> *[GlobalV::NBANDS];
-			for( int ib=0; ib<GlobalV::NBANDS; ++ib)
-			{
-				psi[iq][ib] = new std::complex<double>[rho_basis->nrxx];
-			}
+            psi[iq] = new std::complex<double>*[GlobalV::NBANDS];
+            for (int ib = 0; ib < GlobalV::NBANDS; ++ib)
+            {
+                psi[iq][ib] = new std::complex<double>[rho_basis->nrxx];
+            }
         }
 
-        recip_qkg2 = new double [rho_basis->npw];
+        recip_qkg2 = new double[rho_basis->npw];
 
-		b = new std::complex<double> [GlobalV::NLOCAL*rho_basis->npw];
+        b = new std::complex<double>[GlobalV::NLOCAL * rho_basis->npw];
 
-		sum1 = new std::complex<double> [GlobalV::NLOCAL*GlobalV::NLOCAL];
+        sum1 = new std::complex<double>[GlobalV::NLOCAL * GlobalV::NLOCAL];
 
-		if( Conv_Coulomb_Pot_K::Ccp_Type::Ccp==info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf==info.ccp_type )
-			if(gzero_rank_in_pool==GlobalV::RANK_IN_POOL)
-			{
-				b0 = new std::complex<double> [GlobalV::NLOCAL];
-				sum3 = new std::complex<double> *[GlobalV::NLOCAL];
-				for( int iw_l=0; iw_l<GlobalV::NLOCAL; ++iw_l)
-				{
-					sum3[iw_l] = new std::complex<double> [GlobalV::NLOCAL];
-				}
-			}
-			else
-			{
-				b0 = NULL;
-				sum3 = NULL;
-			}
-		else
-		{
-			b0 = NULL;
-			sum3 = NULL;
-		}
+        if (Conv_Coulomb_Pot_K::Ccp_Type::Ccp == info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf == info.ccp_type)
+            if (gzero_rank_in_pool == GlobalV::RANK_IN_POOL)
+            {
+                b0 = new std::complex<double>[GlobalV::NLOCAL];
+                sum3 = new std::complex<double>*[GlobalV::NLOCAL];
+                for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l)
+                {
+                    sum3[iw_l] = new std::complex<double>[GlobalV::NLOCAL];
+                }
+            }
+            else
+            {
+                b0 = NULL;
+                sum3 = NULL;
+            }
+        else
+        {
+            b0 = NULL;
+            sum3 = NULL;
+        }
 
-		exx_matrix = new std::complex<double> **[k_pack->kv_ptr->get_nks()];
-		for( int ik=0; ik<k_pack->kv_ptr->get_nks(); ++ik)
-		{
-			exx_matrix[ik] = new std::complex<double>*[GlobalV::NLOCAL];
-			for( int iw_l=0; iw_l<GlobalV::NLOCAL; ++iw_l)
-			{
-				exx_matrix[ik][iw_l] = new std::complex<double>[GlobalV::NLOCAL];
-			}
-		}
-	}
-	catch(const std::bad_alloc &ex)
-	{
-		ModuleBase::WARNING_QUIT("exact_exchange","Memory");
-	}
+        exx_matrix = new std::complex<double>**[k_pack->kv_ptr->get_nks()];
+        for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik)
+        {
+            exx_matrix[ik] = new std::complex<double>*[GlobalV::NLOCAL];
+            for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l)
+            {
+                exx_matrix[ik][iw_l] = new std::complex<double>[GlobalV::NLOCAL];
+            }
+        }
+    }
+    catch (const std::bad_alloc& ex)
+    {
+        ModuleBase::WARNING_QUIT("exact_exchange", "Memory");
+    }
 
-	init_finish = true;
+    init_finish = true;
 }
 
 Exx_Lip::~Exx_Lip()
 {
-	// ModuleBase::TITLE("Exx_Lip","~Exx_Lip");
-	if( init_finish)
-	{
-		for( int iw=0; iw<GlobalV::NLOCAL; ++iw)
-		{
-			delete[] phi[iw];	phi[iw]=NULL;
-		}
-		delete[] phi;		phi=NULL;
+    // ModuleBase::TITLE("Exx_Lip","~Exx_Lip");
+    if (init_finish)
+    {
+        for (int iw = 0; iw < GlobalV::NLOCAL; ++iw)
+        {
+            delete[] phi[iw];
+            phi[iw] = NULL;
+        }
+        delete[] phi;
+        phi = NULL;
 
-		for( int iq=0;iq<q_pack->kv_ptr->get_nks();++iq)
-		{
-			for( int ib=0;ib<GlobalV::NBANDS;++ib)
-			{
-				delete[] psi[iq][ib];	psi[iq][ib]=NULL;
-			}
-			delete[] psi[iq];	psi[iq]=NULL;
-		}
-		delete[] psi;		psi=NULL;
+        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
+        {
+            for (int ib = 0; ib < GlobalV::NBANDS; ++ib)
+            {
+                delete[] psi[iq][ib];
+                psi[iq][ib] = NULL;
+            }
+            delete[] psi[iq];
+            psi[iq] = NULL;
+        }
+        delete[] psi;
+        psi = NULL;
 
-		delete[] recip_qkg2;	recip_qkg2=NULL;
+        delete[] recip_qkg2;
+        recip_qkg2 = NULL;
 
-		delete[] b;		b=NULL;
+        delete[] b;
+        b = NULL;
 
-		delete[] sum1;		sum1=NULL;
+        delete[] sum1;
+        sum1 = NULL;
 
-		if( Conv_Coulomb_Pot_K::Ccp_Type::Ccp==info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf==info.ccp_type )
-			if(gzero_rank_in_pool==GlobalV::RANK_IN_POOL)
-			{
-				delete[] b0;	b0=NULL;
-				for( int iw_l=0; iw_l<GlobalV::NLOCAL; ++iw_l)
-				{
-					delete[] sum3[iw_l];	sum3[iw_l]=NULL;
-				}
-				delete[] sum3;		sum3=NULL;
-			}
+        if (Conv_Coulomb_Pot_K::Ccp_Type::Ccp == info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf == info.ccp_type)
+            if (gzero_rank_in_pool == GlobalV::RANK_IN_POOL)
+            {
+                delete[] b0;
+                b0 = NULL;
+                for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l)
+                {
+                    delete[] sum3[iw_l];
+                    sum3[iw_l] = NULL;
+                }
+                delete[] sum3;
+                sum3 = NULL;
+            }
 
-		for( int ik=0; ik<k_pack->kv_ptr->get_nks(); ++ik)
-		{
-			for( int iw_l=0; iw_l<GlobalV::NLOCAL; ++iw_l)
-			{
-				delete[] exx_matrix[ik][iw_l];	exx_matrix[ik][iw_l]=NULL;
-			}
-			delete[] exx_matrix[ik];	exx_matrix[ik]=NULL;
-		}
-		delete[] exx_matrix;	exx_matrix=NULL;
+        for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik)
+        {
+            for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l)
+            {
+                delete[] exx_matrix[ik][iw_l];
+                exx_matrix[ik][iw_l] = NULL;
+            }
+            delete[] exx_matrix[ik];
+            exx_matrix[ik] = NULL;
+        }
+        delete[] exx_matrix;
+        exx_matrix = NULL;
 
-		delete[] k_pack->hvec_array;	k_pack->hvec_array=NULL;
-		delete k_pack;
+        delete[] k_pack->hvec_array;
+        k_pack->hvec_array = NULL;
+        delete k_pack;
 
-		if (GlobalV::init_chg=="atomic")
-		{
-			q_pack = NULL;
-		}
-		else if(GlobalV::init_chg=="file")
-		{
-			delete q_pack->kv_ptr;	q_pack->kv_ptr=NULL;
-			delete q_pack->wf_ptr;	q_pack->wf_ptr=NULL;
-			delete[] q_pack->hvec_array;	q_pack->hvec_array=NULL;
-			delete q_pack;	q_pack=NULL;
-		}
-	}
+        if (GlobalV::init_chg == "atomic")
+        {
+            q_pack = NULL;
+        }
+        else if (GlobalV::init_chg == "file")
+        {
+            delete q_pack->kv_ptr;
+            q_pack->kv_ptr = NULL;
+            delete q_pack->wf_ptr;
+            q_pack->wf_ptr = NULL;
+            delete[] q_pack->hvec_array;
+            q_pack->hvec_array = NULL;
+            delete q_pack;
+            q_pack = NULL;
+        }
+    }
 }
 
 void Exx_Lip::wf_wg_cal()
 {
-	ModuleBase::TITLE("Exx_Lip","wf_wg_cal");
-	if(GlobalV::NSPIN==1)
-		for( int ik=0; ik<k_pack->kv_ptr->get_nks(); ++ik)
-			for( int ib=0; ib<GlobalV::NBANDS; ++ib)
-				k_pack->wf_wg(ik,ib) = k_pack->pelec->wg(ik,ib)/2;
-	else if(GlobalV::NSPIN==2)
-		for( int ik=0; ik<k_pack->kv_ptr->get_nks(); ++ik)
-			for( int ib=0; ib<GlobalV::NBANDS; ++ib)
-				k_pack->wf_wg(ik,ib) = k_pack->pelec->wg(ik,ib);
+    ModuleBase::TITLE("Exx_Lip", "wf_wg_cal");
+    if (GlobalV::NSPIN == 1)
+        for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik)
+            for (int ib = 0; ib < GlobalV::NBANDS; ++ib)
+                k_pack->wf_wg(ik, ib) = k_pack->pelec->wg(ik, ib) / 2;
+    else if (GlobalV::NSPIN == 2)
+        for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik)
+            for (int ib = 0; ib < GlobalV::NBANDS; ++ib)
+                k_pack->wf_wg(ik, ib) = k_pack->pelec->wg(ik, ib);
 }
 
-void Exx_Lip::phi_cal(k_package *kq_pack, int ikq)
+void Exx_Lip::phi_cal(k_package* kq_pack, int ikq)
 {
-	std::complex<double> *porter = new std::complex<double> [wfc_basis->nrxx];
-	for( int iw=0; iw< GlobalV::NLOCAL; ++iw)
-	{
-		wfc_basis->recip2real(&kq_pack->wf_ptr->wanf2[ikq](iw,0), porter, ikq);
-		int ir(0);
-		for( int ix=0; ix<rho_basis->nx; ++ix)
-		{
-			const double phase_x = kq_pack->kv_ptr->kvec_d[ikq].x * ix / rho_basis->nx;
-			for( int iy=0; iy<rho_basis->ny; ++iy)
-			{
-				const double phase_xy = phase_x + kq_pack->kv_ptr->kvec_d[ikq].y * iy / rho_basis->ny;
-				for( int iz=rho_basis->startz_current; iz<rho_basis->startz_current+rho_basis->nplane; ++iz)
-				{
-					const double phase_xyz = phase_xy + kq_pack->kv_ptr->kvec_d[ikq].z * iz / rho_basis->nz;
-					const std::complex<double> exp_tmp = exp(phase_xyz*ModuleBase::TWO_PI*ModuleBase::IMAG_UNIT);
-					phi[iw][ir] =porter[ir]*exp_tmp;
-					++ir;
-				}
-			}
-		}
-	}
-	delete [] porter;
+    std::complex<double>* porter = new std::complex<double>[wfc_basis->nrxx];
+    for (int iw = 0; iw < GlobalV::NLOCAL; ++iw)
+    {
+        wfc_basis->recip2real(&kq_pack->wf_ptr->wanf2[ikq](iw, 0), porter, ikq);
+        int ir(0);
+        for (int ix = 0; ix < rho_basis->nx; ++ix)
+        {
+            const double phase_x = kq_pack->kv_ptr->kvec_d[ikq].x * ix / rho_basis->nx;
+            for (int iy = 0; iy < rho_basis->ny; ++iy)
+            {
+                const double phase_xy = phase_x + kq_pack->kv_ptr->kvec_d[ikq].y * iy / rho_basis->ny;
+                for (int iz = rho_basis->startz_current; iz < rho_basis->startz_current + rho_basis->nplane; ++iz)
+                {
+                    const double phase_xyz = phase_xy + kq_pack->kv_ptr->kvec_d[ikq].z * iz / rho_basis->nz;
+                    const std::complex<double> exp_tmp = exp(phase_xyz * ModuleBase::TWO_PI * ModuleBase::IMAG_UNIT);
+                    phi[iw][ir] = porter[ir] * exp_tmp;
+                    ++ir;
+                }
+            }
+        }
+    }
+    delete[] porter;
 }
 
 // void Exx_Lip::psi_cal()
@@ -381,7 +403,8 @@ void Exx_Lip::phi_cal(k_package *kq_pack, int ikq)
 // 						{
 // 							const double phase_xyz = phase_xy + q_pack->kv_ptr->kvec_d[iq].z * iz / rho_basis->nz;
 // 							const std::complex<double> exp_tmp =
-// exp(phase_xyz*ModuleBase::TWO_PI*ModuleBase::IMAG_UNIT); 							psi[iq][ib][ir] = porter[ir]*exp_tmp;
+// exp(phase_xyz*ModuleBase::TWO_PI*ModuleBase::IMAG_UNIT); 							psi[iq][ib][ir] =
+// porter[ir]*exp_tmp;
 // 							++ir;
 // 						}
 // 					}
@@ -413,293 +436,318 @@ void Exx_Lip::phi_cal(k_package *kq_pack, int ikq)
 // ///////////////////////////////////////////////////////////////////////////
 // }
 
-void Exx_Lip::judge_singularity( int ik)
+void Exx_Lip::judge_singularity(int ik)
 {
-	if (GlobalV::init_chg=="atomic")
-	{
-		iq_vecik = ik;
-	}
-	else if(GlobalV::init_chg=="file")
-	{
-		double min_q_minus_k(std::numeric_limits<double>::max());
-		for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
-		{
-			const double q_minus_k ( (q_pack->kv_ptr->kvec_c[iq] - k_pack->kv_ptr->kvec_c[ik]).norm2() );
-			if(q_minus_k < min_q_minus_k)
-			{
-				min_q_minus_k = q_minus_k;
-				iq_vecik = iq;
-			}
-		}
-	}
+    if (GlobalV::init_chg == "atomic")
+    {
+        iq_vecik = ik;
+    }
+    else if (GlobalV::init_chg == "file")
+    {
+        double min_q_minus_k(std::numeric_limits<double>::max());
+        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
+        {
+            const double q_minus_k((q_pack->kv_ptr->kvec_c[iq] - k_pack->kv_ptr->kvec_c[ik]).norm2());
+            if (q_minus_k < min_q_minus_k)
+            {
+                min_q_minus_k = q_minus_k;
+                iq_vecik = iq;
+            }
+        }
+    }
 }
-
 
 void Exx_Lip::qkg2_exp(int ik, int iq)
 {
-	for( int ig=0; ig<rho_basis->npw; ++ig)
-	{
-		const double qkg2 = ( (q_pack->kv_ptr->kvec_c[iq] - k_pack->kv_ptr->kvec_c[ik] + rho_basis->gcar[ig]) *(ModuleBase::TWO_PI/ucell_ptr->lat0)).norm2();
-		if( Conv_Coulomb_Pot_K::Ccp_Type::Ccp==info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf==info.ccp_type )
-		{
-			if( std::abs(qkg2)<1e-10 )
-				recip_qkg2[ig] = 0.0;												// 0 to ignore bb/qkg2 when qkg2==0
-			else
-				recip_qkg2[ig] = 1.0/qkg2;
-			sum2_factor += recip_qkg2[ig] * exp(-info.lambda*qkg2) ;
-			recip_qkg2[ig] = sqrt(recip_qkg2[ig]);
-		}
-		else if( Conv_Coulomb_Pot_K::Ccp_Type::Hse==info.ccp_type )
-		{
-			if( std::abs(qkg2)<1e-10 )
-				recip_qkg2[ig] = 1.0/(2*info.hse_omega);
-			else
-				recip_qkg2[ig] = sqrt( (1-exp(-qkg2/(4*info.hse_omega*info.hse_omega))) /qkg2);
-		}
-	}
+    for (int ig = 0; ig < rho_basis->npw; ++ig)
+    {
+        const double qkg2 = ((q_pack->kv_ptr->kvec_c[iq] - k_pack->kv_ptr->kvec_c[ik] + rho_basis->gcar[ig])
+                             * (ModuleBase::TWO_PI / ucell_ptr->lat0))
+                                .norm2();
+        if (Conv_Coulomb_Pot_K::Ccp_Type::Ccp == info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf == info.ccp_type)
+        {
+            if (std::abs(qkg2) < 1e-10)
+                recip_qkg2[ig] = 0.0; // 0 to ignore bb/qkg2 when qkg2==0
+            else
+                recip_qkg2[ig] = 1.0 / qkg2;
+            sum2_factor += recip_qkg2[ig] * exp(-info.lambda * qkg2);
+            recip_qkg2[ig] = sqrt(recip_qkg2[ig]);
+        }
+        else if (Conv_Coulomb_Pot_K::Ccp_Type::Hse == info.ccp_type)
+        {
+            if (std::abs(qkg2) < 1e-10)
+                recip_qkg2[ig] = 1.0 / (2 * info.hse_omega);
+            else
+                recip_qkg2[ig] = sqrt((1 - exp(-qkg2 / (4 * info.hse_omega * info.hse_omega))) / qkg2);
+        }
+    }
 }
 
-
-void Exx_Lip::b_cal( int ik, int iq, int ib)
+void Exx_Lip::b_cal(int ik, int iq, int ib)
 {
-	const ModuleBase::Vector3<double> q_minus_k = q_pack->kv_ptr->kvec_d[iq] - k_pack->kv_ptr->kvec_d[ik];
-	std::vector<std::complex<double> > mul_tmp(rho_basis->nrxx);
-	for( size_t ir=0,ix=0; ix<rho_basis->nx; ++ix)
-	{
-		const double phase_x = q_minus_k.x*ix/rho_basis->nx;
-		for( size_t iy=0; iy<rho_basis->ny; ++iy)
-		{
-			const double phase_xy = phase_x + q_minus_k.y*iy/rho_basis->ny;
-			for( size_t iz=rho_basis->startz_current; iz<rho_basis->startz_current+rho_basis->nplane; ++iz)
-			{
-				const double phase_xyz = phase_xy + q_minus_k.z*iz/rho_basis->nz;
-				mul_tmp[ir] = exp(-phase_xyz*ModuleBase::TWO_PI*ModuleBase::IMAG_UNIT);
-				mul_tmp[ir] *= psi[iq][ib][ir];
-				++ir;
-			}
-		}
-	}
+    const ModuleBase::Vector3<double> q_minus_k = q_pack->kv_ptr->kvec_d[iq] - k_pack->kv_ptr->kvec_d[ik];
+    std::vector<std::complex<double>> mul_tmp(rho_basis->nrxx);
+    for (size_t ir = 0, ix = 0; ix < rho_basis->nx; ++ix)
+    {
+        const double phase_x = q_minus_k.x * ix / rho_basis->nx;
+        for (size_t iy = 0; iy < rho_basis->ny; ++iy)
+        {
+            const double phase_xy = phase_x + q_minus_k.y * iy / rho_basis->ny;
+            for (size_t iz = rho_basis->startz_current; iz < rho_basis->startz_current + rho_basis->nplane; ++iz)
+            {
+                const double phase_xyz = phase_xy + q_minus_k.z * iz / rho_basis->nz;
+                mul_tmp[ir] = exp(-phase_xyz * ModuleBase::TWO_PI * ModuleBase::IMAG_UNIT);
+                mul_tmp[ir] *= psi[iq][ib][ir];
+                ++ir;
+            }
+        }
+    }
 
-	std::complex<double> * const porter = new std::complex<double> [rho_basis->nrxx];
+    std::complex<double>* const porter = new std::complex<double>[rho_basis->nrxx];
 
-	for(size_t iw=0; iw< GlobalV::NLOCAL; ++iw)
-	{
-		const std::complex<double> * const phi_w = phi[iw];
-		for( size_t ir=0; ir<rho_basis->nrxx; ++ir)
-		{
-			porter[ir] = conj(phi_w[ir]) * mul_tmp[ir] ;
-//			porter[ir] = phi_w[ir] * psi_q_b[ir] *exp_tmp[ir] ;
-		}
-		std::complex<double> * const b_w = b+iw*rho_basis->npw;
-		rho_basis->real2recip( porter, b_w);
-		if( Conv_Coulomb_Pot_K::Ccp_Type::Ccp==info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf==info.ccp_type )
-			if((iq==iq_vecik) && (gzero_rank_in_pool==GlobalV::RANK_IN_POOL))							/// need to check while use k_point parallel
-				b0[iw] = b_w[rho_basis->ig_gge0];
+    for (size_t iw = 0; iw < GlobalV::NLOCAL; ++iw)
+    {
+        const std::complex<double>* const phi_w = phi[iw];
+        for (size_t ir = 0; ir < rho_basis->nrxx; ++ir)
+        {
+            porter[ir] = conj(phi_w[ir]) * mul_tmp[ir];
+            //			porter[ir] = phi_w[ir] * psi_q_b[ir] *exp_tmp[ir] ;
+        }
+        std::complex<double>* const b_w = b + iw * rho_basis->npw;
+        rho_basis->real2recip(porter, b_w);
+        if (Conv_Coulomb_Pot_K::Ccp_Type::Ccp == info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf == info.ccp_type)
+            if ((iq == iq_vecik)
+                && (gzero_rank_in_pool == GlobalV::RANK_IN_POOL)) /// need to check while use k_point parallel
+                b0[iw] = b_w[rho_basis->ig_gge0];
 
-		for( size_t ig=0; ig<rho_basis->npw; ++ig)
-			b_w[ig] *= recip_qkg2[ig];
-	}
-	delete [] porter;
+        for (size_t ig = 0; ig < rho_basis->npw; ++ig)
+            b_w[ig] *= recip_qkg2[ig];
+    }
+    delete[] porter;
 }
 
-
-void  Exx_Lip::sum3_cal(int iq, int ib)
+void Exx_Lip::sum3_cal(int iq, int ib)
 {
-	if( gzero_rank_in_pool == GlobalV::RANK_IN_POOL )
-		for( int iw_l=0; iw_l<GlobalV::NLOCAL; ++iw_l)
-			for( int iw_r=0; iw_r<GlobalV::NLOCAL; ++iw_r)
-				sum3[iw_l][iw_r] += b0[iw_l] * conj(b0[iw_r]) * q_pack->wf_wg(iq,ib);
+    if (gzero_rank_in_pool == GlobalV::RANK_IN_POOL)
+        for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l)
+            for (int iw_r = 0; iw_r < GlobalV::NLOCAL; ++iw_r)
+                sum3[iw_l][iw_r] += b0[iw_l] * conj(b0[iw_r]) * q_pack->wf_wg(iq, ib);
 }
 
-
-void Exx_Lip::b_sum( int iq, int ib)			// Peize Lin change 2019-04-14
+void Exx_Lip::b_sum(int iq, int ib) // Peize Lin change 2019-04-14
 {
-	// sum1[iw_l,iw_r] += \sum_{ig} b[iw_l,ig] * conj(b[iw_r,ig]) * q_pack->wf_wg(iq,ib)
-	LapackConnector::zherk(
-		'U','N',
-		GlobalV::NLOCAL, rho_basis->npw,
-		q_pack->wf_wg(iq,ib), b, rho_basis->npw,
-		1.0, sum1, GlobalV::NLOCAL);
-//	cblas_zherk( CblasRowMajor, CblasUpper, CblasNoTrans,
-//				GlobalV::NLOCAL, rho_basis->npw,
-//				q_pack->wf_wg(iq,ib), static_cast<void*>(b), rho_basis->npw,
-//				1.0, static_cast<void*>(sum1), GlobalV::NLOCAL);
+    // sum1[iw_l,iw_r] += \sum_{ig} b[iw_l,ig] * conj(b[iw_r,ig]) * q_pack->wf_wg(iq,ib)
+    LapackConnector::zherk('U',
+                           'N',
+                           GlobalV::NLOCAL,
+                           rho_basis->npw,
+                           q_pack->wf_wg(iq, ib),
+                           b,
+                           rho_basis->npw,
+                           1.0,
+                           sum1,
+                           GlobalV::NLOCAL);
+    //	cblas_zherk( CblasRowMajor, CblasUpper, CblasNoTrans,
+    //				GlobalV::NLOCAL, rho_basis->npw,
+    //				q_pack->wf_wg(iq,ib), static_cast<void*>(b), rho_basis->npw,
+    //				1.0, static_cast<void*>(sum1), GlobalV::NLOCAL);
 }
 
 void Exx_Lip::sum_all(int ik)
 {
-	double sum2_factor_g(0.0);
-	#ifdef __MPI
-	if( Conv_Coulomb_Pot_K::Ccp_Type::Ccp==info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf==info.ccp_type )
-		MPI_Reduce( &sum2_factor, &sum2_factor_g, 1, MPI_DOUBLE, MPI_SUM, gzero_rank_in_pool, POOL_WORLD);
-	#endif
-	for( size_t iw_l=1; iw_l<GlobalV::NLOCAL; ++iw_l)
-		for( size_t iw_r=0; iw_r<iw_l; ++iw_r)
-			sum1[iw_l*GlobalV::NLOCAL+iw_r] = conj(sum1[iw_r*GlobalV::NLOCAL+iw_l]);		// Peize Lin add conj 2019-04-14
+    double sum2_factor_g(0.0);
+#ifdef __MPI
+    if (Conv_Coulomb_Pot_K::Ccp_Type::Ccp == info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf == info.ccp_type)
+        MPI_Reduce(&sum2_factor, &sum2_factor_g, 1, MPI_DOUBLE, MPI_SUM, gzero_rank_in_pool, POOL_WORLD);
+#endif
+    for (size_t iw_l = 1; iw_l < GlobalV::NLOCAL; ++iw_l)
+        for (size_t iw_r = 0; iw_r < iw_l; ++iw_r)
+            sum1[iw_l * GlobalV::NLOCAL + iw_r]
+                = conj(sum1[iw_r * GlobalV::NLOCAL + iw_l]); // Peize Lin add conj 2019-04-14
 
-	for( int iw_l=0; iw_l<GlobalV::NLOCAL; ++iw_l)
-	{
-		for( int iw_r=0; iw_r<GlobalV::NLOCAL; ++iw_r)
-		{
-			exx_matrix[ik][iw_l][iw_r] = 2.0* (-4*ModuleBase::PI/ucell_ptr->omega *sum1[iw_l*GlobalV::NLOCAL+iw_r]);
-			if( Conv_Coulomb_Pot_K::Ccp_Type::Ccp==info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf==info.ccp_type )
-				if(gzero_rank_in_pool==GlobalV::RANK_IN_POOL)
-				{
-					exx_matrix[ik][iw_l][iw_r] += 2.0* (4*ModuleBase::PI/ucell_ptr->omega *sum3[iw_l][iw_r] *sum2_factor_g );
-					exx_matrix[ik][iw_l][iw_r] += 2.0* (-1/sqrt(info.lambda*ModuleBase::PI)*(q_pack->kv_ptr->get_nks()/GlobalV::NSPIN) * sum3[iw_l][iw_r]);
-				}
-		}
-	}
+    for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l)
+    {
+        for (int iw_r = 0; iw_r < GlobalV::NLOCAL; ++iw_r)
+        {
+            exx_matrix[ik][iw_l][iw_r]
+                = 2.0 * (-4 * ModuleBase::PI / ucell_ptr->omega * sum1[iw_l * GlobalV::NLOCAL + iw_r]);
+            if (Conv_Coulomb_Pot_K::Ccp_Type::Ccp == info.ccp_type || Conv_Coulomb_Pot_K::Ccp_Type::Hf == info.ccp_type)
+                if (gzero_rank_in_pool == GlobalV::RANK_IN_POOL)
+                {
+                    exx_matrix[ik][iw_l][iw_r]
+                        += 2.0 * (4 * ModuleBase::PI / ucell_ptr->omega * sum3[iw_l][iw_r] * sum2_factor_g);
+                    exx_matrix[ik][iw_l][iw_r] += 2.0
+                                                  * (-1 / sqrt(info.lambda * ModuleBase::PI)
+                                                     * (q_pack->kv_ptr->get_nks() / GlobalV::NSPIN) * sum3[iw_l][iw_r]);
+                }
+        }
+    }
 }
 
 void Exx_Lip::exx_energy_cal()
 {
-	ModuleBase::TITLE("Exx_Lip","exx_energy_cal");
+    ModuleBase::TITLE("Exx_Lip", "exx_energy_cal");
 
-	double exx_energy_tmp = 0.0;
+    double exx_energy_tmp = 0.0;
 
-	for( int ik=0; ik<k_pack->kv_ptr->get_nks(); ++ik)
-	{
-		for( int iw_l=0; iw_l<GlobalV::NLOCAL; ++iw_l)
-		{
-			for( int iw_r=0; iw_r<GlobalV::NLOCAL; ++iw_r)
-			{
-				for( int ib=0; ib<GlobalV::NBANDS; ++ib)
-				{
-					exx_energy_tmp += (exx_matrix[ik][iw_l][iw_r] *conj(k_pack->hvec_array[ik](iw_l,ib)) *k_pack->hvec_array[ik](iw_r,ib) ).real() *k_pack->wf_wg(ik,ib);
-				}
-			}
-		}
-	}
+    for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik)
+    {
+        for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l)
+        {
+            for (int iw_r = 0; iw_r < GlobalV::NLOCAL; ++iw_r)
+            {
+                for (int ib = 0; ib < GlobalV::NBANDS; ++ib)
+                {
+                    exx_energy_tmp += (exx_matrix[ik][iw_l][iw_r] * conj(k_pack->hvec_array[ik](iw_l, ib))
+                                       * k_pack->hvec_array[ik](iw_r, ib))
+                                          .real()
+                                      * k_pack->wf_wg(ik, ib);
+                }
+            }
+        }
+    }
 #ifdef __MPI
-	MPI_Allreduce( &exx_energy_tmp, &exx_energy, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);				// !!! k_point parallel incompleted. different pools have different kv.set_nks(>) deadlock
+    MPI_Allreduce(
+        &exx_energy_tmp,
+        &exx_energy,
+        1,
+        MPI_DOUBLE,
+        MPI_SUM,
+        MPI_COMM_WORLD); // !!! k_point parallel incompleted. different pools have different kv.set_nks(>) deadlock
 #endif
-	exx_energy *= (GlobalV::NSPIN==1) ? 2 : 1;
-	exx_energy /= 2;										// ETOT = E_band - 1/2 E_exx
+    exx_energy *= (GlobalV::NSPIN == 1) ? 2 : 1;
+    exx_energy /= 2; // ETOT = E_band - 1/2 E_exx
 
-	#if TEST_EXX==1
-	{
-		std::ofstream ofs("exx_matrix.dat",std::ofstream::app);
-		static int istep=0;
-		ofs<<"istep:\t"<<istep++<<std::endl;
-		for( int ik=0; ik<k_pack->kv_ptr->get_nks(); ++ik)
-		{
-			ofs<<"ik:\t"<<ik<<std::endl;
-			for( int iw_l=0; iw_l<GlobalV::NLOCAL; ++iw_l)
-			{
-				for( int iw_r=0; iw_r<GlobalV::NLOCAL; ++iw_r)
-				{
-					ofs<<exx_matrix[ik][iw_l][iw_r]<<"\t";
-				}
-				ofs<<std::endl;
-			}
-			ofs<<std::endl;
-		}
-		ofs.close();
-	}
-	{
-		std::ofstream ofs("DM.dat",std::ofstream::app);
-		static int istep=0;
-		ofs<<"istep:\t"<<istep++<<std::endl;
-		for( int ik=0; ik<k_pack->kv_ptr->get_nks(); ++ik)
-		{
-			ofs<<"ik:\t"<<ik<<std::endl;
-			for( int iw_l=0; iw_l<GlobalV::NLOCAL; ++iw_l)
-			{
-				for( int iw_r=0; iw_r<GlobalV::NLOCAL; ++iw_r)
-				{
-					std::complex<double> DM = {0,0};
-					for( int ib=0; ib<GlobalV::NBANDS; ++ib )
-						DM += conj(k_pack->hvec_array[ik](iw_l,ib)) *k_pack->hvec_array[ik](iw_r,ib) *k_pack->wf_wg(ik,ib);
-					ofs<<DM<<"\t";
-				}
-				ofs<<std::endl;
-			}
-			ofs<<std::endl;
-		}
-		ofs.close();
-	}
-	#elif TEST_EXX==-1
-		#error
-	#endif
+#if TEST_EXX == 1
+    {
+        std::ofstream ofs("exx_matrix.dat", std::ofstream::app);
+        static int istep = 0;
+        ofs << "istep:\t" << istep++ << std::endl;
+        for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik)
+        {
+            ofs << "ik:\t" << ik << std::endl;
+            for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l)
+            {
+                for (int iw_r = 0; iw_r < GlobalV::NLOCAL; ++iw_r)
+                {
+                    ofs << exx_matrix[ik][iw_l][iw_r] << "\t";
+                }
+                ofs << std::endl;
+            }
+            ofs << std::endl;
+        }
+        ofs.close();
+    }
+    {
+        std::ofstream ofs("DM.dat", std::ofstream::app);
+        static int istep = 0;
+        ofs << "istep:\t" << istep++ << std::endl;
+        for (int ik = 0; ik < k_pack->kv_ptr->get_nks(); ++ik)
+        {
+            ofs << "ik:\t" << ik << std::endl;
+            for (int iw_l = 0; iw_l < GlobalV::NLOCAL; ++iw_l)
+            {
+                for (int iw_r = 0; iw_r < GlobalV::NLOCAL; ++iw_r)
+                {
+                    std::complex<double> DM = {0, 0};
+                    for (int ib = 0; ib < GlobalV::NBANDS; ++ib)
+                        DM += conj(k_pack->hvec_array[ik](iw_l, ib)) * k_pack->hvec_array[ik](iw_r, ib)
+                              * k_pack->wf_wg(ik, ib);
+                    ofs << DM << "\t";
+                }
+                ofs << std::endl;
+            }
+            ofs << std::endl;
+        }
+        ofs.close();
+    }
+#elif TEST_EXX == -1
+#error
+#endif
 
-	return;
+    return;
 }
 
 void Exx_Lip::write_q_pack() const
 {
-    if (GlobalV::out_chg==0)
-		return;
+    if (GlobalV::out_chg == 0)
+        return;
 
-	if(!GlobalV::RANK_IN_POOL)
-	{
-		const std::string exx_q_pack = "exx_q_pack/";
-		int return_value=0;
-		const std::string command_mkdir = "test -d " + GlobalV::global_out_dir + exx_q_pack + " || mkdir " + GlobalV::global_out_dir + exx_q_pack;
+    if (!GlobalV::RANK_IN_POOL)
+    {
+        const std::string exx_q_pack = "exx_q_pack/";
+        int return_value = 0;
+        const std::string command_mkdir
+            = "test -d " + GlobalV::global_out_dir + exx_q_pack + " || mkdir " + GlobalV::global_out_dir + exx_q_pack;
         return_value = system(command_mkdir.c_str());
         assert(return_value == 0);
 
-        const std::string command_kpoint = "test -f " + GlobalV::global_out_dir + exx_q_pack + GlobalV::global_kpoint_card + " || cp " + GlobalV::global_kpoint_card + " " + GlobalV::global_out_dir + exx_q_pack + GlobalV::global_kpoint_card;
+        const std::string command_kpoint = "test -f " + GlobalV::global_out_dir + exx_q_pack
+                                           + GlobalV::global_kpoint_card + " || cp " + GlobalV::global_kpoint_card + " "
+                                           + GlobalV::global_out_dir + exx_q_pack + GlobalV::global_kpoint_card;
         return_value = system(command_kpoint.c_str());
-		assert(return_value==0);
+        assert(return_value == 0);
 
-		std::stringstream ss_wf_wg;
-		ss_wf_wg << GlobalV::global_out_dir << exx_q_pack << "wf_wg_" << GlobalV::MY_POOL;
-		std::ofstream ofs_wf_wg(ss_wf_wg.str().c_str());
-		for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-		{
-			for( int ib=0; ib<GlobalV::NBANDS; ++ib)
-			{
-				ofs_wf_wg<<q_pack->wf_wg(iq,ib)<<"\t";
-			}
-			ofs_wf_wg<<std::endl;
-		}
-		ofs_wf_wg.close();
+        std::stringstream ss_wf_wg;
+        ss_wf_wg << GlobalV::global_out_dir << exx_q_pack << "wf_wg_" << GlobalV::MY_POOL;
+        std::ofstream ofs_wf_wg(ss_wf_wg.str().c_str());
+        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
+        {
+            for (int ib = 0; ib < GlobalV::NBANDS; ++ib)
+            {
+                ofs_wf_wg << q_pack->wf_wg(iq, ib) << "\t";
+            }
+            ofs_wf_wg << std::endl;
+        }
+        ofs_wf_wg.close();
 
-		std::stringstream ss_hvec;
-		ss_hvec	<< GlobalV::global_out_dir << exx_q_pack << "hvec_" << GlobalV::MY_POOL;
-		std::ofstream ofs_hvec(ss_hvec.str().c_str());
-		for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
-		{
-			for( int iw=0; iw<GlobalV::NLOCAL; ++iw)
-			{
-				for( int ib=0; ib<GlobalV::NBANDS; ++ib)
-				{
-					ofs_hvec<<q_pack->hvec_array[iq](iw,ib).real()<<" "<<q_pack->hvec_array[iq](iw,ib).imag()<<" ";
-				}
-				ofs_hvec<<std::endl;
-			}
-		}
-		ofs_hvec.close();
-	}
-	return;
+        std::stringstream ss_hvec;
+        ss_hvec << GlobalV::global_out_dir << exx_q_pack << "hvec_" << GlobalV::MY_POOL;
+        std::ofstream ofs_hvec(ss_hvec.str().c_str());
+        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
+        {
+            for (int iw = 0; iw < GlobalV::NLOCAL; ++iw)
+            {
+                for (int ib = 0; ib < GlobalV::NBANDS; ++ib)
+                {
+                    ofs_hvec << q_pack->hvec_array[iq](iw, ib).real() << " " << q_pack->hvec_array[iq](iw, ib).imag()
+                             << " ";
+                }
+                ofs_hvec << std::endl;
+            }
+        }
+        ofs_hvec.close();
+    }
+    return;
 }
 
 void Exx_Lip::read_q_pack(const ModuleSymmetry::Symmetry& symm,
                           const ModulePW::PW_Basis_K* wfc_basis,
                           const Structure_Factor& sf)
 {
-	const std::string exx_q_pack = "exx_q_pack/";
+    const std::string exx_q_pack = "exx_q_pack/";
 
-	q_pack = new k_package();
+    q_pack = new k_package();
 
-	q_pack->kv_ptr = new K_Vectors();
-	const std::string exx_kpoint_card = GlobalV::global_out_dir + exx_q_pack + GlobalV::global_kpoint_card;
-	q_pack->kv_ptr->set( symm, exx_kpoint_card, GlobalV::NSPIN, ucell_ptr->G, ucell_ptr->latvec, GlobalV::ofs_running );
+    q_pack->kv_ptr = new K_Vectors();
+    const std::string exx_kpoint_card = GlobalV::global_out_dir + exx_q_pack + GlobalV::global_kpoint_card;
+    q_pack->kv_ptr->set(symm, exx_kpoint_card, GlobalV::NSPIN, ucell_ptr->G, ucell_ptr->latvec, GlobalV::ofs_running);
 
-	q_pack->wf_ptr = new wavefunc();
+    q_pack->wf_ptr = new wavefunc();
     q_pack->wf_ptr->allocate(q_pack->kv_ptr->get_nkstot(),
                              q_pack->kv_ptr->get_nks(),
                              q_pack->kv_ptr->ngk.data(),
                              wfc_basis->npwk_max); // mohan update 2021-02-25
     //	q_pack->wf_ptr->init(q_pack->kv_ptr->get_nks(),q_pack->kv_ptr,ucell_ptr,old_pwptr,&ppcell,&GlobalC::ORB,&hm,&Pkpoints);
     q_pack->wf_ptr->table_local.create(GlobalC::ucell.ntype, GlobalC::ucell.nmax_total, GlobalV::NQX);
-//	q_pack->wf_ptr->table_local.create(q_pack->wf_ptr->ucell_ptr->ntype, q_pack->wf_ptr->ucell_ptr->nmax_total, GlobalV::NQX);
+//	q_pack->wf_ptr->table_local.create(q_pack->wf_ptr->ucell_ptr->ntype, q_pack->wf_ptr->ucell_ptr->nmax_total,
+//GlobalV::NQX);
 #ifdef __LCAO
-	Wavefunc_in_pw::make_table_q(GlobalC::ORB.orbital_file, q_pack->wf_ptr->table_local);
-//	Wavefunc_in_pw::make_table_q(q_pack->wf_ptr->ORB_ptr->orbital_file, q_pack->wf_ptr->table_local, q_pack->wf_ptr);
-	for(int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
-	{
+    Wavefunc_in_pw::make_table_q(GlobalC::ORB.orbital_file, q_pack->wf_ptr->table_local);
+    //	Wavefunc_in_pw::make_table_q(q_pack->wf_ptr->ORB_ptr->orbital_file, q_pack->wf_ptr->table_local,
+    //q_pack->wf_ptr);
+    for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
+    {
         Wavefunc_in_pw::produce_local_basis_in_pw(iq,
                                                   wfc_basis,
                                                   sf,
@@ -709,108 +757,108 @@ void Exx_Lip::read_q_pack(const ModuleSymmetry::Symmetry& symm,
         // q_pack->wf_ptr);
     }
 #endif
-	q_pack->wf_wg.create(q_pack->kv_ptr->get_nks(),GlobalV::NBANDS);
-	if(!GlobalV::RANK_IN_POOL)
-	{
-		std::stringstream ss_wf_wg;
-		ss_wf_wg << GlobalV::global_out_dir << exx_q_pack << "wf_wg_" << GlobalV::MY_POOL;
-		std::ifstream ifs_wf_wg(ss_wf_wg.str().c_str());
-		for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-		{
-			for( int ib=0; ib<GlobalV::NBANDS; ++ib)
-			{
-				ifs_wf_wg>>q_pack->wf_wg(iq,ib);
-			}
-		}
-		ifs_wf_wg.close();
-	}
-	#ifdef __MPI
-	MPI_Bcast( q_pack->wf_wg.c, q_pack->kv_ptr->get_nks()*GlobalV::NBANDS, MPI_DOUBLE, 0, POOL_WORLD);
-	#endif
+    q_pack->wf_wg.create(q_pack->kv_ptr->get_nks(), GlobalV::NBANDS);
+    if (!GlobalV::RANK_IN_POOL)
+    {
+        std::stringstream ss_wf_wg;
+        ss_wf_wg << GlobalV::global_out_dir << exx_q_pack << "wf_wg_" << GlobalV::MY_POOL;
+        std::ifstream ifs_wf_wg(ss_wf_wg.str().c_str());
+        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
+        {
+            for (int ib = 0; ib < GlobalV::NBANDS; ++ib)
+            {
+                ifs_wf_wg >> q_pack->wf_wg(iq, ib);
+            }
+        }
+        ifs_wf_wg.close();
+    }
+#ifdef __MPI
+    MPI_Bcast(q_pack->wf_wg.c, q_pack->kv_ptr->get_nks() * GlobalV::NBANDS, MPI_DOUBLE, 0, POOL_WORLD);
+#endif
 
-	q_pack->hvec_array = new ModuleBase::ComplexMatrix [q_pack->kv_ptr->get_nks()];
-	for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
-	{
-		q_pack->hvec_array[iq].create(GlobalV::NLOCAL,GlobalV::NBANDS);
-	}
-	if(!GlobalV::RANK_IN_POOL)
-	{
-		std::stringstream ss_hvec;
-		ss_hvec	<< GlobalV::global_out_dir << exx_q_pack << "hvec_" << GlobalV::MY_POOL;
-		std::ifstream ifs_hvec(ss_hvec.str().c_str());
-		for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
-		{
-			for( int iw=0; iw<GlobalV::NLOCAL; ++iw)
-			{
-				for( int ib=0; ib<GlobalV::NBANDS; ++ib)
-				{
-					double a,b;
-					ifs_hvec>>a>>b;
-					q_pack->hvec_array[iq](iw,ib) = {a,b};
-				}
-			}
-		}
-		ifs_hvec.close();
-	}
-	#ifdef __MPI
-	for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
-	{
-		MPI_Bcast( q_pack->hvec_array[iq].c, GlobalV::NLOCAL*GlobalV::NBANDS, MPI_DOUBLE_COMPLEX, 0, POOL_WORLD);
-	}
-	#endif
+    q_pack->hvec_array = new ModuleBase::ComplexMatrix[q_pack->kv_ptr->get_nks()];
+    for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
+    {
+        q_pack->hvec_array[iq].create(GlobalV::NLOCAL, GlobalV::NBANDS);
+    }
+    if (!GlobalV::RANK_IN_POOL)
+    {
+        std::stringstream ss_hvec;
+        ss_hvec << GlobalV::global_out_dir << exx_q_pack << "hvec_" << GlobalV::MY_POOL;
+        std::ifstream ifs_hvec(ss_hvec.str().c_str());
+        for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
+        {
+            for (int iw = 0; iw < GlobalV::NLOCAL; ++iw)
+            {
+                for (int ib = 0; ib < GlobalV::NBANDS; ++ib)
+                {
+                    double a, b;
+                    ifs_hvec >> a >> b;
+                    q_pack->hvec_array[iq](iw, ib) = {a, b};
+                }
+            }
+        }
+        ifs_hvec.close();
+    }
+#ifdef __MPI
+    for (int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
+    {
+        MPI_Bcast(q_pack->hvec_array[iq].c, GlobalV::NLOCAL * GlobalV::NBANDS, MPI_DOUBLE_COMPLEX, 0, POOL_WORLD);
+    }
+#endif
 
-	return;
+    return;
 }
 
 /*
 void Exx_Lip::write_q_pack() const
 {
 
-	if( !GlobalV::RANK_IN_POOL )
-	{
-       	std::stringstream ssc;
+    if( !GlobalV::RANK_IN_POOL )
+    {
+        std::stringstream ssc;
         ssc << GlobalV::global_out_dir << "exx_q_pack_" << GlobalV::MY_POOL;
-		std::ofstream ofs(ssc.str().c_str());
-    	if (!ofs)
-    	{
-        	ModuleBase::WARNING("Exx_Lip::write_q_pack","Can't create Exx_Lip File!");
-    	}
+        std::ofstream ofs(ssc.str().c_str());
+        if (!ofs)
+        {
+            ModuleBase::WARNING("Exx_Lip::write_q_pack","Can't create Exx_Lip File!");
+        }
 
-		ofs<<q_pack->kv_ptr->get_nks()<<std::endl;
-		for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-		{
-			ofs<<q_pack->kv_ptr->ngk[iq]<<" ";
-		}
-		ofs<<std::endl;
-		for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-		{
-			ofs<<q_pack.kvec_c[iq].x<<" "<<q_pack.kvec_c[iq].y<<" "<<q_pack.kvec_c[iq].z<<" "<<std::endl;
-			ofs<<q_pack.kvec_d[iq].x<<" "<<q_pack.kvec_d[iq].y<<" "<<q_pack.kvec_d[iq].z<<" "<<std::endl;
-		}
-		ofs<<std::endl;
-		for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-		{
-			for( int ib=0; ib<GlobalV::NBANDS; ++ib)
-			{
-				ofs<<q_pack.wf_wg[iq][ib]<<" ";
-			}
-			ofs<<std::endl;
-		}
-		ofs<<std::endl;
-		for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
-		{
-			for( int iw=0; iw<GlobalV::NLOCAL; ++iw)
-			{
-				for( int ib=0; ib<GlobalV::NBANDS; ++ib)
-				{
-					ofs<<q_pack.hvec_array[iq](iw,ib).real()<<" "<<q_pack.hvec_array[iq](iw,ib).imag()<<" ";
-				}
-				ofs<<std::endl;
-			}
-		}
-		ofs.close();
-	}
-	return;
+        ofs<<q_pack->kv_ptr->get_nks()<<std::endl;
+        for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
+        {
+            ofs<<q_pack->kv_ptr->ngk[iq]<<" ";
+        }
+        ofs<<std::endl;
+        for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
+        {
+            ofs<<q_pack.kvec_c[iq].x<<" "<<q_pack.kvec_c[iq].y<<" "<<q_pack.kvec_c[iq].z<<" "<<std::endl;
+            ofs<<q_pack.kvec_d[iq].x<<" "<<q_pack.kvec_d[iq].y<<" "<<q_pack.kvec_d[iq].z<<" "<<std::endl;
+        }
+        ofs<<std::endl;
+        for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
+        {
+            for( int ib=0; ib<GlobalV::NBANDS; ++ib)
+            {
+                ofs<<q_pack.wf_wg[iq][ib]<<" ";
+            }
+            ofs<<std::endl;
+        }
+        ofs<<std::endl;
+        for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
+        {
+            for( int iw=0; iw<GlobalV::NLOCAL; ++iw)
+            {
+                for( int ib=0; ib<GlobalV::NBANDS; ++ib)
+                {
+                    ofs<<q_pack.hvec_array[iq](iw,ib).real()<<" "<<q_pack.hvec_array[iq](iw,ib).imag()<<" ";
+                }
+                ofs<<std::endl;
+            }
+        }
+        ofs.close();
+    }
+    return;
 }
 */
 
@@ -818,134 +866,134 @@ void Exx_Lip::write_q_pack() const
 void Exx_Lip::read_q_pack()
 {
 
-	std::ifstream ifs;
-	if( !GlobalV::RANK_IN_POOL )
-	{
-       	std::stringstream ssc;
+    std::ifstream ifs;
+    if( !GlobalV::RANK_IN_POOL )
+    {
+        std::stringstream ssc;
         ssc << GlobalV::global_out_dir << "exx_q_pack_" << GlobalV::MY_POOL;
-		ifs.open(ssc.str().c_str());
-    	if (!ifs)
-    	{
-        	ModuleBase::WARNING("Exx_Lip::write_q_pack","Can't read Exx_Lip File!");
-    	}
+        ifs.open(ssc.str().c_str());
+        if (!ifs)
+        {
+            ModuleBase::WARNING("Exx_Lip::write_q_pack","Can't read Exx_Lip File!");
+        }
 
-		ifs >> q_pack->kv_ptr->get_nks();
-	}
+        ifs >> q_pack->kv_ptr->get_nks();
+    }
 
-	MPI_Bcast( &q_pack->kv_ptr->get_nks(), 1, MPI_INT, 0, POOL_WORLD);
+    MPI_Bcast( &q_pack->kv_ptr->get_nks(), 1, MPI_INT, 0, POOL_WORLD);
 
-	q_pack->kv_ptr->ngk = new int [q_pack->kv_ptr->get_nks()];
-	q_pack.kvec_c = new ModuleBase::Vector3<double> [q_pack->kv_ptr->get_nks()];
-	q_pack.kvec_d = new ModuleBase::Vector3<double> [q_pack->kv_ptr->get_nks()];
-	double *kvec_tmp = new double [q_pack->kv_ptr->get_nks()*6];				// just for MPI
-	q_pack.wf_wg = new double *[q_pack->kv_ptr->get_nks()];
-	for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
-	{
-		q_pack.wf_wg[iq] = new double[GlobalV::NBANDS];
-	}
-	q_pack.hvec_array = new ModuleBase::ComplexMatrix [q_pack->kv_ptr->get_nks()];
-	for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
-	{
-		q_pack.hvec_array[iq].create(GlobalV::NLOCAL,GlobalV::NBANDS);
-	}
+    q_pack->kv_ptr->ngk = new int [q_pack->kv_ptr->get_nks()];
+    q_pack.kvec_c = new ModuleBase::Vector3<double> [q_pack->kv_ptr->get_nks()];
+    q_pack.kvec_d = new ModuleBase::Vector3<double> [q_pack->kv_ptr->get_nks()];
+    double *kvec_tmp = new double [q_pack->kv_ptr->get_nks()*6];				// just for MPI
+    q_pack.wf_wg = new double *[q_pack->kv_ptr->get_nks()];
+    for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
+    {
+        q_pack.wf_wg[iq] = new double[GlobalV::NBANDS];
+    }
+    q_pack.hvec_array = new ModuleBase::ComplexMatrix [q_pack->kv_ptr->get_nks()];
+    for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
+    {
+        q_pack.hvec_array[iq].create(GlobalV::NLOCAL,GlobalV::NBANDS);
+    }
 
-	if( !GlobalV::RANK_IN_POOL )
-	{
-		for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-		{
-			ifs>>q_pack->kv_ptr->ngk[iq];
-		}
-		for( int iq_tmp = 0; iq_tmp < q_pack->kv_ptr->get_nks()*6; ++iq_tmp)
-		{
-			ifs>>kvec_tmp[iq_tmp];
-		}
-		for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-		{
-			for( int ib=0; ib<GlobalV::NBANDS; ++ib)
-			{
-				ifs>>q_pack.wf_wg[iq][ib];
-			}
-		}
-		for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
-		{
-			for( int iw=0; iw<GlobalV::NLOCAL; ++iw)
-			{
-				for( int ib=0; ib<GlobalV::NBANDS; ++ib)
-				{
-					ifs>>q_pack.hvec_array[iq](iw,ib).real()>>q_pack.hvec_array[iq](iw,ib).imag();
-				}
-			}
-		}
-		ifs.close();
-	}
+    if( !GlobalV::RANK_IN_POOL )
+    {
+        for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
+        {
+            ifs>>q_pack->kv_ptr->ngk[iq];
+        }
+        for( int iq_tmp = 0; iq_tmp < q_pack->kv_ptr->get_nks()*6; ++iq_tmp)
+        {
+            ifs>>kvec_tmp[iq_tmp];
+        }
+        for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
+        {
+            for( int ib=0; ib<GlobalV::NBANDS; ++ib)
+            {
+                ifs>>q_pack.wf_wg[iq][ib];
+            }
+        }
+        for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
+        {
+            for( int iw=0; iw<GlobalV::NLOCAL; ++iw)
+            {
+                for( int ib=0; ib<GlobalV::NBANDS; ++ib)
+                {
+                    ifs>>q_pack.hvec_array[iq](iw,ib).real()>>q_pack.hvec_array[iq](iw,ib).imag();
+                }
+            }
+        }
+        ifs.close();
+    }
 
-	MPI_Bcast( q_pack->kv_ptr->ngk, q_pack->kv_ptr->get_nks(), MPI_INT, 0, POOL_WORLD);
-	MPI_Bcast( kvec_tmp, q_pack->kv_ptr->get_nks()*6, MPI_DOUBLE, 0, POOL_WORLD);
-	for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
-	{
-		q_pack.kvec_c[iq].x = kvec_tmp[iq*6+0];
-		q_pack.kvec_c[iq].y = kvec_tmp[iq*6+1];
-		q_pack.kvec_c[iq].z = kvec_tmp[iq*6+2];
-		q_pack.kvec_d[iq].x = kvec_tmp[iq*6+3];
-		q_pack.kvec_d[iq].y = kvec_tmp[iq*6+4];
-		q_pack.kvec_d[iq].z = kvec_tmp[iq*6+5];
-	}
-	delete[] kvec_tmp;
-	for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
-	{
-		MPI_Bcast( q_pack.wf_wg[iq], GlobalV::NBANDS, MPI_DOUBLE, 0, POOL_WORLD);
-	}
-	for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
-	{
-		MPI_Bcast( q_pack.hvec_array[iq].c, GlobalV::NLOCAL*GlobalV::NBANDS, MPI_DOUBLE_COMPLEX, 0, POOL_WORLD);
-	}
+    MPI_Bcast( q_pack->kv_ptr->ngk, q_pack->kv_ptr->get_nks(), MPI_INT, 0, POOL_WORLD);
+    MPI_Bcast( kvec_tmp, q_pack->kv_ptr->get_nks()*6, MPI_DOUBLE, 0, POOL_WORLD);
+    for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
+    {
+        q_pack.kvec_c[iq].x = kvec_tmp[iq*6+0];
+        q_pack.kvec_c[iq].y = kvec_tmp[iq*6+1];
+        q_pack.kvec_c[iq].z = kvec_tmp[iq*6+2];
+        q_pack.kvec_d[iq].x = kvec_tmp[iq*6+3];
+        q_pack.kvec_d[iq].y = kvec_tmp[iq*6+4];
+        q_pack.kvec_d[iq].z = kvec_tmp[iq*6+5];
+    }
+    delete[] kvec_tmp;
+    for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
+    {
+        MPI_Bcast( q_pack.wf_wg[iq], GlobalV::NBANDS, MPI_DOUBLE, 0, POOL_WORLD);
+    }
+    for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
+    {
+        MPI_Bcast( q_pack.hvec_array[iq].c, GlobalV::NLOCAL*GlobalV::NBANDS, MPI_DOUBLE_COMPLEX, 0, POOL_WORLD);
+    }
 
 
-	auto test_print = [&]()
-	{
-		std::stringstream sss;
-		sss << GlobalV::global_out_dir << "exx_q_pack_tmp" << GlobalV::MY_RANK;
-		std::ofstream ofs(sss.str().c_str());
-		if (!ofs)
-		{
-			ModuleBase::WARNING("Exx_Lip::write_q_pack","Can't create Exx_Lip File!");
-		}
+    auto test_print = [&]()
+    {
+        std::stringstream sss;
+        sss << GlobalV::global_out_dir << "exx_q_pack_tmp" << GlobalV::MY_RANK;
+        std::ofstream ofs(sss.str().c_str());
+        if (!ofs)
+        {
+            ModuleBase::WARNING("Exx_Lip::write_q_pack","Can't create Exx_Lip File!");
+        }
 
-		ofs<<q_pack->kv_ptr->get_nks()<<std::endl;
-		for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-		{
-			ofs<<q_pack->kv_ptr->ngk[iq]<<" ";
-		}
-		ofs<<std::endl;
-		for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-		{
-			ofs<<q_pack.kvec_c[iq].x<<" "<<q_pack.kvec_c[iq].y<<" "<<q_pack.kvec_c[iq].z<<" "<<std::endl;
-			ofs<<q_pack.kvec_d[iq].x<<" "<<q_pack.kvec_d[iq].y<<" "<<q_pack.kvec_d[iq].z<<" "<<std::endl;
-		}
-		ofs<<std::endl;
-		for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
-		{
-			for( int ib=0; ib<GlobalV::NBANDS; ++ib)
-			{
-				ofs<<q_pack.wf_wg[iq][ib]<<" ";
-			}
-			ofs<<std::endl;
-		}
-		ofs<<std::endl;
-		for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
-		{
-			for( int iw=0; iw<GlobalV::NLOCAL; ++iw)
-			{
-				for( int ib=0; ib<GlobalV::NBANDS; ++ib)
-				{
-					ofs<<q_pack.hvec_array[iq](iw,ib).real()<<" "<<q_pack.hvec_array[iq](iw,ib).imag()<<" ";
-				}
-				ofs<<std::endl;
-			}
-		}
-		ofs.close();
-	};
+        ofs<<q_pack->kv_ptr->get_nks()<<std::endl;
+        for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
+        {
+            ofs<<q_pack->kv_ptr->ngk[iq]<<" ";
+        }
+        ofs<<std::endl;
+        for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
+        {
+            ofs<<q_pack.kvec_c[iq].x<<" "<<q_pack.kvec_c[iq].y<<" "<<q_pack.kvec_c[iq].z<<" "<<std::endl;
+            ofs<<q_pack.kvec_d[iq].x<<" "<<q_pack.kvec_d[iq].y<<" "<<q_pack.kvec_d[iq].z<<" "<<std::endl;
+        }
+        ofs<<std::endl;
+        for( int iq = 0; iq < q_pack->kv_ptr->get_nks(); ++iq)
+        {
+            for( int ib=0; ib<GlobalV::NBANDS; ++ib)
+            {
+                ofs<<q_pack.wf_wg[iq][ib]<<" ";
+            }
+            ofs<<std::endl;
+        }
+        ofs<<std::endl;
+        for( int iq=0; iq<q_pack->kv_ptr->get_nks(); ++iq)
+        {
+            for( int iw=0; iw<GlobalV::NLOCAL; ++iw)
+            {
+                for( int ib=0; ib<GlobalV::NBANDS; ++ib)
+                {
+                    ofs<<q_pack.hvec_array[iq](iw,ib).real()<<" "<<q_pack.hvec_array[iq](iw,ib).imag()<<" ";
+                }
+                ofs<<std::endl;
+            }
+        }
+        ofs.close();
+    };
 
-	return;
+    return;
 }
 */

--- a/tests/integrate/117_PW_out_pot/INPUT
+++ b/tests/integrate/117_PW_out_pot/INPUT
@@ -24,3 +24,4 @@ smearing_sigma			0.002
 mixing_type		broyden
 mixing_beta		0.7
 
+init_chg auto

--- a/tests/integrate/117_PW_out_pot/jd
+++ b/tests/integrate/117_PW_out_pot/jd
@@ -1,1 +1,1 @@
-test out_pot in PW KSDFT. symmetry = on.
+test out_pot in PW KSDFT. symmetry = on.; test init_chg=auto, and no chg file (will use atomic chg). 

--- a/tests/integrate/118_PW_CHG_BINARY/INPUT
+++ b/tests/integrate/118_PW_CHG_BINARY/INPUT
@@ -29,5 +29,5 @@ pseudo_rcut            10
 cal_force              1
 cal_stress             1
 
-init_chg               file
+init_chg               auto
 read_file_dir          .

--- a/tests/integrate/118_PW_CHG_BINARY/jd
+++ b/tests/integrate/118_PW_CHG_BINARY/jd
@@ -1,1 +1,1 @@
-test read rho in G space from binary file charge-density.dat
+test read rho in G space from binary file charge-density.dat; init_chg=auto and has chg file.

--- a/tests/integrate/214_NO_mulliken_nscf/INPUT
+++ b/tests/integrate/214_NO_mulliken_nscf/INPUT
@@ -14,5 +14,5 @@ ecutwfc			25.0              # Rydberg
 basis_type		lcao 	
 scf_thr			1e-10
 
-calculation     	nscf
+calculation     	scf
 out_mul			1

--- a/tests/integrate/214_NO_mulliken_nscf/mulliken.txt.ref
+++ b/tests/integrate/214_NO_mulliken_nscf/mulliken.txt.ref
@@ -3,15 +3,15 @@ CALCULATE THE MULLIkEN ANALYSIS FOR EACH ATOM
  Total charge:	2
 Decomposed Mulliken populations
 0                              Zeta of H              Spin 1
-s                                      0              0.9903
-s                                      1             -0.0021
-SUM OVER M+Zeta                                       0.9881
+s                                      0              0.9980
+s                                      1             -0.0051
+SUM OVER M+Zeta                                       0.9929
 
-pz                                     0              0.0119
+pz                                     0              0.0071
 px                                     0              0.0000
 py                                     0              0.0000
-SUM OVER M                                            0.0119
-SUM OVER M+Zeta                                       0.0119
+SUM OVER M                                            0.0071
+SUM OVER M+Zeta                                       0.0071
 
 SUM OVER M+Zeta+L                                     1.0000
 
@@ -19,15 +19,15 @@ Total Charge on atom:                  H              1.0000
 
 
 1                              Zeta of H              Spin 1
-s                                      0              0.9903
-s                                      1             -0.0021
-SUM OVER M+Zeta                                       0.9881
+s                                      0              0.9980
+s                                      1             -0.0051
+SUM OVER M+Zeta                                       0.9929
 
-pz                                     0              0.0119
+pz                                     0              0.0071
 px                                     0              0.0000
 py                                     0              0.0000
-SUM OVER M                                            0.0119
-SUM OVER M+Zeta                                       0.0119
+SUM OVER M                                            0.0071
+SUM OVER M+Zeta                                       0.0071
 
 SUM OVER M+Zeta+L                                     1.0000
 

--- a/tests/integrate/214_NO_mulliken_nscf/result.ref
+++ b/tests/integrate/214_NO_mulliken_nscf/result.ref
@@ -1,2 +1,4 @@
+etotref -31.57750366324147
+etotperatomref -15.7887518316
 Compare_mulliken_pass 0
-totaltimeref 0.20
+totaltimeref 0.34


### PR DESCRIPTION
- Add a new option `auto` for init_chg, which abacus will firstly read charge density from file and if reading failed will use atomic charge.
- Modify the function of option `file`, and when reading is failed, abacus will warning quit.

### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #4480

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
