### PR TITLE
Refactor: remove GlobalC::ORB from module_io

### DIFF
--- a/source/module_esolver/dpks_cal_e_delta_band.cpp
+++ b/source/module_esolver/dpks_cal_e_delta_band.cpp
@@ -40,7 +40,7 @@ namespace ModuleESolver
     {
         GlobalC::ld.cal_projected_DM(dm,
             GlobalC::ucell,
-            GlobalC::ORB,
+            orb_,
             GlobalC::GridD);
     }
 
@@ -51,7 +51,7 @@ namespace ModuleESolver
     {
         GlobalC::ld.cal_projected_DM_k(dm,
             GlobalC::ucell,
-            GlobalC::ORB,
+            orb_,
             GlobalC::GridD);
     }
 
@@ -62,7 +62,7 @@ namespace ModuleESolver
     {
         GlobalC::ld.cal_projected_DM_k(dm,
             GlobalC::ucell,
-            GlobalC::ORB,
+            orb_,
             GlobalC::GridD);
     }
 #endif

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -63,7 +63,7 @@ namespace ModuleESolver
 //! mohan add 2024-05-11
 //------------------------------------------------------------------------------
 template <typename TK, typename TR>
-ESolver_KS_LCAO<TK, TR>::ESolver_KS_LCAO()
+ESolver_KS_LCAO<TK, TR>::ESolver_KS_LCAO(): orb_(GlobalC::ORB)
 {
     this->classname = "ESolver_KS_LCAO";
     this->basisname = "LCAO";
@@ -240,7 +240,7 @@ void ESolver_KS_LCAO<TK, TR>::before_all_runners(const Input_para& inp, UnitCell
         // load the DeePKS model from deep neural network
         GlobalC::ld.load_model(PARAM.inp.deepks_model);
         // read pdm from file for NSCF or SCF-restart, do it only once in whole calculation
-        GlobalC::ld.read_projected_DM((GlobalV::init_chg == "file"), GlobalV::deepks_equiv, *GlobalC::ORB.Alpha);
+        GlobalC::ld.read_projected_DM((GlobalV::init_chg == "file"), GlobalV::deepks_equiv, *orb_.Alpha);
     }
 #endif
 
@@ -1153,7 +1153,7 @@ void ESolver_KS_LCAO<TK, TR>::after_scf(const int istep)
                           this->pelec->ekb,
                           this->pelec->klist->kvec_d,
                           GlobalC::ucell,
-                          GlobalC::ORB,
+                          orb_,
                           GlobalC::GridD,
                           &(this->pv),
                           *(this->psi),

--- a/source/module_esolver/esolver_ks_lcao.h
+++ b/source/module_esolver/esolver_ks_lcao.h
@@ -78,6 +78,9 @@ class ESolver_KS_LCAO : public ESolver_KS<TK> {
 
     TwoCenterBundle two_center_bundle_;
 
+    // temporary introduced during removing GlobalC::ORB
+    LCAO_Orbitals& orb_;
+
     // Temporarily store the stress to unify the interface with PW,
     // because it's hard to seperate force and stress calculation in LCAO.
     // The copy costs memory and time !

--- a/source/module_esolver/lcao_before_scf.cpp
+++ b/source/module_esolver/lcao_before_scf.cpp
@@ -130,13 +130,13 @@ void ESolver_KS_LCAO<TK, TR>::beforesolver(const int istep)
         // build and save <psi(0)|alpha(R)> at beginning
         GlobalC::ld.build_psialpha(GlobalV::CAL_FORCE,
                                    GlobalC::ucell,
-                                   GlobalC::ORB,
+                                   orb_,
                                    GlobalC::GridD,
                                    *(two_center_bundle_.overlap_orb_alpha));
 
         if (PARAM.inp.deepks_out_unittest)
         {
-            GlobalC::ld.check_psialpha(GlobalV::CAL_FORCE, GlobalC::ucell, GlobalC::ORB, GlobalC::GridD);
+            GlobalC::ld.check_psialpha(GlobalV::CAL_FORCE, GlobalC::ucell, orb_, GlobalC::GridD);
         }
     }
 #endif

--- a/source/module_esolver/lcao_fun.cpp
+++ b/source/module_esolver/lcao_fun.cpp
@@ -61,6 +61,7 @@ ModuleIO::Output_Mat_Sparse<TK> ESolver_KS_LCAO<TK, TR>::create_Output_Mat_Spars
         this->pv,
         this->GK, // mohan add 2024-04-01
         two_center_bundle_,
+        orb_,
         GlobalC::GridD, // mohan add 2024-04-06
         this->kv,
         this->p_hamilt);

--- a/source/module_esolver/lcao_gets.cpp
+++ b/source/module_esolver/lcao_gets.cpp
@@ -46,7 +46,7 @@ void ESolver_KS_LCAO<std::complex<double>, double>::get_S(void)
     // (1) Find adjacent atoms for each atom.
     GlobalV::SEARCH_RADIUS = atom_arrange::set_sr_NL(GlobalV::ofs_running,
                                                      GlobalV::OUT_LEVEL,
-                                                     GlobalC::ORB.get_rcutmax_Phi(),
+                                                     orb_.get_rcutmax_Phi(),
                                                      GlobalC::ucell.infoNL.get_rcutmax_Beta(),
                                                      GlobalV::GAMMA_ONLY_LOCAL);
 
@@ -86,7 +86,7 @@ void ESolver_KS_LCAO<std::complex<double>, std::complex<double>>::get_S(void)
     // (1) Find adjacent atoms for each atom.
     GlobalV::SEARCH_RADIUS = atom_arrange::set_sr_NL(GlobalV::ofs_running,
                                                      GlobalV::OUT_LEVEL,
-                                                     GlobalC::ORB.get_rcutmax_Phi(),
+                                                     orb_.get_rcutmax_Phi(),
                                                      GlobalC::ucell.infoNL.get_rcutmax_Beta(),
                                                      GlobalV::GAMMA_ONLY_LOCAL);
 

--- a/source/module_esolver/lcao_nscf.cpp
+++ b/source/module_esolver/lcao_nscf.cpp
@@ -136,7 +136,8 @@ void ESolver_KS_LCAO<TK, TR>::nscf() {
                                        PARAM.inp.out_wannier_eig,
                                        PARAM.inp.out_wannier_wvfn_formatted,
                                        PARAM.inp.nnkpfile,
-                                       PARAM.inp.wannier_spin);
+                                       PARAM.inp.wannier_spin,
+                                       orb_);
 
             myWannier.calculate(this->pelec->ekb, this->kv, *(this->psi), &(this->pv));
         }
@@ -150,7 +151,8 @@ void ESolver_KS_LCAO<TK, TR>::nscf() {
         std::cout << FmtCore::format("\n * * * * * *\n << Start %s.\n", "Berry phase calculation");
         berryphase bp(&(this->pv));
         bp.lcao_init(this->kv,
-                     this->GridT); // additional step before calling
+                     this->GridT,
+                     orb_); // additional step before calling
                                    // macroscopic_polarization (why capitalize
                                    // the function name?)
         bp.Macroscopic_polarization(this->pw_wfc->npwk_max,

--- a/source/module_esolver/set_matrix_grid.cpp
+++ b/source/module_esolver/set_matrix_grid.cpp
@@ -29,7 +29,7 @@ void ESolver_KS_LCAO<TK, TR>::set_matrix_grid(Record_adj& ra)
     // (1) Find adjacent atoms for each atom.
     GlobalV::SEARCH_RADIUS = atom_arrange::set_sr_NL(GlobalV::ofs_running,
                                                      GlobalV::OUT_LEVEL,
-                                                     GlobalC::ORB.get_rcutmax_Phi(),
+                                                     orb_.get_rcutmax_Phi(),
                                                      GlobalC::ucell.infoNL.get_rcutmax_Beta(),
                                                      GlobalV::GAMMA_ONLY_LOCAL);
 

--- a/source/module_io/berryphase.cpp
+++ b/source/module_io/berryphase.cpp
@@ -39,10 +39,10 @@ void berryphase::get_occupation_bands()
 }
 
 #ifdef __LCAO
-void berryphase::lcao_init(const K_Vectors& kv, const Grid_Technique& grid_tech)
+void berryphase::lcao_init(const K_Vectors& kv, const Grid_Technique& grid_tech, const LCAO_Orbitals& orb)
 {
     ModuleBase::TITLE("berryphase", "lcao_init");
-    lcao_method.init(grid_tech, kv.get_nkstot());
+    lcao_method.init(grid_tech, kv.get_nkstot(), orb);
     lcao_method.cal_R_number();
     lcao_method.cal_orb_overlap();
     return;

--- a/source/module_io/berryphase.h
+++ b/source/module_io/berryphase.h
@@ -37,7 +37,7 @@ class berryphase
 
     void get_occupation_bands();
 #ifdef __LCAO
-    void lcao_init(const K_Vectors& kv, const Grid_Technique& grid_tech);
+    void lcao_init(const K_Vectors& kv, const Grid_Technique& grid_tech, const LCAO_Orbitals& orb);
 #endif
     void set_kpoints(const K_Vectors& kv, const int direction);
 

--- a/source/module_io/cal_r_overlap_R.cpp
+++ b/source/module_io/cal_r_overlap_R.cpp
@@ -13,7 +13,7 @@ cal_r_overlap_R::~cal_r_overlap_R()
 {
 }
 
-void cal_r_overlap_R::initialize_orb_table()
+void cal_r_overlap_R::initialize_orb_table(const LCAO_Orbitals& orb)
 {
     int Lmax_used = 0;
     int Lmax = 0;
@@ -22,17 +22,17 @@ void cal_r_overlap_R::initialize_orb_table()
     exx_lmax = GlobalC::exx_info.info_ri.abfs_Lmax;
 #endif
 
-    const int ntype = GlobalC::ORB.get_ntype();
+    const int ntype = orb.get_ntype();
     int lmax_orb = -1, lmax_beta = -1;
     for (int it = 0; it < ntype; it++)
     {
-        lmax_orb = std::max(lmax_orb, GlobalC::ORB.Phi[it].getLmax());
+        lmax_orb = std::max(lmax_orb, orb.Phi[it].getLmax());
         lmax_beta = std::max(lmax_beta, GlobalC::ucell.infoNL.Beta[it].getLmax());
     }
-    const double dr = GlobalC::ORB.get_dR();
-    const double dk = GlobalC::ORB.get_dk();
-    const int kmesh = GlobalC::ORB.get_kmesh() * 4 + 1;
-    int Rmesh = static_cast<int>(GlobalC::ORB.get_Rmax() / dr) + 4;
+    const double dr = orb.get_dR();
+    const double dk = orb.get_dk();
+    const int kmesh = orb.get_kmesh() * 4 + 1;
+    int Rmesh = static_cast<int>(orb.get_Rmax() / dr) + 4;
     Rmesh += 1 - Rmesh % 2;
 
     Center2_Orb::init_Table_Spherical_Bessel(2,
@@ -52,29 +52,29 @@ void cal_r_overlap_R::initialize_orb_table()
     MGT.init_Gaunt(Lmax);
 }
 
-void cal_r_overlap_R::construct_orbs_and_orb_r()
+void cal_r_overlap_R::construct_orbs_and_orb_r(const LCAO_Orbitals& orb)
 {
     int orb_r_ntype = 0;
-    int mat_Nr = GlobalC::ORB.Phi[0].PhiLN(0, 0).getNr();
+    int mat_Nr = orb.Phi[0].PhiLN(0, 0).getNr();
     int count_Nr = 0;
 
-    orbs.resize(GlobalC::ORB.get_ntype());
-    for (int T = 0; T < GlobalC::ORB.get_ntype(); ++T)
+    orbs.resize(orb.get_ntype());
+    for (int T = 0; T < orb.get_ntype(); ++T)
     {
-        count_Nr = GlobalC::ORB.Phi[T].PhiLN(0, 0).getNr();
+        count_Nr = orb.Phi[T].PhiLN(0, 0).getNr();
         if (count_Nr > mat_Nr)
         {
             mat_Nr = count_Nr;
             orb_r_ntype = T;
         }
 
-        orbs[T].resize(GlobalC::ORB.Phi[T].getLmax() + 1);
-        for (int L = 0; L <= GlobalC::ORB.Phi[T].getLmax(); ++L)
+        orbs[T].resize(orb.Phi[T].getLmax() + 1);
+        for (int L = 0; L <= orb.Phi[T].getLmax(); ++L)
         {
-            orbs[T][L].resize(GlobalC::ORB.Phi[T].getNchi(L));
-            for (int N = 0; N < GlobalC::ORB.Phi[T].getNchi(L); ++N)
+            orbs[T][L].resize(orb.Phi[T].getNchi(L));
+            for (int N = 0; N < orb.Phi[T].getNchi(L); ++N)
             {
-                const auto& orb_origin = GlobalC::ORB.Phi[T].PhiLN(L, N);
+                const auto& orb_origin = orb.Phi[T].PhiLN(L, N);
                 orbs[T][L][N].set_orbital_info(orb_origin.getLabel(),
                                                orb_origin.getType(),
                                                orb_origin.getL(),
@@ -110,17 +110,17 @@ void cal_r_overlap_R::construct_orbs_and_orb_r()
                            true,
                            GlobalV::CAL_FORCE);
 
-    for (int TA = 0; TA < GlobalC::ORB.get_ntype(); ++TA)
+    for (int TA = 0; TA < orb.get_ntype(); ++TA)
     {
-        for (int TB = 0; TB < GlobalC::ORB.get_ntype(); ++TB)
+        for (int TB = 0; TB < orb.get_ntype(); ++TB)
         {
-            for (int LA = 0; LA <= GlobalC::ORB.Phi[TA].getLmax(); ++LA)
+            for (int LA = 0; LA <= orb.Phi[TA].getLmax(); ++LA)
             {
-                for (int NA = 0; NA < GlobalC::ORB.Phi[TA].getNchi(LA); ++NA)
+                for (int NA = 0; NA < orb.Phi[TA].getNchi(LA); ++NA)
                 {
-                    for (int LB = 0; LB <= GlobalC::ORB.Phi[TB].getLmax(); ++LB)
+                    for (int LB = 0; LB <= orb.Phi[TB].getLmax(); ++LB)
                     {
-                        for (int NB = 0; NB < GlobalC::ORB.Phi[TB].getNchi(LB); ++NB)
+                        for (int NB = 0; NB < orb.Phi[TB].getNchi(LB); ++NB)
                         {
                             center2_orb11[TA][TB][LA][NA][LB].insert(
                                 std::make_pair(NB, Center2_Orb::Orb11(orbs[TA][LA][NA], orbs[TB][LB][NB], psb_, MGT)));
@@ -131,17 +131,17 @@ void cal_r_overlap_R::construct_orbs_and_orb_r()
         }
     }
 
-    for (int TA = 0; TA < GlobalC::ORB.get_ntype(); ++TA)
+    for (int TA = 0; TA < orb.get_ntype(); ++TA)
     {
-        for (int TB = 0; TB < GlobalC::ORB.get_ntype(); ++TB)
+        for (int TB = 0; TB < orb.get_ntype(); ++TB)
         {
-            for (int LA = 0; LA <= GlobalC::ORB.Phi[TA].getLmax(); ++LA)
+            for (int LA = 0; LA <= orb.Phi[TA].getLmax(); ++LA)
             {
-                for (int NA = 0; NA < GlobalC::ORB.Phi[TA].getNchi(LA); ++NA)
+                for (int NA = 0; NA < orb.Phi[TA].getNchi(LA); ++NA)
                 {
-                    for (int LB = 0; LB <= GlobalC::ORB.Phi[TB].getLmax(); ++LB)
+                    for (int LB = 0; LB <= orb.Phi[TB].getLmax(); ++LB)
                     {
-                        for (int NB = 0; NB < GlobalC::ORB.Phi[TB].getNchi(LB); ++NB)
+                        for (int NB = 0; NB < orb.Phi[TB].getNchi(LB); ++NB)
                         {
                             center2_orb21_r[TA][TB][LA][NA][LB].insert(std::make_pair(
                                 NB,
@@ -223,14 +223,14 @@ void cal_r_overlap_R::construct_orbs_and_orb_r()
     }
 }
 
-void cal_r_overlap_R::init(const Parallel_Orbitals& pv)
+void cal_r_overlap_R::init(const Parallel_Orbitals& pv, const LCAO_Orbitals& orb)
 {
     ModuleBase::TITLE("cal_r_overlap_R", "init");
     ModuleBase::timer::tick("cal_r_overlap_R", "init");
     this->ParaV = &pv;
 
-    initialize_orb_table();
-    construct_orbs_and_orb_r();
+    initialize_orb_table(orb);
+    construct_orbs_and_orb_r(orb);
 
     ModuleBase::timer::tick("cal_r_overlap_R", "init");
     return;

--- a/source/module_io/cal_r_overlap_R.h
+++ b/source/module_io/cal_r_overlap_R.h
@@ -30,13 +30,13 @@ class cal_r_overlap_R
     double sparse_threshold = 1e-10;
     bool binary = false;
 
-    void init(const Parallel_Orbitals& pv);
+    void init(const Parallel_Orbitals& pv, const LCAO_Orbitals& orb);
     void out_rR(const int& istep);
     void out_rR_other(const int& istep, const std::set<Abfs::Vector3_Order<int>>& output_R_coor);
 
   private:
-    void initialize_orb_table();
-    void construct_orbs_and_orb_r();
+    void initialize_orb_table(const LCAO_Orbitals& orb);
+    void construct_orbs_and_orb_r(const LCAO_Orbitals& orb);
 
     std::vector<int> iw2ia;
     std::vector<int> iw2iL;

--- a/source/module_io/output_mat_sparse.cpp
+++ b/source/module_io/output_mat_sparse.cpp
@@ -17,12 +17,13 @@ Output_Mat_Sparse<T>::Output_Mat_Sparse(int out_mat_hsR,
     const Parallel_Orbitals& pv,
     Gint_k& gint_k, // mohan add 2024-04-01
     const TwoCenterBundle& two_center_bundle,
+    const LCAO_Orbitals& orb,
     Grid_Driver& grid, // mohan add 2024-04-06
     const K_Vectors& kv,
     hamilt::Hamilt<T>* p_ham)
     : _out_mat_hsR(out_mat_hsR), _out_mat_dh(out_mat_dh), _out_mat_t(out_mat_t), _out_mat_r(out_mat_r), _istep(istep),
     _v_eff(v_eff), _pv(pv), _gint_k(gint_k),                     // mohan add 2024-04-01
-    two_center_bundle_(two_center_bundle), _grid(grid), // mohan add 2024-04-06
+    two_center_bundle_(two_center_bundle), orb_(orb), _grid(grid), // mohan add 2024-04-06
     _kv(kv), _p_ham(p_ham) {}
 
 template <>
@@ -69,7 +70,7 @@ void Output_Mat_Sparse<std::complex<double>>::write()
     if (_out_mat_r)
     {
         cal_r_overlap_R r_matrix;
-        r_matrix.init(this->_pv);
+        r_matrix.init(this->_pv, orb_);
         if (_out_mat_hsR)
         {
             r_matrix.out_rR_other(_istep, HS_Arrays.output_R_coor);

--- a/source/module_io/output_mat_sparse.h
+++ b/source/module_io/output_mat_sparse.h
@@ -22,6 +22,7 @@ class Output_Mat_Sparse
         const Parallel_Orbitals& pv,
         Gint_k& gint_k, // mohan add 2024-04-01
         const TwoCenterBundle& two_center_bundle,
+        const LCAO_Orbitals& orb,
         Grid_Driver& grid, // mohan add 2024-04-06
         const K_Vectors& kv,
         hamilt::Hamilt<T>* p_ham);
@@ -46,6 +47,8 @@ class Output_Mat_Sparse
     const ModuleBase::matrix& _v_eff;
 
     const Parallel_Orbitals& _pv;
+
+    const LCAO_Orbitals& orb_;
 
     Gint_k& _gint_k; // mohan add 2024-04-01
 

--- a/source/module_io/to_wannier90_lcao.cpp
+++ b/source/module_io/to_wannier90_lcao.cpp
@@ -203,8 +203,9 @@ void toWannier90_LCAO::cal_Mmn(const K_Vectors& kv, const psi::Psi<std::complex<
         }
     }
 
-    if (GlobalV::MY_RANK == 0)
+    if (GlobalV::MY_RANK == 0) {
         mmn_file.close();
+}
 }
 
 void toWannier90_LCAO::cal_Amn(const K_Vectors& kv, const psi::Psi<std::complex<double>>& psi)
@@ -250,8 +251,9 @@ void toWannier90_LCAO::cal_Amn(const K_Vectors& kv, const psi::Psi<std::complex<
         }
     }
 
-    if (GlobalV::MY_RANK == 0)
+    if (GlobalV::MY_RANK == 0) {
         Amn_file.close();
+}
 }
 
 void toWannier90_LCAO::out_unk(const psi::Psi<std::complex<double>>& psi)
@@ -473,8 +475,9 @@ void toWannier90_LCAO::unkdotkb(const K_Vectors& kv,
     int count_m = -1;
     for (int m = 0; m < GlobalV::NBANDS; m++)
     {
-        if (exclude_bands.count(m))
+        if (exclude_bands.count(m)) {
             continue;
+}
         count_m++;
 
         int ir = this->ParaV->global2local_row(m);
@@ -483,8 +486,9 @@ void toWannier90_LCAO::unkdotkb(const K_Vectors& kv,
             int count_n = -1;
             for (int n = 0; n < GlobalV::NBANDS; n++)
             {
-                if (exclude_bands.count(n))
+                if (exclude_bands.count(n)) {
                     continue;
+}
                 count_n++;
 
                 int ic = this->ParaV->global2local_col(n);
@@ -640,11 +644,13 @@ void toWannier90_LCAO::produce_trial_in_lcao()
         {
             int tmp_size = 0;
 
-            if (L[i] == -1 || L[i] == -2 || L[i] == -3)
+            if (L[i] == -1 || L[i] == -2 || L[i] == -3) {
                 tmp_size = 2;
+}
 
-            if (L[i] == -4 || L[i] == -5)
+            if (L[i] == -4 || L[i] == -5) {
                 tmp_size = 3;
+}
 
             A_orbs[i].resize(tmp_size);
 
@@ -701,11 +707,13 @@ void toWannier90_LCAO::construct_overlap_table_project()
             {
                 int tmp_size = 0;
 
-                if (L[wannier_index] == -1 || L[wannier_index] == -2 || L[wannier_index] == -3)
+                if (L[wannier_index] == -1 || L[wannier_index] == -2 || L[wannier_index] == -3) {
                     tmp_size = 2;
+}
 
-                if (L[wannier_index] == -4 || L[wannier_index] == -5)
+                if (L[wannier_index] == -4 || L[wannier_index] == -5) {
                     tmp_size = 3;
+}
 
                 for (int tmp_L = 0; tmp_L < tmp_size; tmp_L++)
                 {
@@ -788,10 +796,12 @@ void toWannier90_LCAO::cal_orbA_overlap_R()
                 if (L[wannier_index] == -1)
                 {
                     double tmp_bs2 = 0;
-                    if (m[wannier_index] == 0)
+                    if (m[wannier_index] == 0) {
                         tmp_bs2 = bs2;
-                    if (m[wannier_index] == -1)
+}
+                    if (m[wannier_index] == -1) {
                         tmp_bs2 = -bs2;
+}
 
                     for (int iR = 0; iR < R_num; iR++)
                     {
@@ -819,8 +829,9 @@ void toWannier90_LCAO::cal_orbA_overlap_R()
                     if (m[wannier_index] == 0 || m[wannier_index] == 1)
                     {
                         double tmp_bs2 = bs2;
-                        if (m[wannier_index] == -1)
+                        if (m[wannier_index] == -1) {
                             tmp_bs2 = -bs2;
+}
 
                         for (int iR = 0; iR < R_num; iR++)
                         {
@@ -927,8 +938,9 @@ void toWannier90_LCAO::cal_orbA_overlap_R()
                     if (m[wannier_index] == 0 || m[wannier_index] == 1)
                     {
                         double tmp_bs2 = bs2;
-                        if (m[wannier_index] == -1)
+                        if (m[wannier_index] == -1) {
                             tmp_bs2 = -bs2;
+}
 
                         for (int iR = 0; iR < R_num; iR++)
                         {
@@ -977,8 +989,9 @@ void toWannier90_LCAO::cal_orbA_overlap_R()
                     else if (m[wannier_index] == 3 || m[wannier_index] == 4)
                     {
                         double m_pz = 1.0;
-                        if (m[wannier_index] == 4)
+                        if (m[wannier_index] == 4) {
                             m_pz = -1.0;
+}
 
                         for (int iR = 0; iR < R_num; iR++)
                         {
@@ -1079,8 +1092,9 @@ void toWannier90_LCAO::cal_orbA_overlap_R()
                     {
                         double tmp_pz = -1.0;
 
-                        if (m[wannier_index] == 5)
+                        if (m[wannier_index] == 5) {
                             tmp_pz = 1.0;
+}
 
                         for (int iR = 0; iR < R_num; iR++)
                         {
@@ -1125,8 +1139,9 @@ void toWannier90_LCAO::unkdotA(const K_Vectors& kv,
     {
         for (int ib = 0; ib < GlobalV::NBANDS; ib++)
         {
-            if (exclude_bands.count(ib))
+            if (exclude_bands.count(ib)) {
                 continue;
+}
             index_band++;
 
             int ic = this->ParaV->global2local_col(ib);
@@ -1156,8 +1171,9 @@ void toWannier90_LCAO::unkdotA(const K_Vectors& kv,
     {
         for (int ib = 0; ib < GlobalV::NBANDS; ib++)
         {
-            if (exclude_bands.count(ib))
+            if (exclude_bands.count(ib)) {
                 continue;
+}
             index_band++;
 
             int ic = this->ParaV->global2local_col(ib);

--- a/source/module_io/to_wannier90_lcao.h
+++ b/source/module_io/to_wannier90_lcao.h
@@ -74,7 +74,9 @@ class toWannier90_LCAO : public toWannier90
                      const bool& out_wannier_eig,
                      const bool& out_wannier_wvfn_formatted,
                      const std::string& nnkpfile,
-                     const std::string& wannier_spin);
+                     const std::string& wannier_spin,
+                     const LCAO_Orbitals& orb
+                     );
     ~toWannier90_LCAO();
 
     void calculate(const ModuleBase::matrix& ekb,
@@ -99,6 +101,8 @@ class toWannier90_LCAO : public toWannier90
     const int mesh_r = 1001; // unit is a.u.
     const double dr = 0.01;
     std::vector<std::vector<Numerical_Orbital_Lm>> A_orbs;
+
+    const LCAO_Orbitals& orb_;
 
     // Use default element orbital information
     int orb_r_ntype = 0;

--- a/source/module_io/to_wannier90_lcao_in_pw.cpp
+++ b/source/module_io/to_wannier90_lcao_in_pw.cpp
@@ -118,7 +118,6 @@ psi::Psi<std::complex<double>>* toWannier90_LCAO_IN_PW::get_unk_from_lcao(
 
     // Orbital projection to plane wave
     ModuleBase::realArray table_local(GlobalC::ucell.ntype, GlobalC::ucell.nmax_total, GlobalV::NQX);
-    //Wavefunc_in_pw::make_table_q(GlobalC::ORB.orbital_file, table_local);
 
     for (int ik = 0; ik < num_kpts; ik++)
     {

--- a/source/module_io/to_wannier90_lcao_in_pw.cpp
+++ b/source/module_io/to_wannier90_lcao_in_pw.cpp
@@ -216,7 +216,8 @@ void toWannier90_LCAO_IN_PW::nao_G_expansion(
     int npwx = wfcpw->npwk_max;
     this->psi_init_->proj_ao_onkG(ik);
     std::weak_ptr<psi::Psi<std::complex<double>>> psig = this->psi_init_->share_psig();
-    if(psig.expired()) ModuleBase::WARNING_QUIT("toWannier90_LCAO_IN_PW::nao_G_expansion", "psig is expired");
+    if(psig.expired()) { ModuleBase::WARNING_QUIT("toWannier90_LCAO_IN_PW::nao_G_expansion", "psig is expired");
+}
     int nbands = GlobalV::NLOCAL;
     int nbasis = npwx*GlobalV::NPOL;
     for (int ib = 0; ib < nbands; ib++)
@@ -241,7 +242,8 @@ void toWannier90_LCAO_IN_PW::get_lcao_wfc_global_ik(
     int global_row_index = 0;
     for (int ib = 0; ib < GlobalV::NBANDS; ib++)
     {
-        if (exclude_bands.count(ib)) continue;
+        if (exclude_bands.count(ib)) { continue;
+}
         count_b++;
 
         int ic = this->ParaV->global2local_col(ib);

--- a/source/module_io/unk_overlap_lcao.cpp
+++ b/source/module_io/unk_overlap_lcao.cpp
@@ -24,7 +24,7 @@ unkOverlap_lcao::~unkOverlap_lcao()
     // GlobalV::ofs_running << "this is ~unkOverlap_lcao()" << std::endl;
 }
 
-void unkOverlap_lcao::init(const Grid_Technique& gt, const int nkstot)
+void unkOverlap_lcao::init(const Grid_Technique& gt, const int nkstot, const LCAO_Orbitals& orb)
 {
     // std::cout << "unkOverlap_lcao::init start" << std::endl;
 
@@ -34,17 +34,17 @@ void unkOverlap_lcao::init(const Grid_Technique& gt, const int nkstot)
     exx_lmax = GlobalC::exx_info.info_ri.abfs_Lmax;
 #endif
 
-    const int ntype = GlobalC::ORB.get_ntype();
+    const int ntype = orb.get_ntype();
     int lmax_orb = -1, lmax_beta = -1;
     for (int it = 0; it < ntype; it++)
     {
-        lmax_orb = std::max(lmax_orb, GlobalC::ORB.Phi[it].getLmax());
+        lmax_orb = std::max(lmax_orb, orb.Phi[it].getLmax());
         lmax_beta = std::max(lmax_beta, GlobalC::ucell.infoNL.Beta[it].getLmax());
     }
-    const double dr = GlobalC::ORB.get_dR();
-    const double dk = GlobalC::ORB.get_dk();
-    const int kmesh = GlobalC::ORB.get_kmesh() * 4 + 1;
-    int Rmesh = static_cast<int>(GlobalC::ORB.get_Rmax() / dr) + 4;
+    const double dr = orb.get_dR();
+    const double dk = orb.get_dk();
+    const int kmesh = orb.get_kmesh() * 4 + 1;
+    int Rmesh = static_cast<int>(orb.get_Rmax() / dr) + 4;
     Rmesh += 1 - Rmesh % 2;
 
     Center2_Orb::init_Table_Spherical_Bessel(2,
@@ -66,18 +66,18 @@ void unkOverlap_lcao::init(const Grid_Technique& gt, const int nkstot)
     MGT.init_Gaunt(Lmax);
 
     const int T = 0;                                                    // any selected element type
-    orb_r.set_orbital_info(GlobalC::ORB.Phi[T].PhiLN(0, 0).getLabel(),  // atom label
+    orb_r.set_orbital_info(orb.Phi[T].PhiLN(0, 0).getLabel(),  // atom label
                            T,                                           // atom type
                            1,                                           // angular momentum L
                            1,                                           // number of orbitals of this L , just N
-                           GlobalC::ORB.Phi[T].PhiLN(0, 0).getNr(),     // number of radial mesh
-                           GlobalC::ORB.Phi[T].PhiLN(0, 0).getRab(),    // the mesh interval in radial mesh
-                           GlobalC::ORB.Phi[T].PhiLN(0, 0).getRadial(), // radial mesh value(a.u.)
+                           orb.Phi[T].PhiLN(0, 0).getNr(),     // number of radial mesh
+                           orb.Phi[T].PhiLN(0, 0).getRab(),    // the mesh interval in radial mesh
+                           orb.Phi[T].PhiLN(0, 0).getRadial(), // radial mesh value(a.u.)
                            Numerical_Orbital_Lm::Psi_Type::Psi,
-                           GlobalC::ORB.Phi[T].PhiLN(0, 0).getRadial(), // radial wave function
-                           GlobalC::ORB.Phi[T].PhiLN(0, 0).getNk(),
-                           GlobalC::ORB.Phi[T].PhiLN(0, 0).getDk(),
-                           GlobalC::ORB.Phi[T].PhiLN(0, 0).getDruniform(),
+                           orb.Phi[T].PhiLN(0, 0).getRadial(), // radial wave function
+                           orb.Phi[T].PhiLN(0, 0).getNk(),
+                           orb.Phi[T].PhiLN(0, 0).getDk(),
+                           orb.Phi[T].PhiLN(0, 0).getDruniform(),
                            false,
                            true,
                            GlobalV::CAL_FORCE);
@@ -143,18 +143,18 @@ void unkOverlap_lcao::init(const Grid_Technique& gt, const int nkstot)
     {
         for (int TB = 0; TB < GlobalC::ucell.ntype; TB++)
         {
-            for (int LA = 0; LA <= GlobalC::ORB.Phi[TA].getLmax(); LA++)
+            for (int LA = 0; LA <= orb.Phi[TA].getLmax(); LA++)
             {
-                for (int NA = 0; NA < GlobalC::ORB.Phi[TA].getNchi(LA); ++NA)
+                for (int NA = 0; NA < orb.Phi[TA].getNchi(LA); ++NA)
                 {
-                    for (int LB = 0; LB <= GlobalC::ORB.Phi[TB].getLmax(); ++LB)
+                    for (int LB = 0; LB <= orb.Phi[TB].getLmax(); ++LB)
                     {
-                        for (int NB = 0; NB < GlobalC::ORB.Phi[TB].getNchi(LB); ++NB)
+                        for (int NB = 0; NB < orb.Phi[TB].getNchi(LB); ++NB)
                         {
                             center2_orb11[TA][TB][LA][NA][LB].insert(
                                 std::make_pair(NB,
-                                               Center2_Orb::Orb11(GlobalC::ORB.Phi[TA].PhiLN(LA, NA),
-                                                                  GlobalC::ORB.Phi[TB].PhiLN(LB, NB),
+                                               Center2_Orb::Orb11(orb.Phi[TA].PhiLN(LA, NA),
+                                                                  orb.Phi[TB].PhiLN(LB, NB),
                                                                   psb_,
                                                                   MGT)));
                         }
@@ -168,19 +168,19 @@ void unkOverlap_lcao::init(const Grid_Technique& gt, const int nkstot)
     {
         for (int TB = 0; TB < GlobalC::ucell.ntype; TB++)
         {
-            for (int LA = 0; LA <= GlobalC::ORB.Phi[TA].getLmax(); LA++)
+            for (int LA = 0; LA <= orb.Phi[TA].getLmax(); LA++)
             {
-                for (int NA = 0; NA < GlobalC::ORB.Phi[TA].getNchi(LA); ++NA)
+                for (int NA = 0; NA < orb.Phi[TA].getNchi(LA); ++NA)
                 {
-                    for (int LB = 0; LB <= GlobalC::ORB.Phi[TB].getLmax(); ++LB)
+                    for (int LB = 0; LB <= orb.Phi[TB].getLmax(); ++LB)
                     {
-                        for (int NB = 0; NB < GlobalC::ORB.Phi[TB].getNchi(LB); ++NB)
+                        for (int NB = 0; NB < orb.Phi[TB].getNchi(LB); ++NB)
                         {
                             center2_orb21_r[TA][TB][LA][NA][LB].insert(
                                 std::make_pair(NB,
-                                               Center2_Orb::Orb21(GlobalC::ORB.Phi[TA].PhiLN(LA, NA),
+                                               Center2_Orb::Orb21(orb.Phi[TA].PhiLN(LA, NA),
                                                                   orb_r,
-                                                                  GlobalC::ORB.Phi[TB].PhiLN(LB, NB),
+                                                                  orb.Phi[TB].PhiLN(LB, NB),
                                                                   psb_,
                                                                   MGT)));
                         }
@@ -205,6 +205,11 @@ void unkOverlap_lcao::init(const Grid_Technique& gt, const int nkstot)
                     for (auto& co5: co4.second)
                         for (auto& co6: co5.second)
                             co6.second.init_radial_table();
+
+    rcut_orb_.resize(orb.get_ntype());
+    for (int it = 0; it < orb.get_ntype(); ++it) {
+        rcut_orb_[it] = orb.Phi[it].getRcut();
+    }
 
     // std::cout << "unkOverlap_lcao::init end" << std::endl;
     return;
@@ -382,7 +387,7 @@ void unkOverlap_lcao::cal_R_number()
                 tau2 = GlobalC::GridD.getAdjacentTau(ad);
                 dtau = tau2 - tau1;
                 double distance = dtau.norm() * GlobalC::ucell.lat0;
-                double rcut = GlobalC::ORB.Phi[T1].getRcut() + GlobalC::ORB.Phi[T2].getRcut();
+                double rcut = rcut_orb_[T1] + rcut_orb_[T2];
                 if (distance < rcut - 1.0e-15)
                 {
                     // translate: the unit of R_car is GlobalC::ucell.lat0

--- a/source/module_io/unk_overlap_lcao.h
+++ b/source/module_io/unk_overlap_lcao.h
@@ -33,6 +33,8 @@ class unkOverlap_lcao
 
     int kpoints_number;
 
+    std::vector<double> rcut_orb_; // real space cutoffs of LCAO orbitals' radial functions
+
     std::map<
         size_t,
         std::map<size_t, std::map<size_t, std::map<size_t, std::map<size_t, std::map<size_t, Center2_Orb::Orb11>>>>>>
@@ -46,7 +48,7 @@ class unkOverlap_lcao
     unkOverlap_lcao();
     ~unkOverlap_lcao();
 
-    void init(const Grid_Technique& gt, const int nkstot);
+    void init(const Grid_Technique& gt, const int nkstot, const LCAO_Orbitals& orb);
     int iw2it(int iw);
     int iw2ia(int iw);
     int iw2iL(int iw);


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
#4079 

