### PR TITLE
Fix incomplete atom map due to the subtle symmetry_prec

### DIFF
--- a/source/module_cell/module_symmetry/symmetry.cpp
+++ b/source/module_cell/module_symmetry/symmetry.cpp
@@ -1798,7 +1798,8 @@ void Symmetry::set_atom_map(const Atom* atoms)
 
 inline bool check_full_atom_map(const std::vector<std::vector<int>>& m)
 {
-    if (m.empty()) return false;
+    if (m.empty()) { return false;
+}
     for (const auto& v1 : m) { for (const auto& v2 : v1) { if (v2 == -1) { return false; } } }
     return true;
 }

--- a/source/module_cell/module_symmetry/symmetry.cpp
+++ b/source/module_cell/module_symmetry/symmetry.cpp
@@ -1787,13 +1787,53 @@ void Symmetry::set_atom_map(const Atom* atoms)
                     if (equal(diff1, 0.0) && equal(diff2, 0.0) && equal(diff3, 0.0))
                     {
                         this->isym_rotiat_[k][ia] = ja;
-
                         break;
                     }
                 }
             }
         }
     }
+    this->reset_atom_map(atoms);
+}
+
+inline bool check_full_atom_map(const std::vector<std::vector<int>>& m)
+{
+    if (m.empty()) return false;
+    for (const auto& v1 : m) { for (const auto& v2 : v1) { if (v2 == -1) { return false; } } }
+    return true;
+}
+
+void Symmetry::reset_atom_map(const Atom* atoms)
+{
+    const double eps_start = this->epsilon;
+    while (!check_full_atom_map(this->isym_rotiat_) && this->epsilon < 100 * eps_start)
+    {
+        this->epsilon *= 2;
+        this->isym_rotiat_.clear();
+        this->set_atom_map(atoms);
+
+        std::cout << "try eps=" << this->epsilon << std::endl;
+        std::cout << check_full_atom_map(this->isym_rotiat_) << std::endl;
+    }
+    if (this->epsilon > 100 * eps_start)
+    {
+        ModuleBase::WARNING("Symmetry::reset_atom_map", "Cannot find all the equivalent atoms even at 100*symmetry_prec.");
+        if (ModuleSymmetry::Symmetry::symm_autoclose)
+        {
+            ModuleBase::WARNING("K_Vectors::ibz_kpoint", "Automatically set symmetry to 0 and continue ...");
+            std::cout << "Automatically set symmetry to 0 and continue ..." << std::endl;
+            ModuleSymmetry::Symmetry::symm_flag = 0;
+        }
+        else {
+            ModuleBase::WARNING_QUIT("Symmetry::reset_atom_map",
+                "Possible solutions: \n \
+1. Refine the lattice parameters in STRU;\n \
+2. Use a different`symmetry_prec`.  \n \
+3. Close symemtry: set `symmetry` to 0 in INPUT. \n \
+4. Set `symmetry_autoclose` to 1 in INPUT to automatically close symmetry when this error occurs.");
+        }
+    }
+    this->epsilon = eps_start;  //recover symmetry_prec after a successful reset
 }
 
 /// @brief return a map that is inequivalent atom index to its symmetry multiplicity

--- a/source/module_cell/module_symmetry/symmetry.h
+++ b/source/module_cell/module_symmetry/symmetry.h
@@ -142,6 +142,8 @@ public:
 
     /// @brief  set atom map for each symmetry operation
     void set_atom_map(const Atom* atoms);
+    /// @brief deal with the rarely happen incomplete atom map due to a subtle symmetry_prec
+    void reset_atom_map(const Atom* atoms);
     /// @brief check if all the atoms are movable
     ///  delta_pos symmetrization in relax is only meaningful when all the atoms are movable in all the directions.
     bool is_all_movable(const Atom* atoms, const Statistics& st)const;


### PR DESCRIPTION
Fix #4739. The problem is that the incomplete atom map found by a subtle symmetry_prec leads to incomplete force symmetrization. My solution is to temporarily increase symmetry_prec when finding the map, and reset `symmetry_prec` to its original value if it succeeds or warning-quit if it fails.

Now the force of the provided case with symmetry_prec=1e-6 is:
```
------------------------------------------------------------------------------------------
 TOTAL-FORCE (eV/Angstrom)                                                                
------------------------------------------------------------------------------------------
                       Mo1         0.0000000000         0.0000000000         0.0000000000 
                       Mo2         0.0000000000         0.0000000000         0.0000000000 
                        S1         0.0000000000         0.0000000000         0.0541911857 
                        S2         0.0000000000         0.0000000000        -0.0541911857 
                        S3         0.0000000000         0.0000000000         0.0541911857 
                        S4         0.0000000000         0.0000000000        -0.0541911857 
------------------------------------------------------------------------------------------
```

The remaining difference from symmetry_prec=1e-5 is due to another 2 differences related to symmetry_prec: 
- which k-point of the equivalent k-points is selected as ibz-kpoint (different coordinate can make small difference)
- which grid of charge density is symmetrized