### PR TITLE
Fix: memory leak of basis set in david

### DIFF
--- a/source/module_hsolver/diago_david.cpp
+++ b/source/module_hsolver/diago_david.cpp
@@ -38,6 +38,7 @@ DiagoDavid<T, Device>::DiagoDavid(const Real* precondition_in,
 template <typename T, typename Device>
 DiagoDavid<T, Device>::~DiagoDavid()
 {
+    delmem_complex_op()(this->ctx, this->pbasis);
     delmem_complex_op()(this->ctx, this->hphi);
     delmem_complex_op()(this->ctx, this->sphi);
     delmem_complex_op()(this->ctx, this->hcc);


### PR DESCRIPTION
### Linked Issue
Fix #4729

### What's changed?
- Fix memory leak of Davidson method after removal of `Psi` datatype in #4722.
- Add missing memory release code of basis set.
