### PR TITLE
Feature: add rescaling parameter into dp

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -2658,15 +2658,24 @@ These variables are used to control molecular dynamics calculations. For more in
 - **Description**: The filename of DP potential files, see [md.md](../md.md#dpmd) in detail.
 - **Default**: graph.pb
 
+### dp_rescaling
+
+- **Type**: Real
+- **Availability**: [esolver_type](#esolver_type) = `dp`.
+- **Description**: Rescaling factor to use a temperature-dependent DP. Energy, stress and force calculated by DP will be multiplied by this factor.
+- **Default**: 1.0
+
 ### dp_fparam
 
 - **Type**: Real
+- **Availability**: [esolver_type](#esolver_type) = `dp`.
 - **Description**: The frame parameter for dp potential. The array size is dim_fparam, then all frames are assumed to be provided with the same fparam.
 - **Default**: {}
 
 ### dp_aparam
 
 - **Type**: Real
+- **Availability**: [esolver_type](#esolver_type) = `dp`.
 - **Description**: The atomic parameter for dp potential. The array size can be (1) natoms x dim_aparam, then all frames are assumed to be provided with the same aparam; (2) dim_aparam, then all frames and atoms are assumed to be provided with the same aparam.
 - **Default**: {}
 

--- a/source/module_esolver/esolver_dp.cpp
+++ b/source/module_esolver/esolver_dp.cpp
@@ -40,6 +40,7 @@ void ESolver_DP::before_all_runners(const Input_para& inp, UnitCell& ucell)
     atype.resize(ucell.nat);
     coord.resize(3 * ucell.nat);
 
+    rescaling = inp.mdp.dp_rescaling;
     fparam = inp.mdp.dp_fparam;
     aparam = inp.mdp.dp_aparam;
 
@@ -89,21 +90,25 @@ void ESolver_DP::runner(const int istep, UnitCell& ucell)
     GlobalV::ofs_running << " final etot is " << std::setprecision(11) << dp_potential * ModuleBase::Ry_to_eV << " eV"
                          << std::endl;
 
-    const double fact_f = ModuleBase::Ry_to_eV * ModuleBase::ANGSTROM_AU;
-    const double fact_v = ucell.omega * ModuleBase::Ry_to_eV;
+    // rescale the energy, force, and stress
+    const double fact_e = rescaling / ModuleBase::Ry_to_eV;
+    const double fact_f = rescaling / (ModuleBase::Ry_to_eV * ModuleBase::ANGSTROM_AU);
+    const double fact_v = rescaling / (ucell.omega * ModuleBase::Ry_to_eV);
+
+    dp_potential *= fact_e;
 
     for (int i = 0; i < ucell.nat; ++i)
     {
-        dp_force(i, 0) = f[3 * i] / fact_f;
-        dp_force(i, 1) = f[3 * i + 1] / fact_f;
-        dp_force(i, 2) = f[3 * i + 2] / fact_f;
+        dp_force(i, 0) = f[3 * i] * fact_f;
+        dp_force(i, 1) = f[3 * i + 1] * fact_f;
+        dp_force(i, 2) = f[3 * i + 2] * fact_f;
     }
 
     for (int i = 0; i < 3; ++i)
     {
         for (int j = 0; j < 3; ++j)
         {
-            dp_virial(i, j) = v[3 * i + j] / fact_v;
+            dp_virial(i, j) = v[3 * i + j] * fact_v;
         }
     }
 #else

--- a/source/module_esolver/esolver_dp.h
+++ b/source/module_esolver/esolver_dp.h
@@ -100,35 +100,24 @@ class ESolver_DP : public ESolver
 #endif
 
     /**
-     * @brief Variables for storing simulation data in ESolver_DP class
+     * Variables for storing simulation data in ESolver_DP class
      *
      * These variables are used in the ESolver_DP class to store simulation data such as atomic positions, types, and
      * the potential energy and forces.
      *
-     * @param dp_file the directory of DP model file
-     * @param cell the lattice vectors
-     * @param atype the atom type corresponding to DP model
-     * @param coord the atomic positions
-     * @param fparam The frame parameter for dp potential. The array can be of size:
-     *               dim_fparam. Then all frames are assumed to be provided with the same fparam.
-     * @param aparam The atomic parameterfor dp potential. The array can be of size:
-     *               natoms x dim_aparam. Then all frames are assumed to be provided with the same aparam.
-     *               dim_aparam. Then all frames and atoms are assumed to be provided with the same aparam.
-     * @param dp_potential the computed potential energy
-     * @param dp_force the computed atomic forces
-     * @param dp_virial the computed lattice virials
-     * @param ucell_ pointer to the unitcell information
      */
-    std::string dp_file;
-    std::vector<double> cell = {};
-    std::vector<int> atype = {};
-    std::vector<double> coord = {};
-    std::vector<double> fparam = {};
-    std::vector<double> aparam = {};
-    double dp_potential;
-    ModuleBase::matrix dp_force;
-    ModuleBase::matrix dp_virial;
-    UnitCell* ucell_;
+
+    std::string dp_file;             ///< directory of DP model file
+    std::vector<double> cell = {};   ///< lattice vectors
+    std::vector<int> atype = {};     ///< atom type corresponding to DP model
+    std::vector<double> coord = {};  ///< atomic positions
+    std::vector<double> fparam = {}; ///< frame parameter for dp potential: dim_fparam
+    std::vector<double> aparam = {}; ///< atomic parameter for dp potential: natoms x dim_aparam
+    double rescaling = 1.0;          ///< rescaling factor for DP model
+    double dp_potential = 0.0;       ///< computed potential energy
+    ModuleBase::matrix dp_force;     ///< computed atomic forces
+    ModuleBase::matrix dp_virial;    ///< computed lattice virials
+    UnitCell* ucell_;                ///< pointer to the unit cell object
 };
 
 } // namespace ModuleESolver

--- a/source/module_io/read_input_item_md.cpp
+++ b/source/module_io/read_input_item_md.cpp
@@ -218,6 +218,12 @@ void ReadInput::item_md()
         this->add_item(item);
     }
     {
+        Input_Item item("dp_rescaling");
+        item.annotation = "rescaling factor for dp potential";
+        read_sync_double(input.mdp.dp_rescaling);
+        this->add_item(item);
+    }
+    {
         Input_Item item("dp_fparam");
         item.annotation = "the frame parameter for dp potential";
         item.read_value = [](const Input_Item& item, Parameter& para) {

--- a/source/module_io/test/read_input_ptest.cpp
+++ b/source/module_io/test/read_input_ptest.cpp
@@ -393,6 +393,7 @@ TEST_F(InputParaTest, ParaRead)
     EXPECT_DOUBLE_EQ(param.inp.mdp.msst_vel, 0);
     EXPECT_DOUBLE_EQ(param.inp.mdp.msst_vis, 0);
     EXPECT_EQ(param.inp.mdp.pot_file, "graph.pb");
+    EXPECT_DOUBLE_EQ(param.inp.mdp.dp_rescaling, 1.0);
     EXPECT_EQ(param.inp.mdp.dp_fparam.size(), 2);
     EXPECT_EQ(param.inp.mdp.dp_aparam.size(), 2);
     EXPECT_DOUBLE_EQ(param.inp.mdp.dp_fparam[0], 1.0);

--- a/source/module_io/test/support/INPUT
+++ b/source/module_io/test/support/INPUT
@@ -195,6 +195,7 @@ lj_rcut                        8.5 #cutoff radius of LJ potential
 lj_epsilon                     0.01032 #the value of epsilon for LJ potential
 lj_sigma                       3.405 #the value of sigma for LJ potential
 pot_file                       graph.pb #the filename of potential files for CMD such as DP
+dp_rescaling                   1.0 #rescaling factor for dp potential
 dp_fparam                      1.0 1.1 #the frame parameter for dp potential
 dp_aparam                      1.0 1.2 #the atomic parameter for dp potential
 msst_direction                 2 #the direction of shock wave

--- a/source/module_parameter/md_parameter.h
+++ b/source/module_parameter/md_parameter.h
@@ -11,7 +11,7 @@
 struct MD_para
 {
     int md_nstep = 10;                 ///< md nstep
-    bool md_restart = false;               ///< 1: restart MD, 0: no restart MD
+    bool md_restart = false;           ///< 1: restart MD, 0: no restart MD
     std::string md_type = "nvt";       ///< fire, nve, nvt, npt, langevin, msst
     std::string md_thermostat = "nhc"; ///< specify the thermostat: nhc, anderson, berendsen,
                                        ///< rescaling, rescale_v
@@ -29,6 +29,7 @@ struct MD_para
     std::vector<double> lj_epsilon = {}; ///< the value of epsilon for LJ potential (eV)
     std::vector<double> lj_sigma = {};   ///< the value of sigma for LJ potential (\AA)
     std::string pot_file = "graph.pb";   ///< the filename of potential files for CMD such as DP
+    double dp_rescaling = 1.0;           ///< rescaling factor for DP model. Energy, force and stress will be multiplied by this factor.
     std::vector<double> dp_fparam
         = {}; ///< The frame parameter for dp potential. The array can be of size :
               ///< dim_fparam. Then all frames are assumed to be provided with the same fparam.


### PR DESCRIPTION
### Linked Issue
Now temperature-dependent DP can be done in ABACUS.
![image](https://github.com/user-attachments/assets/b2e58894-9dde-4495-a33d-3d60e43df3b5)

Step1:  prepare training data, all data should be divided by rescaling factor s(T)
Step2:  Training DP model, a fparam for temperature should be added into DP model.
Step3:  Use ABACUS to run MD. ABACUS should set "fparam" to temperature and set "dp_rescaling" to s(T). Energy, force and stress will be multiplied by s(T) 
INPUT example:
`calculation       md` 
`esolver_type       dp` 
`pot_file            ../../PP_ORB/Al-SCAN.pb`
`dp_faram         1` 
`dp_rescaling    2.0`
`md_type           1  #NVT`
`md_nstep          4000`
`md_dt             0.1 #fs`
`md_tfirst         11604.5  #K`