### PR TITLE
Style: add braces to avoid dangling else in module_io/restart.cpp

### DIFF
--- a/source/module_io/restart.cpp
+++ b/source/module_io/restart.cpp
@@ -23,15 +23,21 @@ void Restart::read_file1(const std::string &file_name, void*const ptr, const siz
 bool Restart::write_file2(const std::string& file_name, const void* const ptr, const size_t size, const bool error_quit) const
 {
 	const int file = open(file_name.c_str(), O_WRONLY|O_CREAT|O_TRUNC, S_IRUSR|S_IWUSR);
-    if (-1 == file)
-        if (error_quit)
+    if (-1 == file){
+        if (error_quit){
             throw std::runtime_error("can't open restart save file. \nerrno=" + ModuleBase::GlobalFunc::TO_STRING(errno) + ".\n" + ModuleBase::GlobalFunc::TO_STRING(__FILE__) + " line " + ModuleBase::GlobalFunc::TO_STRING(__LINE__));
-        else return false;
+        } else {
+            return false;
+        }
+    }
     auto error = write(file, ptr, size);
-    if (-1 == error)
-        if (error_quit)
+    if (-1 == error) {
+        if (error_quit) {
             throw std::runtime_error("can't write restart save file. \nerrno=" + ModuleBase::GlobalFunc::TO_STRING(errno) + ".\n" + ModuleBase::GlobalFunc::TO_STRING(__FILE__) + " line " + ModuleBase::GlobalFunc::TO_STRING(__LINE__));
-        else return false;
+        } else {
+            return false;
+        }
+    }
     close(file);
     return true;
 }
@@ -39,15 +45,21 @@ bool Restart::write_file2(const std::string& file_name, const void* const ptr, c
 bool Restart::read_file2(const std::string& file_name, void* const ptr, const size_t size, const bool error_quit) const
 {
 	const int file = open(file_name.c_str(), O_RDONLY);
-    if (-1 == file)
-        if (error_quit)
+    if (-1 == file) {
+        if (error_quit) {
             throw std::runtime_error("can't open restart load file. \nerrno=" + ModuleBase::GlobalFunc::TO_STRING(errno) + ".\n" + ModuleBase::GlobalFunc::TO_STRING(__FILE__) + " line " + ModuleBase::GlobalFunc::TO_STRING(__LINE__));
-        else return false;
+        } else {
+            return false;
+        }
+    }
     auto error = read(file, ptr, size);
-    if (-1 == error)
-        if (error_quit)
+    if (-1 == error) {
+        if (error_quit) {
             throw std::runtime_error("can't read restart load file. \nerrno=" + ModuleBase::GlobalFunc::TO_STRING(errno) + ".\n" + ModuleBase::GlobalFunc::TO_STRING(__FILE__) + " line " + ModuleBase::GlobalFunc::TO_STRING(__LINE__));
-        else return false;
+        } else {
+            return false;
+        }
+    }
     close(file);
     return true;
 }


### PR DESCRIPTION
### Linked Issue
Fix #4756

### What's changed?
- Add braces to avoid dangling else in module_io/restart.cpp and thus eliminate compile warnings.
