### PR TITLE
Refactor hsolver remove psi dimensions

### DIFF
--- a/source/module_hsolver/diago_david.cpp
+++ b/source/module_hsolver/diago_david.cpp
@@ -71,7 +71,7 @@ int DiagoDavid<T, Device>::diag_mock(hamilt::Hamilt<T, Device>* phm_in,
     ModuleBase::timer::tick("DiagoDavid", "diag_mock");
 
     assert(this->david_ndim > 1);
-    assert(this->david_ndim * nband < psi.get_current_nbas() * diag_comm.nproc);
+    assert(this->david_ndim * nband < dim * diag_comm.nproc);
 
     // qianrui change it 2021-7-25.
     // In strictly speaking, it shoule be PW_DIAG_NDIM*nband < npw sum of all pools. We roughly estimate it here.
@@ -157,9 +157,9 @@ int DiagoDavid<T, Device>::diag_mock(hamilt::Hamilt<T, Device>* phm_in,
         if(this->use_paw)
         {
 #ifdef USE_PAW
-#ifdef __DEBUG
-            assert(psi.get_k_first());
-#endif 
+// #ifdef __DEBUG
+//             assert(psi.get_k_first());
+// #endif 
             GlobalC::paw_cell.paw_nl_psi(1, reinterpret_cast<const std::complex<double>*> (&psi(m, 0)),
                 reinterpret_cast<std::complex<double>*>(&this->sphi[m * dim]));
 #endif
@@ -1095,8 +1095,8 @@ int DiagoDavid<T, Device>::diag(hamilt::Hamilt<T, Device>* phm_in,
 #if defined(__CUDA) || defined(__ROCM)
     if (this->device == base_device::GpuDevice)
     {
-        resmem_var_op()(this->ctx, this->d_precondition, psi.get_nbasis());
-        syncmem_var_h2d_op()(this->ctx, this->cpu_ctx, this->d_precondition, this->precondition, psi.get_nbasis());
+        resmem_var_op()(this->ctx, this->d_precondition, ldPsi);
+        syncmem_var_h2d_op()(this->ctx, this->cpu_ctx, this->d_precondition, this->precondition, ldPsi);
     }
 #endif
 

--- a/source/module_hsolver/diago_david.cpp
+++ b/source/module_hsolver/diago_david.cpp
@@ -87,7 +87,7 @@ int DiagoDavid<T, Device>::diag_mock(hamilt::Hamilt<T, Device>* phm_in,
     /// - k : k-points, the same meaning as the ground state
     /// - "basis" : number of occupied ks-orbitals(subscripts i,j) * number of unoccupied ks-orbitals(subscripts a,b), corresponding to "bands" of the ground state
     
-    // dim = psi.get_k_first() ? psi.get_current_nbas() : psi.get_nk() * psi.get_nbasis();
+    // this->dim = psi.get_k_first() ? psi.get_current_nbas() : psi.get_nk() * psi.get_nbasis();
     // this->dmx = psi.get_k_first() ? psi.get_nbasis() : psi.get_nk() * psi.get_nbasis();
     // this->n_band = psi.get_nbands();
     this->nbase_x = this->david_ndim * nband; // maximum dimension of the reduced basis set
@@ -166,7 +166,7 @@ int DiagoDavid<T, Device>::diag_mock(hamilt::Hamilt<T, Device>* phm_in,
         }
         else
         {
-            phm_in->sPsi(psi.get_k_first() ? &psi(m, 0) : &psi(m, 0, 0),
+            phm_in->sPsi(&psi(m, 0),
                          &this->sphi[m * dim],
                          dim,
                          dim,
@@ -177,7 +177,7 @@ int DiagoDavid<T, Device>::diag_mock(hamilt::Hamilt<T, Device>* phm_in,
     for (int m = 0; m < nband; m++)
     {
         // haozhihan replace 2022-10-23
-        syncmem_complex_op()(this->ctx, this->ctx, &basis(m, 0), psi.get_k_first() ? &psi(m, 0) : &psi(m, 0, 0), dim);
+        syncmem_complex_op()(this->ctx, this->ctx, &basis(m, 0), &psi(m, 0), dim);
 
         this->SchmitOrth(dim,
                          nband,
@@ -783,7 +783,7 @@ void DiagoDavid<T, Device>::refresh(const int& dim,
     basis.zero_out();
     for (int m = 0; m < nband; m++)
     {
-        syncmem_complex_op()(this->ctx, this->ctx, &basis(m, 0), psi.get_k_first() ? &psi(m, 0) : &psi(m, 0, 0), dim);
+        syncmem_complex_op()(this->ctx, this->ctx, &basis(m, 0),&psi(m, 0), dim);
         /*for (int ig = 0; ig < npw; ig++)
             basis(m, ig) = psi(m, ig);*/
     }

--- a/source/module_hsolver/diago_david.cpp
+++ b/source/module_hsolver/diago_david.cpp
@@ -993,8 +993,10 @@ void DiagoDavid<T, Device>::planSchmitOrth(const int nband, std::vector<int>& pr
     if (nband <= 0) {
         return;
 }
-    ModuleBase::GlobalFunc::ZEROS(pre_matrix_mm_m.data(), nband);
-    ModuleBase::GlobalFunc::ZEROS(pre_matrix_mv_m.data(), nband);
+    // ModuleBase::GlobalFunc::ZEROS(pre_matrix_mm_m.data(), nband);
+    // ModuleBase::GlobalFunc::ZEROS(pre_matrix_mv_m.data(), nband);
+    std::fill(pre_matrix_mm_m.begin(), pre_matrix_mm_m.end(), 0);
+    std::fill(pre_matrix_mv_m.begin(), pre_matrix_mv_m.end(), 0);
     int last_matrix_size = nband;
     int matrix_size = int(nband / 2);
     int divide_times = 0;

--- a/source/module_hsolver/diago_david.cpp
+++ b/source/module_hsolver/diago_david.cpp
@@ -201,7 +201,7 @@ int DiagoDavid<T, Device>::diag_mock(hamilt::Hamilt<T, Device>* phm_in,
     }
 
     // end of SchmitOrth and calculate H|psi>
-    hpsi_info dav_hpsi_in(&basis, psi::Range(1, 0, 0, nband - 1), this->hphi);
+    hpsi_info dav_hpsi_in(&basis, psi::Range(true, 0, 0, nband - 1), this->hphi);
     phm_in->ops->hPsi(dav_hpsi_in);
 
     this->cal_elem(dim, nbase, nbase_x, this->notconv, basis, this->hphi, this->sphi, this->hcc, this->scc);

--- a/source/module_hsolver/diago_david.h
+++ b/source/module_hsolver/diago_david.h
@@ -48,7 +48,7 @@ class DiagoDavid : public DiagH<T, Device>
     /// dimension of the subspace allowed in Davidson
     int david_ndim = 4;
     /// maximum dimension of the reduced basis set
-    int nbase_x = 0;
+    // int nbase_x = 0;
     /// number of unconverged eigenvalues
     int notconv = 0;
 
@@ -80,6 +80,7 @@ class DiagoDavid : public DiagH<T, Device>
     void cal_grad(hamilt::Hamilt<T, Device>* phm_in,
                   const int& dim,
                   const int& nbase,
+                  const int nbase_x,
                   const int& notconv,
                   psi::Psi<T, Device>& basis,
                   T* hphi,
@@ -90,6 +91,7 @@ class DiagoDavid : public DiagH<T, Device>
 
     void cal_elem(const int& dim,
                   int& nbase,
+                  const int nbase_x,// maximum dimension of the reduced basis set
                   const int& notconv,
                   const psi::Psi<T, Device>& basis,
                   const T* hphi,
@@ -100,6 +102,7 @@ class DiagoDavid : public DiagH<T, Device>
     void refresh(const int& dim,
                  const int& nband,
                  int& nbase,
+                 const int nbase_x,
                  const Real* eigenvalue,
                  const psi::Psi<T, Device>& psi,
                  psi::Psi<T, Device>& basis,

--- a/source/module_hsolver/diago_david.h
+++ b/source/module_hsolver/diago_david.h
@@ -28,6 +28,7 @@ class DiagoDavid : public DiagH<T, Device>
 
     int diag(hamilt::Hamilt<T, Device>* phm_in,   // Pointer to the Hamiltonian object for diagonalization
                       const int dim,              // Dimension of the input matrix psi to be diagonalized
+                      const int nband,            // Number of required eigenpairs
                       const int ldPsi,            // Leading dimension of the psi input
                       psi::Psi<T, Device>& psi,   // Reference to the wavefunction object for eigenvectors
                       Real* eigenvalue_in,        // Pointer to store the resulting eigenvalues
@@ -44,10 +45,6 @@ class DiagoDavid : public DiagH<T, Device>
 
     /// number of searched eigenpairs
     int n_band = 0;
-    /// dimension of the input matrix psi to be diagonalized
-    // int dim = 0;
-    // leading dimension of the matrix data
-    // const int dmx = 0;
     /// dimension of the subspace allowed in Davidson
     int david_ndim = 4;
     /// maximum dimension of the reduced basis set
@@ -133,6 +130,7 @@ class DiagoDavid : public DiagH<T, Device>
 
     int diag_mock(hamilt::Hamilt<T, Device>* phm_in,
                    const int dim,
+                   const int nband,
                    const int ldPsi,
                    psi::Psi<T, Device>& psi,
                    Real* eigenvalue_in,

--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -550,6 +550,7 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm,
         const int david_maxiter = DiagoIterAssist<T, Device>::PW_DIAG_NMAX;
         // dimensions
         const int dim = psi.get_k_first() ? psi.get_current_nbas() : psi.get_nk() * psi.get_nbasis();
+        const int nband = psi.get_nbands();
         const int ldPsi = psi.get_k_first() ? psi.get_nbasis() : psi.get_nk() * psi.get_nbasis();
 
         DiagoDavid<T, Device> david(precondition.data(),
@@ -559,6 +560,7 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm,
         DiagoIterAssist<T, Device>::avg_iter
             += static_cast<double>(david.diag(hm,
                                               dim,
+                                              nband,
                                               ldPsi,
                                               psi,
                                               eigenvalue,

--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -549,9 +549,9 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm,
         const Real david_diag_thr = DiagoIterAssist<T, Device>::PW_DIAG_THR;
         const int david_maxiter = DiagoIterAssist<T, Device>::PW_DIAG_NMAX;
         // dimensions
-        const int dim = psi.get_k_first() ? psi.get_current_nbas() : psi.get_nk() * psi.get_nbasis();
+        const int dim = psi.get_current_nbas();
         const int nband = psi.get_nbands();
-        const int ldPsi = psi.get_k_first() ? psi.get_nbasis() : psi.get_nk() * psi.get_nbasis();
+        const int ldPsi = psi.get_nbasis();
 
         DiagoDavid<T, Device> david(precondition.data(),
                                     GlobalV::PW_DIAG_NDIM,

--- a/source/module_hsolver/test/diago_david_float_test.cpp
+++ b/source/module_hsolver/test/diago_david_float_test.cpp
@@ -104,9 +104,10 @@ public:
 #endif	
 
 		const int dim = phi.get_k_first() ? phi.get_current_nbas() : phi.get_nk() * phi.get_nbasis();
+		const int nband = phi.get_nbands();
 		const int ldPsi = phi.get_k_first() ? phi.get_nbasis() : phi.get_nk() * phi.get_nbasis();
 		std::cout << "ldPsi = " << ldPsi << std::endl;
-		dav.diag(phm, dim, ldPsi, phi, en, eps, maxiter);
+		dav.diag(phm, dim, nband, ldPsi, phi, en, eps, maxiter);
 
 #ifdef __MPI		
 		end = MPI_Wtime();

--- a/source/module_hsolver/test/diago_david_float_test.cpp
+++ b/source/module_hsolver/test/diago_david_float_test.cpp
@@ -103,9 +103,9 @@ public:
 		start = clock();
 #endif	
 
-		const int dim = phi.get_k_first() ? phi.get_current_nbas() : phi.get_nk() * phi.get_nbasis();
+		const int dim = phi.get_current_nbas() ;
 		const int nband = phi.get_nbands();
-		const int ldPsi = phi.get_k_first() ? phi.get_nbasis() : phi.get_nk() * phi.get_nbasis();
+		const int ldPsi =phi.get_nbasis();
 		std::cout << "ldPsi = " << ldPsi << std::endl;
 		dav.diag(phm, dim, nband, ldPsi, phi, en, eps, maxiter);
 

--- a/source/module_hsolver/test/diago_david_real_test.cpp
+++ b/source/module_hsolver/test/diago_david_real_test.cpp
@@ -102,9 +102,9 @@ public:
         start = clock();
 #endif	
 
-        const int dim = phi.get_k_first() ? phi.get_current_nbas() : phi.get_nk() * phi.get_nbasis();
+        const int dim = phi.get_current_nbas();
         const int nband = phi.get_nbands();
-        const int ldPsi = phi.get_k_first() ? phi.get_nbasis() : phi.get_nk() * phi.get_nbasis();
+        const int ldPsi = phi.get_nbasis();
         dav.diag(phm, dim, nband, ldPsi, phi, en, eps, maxiter);
 
 #ifdef __MPI		

--- a/source/module_hsolver/test/diago_david_real_test.cpp
+++ b/source/module_hsolver/test/diago_david_real_test.cpp
@@ -103,8 +103,9 @@ public:
 #endif	
 
         const int dim = phi.get_k_first() ? phi.get_current_nbas() : phi.get_nk() * phi.get_nbasis();
+        const int nband = phi.get_nbands();
         const int ldPsi = phi.get_k_first() ? phi.get_nbasis() : phi.get_nk() * phi.get_nbasis();
-        dav.diag(phm, dim, ldPsi, phi, en, eps, maxiter);
+        dav.diag(phm, dim, nband, ldPsi, phi, en, eps, maxiter);
 
 #ifdef __MPI		
         end = MPI_Wtime();

--- a/source/module_hsolver/test/diago_david_test.cpp
+++ b/source/module_hsolver/test/diago_david_test.cpp
@@ -105,9 +105,9 @@ public:
 		start = clock();
 #endif	
 
-		const int dim = phi.get_k_first() ? phi.get_current_nbas() : phi.get_nk() * phi.get_nbasis();
+		const int dim = phi.get_current_nbas();
 		const int nband = phi.get_nbands();
-		const int ldPsi = phi.get_k_first() ? phi.get_nbasis() : phi.get_nk() * phi.get_nbasis();
+		const int ldPsi = phi.get_nbasis();
 		dav.diag(phm, dim, nband, ldPsi, phi, en, eps, maxiter);
 
 #ifdef __MPI		

--- a/source/module_hsolver/test/diago_david_test.cpp
+++ b/source/module_hsolver/test/diago_david_test.cpp
@@ -106,8 +106,9 @@ public:
 #endif	
 
 		const int dim = phi.get_k_first() ? phi.get_current_nbas() : phi.get_nk() * phi.get_nbasis();
+		const int nband = phi.get_nbands();
 		const int ldPsi = phi.get_k_first() ? phi.get_nbasis() : phi.get_nk() * phi.get_nbasis();
-		dav.diag(phm, dim, ldPsi, phi, en, eps, maxiter);
+		dav.diag(phm, dim, nband, ldPsi, phi, en, eps, maxiter);
 
 #ifdef __MPI		
 		end = MPI_Wtime();

--- a/source/module_hsolver/test/hsolver_pw_sup.h
+++ b/source/module_hsolver/test/hsolver_pw_sup.h
@@ -163,6 +163,7 @@ DiagoDavid<T, Device>::~DiagoDavid() {
 template <typename T, typename Device>
 int DiagoDavid<T, Device>::diag(hamilt::Hamilt<T, Device>* phm_in,
                                 const int dim,
+                                const int nband,
                                 const int ldPsi,
                                 psi::Psi<T, Device>& psi,
                                 Real* eigenvalue_in,


### PR DESCRIPTION
### Linked Issue
#4404

### What's changed?
- Most inner access to `psi` dimensions (by calls to member funcions) has been removed.
- Unnecessary class member of `DiagoDavid` has been replaced by local variables where needed.

### Unit Tests and/or Case Tests for my changes
- Corresponding unit tests are modified to fit new function signature.

### Any changes of core modules? 
- Remove deprecated `psi.get_k_first()` logic

The `psi.get_k_first()` function is no longer needed as the `k_first=false` branch does not contribute to the solution of the Kohn-Sham equations. Remove the associated code to streamline the solver.

### Pending further work
- `psi.get_ngk(0)` and `psi.get_pointer()` are still referenced inside `DiagoDavid`, to construct basis set. They need to be replaced by pointers to data field.
- The basis set variable, of type psi, can only be removed after the above steps are completed.
