### PR TITLE
Fix the issue of some `timer` instances not being closed, resulting in incorrect time statistics

### DIFF
--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_k.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_k.cpp
@@ -162,7 +162,7 @@ void Force_LCAO<std::complex<double>>::allocate(const Parallel_Orbitals& pv,
         }
     }
 
-    ModuleBase::timer::tick("Force_LCAO_k", "allocate_k");
+    ModuleBase::timer::tick("Force_LCAO", "allocate");
     return;
 }
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/fedm_k.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/fedm_k.cpp
@@ -89,8 +89,7 @@ void Force_LCAO<std::complex<double>>::cal_fedm(
     edm.init_DMR(*ra, &ucell);
     edm.cal_DMR();
     edm.sum_DMR_spin();
-    //
-    ModuleBase::timer::tick("Force_LCAO_k", "cal_edm_2d");
+
     //--------------------------------------------
     // summation \sum_{i,j} E(i,j)*dS(i,j)
     // BEGIN CALCULATION OF FORCE OF EACH ATOM


### PR DESCRIPTION
### What's changed?
- Close some `timer` instances.
