### PR TITLE
Fix: change C++14 codes to C++11

### DIFF
--- a/source/module_hamilt_lcao/module_gint/gint.h
+++ b/source/module_hamilt_lcao/module_gint/gint.h
@@ -22,7 +22,7 @@ class Gint {
 
     hamilt::HContainer<double>* get_hRGint() const { return hRGint; }
     std::vector<hamilt::HContainer<double>*> get_DMRGint() const { return DMRGint; }
-    const int get_ncxyz() const { return ncxyz; }
+    int get_ncxyz() const { return ncxyz; }
 
     // the unified interface to grid integration
     void cal_gint(Gint_inout* inout);

--- a/source/module_lr/utils/gint_move.hpp
+++ b/source/module_lr/utils/gint_move.hpp
@@ -10,10 +10,14 @@ template <typename T>
 using D2 = void(*) (T**, size_t);
 template <typename T>
 using D3 = void(*) (T***, size_t, size_t);
-template <typename T>
-D2<T> d2 = LR_Util::delete_p2<T>;
-template <typename T>
-D3<T> d3 = LR_Util::delete_p3<T>;
+// template <typename T>
+// D2<T> d2 = LR_Util::delete_p2<T>;
+// template <typename T>
+// D3<T> d3 = LR_Util::delete_p3<T>;
+// Change to C++ 11
+D2<double> d2 = LR_Util::delete_p2<double>;
+D3<double> d3 = LR_Util::delete_p3<double>;
+
 
 Gint& Gint::operator=(Gint&& rhs)
 {
@@ -33,10 +37,10 @@ Gint& Gint::operator=(Gint&& rhs)
     this->nplane = rhs.nplane;
     this->startz_current = rhs.startz_current;
 
-    if (this->pvpR_reduced != nullptr) d2<double>(this->pvpR_reduced, GlobalV::NSPIN);  //nspin*gridt.nnrg
-    if (this->pvdpRx_reduced != nullptr) d2<double>(this->pvdpRx_reduced, GlobalV::NSPIN);
-    if (this->pvdpRy_reduced != nullptr) d2<double>(this->pvdpRy_reduced, GlobalV::NSPIN);
-    if (this->pvdpRz_reduced != nullptr) d2<double>(this->pvdpRz_reduced, GlobalV::NSPIN);
+    if (this->pvpR_reduced != nullptr) d2(this->pvpR_reduced, GlobalV::NSPIN);  //nspin*gridt.nnrg
+    if (this->pvdpRx_reduced != nullptr) d2(this->pvdpRx_reduced, GlobalV::NSPIN);
+    if (this->pvdpRy_reduced != nullptr) d2(this->pvdpRy_reduced, GlobalV::NSPIN);
+    if (this->pvdpRz_reduced != nullptr) d2(this->pvdpRz_reduced, GlobalV::NSPIN);
     this->pvpR_alloc_flag = rhs.pvpR_alloc_flag;
     rhs.pvpR_alloc_flag = false;
     this->pvpR_reduced = rhs.pvpR_reduced;

--- a/source/module_lr/utils/gint_move.hpp
+++ b/source/module_lr/utils/gint_move.hpp
@@ -21,7 +21,8 @@ D3<double> d3 = LR_Util::delete_p3<double>;
 
 Gint& Gint::operator=(Gint&& rhs)
 {
-    if (this == &rhs)return *this;
+    if (this == &rhs) {return *this;
+}
 
     this->nbx = rhs.nbx;
     this->nby = rhs.nby;
@@ -37,10 +38,14 @@ Gint& Gint::operator=(Gint&& rhs)
     this->nplane = rhs.nplane;
     this->startz_current = rhs.startz_current;
 
-    if (this->pvpR_reduced != nullptr) d2(this->pvpR_reduced, GlobalV::NSPIN);  //nspin*gridt.nnrg
-    if (this->pvdpRx_reduced != nullptr) d2(this->pvdpRx_reduced, GlobalV::NSPIN);
-    if (this->pvdpRy_reduced != nullptr) d2(this->pvdpRy_reduced, GlobalV::NSPIN);
-    if (this->pvdpRz_reduced != nullptr) d2(this->pvdpRz_reduced, GlobalV::NSPIN);
+    if (this->pvpR_reduced != nullptr) { d2(this->pvpR_reduced, GlobalV::NSPIN);  //nspin*gridt.nnrg
+}
+    if (this->pvdpRx_reduced != nullptr) { d2(this->pvdpRx_reduced, GlobalV::NSPIN);
+}
+    if (this->pvdpRy_reduced != nullptr) { d2(this->pvdpRy_reduced, GlobalV::NSPIN);
+}
+    if (this->pvdpRz_reduced != nullptr) { d2(this->pvdpRz_reduced, GlobalV::NSPIN);
+}
     this->pvpR_alloc_flag = rhs.pvpR_alloc_flag;
     rhs.pvpR_alloc_flag = false;
     this->pvpR_reduced = rhs.pvpR_reduced;
@@ -69,7 +74,8 @@ Gint& Gint::operator=(Gint&& rhs)
 
 Gint_Gamma& Gint_Gamma::operator=(Gint_Gamma&& rhs)
 {
-    if (this == &rhs)return *this;
+    if (this == &rhs) {return *this;
+}
     Gint::operator=(std::move(rhs));
 
     // DM may not needed in beyond DFT ESolver
@@ -80,7 +86,8 @@ Gint_Gamma& Gint_Gamma::operator=(Gint_Gamma&& rhs)
 
 Gint_k& Gint_k::operator=(Gint_k&& rhs)
 {
-    if (this == &rhs)return *this;
+    if (this == &rhs) {return *this;
+}
     this->Gint::operator=(std::move(rhs));
     return *this;
 }

--- a/source/module_lr/utils/lr_util.cpp
+++ b/source/module_lr/utils/lr_util.cpp
@@ -5,7 +5,7 @@
 namespace LR_Util
 {
     /// =================PHYSICS====================
-    const int cal_nocc(int nelec) { return nelec / ModuleBase::DEGSPIN + nelec % static_cast<int>(ModuleBase::DEGSPIN); }
+    int cal_nocc(int nelec) { return nelec / ModuleBase::DEGSPIN + nelec % static_cast<int>(ModuleBase::DEGSPIN); }
 
     std::pair<ModuleBase::matrix, std::vector<std::pair<int, int>>>
         set_ix_map_diagonal(bool mode, int nocc, int nvirt)

--- a/source/module_lr/utils/lr_util.h
+++ b/source/module_lr/utils/lr_util.h
@@ -20,11 +20,11 @@ namespace LR_Util
     /// @tparam TCell 
     /// @param ucell 
     template <typename TCell>
-    const int cal_nelec(const TCell& ucell);
+    int cal_nelec(const TCell& ucell);
     
     /// @brief calculate the number of occupied orbitals
     /// @param nelec 
-    const int cal_nocc(int nelec);
+    int cal_nocc(int nelec);
     
     /// @brief  set the index map: ix to (ic, iv) and vice versa
     /// by diagonal traverse the c-v pairs

--- a/source/module_lr/utils/lr_util.hpp
+++ b/source/module_lr/utils/lr_util.hpp
@@ -10,7 +10,7 @@ namespace LR_Util
     /// =================PHYSICS====================
 
     template <typename TCell>
-    const int cal_nelec(const TCell& ucell) {
+    int cal_nelec(const TCell& ucell) {
         int nelec = 0;
         for (int it = 0; it < ucell.ntype; ++it)
             nelec += ucell.atoms[it].ncpp.zv * ucell.atoms[it].na;

--- a/source/module_lr/utils/lr_util.hpp
+++ b/source/module_lr/utils/lr_util.hpp
@@ -12,8 +12,9 @@ namespace LR_Util
     template <typename TCell>
     int cal_nelec(const TCell& ucell) {
         int nelec = 0;
-        for (int it = 0; it < ucell.ntype; ++it)
+        for (int it = 0; it < ucell.ntype; ++it) {
             nelec += ucell.atoms[it].ncpp.zv * ucell.atoms[it].na;
+}
         return nelec;
     }
 
@@ -62,7 +63,8 @@ namespace LR_Util
         {
             for (size_t i = 0; i < size; ++i)
             {
-                if (p2[i] != nullptr) delete[] p2[i];
+                if (p2[i] != nullptr) { delete[] p2[i];
+}
             }
             delete[] p2;
         }
@@ -97,26 +99,30 @@ namespace LR_Util
     template <typename T>
     void matsym(const T* in, const int n, T* out)
     {
-        for (int i = 0; i < n; ++i)
+        for (int i = 0; i < n; ++i) {
             out[i * n + i] = 0.5 * in[i * n + i] + 0.5 * get_conj(in[i * n + i]);
-        for (int i = 0;i < n;++i)
+}
+        for (int i = 0;i < n;++i) {
             for (int j = i + 1;j < n;++j)
             {
                 out[i * n + j] = 0.5 * (in[i * n + j] + get_conj(in[j * n + i]));
                 out[j * n + i] = get_conj(out[i * n + j]);
             }
+}
     }
     template <typename T>
     void matsym(T* inout, const int n)
     {
-        for (int i = 0; i < n; ++i)
+        for (int i = 0; i < n; ++i) {
             inout[i * n + i] = 0.5 * (inout[i * n + i] + get_conj(inout[i * n + i]));
-        for (int i = 0;i < n;++i)
+}
+        for (int i = 0;i < n;++i) {
             for (int j = i + 1;j < n;++j)
             {
                 inout[i * n + j] = 0.5 * (inout[i * n + j] + get_conj(inout[j * n + i]));
                 inout[j * n + i] = get_conj(inout[i * n + j]);
             }
+}
     }
 
     /// psi(nk=1, nbands=nb, nk * nbasis) -> psi(nb, nk, nbasis) without memory copy
@@ -159,14 +165,18 @@ namespace LR_Util
             };
 
         // zeros
-        for (int i = 0;i < global_nrow * global_ncol;++i) fullmat[i] = 0.0;
+        for (int i = 0;i < global_nrow * global_ncol;++i) { fullmat[i] = 0.0;
+}
         //copy
-        for (int i = 0;i < pv.get_row_size();++i)
-            for (int j = 0;j < pv.get_col_size();++j)
-                if (col_first)
+        for (int i = 0;i < pv.get_row_size();++i) {
+            for (int j = 0;j < pv.get_col_size();++j) {
+                if (col_first) {
                     fullmat[pv.local2global_row(i) * global_ncol + pv.local2global_col(j)] = submat[i * pv.get_col_size() + j];
-                else
+                } else {
                     fullmat[pv.local2global_col(j) * global_nrow + pv.local2global_row(i)] = submat[j * pv.get_row_size() + i];
+}
+}
+}
 
         //reduce to root
         MPI_Allreduce(MPI_IN_PLACE, fullmat, global_nrow * global_ncol, get_mpi_datatype(), MPI_SUM, pv.comm());


### PR DESCRIPTION
1. Before Cmakelists.txt support C++14, we need to write C++11 codes.
2. Fix warning of meaningless const

### Linked Issue
Fix #4681 
