### PR TITLE
Fix: out-of-bound indexing of j_{l-1} when l=0

### DIFF
--- a/source/module_hamilt_lcao/hamilt_lcaodft/center2_orb.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/center2_orb.cpp
@@ -13,8 +13,9 @@ int Center2_Orb::get_rmesh(const double& R1, const double& R2, const double dr)
     int rmesh = static_cast<int>((R1 + R2) / dr) + 5;
     // mohan update 2009-09-08 +1 ==> +5
     // considering interpolation or so on...
-    if (rmesh % 2 == 0)
+    if (rmesh % 2 == 0) {
         rmesh++;
+    }
 
     if (rmesh <= 0)
     {
@@ -344,8 +345,9 @@ void Center2_Orb::cal_ST_Phi12_R(const int& job,
         // if(rs[ir])  => rs[ir]  has been calculated
         // if(drs[ir]) => drs[ir] has been calculated
         // Actually, if(ir[ir]||dr[ir]) is enough. Double insurance for the sake of avoiding numerical errors
-        if (rs[ir] && drs[ir])
+        if (rs[ir] && drs[ir]) {
             continue;
+        }
 
         const std::vector<double>& jl_r = jl[ir];
         for (int ik = 0; ik < kmesh; ++ik)

--- a/source/module_hamilt_lcao/hamilt_lcaodft/center2_orb.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/center2_orb.cpp
@@ -334,7 +334,8 @@ void Center2_Orb::cal_ST_Phi12_R(const int& job,
 
     std::vector<double> integrated_func(kmesh);
 
-    const std::vector<std::vector<double>>& jlm1 = psb->get_jlx()[l - 1];
+    const int lm1 = (l > 0 ? l - 1 : 0);
+    const std::vector<std::vector<double>>& jlm1 = psb->get_jlx()[lm1];
     const std::vector<std::vector<double>>& jl = psb->get_jlx()[l];
     const std::vector<std::vector<double>>& jlp1 = psb->get_jlx()[l + 1];
 


### PR DESCRIPTION
In center2_orb.cpp, a recurrence formula that makes use of j_{l-1} and j_{l+1} is used when computing the derivative of the l-th order spherical Bessel transform. This formula has a corner case of l=0, where only j_1 is necessary.

In the previous code, some const reference variables are introduced as aliases of j_{l-1} and j_{l+1} respectively for the sake of derivative calculations. While later calculations do account for the corner case, the initialization of the const reference supposed to bind to j_{l-1} fails to take the corner case into account, resulting an attempt to access j_{-1}, thereby causing the buffer overflow.

This lapse does not yield any serious bug since the const reference binds to "j_{-1}" is never referenced.

### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #4545 