### PR TITLE
Fix: out-of-bound indexing for jlm1 when l=0

### DIFF
--- a/source/module_hamilt_lcao/hamilt_lcaodft/center2_orb.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/center2_orb.cpp
@@ -8,16 +8,16 @@
 #include "module_base/tool_quit.h"
 #include "module_base/tool_title.h"
 
-int Center2_Orb::get_rmesh(const double& R1, const double& R2, const double dr)
-{
+int Center2_Orb::get_rmesh(const double& R1,
+                           const double& R2,
+                           const double dr) {
     int rmesh = static_cast<int>((R1 + R2) / dr) + 5;
     // mohan update 2009-09-08 +1 ==> +5
     // considering interpolation or so on...
     if (rmesh % 2 == 0)
         rmesh++;
 
-    if (rmesh <= 0)
-    {
+    if (rmesh <= 0) {
         // GlobalV::ofs_warning << "\n R1 = " << R1 << " R2 = " << R2;
         // GlobalV::ofs_warning << "\n rmesh = " << rmesh;
         std::cout << "\n R1 = " << R1 << " R2 = " << R2;
@@ -34,16 +34,13 @@ void Center2_Orb::init_Lmax(const int orb_num,
                             int& Lmax,
                             const int& Lmax_exx,
                             const int lmax_orb,
-                            const int lmax_beta)
-{
+                            const int lmax_beta) {
 
     Lmax = -1;
 
-    switch (orb_num)
-    {
+    switch (orb_num) {
     case 2:
-        switch (mode)
-        {
+        switch (mode) {
         case 1: // used in <Phi|Phi> or <Beta|Phi>
             Lmax = std::max({Lmax, lmax_orb, lmax_beta});
             // use 2lmax+1 in dS
@@ -59,13 +56,13 @@ void Center2_Orb::init_Lmax(const int orb_num,
             Lmax_used = 2 * Lmax + 1;
             break;
         default:
-            throw std::invalid_argument("Center2_Orb::init_Lmax orb_num=2, mode error");
+            throw std::invalid_argument(
+                "Center2_Orb::init_Lmax orb_num=2, mode error");
             break;
         }
         break;
     case 3:
-        switch (mode)
-        {
+        switch (mode) {
         case 1: // used in <jY|PhiPhi> or <Abfs|PhiPhi>
             Lmax = std::max(Lmax, lmax_orb);
             Lmax_used = 2 * Lmax + 1;
@@ -73,19 +70,20 @@ void Center2_Orb::init_Lmax(const int orb_num,
             Lmax_used += Lmax_exx;
             break;
         default:
-            throw std::invalid_argument("Center2_Orb::init_Lmax orb_num=3, mode error");
+            throw std::invalid_argument(
+                "Center2_Orb::init_Lmax orb_num=3, mode error");
             break;
         }
         break;
     case 4:
-        switch (mode)
-        {
+        switch (mode) {
         case 1: // used in <PhiPhi|PhiPhi>
             Lmax = std::max(Lmax, lmax_orb);
             Lmax_used = 2 * (2 * Lmax + 1);
             break;
         default:
-            throw std::invalid_argument("Center2_Orb::init_Lmax orb_num=4, mode error");
+            throw std::invalid_argument(
+                "Center2_Orb::init_Lmax orb_num=4, mode error");
             break;
         }
         break;
@@ -98,34 +96,37 @@ void Center2_Orb::init_Lmax(const int orb_num,
 }
 
 // Peize Lin update 2016-01-26
-void Center2_Orb::init_Table_Spherical_Bessel(const int orb_num,
-                                              const int mode,
-                                              int& Lmax_used,
-                                              int& Lmax,
-                                              const int& Lmax_exx,
-                                              const int lmax_orb,
-                                              const int lmax_beta,
-                                              const double dr,
-                                              const double dk,
-                                              const int kmesh,
-                                              const int Rmesh,
-                                              ModuleBase::Sph_Bessel_Recursive::D2*& psb)
-{
+void Center2_Orb::init_Table_Spherical_Bessel(
+    const int orb_num,
+    const int mode,
+    int& Lmax_used,
+    int& Lmax,
+    const int& Lmax_exx,
+    const int lmax_orb,
+    const int lmax_beta,
+    const double dr,
+    const double dk,
+    const int kmesh,
+    const int Rmesh,
+    ModuleBase::Sph_Bessel_Recursive::D2*& psb) {
     ModuleBase::TITLE("Center2_Orb", "init_Table_Spherical_Bessel");
 
-    init_Lmax(orb_num, mode, Lmax_used, Lmax, Lmax_exx, lmax_orb, lmax_beta); // Peize Lin add 2016-01-26
+    init_Lmax(orb_num,
+              mode,
+              Lmax_used,
+              Lmax,
+              Lmax_exx,
+              lmax_orb,
+              lmax_beta); // Peize Lin add 2016-01-26
 
-    for (auto& sb: ModuleBase::Sph_Bessel_Recursive_Pool::D2::sb_pool)
-    {
-        if (dr * dk == sb.get_dx())
-        {
+    for (auto& sb: ModuleBase::Sph_Bessel_Recursive_Pool::D2::sb_pool) {
+        if (dr * dk == sb.get_dx()) {
             psb = &sb;
             break;
         }
     }
 
-    if (!psb)
-    {
+    if (!psb) {
         ModuleBase::Sph_Bessel_Recursive_Pool::D2::sb_pool.push_back({});
         psb = &ModuleBase::Sph_Bessel_Recursive_Pool::D2::sb_pool.back();
     }
@@ -133,19 +134,21 @@ void Center2_Orb::init_Table_Spherical_Bessel(const int orb_num,
     psb->set_dx(dr * dk);
     psb->cal_jlx(Lmax_used, Rmesh, kmesh);
 
-    ModuleBase::Memory::record("ORB::Jl(x)", sizeof(double) * (Lmax_used + 1) * kmesh * Rmesh);
+    ModuleBase::Memory::record("ORB::Jl(x)",
+                               sizeof(double) * (Lmax_used + 1) * kmesh
+                                   * Rmesh);
 }
 
 // Peize Lin accelerate 2017-10-02
-void Center2_Orb::cal_ST_Phi12_R(const int& job,
-                                 const int& l,
-                                 const Numerical_Orbital_Lm& n1,
-                                 const Numerical_Orbital_Lm& n2,
-                                 const int& rmesh,
-                                 double* rs,
-                                 double* drs,
-                                 const ModuleBase::Sph_Bessel_Recursive::D2* psb)
-{
+void Center2_Orb::cal_ST_Phi12_R(
+    const int& job,
+    const int& l,
+    const Numerical_Orbital_Lm& n1,
+    const Numerical_Orbital_Lm& n2,
+    const int& rmesh,
+    double* rs,
+    double* drs,
+    const ModuleBase::Sph_Bessel_Recursive::D2* psb) {
     ModuleBase::timer::tick("Center2_Orb", "cal_ST_Phi12_R");
 
     const int kmesh = n1.getNk();
@@ -154,43 +157,32 @@ void Center2_Orb::cal_ST_Phi12_R(const int& job,
 
     std::vector<double> k1_dot_k2(kmesh);
     // Peize Lin change 2017-12-12
-    switch (job)
-    {
+    switch (job) {
     case 1: // calculate overlap
-        if (!n1.get_psif().empty() && !n2.get_psi_k2().empty())
-        {
-            for (int ik = 0; ik < kmesh; ik++)
-            {
+        if (!n1.get_psif().empty() && !n2.get_psi_k2().empty()) {
+            for (int ik = 0; ik < kmesh; ik++) {
                 k1_dot_k2[ik] = n1.getPsif(ik) * n2.getPsi_k2(ik);
             }
-        }
-        else if (!n1.get_psi_k().empty() && !n2.get_psi_k().empty())
-        {
-            for (int ik = 0; ik < kmesh; ik++)
-            {
+        } else if (!n1.get_psi_k().empty() && !n2.get_psi_k().empty()) {
+            for (int ik = 0; ik < kmesh; ik++) {
                 k1_dot_k2[ik] = n1.getPsi_k(ik) * n2.getPsi_k(ik);
             }
-        }
-        else if (!n1.get_psi_k2().empty() && !n2.get_psif().empty())
-        {
-            for (int ik = 0; ik < kmesh; ik++)
-            {
+        } else if (!n1.get_psi_k2().empty() && !n2.get_psif().empty()) {
+            for (int ik = 0; ik < kmesh; ik++) {
                 k1_dot_k2[ik] = n1.getPsi_k2(ik) * n2.getPsif(ik);
             }
         }
         break;
 
     case 2: // calculate kinetic energy
-        for (int ik = 0; ik < kmesh; ik++)
-        {
+        for (int ik = 0; ik < kmesh; ik++) {
             k1_dot_k2[ik] = n1.getPsi_k2(ik) * n2.getPsi_k2(ik);
         }
         break;
     }
 
     std::vector<double> k1_dot_k2_dot_kpoint(kmesh);
-    for (int ik = 0; ik < kmesh; ik++)
-    {
+    for (int ik = 0; ik < kmesh; ik++) {
         k1_dot_k2_dot_kpoint[ik] = k1_dot_k2[ik] * kpoint[ik];
     }
 
@@ -202,8 +194,7 @@ void Center2_Orb::cal_ST_Phi12_R(const int& job,
     // double* integrated_func = new double[kmesh];
 
     int ll = 0;
-    if (l != 0)
-    {
+    if (l != 0) {
         ll = l - 1;
     }
 
@@ -214,40 +205,40 @@ void Center2_Orb::cal_ST_Phi12_R(const int& job,
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
-    for (int ir = 0; ir < rmesh; ir++)
-    {
+    for (int ir = 0; ir < rmesh; ir++) {
         std::vector<double> integrated_func(kmesh);
         const std::vector<double>& jl_r = jl[ir];
-        for (int ik = 0; ik < kmesh; ++ik)
-        {
+        for (int ik = 0; ik < kmesh; ++ik) {
             integrated_func[ik] = jl_r[ik] * k1_dot_k2[ik];
         }
         // Call simpson integration
         double temp = 0.0;
 
-        ModuleBase::Integral::Simpson_Integral(kmesh, integrated_func.data(), dk, temp);
+        ModuleBase::Integral::Simpson_Integral(kmesh,
+                                               integrated_func.data(),
+                                               dk,
+                                               temp);
         rs[ir] = temp * ModuleBase::FOUR_PI;
 
         // Peize Lin accelerate 2017-10-02
         const std::vector<double>& jlm1_r = jlm1[ir];
         const std::vector<double>& jlp1_r = jlp1[ir];
         const double fac = l / (l + 1.0);
-        if (l == 0)
-        {
-            for (int ik = 0; ik < kmesh; ++ik)
-            {
+        if (l == 0) {
+            for (int ik = 0; ik < kmesh; ++ik) {
                 integrated_func[ik] = jlp1_r[ik] * k1_dot_k2_dot_kpoint[ik];
             }
-        }
-        else
-        {
-            for (int ik = 0; ik < kmesh; ++ik)
-            {
-                integrated_func[ik] = (jlp1_r[ik] - fac * jlm1_r[ik]) * k1_dot_k2_dot_kpoint[ik];
+        } else {
+            for (int ik = 0; ik < kmesh; ++ik) {
+                integrated_func[ik] = (jlp1_r[ik] - fac * jlm1_r[ik])
+                                      * k1_dot_k2_dot_kpoint[ik];
             }
         }
 
-        ModuleBase::Integral::Simpson_Integral(kmesh, integrated_func.data(), dk, temp);
+        ModuleBase::Integral::Simpson_Integral(kmesh,
+                                               integrated_func.data(),
+                                               dk,
+                                               temp);
         drs[ir] = -ModuleBase::FOUR_PI * (l + 1) / (2.0 * l + 1) * temp;
     }
 
@@ -255,18 +246,20 @@ void Center2_Orb::cal_ST_Phi12_R(const int& job,
     // special case for R=0
     // we store Slm(R) / R**l at the fisrt point, rather than Slm(R)
 
-    if (l > 0)
-    {
+    if (l > 0) {
         std::vector<double> integrated_func(kmesh);
         double temp = 0.0;
 
-        for (int ik = 0; ik < kmesh; ik++)
-        {
+        for (int ik = 0; ik < kmesh; ik++) {
             integrated_func[ik] = k1_dot_k2[ik] * std::pow(kpoint[ik], l);
         }
 
-        ModuleBase::Integral::Simpson_Integral(kmesh, integrated_func.data(), dk, temp);
-        rs[0] = ModuleBase::FOUR_PI / ModuleBase::Mathzone_Add1::dualfac(2 * l + 1) * temp;
+        ModuleBase::Integral::Simpson_Integral(kmesh,
+                                               integrated_func.data(),
+                                               dk,
+                                               temp);
+        rs[0] = ModuleBase::FOUR_PI
+                / ModuleBase::Mathzone_Add1::dualfac(2 * l + 1) * temp;
     }
 
     ModuleBase::timer::tick("Center2_Orb", "cal_ST_Phi12_R");
@@ -275,15 +268,15 @@ void Center2_Orb::cal_ST_Phi12_R(const int& job,
 #include "module_base/constants.h"
 
 // Peize Lin add 2017-10-27
-void Center2_Orb::cal_ST_Phi12_R(const int& job,
-                                 const int& l,
-                                 const Numerical_Orbital_Lm& n1,
-                                 const Numerical_Orbital_Lm& n2,
-                                 const std::set<size_t>& radials,
-                                 double* rs,
-                                 double* drs,
-                                 const ModuleBase::Sph_Bessel_Recursive::D2* psb)
-{
+void Center2_Orb::cal_ST_Phi12_R(
+    const int& job,
+    const int& l,
+    const Numerical_Orbital_Lm& n1,
+    const Numerical_Orbital_Lm& n2,
+    const std::set<size_t>& radials,
+    double* rs,
+    double* drs,
+    const ModuleBase::Sph_Bessel_Recursive::D2* psb) {
     //	ModuleBase::TITLE("Center2_Orb","cal_ST_Phi12_R");
     ModuleBase::timer::tick("Center2_Orb", "cal_ST_Phi12_R");
 
@@ -292,111 +285,103 @@ void Center2_Orb::cal_ST_Phi12_R(const int& job,
     const double dk = n1.getDk();
 
     std::vector<double> k1_dot_k2(kmesh);
-    switch (job)
-    {
+    switch (job) {
     case 1: // calculate overlap
-        if (!n1.get_psif().empty() && !n2.get_psi_k2().empty())
-        {
-            for (int ik = 0; ik < kmesh; ik++)
-            {
+        if (!n1.get_psif().empty() && !n2.get_psi_k2().empty()) {
+            for (int ik = 0; ik < kmesh; ik++) {
                 k1_dot_k2[ik] = n1.getPsif(ik) * n2.getPsi_k2(ik);
             }
-        }
-        else if (!n1.get_psi_k().empty() && !n2.get_psi_k().empty())
-        {
-            for (int ik = 0; ik < kmesh; ik++)
-            {
+        } else if (!n1.get_psi_k().empty() && !n2.get_psi_k().empty()) {
+            for (int ik = 0; ik < kmesh; ik++) {
                 k1_dot_k2[ik] = n1.getPsi_k(ik) * n2.getPsi_k(ik);
             }
-        }
-        else if (!n1.get_psi_k2().empty() && !n2.get_psif().empty())
-        {
-            for (int ik = 0; ik < kmesh; ik++)
-            {
+        } else if (!n1.get_psi_k2().empty() && !n2.get_psif().empty()) {
+            for (int ik = 0; ik < kmesh; ik++) {
                 k1_dot_k2[ik] = n1.getPsi_k2(ik) * n2.getPsif(ik);
             }
         }
         break;
 
     case 2: // calculate kinetic energy
-        for (int ik = 0; ik < kmesh; ik++)
-        {
+        for (int ik = 0; ik < kmesh; ik++) {
             k1_dot_k2[ik] = n1.getPsi_k2(ik) * n2.getPsi_k2(ik);
         }
         break;
     }
 
     std::vector<double> k1_dot_k2_dot_kpoint(kmesh);
-    for (int ik = 0; ik < kmesh; ik++)
-    {
+    for (int ik = 0; ik < kmesh; ik++) {
         k1_dot_k2_dot_kpoint[ik] = k1_dot_k2[ik] * kpoint[ik];
     }
 
     std::vector<double> integrated_func(kmesh);
 
-    const std::vector<std::vector<double>>& jlm1 = l > 0 ? psb->get_jlx()[l - 1] : std::vector<std::vector<double>>{};
+    const std::vector<std::vector<double>>& jlm1
+        = l > 0 ? psb->get_jlx()[l - 1] : std::vector<std::vector<double>>{};
     const std::vector<std::vector<double>>& jl = psb->get_jlx()[l];
     const std::vector<std::vector<double>>& jlp1 = psb->get_jlx()[l + 1];
 
-    for (const size_t& ir: radials)
-    {
+    for (const size_t& ir: radials) {
         // if(rs[ir])  => rs[ir]  has been calculated
         // if(drs[ir]) => drs[ir] has been calculated
-        // Actually, if(ir[ir]||dr[ir]) is enough. Double insurance for the sake of avoiding numerical errors
+        // Actually, if(ir[ir]||dr[ir]) is enough. Double insurance for the sake
+        // of avoiding numerical errors
         if (rs[ir] && drs[ir])
             continue;
 
         const std::vector<double>& jl_r = jl[ir];
-        for (int ik = 0; ik < kmesh; ++ik)
-        {
+        for (int ik = 0; ik < kmesh; ++ik) {
             integrated_func[ik] = jl_r[ik] * k1_dot_k2[ik];
         }
         double temp = 0.0;
 
-        ModuleBase::Integral::Simpson_Integral(kmesh, ModuleBase::GlobalFunc::VECTOR_TO_PTR(integrated_func), dk, temp);
+        ModuleBase::Integral::Simpson_Integral(
+            kmesh,
+            ModuleBase::GlobalFunc::VECTOR_TO_PTR(integrated_func),
+            dk,
+            temp);
         rs[ir] = temp * ModuleBase::FOUR_PI;
 
         const std::vector<double>& jlp1_r = jlp1[ir];
         const double fac = l / (l + 1.0);
-        if (l == 0)
-        {
-            for (int ik = 0; ik < kmesh; ++ik)
-            {
+        if (l == 0) {
+            for (int ik = 0; ik < kmesh; ++ik) {
                 integrated_func[ik] = jlp1_r[ik] * k1_dot_k2_dot_kpoint[ik];
             }
-        }
-        else
-        {
+        } else {
             const std::vector<double>& jlm1_r = jlm1[ir];
-            for (int ik = 0; ik < kmesh; ++ik)
-            {
-                integrated_func[ik] = (jlp1_r[ik] - fac * jlm1_r[ik]) * k1_dot_k2_dot_kpoint[ik];
+            for (int ik = 0; ik < kmesh; ++ik) {
+                integrated_func[ik] = (jlp1_r[ik] - fac * jlm1_r[ik])
+                                      * k1_dot_k2_dot_kpoint[ik];
             }
         }
 
-        ModuleBase::Integral::Simpson_Integral(kmesh, ModuleBase::GlobalFunc::VECTOR_TO_PTR(integrated_func), dk, temp);
+        ModuleBase::Integral::Simpson_Integral(
+            kmesh,
+            ModuleBase::GlobalFunc::VECTOR_TO_PTR(integrated_func),
+            dk,
+            temp);
         drs[ir] = -ModuleBase::FOUR_PI * (l + 1) / (2.0 * l + 1) * temp;
     }
 
     // cal rs[0] special
-    if (l > 0)
-    {
-        if (radials.find(0) != radials.end())
-        {
-            for (int ik = 0; ik < kmesh; ik++)
-            {
+    if (l > 0) {
+        if (radials.find(0) != radials.end()) {
+            for (int ik = 0; ik < kmesh; ik++) {
                 integrated_func[ik] = k1_dot_k2[ik] * pow(kpoint[ik], l);
             }
             double temp = 0.0;
 
-            ModuleBase::Integral::Simpson_Integral(kmesh,
-                                                   ModuleBase::GlobalFunc::VECTOR_TO_PTR(integrated_func),
-                                                   dk,
-                                                   temp);
+            ModuleBase::Integral::Simpson_Integral(
+                kmesh,
+                ModuleBase::GlobalFunc::VECTOR_TO_PTR(integrated_func),
+                dk,
+                temp);
 
             // PLEASE try to make dualfac function as input parameters
             // mohan note 2021-03-23
-            rs[0] = ModuleBase::FOUR_PI / ModuleBase::Mathzone_Add1::dualfac(2 * l + 1) * temp;
+            rs[0] = ModuleBase::FOUR_PI
+                    / ModuleBase::Mathzone_Add1::dualfac(2 * l + 1) * temp;
         }
     }
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/center2_orb.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/center2_orb.cpp
@@ -316,8 +316,8 @@ void Center2_Orb::cal_ST_Phi12_R(
 
     std::vector<double> integrated_func(kmesh);
 
-    const std::vector<std::vector<double>>& jlm1
-        = l > 0 ? psb->get_jlx()[l - 1] : std::vector<std::vector<double>>{};
+    int lm1 = (l != 0 ? l - 1 : 0);
+    const std::vector<std::vector<double>>& jlm1 = psb->get_jlx()[lm1];
     const std::vector<std::vector<double>>& jl = psb->get_jlx()[l];
     const std::vector<std::vector<double>>& jlp1 = psb->get_jlx()[l + 1];
 
@@ -342,6 +342,7 @@ void Center2_Orb::cal_ST_Phi12_R(
             temp);
         rs[ir] = temp * ModuleBase::FOUR_PI;
 
+        const std::vector<double>& jlm1_r = jlm1[ir];
         const std::vector<double>& jlp1_r = jlp1[ir];
         const double fac = l / (l + 1.0);
         if (l == 0) {
@@ -349,7 +350,6 @@ void Center2_Orb::cal_ST_Phi12_R(
                 integrated_func[ik] = jlp1_r[ik] * k1_dot_k2_dot_kpoint[ik];
             }
         } else {
-            const std::vector<double>& jlm1_r = jlm1[ir];
             for (int ik = 0; ik < kmesh; ++ik) {
                 integrated_func[ik] = (jlp1_r[ik] - fac * jlm1_r[ik])
                                       * k1_dot_k2_dot_kpoint[ik];

--- a/source/module_hamilt_lcao/hamilt_lcaodft/center2_orb.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/center2_orb.cpp
@@ -334,7 +334,7 @@ void Center2_Orb::cal_ST_Phi12_R(const int& job,
 
     std::vector<double> integrated_func(kmesh);
 
-    const std::vector<std::vector<double>>& jlm1 = psb->get_jlx()[l - 1];
+    const std::vector<std::vector<double>>& jlm1 = l > 0 ? psb->get_jlx()[l - 1] : std::vector<std::vector<double>>{};
     const std::vector<std::vector<double>>& jl = psb->get_jlx()[l];
     const std::vector<std::vector<double>>& jlp1 = psb->get_jlx()[l + 1];
 
@@ -356,7 +356,6 @@ void Center2_Orb::cal_ST_Phi12_R(const int& job,
         ModuleBase::Integral::Simpson_Integral(kmesh, ModuleBase::GlobalFunc::VECTOR_TO_PTR(integrated_func), dk, temp);
         rs[ir] = temp * ModuleBase::FOUR_PI;
 
-        const std::vector<double>& jlm1_r = jlm1[ir];
         const std::vector<double>& jlp1_r = jlp1[ir];
         const double fac = l / (l + 1.0);
         if (l == 0)
@@ -368,6 +367,7 @@ void Center2_Orb::cal_ST_Phi12_R(const int& job,
         }
         else
         {
+            const std::vector<double>& jlm1_r = jlm1[ir];
             for (int ik = 0; ik < kmesh; ++ik)
             {
                 integrated_func[ik] = (jlp1_r[ik] - fac * jlm1_r[ik]) * k1_dot_k2_dot_kpoint[ik];


### PR DESCRIPTION
In center2_orb.cpp, a recurrence formula that makes use of j_{l-1} and j_{l+1} is used when computing the derivative of the l-th order spherical Bessel transform. This formula has a corner case of l=0, where only j_1 is necessary.

In the previous code, some const reference variables are introduced as aliases of j_{l-1} and j_{l+1} respectively for the sake of derivative calculations. While later calculations do account for the corner case, the initialization of the const reference supposed to bind to j_{l-1} fails to take the corner case into account, resulting an attempt to access j_{-1}, thereby causing the buffer overflow.

This lapse does not yield any serious bug since the const reference binds to "j_{-1}" is never referenced.

### Reminder
- [x] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #4545


