### PR TITLE
Fix: add threshold file and enlarge ecut in exx test cases to prevent CI test failure by randomness

### DIFF
--- a/tests/integrate/281_NO_KP_HSE_symmetry/threshold
+++ b/tests/integrate/281_NO_KP_HSE_symmetry/threshold
@@ -1,0 +1,4 @@
+threshold 0.00001
+force_threshold 0.00001 
+stress_threshold 0.00001
+fatal_threshold 0.00001

--- a/tests/integrate/286_NO_KP_CR_HSE/INPUT
+++ b/tests/integrate/286_NO_KP_CR_HSE/INPUT
@@ -7,7 +7,7 @@ gamma_only      0
 nspin			1
 
 #Parameters (2.Iteration)
-ecutwfc			20
+ecutwfc			50
 scf_thr			1E-5
 scf_nmax		100
 

--- a/tests/integrate/286_NO_KP_CR_HSE/result.ref
+++ b/tests/integrate/286_NO_KP_CR_HSE/result.ref
@@ -1,3 +1,4 @@
-etotref -196.7590796477498429
-etotperatomref -98.3795398239
-totaltimeref 25.24
+etotref -196.7312320266655092
+etotperatomref -98.3656160133
+totaltimeref 56.4969
+37.12


### PR DESCRIPTION
A temporary solution of #5030 before finding out the undefined behavior.