### PR TITLE
Feature: enable SCF can converge if SCF reach a chosen energy threshold

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -87,6 +87,7 @@
     - [printe](#printe)
     - [scf\_nmax](#scf_nmax)
     - [scf\_thr](#scf_thr)
+    - [scf\_ene\_thr](#scf_ene_thr)
     - [scf\_thr\_type](#scf_thr_type)
     - [chg\_extrap](#chg_extrap)
     - [lspinorb](#lspinorb)
@@ -1171,8 +1172,15 @@ Note: In new angle mixing, you should set `mixing_beta_mag >> mixing_beta`. The 
 ### scf_thr
 
 - **Type**: Real
-- **Description**: It's the threshold for electronic iteration. It represents the charge density error between two sequential densities from electronic iterations. Usually for local orbitals, usually 1e-6 may be accurate enough.
+- **Description**: It's the density threshold for electronic iteration. It represents the charge density error between two sequential densities from electronic iterations. Usually for local orbitals, usually 1e-6 may be accurate enough.
 - **Default**: 1.0e-9 (plane-wave basis), or 1.0e-7 (localized atomic orbital basis).
+
+### scf_ene_thr
+
+- **Type**: Real
+- **Description**: It's the energy threshold for electronic iteration. It represents the total energy error between two sequential densities from electronic iterations.
+- **Default**: -1.0. If the user does not set this parameter, it will not take effect.
+- **Unit**: eV
 
 ### scf_thr_type
 

--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -42,6 +42,7 @@ ESolver_KS<T, Device>::ESolver_KS()
 
     // should not use GlobalV here, mohan 2024-05-12
     scf_thr = PARAM.inp.scf_thr;
+    scf_ene_thr = PARAM.inp.scf_ene_thr;
     drho = 0.0;
 
     // should not use GlobalV here, mohan 2024-05-12
@@ -560,6 +561,12 @@ void ESolver_KS<T, Device>::runner(const int istep, UnitCell& ucell)
             dkin = p_chgmix->get_dkin(pelec->charge, GlobalV::nelec);
         }
         this->print_iter(iter, drho, dkin, duration, diag_ethr);
+
+        // add a energy threshold for SCF convergence
+        if (this->conv_elec == 0) // only check when density is not converged
+        {
+            this->conv_elec = ( iter != 1 && std::abs(this->pelec->f_en.etot_delta * ModuleBase::Ry_to_eV) < this->scf_ene_thr );
+        }
 
         // 12) Json, need to be moved to somewhere else
 #ifdef __RAPIDJSON

--- a/source/module_esolver/esolver_ks.h
+++ b/source/module_esolver/esolver_ks.h
@@ -26,7 +26,9 @@ class ESolver_KS : public ESolver_FP
         //! Deconstructor
 		virtual ~ESolver_KS();
 
-		double scf_thr;   // scf threshold
+		double scf_thr;   // scf density threshold
+
+		double scf_ene_thr; // scf energy threshold
 
 		double drho;      // the difference between rho_in (before HSolver) and rho_out (After HSolver)
 

--- a/source/module_esolver/esolver_ks.h
+++ b/source/module_esolver/esolver_ks.h
@@ -11,7 +11,7 @@
 #include "module_psi/psi.h"
 
 #include <fstream>
-#include <string.h>
+#include <cstring>
 namespace ModuleESolver
 {
 

--- a/source/module_io/read_input_item_elec_stru.cpp
+++ b/source/module_io/read_input_item_elec_stru.cpp
@@ -522,6 +522,12 @@ void ReadInput::item_elec_stru()
         this->add_item(item);
     }
     {
+        Input_Item item("scf_ene_thr");
+        item.annotation = "total energy error threshold";
+        read_sync_double(input.scf_ene_thr);
+        this->add_item(item);
+    }
+    {
         Input_Item item("scf_thr_type");
         item.annotation = "type of the criterion of scf_thr, 1: reci drho for "
                           "pw, 2: real drho for lcao";

--- a/source/module_io/test/read_input_ptest.cpp
+++ b/source/module_io/test/read_input_ptest.cpp
@@ -162,6 +162,7 @@ TEST_F(InputParaTest, ParaRead)
     EXPECT_EQ(param.inp.test_force, 0);
     EXPECT_EQ(param.inp.test_stress, 0);
     EXPECT_NEAR(param.inp.scf_thr, 1.0e-8, 1.0e-15);
+    EXPECT_NEAR(param.inp.scf_ene_thr, -1.0, 1.0e-15);
     EXPECT_EQ(param.inp.scf_nmax, 50);
     EXPECT_EQ(param.inp.relax_nmax, 1);
     EXPECT_EQ(param.inp.out_stru, 0);

--- a/source/module_parameter/input_parameter.h
+++ b/source/module_parameter/input_parameter.h
@@ -112,6 +112,7 @@ struct Input_para
     bool gamma_only = false; ///< for plane wave.
     int scf_nmax = 100;      ///< number of max elec iter
     double scf_thr = -1.0;   ///< \sum |rhog_out - rhog_in |^2
+    double scf_ene_thr = -1.0; ///< energy threshold for scf convergence, in eV
     int scf_thr_type = -1;   ///< type of the criterion of scf_thr, 1: reci drho, 2: real drho
 
     bool lspinorb = false;   ///< consider the spin-orbit interaction


### PR DESCRIPTION
Fix #4896

### The list of changes
1. add an input parameter `scf_ene_thr` (in eV).
2. ABACUS can converge if total energy diff is smaller than input `scf_ene_thr`.
3. The current SCF will exit after converging to either energy or density. If `scf_ene_thr` is not set in the `INPUT`, the default value `-1.0` will ensure that this feature has no effect.