### PR TITLE
Fix: fix the bug induced by `pseudo_dir` and `orbital_dir` default value

### DIFF
--- a/source/module_parameter/input_parameter.h
+++ b/source/module_parameter/input_parameter.h
@@ -56,8 +56,8 @@ struct Input_para
     std::string stru_file = "STRU";     ///< file contains atomic positions --
                                         ///< xiaohui modify 2015-02-01
     std::string kpoint_file = "KPT";    ///< file contains k-points -- xiaohui modify 2015-02-01
-    std::string pseudo_dir = "./";      ///< directory of pseudopotential
-    std::string orbital_dir = "./";     ///< directory of orbital file
+    std::string pseudo_dir = "";      ///< directory of pseudopotential
+    std::string orbital_dir = "";     ///< directory of orbital file
     std::string read_file_dir = "auto"; ///< directory of files for reading
     bool restart_load = false;
     std::string wannier_card = "none";              ///< input card for wannier functions.


### PR DESCRIPTION
This change was introduced by #4706

Fix #4760 
Fix #4877 