### PR TITLE
Fix: a possible bug when dir is auto

### DIFF
--- a/source/module_io/read_input_item_system.cpp
+++ b/source/module_io/read_input_item_system.cpp
@@ -605,58 +605,32 @@ void ReadInput::item_system()
         Input_Item item("pseudo_dir");
         item.annotation = "the directory containing pseudo files";
         item.read_value = [](const Input_Item& item, Parameter& para) {
-            para.input.pseudo_dir = strvalue;
-        };
-        item.reset_value = [](const Input_Item& item, Parameter& para) {
-            if(para.input.pseudo_dir == "auto")
+            if(item.get_size() == 0)
             {
                 para.input.pseudo_dir = "";
             }
             else
             {
-                para.input.pseudo_dir = to_dir(para.input.pseudo_dir);
+                para.input.pseudo_dir = to_dir(strvalue);
             }
         };
-        item.get_final_value = [](Input_Item& item, const Parameter& para) {
-            if (para.input.pseudo_dir == "")
-            {
-                item.final_value << "auto";
-            }
-            else
-            {
-                item.final_value << para.input.pseudo_dir;
-            }
-        };
-        add_string_bcast(input.pseudo_dir);
+        sync_string(input.pseudo_dir);
         this->add_item(item);
     }
     {
         Input_Item item("orbital_dir");
         item.annotation = "the directory containing orbital files";
         item.read_value = [](const Input_Item& item, Parameter& para) {
-            para.input.orbital_dir = strvalue;
-        };
-        item.reset_value = [](const Input_Item& item, Parameter& para) {
-            if(para.input.orbital_dir == "auto")
+            if(item.get_size() == 0)
             {
                 para.input.orbital_dir = "";
             }
             else
             {
-                para.input.orbital_dir = to_dir(para.input.orbital_dir);
+                para.input.orbital_dir = to_dir(strvalue);
             }
         };
-        item.get_final_value = [](Input_Item& item, const Parameter& para) {
-            if (para.input.orbital_dir == "")
-            {
-                item.final_value << "auto";
-            }
-            else
-            {
-                item.final_value << para.input.orbital_dir;
-            }
-        };
-        add_string_bcast(input.orbital_dir);
+        sync_string(input.orbital_dir);
         this->add_item(item);
     }
     {

--- a/source/module_parameter/input_parameter.h
+++ b/source/module_parameter/input_parameter.h
@@ -56,8 +56,8 @@ struct Input_para
     std::string stru_file = "STRU";     ///< file contains atomic positions --
                                         ///< xiaohui modify 2015-02-01
     std::string kpoint_file = "KPT";    ///< file contains k-points -- xiaohui modify 2015-02-01
-    std::string pseudo_dir = "auto";      ///< directory of pseudopotential
-    std::string orbital_dir = "auto";     ///< directory of orbital file
+    std::string pseudo_dir = "";      ///< directory of pseudopotential
+    std::string orbital_dir = "";     ///< directory of orbital file
     std::string read_file_dir = "auto"; ///< directory of files for reading
     bool restart_load = false;
     std::string wannier_card = "none";              ///< input card for wannier functions.


### PR DESCRIPTION
Fix a bug caused by PR #4881
In that PR, when dir is "auto", dir is set to "". However, it can not read files in "auto" directory.
In this PR, it is solved. Also issue https://github.com/deepmodeling/abacus-develop/issues/4760 and https://github.com/deepmodeling/abacus-develop/issues/4877 are also checked.