### PR TITLE
Refactor:Replace GlobalV::KSPACING with PARAM.inp.kspacing.

### DIFF
--- a/source/module_base/global_variable.cpp
+++ b/source/module_base/global_variable.cpp
@@ -21,7 +21,6 @@ namespace GlobalV
 int NBANDS = 0;
 int NLOCAL = 0;        // total number of local basis.
 
-double KSPACING[3] = {0.0, 0.0, 0.0};
 
 double PSEUDORCUT = 0;
 

--- a/source/module_base/global_variable.h
+++ b/source/module_base/global_variable.h
@@ -20,7 +20,6 @@ namespace GlobalV
 extern int NBANDS;
 extern int NLOCAL;        // 1.1 // mohan add 2009-05-29
 
-extern double KSPACING[3];
 
 extern double PSEUDORCUT;
 

--- a/source/module_cell/klist.cpp
+++ b/source/module_cell/klist.cpp
@@ -8,6 +8,7 @@
 #include "module_cell/module_symmetry/symmetry.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
 #include "module_io/berryphase.h"
+#include "module_parameter/parameter.h"
 #ifdef USE_PAW
 #include "module_cell/module_paw/paw_cell.h"
 #endif
@@ -214,9 +215,9 @@ bool K_Vectors::read_kpoints(const std::string& fn)
         ofs << "1 1 1 0 0 0" << std::endl;
         ofs.close();
     }
-    else if (GlobalV::KSPACING[0] > 0.0)
+    else if (PARAM.inp.kspacing[0] > 0.0)
     {
-        if (GlobalV::KSPACING[1] <= 0 || GlobalV::KSPACING[2] <= 0)
+        if (PARAM.inp.kspacing[1] <= 0 || PARAM.inp.kspacing[2] <= 0)
         {
             ModuleBase::WARNING_QUIT("K_Vectors", "kspacing should > 0");
         };
@@ -226,11 +227,11 @@ bool K_Vectors::read_kpoints(const std::string& fn)
         double b2 = sqrt(btmp.e21 * btmp.e21 + btmp.e22 * btmp.e22 + btmp.e23 * btmp.e23);
         double b3 = sqrt(btmp.e31 * btmp.e31 + btmp.e32 * btmp.e32 + btmp.e33 * btmp.e33);
         int nk1
-            = std::max(1, static_cast<int>(b1 * ModuleBase::TWO_PI / GlobalV::KSPACING[0] / GlobalC::ucell.lat0 + 1));
+            = std::max(1, static_cast<int>(b1 * ModuleBase::TWO_PI / PARAM.inp.kspacing[0] / GlobalC::ucell.lat0 + 1));
         int nk2
-            = std::max(1, static_cast<int>(b2 * ModuleBase::TWO_PI / GlobalV::KSPACING[1] / GlobalC::ucell.lat0 + 1));
+            = std::max(1, static_cast<int>(b2 * ModuleBase::TWO_PI / PARAM.inp.kspacing[1] / GlobalC::ucell.lat0 + 1));
         int nk3
-            = std::max(1, static_cast<int>(b3 * ModuleBase::TWO_PI / GlobalV::KSPACING[2] / GlobalC::ucell.lat0 + 1));
+            = std::max(1, static_cast<int>(b3 * ModuleBase::TWO_PI / PARAM.inp.kspacing[2] / GlobalC::ucell.lat0 + 1));
 
         GlobalV::ofs_warning << " Generate k-points file according to KSPACING: " << fn << std::endl;
         std::ofstream ofs(fn.c_str());

--- a/source/module_cell/test/CMakeLists.txt
+++ b/source/module_cell/test/CMakeLists.txt
@@ -60,13 +60,13 @@ AddTest(
 
 AddTest(
   TARGET cell_klist_test
-  LIBS ${math_libs} base device symmetry
+  LIBS ${math_libs} base device symmetry parameter
   SOURCES klist_test.cpp ../klist.cpp ../parallel_kpoints.cpp ../../module_io/output.cpp
 )
 
 AddTest(
   TARGET cell_klist_test_para1
-  LIBS ${math_libs} base device symmetry
+  LIBS ${math_libs} base device symmetry parameter
   SOURCES klist_test_para.cpp ../klist.cpp ../parallel_kpoints.cpp ../../module_io/output.cpp
 )
 

--- a/source/module_cell/test/klist_test.cpp
+++ b/source/module_cell/test/klist_test.cpp
@@ -1,12 +1,9 @@
-#include "module_base/mathzone.h"
-#include "module_base/parallel_global.h"
-#include "module_cell/parallel_kpoints.h"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <iostream>
 #include <streambuf>
 #define private public
+#include "module_parameter/parameter.h"
 #include "module_basis/module_ao/ORB_gaunt_table.h"
 #include "module_cell/atom_pseudo.h"
 #include "module_cell/atom_spec.h"
@@ -20,6 +17,9 @@
 #include "module_hamilt_pw/hamilt_pwdft/parallel_grid.h"
 #include "module_io/berryphase.h"
 #undef private
+#include "module_base/mathzone.h"
+#include "module_base/parallel_global.h"
+#include "module_cell/parallel_kpoints.h"
 bool berryphase::berry_phase_flag = false;
 
 pseudo::pseudo()
@@ -311,44 +311,44 @@ TEST_F(KlistTest, ReadKpointsGammaOnlyLocal)
 TEST_F(KlistTest, ReadKpointsKspacing)
 {
     kv->nspin = 1;
-    GlobalV::KSPACING[0] = 0.052918; // 0.52918/Bohr = 1/A
-    GlobalV::KSPACING[1] = 0.052918; // 0.52918/Bohr = 1/A
-    GlobalV::KSPACING[2] = 0.052918; // 0.52918/Bohr = 1/A
+    PARAM.input.kspacing[0] = 0.052918; // 0.52918/Bohr = 1/A
+    PARAM.input.kspacing[1] = 0.052918; // 0.52918/Bohr = 1/A
+    PARAM.input.kspacing[2] = 0.052918; // 0.52918/Bohr = 1/A
     std::string k_file = "./support/KPT3";
     kv->read_kpoints(k_file);
     EXPECT_EQ(kv->get_nkstot(), 343);
-    GlobalV::KSPACING[0] = 0.0;
-    GlobalV::KSPACING[1] = 0.0;
-    GlobalV::KSPACING[2] = 0.0;
+    PARAM.input.kspacing[0] = 0.0;
+    PARAM.input.kspacing[1] = 0.0;
+    PARAM.input.kspacing[2] = 0.0;
 }
 
 TEST_F(KlistTest, ReadKpointsKspacing3values)
 {
     kv->nspin = 1;
-    GlobalV::KSPACING[0] = 0.052918; // 0.52918/Bohr = 1/A
-    GlobalV::KSPACING[1] = 0.06;     // 0.52918/Bohr = 1/A
-    GlobalV::KSPACING[2] = 0.07;     // 0.52918/Bohr = 1/A
+    PARAM.input.kspacing[0] = 0.052918; // 0.52918/Bohr = 1/A
+    PARAM.input.kspacing[1] = 0.06;     // 0.52918/Bohr = 1/A
+    PARAM.input.kspacing[2] = 0.07;     // 0.52918/Bohr = 1/A
     std::string k_file = "./support/KPT3";
     kv->read_kpoints(k_file);
     EXPECT_EQ(kv->get_nkstot(), 210);
-    GlobalV::KSPACING[0] = 0.0;
-    GlobalV::KSPACING[1] = 0.0;
-    GlobalV::KSPACING[2] = 0.0;
+    PARAM.input.kspacing[0] = 0.0;
+    PARAM.input.kspacing[1] = 0.0;
+    PARAM.input.kspacing[2] = 0.0;
 }
 
 TEST_F(KlistTest, ReadKpointsInvalidKspacing3values)
 {
     kv->nspin = 1;
-    GlobalV::KSPACING[0] = 0.052918; // 0.52918/Bohr = 1/A
-    GlobalV::KSPACING[1] = 0;        // 0.52918/Bohr = 1/A
-    GlobalV::KSPACING[2] = 0.07;     // 0.52918/Bohr = 1/A
+    PARAM.input.kspacing[0] = 0.052918; // 0.52918/Bohr = 1/A
+    PARAM.input.kspacing[1] = 0;        // 0.52918/Bohr = 1/A
+    PARAM.input.kspacing[2] = 0.07;     // 0.52918/Bohr = 1/A
     std::string k_file = "./support/KPT3";
     testing::internal::CaptureStdout();
     EXPECT_EXIT(kv->read_kpoints(k_file), ::testing::ExitedWithCode(0), "");
     output = testing::internal::GetCapturedStdout();
-    GlobalV::KSPACING[0] = 0.0;
-    GlobalV::KSPACING[1] = 0.0;
-    GlobalV::KSPACING[2] = 0.0;
+    PARAM.input.kspacing[0] = 0.0;
+    PARAM.input.kspacing[1] = 0.0;
+    PARAM.input.kspacing[2] = 0.0;
 }
 
 TEST_F(KlistTest, ReadKpointsGamma)

--- a/source/module_io/input_conv.cpp
+++ b/source/module_io/input_conv.cpp
@@ -209,10 +209,7 @@ void Input_Conv::Convert()
         GlobalV::fixed_atoms = PARAM.inp.fixed_atoms;
     }
 
-    for (int i = 0; i < 3; i++)
-    {
-        GlobalV::KSPACING[i] = PARAM.inp.kspacing[i];
-    }
+
     GlobalV::NBANDS = PARAM.inp.nbands;
 
     GlobalV::device_flag = base_device::information::get_device_flag(PARAM.inp.device,

--- a/source/module_io/test/CMakeLists.txt
+++ b/source/module_io/test/CMakeLists.txt
@@ -48,7 +48,7 @@ AddTest(
 
 AddTest(
   TARGET io_write_istate_info_test
-  LIBS ${math_libs} base device symmetry
+  LIBS ${math_libs} base device symmetry parameter
   SOURCES write_istate_info_test.cpp ../write_istate_info.cpp ../output.cpp ../../module_cell/parallel_kpoints.cpp ../../module_cell/klist.cpp
 )
 


### PR DESCRIPTION
### Unit Tests and/or Case Tests for my changes
- Modify the unit test and the CMakeLists.txt for KSPACING.

### What's changed?
- :Replace GlobalV::KSPACING with PARAM.inp.kspacing in the cpp file
- Delete the parameter GlobalV::KSPACING in global_variable.h

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
