### PR TITLE
Fix MKL finding problem in pyabacus

### DIFF
--- a/python/pyabacus/CMakeLists.txt
+++ b/python/pyabacus/CMakeLists.txt
@@ -33,9 +33,9 @@ if(MKLROOT)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
     add_link_options(${OpenMP_CXX_LIBRARIES})
   endif()
-  find_package(IntelMKL REQUIRED)
+  find_package(MKL REQUIRED)
   add_definitions(-D__MKL)
-  include_directories(${MKL_INCLUDE_DIRS} ${MKL_INCLUDE_DIRS}/fftw)
+  include_directories(${MKL_INCLUDE} ${MKL_INCLUDE}/fftw)
 
 # Since libtorch will find its own MKL, the fftw part conflicts with the original one.
 # When enable deepks, mkl will be linked within ${TORCH_LIBRARIES}.


### PR DESCRIPTION
Fix the MKL finding problem in pyabacus according to the newest fix in #4644.

My environment is updated to oneAPI 2024.2 now. This fix solves MKL not finding problem when running `pip install -v .` in `python/pyabacus`. 
Now I have successfully installed pyabacus but found another issue #4655 when running examples.

Thanks for the previous help of @jieli-matrix and @caic99 .