### PR TITLE
Refactor david: complete removal of Psi and Hamilt datatypes

### DIFF
--- a/source/module_hsolver/diago_david.cpp
+++ b/source/module_hsolver/diago_david.cpp
@@ -60,7 +60,7 @@ int DiagoDavid<T, Device>::diag_mock(const HPsiFunc& hpsi_func,
                                      const int dim,
                                      const int nband,
                                      const int ldPsi,
-                                     psi::Psi<T, Device>& psi,
+                                     T *psi_in,//psi::Psi<T, Device>& psi,
                                      Real* eigenvalue_in,
                                      const Real david_diag_thr,
                                      const int david_maxiter)
@@ -90,7 +90,7 @@ int DiagoDavid<T, Device>::diag_mock(const HPsiFunc& hpsi_func,
 
     const int nbase_x = this->david_ndim * nband; // maximum dimension of the reduced basis set
 
-    T *psi_in = psi.get_pointer();
+    // T *psi_in = psi.get_pointer();
 
     // the lowest N eigenvalues
     base_device::memory::resize_memory_op<Real, base_device::DEVICE_CPU>()(
@@ -101,10 +101,13 @@ int DiagoDavid<T, Device>::diag_mock(const HPsiFunc& hpsi_func,
     psi::Psi<T, Device> basis(1,
                               nbase_x,
                               dim,
-                              &(psi.get_ngk(0))); // the reduced basis set
+                              nullptr);
+                              //&(psi.get_ngk(0))); // the reduced basis set
     // basis(dim, nbase_x), leading dimension = dim
     pbasis = basis.get_pointer();
     ModuleBase::Memory::record("DAV::basis", nbase_x * dim * sizeof(T));
+    resmem_complex_op()(this->ctx, pbasis, nbase_x * dim, "DAV::basis");
+    setmem_complex_op()(this->ctx, pbasis, 0, nbase_x * dim);
 
     //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
     // ModuleBase::ComplexMatrix hp(nbase_x, dim); // the product of H and psi in the reduced basis set
@@ -1079,7 +1082,7 @@ int DiagoDavid<T, Device>::diag(const HPsiFunc& hpsi_func,
                                 const int dim,
                                 const int nband,
                                 const int ldPsi,
-                                psi::Psi<T, Device>& psi,
+                                T *psi_in,//psi::Psi<T, Device>& psi,
                                 Real* eigenvalue_in,
                                 const Real david_diag_thr,
                                 const int david_maxiter,
@@ -1101,7 +1104,7 @@ int DiagoDavid<T, Device>::diag(const HPsiFunc& hpsi_func,
     int sum_dav_iter = 0;
     do
     {
-        sum_dav_iter += this->diag_mock(hpsi_func, spsi_func, dim, nband, ldPsi, psi, eigenvalue_in, david_diag_thr, david_maxiter);
+        sum_dav_iter += this->diag_mock(hpsi_func, spsi_func, dim, nband, ldPsi, psi_in, eigenvalue_in, david_diag_thr, david_maxiter);
         ++ntry;
     } while (!check_block_conv(ntry, this->notconv, ntry_max, notconv_max));
 

--- a/source/module_hsolver/diago_david.cpp
+++ b/source/module_hsolver/diago_david.cpp
@@ -98,14 +98,14 @@ int DiagoDavid<T, Device>::diag_mock(const HPsiFunc& hpsi_func,
     base_device::memory::set_memory_op<Real, base_device::DEVICE_CPU>()(
                         this->cpu_ctx, this->eigenvalue, 0, nbase_x);
 
-    psi::Psi<T, Device> basis(1,
-                              nbase_x,
-                              dim,
-                              nullptr);
+    // psi::Psi<T, Device> basis(1,
+    //                           nbase_x,
+    //                           dim,
+    //                           nullptr);
                               //&(psi.get_ngk(0))); // the reduced basis set
     // basis(dim, nbase_x), leading dimension = dim
-    pbasis = basis.get_pointer();
-    ModuleBase::Memory::record("DAV::basis", nbase_x * dim * sizeof(T));
+    // pbasis = basis.get_pointer();
+    // ModuleBase::Memory::record("DAV::basis", nbase_x * dim * sizeof(T));
     resmem_complex_op()(this->ctx, pbasis, nbase_x * dim, "DAV::basis");
     setmem_complex_op()(this->ctx, pbasis, 0, nbase_x * dim);
 
@@ -180,7 +180,7 @@ int DiagoDavid<T, Device>::diag_mock(const HPsiFunc& hpsi_func,
         this->SchmitOrth(dim,
                          nband,
                          m,
-                         basis,
+                        //  basis,
                          this->sphi,
                          &this->lagrange_matrix[m * nband],
                          pre_matrix_mm_m[m],
@@ -204,7 +204,7 @@ int DiagoDavid<T, Device>::diag_mock(const HPsiFunc& hpsi_func,
     // phm_in->ops->hPsi(dav_hpsi_in);
     hpsi_func(this->hphi, pbasis, nbase_x, dim, 0, nband - 1);
 
-    this->cal_elem(dim, nbase, nbase_x, this->notconv, basis, this->hphi, this->sphi, this->hcc, this->scc);
+    this->cal_elem(dim, nbase, nbase_x, this->notconv, /*basis,*/ this->hphi, this->sphi, this->hcc, this->scc);
 
     this->diag_zhegvx(nbase, nband, this->hcc, this->scc, nbase_x, this->eigenvalue, this->vcc);
 
@@ -226,14 +226,14 @@ int DiagoDavid<T, Device>::diag_mock(const HPsiFunc& hpsi_func,
                        nbase,
                        nbase_x,
                        this->notconv,
-                       basis,
+                    //    basis,
                        this->hphi,
                        this->sphi,
                        this->vcc,
                        unconv.data(),
                        this->eigenvalue);
 
-        this->cal_elem(dim, nbase, nbase_x, this->notconv, basis, this->hphi, this->sphi, this->hcc, this->scc);
+        this->cal_elem(dim, nbase, nbase_x, this->notconv, /*basis,*/ this->hphi, this->sphi, this->hcc, this->scc);
 
         this->diag_zhegvx(nbase, nband, this->hcc, this->scc, nbase_x, this->eigenvalue, this->vcc);
 
@@ -301,7 +301,7 @@ int DiagoDavid<T, Device>::diag_mock(const HPsiFunc& hpsi_func,
                               eigenvalue_in,
                               psi_in, //psi,
                               ldPsi,
-                              basis,
+                            //   basis,
                               this->hphi,
                               this->sphi,
                               this->hcc,
@@ -326,7 +326,7 @@ void DiagoDavid<T, Device>::cal_grad(const HPsiFunc& hpsi_func, // hamilt::Hamil
                                         const int& nbase, // current dimension of the reduced basis
                                         const int nbase_x, // maximum dimension of the reduced basis set
                                         const int& notconv,
-                                        psi::Psi<T, Device>& basis,
+                                        // psi::Psi<T, Device>& basis,
                                         T* hphi,
                                         T* sphi,
                                         const T* vcc,
@@ -528,7 +528,7 @@ void DiagoDavid<T, Device>::cal_grad(const HPsiFunc& hpsi_func, // hamilt::Hamil
         this->SchmitOrth(dim,
                          nbase + notconv,
                          nbase + m,
-                         basis,
+                        //  basis,
                          sphi,
                          &lagrange[m * (nbase + notconv)],
                          pre_matrix_mm_m[m],
@@ -565,7 +565,7 @@ void DiagoDavid<T, Device>::cal_elem(const int& dim,
                                           int& nbase, // current dimension of the reduced basis
                                           const int nbase_x, // maximum dimension of the reduced basis set
                                           const int& notconv, // number of newly added basis vectors
-                                          const psi::Psi<T, Device>& basis,
+                                        //   const psi::Psi<T, Device>& basis,
                                           const T* hphi,
                                           const T* sphi,
                                           T* hcc,
@@ -723,7 +723,7 @@ void DiagoDavid<T, Device>::refresh(const int& dim,
                                          const Real* eigenvalue_in,
                                          const T *psi_in, // const psi::Psi<T, Device>& psi,
                                          const int ldPsi,
-                                         psi::Psi<T, Device>& basis,
+                                        //  psi::Psi<T, Device>& basis,
                                          T* hp,
                                          T* sp,
                                          T* hc,
@@ -864,7 +864,7 @@ template <typename T, typename Device>
 void DiagoDavid<T, Device>::SchmitOrth(const int& dim,
                                             const int nband,
                                             const int m,
-                                            psi::Psi<T, Device>& basis,
+                                            // psi::Psi<T, Device>& basis,
                                             const T* sphi,
                                             T* lagrange_m,
                                             const int mm_size,

--- a/source/module_hsolver/diago_david.h
+++ b/source/module_hsolver/diago_david.h
@@ -34,7 +34,7 @@ class DiagoDavid : public DiagH<T, Device>
                       const int dim,              // Dimension of the input matrix psi to be diagonalized
                       const int nband,            // Number of required eigenpairs
                       const int ldPsi,            // Leading dimension of the psi input
-                      psi::Psi<T, Device>& psi,   // Reference to the wavefunction object for eigenvectors
+                      T *psi_in,//psi::Psi<T, Device>& psi,   // Reference to the wavefunction object for eigenvectors
                       Real* eigenvalue_in,        // Pointer to store the resulting eigenvalues
                       const Real david_diag_thr,  // Convergence threshold for the Davidson iteration
                       const int david_maxiter,    // Maximum allowed iterations for the Davidson method
@@ -82,6 +82,16 @@ class DiagoDavid : public DiagH<T, Device>
     Device* ctx = {};
     base_device::DEVICE_CPU* cpu_ctx = {};
     base_device::AbacusDevice_t device = {};
+
+    int diag_mock(const HPsiFunc& hpsi_func,
+                  const SPsiFunc& spsi_func,
+                  const int dim,
+                  const int nband,
+                  const int ldPsi,
+                  T *psi_in,//psi::Psi<T, Device>& psi,
+                  Real* eigenvalue_in,
+                  const Real david_diag_thr,
+                  const int david_maxiter);
 
     void cal_grad(const HPsiFunc& hpsi_func,
                   const SPsiFunc& spsi_func,
@@ -139,15 +149,7 @@ class DiagoDavid : public DiagH<T, Device>
                      Real* eigenvalue,
                      T* vcc);
 
-    int diag_mock(const HPsiFunc& hpsi_func,
-                  const SPsiFunc& spsi_func,
-                  const int dim,
-                  const int nband,
-                  const int ldPsi,
-                  psi::Psi<T, Device>& psi,
-                  Real* eigenvalue_in,
-                  const Real david_diag_thr,
-                  const int david_maxiter);
+    
 
     bool check_block_conv(const int &ntry, const int &notconv, const int &ntry_max, const int &notconv_max);
 

--- a/source/module_hsolver/diago_david.h
+++ b/source/module_hsolver/diago_david.h
@@ -56,25 +56,24 @@ class DiagoDavid : public DiagH<T, Device>
     /// number of unconverged eigenvalues
     int notconv = 0;
 
-    /// precondition for diag, diagonal approximation of
-    /// matrix A (i.e. Hamilt)
+    /// precondition for diag, diagonal approximation of matrix A(i.e. Hamilt)
     const Real* precondition = nullptr;
     Real* d_precondition = nullptr;
 
     /// eigenvalue results
     Real* eigenvalue = nullptr;
 
-    T *pbasis = nullptr; // basis set
+    T *pbasis = nullptr; /// pointer to basis set(dim, nbase_x), leading dimension = dim
 
-    T* hphi = nullptr; // the product of H and psi in the reduced basis set
+    T* hphi = nullptr; /// the product of H and psi in the reduced basis set
 
-    T* sphi = nullptr; // the Product of S and psi in the reduced basis set
+    T* sphi = nullptr; /// the Product of S and psi in the reduced basis set
 
-    T* hcc = nullptr; // Hamiltonian on the reduced basis
+    T* hcc = nullptr; /// Hamiltonian on the reduced basis
 
-    T* scc = nullptr; // Overlap on the reduced basis
+    T* scc = nullptr; /// Overlap on the reduced basis
 
-    T* vcc = nullptr; // Eigenvectors of hc
+    T* vcc = nullptr; /// Eigenvectors of hc
 
     T* lagrange_matrix = nullptr;
 
@@ -99,7 +98,6 @@ class DiagoDavid : public DiagH<T, Device>
                   const int& nbase,
                   const int nbase_x,
                   const int& notconv,
-                  // psi::Psi<T, Device>& basis,
                   T* hphi,
                   T* sphi,
                   const T* vcc,
@@ -110,7 +108,6 @@ class DiagoDavid : public DiagH<T, Device>
                   int& nbase,
                   const int nbase_x,
                   const int& notconv,
-                  // const psi::Psi<T, Device>& basis,
                   const T* hphi,
                   const T* sphi,
                   T* hcc,
@@ -123,7 +120,6 @@ class DiagoDavid : public DiagH<T, Device>
                  const Real* eigenvalue,
                  const T *psi_in,
                  const int ldPsi,
-                //  psi::Psi<T, Device>& basis,
                  T* hphi,
                  T* sphi,
                  T* hcc,
@@ -133,7 +129,6 @@ class DiagoDavid : public DiagH<T, Device>
     void SchmitOrth(const int& dim,
                     const int nband,
                     const int m,
-                    // psi::Psi<T, Device>& basis,
                     const T* sphi,
                     T* lagrange_m,
                     const int mm_size,

--- a/source/module_hsolver/diago_david.h
+++ b/source/module_hsolver/diago_david.h
@@ -34,7 +34,7 @@ class DiagoDavid : public DiagH<T, Device>
                       const int dim,              // Dimension of the input matrix psi to be diagonalized
                       const int nband,            // Number of required eigenpairs
                       const int ldPsi,            // Leading dimension of the psi input
-                      T *psi_in,//psi::Psi<T, Device>& psi,   // Reference to the wavefunction object for eigenvectors
+                      T *psi_in,                  // Pointer to eigenvectors
                       Real* eigenvalue_in,        // Pointer to store the resulting eigenvalues
                       const Real david_diag_thr,  // Convergence threshold for the Davidson iteration
                       const int david_maxiter,    // Maximum allowed iterations for the Davidson method
@@ -88,7 +88,7 @@ class DiagoDavid : public DiagH<T, Device>
                   const int dim,
                   const int nband,
                   const int ldPsi,
-                  T *psi_in,//psi::Psi<T, Device>& psi,
+                  T *psi_in,
                   Real* eigenvalue_in,
                   const Real david_diag_thr,
                   const int david_maxiter);
@@ -99,7 +99,7 @@ class DiagoDavid : public DiagH<T, Device>
                   const int& nbase,
                   const int nbase_x,
                   const int& notconv,
-                  psi::Psi<T, Device>& basis,
+                  // psi::Psi<T, Device>& basis,
                   T* hphi,
                   T* sphi,
                   const T* vcc,
@@ -110,7 +110,7 @@ class DiagoDavid : public DiagH<T, Device>
                   int& nbase,
                   const int nbase_x,
                   const int& notconv,
-                  const psi::Psi<T, Device>& basis,
+                  // const psi::Psi<T, Device>& basis,
                   const T* hphi,
                   const T* sphi,
                   T* hcc,
@@ -123,7 +123,7 @@ class DiagoDavid : public DiagH<T, Device>
                  const Real* eigenvalue,
                  const T *psi_in,
                  const int ldPsi,
-                 psi::Psi<T, Device>& basis,
+                //  psi::Psi<T, Device>& basis,
                  T* hphi,
                  T* sphi,
                  T* hcc,
@@ -133,7 +133,7 @@ class DiagoDavid : public DiagH<T, Device>
     void SchmitOrth(const int& dim,
                     const int nband,
                     const int m,
-                    psi::Psi<T, Device>& basis,
+                    // psi::Psi<T, Device>& basis,
                     const T* sphi,
                     T* lagrange_m,
                     const int mm_size,
@@ -148,8 +148,6 @@ class DiagoDavid : public DiagH<T, Device>
                      const int& nbase_x,
                      Real* eigenvalue,
                      T* vcc);
-
-    
 
     bool check_block_conv(const int &ntry, const int &notconv, const int &ntry_max, const int &notconv_max);
 

--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -571,7 +571,7 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm,
         DiagoDavid<T, Device> david(pre_condition.data(), GlobalV::PW_DIAG_NDIM, GlobalV::use_paw, comm_info);
         // do diag and add davidson iteration counts up to avg_iter
         DiagoIterAssist<T, Device>::avg_iter += static_cast<double>(
-            david.diag(hpsi_func, spsi_func, dim, nband, ldPsi, psi, eigenvalue, david_diag_thr, david_maxiter, ntry_max, notconv_max));
+            david.diag(hpsi_func, spsi_func, dim, nband, ldPsi, psi.get_pointer(), eigenvalue, david_diag_thr, david_maxiter, ntry_max, notconv_max));
     }
     return;
 }

--- a/source/module_hsolver/test/diago_david_float_test.cpp
+++ b/source/module_hsolver/test/diago_david_float_test.cpp
@@ -119,7 +119,7 @@ public:
 		auto spsi_func = [phm](const std::complex<float>* psi_in, std::complex<float>* spsi_out,const int nrow, const int npw,  const int nbands){
 			phm->sPsi(psi_in, spsi_out, nrow, npw, nbands);
 		};
-		dav.diag(hpsi_func,spsi_func, dim, nband, ldPsi, phi, en, eps, maxiter);
+		dav.diag(hpsi_func,spsi_func, dim, nband, ldPsi, phi.get_pointer(), en, eps, maxiter);
 
 #ifdef __MPI		
 		end = MPI_Wtime();

--- a/source/module_hsolver/test/diago_david_real_test.cpp
+++ b/source/module_hsolver/test/diago_david_real_test.cpp
@@ -118,7 +118,7 @@ public:
         auto spsi_func = [phm](const double* psi_in, double* spsi_out,const int nrow, const int npw,  const int nbands){
 			phm->sPsi(psi_in, spsi_out, nrow, npw, nbands);
 		};
-        dav.diag(hpsi_func,spsi_func, dim, nband, ldPsi, phi, en, eps, maxiter);
+        dav.diag(hpsi_func,spsi_func, dim, nband, ldPsi, phi.get_pointer(), en, eps, maxiter);
 
 #ifdef __MPI		
         end = MPI_Wtime();

--- a/source/module_hsolver/test/diago_david_test.cpp
+++ b/source/module_hsolver/test/diago_david_test.cpp
@@ -121,7 +121,7 @@ public:
 		auto spsi_func = [phm](const std::complex<double>* psi_in, std::complex<double>* spsi_out,const int nrow, const int npw,  const int nbands){
 			phm->sPsi(psi_in, spsi_out, nrow, npw, nbands);
 		};
-		dav.diag(hpsi_func,spsi_func, dim, nband, ldPsi, phi, en, eps, maxiter);
+		dav.diag(hpsi_func,spsi_func, dim, nband, ldPsi, phi.get_pointer(), en, eps, maxiter);
 
 #ifdef __MPI		
 		end = MPI_Wtime();

--- a/source/module_hsolver/test/hsolver_pw_sup.h
+++ b/source/module_hsolver/test/hsolver_pw_sup.h
@@ -166,22 +166,23 @@ int DiagoDavid<T, Device>::diag(const std::function<void(T*, T*, const int, cons
                                 const int dim,
                                 const int nband,
                                 const int ldPsi,
-                                psi::Psi<T, Device>& psi,
+                                T *psi_in,
                                 Real* eigenvalue_in,
                                 const Real david_diag_thr,
                                 const int david_maxiter,
                                 const int ntry_max,
                                 const int notconv_max) {
+    // do nothing, we dont need it
     // do something
-    for (int ib = 0; ib < psi.get_nbands(); ib++) {
-        eigenvalue_in[ib] = 0.0;
-        for (int ig = 0; ig < psi.get_nbasis(); ig++) {
-            psi(ib, ig) += T(1.0, 0.0);
-            eigenvalue_in[ib] += psi(ib, ig).real();
-        }
-        eigenvalue_in[ib] /= psi.get_nbasis();
-    }
-    DiagoIterAssist<T, Device>::avg_iter += 1.0;
+    // for (int ib = 0; ib < psi.get_nbands(); ib++) {
+    //     eigenvalue_in[ib] = 0.0;
+    //     for (int ig = 0; ig < psi.get_nbasis(); ig++) {
+    //         psi(ib, ig) += T(1.0, 0.0);
+    //         eigenvalue_in[ib] += psi(ib, ig).real();
+    //     }
+    //     eigenvalue_in[ib] /= psi.get_nbasis();
+    // }
+    // DiagoIterAssist<T, Device>::avg_iter += 1.0;
     return 1;
 }
 template class DiagoDavid<std::complex<float>, base_device::DEVICE_CPU>;

--- a/source/module_lr/hsolver_lrtd.cpp
+++ b/source/module_lr/hsolver_lrtd.cpp
@@ -88,7 +88,7 @@ namespace LR
                 const int& nband = psi_k1_dav.get_nbands();
                 hsolver::DiagoDavid<T, Device> david(precondition.data(), GlobalV::PW_DIAG_NDIM, GlobalV::use_paw, comm_info);
                 hsolver::DiagoIterAssist<T, Device>::avg_iter += static_cast<double>(david.diag(hpsi_func, spsi_func,
-                    dim, nband, dim, psi_k1_dav, eigenvalue.data(), this->diag_ethr, david_maxiter, ntry_max, 0/*notconv_max*/));
+                    dim, nband, dim, psi_k1_dav.get_pointer(), eigenvalue.data(), this->diag_ethr, david_maxiter, ntry_max, 0/*notconv_max*/));
             }
             else if (this->method == "dav_subspace") //need refactor
             {


### PR DESCRIPTION
### Linked Issue
#4404

### What's changed?
- `Psi` datatype parameter of `DiagoDavid::diag` is replaced with `T *` pointer.
- Remove intermediate variable `psi::Psi basis` in `DiagoDavid`.
- `hsolver_lrtd.cpp` is modified accordingly.
- Corresponding tests are modified to fit new `diag` signature

### Docs
- Documents will be updated after interfaces are unified.
