### PR TITLE
Fix the issue of mete-vlocal not being initialized.

### DIFF
--- a/source/module_hamilt_lcao/module_gint/gint_vl_cpu_interface.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_vl_cpu_interface.cpp
@@ -241,6 +241,15 @@ void Gint::gint_kernel_vlocal_meta(Gint_inout* inout) {
     const double dv = ucell.omega / this->ncxyz;
     const double delta_r = this->gridt->dr_uniform;
 
+    if (!GlobalV::GAMMA_ONLY_LOCAL) {
+        if (!pvpR_alloc_flag) {
+            ModuleBase::WARNING_QUIT("Gint_interface::cal_gint",
+                                     "pvpR has not been allocated yet!");
+        } else {
+            ModuleBase::GlobalFunc::ZEROS(this->pvpR_reduced[inout->ispin], nnrg);
+        }
+    }
+    
 #pragma omp parallel
 {
     // define HContainer here to reference.


### PR DESCRIPTION
### Reminder
In pvpr_reduced, the initialized variable should be used. The code was causing errors due to uninitialized variables, and it has been fixed.

### Linked Issue
Fix #4927 

The test results are as follows, The calculation results match the previous calculations.

```
> ` 
> Initial plane wave basis and FFT box
>  ---------------------------------------------------------
>  DONE(0.838252   SEC) : INIT PLANEWAVE
>  -------------------------------------------
>  SELF-CONSISTENT : 
>  -------------------------------------------
>  START CHARGE      : atomic
>  DONE(30.1407    SEC) : INIT SCF
>  * * * * * *
>  << Start SCF iteration.
>  ITER      TMAG       AMAG        ETOT/eV          EDIFF/eV         DRHO         DKIN     TIME/s
>  GE1      1.60e+02   1.68e+02  -2.63961105e+05   0.00000000e+00   6.8122e-02   2.3313e+00 173.07
> `
> 
```