### PR TITLE
Bug: close symmetry if cell-relax

### DIFF
--- a/source/module_io/read_input_item_general.cpp
+++ b/source/module_io/read_input_item_general.cpp
@@ -311,6 +311,11 @@ void ReadInput::item_general()
             {
                 para.input.symmetry = "0";
             }
+            if (para.input.calculation == "cell-relax")
+            {
+                para.input.symmetry = "0"; // if cell-relax, symmetry will be closed
+                                           // until issue #4171 solved
+            }
             if (para.input.efield_flag)
             {
                 para.input.symmetry = "0";


### PR DESCRIPTION
Related with #4171, which indicate there is a unsolved bug for cell-relax calculations with `symmetry=1`.
Recently, we find some OpenLAM users try to perform cell-relax with `symmetry=1`, which is quite risky. 
So, I force set `symmetry=0` if `calculation=cell-relax` until #4171 solved.