### PR TITLE
fix: avoid nan in the output of time percentage

### DIFF
--- a/source/module_base/timer.cpp
+++ b/source/module_base/timer.cpp
@@ -5,7 +5,7 @@
 //==========================================================
 #include "timer.h"
 
-#include <math.h>
+#include <cmath>
 
 #ifdef __MPI
 #include <mpi.h>
@@ -32,20 +32,21 @@ std::map<std::string,std::map<std::string,timer::Timer_One>> timer::timer_pool;
 void timer::finish(std::ofstream &ofs,const bool print_flag)
 {
 	timer::tick("","total");
-	if(print_flag)
+	if(print_flag) {
 		print_all( ofs );
+}
 }
 
 //----------------------------------------------------------
 //
 //----------------------------------------------------------
-void timer::start(void)
+void timer::start()
 {
 	// first init ,then we can use tick
 	timer::tick("","total");
 }
 
-double timer::cpu_time(void)
+double timer::cpu_time()
 {
 //----------------------------------------------------------
 // EXPLAIN : here static is important !!
@@ -72,8 +73,9 @@ void timer::tick(const std::string &class_name,const std::string &name)
 //----------------------------------------------------------
 // EXPLAIN : if timer is disabled , return
 //----------------------------------------------------------
-	if (disabled)
+	if (disabled) {
 		return;
+}
 
 #ifdef _OPENMP
 	if(!omp_get_thread_num())
@@ -130,7 +132,7 @@ void timer::tick(const std::string &class_name,const std::string &name)
 	} // end if(!omp_get_thread_num())
 }
 
-long double timer::print_until_now(void)
+long double timer::print_until_now()
 {
 	// stop the clock
 	timer::tick("","total");
@@ -146,12 +148,14 @@ void timer::write_to_json(std::string file_name)
 	// if mpi is not initialized, we do not run this function
 	int is_initialized = 0;
     MPI_Initialized(&is_initialized);
-	if (!is_initialized)
+	if (!is_initialized) {
 		return;	
+}
 	int my_rank = 0;
 	MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
-	if (my_rank != 0)
+	if (my_rank != 0) {
 		return;
+}
 #endif
 
     // check if a double is inf, if so, return "null", else return a string of the input double

--- a/source/module_base/timer.cpp
+++ b/source/module_base/timer.cpp
@@ -255,7 +255,6 @@ void timer::print_all(std::ofstream &ofs)
 	std::vector<int> calls;
 	std::vector<double> avgs;
 	std::vector<double> pers;
-	const double TIME_EPSILON = 1e-9;
 	for(auto &timer_pool_order_A : timer_pool_order)
 	{
 		const std::string &class_name = timer_pool_order_A.first.first;
@@ -269,7 +268,9 @@ void timer::print_all(std::ofstream &ofs)
 		times.push_back(timer_one.cpu_second);
 		calls.push_back(timer_one.calls);
 		avgs.push_back(timer_one.cpu_second/timer_one.calls);
-		if (timer_pool_order[0].second.cpu_second < TIME_EPSILON) {
+
+		// if the total time is too small, we do not calculate the percentage
+		if (timer_pool_order[0].second.cpu_second < 1e-9) {
     		pers.push_back(0);
 		} else {
     		pers.push_back(timer_one.cpu_second / timer_pool_order[0].second.cpu_second * 100);

--- a/source/module_base/timer.cpp
+++ b/source/module_base/timer.cpp
@@ -255,6 +255,7 @@ void timer::print_all(std::ofstream &ofs)
 	std::vector<int> calls;
 	std::vector<double> avgs;
 	std::vector<double> pers;
+	const double TIME_EPSILON = 1e-9;
 	for(auto &timer_pool_order_A : timer_pool_order)
 	{
 		const std::string &class_name = timer_pool_order_A.first.first;
@@ -268,7 +269,11 @@ void timer::print_all(std::ofstream &ofs)
 		times.push_back(timer_one.cpu_second);
 		calls.push_back(timer_one.calls);
 		avgs.push_back(timer_one.cpu_second/timer_one.calls);
-		pers.push_back(timer_one.cpu_second / timer_pool_order[0].second.cpu_second * 100);
+		if (timer_pool_order[0].second.cpu_second < TIME_EPSILON) {
+    		pers.push_back(0);
+		} else {
+    		pers.push_back(timer_one.cpu_second / timer_pool_order[0].second.cpu_second * 100);
+		}
 	}
 	assert(class_names.size() == names.size());
 	assert(class_names.size() == times.size());


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #4791 

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
