### PR TITLE
Fix: close mixing_gg0 after PBE-loop in no-separate-loop EXX process

### DIFF
--- a/source/module_elecstate/module_charge/charge_mixing.h
+++ b/source/module_elecstate/module_charge/charge_mixing.h
@@ -48,6 +48,7 @@ class Charge_Mixing
                     const double& mixing_angle_in,
                     const bool& mixing_dmr_in);
 
+    void close_kerker_gg0() { mixing_gg0 = 0.0; mixing_gg0_mag = 0.0; }
     /**
      * @brief initialize mixing, including constructing mixing and allocating memory for mixing data
      * @brief this function should be called at eachiterinit()

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -977,6 +977,10 @@ void ESolver_KS_LCAO<TK, TR>::iter_finish(int& iter)
 
     if (GlobalC::exx_info.info_global.cal_exx && this->conv_elec)
     {
+        // Kerker mixing does not work for the density matrix.
+        // In the separate loop case, it can still work in the subsequent inner loops where Hexx(DM) is fixed.
+        // In the non-separate loop case where Hexx(DM) is updated in every iteration of the 2nd loop, it should be closed.
+        if (!GlobalC::exx_info.info_global.separate_loop) { this->p_chgmix->close_kerker_gg0(); }
         if (GlobalC::exx_info.info_ri.real_number)
         {
             this->conv_elec = this->exd->exx_after_converge(


### PR DESCRIPTION
fix #5032