### PR TITLE
Fix: eliminate compilaton error due to the `#define private public` macro in all unittests

### DIFF
--- a/source/module_base/global_file.cpp
+++ b/source/module_base/global_file.cpp
@@ -9,7 +9,7 @@
 #endif
 
 #include <unistd.h>
-
+#include <sstream>
 #include "global_function.h"
 #include "global_variable.h"
 #include "module_base/parallel_common.h"

--- a/source/module_base/global_file.h
+++ b/source/module_base/global_file.h
@@ -10,7 +10,6 @@
 #include <string>
 #include <fstream>
 #include <iostream>
-#include <sstream>
 #include <iomanip>
 
 //==========================================================

--- a/source/module_base/global_variable.h
+++ b/source/module_base/global_variable.h
@@ -8,7 +8,6 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <sstream>
 #include <string>
 #include <vector>
 

--- a/source/module_base/test/memory_test.cpp
+++ b/source/module_base/test/memory_test.cpp
@@ -27,6 +27,7 @@ namespace GlobalV
 
 #define private public
 #include "../memory.h"
+#undef private
 
 class MemoryTest : public testing::Test
 {

--- a/source/module_base/test/memory_test.cpp
+++ b/source/module_base/test/memory_test.cpp
@@ -152,4 +152,3 @@ TEST_F(MemoryTest, finish)
 	ofs.close();
 	EXPECT_FALSE(ModuleBase::Memory::init_flag);
 }
-#undef private

--- a/source/module_base/timer.h
+++ b/source/module_base/timer.h
@@ -6,7 +6,6 @@
 #include <iomanip>
 #include <iostream>
 #include <map>
-#include <sstream>
 #include <string>
 
 namespace ModuleBase

--- a/source/module_base/tool_check.cpp
+++ b/source/module_base/tool_check.cpp
@@ -1,5 +1,4 @@
 #include "tool_check.h"
-
 #include "tool_quit.h"
 
 namespace ModuleBase

--- a/source/module_base/tool_check.h
+++ b/source/module_base/tool_check.h
@@ -6,7 +6,6 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <sstream>
 #include <string>
 #include <valarray>
 #include <vector>

--- a/source/module_base/tool_quit.h
+++ b/source/module_base/tool_quit.h
@@ -6,7 +6,6 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <sstream>
 #include <string>
 #include <valarray>
 #include <vector>

--- a/source/module_base/tool_title.h
+++ b/source/module_base/tool_title.h
@@ -6,7 +6,6 @@
 #include <string>
 #include <fstream>
 #include <iostream>
-#include <sstream>
 #include <iomanip>
 #include <complex>
 #include <cassert>

--- a/source/module_basis/module_pw/test_serial/pw_basis_k_test.cpp
+++ b/source/module_basis/module_pw/test_serial/pw_basis_k_test.cpp
@@ -29,6 +29,8 @@
 #include "../pw_basis.h"
 #include "../fft.h"
 #undef private
+#undef protected
+
 class PWBasisKTEST: public testing::Test
 {
 public:
@@ -189,5 +191,4 @@ TEST_F(PWBasisKTEST, CollectLocalPW)
 	EXPECT_EQ(basis_k.npwk_max,2721);
 }
 
-#undef private
-#undef protected
+

--- a/source/module_basis/module_pw/test_serial/pw_basis_k_test.cpp
+++ b/source/module_basis/module_pw/test_serial/pw_basis_k_test.cpp
@@ -28,6 +28,7 @@
 #include "../pw_basis_k.h"
 #include "../pw_basis.h"
 #include "../fft.h"
+#undef private
 class PWBasisKTEST: public testing::Test
 {
 public:

--- a/source/module_basis/module_pw/test_serial/pw_basis_test.cpp
+++ b/source/module_basis/module_pw/test_serial/pw_basis_test.cpp
@@ -39,6 +39,7 @@
 #define private public
 #include "../pw_basis.h"
 #include "../fft.h"
+#undef private
 class PWBasisTEST: public testing::Test
 {
 public:

--- a/source/module_basis/module_pw/test_serial/pw_basis_test.cpp
+++ b/source/module_basis/module_pw/test_serial/pw_basis_test.cpp
@@ -40,6 +40,8 @@
 #include "../pw_basis.h"
 #include "../fft.h"
 #undef private
+#undef protected
+
 class PWBasisTEST: public testing::Test
 {
 public:
@@ -361,5 +363,3 @@ TEST_F(PWBasisTEST,CollectUniqgg)
 	pwb.collect_uniqgg();
 	EXPECT_EQ(pwb.ngg,78);
 }
-#undef private
-#undef protected

--- a/source/module_cell/module_neighbor/test/sltk_grid_test.cpp
+++ b/source/module_cell/module_neighbor/test/sltk_grid_test.cpp
@@ -4,7 +4,7 @@
 #define private public
 #include "../sltk_grid.h"
 #include "prepare_unitcell.h"
-
+#undef private
 #ifdef __LCAO
 InfoNonlocal::InfoNonlocal()
 {

--- a/source/module_cell/module_neighbor/test/sltk_grid_test.cpp
+++ b/source/module_cell/module_neighbor/test/sltk_grid_test.cpp
@@ -174,5 +174,3 @@ TEST_F(SltkGridTest, InitNoExpand)
     ofs.close();
 }
 */
-
-#undef private

--- a/source/module_cell/module_paw/paw_element.cpp
+++ b/source/module_cell/module_paw/paw_element.cpp
@@ -1,6 +1,7 @@
 #include "paw_element.h"
 #include "module_base/tool_title.h"
 #include "module_base/tool_quit.h"
+#include <sstream>
 
 void Paw_Element::init_paw_element(const double ecutwfc_in, const double cell_factor_in)
 {

--- a/source/module_cell/module_paw/paw_element.cpp
+++ b/source/module_cell/module_paw/paw_element.cpp
@@ -173,7 +173,7 @@ std::string Paw_Element::scan_file(std::ifstream &ifs, std::string pattern)
     }
 
     ModuleBase::WARNING_QUIT("Paw_Element::scan_file","pattern not found in xml file!");
-    return 0;    
+    return nullptr;    
 }
 
 double Paw_Element::extract_double(std::string line, std::string key)
@@ -213,7 +213,7 @@ std::string Paw_Element::extract_string(std::string line, std::string key)
         ModuleBase::WARNING_QUIT("Paw_Element::extract_double","key not found in line!");
     }
 
-    return 0;
+    return nullptr;
 }
 
 int Paw_Element::extract_int(std::string line, std::string key)

--- a/source/module_cell/module_paw/paw_element.h
+++ b/source/module_cell/module_paw/paw_element.h
@@ -9,7 +9,6 @@
 #include <vector>
 #include <string>
 #include <fstream>
-#include <sstream>
 #include <iostream>
 
 class Paw_Element

--- a/source/module_cell/test/atom_pseudo_test.cpp
+++ b/source/module_cell/test/atom_pseudo_test.cpp
@@ -25,7 +25,7 @@
 #include "module_cell/read_pp.h"
 #include "module_cell/pseudo.h"
 #include "module_cell/atom_pseudo.h"
-
+#undef private
 class AtomPseudoTest : public testing::Test
 {
 protected:

--- a/source/module_cell/test/atom_pseudo_test.cpp
+++ b/source/module_cell/test/atom_pseudo_test.cpp
@@ -99,4 +99,3 @@ int main(int argc, char **argv)
 	return result;
 }
 #endif
-#undef private

--- a/source/module_cell/test/atom_spec_test.cpp
+++ b/source/module_cell/test/atom_spec_test.cpp
@@ -218,4 +218,4 @@ int main(int argc, char **argv)
 	return result;
 }
 #endif
-#undef private
+

--- a/source/module_cell/test/atom_spec_test.cpp
+++ b/source/module_cell/test/atom_spec_test.cpp
@@ -30,7 +30,7 @@
 #include "module_cell/pseudo.h"
 #include "module_cell/atom_pseudo.h"
 #include "module_cell/atom_spec.h"
-
+#undef private
 class AtomSpecTest : public testing::Test
 {
 protected:

--- a/source/module_cell/test/klist_test.cpp
+++ b/source/module_cell/test/klist_test.cpp
@@ -19,7 +19,7 @@
 #include "module_hamilt_pw/hamilt_pwdft/VNL_in_pw.h"
 #include "module_hamilt_pw/hamilt_pwdft/parallel_grid.h"
 #include "module_io/berryphase.h"
-
+#undef private
 bool berryphase::berry_phase_flag = 0;
 
 pseudo::pseudo()

--- a/source/module_cell/test/klist_test.cpp
+++ b/source/module_cell/test/klist_test.cpp
@@ -20,7 +20,7 @@
 #include "module_hamilt_pw/hamilt_pwdft/parallel_grid.h"
 #include "module_io/berryphase.h"
 #undef private
-bool berryphase::berry_phase_flag = 0;
+bool berryphase::berry_phase_flag = false;
 
 pseudo::pseudo()
 {
@@ -296,7 +296,7 @@ TEST_F(KlistTest, MP)
 
 TEST_F(KlistTest, ReadKpointsGammaOnlyLocal)
 {
-    GlobalV::GAMMA_ONLY_LOCAL = 1;
+    GlobalV::GAMMA_ONLY_LOCAL = true;
     std::string kfile = "KPT_GO";
     kv->nspin = 1;
     kv->read_kpoints(kfile);
@@ -305,7 +305,7 @@ TEST_F(KlistTest, ReadKpointsGammaOnlyLocal)
     EXPECT_THAT(str, testing::HasSubstr("Gamma"));
     EXPECT_THAT(str, testing::HasSubstr("1 1 1 0 0 0"));
     ifs.close();
-    GlobalV::GAMMA_ONLY_LOCAL = 0; // this is important for the following tests because it is global
+    GlobalV::GAMMA_ONLY_LOCAL = false; // this is important for the following tests because it is global
 }
 
 TEST_F(KlistTest, ReadKpointsKspacing)
@@ -651,9 +651,9 @@ TEST_F(KlistTest, SetBothKvecFinalSCF)
     kv->kvec_c[0].y = 0.0;
     kv->kvec_c[0].z = 0.0;
     std::string skpt;
-    GlobalV::FINAL_SCF = 1;
-    kv->kd_done = 0;
-    kv->kc_done = 0;
+    GlobalV::FINAL_SCF = true;
+    kv->kd_done = false;
+    kv->kc_done = false;
     // case 1
     kv->k_nkstot = 0;
     kv->set_both_kvec(GlobalC::ucell.G, GlobalC::ucell.latvec, skpt);
@@ -691,14 +691,14 @@ TEST_F(KlistTest, SetBothKvec)
     kv->kvec_d[0].x = 0.0;
     kv->kvec_d[0].y = 0.0;
     kv->kvec_d[0].z = 0.0;
-    kv->kc_done = 0;
-    kv->kd_done = 1;
+    kv->kc_done = false;
+    kv->kd_done = true;
     std::string skpt;
-    GlobalV::FINAL_SCF = 0;
+    GlobalV::FINAL_SCF = false;
     kv->set_both_kvec(GlobalC::ucell.G, GlobalC::ucell.latvec, skpt);
     EXPECT_TRUE(kv->kc_done);
-    kv->kc_done = 1;
-    kv->kd_done = 0;
+    kv->kc_done = true;
+    kv->kd_done = false;
     kv->set_both_kvec(GlobalC::ucell.G, GlobalC::ucell.latvec, skpt);
     EXPECT_TRUE(kv->kd_done);
 }

--- a/source/module_cell/test/klist_test.cpp
+++ b/source/module_cell/test/klist_test.cpp
@@ -778,5 +778,3 @@ TEST_F(KlistTest, IbzKpointIsMP)
     ClearUcell();
     remove("tmp_klist_4");
 }
-
-#undef private

--- a/source/module_cell/test/klist_test_para.cpp
+++ b/source/module_cell/test/klist_test_para.cpp
@@ -19,7 +19,7 @@
 #include "module_hamilt_pw/hamilt_pwdft/VNL_in_pw.h"
 #include "module_hamilt_pw/hamilt_pwdft/parallel_grid.h"
 #include "module_io/berryphase.h"
-
+#undef private
 bool berryphase::berry_phase_flag = 0;
 
 pseudo::pseudo()

--- a/source/module_cell/test/klist_test_para.cpp
+++ b/source/module_cell/test/klist_test_para.cpp
@@ -20,7 +20,7 @@
 #include "module_hamilt_pw/hamilt_pwdft/parallel_grid.h"
 #include "module_io/berryphase.h"
 #undef private
-bool berryphase::berry_phase_flag = 0;
+bool berryphase::berry_phase_flag = false;
 
 pseudo::pseudo()
 {
@@ -213,8 +213,9 @@ TEST_F(KlistParaTest, Set)
     // construct cell and symmetry
     ModuleSymmetry::Symmetry symm;
     construct_ucell(stru_lib[0]);
-    if (GlobalV::MY_RANK == 0)
+    if (GlobalV::MY_RANK == 0) {
         GlobalV::ofs_running.open("tmp_klist_5");
+}
     symm.analy_sys(GlobalC::ucell.lat, GlobalC::ucell.st, GlobalC::ucell.atoms, GlobalV::ofs_running);
     // read KPT
     std::string k_file = "./support/KPT1";
@@ -242,14 +243,18 @@ TEST_F(KlistParaTest, Set)
     EXPECT_TRUE(kv->kd_done);
     if (GlobalV::NPROC == 4)
     {
-        if (GlobalV::MY_RANK == 0)
+        if (GlobalV::MY_RANK == 0) {
             EXPECT_EQ(kv->get_nks(), 18);
-        if (GlobalV::MY_RANK == 1)
+}
+        if (GlobalV::MY_RANK == 1) {
             EXPECT_EQ(kv->get_nks(), 18);
-        if (GlobalV::MY_RANK == 2)
+}
+        if (GlobalV::MY_RANK == 2) {
             EXPECT_EQ(kv->get_nks(), 17);
-        if (GlobalV::MY_RANK == 3)
+}
+        if (GlobalV::MY_RANK == 3) {
             EXPECT_EQ(kv->get_nks(), 17);
+}
     }
     ClearUcell();
     if (GlobalV::MY_RANK == 0)
@@ -265,8 +270,9 @@ TEST_F(KlistParaTest, SetAfterVC)
     // construct cell and symmetry
     ModuleSymmetry::Symmetry symm;
     construct_ucell(stru_lib[0]);
-    if (GlobalV::MY_RANK == 0)
+    if (GlobalV::MY_RANK == 0) {
         GlobalV::ofs_running.open("tmp_klist_6");
+}
     symm.analy_sys(GlobalC::ucell.lat, GlobalC::ucell.st, GlobalC::ucell.atoms, GlobalV::ofs_running);
     // read KPT
     std::string k_file = "./support/KPT1";
@@ -294,17 +300,21 @@ TEST_F(KlistParaTest, SetAfterVC)
     EXPECT_TRUE(kv->kd_done);
     if (GlobalV::NPROC == 4)
     {
-        if (GlobalV::MY_RANK == 0)
+        if (GlobalV::MY_RANK == 0) {
             EXPECT_EQ(kv->get_nks(), 35);
-        if (GlobalV::MY_RANK == 1)
+}
+        if (GlobalV::MY_RANK == 1) {
             EXPECT_EQ(kv->get_nks(), 35);
-        if (GlobalV::MY_RANK == 2)
+}
+        if (GlobalV::MY_RANK == 2) {
             EXPECT_EQ(kv->get_nks(), 35);
-        if (GlobalV::MY_RANK == 3)
+}
+        if (GlobalV::MY_RANK == 3) {
             EXPECT_EQ(kv->get_nks(), 35);
+}
     }
     // call set_after_vc here
-    kv->kc_done = 0;
+    kv->kc_done = false;
     kv->set_after_vc(kv->nspin, GlobalC::ucell.G, GlobalC::ucell.latvec);
     EXPECT_TRUE(kv->kc_done);
     EXPECT_TRUE(kv->kd_done);

--- a/source/module_cell/test/klist_test_para.cpp
+++ b/source/module_cell/test/klist_test_para.cpp
@@ -331,4 +331,3 @@ int main(int argc, char** argv)
     return result;
 }
 #endif
-#undef private

--- a/source/module_cell/test/pseudo_nc_test.cpp
+++ b/source/module_cell/test/pseudo_nc_test.cpp
@@ -23,7 +23,7 @@
 #define private public
 #include "module_cell/read_pp.h"
 #include "module_cell/atom_pseudo.h"
-
+#undef private
 class NCPPTest : public testing::Test
 {
 protected:

--- a/source/module_cell/test/pseudo_nc_test.cpp
+++ b/source/module_cell/test/pseudo_nc_test.cpp
@@ -126,4 +126,3 @@ TEST_F(NCPPTest, PrintNC)
 	ifs.close();
 	remove("./tmp_log");
 }
-#undef private

--- a/source/module_cell/test/read_pp_test.cpp
+++ b/source/module_cell/test/read_pp_test.cpp
@@ -807,4 +807,3 @@ TEST_F(ReadPPTest, AverageLSPINORB1)
 	EXPECT_EQ(upf->nbeta,6);
 	EXPECT_TRUE(upf->has_so); // has soc info
 }
-#undef private

--- a/source/module_cell/test/read_pp_test.cpp
+++ b/source/module_cell/test/read_pp_test.cpp
@@ -62,7 +62,7 @@
 #define private public
 #include "module_cell/read_pp.h"
 #include "module_cell/atom_pseudo.h"
-
+#undef private
 class ReadPPTest : public testing::Test
 {
 protected:

--- a/source/module_elecstate/module_dm/test/test_dm_R_init.cpp
+++ b/source/module_elecstate/module_dm/test/test_dm_R_init.cpp
@@ -6,7 +6,7 @@
 #include "module_elecstate/module_dm/density_matrix.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
 #include "module_cell/klist.h"
-
+#undef private
 K_Vectors::K_Vectors()
 {
 }

--- a/source/module_elecstate/test/charge_extra_test.cpp
+++ b/source/module_elecstate/test/charge_extra_test.cpp
@@ -6,6 +6,7 @@
 #include "module_elecstate/module_charge/charge_extra.h"
 #include "prepare_unitcell.h"
 #undef private
+#undef protected
 // mock functions for UnitCell
 #ifdef __LCAO
 InfoNonlocal::InfoNonlocal()

--- a/source/module_elecstate/test/charge_extra_test.cpp
+++ b/source/module_elecstate/test/charge_extra_test.cpp
@@ -5,7 +5,7 @@
 #define protected public
 #include "module_elecstate/module_charge/charge_extra.h"
 #include "prepare_unitcell.h"
-
+#undef private
 // mock functions for UnitCell
 #ifdef __LCAO
 InfoNonlocal::InfoNonlocal()

--- a/source/module_elecstate/test/charge_mixing_test.cpp
+++ b/source/module_elecstate/test/charge_mixing_test.cpp
@@ -1018,5 +1018,3 @@ TEST_F(ChargeMixingTest, MixDivCombTest)
     EXPECT_EQ(datas2, nullptr);
     EXPECT_EQ(datahf2, nullptr);
 }
-
-#undef private

--- a/source/module_elecstate/test/charge_mixing_test.cpp
+++ b/source/module_elecstate/test/charge_mixing_test.cpp
@@ -5,6 +5,7 @@
 #include "../module_charge/charge_mixing.h"
 #include "module_basis/module_pw/pw_basis.h"
 #include "module_hamilt_general/module_xc/xc_functional.h"
+#undef private
 #include <omp.h>
 
 int FUNC_TYPE = 1;

--- a/source/module_elecstate/test/charge_test.cpp
+++ b/source/module_elecstate/test/charge_test.cpp
@@ -6,7 +6,9 @@
 #include "module_cell/unitcell.h"
 #include "module_elecstate/module_charge/charge.h"
 #include "prepare_unitcell.h"
+#undef protected
 #undef private
+
 // mock functions for UnitCell
 #ifdef __LCAO
 InfoNonlocal::InfoNonlocal()
@@ -219,5 +221,3 @@ TEST_F(ChargeTest, InitFinalScf)
     EXPECT_TRUE(charge->allocate_rho_final_scf);
 }
 
-#undef protected
-#undef private

--- a/source/module_elecstate/test/charge_test.cpp
+++ b/source/module_elecstate/test/charge_test.cpp
@@ -6,7 +6,7 @@
 #include "module_cell/unitcell.h"
 #include "module_elecstate/module_charge/charge.h"
 #include "prepare_unitcell.h"
-
+#undef private
 // mock functions for UnitCell
 #ifdef __LCAO
 InfoNonlocal::InfoNonlocal()

--- a/source/module_elecstate/test/elecstate_base_test.cpp
+++ b/source/module_elecstate/test/elecstate_base_test.cpp
@@ -6,6 +6,7 @@
 #define protected public
 #include "module_elecstate/elecstate.h"
 #include "module_elecstate/occupy.h"
+#undef protected
 #undef private
 
 // Mock functions for testing elecstate.cpp
@@ -700,7 +701,3 @@ TEST_F(ElecStateTest, CalculateWeightsGWeightsTwoFermi)
     delete klist;
     Occupy::use_gaussian_broadening = false;
 }
-
-
-#undef protected
-#undef private

--- a/source/module_elecstate/test/elecstate_base_test.cpp
+++ b/source/module_elecstate/test/elecstate_base_test.cpp
@@ -6,7 +6,7 @@
 #define protected public
 #include "module_elecstate/elecstate.h"
 #include "module_elecstate/occupy.h"
-
+#undef private
 
 // Mock functions for testing elecstate.cpp
 namespace elecstate

--- a/source/module_elecstate/test/elecstate_magnetism_test.cpp
+++ b/source/module_elecstate/test/elecstate_magnetism_test.cpp
@@ -20,7 +20,7 @@
 
 #define private public
 #include "module_elecstate/magnetism.h"
-
+#undef private
 Charge::Charge()
 {
 }

--- a/source/module_elecstate/test/elecstate_magnetism_test.cpp
+++ b/source/module_elecstate/test/elecstate_magnetism_test.cpp
@@ -153,5 +153,3 @@ int main(int argc, char **argv)
     return result;
 }
 #endif
-
-#undef private

--- a/source/module_elecstate/test/elecstate_occupy_test.cpp
+++ b/source/module_elecstate/test/elecstate_occupy_test.cpp
@@ -15,7 +15,7 @@
  */
 #define private public
 #include "module_elecstate/occupy.h"
-
+#undef private
 class OccupyTest : public ::testing::Test
 {
 protected:

--- a/source/module_elecstate/test/elecstate_occupy_test.cpp
+++ b/source/module_elecstate/test/elecstate_occupy_test.cpp
@@ -296,5 +296,3 @@ TEST_F(OccupyTest, Gweights)
   EXPECT_NEAR(demet, 0.0, 1e-13);
   EXPECT_NEAR(wg(0, 0), 1.0, 1e-13);
 }
-
-#undef private

--- a/source/module_elecstate/test/potential_new_test.cpp
+++ b/source/module_elecstate/test/potential_new_test.cpp
@@ -4,6 +4,7 @@
 
 #define private public
 #include "module_elecstate/potentials/potential_new.h"
+#undef private
 // mock functions
 Structure_Factor::Structure_Factor()
 {

--- a/source/module_elecstate/test/potential_new_test.cpp
+++ b/source/module_elecstate/test/potential_new_test.cpp
@@ -643,5 +643,3 @@ TEST_F(PotentialNewTest, InterpolateVrsSingleGrids)
     }
 
 }
-
-#undef private

--- a/source/module_esolver/test/esolver_dp_test.cpp
+++ b/source/module_esolver/test/esolver_dp_test.cpp
@@ -1,9 +1,9 @@
 #include "for_test.h"
-#define private public
-#define protected public
 #include "../esolver_dp.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#define private public
+#define protected public
 /************************************************
  *  unit tests of class ESolver_DP
  ***********************************************/

--- a/source/module_esolver/test/esolver_dp_test.cpp
+++ b/source/module_esolver/test/esolver_dp_test.cpp
@@ -5,7 +5,7 @@
 #define private public
 #define protected public
 #include "../esolver_dp.h"
-
+#undef private
 /************************************************
  *  unit tests of class ESolver_DP
  ***********************************************/

--- a/source/module_esolver/test/esolver_dp_test.cpp
+++ b/source/module_esolver/test/esolver_dp_test.cpp
@@ -1,9 +1,11 @@
-#include "for_test.h"
-#include "../esolver_dp.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "for_test.h"
+
 #define private public
 #define protected public
+#include "../esolver_dp.h"
+
 /************************************************
  *  unit tests of class ESolver_DP
  ***********************************************/

--- a/source/module_hamilt_general/module_vdw/test/vdw_test.cpp
+++ b/source/module_hamilt_general/module_vdw/test/vdw_test.cpp
@@ -597,9 +597,6 @@ TEST_F(vdwd3abcTest, D3bjGetStress)
     EXPECT_NEAR(stress.e33, -3.4278442125590892e-05,1e-12);
 }
 
-#undef private
-
-
 int main(int argc, char **argv)
 {
     MPI_Init(&argc, &argv);

--- a/source/module_hamilt_general/module_vdw/test/vdw_test.cpp
+++ b/source/module_hamilt_general/module_vdw/test/vdw_test.cpp
@@ -12,7 +12,7 @@
 #include "module_hamilt_general/module_vdw/vdwd2.h"
 #include "module_hamilt_general/module_vdw/vdwd3.h"
 #include "module_hamilt_general/module_vdw/vdw.h"
-
+#undef private
 
 /************************************************
 *  unit test of class VDW and related functions

--- a/source/module_hamilt_pw/hamilt_pwdft/test/soc_test.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/test/soc_test.cpp
@@ -26,6 +26,7 @@ void EXPECT_COMPLEX_DOUBLE_EQ(const std::complex<double>& a,const std::complex<d
 
 #define private public
 #include "module_hamilt_pw/hamilt_pwdft/soc.h"
+#undef private
 class FcoefTest : public testing::Test
 {
 protected:

--- a/source/module_hamilt_pw/hamilt_pwdft/test/soc_test.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/test/soc_test.cpp
@@ -145,4 +145,3 @@ TEST_F(SocTest, SetFcoef)
                   soc.set_fcoef(0, 0, 0, 0, 0, 0, 0.5, 0.5, 0, 0, 0);
                   EXPECT_COMPLEX_DOUBLE_EQ(soc.fcoef(0, 0, 0, 0, 0), std::complex<double>(1.0, 0.0));
 }
-#undef private

--- a/source/module_hsolver/test/test_hsolver_pw.cpp
+++ b/source/module_hsolver/test/test_hsolver_pw.cpp
@@ -4,7 +4,6 @@
 
 #define private public
 #define protected public
-
 #include "module_hsolver/hsolver_pw.h"
 #include "module_hsolver/hsolver_lcaopw.h"
 #include "hsolver_supplementary_mock.h"
@@ -12,7 +11,7 @@
 #include "hsolver_supplementary_mock.h"
 #include "module_base/global_variable.h"
 #include "module_hsolver/hsolver_pw.h"
-
+#undef private
 /************************************************
  *  unit test of HSolverPW class
  ***********************************************/

--- a/source/module_hsolver/test/test_hsolver_pw.cpp
+++ b/source/module_hsolver/test/test_hsolver_pw.cpp
@@ -12,6 +12,7 @@
 #include "module_base/global_variable.h"
 #include "module_hsolver/hsolver_pw.h"
 #undef private
+#undef protected
 /************************************************
  *  unit test of HSolverPW class
  ***********************************************/

--- a/source/module_hsolver/test/test_hsolver_sdft.cpp
+++ b/source/module_hsolver/test/test_hsolver_sdft.cpp
@@ -10,6 +10,7 @@
 #include "module_hsolver/hsolver_pw_sdft.h"
 #include "module_base/global_variable.h"
 #undef private
+#undef protected
 
 //mock for module_sdft
 template<typename REAL>

--- a/source/module_hsolver/test/test_hsolver_sdft.cpp
+++ b/source/module_hsolver/test/test_hsolver_sdft.cpp
@@ -4,13 +4,12 @@
 
 #define private public
 #define protected public
-
 #include "module_hsolver/hsolver_pw.h"
 #include "hsolver_supplementary_mock.h"
 #include "hsolver_pw_sup.h"
 #include "module_hsolver/hsolver_pw_sdft.h"
-
 #include "module_base/global_variable.h"
+#undef private
 
 //mock for module_sdft
 template<typename REAL>

--- a/source/module_io/input.h
+++ b/source/module_io/input.h
@@ -2,7 +2,6 @@
 #define INPUT_H
 
 #include <fstream>
-#include <sstream>
 #include <string>
 #include <type_traits>
 #include <vector>

--- a/source/module_io/json_output/test/para_json_test.cpp
+++ b/source/module_io/json_output/test/para_json_test.cpp
@@ -8,7 +8,7 @@
 #include "module_parameter/parameter.h"
 #include "module_io/para_json.h"
 #include "version.h"
-
+#undef private
 /************************************************
  *  unit test of json output module
  ************************************************

--- a/source/module_io/read_input.cpp
+++ b/source/module_io/read_input.cpp
@@ -4,7 +4,7 @@
 #include <cstring>
 #include <fstream>
 #include <iostream>
-
+#include <sstream>
 #include "module_base/global_file.h"
 #include "module_base/global_function.h"
 #include "module_base/tool_quit.h"

--- a/source/module_io/read_input.h
+++ b/source/module_io/read_input.h
@@ -1,6 +1,6 @@
 #ifndef READ_INPUT_H
 #define READ_INPUT_H
-#include <sstream>
+
 #include <string>
 
 #include "input_item.h"

--- a/source/module_io/read_input_tool.h
+++ b/source/module_io/read_input_tool.h
@@ -1,8 +1,6 @@
-
-#include <sstream>
 #include <string>
 #include <vector>
-
+#include <stdexcept>
 #ifdef __MPI
 #include "module_base/parallel_common.h"
 #endif

--- a/source/module_io/test/bessel_basis_test.cpp
+++ b/source/module_io/test/bessel_basis_test.cpp
@@ -389,7 +389,7 @@ void output::printM3(std::ofstream &ofs, const std::string &description, const M
  *     - return (cubic spline) interpolated element value of Faln 4d-matrix
  */
 
-#define private public
+
 class TestBesselBasis : public ::testing::Test {
 protected:
     UnitCell ucell;

--- a/source/module_io/test/bessel_basis_test.cpp
+++ b/source/module_io/test/bessel_basis_test.cpp
@@ -558,4 +558,3 @@ TEST_F(TestBesselBasis, PolynomialInterpolationTest) {
     double d_yTested = besselBasis.Polynomial_Interpolation(0, 0, 0, d_Gnorm);
     EXPECT_NEAR(d_yExpected, d_yTested, 0.01);
 }
-#undef private

--- a/source/module_io/test/for_testing_input_conv.h
+++ b/source/module_io/test/for_testing_input_conv.h
@@ -393,7 +393,4 @@ double PEXSI_Solver::pexsi_elec_thr = 0.0;
 double PEXSI_Solver::pexsi_zero_thr = 0.0;
 } // namespace pexsi
 #endif
-
-#undef private
-
 #endif

--- a/source/module_io/test/for_testing_input_conv.h
+++ b/source/module_io/test/for_testing_input_conv.h
@@ -2,7 +2,6 @@
 #define INPUT_CONV_TEST_H
 
 #define private public
-
 #include "module_cell/module_symmetry/symmetry.h"
 #include "module_cell/unitcell.h"
 #include "module_elecstate/elecstate_lcao.h"
@@ -30,7 +29,7 @@
 #ifdef __PEXSI
 #include "module_hsolver/module_pexsi/pexsi_solver.h"
 #endif
-
+#undef private
 bool berryphase::berry_phase_flag = false;
 
 double module_tddft::Evolve_elec::td_force_dt;

--- a/source/module_io/test/print_info_test.cpp
+++ b/source/module_io/test/print_info_test.cpp
@@ -8,7 +8,7 @@
 #include "module_cell/klist.h"
 #include "module_cell/parallel_kpoints.h"
 #include "module_io/berryphase.h"
-
+#undef private
 #ifdef __LCAO
 InfoNonlocal::InfoNonlocal(){}
 InfoNonlocal::~InfoNonlocal(){}

--- a/source/module_io/test/print_info_test.cpp
+++ b/source/module_io/test/print_info_test.cpp
@@ -228,4 +228,3 @@ TEST_F(PrintInfoTest, PrintTime)
 	EXPECT_THAT(output,testing::HasSubstr("FINISH Time"));
 	EXPECT_THAT(output,testing::HasSubstr("TOTAL  Time"));
 }
-#undef private

--- a/source/module_io/test/print_info_test.cpp
+++ b/source/module_io/test/print_info_test.cpp
@@ -24,7 +24,7 @@ void LCAO_Orbitals::bcast_files(
 Magnetism::Magnetism(){}
 Magnetism::~Magnetism(){}
 
-bool berryphase::berry_phase_flag=0;
+bool berryphase::berry_phase_flag=false;
 
 namespace GlobalC
 {
@@ -219,8 +219,8 @@ TEST_F(PrintInfoTest, PrintScreen)
 
 TEST_F(PrintInfoTest, PrintTime)
 {
-	time_t time_start = std::time(NULL);
-	time_t time_finish = std::time(NULL);
+	time_t time_start = std::time(nullptr);
+	time_t time_finish = std::time(nullptr);
 	testing::internal::CaptureStdout();
 	EXPECT_NO_THROW(Print_Info::print_time(time_start,time_finish));
 	output = testing::internal::GetCapturedStdout();

--- a/source/module_io/test/winput_test.cpp
+++ b/source/module_io/test/winput_test.cpp
@@ -14,7 +14,7 @@
 
 #define private public
 #include "../winput.h"
-
+#undef private
 class WInputTest : public testing::Test
 {
 protected:

--- a/source/module_io/test_serial/read_input_item_test.cpp
+++ b/source/module_io/test_serial/read_input_item_test.cpp
@@ -18,6 +18,7 @@
 #define private public
 #include "module_io/input_item.h"
 #include "module_io/read_input.h"
+#undef private
 
 class InputTest : public testing::Test
 {

--- a/source/module_io/test_serial/read_input_tool_test.cpp
+++ b/source/module_io/test_serial/read_input_tool_test.cpp
@@ -1,7 +1,5 @@
 #include "../read_input_tool.h"
-
 #include <gtest/gtest.h>
-#include <stdexcept>
 
 // Test fixture for parse_expression tests
 class ReadInputTool : public ::testing::Test

--- a/source/module_md/test/fire_test.cpp
+++ b/source/module_md/test/fire_test.cpp
@@ -6,7 +6,7 @@
 #define private public
 #define protected public
 #include "module_md/fire.h"
-
+#undef private
 #define doublethreshold 1e-12
 
 /************************************************

--- a/source/module_md/test/fire_test.cpp
+++ b/source/module_md/test/fire_test.cpp
@@ -7,6 +7,7 @@
 #define protected public
 #include "module_md/fire.h"
 #undef private
+#undef protected
 #define doublethreshold 1e-12
 
 /************************************************

--- a/source/module_md/test/langevin_test.cpp
+++ b/source/module_md/test/langevin_test.cpp
@@ -6,7 +6,7 @@
 #define private public
 #define protected public
 #include "module_md/langevin.h"
-
+#undef private
 #define doublethreshold 1e-12
 
 /************************************************

--- a/source/module_md/test/langevin_test.cpp
+++ b/source/module_md/test/langevin_test.cpp
@@ -7,6 +7,7 @@
 #define protected public
 #include "module_md/langevin.h"
 #undef private
+#undef protected
 #define doublethreshold 1e-12
 
 /************************************************

--- a/source/module_md/test/lj_pot_test.cpp
+++ b/source/module_md/test/lj_pot_test.cpp
@@ -3,7 +3,7 @@
 #include "module_esolver/esolver_lj.h"
 #include "module_md/md_func.h"
 #include "setcell.h"
-
+#undef private
 #define doublethreshold 1e-12
 
 /************************************************

--- a/source/module_md/test/msst_test.cpp
+++ b/source/module_md/test/msst_test.cpp
@@ -7,7 +7,7 @@
 #define protected public
 #include "module_md/msst.h"
 #undef private
-
+#undef protected
 #define doublethreshold 1e-12
 
 /************************************************

--- a/source/module_md/test/msst_test.cpp
+++ b/source/module_md/test/msst_test.cpp
@@ -6,6 +6,7 @@
 #define private public
 #define protected public
 #include "module_md/msst.h"
+#undef private
 
 #define doublethreshold 1e-12
 

--- a/source/module_md/test/nhchain_test.cpp
+++ b/source/module_md/test/nhchain_test.cpp
@@ -7,7 +7,7 @@
 #define protected public
 #include "module_md/nhchain.h"
 #undef private
-
+#undef protected
 #define doublethreshold 1e-12
 /************************************************
  *  unit test of functions in nhchain.h

--- a/source/module_md/test/nhchain_test.cpp
+++ b/source/module_md/test/nhchain_test.cpp
@@ -6,6 +6,7 @@
 #define private public
 #define protected public
 #include "module_md/nhchain.h"
+#undef private
 
 #define doublethreshold 1e-12
 /************************************************

--- a/source/module_md/test/verlet_test.cpp
+++ b/source/module_md/test/verlet_test.cpp
@@ -7,7 +7,7 @@
 #define protected public
 #include "module_md/verlet.h"
 #undef private
-
+#undef protected
 #define doublethreshold 1e-12
 
 

--- a/source/module_md/test/verlet_test.cpp
+++ b/source/module_md/test/verlet_test.cpp
@@ -6,6 +6,7 @@
 #define private public
 #define protected public
 #include "module_md/verlet.h"
+#undef private
 
 #define doublethreshold 1e-12
 

--- a/source/module_relax/relax_old/test/bfgs_basic_test.cpp
+++ b/source/module_relax/relax_old/test/bfgs_basic_test.cpp
@@ -5,6 +5,7 @@
 #define protected public
 #include "module_relax/relax_old/bfgs_basic.h"
 #undef private
+#undef protected
 /************************************************
  *  unit tests of class BFGS_Basic
  ***********************************************/

--- a/source/module_relax/relax_old/test/bfgs_basic_test.cpp
+++ b/source/module_relax/relax_old/test/bfgs_basic_test.cpp
@@ -1,9 +1,10 @@
 #include "module_relax/relax_old/ions_move_basic.h"
-#define private public
-#define protected public
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#define private public
+#define protected public
 #include "module_relax/relax_old/bfgs_basic.h"
+#undef private
 /************************************************
  *  unit tests of class BFGS_Basic
  ***********************************************/

--- a/source/module_relax/relax_old/test/ions_move_bfgs_test.cpp
+++ b/source/module_relax/relax_old/test/ions_move_bfgs_test.cpp
@@ -6,6 +6,7 @@
 #include "module_relax/relax_old/ions_move_basic.h"
 #include "module_relax/relax_old/ions_move_bfgs.h"
 #undef private
+#undef protected
 /************************************************
  *  unit tests of class Ions_Move_BFGS
  ***********************************************/

--- a/source/module_relax/relax_old/test/ions_move_bfgs_test.cpp
+++ b/source/module_relax/relax_old/test/ions_move_bfgs_test.cpp
@@ -1,10 +1,11 @@
 #include "for_test.h"
-#define private public
-#define protected public
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#define private public
+#define protected public
 #include "module_relax/relax_old/ions_move_basic.h"
 #include "module_relax/relax_old/ions_move_bfgs.h"
+#undef private
 /************************************************
  *  unit tests of class Ions_Move_BFGS
  ***********************************************/

--- a/source/module_relax/relax_old/test/ions_move_cg_test.cpp
+++ b/source/module_relax/relax_old/test/ions_move_cg_test.cpp
@@ -1,8 +1,9 @@
 #include "for_test.h"
-#define private public
 #include "gtest/gtest.h"
+#define private public
 #include "module_relax/relax_old/ions_move_basic.h"
 #include "module_relax/relax_old/ions_move_cg.h"
+#undef private
 /************************************************
  *  unit tests of class Ions_Move_CG
  ***********************************************/

--- a/source/module_relax/relax_old/test/ions_move_methods_test.cpp
+++ b/source/module_relax/relax_old/test/ions_move_methods_test.cpp
@@ -1,8 +1,9 @@
 #include "for_test.h"
-#define private public
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#define private public
 #include "module_relax/relax_old/ions_move_methods.h"
+#undef private
 /************************************************
  *  unit tests of class Ions_Move_Methods
  ***********************************************/

--- a/source/module_relax/relax_old/test/ions_move_sd_test.cpp
+++ b/source/module_relax/relax_old/test/ions_move_sd_test.cpp
@@ -1,9 +1,10 @@
 #include "for_test.h"
-#define private public
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#define private public
 #include "module_relax/relax_old/ions_move_basic.h"
 #include "module_relax/relax_old/ions_move_sd.h"
+#undef private
 /************************************************
  *  unit tests of class Ions_Move_SD
  ***********************************************/

--- a/source/module_relax/relax_old/test/lattice_change_cg_test.cpp
+++ b/source/module_relax/relax_old/test/lattice_change_cg_test.cpp
@@ -1,8 +1,9 @@
 #include "for_test.h"
-#define private public
 #include "gtest/gtest.h"
+#define private public
 #include "module_relax/relax_old/lattice_change_basic.h"
 #include "module_relax/relax_old/lattice_change_cg.h"
+#undef private
 /************************************************
  *  unit tests of class Lattice_Change_CG
  ***********************************************/

--- a/tools/SIAB/SimulatedAnnealing/backup_old_version/1_Source/src_tools/mathzone.h
+++ b/tools/SIAB/SimulatedAnnealing/backup_old_version/1_Source/src_tools/mathzone.h
@@ -7,7 +7,6 @@
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <sstream>
 #include <iomanip>
 #include <cassert>
 

--- a/tools/SIAB/SimulatedAnnealing/backup_old_version/1_Source/src_tools/timer.h
+++ b/tools/SIAB/SimulatedAnnealing/backup_old_version/1_Source/src_tools/timer.h
@@ -8,7 +8,6 @@
 #include <ctime>
 #include <string>
 #include <fstream>
-#include <sstream>
 #include <iostream>
 #include <iomanip>
 using namespace std;

--- a/tools/SIAB/SimulatedAnnealing/source/src_tools/mathzone.h
+++ b/tools/SIAB/SimulatedAnnealing/source/src_tools/mathzone.h
@@ -7,7 +7,6 @@
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <sstream>
 #include <iomanip>
 #include <cassert>
 

--- a/tools/SIAB/SimulatedAnnealing/source/src_tools/timer.h
+++ b/tools/SIAB/SimulatedAnnealing/source/src_tools/timer.h
@@ -8,7 +8,6 @@
 #include <ctime>
 #include <string>
 #include <fstream>
-#include <sstream>
 #include <iostream>
 #include <iomanip>
 using namespace std;

--- a/tools/SIAB/SimulatedAnnealing/source/src_tools/timer.h
+++ b/tools/SIAB/SimulatedAnnealing/source/src_tools/timer.h
@@ -34,14 +34,14 @@ class timer
 //==========================================================
 	static void tick(const string &class_name_in,const string &name_in);
 
-	static void start(void);
-	static void finish(void);
+	static void start();
+	static void finish();
 
-	static void enable(void);
-	static void disable(void);
+	static void enable();
+	static void disable();
 
-	static void print_all(void);
-	static long double print_until_now(void);
+	static void print_all();
+	static long double print_until_now();
 	static double print(const string &name_in);
 
 	private:
@@ -71,7 +71,7 @@ class timer
 // MEMBER FUNCTIONS :
 // NAME : cpu_time(calculate time)
 //==========================================================
-	static double cpu_time(void);
+	static double cpu_time();
 	static bool delete_flag;
 
 };


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?
- [x] Have you added adequate unit tests and/or case tests for your pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [x] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #4673

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- enclose the `#define private public` and `#define protected public` with `#undef private` and `#undef protected`.
- eliminate the impact of `#define private public` on gtest and gmock
- remove unnecessary inclusion of header `<sstream>` which is known to cause compilation crash with `#define private public`-like macro

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
