### PR TITLE
Refactor: remove GlobalC::ORB

### DIFF
--- a/source/module_basis/module_ao/ORB_read.cpp
+++ b/source/module_basis/module_ao/ORB_read.cpp
@@ -15,10 +15,6 @@
 //==============================
 /// PLEASE avoid using 'ORB' as global variable
 // mohan note 2021-03-23
-namespace GlobalC
-{
-LCAO_Orbitals ORB;
-}
 
 LCAO_Orbitals::LCAO_Orbitals()
 {
@@ -39,11 +35,6 @@ LCAO_Orbitals::~LCAO_Orbitals()
 {
     delete[] Phi;
     delete[] Alpha;
-}
-
-const LCAO_Orbitals& LCAO_Orbitals::get_const_instance()
-{
-    return GlobalC::ORB;
 }
 
 std::vector<double> LCAO_Orbitals::cutoffs() const {

--- a/source/module_basis/module_ao/ORB_read.h
+++ b/source/module_basis/module_ao/ORB_read.h
@@ -22,9 +22,6 @@ class LCAO_Orbitals
 	LCAO_Orbitals();
 	~LCAO_Orbitals();
 
-	// static function to get global instance
-	static const LCAO_Orbitals& get_const_instance();
-
     void init(
         std::ofstream& ofs_in,
         const int& ntype,
@@ -134,11 +131,4 @@ private:
     friend class TwoCenterBundle; // for the sake of TwoCenterBundle::to_LCAO_Orbitals
 };
 
-/// PLEASE avoid using 'ORB' as global variable 
-///
-///mohan note 2021 - 03 - 23
-namespace GlobalC
-{
-extern LCAO_Orbitals ORB;
-}
 #endif

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -204,8 +204,8 @@ void ESolver_KS_LCAO<TK, TR>::before_all_runners(const Input_para& inp, UnitCell
         {
             XC_Functional::set_xc_first_loop(ucell);
             // initialize 2-center radial tables for EXX-LRI
-            if (GlobalC::exx_info.info_ri.real_number) { this->exx_lri_double->init(MPI_COMM_WORLD, this->kv); }
-            else { this->exx_lri_complex->init(MPI_COMM_WORLD, this->kv); }
+            if (GlobalC::exx_info.info_ri.real_number) { this->exx_lri_double->init(MPI_COMM_WORLD, this->kv, orb_); }
+            else { this->exx_lri_complex->init(MPI_COMM_WORLD, this->kv, orb_); }
         }
     }
 #endif
@@ -1175,8 +1175,9 @@ void ESolver_KS_LCAO<TK, TR>::after_scf(const int istep)
         RPA_LRI<TK, double> rpa_lri_double(GlobalC::exx_info.info_ri);
         rpa_lri_double.cal_postSCF_exx(*dynamic_cast<const elecstate::ElecStateLCAO<TK>*>(this->pelec)->get_DM(),
                                        MPI_COMM_WORLD,
-                                       this->kv);
-        rpa_lri_double.init(MPI_COMM_WORLD, this->kv);
+                                       this->kv,
+                                       orb_);
+        rpa_lri_double.init(MPI_COMM_WORLD, this->kv, orb_.cutoffs());
         rpa_lri_double.out_for_RPA(this->pv, *(this->psi), this->pelec);
     }
 #endif

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -63,7 +63,7 @@ namespace ModuleESolver
 //! mohan add 2024-05-11
 //------------------------------------------------------------------------------
 template <typename TK, typename TR>
-ESolver_KS_LCAO<TK, TR>::ESolver_KS_LCAO(): orb_(GlobalC::ORB)
+ESolver_KS_LCAO<TK, TR>::ESolver_KS_LCAO()
 {
     this->classname = "ESolver_KS_LCAO";
     this->basisname = "LCAO";
@@ -463,6 +463,7 @@ void ESolver_KS_LCAO<TK, TR>::after_all_runners()
             this->GG,
             this->GK,
             this->kv,
+            orb_.cutoffs(),
             this->pelec->wg,
             GlobalC::GridD
 #ifdef __EXX
@@ -490,6 +491,7 @@ void ESolver_KS_LCAO<TK, TR>::after_all_runners()
             this->kv,
             this->pelec->wg,
             GlobalC::GridD,
+            orb_.cutoffs(),
             this->two_center_bundle_
 #ifdef __EXX
             , this->exx_lri_double ? &this->exx_lri_double->Hexxs : nullptr
@@ -1266,6 +1268,7 @@ void ESolver_KS_LCAO<TK, TR>::after_scf(const int istep)
                                                                   this->kv.kvec_d,
                                                                   &hR,
                                                                   &GlobalC::ucell,
+                                                                  orb_.cutoffs(),
                                                                   &GlobalC::GridD,
                                                                   two_center_bundle_.kinetic_orb.get());
 

--- a/source/module_esolver/esolver_ks_lcao.h
+++ b/source/module_esolver/esolver_ks_lcao.h
@@ -79,7 +79,7 @@ class ESolver_KS_LCAO : public ESolver_KS<TK> {
     TwoCenterBundle two_center_bundle_;
 
     // temporary introduced during removing GlobalC::ORB
-    LCAO_Orbitals& orb_;
+    LCAO_Orbitals orb_;
 
     // Temporarily store the stress to unify the interface with PW,
     // because it's hard to seperate force and stress calculation in LCAO.

--- a/source/module_esolver/esolver_ks_lcao_tddft.cpp
+++ b/source/module_esolver/esolver_ks_lcao_tddft.cpp
@@ -425,6 +425,7 @@ void ESolver_KS_LCAO_TDDFT::after_scf(const int istep)
                                 kv,
                                 two_center_bundle_.overlap_orb.get(),
                                 tmp_DM->get_paraV_pointer(),
+                                orb_,
                                 this->RA);
     }
     ESolver_KS_LCAO<std::complex<double>, double>::after_scf(istep);

--- a/source/module_esolver/lcao_before_scf.cpp
+++ b/source/module_esolver/lcao_before_scf.cpp
@@ -210,11 +210,11 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(const int istep)
 #ifdef __EXX // set xc type before the first cal of xc in pelec->init_scf
     if (GlobalC::exx_info.info_ri.real_number)
     {
-        this->exd->exx_beforescf(this->kv, *this->p_chgmix, GlobalC::ucell, this->pv);
+        this->exd->exx_beforescf(this->kv, *this->p_chgmix, GlobalC::ucell, this->pv, orb_);
     }
     else
     {
-        this->exc->exx_beforescf(this->kv, *this->p_chgmix, GlobalC::ucell, this->pv);
+        this->exc->exx_beforescf(this->kv, *this->p_chgmix, GlobalC::ucell, this->pv, orb_);
     }
 #endif // __EXX
 

--- a/source/module_esolver/lcao_gets.cpp
+++ b/source/module_esolver/lcao_gets.cpp
@@ -63,7 +63,8 @@ void ESolver_KS_LCAO<std::complex<double>, double>::get_S(void)
         this->p_hamilt = new hamilt::HamiltLCAO<std::complex<double>, double>(
             &this->pv,
             this->kv,
-            *(two_center_bundle_.overlap_orb));
+            *(two_center_bundle_.overlap_orb),
+            orb_.cutoffs());
         dynamic_cast<hamilt::OperatorLCAO<std::complex<double>, double>*>(
             this->p_hamilt->ops)
             ->contributeHR();
@@ -103,7 +104,9 @@ void ESolver_KS_LCAO<std::complex<double>, std::complex<double>>::get_S(void)
                                                 std::complex<double>>(
             &this->pv,
             this->kv,
-            *(two_center_bundle_.overlap_orb));
+            *(two_center_bundle_.overlap_orb),
+            orb_.cutoffs()
+            );
         dynamic_cast<
             hamilt::OperatorLCAO<std::complex<double>, std::complex<double>>*>(
             this->p_hamilt->ops)

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
@@ -257,6 +257,7 @@ void Force_Stress_LCAO<T>::getForceStress(const bool isforce,
                                                                    GlobalC::ucell,
                                                                    &GlobalC::GridD,
                                                                    two_center_bundle.overlap_orb_onsite.get(),
+                                                                   orb.cutoffs(),
                                                                    &GlobalC::dftu);
 
             tmp_dftu.cal_force_stress(isforce, isstress, force_dftu, stress_dftu);

--- a/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.cpp
@@ -6,6 +6,7 @@
 #include "module_base/timer.h"
 #include "module_hamilt_lcao/module_dftu/dftu.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
+#include <vector>
 
 #ifdef __DEEPKS
 #include "module_hamilt_lcao/module_deepks/LCAO_deepks.h"
@@ -41,7 +42,7 @@ namespace hamilt
 {
 
 template <typename TK, typename TR>
-HamiltLCAO<TK, TR>::HamiltLCAO(const Parallel_Orbitals* paraV, const K_Vectors& kv_in, const TwoCenterIntegrator& intor_overlap_orb)
+HamiltLCAO<TK, TR>::HamiltLCAO(const Parallel_Orbitals* paraV, const K_Vectors& kv_in, const TwoCenterIntegrator& intor_overlap_orb, const std::vector<double>& orb_cutoff)
 {
     this->classname = "HamiltLCAO";
 
@@ -57,6 +58,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(const Parallel_Orbitals* paraV, const K_Vectors& 
                                                                this->hR,
                                                                this->sR,
                                                                &GlobalC::ucell,
+                                                               orb_cutoff,
                                                                &GlobalC::GridD,
                                                                &intor_overlap_orb);
 }
@@ -130,6 +132,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                    this->hR,
                                                                    this->sR,
                                                                    &GlobalC::ucell,
+                                                                   orb.cutoffs(),
                                                                    &GlobalC::GridD,
                                                                    two_center_bundle.overlap_orb.get());
 
@@ -140,6 +143,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                            this->kv->kvec_d,
                                                                            this->hR,
                                                                            &GlobalC::ucell,
+                                                                           orb.cutoffs(),
                                                                            &GlobalC::GridD,
                                                                            two_center_bundle.kinetic_orb.get());
             this->getOperator()->add(ekinetic);
@@ -153,6 +157,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                            this->kv->kvec_d,
                                                                            this->hR,
                                                                            &GlobalC::ucell,
+                                                                           orb.cutoffs(),
                                                                            &GlobalC::GridD,
                                                                            two_center_bundle.overlap_orb_beta.get());
             this->getOperator()->add(nonlocal);
@@ -174,6 +179,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                     pot_in,
                                                                     this->hR, // no explicit call yet
                                                                     &GlobalC::ucell,
+                                                                    orb.cutoffs(),
                                                                     &GlobalC::GridD
                 );
                 this->getOperator()->add(veff);
@@ -215,6 +221,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                       GlobalC::ucell,
                                                       &GlobalC::GridD,
                                                       two_center_bundle.overlap_orb_onsite.get(),
+                                                      orb.cutoffs(),
                                                       &GlobalC::dftu);
             }
             this->getOperator()->add(dftu);
@@ -240,6 +247,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                      pot_in,
                                                                      this->hR,
                                                                      &GlobalC::ucell,
+                                                                     orb.cutoffs(),
                                                                      &GlobalC::GridD);
                 // reset spin index and real space Hamiltonian matrix
                 int start_spin = -1;
@@ -256,6 +264,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                      this->hR,
                                                                      this->sR,
                                                                      &GlobalC::ucell,
+                                                                     orb.cutoffs(),
                                                                      &GlobalC::GridD,
                                                                      two_center_bundle.overlap_orb.get());
         if (this->getOperator() == nullptr)
@@ -275,6 +284,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                            this->kv->kvec_d,
                                                                            this->hR,
                                                                            &GlobalC::ucell,
+                                                                           orb.cutoffs(),
                                                                            &GlobalC::GridD,
                                                                            two_center_bundle.kinetic_orb.get());
             this->getOperator()->add(ekinetic);
@@ -288,6 +298,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                            this->kv->kvec_d,
                                                                            this->hR,
                                                                            &GlobalC::ucell,
+                                                                           orb.cutoffs(),
                                                                            &GlobalC::GridD,
                                                                            two_center_bundle.overlap_orb_beta.get());
             // TDDFT velocity gague will calculate full non-local potential including the original one and the
@@ -326,6 +337,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                              this->hR,
                                                                              kv,
                                                                              &GlobalC::ucell,
+                                                                             orb.cutoffs(),
                                                                              &GlobalC::GridD,
                                                                              two_center_bundle.overlap_orb.get());
             this->getOperator()->add(td_ekinetic);
@@ -334,6 +346,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                              this->kv->kvec_d,
                                                                              this->hR,
                                                                              &GlobalC::ucell,
+                                                                             orb,
                                                                              &GlobalC::GridD);
             this->getOperator()->add(td_nonlocal);
         }
@@ -355,6 +368,7 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                       GlobalC::ucell,
                                                       &GlobalC::GridD,
                                                       two_center_bundle.overlap_orb_onsite.get(),
+                                                      orb.cutoffs(),
                                                       &GlobalC::dftu);
             }
             this->getOperator()->add(dftu);

--- a/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h
@@ -9,6 +9,7 @@
 #include "module_hamilt_lcao/module_gint/gint_k.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/hs_matrix_k.hpp"
+#include <vector>
 #ifdef __EXX
 #include "module_ri/Exx_LRI.h"
 #endif
@@ -43,7 +44,7 @@ class HamiltLCAO : public Hamilt<TK>
     /**
      * @brief Constructor of vacuum Operators, only HR and SR will be initialed as empty HContainer
      */
-    HamiltLCAO(const Parallel_Orbitals* paraV, const K_Vectors& kv_in, const TwoCenterIntegrator& intor_overlap_orb);
+    HamiltLCAO(const Parallel_Orbitals* paraV, const K_Vectors& kv_in, const TwoCenterIntegrator& intor_overlap_orb, const std::vector<double>& orb_cutoff);
 
     ~HamiltLCAO()
     {

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.cpp
@@ -89,12 +89,11 @@ void hamilt::DeePKS<hamilt::OperatorLCAO<TK, TR>>::initialize_HR(Grid_Driver* Gr
             const ModuleBase::Vector3<double>& tau1 = adjs.adjacent_tau[ad1];
             const ModuleBase::Vector3<int>& R_index1 = adjs.box[ad1];
             // choose the real adjacent atoms
-            const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
             // Note: the distance of atoms should less than the cutoff radius,
             // When equal, the theoretical value of matrix element is zero,
             // but the calculated value is not zero due to the numerical error, which would lead to result changes.
             if (this->ucell->cal_dtau(iat0, iat1, R_index1).norm() * this->ucell->lat0
-                < orb.Phi[T1].getRcut() + orb.Alpha[0].getRcut())
+                < ptr_orb_->Phi[T1].getRcut() + ptr_orb_->Alpha[0].getRcut())
             {
                 is_adj[ad1] = true;
             }
@@ -310,8 +309,6 @@ void hamilt::DeePKS<hamilt::OperatorLCAO<TK, TR>>::calculate_HR()
     const Parallel_Orbitals* paraV = this->H_V_delta->get_paraV();
     const int npol = this->ucell->get_npol();
 
-    const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
-
     // 1. calculate <psi|alpha> for each pair of atoms
     for (int iat0 = 0; iat0 < this->ucell->nat; iat0++)
     {
@@ -327,9 +324,9 @@ void hamilt::DeePKS<hamilt::OperatorLCAO<TK, TR>>::calculate_HR()
         if (!GlobalV::deepks_equiv)
         {
             int ib = 0;
-            for (int L0 = 0; L0 <= orb.Alpha[0].getLmax(); ++L0)
+            for (int L0 = 0; L0 <= ptr_orb_->Alpha[0].getLmax(); ++L0)
             {
-                for (int N0 = 0; N0 < orb.Alpha[0].getNchi(L0); ++N0)
+                for (int N0 = 0; N0 < ptr_orb_->Alpha[0].getNchi(L0); ++N0)
                 {
                     const int inl = GlobalC::ld.get_inl(T0, I0, L0, N0);
                     const double* pgedm = GlobalC::ld.get_gedms(inl);
@@ -354,7 +351,7 @@ void hamilt::DeePKS<hamilt::OperatorLCAO<TK, TR>>::calculate_HR()
             int nproj = 0;
             for (int il = 0; il < GlobalC::ld.get_lmaxd() + 1; il++)
             {
-                nproj += (2 * il + 1) * orb.Alpha[0].getNchi(il);
+                nproj += (2 * il + 1) * ptr_orb_->Alpha[0].getNchi(il);
             }
             for (int iproj = 0; iproj < nproj; iproj++)
             {

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/dftu_force_stress.hpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/dftu_force_stress.hpp
@@ -64,7 +64,6 @@ void DFTU<OperatorLCAO<TK, TR>>::cal_force_stress(const bool cal_force,
             const ModuleBase::Vector3<double>& tau1 = adjs.adjacent_tau[ad];
             const Atom* atom1 = &ucell->atoms[T1];
 
-            const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
             auto all_indexes = paraV->get_indexes_row(iat1);
             auto col_indexes = paraV->get_indexes_col(iat1);
             // insert col_indexes into all_indexes to get universal set with no repeat elements

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/dftu_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/dftu_lcao.cpp
@@ -18,8 +18,9 @@ hamilt::DFTU<hamilt::OperatorLCAO<TK, TR>>::DFTU(HS_Matrix_K<TK>* hsk_in,
                                                  const UnitCell& ucell_in,
                                                  Grid_Driver* GridD_in,
                                                  const TwoCenterIntegrator* intor,
+                                                 const std::vector<double>& orb_cutoff,
                                                  ModuleDFTU::DFTU* dftu_in)
-    : hamilt::OperatorLCAO<TK, TR>(hsk_in, kvec_d_in, hR_in), intor_(intor)
+    : hamilt::OperatorLCAO<TK, TR>(hsk_in, kvec_d_in, hR_in), intor_(intor), orb_cutoff_(orb_cutoff)
 {
     this->cal_type = calculation_type::lcao_dftu;
     this->ucell = &ucell_in;
@@ -71,12 +72,11 @@ void hamilt::DFTU<hamilt::OperatorLCAO<TK, TR>>::initialize_HR(Grid_Driver* Grid
             const ModuleBase::Vector3<double>& tau1 = adjs.adjacent_tau[ad1];
             const ModuleBase::Vector3<int>& R_index1 = adjs.box[ad1];
             // choose the real adjacent atoms
-            const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
             // Note: the distance of atoms should less than the cutoff radius,
             // When equal, the theoretical value of matrix element is zero,
             // but the calculated value is not zero due to the numerical error, which would lead to result changes.
             if (this->ucell->cal_dtau(iat0, iat1, R_index1).norm() * this->ucell->lat0
-                < orb.Phi[T1].getRcut() + PARAM.inp.onsite_radius)
+                < orb_cutoff_[T1] + PARAM.inp.onsite_radius)
             {
                 is_adj[ad1] = true;
             }
@@ -120,7 +120,6 @@ void hamilt::DFTU<hamilt::OperatorLCAO<TK, TR>>::cal_nlm_all(const Parallel_Orbi
             const ModuleBase::Vector3<double>& tau1 = adjs.adjacent_tau[ad];
             const Atom* atom1 = &ucell->atoms[T1];
 
-            const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
             auto all_indexes = paraV->get_indexes_row(iat1);
             auto col_indexes = paraV->get_indexes_col(iat1);
             // insert col_indexes into all_indexes to get universal set with no repeat elements

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/dftu_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/dftu_lcao.h
@@ -32,6 +32,7 @@ class DFTU<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                                const UnitCell& ucell_in,
                                Grid_Driver* gridD_in,
                                const TwoCenterIntegrator* intor,
+                               const std::vector<double>& orb_cutoff,
                                ModuleDFTU::DFTU* dftu_in);
     ~DFTU<OperatorLCAO<TK, TR>>();
 
@@ -55,6 +56,8 @@ class DFTU<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
     hamilt::HContainer<TR>* HR = nullptr;
 
     const TwoCenterIntegrator* intor_ = nullptr;
+
+    std::vector<double> orb_cutoff_;
 
     /// @brief the number of spin components, 1 for no-spin, 2 for collinear spin case and 4 for non-collinear spin case
     int nspin = 0;

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/ekinetic_new.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/ekinetic_new.cpp
@@ -13,9 +13,10 @@ hamilt::EkineticNew<hamilt::OperatorLCAO<TK, TR>>::EkineticNew(
     const std::vector<ModuleBase::Vector3<double>>& kvec_d_in,
     hamilt::HContainer<TR>* hR_in,
     const UnitCell* ucell_in,
+    const std::vector<double>& orb_cutoff,
     Grid_Driver* GridD_in,
     const TwoCenterIntegrator* intor)
-    : hamilt::OperatorLCAO<TK, TR>(hsk_in, kvec_d_in, hR_in), intor_(intor)
+    : hamilt::OperatorLCAO<TK, TR>(hsk_in, kvec_d_in, hR_in), orb_cutoff_(orb_cutoff), intor_(intor)
 {
     this->cal_type = calculation_type::lcao_fixed;
     this->ucell = ucell_in;
@@ -66,12 +67,11 @@ void hamilt::EkineticNew<hamilt::OperatorLCAO<TK, TR>>::initialize_HR(Grid_Drive
             }
             const ModuleBase::Vector3<int>& R_index2 = adjs.box[ad1];
             // choose the real adjacent atoms
-            const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
             // Note: the distance of atoms should less than the cutoff radius,
             // When equal, the theoretical value of matrix element is zero,
             // but the calculated value is not zero due to the numerical error, which would lead to result changes.
             if (this->ucell->cal_dtau(iat1, iat2, R_index2).norm() * this->ucell->lat0
-                < orb.Phi[T1].getRcut() + orb.Phi[T2].getRcut())
+                < orb_cutoff_[T1] + orb_cutoff_[T2])
             {
                 is_adj[ad1] = true;
             }

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/ekinetic_new.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/ekinetic_new.h
@@ -6,6 +6,7 @@
 #include "module_cell/unitcell.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/operator_lcao.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
+#include <vector>
 
 namespace hamilt
 {
@@ -43,6 +44,7 @@ class EkineticNew<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                                       const std::vector<ModuleBase::Vector3<double>>& kvec_d_in,
                                       HContainer<TR>* hR_in,
                                       const UnitCell* ucell_in,
+                                      const std::vector<double>& orb_cutoff,
                                       Grid_Driver* GridD_in,
                                       const TwoCenterIntegrator* intor);
 
@@ -61,6 +63,7 @@ class EkineticNew<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
 
   private:
     const UnitCell* ucell = nullptr;
+    std::vector<double> orb_cutoff_;
 
     hamilt::HContainer<TR>* HR_fixed = nullptr;
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/nonlocal_new.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/nonlocal_new.cpp
@@ -15,9 +15,10 @@ hamilt::NonlocalNew<hamilt::OperatorLCAO<TK, TR>>::NonlocalNew(
     const std::vector<ModuleBase::Vector3<double>>& kvec_d_in,
     hamilt::HContainer<TR>* hR_in,
     const UnitCell* ucell_in,
+    const std::vector<double>& orb_cutoff,
     Grid_Driver* GridD_in,
     const TwoCenterIntegrator* intor)
-    : hamilt::OperatorLCAO<TK, TR>(hsk_in, kvec_d_in, hR_in), intor_(intor)
+    : hamilt::OperatorLCAO<TK, TR>(hsk_in, kvec_d_in, hR_in), orb_cutoff_(orb_cutoff), intor_(intor)
 {
     this->cal_type = calculation_type::lcao_fixed;
     this->ucell = ucell_in;
@@ -66,12 +67,11 @@ void hamilt::NonlocalNew<hamilt::OperatorLCAO<TK, TR>>::initialize_HR(Grid_Drive
             const ModuleBase::Vector3<double>& tau1 = adjs.adjacent_tau[ad1];
             const ModuleBase::Vector3<int>& R_index1 = adjs.box[ad1];
             // choose the real adjacent atoms
-            const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
             // Note: the distance of atoms should less than the cutoff radius,
             // When equal, the theoretical value of matrix element is zero,
             // but the calculated value is not zero due to the numerical error, which would lead to result changes.
             if (this->ucell->cal_dtau(iat0, iat1, R_index1).norm() * this->ucell->lat0
-                < orb.Phi[T1].getRcut() + this->ucell->infoNL.Beta[T0].get_rcut_max())
+                < orb_cutoff_[T1] + this->ucell->infoNL.Beta[T0].get_rcut_max())
             {
                 is_adj[ad1] = true;
             }

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/nonlocal_new.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/nonlocal_new.h
@@ -8,6 +8,7 @@
 #include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
 
 #include <unordered_map>
+#include <vector>
 
 namespace hamilt
 {
@@ -42,6 +43,7 @@ class NonlocalNew<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                                       const std::vector<ModuleBase::Vector3<double>>& kvec_d_in,
                                       hamilt::HContainer<TR>* hR_in,
                                       const UnitCell* ucell_in,
+                                      const std::vector<double>& orb_cutoff,
                                       Grid_Driver* GridD_in,
                                       const TwoCenterIntegrator* intor);
     ~NonlocalNew<OperatorLCAO<TK, TR>>();
@@ -56,6 +58,8 @@ class NonlocalNew<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
 
   private:
     const UnitCell* ucell = nullptr;
+
+    std::vector<double> orb_cutoff_;
 
     hamilt::HContainer<TR>* HR_fixed = nullptr;
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/overlap_new.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/overlap_new.cpp
@@ -5,6 +5,7 @@
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/operator_lcao.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer_funcs.h"
+#include <vector>
 
 template <typename TK, typename TR>
 hamilt::OverlapNew<hamilt::OperatorLCAO<TK, TR>>::OverlapNew(HS_Matrix_K<TK>* hsk_in,
@@ -12,9 +13,10 @@ hamilt::OverlapNew<hamilt::OperatorLCAO<TK, TR>>::OverlapNew(HS_Matrix_K<TK>* hs
                                                              hamilt::HContainer<TR>* hR_in,
                                                              hamilt::HContainer<TR>* SR_in,
                                                              const UnitCell* ucell_in,
+                                                             const std::vector<double>& orb_cutoff,
                                                              Grid_Driver* GridD_in,
                                                              const TwoCenterIntegrator* intor)
-    : hamilt::OperatorLCAO<TK, TR>(hsk_in, kvec_d_in, hR_in), intor_(intor)
+    : hamilt::OperatorLCAO<TK, TR>(hsk_in, kvec_d_in, hR_in), orb_cutoff_(orb_cutoff), intor_(intor)
 {
     this->cal_type = calculation_type::lcao_overlap;
     this->ucell = ucell_in;
@@ -53,12 +55,11 @@ void hamilt::OverlapNew<hamilt::OperatorLCAO<TK, TR>>::initialize_SR(Grid_Driver
             }
             const ModuleBase::Vector3<int>& R_index = adjs.box[ad];
             // choose the real adjacent atoms
-            const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
             // Note: the distance of atoms should less than the cutoff radius,
             // When equal, the theoretical value of matrix element is zero,
             // but the calculated value is not zero due to the numerical error, which would lead to result changes.
             if (this->ucell->cal_dtau(iat1, iat2, R_index).norm() * this->ucell->lat0
-                >= orb.Phi[T1].getRcut() + orb.Phi[T2].getRcut())
+                >= orb_cutoff_[T1] + orb_cutoff_[T2])
             {
                 continue;
             }

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/overlap_new.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/overlap_new.h
@@ -6,6 +6,7 @@
 #include "module_cell/unitcell.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/operator_lcao/operator_lcao.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
+#include <vector>
 
 namespace hamilt
 {
@@ -41,6 +42,7 @@ class OverlapNew<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                                      hamilt::HContainer<TR>* hR_in,
                                      hamilt::HContainer<TR>* SR_in,
                                      const UnitCell* ucell_in,
+                                     const std::vector<double>& orb_cutoff,
                                      Grid_Driver* GridD_in,
                                      const TwoCenterIntegrator* intor);
 
@@ -52,6 +54,8 @@ class OverlapNew<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
 
   private:
     const UnitCell* ucell = nullptr;
+
+    std::vector<double> orb_cutoff_;
 
     hamilt::HContainer<TR>* SR = nullptr;
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_ekinetic_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_ekinetic_lcao.cpp
@@ -18,9 +18,10 @@ TDEkinetic<OperatorLCAO<TK, TR>>::TDEkinetic(HS_Matrix_K<TK>* hsk_in,
                                              hamilt::HContainer<TR>* hR_in,
                                              const K_Vectors* kv_in,
                                              const UnitCell* ucell_in,
+                                             const std::vector<double>& orb_cutoff,
                                              Grid_Driver* GridD_in,
                                              const TwoCenterIntegrator* intor)
-    : kv(kv_in), OperatorLCAO<TK, TR>(hsk_in, kv_in->kvec_d, hR_in), intor_(intor)
+    : OperatorLCAO<TK, TR>(hsk_in, kv_in->kvec_d, hR_in), orb_cutoff_(orb_cutoff), kv(kv_in), intor_(intor)
 {
     this->ucell = ucell_in;
     this->cal_type = calculation_type::lcao_tddft_velocity;
@@ -131,7 +132,6 @@ void TDEkinetic<OperatorLCAO<TK, TR>>::cal_HR_IJR(const int& iat1,
                                                   std::complex<double>* hr_mat_p,
                                                   std::complex<double>** current_mat_p)
 {
-    const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
     // ---------------------------------------------
     // get info of orbitals of atom1 and atom2 from ucell
     // ---------------------------------------------
@@ -276,12 +276,11 @@ void TDEkinetic<OperatorLCAO<TK, TR>>::initialize_HR(Grid_Driver* GridD)
             }
             const ModuleBase::Vector3<int>& R_index2 = adjs.box[ad1];
             // choose the real adjacent atoms
-            const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
             // Note: the distance of atoms should less than the cutoff radius,
             // When equal, the theoretical value of matrix element is zero,
             // but the calculated value is not zero due to the numerical error, which would lead to result changes.
             if (this->ucell->cal_dtau(iat1, iat2, R_index2).norm() * this->ucell->lat0
-                < orb.Phi[T1].getRcut() + orb.Phi[T2].getRcut())
+                < orb_cutoff_[T1] + orb_cutoff_[T2])
             {
                 is_adj[ad1] = true;
             }

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_ekinetic_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_ekinetic_lcao.h
@@ -7,6 +7,7 @@
 #include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
 #include "module_hamilt_lcao/module_tddft/td_velocity.h"
 #include "operator_lcao.h"
+#include <vector>
 
 
 namespace hamilt
@@ -38,6 +39,7 @@ class TDEkinetic<OperatorLCAO<TK,TR>> : public OperatorLCAO<TK, TR>
                                  hamilt::HContainer<TR>* hR_in,
                                  const K_Vectors* kv_in,
                                  const UnitCell* ucell_in,
+                                 const std::vector<double>& orb_cutoff,
                                  Grid_Driver* GridD_in,
                                  const TwoCenterIntegrator* intor);
     ~TDEkinetic();
@@ -82,6 +84,7 @@ class TDEkinetic<OperatorLCAO<TK,TR>> : public OperatorLCAO<TK, TR>
 
   private:
     const UnitCell* ucell = nullptr;
+    std::vector<double> orb_cutoff_;
     
     HContainer<TR>* SR = nullptr;
     /// @brief Store real space hamiltonian. TD term should include imaginary part, thus it has to be complex type. Only shared between TD operators.

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_nonlocal_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/td_nonlocal_lcao.h
@@ -38,6 +38,7 @@ class TDNonlocal<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                                      const std::vector<ModuleBase::Vector3<double>>& kvec_d_in,
                                      hamilt::HContainer<TR>* hR_in,
                                      const UnitCell* ucell_in,
+                                     const LCAO_Orbitals& orb,
                                      Grid_Driver* GridD_in);
     ~TDNonlocal<OperatorLCAO<TK, TR>>();
 
@@ -52,6 +53,7 @@ class TDNonlocal<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
 
   private:
     const UnitCell* ucell = nullptr;
+    const LCAO_Orbitals& orb_;
 
     HContainer<TR>* HR = nullptr;
     /// @brief Store real space hamiltonian. TD term should include imaginary part, thus it has to be complex type. Only

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_T_NL_cd.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_T_NL_cd.cpp
@@ -141,6 +141,7 @@ TEST_F(TNLTest, testTVNLcd2cd)
                                                                                                     kvec_d_in,
                                                                                                     HR,
                                                                                                     &ucell,
+                                                                                                    {1.0},
                                                                                                     &gd,
                                                                                                     &intor_);
     hamilt::Operator<std::complex<double>>* op1
@@ -148,6 +149,7 @@ TEST_F(TNLTest, testTVNLcd2cd)
                                                                                                     kvec_d_in,
                                                                                                     HR,
                                                                                                     &ucell,
+                                                                                                    {1.0},
                                                                                                     &gd,
                                                                                                     &intor_);
     // merge two Operators to a chain

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_dftu.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_dftu.cpp
@@ -153,8 +153,6 @@ TEST_F(DFTUTest, constructHRd2d)
     hamilt::HS_Matrix_K<double> hsk(paraV, true);
     hsk.set_zero_hk();
     Grid_Driver gd(0, 0);
-    // check some input values
-    EXPECT_EQ(LCAO_Orbitals::get_const_instance().Phi[0].getRcut(), 1.0);
     // reset HR and DMR
     const double factor = 1.0 / test_nw / test_nw / test_size / test_size;
     for (int i = 0; i < DMR->get_nnr(); i++)
@@ -164,7 +162,7 @@ TEST_F(DFTUTest, constructHRd2d)
     }
     std::chrono::high_resolution_clock::time_point start_time = std::chrono::high_resolution_clock::now();
     hamilt::DFTU<hamilt::OperatorLCAO<double, double>>
-        op(&hsk, kvec_d_in, HR, ucell, &gd, &intor_, &GlobalC::dftu);
+        op(&hsk, kvec_d_in, HR, ucell, &gd, &intor_, {1.0}, &GlobalC::dftu);
     std::chrono::high_resolution_clock::time_point end_time = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> elapsed_time
         = std::chrono::duration_cast<std::chrono::duration<double>>(end_time - start_time);
@@ -221,7 +219,6 @@ TEST_F(DFTUTest, constructHRd2cd)
     hamilt::HS_Matrix_K<std::complex<double>> hsk(paraV, true);
     hsk.set_zero_hk();
     Grid_Driver gd(0, 0);
-    EXPECT_EQ(LCAO_Orbitals::get_const_instance().Phi[0].getRcut(), 1.0);
     // reset HR and DMR
     const double factor = 0.5 / test_nw / test_nw / test_size / test_size;
     for (int i = 0; i < DMR->get_nnr(); i++)
@@ -230,7 +227,7 @@ TEST_F(DFTUTest, constructHRd2cd)
         HR->get_wrapper()[i] = 0.0;
     }
     hamilt::DFTU<hamilt::OperatorLCAO<std::complex<double>, double>>
-        op(&hsk, kvec_d_in, HR, ucell, &gd, &intor_, &GlobalC::dftu);
+        op(&hsk, kvec_d_in, HR, ucell, &gd, &intor_, {1.0}, &GlobalC::dftu);
     op.contributeHR();
     // check the occupations of dftu for spin-up
     for (int iat = 0; iat < test_size; iat++)

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_ekineticnew.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_ekineticnew.cpp
@@ -108,7 +108,7 @@ TEST_F(EkineticNewTest, constructHRd2d)
     hsk.set_zero_hk();
     Grid_Driver gd(0, 0);
     hamilt::EkineticNew<hamilt::OperatorLCAO<double, double>>
-        op(&hsk, kvec_d_in, HR, &ucell, &gd, &intor_);
+        op(&hsk, kvec_d_in, HR, &ucell, {1.0}, &gd, &intor_);
     op.contributeHR();
     // check the value of HR
     for (int iap = 0; iap < HR->size_atom_pairs(); ++iap)
@@ -158,7 +158,7 @@ TEST_F(EkineticNewTest, constructHRd2cd)
     hsk.set_zero_hk();
     Grid_Driver gd(0, 0);
     hamilt::EkineticNew<hamilt::OperatorLCAO<std::complex<double>, double>>
-        op(&hsk, kvec_d_in, HR, &ucell, &gd, &intor_);
+        op(&hsk, kvec_d_in, HR, &ucell, {1.0}, &gd, &intor_);
     op.contributeHR();
     // check the value of HR
     for (int iap = 0; iap < HR->size_atom_pairs(); ++iap)

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_nonlocalnew.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_nonlocalnew.cpp
@@ -134,10 +134,9 @@ TEST_F(NonlocalNewTest, constructHRd2d)
     Grid_Driver gd(0, 0);
     // check some input values
     EXPECT_EQ(ucell.infoNL.Beta[0].get_rcut_max(), 1.0);
-    EXPECT_EQ(LCAO_Orbitals::get_const_instance().Phi[0].getRcut(), 1.0);
     std::chrono::high_resolution_clock::time_point start_time = std::chrono::high_resolution_clock::now();
     hamilt::NonlocalNew<hamilt::OperatorLCAO<double, double>>
-        op(&hsk, kvec_d_in, HR, &ucell, &gd, &intor_);
+        op(&hsk, kvec_d_in, HR, &ucell, {1.0}, &gd, &intor_);
     std::chrono::high_resolution_clock::time_point end_time = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> elapsed_time
         = std::chrono::duration_cast<std::chrono::duration<double>>(end_time - start_time);
@@ -207,7 +206,7 @@ TEST_F(NonlocalNewTest, constructHRd2cd)
     hsk.set_zero_hk();
     Grid_Driver gd(0, 0);
     hamilt::NonlocalNew<hamilt::OperatorLCAO<std::complex<double>, double>>
-        op(&hsk, kvec_d_in, HR, &ucell, &gd, &intor_);
+        op(&hsk, kvec_d_in, HR, &ucell, {1.0}, &gd, &intor_);
     op.contributeHR();
     // check the value of HR
     for (int iap = 0; iap < HR->size_atom_pairs(); ++iap)

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_overlapnew.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_overlapnew.cpp
@@ -108,7 +108,7 @@ TEST_F(OverlapNewTest, constructHRd2d)
     hsk.set_zero_sk();
     Grid_Driver gd(0, 0);
     hamilt::OverlapNew<hamilt::OperatorLCAO<double, double>>
-        op(&hsk, kvec_d_in, nullptr, SR, &ucell, &gd, &intor_);
+        op(&hsk, kvec_d_in, nullptr, SR, &ucell, {1.0}, &gd, &intor_);
     op.contributeHR();
     // check the value of SR
     for (int iap = 0; iap < SR->size_atom_pairs(); ++iap)
@@ -142,7 +142,7 @@ TEST_F(OverlapNewTest, constructHRd2cd)
     hsk.set_zero_sk();
     Grid_Driver gd(0, 0);
     hamilt::OverlapNew<hamilt::OperatorLCAO<std::complex<double>, double>>
-        op(&hsk, kvec_d_in, nullptr, SR, &ucell, &gd, &intor_);
+        op(&hsk, kvec_d_in, nullptr, SR, &ucell, {1.0}, &gd, &intor_);
     op.contributeHR();
     // check the value of SR
     for (int iap = 0; iap < SR->size_atom_pairs(); ++iap)

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_overlapnew_cd.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_overlapnew_cd.cpp
@@ -108,7 +108,7 @@ TEST_F(OverlapNewTest, constructHRcd2cd)
     hsk.set_zero_sk();
     Grid_Driver gd(0, 0);
     hamilt::OverlapNew<hamilt::OperatorLCAO<std::complex<double>, std::complex<double>>>
-        op(&hsk, kvec_d_in, nullptr, SR, &ucell, &gd, &intor_);
+        op(&hsk, kvec_d_in, nullptr, SR, &ucell, {1.0}, &gd, &intor_);
     op.contributeHR();
     // check the value of SR
     for (int iap = 0; iap < SR->size_atom_pairs(); ++iap)

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/tmp_mocks.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/tmp_mocks.cpp
@@ -147,10 +147,6 @@ void TwoCenterIntegrator::snap(
 }
 
 #include "module_basis/module_ao/ORB_read.h"
-const LCAO_Orbitals& LCAO_Orbitals::get_const_instance() {
-    static LCAO_Orbitals instance;
-    return instance;
-}
 LCAO_Orbitals::LCAO_Orbitals() { this->Phi = new Numerical_Orbital[1]; }
 LCAO_Orbitals::~LCAO_Orbitals() { delete[] Phi; }
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/veff_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/veff_lcao.cpp
@@ -38,12 +38,11 @@ void Veff<OperatorLCAO<TK, TR>>::initialize_HR(const UnitCell* ucell_in,
             }
             const ModuleBase::Vector3<int>& R_index2 = adjs.box[ad1];
             // choose the real adjacent atoms
-            const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
             // Note: the distance of atoms should less than the cutoff radius, 
             // When equal, the theoretical value of matrix element is zero, 
             // but the calculated value is not zero due to the numerical error, which would lead to result changes.
             if (ucell_in->cal_dtau(iat1, iat2, R_index2).norm() * ucell_in->lat0
-                < orb.Phi[T1].getRcut() + orb.Phi[T2].getRcut())
+                < orb_cutoff_[T1] + orb_cutoff_[T2])
             {
                 hamilt::AtomPair<TR> tmp(iat1, iat2, R_index2, paraV);
                 this->hR->insert_pair(tmp);

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/veff_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/veff_lcao.h
@@ -7,6 +7,7 @@
 #include "operator_lcao.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
 #include "module_cell/unitcell.h"
+#include <vector>
 
 namespace hamilt
 {
@@ -40,8 +41,9 @@ class Veff<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                                elecstate::Potential* pot_in,
                                hamilt::HContainer<TR>* hR_in,
                                const UnitCell* ucell_in,
+                               const std::vector<double>& orb_cutoff,
                                Grid_Driver* GridD_in)
-        : GK(GK_in), pot(pot_in), ucell(ucell_in),
+        : GK(GK_in), orb_cutoff_(orb_cutoff), pot(pot_in), ucell(ucell_in),
           gd(GridD_in), OperatorLCAO<TK, TR>(hsk_in, kvec_d_in, hR_in)
     {
         this->cal_type = calculation_type::lcao_gint;
@@ -59,8 +61,9 @@ class Veff<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                                elecstate::Potential* pot_in,
                                hamilt::HContainer<TR>* hR_in,
                                const UnitCell* ucell_in,
+                               const std::vector<double>& orb_cutoff,
                                Grid_Driver* GridD_in)
-        : GG(GG_in), pot(pot_in), OperatorLCAO<TK, TR>(hsk_in, kvec_d_in, hR_in)
+        : GG(GG_in), orb_cutoff_(orb_cutoff), pot(pot_in), OperatorLCAO<TK, TR>(hsk_in, kvec_d_in, hR_in)
     {
         this->cal_type = calculation_type::lcao_gint;
         this->initialize_HR(ucell_in, GridD_in);
@@ -86,6 +89,8 @@ class Veff<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
 
     // used for gamma only algorithms.
     Gint_Gamma* GG = nullptr;
+
+    std::vector<double> orb_cutoff_;
 
     // Charge calculating method in LCAO base and contained grid base calculation: DM_R, DM, pvpR_reduced
 

--- a/source/module_hamilt_lcao/module_tddft/td_current.h
+++ b/source/module_hamilt_lcao/module_tddft/td_current.h
@@ -17,6 +17,7 @@ class TD_current
     TD_current(const UnitCell* ucell_in,
                Grid_Driver* GridD_in,
                const Parallel_Orbitals* paraV,
+               const LCAO_Orbitals& orb,
                const TwoCenterIntegrator* intor);
     ~TD_current();
 
@@ -32,6 +33,8 @@ class TD_current
     const UnitCell* ucell = nullptr;
 
     const Parallel_Orbitals* paraV = nullptr;
+
+    const LCAO_Orbitals& orb_;
 
     Grid_Driver* Grid = nullptr;
     /// @brief Store real space hamiltonian. TD term should include imaginary part, thus it has to be complex type. Only shared between TD operators.

--- a/source/module_io/td_current_io.cpp
+++ b/source/module_io/td_current_io.cpp
@@ -122,6 +122,7 @@ void ModuleIO::write_current(const int istep,
                              const K_Vectors& kv,
                              const TwoCenterIntegrator* intor,
                              const Parallel_Orbitals* pv,
+                             const LCAO_Orbitals& orb,
                              Record_adj& ra)
 {
 
@@ -131,7 +132,7 @@ void ModuleIO::write_current(const int istep,
     std::vector<hamilt::HContainer<std::complex<double>>*> current_term = {nullptr, nullptr, nullptr};
     if (!TD_Velocity::tddft_velocity)
     {
-        cal_current = new TD_current(&GlobalC::ucell, &GlobalC::GridD, pv, intor);
+        cal_current = new TD_current(&GlobalC::ucell, &GlobalC::GridD, pv, orb, intor);
         cal_current->calculate_vcomm_r();
         cal_current->calculate_grad_term();
         for (int dir = 0; dir < 3; dir++)

--- a/source/module_io/td_current_io.h
+++ b/source/module_io/td_current_io.h
@@ -16,6 +16,7 @@ void write_current(const int istep,
                    const K_Vectors& kv,
                    const TwoCenterIntegrator* intor,
                    const Parallel_Orbitals* pv,
+                   const LCAO_Orbitals& orb,
                    Record_adj& ra);
 
 /// @brief calculate sum_n[𝜌_(𝑛𝑘,𝜇𝜈)] for current calculation

--- a/source/module_io/write_eband_terms.hpp
+++ b/source/module_io/write_eband_terms.hpp
@@ -23,6 +23,7 @@ namespace ModuleIO
         const K_Vectors& kv,
         const ModuleBase::matrix& wg,
         Grid_Driver& gd,
+        const std::vector<double>& orb_cutoff,
         const TwoCenterBundle& two_center_bundle
 #ifdef __EXX
         , std::vector<std::map<int, std::map<TAC, RI::Tensor<double>>>>* Hexxd = nullptr
@@ -60,7 +61,7 @@ namespace ModuleIO
             hamilt::HContainer<TR> kinetic_R_ao(pv);
             if_gamma_fix(kinetic_R_ao);
             hamilt::EkineticNew<hamilt::OperatorLCAO<TK, TR>> kinetic_op(&kinetic_k_ao, kv.kvec_d,
-                &kinetic_R_ao, &ucell, &gd, two_center_bundle.kinetic_orb.get());
+                &kinetic_R_ao, &ucell, orb_cutoff, &gd, two_center_bundle.kinetic_orb.get());
             kinetic_op.contributeHR();
             std::vector<std::vector<double>> e_orb_kinetic;
             for (int ik = 0;ik < kv.get_nks();++ik)
@@ -86,7 +87,7 @@ namespace ModuleIO
             hamilt::HContainer<TR> v_pp_local_R_ao(pv);
             if_gamma_fix(v_pp_local_R_ao);
             std::vector<std::vector<double>> e_orb_pp_local;
-            hamilt::Veff<hamilt::OperatorLCAO<TK, TR>> v_pp_local_op(gint, &v_pp_local_k_ao, kv.kvec_d, &pot_local, &v_pp_local_R_ao, &ucell, &gd);
+            hamilt::Veff<hamilt::OperatorLCAO<TK, TR>> v_pp_local_op(gint, &v_pp_local_k_ao, kv.kvec_d, &pot_local, &v_pp_local_R_ao, &ucell, orb_cutoff, &gd);
             v_pp_local_op.contributeHR();
             for (int ik = 0;ik < kv.get_nks();++ik)
             {
@@ -109,7 +110,7 @@ namespace ModuleIO
             if_gamma_fix(v_pp_nonlocal_R_ao);
             std::vector<std::vector<double>> e_orb_pp_nonlocal;
             hamilt::NonlocalNew<hamilt::OperatorLCAO<TK, TR>> v_pp_nonlocal_op(&v_pp_nonlocal_k_ao, kv.kvec_d,
-                &v_pp_nonlocal_R_ao, &ucell, &gd, two_center_bundle.overlap_orb_beta.get());
+                &v_pp_nonlocal_R_ao, &ucell, orb_cutoff, &gd, two_center_bundle.overlap_orb_beta.get());
             v_pp_nonlocal_op.contributeHR();
             for (int ik = 0;ik < kv.get_nks();++ik)
             {
@@ -141,7 +142,7 @@ namespace ModuleIO
             for (int is = 0; is < nspin0; ++is)
             {
                 v_hartree_op[is] = new hamilt::Veff<hamilt::OperatorLCAO<TK, TR>>(gint,
-                    &v_hartree_k_ao, kv.kvec_d, &pot_hartree, &v_hartree_R_ao[is], &ucell, &gd);
+                    &v_hartree_k_ao, kv.kvec_d, &pot_hartree, &v_hartree_R_ao[is], &ucell, orb_cutoff, &gd);
                 v_hartree_op[is]->contributeHR();
             }
             std::vector<std::vector<double>> e_orb_hartree;
@@ -163,7 +164,7 @@ namespace ModuleIO
         // 5. xc (including exx)
         if (!PARAM.inp.out_mat_xc)  // avoid duplicate output
         {
-            write_Vxc<TK, TR>(nspin, nbasis, drank, pv, psi, ucell, sf, rho_basis, rhod_basis, vloc, chg, gint_gamma, gint_k, kv, wg, gd
+            write_Vxc<TK, TR>(nspin, nbasis, drank, pv, psi, ucell, sf, rho_basis, rhod_basis, vloc, chg, gint_gamma, gint_k, kv, orb_cutoff, wg, gd
 #ifdef __EXX
                 , Hexxd, Hexxc
 #endif

--- a/source/module_io/write_vxc.hpp
+++ b/source/module_io/write_vxc.hpp
@@ -195,6 +195,7 @@ void write_Vxc(const int nspin,
     Gint_Gamma& gint_gamma, // mohan add 2024-04-01
     Gint_k& gint_k,         // mohan add 2024-04-01
     const K_Vectors& kv,
+    const std::vector<double>& orb_cutoff,
     const ModuleBase::matrix& wg,
     Grid_Driver& gd
 #ifdef __EXX
@@ -242,6 +243,7 @@ void write_Vxc(const int nspin,
                                                                         potxc,
                                                                         &vxcs_R_ao[is],
                                                                         &ucell,
+                                                                        orb_cutoff,
                                                                         &gd);
 
         vxcs_op_ao[is]->contributeHR();

--- a/source/module_lr/esolver_lrtd_lcao.cpp
+++ b/source/module_lr/esolver_lrtd_lcao.cpp
@@ -200,7 +200,7 @@ LR::ESolver_LR<T, TR>::ESolver_LR(ModuleESolver::ESolver_KS_LCAO<T, TR>&& ks_sol
         } else    // construct C, V from scratch
         {
             this->exx_lri = std::make_shared<Exx_LRI<T>>(exx_info.info_ri);
-            this->exx_lri->init(MPI_COMM_WORLD, this->kv);
+            this->exx_lri->init(MPI_COMM_WORLD, this->kv, ks_sol.orb_);
             this->exx_lri->cal_exx_ions();
         }
     }
@@ -365,7 +365,7 @@ LR::ESolver_LR<T, TR>::ESolver_LR(const Input_para& inp, UnitCell& ucell) : inpu
     if ((xc_kernel == "hf" || xc_kernel == "hse") && this->input.lr_solver != "spectrum")
     {
         this->exx_lri = std::make_shared<Exx_LRI<T>>(exx_info.info_ri);
-        this->exx_lri->init(MPI_COMM_WORLD, this->kv);
+        this->exx_lri->init(MPI_COMM_WORLD, this->kv, orb);
         this->exx_lri->cal_exx_ions();
     }
     // else

--- a/source/module_lr/esolver_lrtd_lcao.cpp
+++ b/source/module_lr/esolver_lrtd_lcao.cpp
@@ -206,6 +206,7 @@ LR::ESolver_LR<T, TR>::ESolver_LR(ModuleESolver::ESolver_KS_LCAO<T, TR>&& ks_sol
     }
 #endif
     this->pelec = new elecstate::ElecStateLCAO<T>();
+    orb_cutoff_ = ks_sol.orb_.cutoffs();
 }
 
 template <typename T, typename TR>
@@ -242,6 +243,7 @@ LR::ESolver_LR<T, TR>::ESolver_LR(const Input_para& inp, UnitCell& ucell) : inpu
 
     LCAO_Orbitals orb;
     two_center_bundle_.to_LCAO_Orbitals(orb, inp.lcao_ecut, inp.lcao_dk, inp.lcao_dr, inp.lcao_rmax);
+    orb_cutoff_ = orb.cutoffs();
 
     this->set_dimension();
     //  setup 2d-block distribution for AO-matrix and KS wfc
@@ -388,7 +390,7 @@ void LR::ESolver_LR<T, TR>::runner(int istep, UnitCell& cell)
         for (int is = 0;is < nspin;++is)
         {
             if (nspin == 2) { std::cout << "Calculating " << spin_type[is] << " excitations" << std::endl; }
-            hamilt::Hamilt<T>* phamilt = new HamiltCasidaLR<T>(xc_kernel, nspin, this->nbasis, this->nocc, this->nvirt, this->ucell, GlobalC::GridD, this->psi_ks, this->eig_ks,
+            hamilt::Hamilt<T>* phamilt = new HamiltCasidaLR<T>(xc_kernel, nspin, this->nbasis, this->nocc, this->nvirt, this->ucell, orb_cutoff_, GlobalC::GridD, this->psi_ks, this->eig_ks,
 #ifdef __EXX
                 this->exx_lri, this->exx_info.info_global.hybrid_alpha,
 #endif

--- a/source/module_lr/esolver_lrtd_lcao.h
+++ b/source/module_lr/esolver_lrtd_lcao.h
@@ -50,6 +50,7 @@ namespace LR
     protected:
         const Input_para& input;
         const UnitCell& ucell;
+        std::vector<double> orb_cutoff_;
 
         // not to use ElecState because 2-particle state is quite different from 1-particle state.
         // implement a independent one (ExcitedState) to pack physical properties if needed.

--- a/source/module_lr/hamilt_casida.h
+++ b/source/module_lr/hamilt_casida.h
@@ -20,6 +20,7 @@ namespace LR
             const int& nocc,
             const int& nvirt,
             const UnitCell& ucell_in,
+            const std::vector<double>& orb_cutoff,
             Grid_Driver& gd_in,
             const psi::Psi<T>* psi_ks_in,
             const ModuleBase::matrix& eig_ks,
@@ -42,7 +43,7 @@ namespace LR
             this->ops = new OperatorLRDiag<T>(eig_ks, pX_in, nk, nocc, nvirt);
             //add Hxc operator
             OperatorLRHxc<T>* lr_hxc = new OperatorLRHxc<T>(nspin, naos, nocc, nvirt, psi_ks_in,
-                this->DM_trans, gint_in, pot_in, ucell_in, gd_in, kv_in, pX_in, pc_in, pmat_in);
+                this->DM_trans, gint_in, pot_in, ucell_in, orb_cutoff, gd_in, kv_in, pX_in, pc_in, pmat_in);
             this->ops->add(lr_hxc);
 #ifdef __EXX
             if (xc_kernel == "hf" || xc_kernel == "hse")

--- a/source/module_lr/operator_casida/operator_lr_hxc.h
+++ b/source/module_lr/operator_casida/operator_lr_hxc.h
@@ -23,6 +23,7 @@ namespace LR
             typename TGint<T>::type* gint_in,
             std::weak_ptr<PotHxcLR> pot_in,
             const UnitCell& ucell_in,
+            const std::vector<double>& orb_cutoff,
             Grid_Driver& gd_in,
             const K_Vectors& kv_in,
             Parallel_2D* pX_in,
@@ -30,7 +31,7 @@ namespace LR
             Parallel_Orbitals* pmat_in)
             : nspin(nspin), naos(naos), nocc(nocc), nvirt(nvirt),
             psi_ks(psi_ks_in), DM_trans(DM_trans_in), gint(gint_in), pot(pot_in),
-            ucell(ucell_in), gd(gd_in), kv(kv_in),
+            ucell(ucell_in), orb_cutoff_(orb_cutoff), gd(gd_in), kv(kv_in),
             pX(pX_in), pc(pc_in), pmat(pmat_in)
         {
             ModuleBase::TITLE("OperatorLRHxc", "OperatorLRHxc");
@@ -65,8 +66,7 @@ namespace LR
                     int iat2 = this->ucell.itia2iat(T2, I2);
                     if (pmat->get_row_size(iat1) <= 0 || pmat->get_col_size(iat2) <= 0) { continue; }
                     const ModuleBase::Vector3<int>& R_index = adjs.box[ad];
-                    const LCAO_Orbitals& orb = LCAO_Orbitals::get_const_instance();
-                    if (ucell.cal_dtau(iat1, iat2, R_index).norm() * this->ucell.lat0 >= orb.Phi[T1].getRcut() + orb.Phi[T2].getRcut()) { continue; }
+                    if (ucell.cal_dtau(iat1, iat2, R_index).norm() * this->ucell.lat0 >= orb_cutoff_[T1] + orb_cutoff_[T2]) { continue; }
                     hamilt::AtomPair<TR> tmp(iat1, iat2, R_index.x, R_index.y, R_index.z, pmat);
                     hR.insert_pair(tmp);
                 }
@@ -120,6 +120,7 @@ namespace LR
         typename TGint<T>::type* gint = nullptr;
 
         const UnitCell& ucell;
+        std::vector<double> orb_cutoff_;
         Grid_Driver& gd;
 
         bool tdm_sym = false; ///< whether transition density matrix is symmetric

--- a/source/module_ri/ABFs_Construct-PCA.cpp
+++ b/source/module_ri/ABFs_Construct-PCA.cpp
@@ -42,10 +42,13 @@ namespace PCA
 		ModuleBase::TITLE("ABFs_Construct::PCA::get_sub_matrix");		
 		assert(m.shape.size() == 3);
 		RI::Tensor<double> m_sub({ m.shape[0], m.shape[1], range[T][L].N });
-		for (std::size_t ir=0; ir!=m.shape[0]; ++ir)
-			for (std::size_t jr=0; jr!=m.shape[1]; ++jr)
-				for (std::size_t N=0; N!=range[T][L].N; ++N)
+		for (std::size_t ir=0; ir!=m.shape[0]; ++ir) {
+			for (std::size_t jr=0; jr!=m.shape[1]; ++jr) {
+				for (std::size_t N=0; N!=range[T][L].N; ++N) {
 					m_sub(ir, jr, N) = m(ir, jr, index[T][L][N][0]);
+}
+}
+}
 		m_sub = m_sub.reshape({ m.shape[0] * m.shape[1], range[T][L].N });
 		return m_sub;
 	}
@@ -57,11 +60,13 @@ namespace PCA
 		for( std::size_t ic=0; ic!=m.shape[1]; ++ic )
 		{
 			double sum=0;
-			for( std::size_t ir=0; ir!=m.shape[0]; ++ir )
+			for( std::size_t ir=0; ir!=m.shape[0]; ++ir ) {
 				sum += m(ir,ic);
+}
 			const double mean = sum/m.shape[0];
-			for( std::size_t ir=0; ir!=m.shape[0]; ++ir )
+			for( std::size_t ir=0; ir!=m.shape[0]; ++ir ) {
 				m_new(ir,ic) = m(ir,ic) - mean;
+}
 		}
 		return m_new;
 	}
@@ -86,16 +91,18 @@ namespace PCA
 
 		const int Lmax_bak = GlobalC::exx_info.info_ri.abfs_Lmax;
 		GlobalC::exx_info.info_ri.abfs_Lmax = std::numeric_limits<int>::min();
-		for( std::size_t T=0; T!=abfs.size(); ++T )
+		for( std::size_t T=0; T!=abfs.size(); ++T ) {
 			GlobalC::exx_info.info_ri.abfs_Lmax = std::max( GlobalC::exx_info.info_ri.abfs_Lmax, static_cast<int>(abfs[T].size())-1 );
+}
 
 		Matrix_Orbs21 m_abfslcaos_lcaos;
 		m_abfslcaos_lcaos.init( 1, orb, kmesh_times, 1 );
 		m_abfslcaos_lcaos.init_radial( abfs, lcaos, lcaos );
 
 		std::map<std::size_t,std::map<std::size_t,std::set<double>>> delta_R;
-		for( std::size_t it=0; it!=abfs.size(); ++it )
+		for( std::size_t it=0; it!=abfs.size(); ++it ) {
 			delta_R[it][it] = {0.0};
+}
 		m_abfslcaos_lcaos.init_radial_table(delta_R);
 
 		GlobalC::exx_info.info_ri.abfs_Lmax = Lmax_bak;
@@ -133,10 +140,11 @@ namespace PCA
 						{
 							for (int ic = 0; ic != m.shape[1]; ++ic)
 							{
-								if (std::abs(m(ir, ic)) > threshold)
+								if (std::abs(m(ir, ic)) > threshold) {
 									os << m(ir, ic) << "\t";
-								else
+								} else {
 									os << 0 << "\t";
+}
 							}
 							os << std::endl;
 						}

--- a/source/module_ri/ABFs_Construct-PCA.cpp
+++ b/source/module_ri/ABFs_Construct-PCA.cpp
@@ -67,6 +67,7 @@ namespace PCA
 	}
 
 	std::vector<std::vector<std::pair<std::vector<double>, RI::Tensor<double>>>> cal_PCA(
+        const LCAO_Orbitals& orb,
 		const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &lcaos, 
 		const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &abfs,
 		const double kmesh_times )
@@ -89,7 +90,7 @@ namespace PCA
 			GlobalC::exx_info.info_ri.abfs_Lmax = std::max( GlobalC::exx_info.info_ri.abfs_Lmax, static_cast<int>(abfs[T].size())-1 );
 
 		Matrix_Orbs21 m_abfslcaos_lcaos;
-		m_abfslcaos_lcaos.init( 1, kmesh_times, 1 );
+		m_abfslcaos_lcaos.init( 1, orb, kmesh_times, 1 );
 		m_abfslcaos_lcaos.init_radial( abfs, lcaos, lcaos );
 
 		std::map<std::size_t,std::map<std::size_t,std::set<double>>> delta_R;

--- a/source/module_ri/ABFs_Construct-PCA.h
+++ b/source/module_ri/ABFs_Construct-PCA.h
@@ -1,7 +1,7 @@
 #ifndef ABFS_CONSTRUCT_PCA_H
 #define ABFS_CONSTRUCT_PCA_H
 
-#include "../module_basis/module_ao/ORB_atomic_lm.h"
+#include "../module_basis/module_ao/ORB_read.h"
 #include <vector>
 #include <RI/global/Tensor.h>
 
@@ -15,6 +15,7 @@ namespace ABFs_Construct
 namespace PCA
 {
 	extern std::vector<std::vector<std::pair<std::vector<double>,RI::Tensor<double>>>> cal_PCA( 
+        const LCAO_Orbitals &orb,
 		const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &lcaos, 
 		const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &abfs,		// abfs must be orthonormal
 		const double kmesh_times );

--- a/source/module_ri/Exx_LRI.h
+++ b/source/module_ri/Exx_LRI.h
@@ -54,7 +54,7 @@ public:
     Exx_LRI operator=(Exx_LRI&&);
 
 
-	void init(const MPI_Comm &mpi_comm_in, const K_Vectors &kv_in);
+	void init(const MPI_Comm &mpi_comm_in, const K_Vectors &kv_in, const LCAO_Orbitals& orb);
 	void cal_exx_force();
     void cal_exx_stress();
     std::vector<std::vector<int>> get_abfs_nchis() const;
@@ -69,6 +69,7 @@ private:
 	const Exx_Info::Exx_Info_RI &info;
 	MPI_Comm mpi_comm;
 	const K_Vectors *p_kv = nullptr;
+    std::vector<double> orb_cutoff_;
 
 	std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> lcaos;
 	std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> abfs;

--- a/source/module_ri/Exx_LRI_interface.h
+++ b/source/module_ri/Exx_LRI_interface.h
@@ -49,7 +49,7 @@ public:
 
     // Processes in ESolver_KS_LCAO
     /// @brief in beforescf: set xc type, opt_orb, do DM mixing
-    void exx_beforescf(const K_Vectors& kv, const Charge_Mixing& chgmix, const UnitCell& ucell, const Parallel_2D& pv);
+    void exx_beforescf(const K_Vectors& kv, const Charge_Mixing& chgmix, const UnitCell& ucell, const Parallel_2D& pv, const LCAO_Orbitals& orb);
 
     /// @brief in eachiterinit:  do DM mixing and calculate Hexx when entering 2nd SCF
     void exx_eachiterinit(const elecstate::DensityMatrix<T, double>& dm/**< double should be Tdata if complex-PBE-DM is supported*/,

--- a/source/module_ri/Exx_LRI_interface.hpp
+++ b/source/module_ri/Exx_LRI_interface.hpp
@@ -37,7 +37,7 @@ void Exx_LRI_Interface<T, Tdata>::read_Hexxs_cereal(const std::string& file_name
 }
 
 template<typename T, typename Tdata>
-void Exx_LRI_Interface<T, Tdata>::exx_beforescf(const K_Vectors& kv, const Charge_Mixing& chgmix, const UnitCell& ucell, const Parallel_2D& pv)
+void Exx_LRI_Interface<T, Tdata>::exx_beforescf(const K_Vectors& kv, const Charge_Mixing& chgmix, const UnitCell& ucell, const Parallel_2D& pv, const LCAO_Orbitals& orb)
 {
 #ifdef __MPI
     if (GlobalC::exx_info.info_global.cal_exx)
@@ -72,7 +72,7 @@ void Exx_LRI_Interface<T, Tdata>::exx_beforescf(const K_Vectors& kv, const Charg
 		{
 			//program should be stopped after this judgement
 			Exx_Opt_Orb exx_opt_orb;
-			exx_opt_orb.generate_matrix(kv);
+			exx_opt_orb.generate_matrix(kv, orb);
 			ModuleBase::timer::tick("ESolver_KS_LCAO", "beforescf");
 			return;
 		}

--- a/source/module_ri/LRI_CV.h
+++ b/source/module_ri/LRI_CV.h
@@ -34,6 +34,7 @@ public:
 	~LRI_CV();
 
 	void set_orbitals(
+        const LCAO_Orbitals& orb,
 		const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &lcaos_in,
 		const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &abfs_in,
 		const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &abfs_ccp_in,
@@ -59,6 +60,7 @@ public:
 	size_t get_index_abfs_size(const size_t &iat){return this->index_abfs[iat].count_size; }
 
 private:
+    std::vector<double> orb_cutoff_;
 	std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> lcaos;
 	std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> abfs;
 	std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> abfs_ccp;

--- a/source/module_ri/LRI_CV_Tools.h
+++ b/source/module_ri/LRI_CV_Tools.h
@@ -78,7 +78,7 @@ namespace LRI_CV_Tools
 		std::map<TkeyA,std::map<TkeyB,std::array<Tvalue,N>>> && ds_in);
 
 	template<typename Tcell>
-	extern std::array<Tcell,3> cal_latvec_range(const double &rcut_times);
+	extern std::array<Tcell,3> cal_latvec_range(const double &rcut_times, const std::vector<double>& orb_cutoff);
 
 	template<typename TA, typename Tcell, typename Tdata>
 	extern std::map<int,std::map<int,std::map<Abfs::Vector3_Order<double>,RI::Tensor<Tdata>>>>

--- a/source/module_ri/LRI_CV_Tools.hpp
+++ b/source/module_ri/LRI_CV_Tools.hpp
@@ -245,11 +245,11 @@ LRI_CV_Tools::change_order(std::map<TkeyA,std::map<TkeyB,std::array<Tvalue,N>>> 
 
 template<typename Tcell>
 std::array<Tcell,3>
-LRI_CV_Tools::cal_latvec_range(const double &rcut_times)
+LRI_CV_Tools::cal_latvec_range(const double &rcut_times, const std::vector<double>& orb_cutoff)
 {
 	double Rcut_max = 0;
 	for(int T=0; T<GlobalC::ucell.ntype; ++T)
-		Rcut_max = std::max(Rcut_max, GlobalC::ORB.Phi[T].getRcut());
+		Rcut_max = std::max(Rcut_max, orb_cutoff[T]);
 	const ModuleBase::Vector3<double> proj = ModuleBase::Mathzone::latvec_projection(
 		std::array<ModuleBase::Vector3<double>,3>{GlobalC::ucell.a1, GlobalC::ucell.a2, GlobalC::ucell.a3});
 	const ModuleBase::Vector3<double> latvec_times = Rcut_max * rcut_times / (proj * GlobalC::ucell.lat0);

--- a/source/module_ri/Matrix_Orbs11.cpp
+++ b/source/module_ri/Matrix_Orbs11.cpp
@@ -56,15 +56,21 @@ void Matrix_Orbs11::init_radial(const std::vector<std::vector<std::vector<Numeri
 {
     ModuleBase::TITLE("Matrix_Orbs11", "init_radial");
     ModuleBase::timer::tick("Matrix_Orbs11", "init_radial");
-    for (size_t TA = 0; TA != orb_A.size(); ++TA)
-        for (size_t TB = 0; TB != orb_B.size(); ++TB)
-            for (int LA = 0; LA != orb_A[TA].size(); ++LA)
-                for (size_t NA = 0; NA != orb_A[TA][LA].size(); ++NA)
-                    for (int LB = 0; LB != orb_B[TB].size(); ++LB)
-                        for (size_t NB = 0; NB != orb_B[TB][LB].size(); ++NB)
+    for (size_t TA = 0; TA != orb_A.size(); ++TA) {
+        for (size_t TB = 0; TB != orb_B.size(); ++TB) {
+            for (int LA = 0; LA != orb_A[TA].size(); ++LA) {
+                for (size_t NA = 0; NA != orb_A[TA][LA].size(); ++NA) {
+                    for (int LB = 0; LB != orb_B[TB].size(); ++LB) {
+                        for (size_t NB = 0; NB != orb_B[TB][LB].size(); ++NB) {
                             center2_orb11_s[TA][TB][LA][NA][LB].insert(std::make_pair(
                                 NB,
                                 Center2_Orb::Orb11(orb_A[TA][LA][NA], orb_B[TB][LB][NB], psb_, this->MGT)));
+}
+}
+}
+}
+}
+}
     ModuleBase::timer::tick("Matrix_Orbs11", "init_radial");
 }
 
@@ -72,18 +78,24 @@ void Matrix_Orbs11::init_radial(const LCAO_Orbitals& orb_A, const LCAO_Orbitals&
 {
     ModuleBase::TITLE("Matrix_Orbs11", "init_radial");
     ModuleBase::timer::tick("Matrix_Orbs11", "init_radial");
-    for (size_t TA = 0; TA != orb_A.get_ntype(); ++TA)
-        for (size_t TB = 0; TB != orb_B.get_ntype(); ++TB)
-            for (int LA = 0; LA <= orb_A.Phi[TA].getLmax(); ++LA)
-                for (size_t NA = 0; NA != orb_A.Phi[TA].getNchi(LA); ++NA)
-                    for (int LB = 0; LB <= orb_B.Phi[TB].getLmax(); ++LB)
-                        for (size_t NB = 0; NB != orb_B.Phi[TB].getNchi(LB); ++NB)
+    for (size_t TA = 0; TA != orb_A.get_ntype(); ++TA) {
+        for (size_t TB = 0; TB != orb_B.get_ntype(); ++TB) {
+            for (int LA = 0; LA <= orb_A.Phi[TA].getLmax(); ++LA) {
+                for (size_t NA = 0; NA != orb_A.Phi[TA].getNchi(LA); ++NA) {
+                    for (int LB = 0; LB <= orb_B.Phi[TB].getLmax(); ++LB) {
+                        for (size_t NB = 0; NB != orb_B.Phi[TB].getNchi(LB); ++NB) {
                             center2_orb11_s[TA][TB][LA][NA][LB].insert(
                                 std::make_pair(NB,
                                                Center2_Orb::Orb11(orb_A.Phi[TA].PhiLN(LA, NA),
                                                                   orb_B.Phi[TB].PhiLN(LB, NB),
                                                                   psb_,
                                                                   this->MGT)));
+}
+}
+}
+}
+}
+}
     ModuleBase::timer::tick("Matrix_Orbs11", "init_radial");
 }
 
@@ -91,13 +103,19 @@ void Matrix_Orbs11::init_radial_table()
 {
     ModuleBase::TITLE("Matrix_Orbs11", "init_radial_table");
     ModuleBase::timer::tick("Matrix_Orbs11", "init_radial_table");
-    for (auto& coA: center2_orb11_s)
-        for (auto& coB: coA.second)
-            for (auto& coC: coB.second)
-                for (auto& coD: coC.second)
-                    for (auto& coE: coD.second)
-                        for (auto& coF: coE.second)
+    for (auto& coA: center2_orb11_s) {
+        for (auto& coB: coA.second) {
+            for (auto& coC: coB.second) {
+                for (auto& coD: coC.second) {
+                    for (auto& coE: coD.second) {
+                        for (auto& coF: coE.second) {
                             coF.second.init_radial_table();
+}
+}
+}
+}
+}
+}
     ModuleBase::timer::tick("Matrix_Orbs11", "init_radial_table");
 }
 
@@ -105,7 +123,7 @@ void Matrix_Orbs11::init_radial_table(const std::map<size_t, std::map<size_t, st
 {
     ModuleBase::TITLE("Matrix_Orbs11", "init_radial_table_Rs");
     ModuleBase::timer::tick("Matrix_Orbs11", "init_radial_table");
-    for (const auto& RsA: Rs)
+    for (const auto& RsA: Rs) {
         for (const auto& RsB: RsA.second)
         {
             if (auto* const center2_orb11_sAB = static_cast<
@@ -117,15 +135,21 @@ void Matrix_Orbs11::init_radial_table(const std::map<size_t, std::map<size_t, st
                 {
                     const double position = R * GlobalC::ucell.lat0 / lcao_dr_;
                     const size_t iq = static_cast<size_t>(position);
-                    for (size_t i = 0; i != 4; ++i)
+                    for (size_t i = 0; i != 4; ++i) {
                         radials.insert(iq + i);
+}
                 }
-                for (auto& coC: *center2_orb11_sAB)
-                    for (auto& coD: coC.second)
-                        for (auto& coE: coD.second)
-                            for (auto& coF: coE.second)
+                for (auto& coC: *center2_orb11_sAB) {
+                    for (auto& coD: coC.second) {
+                        for (auto& coE: coD.second) {
+                            for (auto& coF: coE.second) {
                                 coF.second.init_radial_table(radials);
+}
+}
+}
+}
             }
         }
+}
     ModuleBase::timer::tick("Matrix_Orbs11", "init_radial_table");
 }

--- a/source/module_ri/Matrix_Orbs11.cpp
+++ b/source/module_ri/Matrix_Orbs11.cpp
@@ -9,24 +9,24 @@
 #include "module_base/tool_title.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
 
-void Matrix_Orbs11::init(const int mode, const double kmesh_times, const double rmesh_times)
+void Matrix_Orbs11::init(const int mode, const LCAO_Orbitals& orb, const double kmesh_times, const double rmesh_times)
 {
     ModuleBase::TITLE("Matrix_Orbs11", "init");
     ModuleBase::timer::tick("Matrix_Orbs11", "init");
 
     int Lmax_used, Lmax;
 
-    const int ntype = GlobalC::ORB.get_ntype();
+    const int ntype = orb.get_ntype();
     int lmax_orb = -1, lmax_beta = -1;
     for (int it = 0; it < ntype; it++)
     {
-        lmax_orb = std::max(lmax_orb, GlobalC::ORB.Phi[it].getLmax());
+        lmax_orb = std::max(lmax_orb, orb.Phi[it].getLmax());
         lmax_beta = std::max(lmax_beta, GlobalC::ucell.infoNL.Beta[it].getLmax());
     }
-    const double dr = GlobalC::ORB.get_dR();
-    const double dk = GlobalC::ORB.get_dk();
-    const int kmesh = GlobalC::ORB.get_kmesh() * kmesh_times + 1;
-    int Rmesh = static_cast<int>(GlobalC::ORB.get_Rmax() * rmesh_times / dr) + 4;
+    const double dr = orb.get_dR();
+    const double dk = orb.get_dk();
+    const int kmesh = orb.get_kmesh() * kmesh_times + 1;
+    int Rmesh = static_cast<int>(orb.get_Rmax() * rmesh_times / dr) + 4;
     Rmesh += 1 - Rmesh % 2;
 
     Center2_Orb::init_Table_Spherical_Bessel(2,

--- a/source/module_ri/Matrix_Orbs11.h
+++ b/source/module_ri/Matrix_Orbs11.h
@@ -25,6 +25,7 @@ class Matrix_Orbs11
     //    1: <lcaos|lcaos>
     //    2: <jYs|jYs>  <abfs|abfs>
     void init(const int mode,
+              const LCAO_Orbitals& orb,
               const double kmesh_times,  // extend Kcut, keep dK
               const double rmesh_times); // extend Rcut, keep dR
 

--- a/source/module_ri/Matrix_Orbs21.cpp
+++ b/source/module_ri/Matrix_Orbs21.cpp
@@ -9,23 +9,23 @@
 #include "module_base/tool_title.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
 
-void Matrix_Orbs21::init(const int mode, const double kmesh_times, const double rmesh_times)
+void Matrix_Orbs21::init(const int mode, const LCAO_Orbitals& orb, const double kmesh_times, const double rmesh_times)
 {
     ModuleBase::TITLE("Matrix_Orbs21", "init");
     ModuleBase::timer::tick("Matrix_Orbs21", "init");
     int Lmax_used, Lmax;
 
-    const int ntype = GlobalC::ORB.get_ntype();
+    const int ntype = orb.get_ntype();
     int lmax_orb = -1, lmax_beta = -1;
     for (int it = 0; it < ntype; it++)
     {
-        lmax_orb = std::max(lmax_orb, GlobalC::ORB.Phi[it].getLmax());
+        lmax_orb = std::max(lmax_orb, orb.Phi[it].getLmax());
         lmax_beta = std::max(lmax_beta, GlobalC::ucell.infoNL.Beta[it].getLmax());
     }
-    const double dr = GlobalC::ORB.get_dR();
-    const double dk = GlobalC::ORB.get_dk();
-    const int kmesh = GlobalC::ORB.get_kmesh() * kmesh_times + 1;
-    int Rmesh = static_cast<int>(GlobalC::ORB.get_Rmax() * rmesh_times / dr) + 4;
+    const double dr = orb.get_dR();
+    const double dk = orb.get_dk();
+    const int kmesh = orb.get_kmesh() * kmesh_times + 1;
+    int Rmesh = static_cast<int>(orb.get_Rmax() * rmesh_times / dr) + 4;
     Rmesh += 1 - Rmesh % 2;
 
     Center2_Orb::init_Table_Spherical_Bessel(3,

--- a/source/module_ri/Matrix_Orbs21.h
+++ b/source/module_ri/Matrix_Orbs21.h
@@ -23,6 +23,7 @@ class Matrix_Orbs21
     // mode:
     //    1: <jYs lcaos|lcaos>  <abfs lcaos|lcaos>
     void init(const int mode,
+              const LCAO_Orbitals& orb,
               const double kmesh_times,  // extend Kcut, keep dK
               const double rmesh_times); // extend Rcut, keep dR
 

--- a/source/module_ri/Matrix_Orbs22.cpp
+++ b/source/module_ri/Matrix_Orbs22.cpp
@@ -9,23 +9,23 @@
 #include "module_base/tool_title.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
 
-void Matrix_Orbs22::init(const int mode, const double kmesh_times, const double rmesh_times)
+void Matrix_Orbs22::init(const int mode, const LCAO_Orbitals& orb, const double kmesh_times, const double rmesh_times)
 {
     ModuleBase::TITLE("Matrix_Orbs22", "init");
     ModuleBase::timer::tick("Matrix_Orbs22", "init");
     int Lmax_used, Lmax;
 
-    const int ntype = GlobalC::ORB.get_ntype();
+    const int ntype = orb.get_ntype();
     int lmax_orb = -1, lmax_beta = -1;
     for (int it = 0; it < ntype; it++)
     {
-        lmax_orb = std::max(lmax_orb, GlobalC::ORB.Phi[it].getLmax());
+        lmax_orb = std::max(lmax_orb, orb.Phi[it].getLmax());
         lmax_beta = std::max(lmax_beta, GlobalC::ucell.infoNL.Beta[it].getLmax());
     }
-    const double dr = GlobalC::ORB.get_dR();
-    const double dk = GlobalC::ORB.get_dk();
-    const int kmesh = GlobalC::ORB.get_kmesh() * kmesh_times + 1;
-    int Rmesh = static_cast<int>(GlobalC::ORB.get_Rmax() * rmesh_times / dr) + 4;
+    const double dr = orb.get_dR();
+    const double dk = orb.get_dk();
+    const int kmesh = orb.get_kmesh() * kmesh_times + 1;
+    int Rmesh = static_cast<int>(orb.get_Rmax() * rmesh_times / dr) + 4;
     Rmesh += 1 - Rmesh % 2;
 
     Center2_Orb::init_Table_Spherical_Bessel(4,

--- a/source/module_ri/Matrix_Orbs22.h
+++ b/source/module_ri/Matrix_Orbs22.h
@@ -23,6 +23,7 @@ class Matrix_Orbs22
     // mode:
     //    1: <lcaos lcaos|lcaos lcaos>
     void init(const int mode,
+              const LCAO_Orbitals& orb,
               const double kmesh_times,  // extend Kcut, keep dK
               const double rmesh_times); // extend Rcut, keep dR
 

--- a/source/module_ri/RPA_LRI.h
+++ b/source/module_ri/RPA_LRI.h
@@ -37,11 +37,12 @@ template <typename T, typename Tdata> class RPA_LRI
     {
     }
     ~RPA_LRI(){};
-    void init(const MPI_Comm &mpi_comm_in, const K_Vectors &kv_in);
+    void init(const MPI_Comm &mpi_comm_in, const K_Vectors &kv_in, const std::vector<double>& orb_cutoff);
     void cal_rpa_cv();
     void cal_postSCF_exx(const elecstate::DensityMatrix<T, Tdata>& dm,
         const MPI_Comm& mpi_comm_in,
-        const K_Vectors& kv);
+        const K_Vectors& kv,
+        const LCAO_Orbitals& orb);
     void out_for_RPA(const Parallel_Orbitals& parav,
         const psi::Psi<T>& psi,
         const elecstate::ElecState* pelec);
@@ -62,6 +63,8 @@ template <typename T, typename Tdata> class RPA_LRI
     const Exx_Info::Exx_Info_RI &info;
     const K_Vectors *p_kv=nullptr;
     MPI_Comm mpi_comm;
+    std::vector<double> orb_cutoff_;
+
     std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> lcaos;
     std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> abfs;
     std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> abfs_ccp;

--- a/source/module_ri/exx_abfs-construct_orbs.cpp
+++ b/source/module_ri/exx_abfs-construct_orbs.cpp
@@ -77,6 +77,7 @@ std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_
 
 // P = f * Y
 std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_Orbs::abfs_same_atom(
+    const LCAO_Orbitals& orb,
 	const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &orbs,
 	const double kmesh_times_mot,
 	const double times_threshold )
@@ -99,7 +100,7 @@ std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> Exx_Abfs::Construct_
 	#endif
 
 	const std::vector<std::vector<std::vector<std::vector<double>>>>
-		abfs_same_atom_pca_psi = pca( abfs_same_atom, orbs, kmesh_times_mot, times_threshold );
+		abfs_same_atom_pca_psi = pca( orb, abfs_same_atom, orbs, kmesh_times_mot, times_threshold );
 
 	#if TEST_EXX_LCAO==1
 		print_orbs(abfs_same_atom_pca_psi,"abfs_same_atom_pca_psi.dat");
@@ -255,6 +256,7 @@ std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_O
 }
 
 std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_Orbs::pca(
+    const LCAO_Orbitals& orb,
 	const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &abfs,
 	const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &orbs,
 	const double kmesh_times_mot,
@@ -264,7 +266,7 @@ std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_O
 		return std::vector<std::vector<std::vector<std::vector<double>>>>(abfs.size());
 
 	const std::vector<std::vector<std::pair<std::vector<double>,RI::Tensor<double>>>>
-		eig = ABFs_Construct::PCA::cal_PCA( orbs, abfs, kmesh_times_mot );
+		eig = ABFs_Construct::PCA::cal_PCA( orb, orbs, abfs, kmesh_times_mot );
 
 	const std::vector<std::vector<std::vector<std::vector<double>>>> psis = get_psi( abfs );
 	std::vector<std::vector<std::vector<std::vector<double>>>> psis_new( psis.size() );

--- a/source/module_ri/exx_abfs-construct_orbs.h
+++ b/source/module_ri/exx_abfs-construct_orbs.h
@@ -19,6 +19,7 @@ public:
 		const double kmesh_times );
 
 	static std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> abfs_same_atom( 
+        const LCAO_Orbitals& orb,
 		const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &lcaos,
 		const double kmesh_times_mot,
 		const double times_threshold=0);
@@ -40,6 +41,7 @@ private:
 		const double norm_threshold = std::numeric_limits<double>::min() );
 
 	static std::vector<std::vector<std::vector<std::vector<double>>>> pca(
+        const LCAO_Orbitals& orb,
 		const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &abfs,
 		const std::vector<std::vector<std::vector<Numerical_Orbital_Lm>>> &orbs,
 		const double kmesh_times_mot,

--- a/source/module_ri/exx_abfs-jle.cpp
+++ b/source/module_ri/exx_abfs-jle.cpp
@@ -12,7 +12,7 @@ int Exx_Abfs::Jle::Lmax = 2;
 double Exx_Abfs::Jle::Ecut_exx = 60;
 double Exx_Abfs::Jle::tolerence = 1.0e-12;	
 
-void Exx_Abfs::Jle::init_jle( const double kmesh_times )
+void Exx_Abfs::Jle::init_jle( const double kmesh_times, const LCAO_Orbitals& orb )
 {
 	jle.resize( GlobalC::ucell.ntype );
 
@@ -22,35 +22,35 @@ void Exx_Abfs::Jle::init_jle( const double kmesh_times )
 		for (int L=0; L <= Lmax ; ++L)
 		{
 			const size_t ecut_number 
-				= static_cast<size_t>( sqrt( Ecut_exx ) * GlobalC::ORB.Phi[T].getRcut() / ModuleBase::PI ); // Rydberg Unit.
+				= static_cast<size_t>( sqrt( Ecut_exx ) * orb.Phi[T].getRcut() / ModuleBase::PI ); // Rydberg Unit.
 
 			jle[T][L].resize( ecut_number );
 
 			std::vector<double> en(ecut_number, 0.0);
-			ModuleBase::Sphbes::Spherical_Bessel_Roots(ecut_number, L, tolerence, ModuleBase::GlobalFunc::VECTOR_TO_PTR(en), GlobalC::ORB.Phi[T].getRcut());
+			ModuleBase::Sphbes::Spherical_Bessel_Roots(ecut_number, L, tolerence, ModuleBase::GlobalFunc::VECTOR_TO_PTR(en), orb.Phi[T].getRcut());
 
 			for(size_t E=0; E!=ecut_number; ++E)
 			{
-				std::vector<double> jle_r( GlobalC::ORB.Phi[T].PhiLN(0,0).getNr() );
+				std::vector<double> jle_r( orb.Phi[T].PhiLN(0,0).getNr() );
 				ModuleBase::Sphbes::Spherical_Bessel(
-					GlobalC::ORB.Phi[T].PhiLN(0,0).getNr(), 
-					GlobalC::ORB.Phi[T].PhiLN(0,0).getRadial(), 
+					orb.Phi[T].PhiLN(0,0).getNr(), 
+					orb.Phi[T].PhiLN(0,0).getRadial(), 
 					en[E], 
 					L, 
 					ModuleBase::GlobalFunc::VECTOR_TO_PTR(jle_r));
 				jle[T][L][E].set_orbital_info(
-					GlobalC::ORB.Phi[T].PhiLN(0,0).getLabel(),
-					GlobalC::ORB.Phi[T].PhiLN(0,0).getType(),
+					orb.Phi[T].PhiLN(0,0).getLabel(),
+					orb.Phi[T].PhiLN(0,0).getType(),
 					L,
 					E,						// N?
-					GlobalC::ORB.Phi[T].PhiLN(0,0).getNr(),
-					GlobalC::ORB.Phi[T].PhiLN(0,0).getRab(),
-					GlobalC::ORB.Phi[T].PhiLN(0,0).getRadial(),
+					orb.Phi[T].PhiLN(0,0).getNr(),
+					orb.Phi[T].PhiLN(0,0).getRab(),
+					orb.Phi[T].PhiLN(0,0).getRadial(),
 					Numerical_Orbital_Lm::Psi_Type::Psi,
 					ModuleBase::GlobalFunc::VECTOR_TO_PTR(jle_r),
-					static_cast<int>(GlobalC::ORB.Phi[T].PhiLN(0,0).getNk() * kmesh_times) | 1,
-					GlobalC::ORB.Phi[T].PhiLN(0,0).getDk(),
-					GlobalC::ORB.Phi[T].PhiLN(0,0).getDruniform(),
+					static_cast<int>(orb.Phi[T].PhiLN(0,0).getNk() * kmesh_times) | 1,
+					orb.Phi[T].PhiLN(0,0).getDk(),
+					orb.Phi[T].PhiLN(0,0).getDruniform(),
 					false,
 					true, PARAM.inp.cal_force);
 			}

--- a/source/module_ri/exx_abfs-jle.h
+++ b/source/module_ri/exx_abfs-jle.h
@@ -4,7 +4,7 @@
 #include "exx_abfs.h"
 
 #include <vector>
-#include "../module_basis/module_ao/ORB_atomic_lm.h"
+#include "../module_basis/module_ao/ORB_read.h"
 
 class Exx_Abfs::Jle
 {
@@ -15,7 +15,7 @@ public:
 			std::vector<
 				Numerical_Orbital_Lm>>> jle;
 
-	void init_jle( const double kmesh_times );
+	void init_jle( const double kmesh_times, const LCAO_Orbitals& orb );
 
 	static bool generate_matrix;
 	static int Lmax;

--- a/source/module_ri/exx_opt_orb-print.cpp
+++ b/source/module_ri/exx_opt_orb-print.cpp
@@ -9,6 +9,7 @@ void Exx_Opt_Orb::print_matrix(
 	const std::vector<std::vector<RI::Tensor<double>>> &matrix_S,
 	const RI::Tensor<double> &matrix_V,
 	const size_t TA, const size_t IA, const size_t TB, const size_t IB,
+    const std::vector<double>& orb_cutoff,
 	const ModuleBase::Element_Basis_Index::Range &range_jles, 
 	const ModuleBase::Element_Basis_Index::IndexLNM &index_jles) const
 {
@@ -64,9 +65,9 @@ void Exx_Opt_Orb::print_matrix(
 		ofs << Exx_Abfs::Jle::Ecut_exx << " ecutwfc_jlq" << std::endl;//mohan modify 2009-09-08
 
 		if(TA==TB)
-			ofs << GlobalC::ORB.Phi[TA].getRcut() << " rcut_Jlq" << std::endl;
+			ofs << orb_cutoff[TA] << " rcut_Jlq" << std::endl;
 		else
-			ofs << GlobalC::ORB.Phi[TA].getRcut() << " " << GlobalC::ORB.Phi[TB].getRcut() << " rcut_Jlq" << std::endl;
+			ofs << orb_cutoff[TA] << " " << orb_cutoff[TB] << " rcut_Jlq" << std::endl;
 
 		// mohan add 'smooth' and 'smearing_sigma' 2009-08-28
 		ofs << 0 << " smooth" << std::endl;
@@ -90,8 +91,8 @@ void Exx_Opt_Orb::print_matrix(
 		const size_t nwfc = (TA==TB && IA==IB) ? cal_sum_M(TA) : cal_sum_M(TA)+cal_sum_M(TB);
 		ofs	<< nwfc << " nwfc" << std::endl;
 		
-		const size_t ecut_numberA = static_cast<size_t>( sqrt( Exx_Abfs::Jle::Ecut_exx ) * GlobalC::ORB.Phi[TA].getRcut() / ModuleBase::PI ); // Rydberg Unit
-		const size_t ecut_numberB = static_cast<size_t>( sqrt( Exx_Abfs::Jle::Ecut_exx ) * GlobalC::ORB.Phi[TB].getRcut() / ModuleBase::PI ); // Rydberg Unit
+		const size_t ecut_numberA = static_cast<size_t>( sqrt( Exx_Abfs::Jle::Ecut_exx ) * orb_cutoff[TA] / ModuleBase::PI ); // Rydberg Unit
+		const size_t ecut_numberB = static_cast<size_t>( sqrt( Exx_Abfs::Jle::Ecut_exx ) * orb_cutoff[TB] / ModuleBase::PI ); // Rydberg Unit
 		if(TA==TB)
 			ofs	<< ecut_numberA << " ne" << std::endl;
 		else

--- a/source/module_ri/exx_opt_orb.cpp
+++ b/source/module_ri/exx_opt_orb.cpp
@@ -36,8 +36,9 @@ void Exx_Opt_Orb::generate_matrix(const K_Vectors &kv, const LCAO_Orbitals& orb)
 // ofs_mpi<<"memory:\t"<<get_memory(10)<<std::endl;
 	
 	GlobalC::exx_info.info_ri.abfs_Lmax = Exx_Abfs::Jle::Lmax;
-	for( size_t T=0; T!=abfs.size(); ++T )
+	for( size_t T=0; T!=abfs.size(); ++T ) {
 		GlobalC::exx_info.info_ri.abfs_Lmax = std::max( GlobalC::exx_info.info_ri.abfs_Lmax, static_cast<int>(abfs[T].size())-1 );
+}
 
 	const ModuleBase::Element_Basis_Index::Range    range_lcaos = Exx_Abfs::Abfs_Index::construct_range( lcaos );
 	const ModuleBase::Element_Basis_Index::IndexLNM index_lcaos = ModuleBase::Element_Basis_Index::construct_index( range_lcaos );
@@ -357,9 +358,9 @@ std::map<size_t,std::map<size_t,std::set<double>>> Exx_Opt_Orb::get_radial_R() c
 {
 	ModuleBase::TITLE("Exx_Opt_Orb::get_radial_R");
 	std::map<size_t,std::map<size_t,std::set<double>>> radial_R;
-	for( size_t TA=0; TA!=GlobalC::ucell.ntype; ++TA )
-		for( size_t IA=0; IA!=GlobalC::ucell.atoms[TA].na; ++IA )
-			for( size_t TB=0; TB!=GlobalC::ucell.ntype; ++TB )
+	for( size_t TA=0; TA!=GlobalC::ucell.ntype; ++TA ) {
+		for( size_t IA=0; IA!=GlobalC::ucell.atoms[TA].na; ++IA ) {
+			for( size_t TB=0; TB!=GlobalC::ucell.ntype; ++TB ) {
 				for( size_t IB=0; IB!=GlobalC::ucell.atoms[TB].na; ++IB )
 				{
 					const ModuleBase::Vector3<double> &tauA = GlobalC::ucell.atoms[TA].tau[IA];
@@ -368,5 +369,8 @@ std::map<size_t,std::map<size_t,std::set<double>>> Exx_Opt_Orb::get_radial_R() c
 					radial_R[TA][TB].insert( delta_R );
 					radial_R[TB][TA].insert( delta_R );
 				}
+}
+}
+}
 	return radial_R;
 }

--- a/source/module_ri/exx_opt_orb.h
+++ b/source/module_ri/exx_opt_orb.h
@@ -4,6 +4,7 @@
 #include "../module_base/matrix.h"
 #include "../module_base/element_basis_index.h"
 #include "module_cell/klist.h"
+#include "module_basis/module_ao/ORB_read.h"
 #include <vector>
 #include <map>
 #include <set>
@@ -12,7 +13,7 @@
 class Exx_Opt_Orb
 {
 public:
-	void generate_matrix(const K_Vectors &kv) const;
+	void generate_matrix(const K_Vectors &kv, const LCAO_Orbitals& orb) const;
 private:
 	std::vector<std::vector<RI::Tensor<double>>> cal_I( 
 		const std::map<size_t,std::map<size_t,std::map<size_t,std::map<size_t,RI::Tensor<double>>>>> &ms, 
@@ -29,6 +30,7 @@ private:
 		const std::vector<std::vector<RI::Tensor<double>>> &matrix_S,
 		const RI::Tensor<double> &matrix_V,
 		const size_t TA, const size_t IA, const size_t TB, const size_t IB,
+        const std::vector<double>& orb_cutoff,
 		const ModuleBase::Element_Basis_Index::Range &range_jles, 
 		const ModuleBase::Element_Basis_Index::IndexLNM &index_jles) const;
 	std::map<size_t,std::map<size_t,std::set<double>>> get_radial_R() const;


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
#4079 
