### PR TITLE
Perf: optimize function grad_rl_sph_harm

### DIFF
--- a/source/module_base/array_pool.h
+++ b/source/module_base/array_pool.h
@@ -17,8 +17,8 @@ namespace ModuleBase
     public:
         Array_Pool();
         Array_Pool(const int nr, const int nc);
-        Array_Pool(Array_Pool<T>&& other) = default;
-        Array_Pool& operator=(Array_Pool<T>&& other) = default;
+        Array_Pool(Array_Pool<T>&& other);
+        Array_Pool& operator=(Array_Pool<T>&& other);
         ~Array_Pool();
         Array_Pool(const Array_Pool<T>& other) = delete;
         Array_Pool& operator=(const Array_Pool& other) = delete;
@@ -56,6 +56,38 @@ namespace ModuleBase
     {
         delete[] ptr_2D;
         delete[] ptr_1D;
+    }
+
+    template <typename T>
+    Array_Pool<T>::Array_Pool(Array_Pool<T>&& other)
+    {
+        ptr_2D = other.ptr_2D;
+        ptr_1D = other.ptr_1D;
+        nr = other.nr;
+        nc = other.nc;
+        other.ptr_2D = nullptr;
+        other.ptr_1D = nullptr;
+        other.nr = 0;
+        other.nc = 0;
+    }
+
+    template <typename T>
+    Array_Pool<T>& Array_Pool<T>::operator=(Array_Pool<T>&& other)
+    {
+        if (this != &other)
+        {
+            delete[] ptr_2D;
+            delete[] ptr_1D;
+            ptr_2D = other.ptr_2D;
+            ptr_1D = other.ptr_1D;
+            nr = other.nr;
+            nc = other.nc;
+            other.ptr_2D = nullptr;
+            other.ptr_1D = nullptr;
+            other.nr = 0;
+            other.nc = 0;
+        }
+        return *this;
     }
 
 }

--- a/source/module_base/array_pool.h
+++ b/source/module_base/array_pool.h
@@ -1,0 +1,62 @@
+#ifndef ARRAY_POOL_H
+#define ARRAY_POOL_H
+
+
+namespace ModuleBase
+{
+    /**
+     * @brief Array_Pool is a class designed for dynamically allocating a two-dimensional array
+     *  with all its elements contiguously arranged in memory. Compared to a two-dimensional vector,
+     *  it offers better data locality because all elements are stored in a continuous block of memory.
+     *  
+     * @tparam T 
+     */
+    template <typename T>
+    class Array_Pool
+    {
+    public:
+        Array_Pool();
+        Array_Pool(const int nr, const int nc);
+        Array_Pool(Array_Pool<T>&& other) = default;
+        Array_Pool& operator=(Array_Pool<T>&& other) = default;
+        ~Array_Pool();
+        Array_Pool(const Array_Pool<T>& other) = delete;
+        Array_Pool& operator=(const Array_Pool& other) = delete;
+
+        T** get_ptr_2D() const { return ptr_2D; }
+        T* get_ptr_1D() const { return ptr_1D; }
+        int get_nr() const { return nr; }
+        int get_nc() const { return nc; }
+        T* operator[](const int ir) const { return ptr_2D[ir]; }
+    private:
+        T** ptr_2D;
+        T* ptr_1D;
+        int nr;
+        int nc;
+    };
+
+    template <typename T>
+    Array_Pool<T>::Array_Pool() : ptr_2D(nullptr), ptr_1D(nullptr), nr(0), nc(0)
+    {
+    }
+
+    template <typename T>
+    Array_Pool<T>::Array_Pool(const int nr, const int nc) // Attention: uninitialized
+    {
+        this->nr = nr;
+        this->nc = nc;
+        ptr_1D = new T[nr * nc];
+        ptr_2D = new T*[nr];
+        for (int ir = 0; ir < nr; ++ir)
+            ptr_2D[ir] = &ptr_1D[ir * nc];
+    }
+
+    template <typename T>
+    Array_Pool<T>::~Array_Pool()
+    {
+        delete[] ptr_2D;
+        delete[] ptr_1D;
+    }
+
+}
+#endif

--- a/source/module_base/math_ylmreal.cpp
+++ b/source/module_base/math_ylmreal.cpp
@@ -4,6 +4,7 @@
 #include "module_base/kernels/math_op.h"
 #include "module_base/libm/libm.h"
 #include "module_base/module_device/memory_op.h"
+#include "module_base/array_pool.h"
 #include "realarray.h"
 #include "timer.h"
 #include "tool_quit.h"
@@ -629,7 +630,9 @@ void YlmReal::grad_Ylm_Real
     )
 {
 	ModuleBase::Ylm::set_coefficients();
-	int lmax = int(sqrt( double(lmax2) ) + 0.1) - 1;
+	const int lmax = int(sqrt( double(lmax2) ) + 0.1) - 1;
+	std::vector<double> tmpylm((lmax2+1) * (lmax2+1));
+	Array_Pool<double> tmpgylm((lmax2+1) * (lmax2+1), 3);
 
 	for (int ig = 0;ig < ng;ig++)
     {
@@ -648,9 +651,7 @@ void YlmReal::grad_Ylm_Real
 		}
 		else
 		{
-			std::vector<double> tmpylm;
-			std::vector<std::vector<double>> tmpgylm;
-			Ylm::grad_rl_sph_harm(lmax2, gg.x, gg.y, gg.z, tmpylm,tmpgylm);
+			Ylm::grad_rl_sph_harm(lmax2, gg.x, gg.y, gg.z, tmpylm.data(),tmpgylm.get_ptr_2D());
 			int lm = 0;
 			for(int il = 0 ; il <= lmax ; ++il)
 			{

--- a/source/module_base/test/math_ylmreal_test.cpp
+++ b/source/module_base/test/math_ylmreal_test.cpp
@@ -5,6 +5,7 @@
 #include"gtest/gtest.h"
 #include<math.h>
 #include "module_psi/psi.h"
+#include "module_base/array_pool.h"
 
 #define doublethreshold 1e-12
 
@@ -60,7 +61,7 @@ class YlmRealTest : public testing::Test
     double *rly;        //Ylm
     double (*rlgy)[3];  //the gradient of Ylm
     std::vector<double> rlyvector; //Ylm
-    std::vector<std::vector<double>> rlgyvector; //the gradient of Ylm
+    ModuleBase::Array_Pool<double> rlgyvector; //the gradient of Ylm
 
     //Ylm function
     inline double norm(const double &x, const double &y, const double &z) {return sqrt(x*x + y*y + z*z);}
@@ -204,7 +205,7 @@ class YlmRealTest : public testing::Test
         rly = new double[nylm];
         rlyvector.resize(nylm);
         rlgy = new double[nylm][3];
-        rlgyvector.resize(nylm,std::vector<double>(3));
+        rlgyvector = ModuleBase::Array_Pool<double>(nylm,3);
         ref = new double[64*4]{
             y00(g[0].x, g[0].y, g[0].z),  y00(g[1].x, g[1].y, g[1].z),  y00(g[2].x, g[2].y, g[2].z),  y00(g[3].x, g[3].y, g[3].z),
             y10(g[0].x, g[0].y, g[0].z),  y10(g[1].x, g[1].y, g[1].z),  y10(g[2].x, g[2].y, g[2].z),  y10(g[3].x, g[3].y, g[3].z),
@@ -421,7 +422,7 @@ TEST_F(YlmRealTest,YlmGradRlSphHarm)
     for(int j=0;j<ng;++j)
     {
         double r = sqrt(g[j].x * g[j].x + g[j].y * g[j].y + g[j].z * g[j].z);
-        ModuleBase::Ylm::grad_rl_sph_harm(lmax,g[j].x/r,g[j].y/r,g[j].z/r,rlyvector,rlgyvector);
+        ModuleBase::Ylm::grad_rl_sph_harm(lmax,g[j].x/r,g[j].y/r,g[j].z/r,rlyvector.data(),rlgyvector.get_ptr_2D());
         for(int i=0;i<nylm;++i)
         {
             EXPECT_NEAR(rlyvector[i],ref[i*ng+j],doublethreshold)  << "Ylm[" << i << "], example " << j << " not pass";
@@ -473,13 +474,13 @@ TEST_F(YlmRealTest, equality_gradient_test)
 
 	//int nu = 100;
 
-	std::vector<double> rlya;
+	double rlya[100];
 	double rlyb[400];
 
-	std::vector<std::vector<double>> grlya;
+	ModuleBase::Array_Pool<double> grlya(100, 3);
 	double grlyb[400][3];
 
-	ModuleBase::Ylm::grad_rl_sph_harm (9, R.x, R.y, R.z, rlya, grlya);
+	ModuleBase::Ylm::grad_rl_sph_harm (9, R.x, R.y, R.z, rlya, grlya.get_ptr_2D());
 	ModuleBase::Ylm::rlylm (10, R.x, R.y, R.z, rlyb, grlyb);
 
 	for (int i = 0; i < 100; i++)

--- a/source/module_base/ylm.cpp
+++ b/source/module_base/ylm.cpp
@@ -6,6 +6,7 @@
 #include "constants.h"
 #include "timer.h"
 #include "tool_quit.h"
+#include "array_pool.h"
 
 namespace ModuleBase
 {
@@ -810,13 +811,10 @@ void Ylm::grad_rl_sph_harm
  	const double& x,
 	const double& y,
 	const double& z,
-	std::vector<double>& rly,
-	std::vector<std::vector<double>>& grly
+	double* rly,
+	double** grly
 )
 {
-	rly.resize( (Lmax+1)*(Lmax+1) );
-	grly.resize( (Lmax+1)*(Lmax+1), std::vector<double>(3) );
-
 	double radius2 = x*x+y*y+z*z;
 	double tx = 2.0*x;
 	double ty = 2.0*y;

--- a/source/module_base/ylm.h
+++ b/source/module_base/ylm.h
@@ -120,14 +120,15 @@ class Ylm
 	 * @param z [in] z/r
 	 * @param rly [in] calculated Ylm, Y00, Y10, Y11, Y1-1, Y20, Y21, Y2-1, Y22, Y2-2...
 	 * @param grly [out] gradient of Ylm, [dY00/dx, dY00/dy, dY00/dz], [dY10/dx, dY10/dy, dY10/dz], [dY11/dx, dY11/dy, dY11/dz],...
+	 *             grly should be a memory-contiguous two-dimensional array for better performance.
 	 */
 	static void grad_rl_sph_harm(
 			const int& Lmax,
 			const double& x,
 			const double& y,
 			const double& z,
-			std::vector<double>& rly,
-			std::vector<std::vector<double>>& grly);
+			double* rly,
+			double** grly);
 
 	/**
 	 * @brief Get the hessian of r^l Ylm (used in getting derivative of overlap)

--- a/source/module_basis/module_nao/two_center_integrator.cpp
+++ b/source/module_basis/module_nao/two_center_integrator.cpp
@@ -2,6 +2,7 @@
 
 #include "module_base/vector3.h"
 #include "module_base/ylm.h"
+#include "module_base/array_pool.h"
 
 TwoCenterIntegrator::TwoCenterIntegrator():
     is_tabulated_(false),
@@ -51,12 +52,13 @@ void TwoCenterIntegrator::calculate(const int itype1,
     ModuleBase::Vector3<double> uR = (R == 0.0 ? ModuleBase::Vector3<double>(0., 0., 1.) : vR / R);
 
     // generate all necessary real (solid) spherical harmonics
-	std::vector<double> Rl_Y;
-	std::vector<std::vector<double>> grad_Rl_Y;
+    const int lmax = l1 + l2;
+	std::vector<double> Rl_Y((lmax+1) * (lmax+1));
+	ModuleBase::Array_Pool<double> grad_Rl_Y((lmax+1) * (lmax+1), 3);
 
     // R^l * Y is necessary anyway
     ModuleBase::Ylm::rl_sph_harm(l1 + l2, vR[0], vR[1], vR[2], Rl_Y);
-    if (grad_out) ModuleBase::Ylm::grad_rl_sph_harm(l1 + l2, vR[0], vR[1], vR[2], Rl_Y, grad_Rl_Y);
+    if (grad_out) ModuleBase::Ylm::grad_rl_sph_harm(l1 + l2, vR[0], vR[1], vR[2], Rl_Y.data(), grad_Rl_Y.get_ptr_2D());
 
     double tmp[2] = {0.0, 0.0};
     double* S_by_Rl = tmp;

--- a/source/module_hamilt_lcao/hamilt_lcaodft/center2_orb-orb11.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/center2_orb-orb11.cpp
@@ -58,14 +58,17 @@ void Center2_Orb::Orb11::init_radial_table(const std::set<size_t>& radials)
     const size_t rmesh = Center2_Orb::get_rmesh(this->nA.getRcut(), this->nB.getRcut(), dr_);
 
     std::set<size_t> radials_used;
-    for (const size_t& ir: radials)
-        if (ir < rmesh)
+    for (const size_t& ir: radials) {
+        if (ir < rmesh) {
             radials_used.insert(ir);
+}
+}
 
     for (int LAB = std::abs(LA - LB); LAB <= LA + LB; ++LAB)
     {
-        if ((LAB - std::abs(LA - LB)) % 2 == 1) // if LA+LB-LAB == odd, then Gaunt_Coefficients = 0
+        if ((LAB - std::abs(LA - LB)) % 2 == 1) { // if LA+LB-LAB == odd, then Gaunt_Coefficients = 0
             continue;
+}
 
         this->Table_r[LAB].resize(rmesh, 0);
         this->Table_dr[LAB].resize(rmesh, 0);
@@ -94,8 +97,9 @@ double Center2_Orb::Orb11::cal_overlap(const ModuleBase::Vector3<double>& RA,
     const double distance = (distance_true >= tiny1) ? distance_true : distance_true + tiny1;
     const double RcutA = this->nA.getRcut();
     const double RcutB = this->nB.getRcut();
-    if (distance > (RcutA + RcutB))
+    if (distance > (RcutA + RcutB)) {
         return 0.0;
+}
 
     const int LA = this->nA.getL();
     const int LB = this->nB.getL();
@@ -119,12 +123,14 @@ double Center2_Orb::Orb11::cal_overlap(const ModuleBase::Vector3<double>& RA,
             const double Gaunt_real_A_B_AB = this->MGT.Gaunt_Coefficients(this->MGT.get_lm_index(LA, mA),
                                                                           this->MGT.get_lm_index(LB, mB),
                                                                           this->MGT.get_lm_index(LAB, mAB));
-            if (0 == Gaunt_real_A_B_AB)
+            if (0 == Gaunt_real_A_B_AB) {
                 continue;
+}
 
             const double ylm_solid = rly[this->MGT.get_lm_index(LAB, mAB)];
-            if (0 == ylm_solid)
+            if (0 == ylm_solid) {
                 continue;
+}
             const double ylm_real = (distance > tiny2) ? ylm_solid / pow(distance, LAB) : ylm_solid;
 
             const double i_exp = std::pow(-1.0, (LA - LB - LAB) / 2);
@@ -160,8 +166,9 @@ ModuleBase::Vector3<double> Center2_Orb::Orb11::cal_grad_overlap( // caoyu add 2
     const double distance = (distance_true >= tiny1) ? distance_true : distance_true + tiny1;
     const double RcutA = this->nA.getRcut();
     const double RcutB = this->nB.getRcut();
-    if (distance > (RcutA + RcutB))
+    if (distance > (RcutA + RcutB)) {
         return ModuleBase::Vector3<double>(0.0, 0.0, 0.0);
+}
 
     const int LA = this->nA.getL();
     const int LB = this->nB.getL();
@@ -187,8 +194,9 @@ ModuleBase::Vector3<double> Center2_Orb::Orb11::cal_grad_overlap( // caoyu add 2
             const double Gaunt_real_A_B_AB = this->MGT.Gaunt_Coefficients(this->MGT.get_lm_index(LA, mA),
                                                                           this->MGT.get_lm_index(LB, mB),
                                                                           this->MGT.get_lm_index(LAB, mAB));
-            if (0 == Gaunt_real_A_B_AB)
+            if (0 == Gaunt_real_A_B_AB) {
                 continue;
+}
 
             const double ylm_solid = rly[this->MGT.get_lm_index(LAB, mAB)];
             const double ylm_real = (distance > tiny2) ? ylm_solid / pow(distance, LAB) : ylm_solid;

--- a/source/module_hamilt_lcao/hamilt_lcaodft/center2_orb-orb11.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/center2_orb-orb11.cpp
@@ -10,6 +10,7 @@
 #include "module_base/math_polyint.h"
 #include "module_base/sph_bessel_recursive.h"
 #include "module_base/ylm.h"
+#include "module_base/array_pool.h"
 
 #include <cmath>
 
@@ -165,13 +166,13 @@ ModuleBase::Vector3<double> Center2_Orb::Orb11::cal_grad_overlap( // caoyu add 2
     const int LA = this->nA.getL();
     const int LB = this->nB.getL();
 
-    std::vector<double> rly;
-    std::vector<vector<double>> tmp_grly;
+    std::vector<double> rly((LA + LB + 1) * (LA + LB + 1));
     std::vector<ModuleBase::Vector3<double>> grly;
-    ModuleBase::Ylm::grad_rl_sph_harm(LA + LB, delta_R.x, delta_R.y, delta_R.z, rly, tmp_grly);
-    for (const auto& tmp_ele: tmp_grly)
+    ModuleBase::Array_Pool<double> tmp_grly((LA + LB + 1) * (LA + LB + 1), 3);
+    ModuleBase::Ylm::grad_rl_sph_harm(LA + LB, delta_R.x, delta_R.y, delta_R.z, rly.data(), tmp_grly.get_ptr_2D());
+    for (int i=0; i<(LA + LB + 1) * (LA + LB + 1); ++i)
     {
-        ModuleBase::Vector3<double> ele(tmp_ele[0], tmp_ele[1], tmp_ele[2]);
+        ModuleBase::Vector3<double> ele(tmp_grly[i][0], tmp_grly[i][1], tmp_grly[i][2]);
         grly.push_back(ele);
     }
 

--- a/source/module_hamilt_lcao/module_gint/cal_ddpsir_ylm.cpp
+++ b/source/module_hamilt_lcao/module_gint/cal_ddpsir_ylm.cpp
@@ -19,6 +19,10 @@ void cal_ddpsir_ylm(
     std::vector<const double*> it_dpsi_uniform(gt.nwmax);
     std::vector<const double*> it_d2psi_uniform(gt.nwmax);
     std::vector<int> it_psi_nr_uniform(gt.nwmax);
+    // array to store spherical harmonics and its derivatives
+    // the first dimension equals 36 because the maximum nwl is 5.
+    double rly[36];
+    ModuleBase::Array_Pool<double> grly(36, 3);
 
     for (int id = 0; id < na_grid; id++)
     {
@@ -105,10 +109,7 @@ void cal_ddpsir_ylm(
                         dr1[1] = dr[1] + displ[i][1];
                         dr1[2] = dr[2] + displ[i][2];
 
-                        // array to store spherical harmonics and its derivatives
-                        std::vector<double> rly;
-                        std::vector<std::vector<double>> grly;
-                        ModuleBase::Ylm::grad_rl_sph_harm(ucell.atoms[it].nwl, dr1[0], dr1[1], dr1[2], rly, grly);
+                        ModuleBase::Ylm::grad_rl_sph_harm(ucell.atoms[it].nwl, dr1[0], dr1[1], dr1[2], rly, grly.get_ptr_2D());
 
                         double distance1 = std::sqrt(dr1[0] * dr1[0] + dr1[1] * dr1[1] + dr1[2] * dr1[2]);
                         if (distance1 < 1e-9)
@@ -215,11 +216,8 @@ void cal_ddpsir_ylm(
                     }
                     // End of code addition section.
 
-                    // array to store spherical harmonics and its derivatives
-                    std::vector<double> rly;
-                    std::vector<std::vector<double>> grly;
                     std::vector<std::vector<double>> hrly;
-                    ModuleBase::Ylm::grad_rl_sph_harm(ucell.atoms[it].nwl, dr[0], dr[1], dr[2], rly, grly);
+                    ModuleBase::Ylm::grad_rl_sph_harm(ucell.atoms[it].nwl, dr[0], dr[1], dr[2], rly, grly.get_ptr_2D());
                     ModuleBase::Ylm::hes_rl_sph_harm(ucell.atoms[it].nwl, dr[0], dr[1], dr[2], hrly);
                     const double position = distance / delta_r;
 

--- a/source/module_hamilt_lcao/module_gint/cal_ddpsir_ylm.cpp
+++ b/source/module_hamilt_lcao/module_gint/cal_ddpsir_ylm.cpp
@@ -112,8 +112,9 @@ void cal_ddpsir_ylm(
                         ModuleBase::Ylm::grad_rl_sph_harm(ucell.atoms[it].nwl, dr1[0], dr1[1], dr1[2], rly, grly.get_ptr_2D());
 
                         double distance1 = std::sqrt(dr1[0] * dr1[0] + dr1[1] * dr1[1] + dr1[2] * dr1[2]);
-                        if (distance1 < 1e-9)
+                        if (distance1 < 1e-9) {
                             distance1 = 1e-9;
+}
 
                         const double position = distance1 / delta_r;
 

--- a/source/module_hamilt_lcao/module_gint/cal_dpsir_ylm.cpp
+++ b/source/module_hamilt_lcao/module_gint/cal_dpsir_ylm.cpp
@@ -1,6 +1,7 @@
 #include "gint_tools.h"
 #include "module_base/timer.h"
 #include "module_base/ylm.h"
+#include "module_base/array_pool.h"
 namespace Gint_Tools{
 void cal_dpsir_ylm(
     const Grid_Technique& gt, const int bxyz,
@@ -18,6 +19,10 @@ void cal_dpsir_ylm(
     std::vector<const double*> it_psi_uniform(gt.nwmax);
     std::vector<const double*> it_dpsi_uniform(gt.nwmax);
     std::vector<int> it_psi_nr_uniform(gt.nwmax);
+    // array to store spherical harmonics and its derivatives
+    // the first dimension equals 36 because the maximum nwl is 5.
+    double rly[36];
+    ModuleBase::Array_Pool<double> grly(36, 3);
 
     for (int id = 0; id < na_grid; id++)
     {
@@ -62,10 +67,7 @@ void cal_dpsir_ylm(
                        gt.meshcell_pos[ib][0] + mt[0], gt.meshcell_pos[ib][1] + mt[1], gt.meshcell_pos[ib][2] + mt[2]};
                 double distance = std::sqrt(dr[0] * dr[0] + dr[1] * dr[1] + dr[2] * dr[2]);
 
-                // array to store spherical harmonics and its derivatives
-                std::vector<double> rly;
-                std::vector<std::vector<double>> grly;
-                ModuleBase::Ylm::grad_rl_sph_harm(ucell.atoms[it].nwl, dr[0], dr[1], dr[2], rly, grly);
+                ModuleBase::Ylm::grad_rl_sph_harm(ucell.atoms[it].nwl, dr[0], dr[1], dr[2], rly, grly.get_ptr_2D());
                 if (distance < 1e-9)
                     distance = 1e-9;
 

--- a/source/module_hamilt_lcao/module_gint/gint_gamma_env.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_gamma_env.cpp
@@ -2,6 +2,7 @@
 #include "grid_technique.h"
 #include "module_base/timer.h"
 #include "module_base/ylm.h"
+#include "module_base/array_pool.h"
 #include "module_basis/module_ao/ORB_read.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
 
@@ -42,7 +43,7 @@ void Gint_Gamma::cal_env(const double* wfc, double* rho, UnitCell& ucell)
                                        cal_flag);
 
             // evaluate psi on grids
-            Gint_Tools::Array_Pool<double> psir_ylm(this->bxyz, LD_pool);
+            ModuleBase::Array_Pool<double> psir_ylm(this->bxyz, LD_pool);
             Gint_Tools::cal_psir_ylm(*this->gridt,
                                      this->bxyz,
                                      size,
@@ -51,7 +52,7 @@ void Gint_Gamma::cal_env(const double* wfc, double* rho, UnitCell& ucell)
                                      block_index,
                                      block_size,
                                      cal_flag,
-                                     psir_ylm.ptr_2D);
+                                     psir_ylm.get_ptr_2D());
 
             int* vindex = Gint_Tools::get_vindex(this->bxyz,
                                                  this->bx,
@@ -75,7 +76,7 @@ void Gint_Gamma::cal_env(const double* wfc, double* rho, UnitCell& ucell)
                     if (cal_flag[ib][ia1])
                     {
                         int iw1_lo = this->gridt->trace_lo[start1];
-                        double* psi1 = &psir_ylm.ptr_2D[ib][block_index[ia1]];
+                        double* psi1 = &psir_ylm[ib][block_index[ia1]];
                         double tmp = 0.0;
                         for (int iw = 0; iw < atom1->nw; ++iw, ++iw1_lo)
                         {

--- a/source/module_hamilt_lcao/module_gint/gint_k_env.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_k_env.cpp
@@ -4,6 +4,7 @@
 #include "module_base/ylm.h"
 #include "module_basis/module_ao/ORB_read.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
+#include "module_base/array_pool.h"
 
 void Gint_k::cal_env_k(int ik,
                        const std::complex<double>* psi_k,
@@ -52,7 +53,7 @@ void Gint_k::cal_env_k(int ik,
                                        cal_flag);
 
             // evaluate psi on grids
-            Gint_Tools::Array_Pool<double> psir_ylm(this->bxyz, LD_pool);
+            ModuleBase::Array_Pool<double> psir_ylm(this->bxyz, LD_pool);
             Gint_Tools::cal_psir_ylm(*this->gridt,
                                      this->bxyz,
                                      size,
@@ -61,7 +62,7 @@ void Gint_k::cal_env_k(int ik,
                                      block_index,
                                      block_size,
                                      cal_flag,
-                                     psir_ylm.ptr_2D);
+                                     psir_ylm.get_ptr_2D());
 
             int* vindex = Gint_Tools::get_vindex(this->bxyz,
                                                  this->bx,
@@ -101,7 +102,7 @@ void Gint_k::cal_env_k(int ik,
                     if (cal_flag[ib][ia1])
                     {
                         int iw1_lo = 0;
-                        double* psi1 = &psir_ylm.ptr_2D[ib][block_index[ia1]];
+                        double* psi1 = &psir_ylm[ib][block_index[ia1]];
                         std::complex<double> tmp{0.0, 0.0};
                         if (GlobalV::NSPIN == 4) // is it a simple add of 2 spins?
                         {

--- a/source/module_hamilt_lcao/module_gint/gint_rho.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_rho.cpp
@@ -5,6 +5,7 @@
 #include "module_base/global_function.h"
 #include "module_base/global_variable.h"
 #include "module_base/timer.h"
+#include "module_base/array_pool.h"
 #include "module_base/ylm.h"
 #include "module_basis/module_ao/ORB_read.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
@@ -30,7 +31,7 @@ void Gint::gint_kernel_rho(const int na_grid,
                                cal_flag);
 
     // evaluate psi on grids
-    Gint_Tools::Array_Pool<double> psir_ylm(this->bxyz, LD_pool);
+    ModuleBase::Array_Pool<double> psir_ylm(this->bxyz, LD_pool);
     Gint_Tools::cal_psir_ylm(*this->gridt,
                              this->bxyz,
                              na_grid,
@@ -39,12 +40,12 @@ void Gint::gint_kernel_rho(const int na_grid,
                              block_index,
                              block_size,
                              cal_flag,
-                             psir_ylm.ptr_2D);
+                             psir_ylm.get_ptr_2D());
 
     for (int is = 0; is < GlobalV::NSPIN; ++is)
     {
-        Gint_Tools::Array_Pool<double> psir_DM(this->bxyz, LD_pool);
-        ModuleBase::GlobalFunc::ZEROS(psir_DM.ptr_1D, this->bxyz * LD_pool);
+        ModuleBase::Array_Pool<double> psir_DM(this->bxyz, LD_pool);
+        ModuleBase::GlobalFunc::ZEROS(psir_DM.get_ptr_1D(), this->bxyz * LD_pool);
         if (GlobalV::GAMMA_ONLY_LOCAL)
         {
             Gint_Tools::mult_psi_DM_new(*this->gridt,
@@ -56,8 +57,8 @@ void Gint::gint_kernel_rho(const int na_grid,
                                         block_size,
                                         block_index,
                                         cal_flag,
-                                        psir_ylm.ptr_2D,
-                                        psir_DM.ptr_2D,
+                                        psir_ylm.get_ptr_2D(),
+                                        psir_DM.get_ptr_2D(),
                                         this->DMRGint[is],
                                         inout->if_symm);
         }
@@ -71,14 +72,14 @@ void Gint::gint_kernel_rho(const int na_grid,
                                      block_index,
                                      block_size,
                                      cal_flag,
-                                     psir_ylm.ptr_2D,
-                                     psir_DM.ptr_2D,
+                                     psir_ylm.get_ptr_2D(),
+                                     psir_DM.get_ptr_2D(),
                                      this->DMRGint[is],
                                      inout->if_symm);
         }
 
         // do sum_mu g_mu(r)psi_mu(r) to get electron density on grid
-        this->cal_meshball_rho(na_grid, block_index, vindex, psir_ylm.ptr_2D, psir_DM.ptr_2D, inout->rho[is]);
+        this->cal_meshball_rho(na_grid, block_index, vindex, psir_ylm.get_ptr_2D(), psir_DM.get_ptr_2D(), inout->rho[is]);
     }
     delete[] block_iw;
     delete[] block_index;

--- a/source/module_hamilt_lcao/module_gint/gint_tau.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_tau.cpp
@@ -7,6 +7,7 @@
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
 #include "module_base/blas_connector.h"
 #include "module_base/timer.h"
+#include "module_base/array_pool.h"
 #include "gint_tools.h"
 #include "module_base/memory.h"
 #include "module_hamilt_lcao/module_gint/grid_technique.h"
@@ -27,28 +28,28 @@ void Gint::gint_kernel_tau(
 	Gint_Tools::get_block_info(*this->gridt, this->bxyz, na_grid, grid_index, block_iw, block_index, block_size, cal_flag);
 
     //evaluate psi and dpsi on grids
-	Gint_Tools::Array_Pool<double> psir_ylm(this->bxyz, LD_pool);
-	Gint_Tools::Array_Pool<double> dpsir_ylm_x(this->bxyz, LD_pool);
-	Gint_Tools::Array_Pool<double> dpsir_ylm_y(this->bxyz, LD_pool);
-	Gint_Tools::Array_Pool<double> dpsir_ylm_z(this->bxyz, LD_pool);
+	ModuleBase::Array_Pool<double> psir_ylm(this->bxyz, LD_pool);
+	ModuleBase::Array_Pool<double> dpsir_ylm_x(this->bxyz, LD_pool);
+	ModuleBase::Array_Pool<double> dpsir_ylm_y(this->bxyz, LD_pool);
+	ModuleBase::Array_Pool<double> dpsir_ylm_z(this->bxyz, LD_pool);
 
 	Gint_Tools::cal_dpsir_ylm(*this->gridt, 
 		this->bxyz, na_grid, grid_index, delta_r,
 		block_index, block_size, 
 		cal_flag,
-		psir_ylm.ptr_2D,
-		dpsir_ylm_x.ptr_2D,
-		dpsir_ylm_y.ptr_2D,
-		dpsir_ylm_z.ptr_2D);
+		psir_ylm.get_ptr_2D(),
+		dpsir_ylm_x.get_ptr_2D(),
+		dpsir_ylm_y.get_ptr_2D(),
+		dpsir_ylm_z.get_ptr_2D());
 
 	for(int is=0; is<GlobalV::NSPIN; ++is)
 	{
-		Gint_Tools::Array_Pool<double> dpsix_DM(this->bxyz, LD_pool);
-		Gint_Tools::Array_Pool<double> dpsiy_DM(this->bxyz, LD_pool);
-		Gint_Tools::Array_Pool<double> dpsiz_DM(this->bxyz, LD_pool);
-		ModuleBase::GlobalFunc::ZEROS(dpsix_DM.ptr_1D, this->bxyz*LD_pool);
-		ModuleBase::GlobalFunc::ZEROS(dpsiy_DM.ptr_1D, this->bxyz*LD_pool);
-		ModuleBase::GlobalFunc::ZEROS(dpsiz_DM.ptr_1D, this->bxyz*LD_pool);
+		ModuleBase::Array_Pool<double> dpsix_DM(this->bxyz, LD_pool);
+		ModuleBase::Array_Pool<double> dpsiy_DM(this->bxyz, LD_pool);
+		ModuleBase::Array_Pool<double> dpsiz_DM(this->bxyz, LD_pool);
+		ModuleBase::GlobalFunc::ZEROS(dpsix_DM.get_ptr_1D(), this->bxyz*LD_pool);
+		ModuleBase::GlobalFunc::ZEROS(dpsiy_DM.get_ptr_1D(), this->bxyz*LD_pool);
+		ModuleBase::GlobalFunc::ZEROS(dpsiz_DM.get_ptr_1D(), this->bxyz*LD_pool);
 
 		//calculating g_i,mu(r) = sum_nu rho_mu,nu d/dx_i psi_nu(r), x_i=x,y,z
 		if(GlobalV::GAMMA_ONLY_LOCAL)
@@ -58,44 +59,44 @@ void Gint::gint_kernel_tau(
 				*this->gridt,this->bxyz, na_grid, LD_pool,
 				block_iw, block_size,
 				block_index, cal_flag,
-				dpsir_ylm_x.ptr_2D,
-				dpsix_DM.ptr_2D,
+				dpsir_ylm_x.get_ptr_2D(),
+				dpsix_DM.get_ptr_2D(),
 				inout->DM[is], 1);
 			Gint_Tools::mult_psi_DM(
 				*this->gridt, this->bxyz, na_grid, LD_pool,
 				block_iw, block_size,
 				block_index, cal_flag,
-				dpsir_ylm_y.ptr_2D,
-				dpsiy_DM.ptr_2D,
+				dpsir_ylm_y.get_ptr_2D(),
+				dpsiy_DM.get_ptr_2D(),
 				inout->DM[is], 1);	
 			Gint_Tools::mult_psi_DM(
 				*this->gridt, this->bxyz, na_grid, LD_pool,
 				block_iw, block_size,
 				block_index, cal_flag,
-				dpsir_ylm_z.ptr_2D,
-				dpsiz_DM.ptr_2D,
+				dpsir_ylm_z.get_ptr_2D(),
+				dpsiz_DM.get_ptr_2D(),
 				inout->DM[is], 1);
 			*/
 			Gint_Tools::mult_psi_DM_new(
 				*this->gridt,this->bxyz, grid_index, na_grid, LD_pool,
 				block_iw, block_size,
 				block_index, cal_flag,
-				dpsir_ylm_x.ptr_2D,
-				dpsix_DM.ptr_2D,
+				dpsir_ylm_x.get_ptr_2D(),
+				dpsix_DM.get_ptr_2D(),
 				this->DMRGint[is], 1);
 			Gint_Tools::mult_psi_DM_new(
 				*this->gridt, this->bxyz, grid_index, na_grid, LD_pool,
 				block_iw, block_size,
 				block_index, cal_flag,
-				dpsir_ylm_y.ptr_2D,
-				dpsiy_DM.ptr_2D,
+				dpsir_ylm_y.get_ptr_2D(),
+				dpsiy_DM.get_ptr_2D(),
 				this->DMRGint[is], 1);	
 			Gint_Tools::mult_psi_DM_new(
 				*this->gridt, this->bxyz, grid_index, na_grid, LD_pool,
 				block_iw, block_size,
 				block_index, cal_flag,
-				dpsir_ylm_z.ptr_2D,
-				dpsiz_DM.ptr_2D,
+				dpsir_ylm_z.get_ptr_2D(),
+				dpsiz_DM.get_ptr_2D(),
 				this->DMRGint[is], 1);
 		}
 		else
@@ -104,24 +105,24 @@ void Gint::gint_kernel_tau(
 				*this->gridt, this->bxyz, grid_index, na_grid,
 				block_index, block_size,
 				cal_flag, 
-				dpsir_ylm_x.ptr_2D,
-                dpsix_DM.ptr_2D,
+				dpsir_ylm_x.get_ptr_2D(),
+                dpsix_DM.get_ptr_2D(),
 				this->DMRGint[is],
 				1);
 			Gint_Tools::mult_psi_DMR(
 				*this->gridt, this->bxyz, grid_index, na_grid,
 				block_index, block_size,
 				cal_flag,
-				dpsir_ylm_y.ptr_2D,
-                dpsiy_DM.ptr_2D,
+				dpsir_ylm_y.get_ptr_2D(),
+                dpsiy_DM.get_ptr_2D(),
 				this->DMRGint[is],
 				1);
 			Gint_Tools::mult_psi_DMR(
 				*this->gridt, this->bxyz, grid_index, na_grid,
 				block_index, block_size,
 				cal_flag, 
-				dpsir_ylm_z.ptr_2D,
-                dpsiz_DM.ptr_2D,
+				dpsir_ylm_z.get_ptr_2D(),
+                dpsiz_DM.get_ptr_2D(),
 				this->DMRGint[is],
 				1);
 		}
@@ -132,8 +133,8 @@ void Gint::gint_kernel_tau(
 			this->cal_meshball_tau(
 				na_grid, block_index,
 				vindex,
-				dpsir_ylm_x.ptr_2D, dpsir_ylm_y.ptr_2D, dpsir_ylm_z.ptr_2D,
-				dpsix_DM.ptr_2D, dpsiy_DM.ptr_2D, dpsiz_DM.ptr_2D,
+				dpsir_ylm_x.get_ptr_2D(), dpsir_ylm_y.get_ptr_2D(), dpsir_ylm_z.get_ptr_2D(),
+				dpsix_DM.get_ptr_2D(), dpsiy_DM.get_ptr_2D(), dpsiz_DM.get_ptr_2D(),
 				inout->rho[is]);
 		}
 	}

--- a/source/module_hamilt_lcao/module_gint/gint_tools.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_tools.cpp
@@ -153,10 +153,11 @@ void get_block_info(const Grid_Technique& gt, const int bxyz, const int na_grid,
 					gt.meshcell_pos[ib][2] + mt[2]};
 				const double distance = std::sqrt(dr[0]*dr[0] + dr[1]*dr[1] + dr[2]*dr[2]);	// distance between atom and grid
 
-            if (distance > gt.rcuts[it] - 1.0e-10)
+            if (distance > gt.rcuts[it] - 1.0e-10) {
                 cal_flag[ib][id] = false;
-            else
+            } else {
                 cal_flag[ib][id] = true;
+}
         } // end ib
     }
 }

--- a/source/module_hamilt_lcao/module_gint/gint_tools.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_tools.cpp
@@ -7,6 +7,7 @@
 
 #include "module_base/timer.h"
 #include "module_base/ylm.h"
+#include "module_base/array_pool.h"
 #include "module_basis/module_ao/ORB_read.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
 
@@ -233,7 +234,7 @@ void cal_dpsirr_ylm(
 
 	// atomic basis sets
 	// psir_vlbr3[bxyz][LD_pool]
-    Gint_Tools::Array_Pool<double> get_psir_vlbr3(
+    ModuleBase::Array_Pool<double> get_psir_vlbr3(
         const int bxyz,
         const int na_grid,  					    // how many atoms on this (i,j,k) grid
 		const int LD_pool,
@@ -242,7 +243,7 @@ void cal_dpsirr_ylm(
 		const double*const vldr3,			    	// vldr3[bxyz]
 		const double*const*const psir_ylm)		    // psir_ylm[bxyz][LD_pool]
 	{
-		Gint_Tools::Array_Pool<double> psir_vlbr3(bxyz, LD_pool);
+		ModuleBase::Array_Pool<double> psir_vlbr3(bxyz, LD_pool);
 		for(int ib=0; ib<bxyz; ++ib)
 		{
 			for(int ia=0; ia<na_grid; ++ia)
@@ -251,14 +252,14 @@ void cal_dpsirr_ylm(
 				{
 					for(int i=block_index[ia]; i<block_index[ia+1]; ++i)
 					{
-						psir_vlbr3.ptr_2D[ib][i]=psir_ylm[ib][i]*vldr3[ib];
+						psir_vlbr3[ib][i]=psir_ylm[ib][i]*vldr3[ib];
 					}
 				}
 				else
 				{
 					for(int i=block_index[ia]; i<block_index[ia+1]; ++i)
 					{
-						psir_vlbr3.ptr_2D[ib][i]=0;
+						psir_vlbr3[ib][i]=0;
 					}
 				}
 

--- a/source/module_hamilt_lcao/module_gint/gint_tools.h
+++ b/source/module_hamilt_lcao/module_gint/gint_tools.h
@@ -6,6 +6,7 @@
 #include "grid_technique.h"
 #include "module_elecstate/module_charge/charge.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
+#include "module_base/array_pool.h"
 
 #include <cstdlib>
 
@@ -135,19 +136,6 @@ class Gint_inout
 
 namespace Gint_Tools
 {
-template <typename T>
-class Array_Pool
-{
-  public:
-    T** ptr_2D;
-    T* ptr_1D;
-    Array_Pool(const int nr, const int nc);
-    Array_Pool(Array_Pool<T>&& array);
-    ~Array_Pool();
-    Array_Pool(const Array_Pool<T>& array) = delete;
-    Array_Pool(Array_Pool<T>& array) = delete;
-};
-
 // vindex[pw.bxyz]
 int* get_vindex(const int bxyz,
                 const int bx,
@@ -276,7 +264,7 @@ void cal_ddpsir_ylm(
     double* const* const ddpsir_ylm_zz);
 
 // psir_ylm * vldr3
-Gint_Tools::Array_Pool<double> get_psir_vlbr3(
+ModuleBase::Array_Pool<double> get_psir_vlbr3(
     const int bxyz,
     const int na_grid, // how many atoms on this (i,j,k) grid
     const int LD_pool,
@@ -330,33 +318,4 @@ void mult_psi_DM_new(
     const bool if_symm);
 
 } // namespace Gint_Tools
-
-namespace Gint_Tools
-{
-template <typename T>
-Array_Pool<T>::Array_Pool(const int nr, const int nc) // Attention: uninitialized
-{
-    ptr_1D = new T[nr * nc];
-    ptr_2D = new T*[nr];
-    for (int ir = 0; ir < nr; ++ir)
-        ptr_2D[ir] = &ptr_1D[ir * nc];
-}
-
-template <typename T>
-Array_Pool<T>::Array_Pool(Array_Pool<T>&& array)
-{
-    ptr_1D = array.ptr_1D;
-    ptr_2D = array.ptr_2D;
-    delete[] array.ptr_2D;
-    delete[] array.ptr_1D;
-}
-
-template <typename T>
-Array_Pool<T>::~Array_Pool()
-{
-    delete[] ptr_2D;
-    delete[] ptr_1D;
-}
-} // namespace Gint_Tools
-
 #endif

--- a/source/module_hamilt_lcao/module_gint/gint_vl.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_vl.cpp
@@ -7,6 +7,7 @@
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
 #include "module_base/blas_connector.h"
 #include "module_base/timer.h"
+#include "module_base/array_pool.h"
 //#include <mkl_cblas.h>
 
 #ifdef _OPENMP
@@ -33,16 +34,16 @@ void Gint::gint_kernel_vlocal(
 	Gint_Tools::get_block_info(*this->gridt, this->bxyz, na_grid, grid_index, block_iw, block_index, block_size, cal_flag);
 	
 	//evaluate psi and dpsi on grids
-	Gint_Tools::Array_Pool<double> psir_ylm(this->bxyz, LD_pool);
+	ModuleBase::Array_Pool<double> psir_ylm(this->bxyz, LD_pool);
 	Gint_Tools::cal_psir_ylm(*this->gridt, 
 		this->bxyz, na_grid, grid_index, delta_r,
 		block_index, block_size, 
 		cal_flag,
-		psir_ylm.ptr_2D);
+		psir_ylm.get_ptr_2D());
 	
 	//calculating f_mu(r) = v(r)*psi_mu(r)*dv
-	const Gint_Tools::Array_Pool<double> psir_vlbr3 = Gint_Tools::get_psir_vlbr3(
-			this->bxyz, na_grid, LD_pool, block_index, cal_flag, vldr3, psir_ylm.ptr_2D);
+	const ModuleBase::Array_Pool<double> psir_vlbr3 = Gint_Tools::get_psir_vlbr3(
+			this->bxyz, na_grid, LD_pool, block_index, cal_flag, vldr3, psir_ylm.get_ptr_2D());
 
 	//integrate (psi_mu*v(r)*dv) * psi_nu on grid
 	//and accumulates to the corresponding element in Hamiltonian
@@ -51,13 +52,13 @@ void Gint::gint_kernel_vlocal(
 		if(hR == nullptr) hR = this->hRGint;
 		this->cal_meshball_vlocal_gamma(
 			na_grid, LD_pool, block_iw, block_size, block_index, grid_index, cal_flag,
-			psir_ylm.ptr_2D, psir_vlbr3.ptr_2D, hR);
+			psir_ylm.get_ptr_2D(), psir_vlbr3.get_ptr_2D(), hR);
     }
     else
     {
         this->cal_meshball_vlocal_k(
             na_grid, LD_pool, grid_index, block_size, block_index, block_iw, cal_flag,
-            psir_ylm.ptr_2D, psir_vlbr3.ptr_2D, pvpR_in,ucell);
+            psir_ylm.get_ptr_2D(), psir_vlbr3.get_ptr_2D(), pvpR_in,ucell);
     }
 
     //release memories
@@ -90,29 +91,29 @@ void Gint::gint_kernel_dvlocal(
 	Gint_Tools::get_block_info(*this->gridt, this->bxyz, na_grid, grid_index, block_iw, block_index, block_size, cal_flag);
 	
 	//evaluate psi and dpsi on grids
-	Gint_Tools::Array_Pool<double> psir_ylm(this->bxyz, LD_pool);
-	Gint_Tools::Array_Pool<double> dpsir_ylm_x(this->bxyz, LD_pool);
-	Gint_Tools::Array_Pool<double> dpsir_ylm_y(this->bxyz, LD_pool);
-	Gint_Tools::Array_Pool<double> dpsir_ylm_z(this->bxyz, LD_pool);
+	ModuleBase::Array_Pool<double> psir_ylm(this->bxyz, LD_pool);
+	ModuleBase::Array_Pool<double> dpsir_ylm_x(this->bxyz, LD_pool);
+	ModuleBase::Array_Pool<double> dpsir_ylm_y(this->bxyz, LD_pool);
+	ModuleBase::Array_Pool<double> dpsir_ylm_z(this->bxyz, LD_pool);
 
 	Gint_Tools::cal_dpsir_ylm(*this->gridt, this->bxyz, na_grid, grid_index, delta_r,	block_index, block_size, cal_flag,
-		psir_ylm.ptr_2D, dpsir_ylm_x.ptr_2D, dpsir_ylm_y.ptr_2D, dpsir_ylm_z.ptr_2D);
+		psir_ylm.get_ptr_2D(), dpsir_ylm_x.get_ptr_2D(), dpsir_ylm_y.get_ptr_2D(), dpsir_ylm_z.get_ptr_2D());
 
 	//calculating f_mu(r) = v(r)*psi_mu(r)*dv
-	const Gint_Tools::Array_Pool<double> psir_vlbr3 = Gint_Tools::get_psir_vlbr3(
-			this->bxyz, na_grid, LD_pool, block_index, cal_flag, vldr3, psir_ylm.ptr_2D);
+	const ModuleBase::Array_Pool<double> psir_vlbr3 = Gint_Tools::get_psir_vlbr3(
+			this->bxyz, na_grid, LD_pool, block_index, cal_flag, vldr3, psir_ylm.get_ptr_2D());
 
 	//integrate (psi_mu*v(r)*dv) * psi_nu on grid
 	//and accumulates to the corresponding element in Hamiltonian
 	this->cal_meshball_vlocal_k(
 		na_grid, LD_pool, grid_index, block_size, block_index, block_iw, cal_flag,
-		psir_vlbr3.ptr_2D, dpsir_ylm_x.ptr_2D, pvdpRx,ucell);
+		psir_vlbr3.get_ptr_2D(), dpsir_ylm_x.get_ptr_2D(), pvdpRx,ucell);
 	this->cal_meshball_vlocal_k(
 		na_grid, LD_pool, grid_index, block_size, block_index, block_iw, cal_flag,
-		psir_vlbr3.ptr_2D, dpsir_ylm_y.ptr_2D, pvdpRy,ucell);
+		psir_vlbr3.get_ptr_2D(), dpsir_ylm_y.get_ptr_2D(), pvdpRy,ucell);
 	this->cal_meshball_vlocal_k(
 		na_grid, LD_pool, grid_index, block_size, block_index, block_iw, cal_flag,
-		psir_vlbr3.ptr_2D, dpsir_ylm_z.ptr_2D, pvdpRz,ucell);
+		psir_vlbr3.get_ptr_2D(), dpsir_ylm_z.get_ptr_2D(), pvdpRz,ucell);
 
     //release memories
 	delete[] block_iw;
@@ -144,32 +145,32 @@ void Gint::gint_kernel_vlocal_meta(
 	Gint_Tools::get_block_info(*this->gridt, this->bxyz, na_grid, grid_index, block_iw, block_index, block_size, cal_flag);
 
     //evaluate psi and dpsi on grids
-	Gint_Tools::Array_Pool<double> psir_ylm(this->bxyz, LD_pool);
-	Gint_Tools::Array_Pool<double> dpsir_ylm_x(this->bxyz, LD_pool);
-	Gint_Tools::Array_Pool<double> dpsir_ylm_y(this->bxyz, LD_pool);
-	Gint_Tools::Array_Pool<double> dpsir_ylm_z(this->bxyz, LD_pool);
+	ModuleBase::Array_Pool<double> psir_ylm(this->bxyz, LD_pool);
+	ModuleBase::Array_Pool<double> dpsir_ylm_x(this->bxyz, LD_pool);
+	ModuleBase::Array_Pool<double> dpsir_ylm_y(this->bxyz, LD_pool);
+	ModuleBase::Array_Pool<double> dpsir_ylm_z(this->bxyz, LD_pool);
 
 	Gint_Tools::cal_dpsir_ylm(*this->gridt,
 		this->bxyz, na_grid, grid_index, delta_r,
 		block_index, block_size, 
 		cal_flag,
-		psir_ylm.ptr_2D,
-		dpsir_ylm_x.ptr_2D,
-		dpsir_ylm_y.ptr_2D,
-		dpsir_ylm_z.ptr_2D
+		psir_ylm.get_ptr_2D(),
+		dpsir_ylm_x.get_ptr_2D(),
+		dpsir_ylm_y.get_ptr_2D(),
+		dpsir_ylm_z.get_ptr_2D()
 	);
 	
 	//calculating f_mu(r) = v(r)*psi_mu(r)*dv
-	const Gint_Tools::Array_Pool<double> psir_vlbr3 = Gint_Tools::get_psir_vlbr3(
-			this->bxyz, na_grid, LD_pool, block_index, cal_flag, vldr3, psir_ylm.ptr_2D);
+	const ModuleBase::Array_Pool<double> psir_vlbr3 = Gint_Tools::get_psir_vlbr3(
+			this->bxyz, na_grid, LD_pool, block_index, cal_flag, vldr3, psir_ylm.get_ptr_2D());
 
 	//calculating df_mu(r) = vofk(r) * dpsi_mu(r) * dv
-	const Gint_Tools::Array_Pool<double> dpsix_vlbr3 = Gint_Tools::get_psir_vlbr3(
-			this->bxyz, na_grid, LD_pool, block_index, cal_flag, vkdr3, dpsir_ylm_x.ptr_2D);
-	const Gint_Tools::Array_Pool<double> dpsiy_vlbr3 = Gint_Tools::get_psir_vlbr3(
-			this->bxyz, na_grid, LD_pool, block_index, cal_flag, vkdr3, dpsir_ylm_y.ptr_2D);	
-	const Gint_Tools::Array_Pool<double> dpsiz_vlbr3 = Gint_Tools::get_psir_vlbr3(
-			this->bxyz, na_grid, LD_pool, block_index, cal_flag, vkdr3, dpsir_ylm_z.ptr_2D);
+	const ModuleBase::Array_Pool<double> dpsix_vlbr3 = Gint_Tools::get_psir_vlbr3(
+			this->bxyz, na_grid, LD_pool, block_index, cal_flag, vkdr3, dpsir_ylm_x.get_ptr_2D());
+	const ModuleBase::Array_Pool<double> dpsiy_vlbr3 = Gint_Tools::get_psir_vlbr3(
+			this->bxyz, na_grid, LD_pool, block_index, cal_flag, vkdr3, dpsir_ylm_y.get_ptr_2D());	
+	const ModuleBase::Array_Pool<double> dpsiz_vlbr3 = Gint_Tools::get_psir_vlbr3(
+			this->bxyz, na_grid, LD_pool, block_index, cal_flag, vkdr3, dpsir_ylm_z.get_ptr_2D());
 
     if(GlobalV::GAMMA_ONLY_LOCAL)
     {
@@ -178,33 +179,33 @@ void Gint::gint_kernel_vlocal_meta(
 		//and accumulates to the corresponding element in Hamiltonian
 		this->cal_meshball_vlocal_gamma(
 			na_grid, LD_pool, block_iw, block_size, block_index, grid_index, cal_flag,
-			psir_ylm.ptr_2D, psir_vlbr3.ptr_2D, hR);
+			psir_ylm.get_ptr_2D(), psir_vlbr3.get_ptr_2D(), hR);
 		//integrate (d/dx_i psi_mu*vk(r)*dv) * (d/dx_i psi_nu) on grid (x_i=x,y,z)
 		//and accumulates to the corresponding element in Hamiltonian
 		this->cal_meshball_vlocal_gamma(
 			na_grid, LD_pool, block_iw, block_size, block_index, grid_index, cal_flag,
-			dpsir_ylm_x.ptr_2D, dpsix_vlbr3.ptr_2D, hR);
+			dpsir_ylm_x.get_ptr_2D(), dpsix_vlbr3.get_ptr_2D(), hR);
 		this->cal_meshball_vlocal_gamma(
 			na_grid, LD_pool, block_iw, block_size, block_index, grid_index, cal_flag,
-			dpsir_ylm_y.ptr_2D, dpsiy_vlbr3.ptr_2D, hR);
+			dpsir_ylm_y.get_ptr_2D(), dpsiy_vlbr3.get_ptr_2D(), hR);
 		this->cal_meshball_vlocal_gamma(
 			na_grid, LD_pool, block_iw, block_size, block_index, grid_index, cal_flag,
-			dpsir_ylm_z.ptr_2D, dpsiz_vlbr3.ptr_2D, hR);
+			dpsir_ylm_z.get_ptr_2D(), dpsiz_vlbr3.get_ptr_2D(), hR);
     }
     else
     {
         this->cal_meshball_vlocal_k(
             na_grid, LD_pool, grid_index, block_size, block_index, block_iw, cal_flag,
-            psir_ylm.ptr_2D, psir_vlbr3.ptr_2D, pvpR_in,ucell);
+            psir_ylm.get_ptr_2D(), psir_vlbr3.get_ptr_2D(), pvpR_in,ucell);
 		this->cal_meshball_vlocal_k(
             na_grid, LD_pool, grid_index, block_size, block_index, block_iw, cal_flag,
-			dpsir_ylm_x.ptr_2D, dpsix_vlbr3.ptr_2D, pvpR_in,ucell);
+			dpsir_ylm_x.get_ptr_2D(), dpsix_vlbr3.get_ptr_2D(), pvpR_in,ucell);
 		this->cal_meshball_vlocal_k(
             na_grid, LD_pool, grid_index, block_size, block_index, block_iw, cal_flag,
-			dpsir_ylm_y.ptr_2D, dpsiy_vlbr3.ptr_2D, pvpR_in,ucell);
+			dpsir_ylm_y.get_ptr_2D(), dpsiy_vlbr3.get_ptr_2D(), pvpR_in,ucell);
 		this->cal_meshball_vlocal_k(
             na_grid, LD_pool, grid_index, block_size, block_index, block_iw, cal_flag,
-			dpsir_ylm_z.ptr_2D, dpsiz_vlbr3.ptr_2D, pvpR_in,ucell);
+			dpsir_ylm_z.get_ptr_2D(), dpsiz_vlbr3.get_ptr_2D(), pvpR_in,ucell);
     }
 
     //release memories

--- a/source/module_hamilt_lcao/module_gint/gint_vl.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_vl.cpp
@@ -49,7 +49,8 @@ void Gint::gint_kernel_vlocal(
 	//and accumulates to the corresponding element in Hamiltonian
     if(GlobalV::GAMMA_ONLY_LOCAL)
     {
-		if(hR == nullptr) hR = this->hRGint;
+		if(hR == nullptr) { hR = this->hRGint;
+}
 		this->cal_meshball_vlocal_gamma(
 			na_grid, LD_pool, block_iw, block_size, block_index, grid_index, cal_flag,
 			psir_ylm.get_ptr_2D(), psir_vlbr3.get_ptr_2D(), hR);
@@ -174,7 +175,8 @@ void Gint::gint_kernel_vlocal_meta(
 
     if(GlobalV::GAMMA_ONLY_LOCAL)
     {
-		if(hR == nullptr) hR = this->hRGint;
+		if(hR == nullptr) { hR = this->hRGint;
+}
 		//integrate (psi_mu*v(r)*dv) * psi_nu on grid
 		//and accumulates to the corresponding element in Hamiltonian
 		this->cal_meshball_vlocal_gamma(
@@ -268,7 +270,8 @@ void Gint::cal_meshball_vlocal_gamma(
                     }
                 }
                 const int ib_length = last_ib-first_ib;
-                if(ib_length<=0) continue;
+                if(ib_length<=0) { continue;
+}
 
 				// calculate the BaseMatrix of <iat1, iat2, R> atom-pair
 				hamilt::AtomPair<double>* tmp_ap = hR->find_pair(iat1, iat2);
@@ -370,11 +373,13 @@ void Gint::cal_meshball_vlocal_k(
     			int cal_num=0;
     			for(int ib=0; ib<this->bxyz; ++ib)
     			{
-    				if(cal_flag[ib][ia1] && cal_flag[ib][ia2])
+    				if(cal_flag[ib][ia1] && cal_flag[ib][ia2]) {
     				    ++cal_num;
+}
     			}
 
-    			if(cal_num==0) continue;
+    			if(cal_num==0) { continue;
+}
     			
                 const int idx2=block_index[ia2];
         		int n=block_size[ia2];

--- a/source/module_hamilt_lcao/module_gint/test/test_sph.cpp
+++ b/source/module_hamilt_lcao/module_gint/test/test_sph.cpp
@@ -163,13 +163,10 @@ void grad_rl_sph_harm(const int& Lmax, // max momentum of L
                       const double& x,
                       const double& y,
                       const double& z,
-                      std::vector<double>& rly,
-                      std::vector<std::vector<double>>& grly,
+                      double* rly,
+                      double** grly,
                       const double* ylmcoef)
 {
-    rly.resize((Lmax + 1) * (Lmax + 1));
-    grly.resize((Lmax + 1) * (Lmax + 1), std::vector<double>(3));
-
     double radius2 = x * x + y * y + z * z;
     double tx = 2.0 * x;
     double ty = 2.0 * y;

--- a/source/module_hamilt_lcao/module_gint/test/test_sph.cu
+++ b/source/module_hamilt_lcao/module_gint/test/test_sph.cu
@@ -8,6 +8,7 @@
 #include "gtest/gtest.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
 #include "test_sph.h"
+#include "module_base/array_pool.h"
 using namespace std;
 
 class gintTest : public ::testing::Test
@@ -72,7 +73,7 @@ TEST_F(gintTest, test)
 
     std::vector<double> ylma_cpu(49, 0.0);
     std::vector<double> ylma_cpu_dpsir(49, 0.0);
-    std::vector<std::vector<double>> ylma_cpu_ddpsir(49, vector<double>(3, 0.0));
+    ModuleBase::Array_Pool<double> ylma_cpu_ddpsir(49, 3);
     
     nwl=3;
     for (int i=0;i<3;i++){
@@ -97,7 +98,7 @@ TEST_F(gintTest, test)
     cuda_test<<<1, 1>>>(dr_g, nwl, ylma_g, ylmcoef_g);
     cuda_test2<<<1, 1>>>(dr_g, distance, nwl, dylma_g, ylmcoef_g);
     sph_harm(nwl, dr[0], dr[1], dr[2], ylma_cpu, ylmcoef);
-    grad_rl_sph_harm(nwl, dr[0], dr[1], dr[2], ylma_cpu_dpsir, ylma_cpu_ddpsir, ylmcoef);
+    grad_rl_sph_harm(nwl, dr[0], dr[1], dr[2], ylma_cpu_dpsir.data(), ylma_cpu_ddpsir.get_ptr_2D(), ylmcoef);
     cudaMemcpy(ylma, ylma_g, 49 * sizeof(double), cudaMemcpyDeviceToHost);
     cudaMemcpy(dylma, dylma_g, 49 * sizeof(double), cudaMemcpyDeviceToHost);
     cudaDeviceReset();

--- a/source/module_hamilt_lcao/module_gint/test/test_sph.h
+++ b/source/module_hamilt_lcao/module_gint/test/test_sph.h
@@ -13,7 +13,7 @@ void grad_rl_sph_harm(const int& Lmax, // max momentum of L
                       const double& x,
                       const double& y,
                       const double& z,
-                      std::vector<double>& rly,
-                      std::vector<std::vector<double>>& grly,
+                      double* rly,
+                      double** grly,
                       const double* ylmcoef);
 #endif


### PR DESCRIPTION
### What's changed?
- The original `grad_rl_sph_harm` function utilized `std::vector<std::vector>`, which led to poor data locality. Additionally, there were unnecessary resize operations within the function that added overhead. In this PR, I have replaced the 2D vector with `Array_Pool` and removed `resize` operations, thereby accelerating this function.