### PR TITLE
Fix the exx-md/relax bug induced by LM refactor

### DIFF
--- a/source/module_esolver/esolver_ks_lcao_elec.cpp
+++ b/source/module_esolver/esolver_ks_lcao_elec.cpp
@@ -284,12 +284,10 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(const int istep)
 #ifdef __EXX // set xc type before the first cal of xc in pelec->init_scf
     if (GlobalC::exx_info.info_ri.real_number)
     {
-        this->exd = std::make_shared<Exx_LRI_Interface<TK, double>>(exx_lri_double);
         this->exd->exx_beforescf(this->kv, *this->p_chgmix);
     }
     else
     {
-        this->exc = std::make_shared<Exx_LRI_Interface<TK, std::complex<double>>>(exx_lri_complex);
         this->exc->exx_beforescf(this->kv, *this->p_chgmix);
     }
 #endif // __EXX

--- a/source/module_ri/Exx_LRI_interface.hpp
+++ b/source/module_ri/Exx_LRI_interface.hpp
@@ -72,10 +72,10 @@ void Exx_LRI_Interface<T, Tdata>::exx_beforescf(const K_Vectors& kv, const Charg
                 this->mix_DMk_2D.set_mixing(nullptr);
 			} else {
 				this->mix_DMk_2D.set_mixing(chgmix.get_mixing());
-}
+            }
+            // for exx two_level scf
+            this->two_level_step = 0;
         }
-        // for exx two_level scf
-        this->two_level_step = 0;
 #endif // __MPI
 }
 


### PR DESCRIPTION
In #4679 I initialized `Exx_LRI_Interface exd/exc` after the construction of HamiltLCAO, which caused the bug because `OperatorEXX` picks a nullptr `two_level_step` that controls whether to add Hexx. 
(and due to the previous bug which have been fixed by #4678 , tests passed in #4679 )

 Now their initialization is put back to `before_all_runners`.

Fix #4687 