### PR TITLE
CI: use alicloud image sync

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -43,7 +43,8 @@ jobs:
       - name: Login to Aliyun Registry
         uses: docker/login-action@v3
         with:
-          registry: registry.dp.tech
+          registry: dp-harbor-registry.us-east-1.cr.aliyuncs.com
+            # AliCloud automatically mirrors to registry.dp.tech
           username: ${{ secrets.DP_HARBOR_USERNAME }}
           password: ${{ secrets.DP_HARBOR_PASSWORD }}
 


### PR DESCRIPTION
Modifies the workflow to use alicloud image sync service, preventing image pushing timeout.