### PR TITLE
Fix the problematic logic in catch_properties.sh induced by #4472

### DIFF
--- a/tests/integrate/tools/catch_properties.sh
+++ b/tests/integrate/tools/catch_properties.sh
@@ -74,9 +74,14 @@ test -e $1 && rm $1
 #--------------------------------------------
 # if NOT non-self-consistent calculations or linear response
 #--------------------------------------------
+is_lr=0
+if [ ! -z $esolver_type ] && ([ $esolver_type == "lr" ] || [ $esolver_type == "ks-lr" ]); then
+	is_lr=1
+fi
+
 if [ $calculation != "nscf" ] && [ $calculation != "get_wf" ]\
 && [ $calculation != "get_pchg" ] && [ $calculation != "get_S" ]\
-&& [ $esolver_type != "ks-lr" ] && [ $esolver_type != "lr" ]; then
+&& [ $is_lr == 0 ]; then
 	#etot=`grep ETOT_ $running_path | awk '{print $2}'` 
 	etot=$(grep "ETOT_" "$running_path" | tail -1 | awk '{print $2}')
 	etotperatom=`awk 'BEGIN {x='$etot';y='$natom';printf "%.10f\n",x/y}'`
@@ -467,7 +472,7 @@ if ! test -z "$out_current" && [ $out_current ]; then
 	echo "CompareCurrent_pass $?" >>$1
 fi
 
-if ! test -z "$esolver_type" && ([ $esolver_type == "lr" ] || [ $esolver_type == "ks-lr" ]); then
+if [ $is_lr == 1 ]; then
 	lr_path=OUT.autotest/running_lr.log
 	lrns=$(get_input_key_value "lr_nstates" "INPUT")
 	lrns1=`echo "$lrns + 1" |bc`


### PR DESCRIPTION
Problem induced by #4472 :
```
[ RUN      ] 307_NO_GO_OXC
../tools/catch_properties.sh: 第 79 行： [: !=: 需要一元运算符
[----------] test for output XC matrix with gamma_only
[      OK  ]  CompareXC_pass
[      OK  ]  CompareOE_pass
[      OK  ]  pointgroupref
[      OK  ]  spacegroupref
[      OK  ]  nksibzref
[----------] Time elapsed: 2.288 seconds
```
fixed: 
```
[ RUN      ] 307_NO_GO_OXC
[----------] test for output XC matrix with gamma_only
[      OK  ]  etotref
[      OK  ]  etotperatomref
[      OK  ]  CompareXC_pass
[      OK  ]  CompareOE_pass
[      OK  ]  pointgroupref
[      OK  ]  spacegroupref
[      OK  ]  nksibzref
[----------] Time elapsed: 2.346 seconds
```