### PR TITLE
move back Kpoint when basis_type="pw"

### DIFF
--- a/source/module_io/read_input_item_elec_stru.cpp
+++ b/source/module_io/read_input_item_elec_stru.cpp
@@ -451,10 +451,21 @@ void ReadInput::item_elec_stru()
                           "set to 1, a fast algorithm is used";
         read_sync_bool(input.gamma_only);
         item.reset_value = [](const Input_Item& item, Parameter& para) {
-            if (para.input.gamma_only && para.input.basis_type == "pw")
+            if (para.input.basis_type == "pw" && para.input.gamma_only) 
             {
-                    para.input.gamma_only = false;   
-                    GlobalV::ofs_warning << "gamma_only is not supported in the pw model" << std::endl;
+                para.input.gamma_only = false;   
+                GlobalV::ofs_warning << " WARNING : gamma_only has not been implemented for pw yet" << std::endl;
+                GlobalV::ofs_warning << "gamma_only is not supported in the pw model" << std::endl;
+                GlobalV::ofs_warning << " the INPUT parameter gamma_only has been reset to 0" << std::endl;
+                GlobalV::ofs_warning << " and a new KPT is generated with "
+                                        "gamma point as the only k point"<< std::endl;
+                GlobalV::ofs_warning << " Auto generating k-points file: " << para.input.kpoint_file << std::endl;
+                std::ofstream ofs(para.input.kpoint_file.c_str());
+                ofs << "K_POINTS" << std::endl;
+                ofs << "0" << std::endl;
+                ofs << "Gamma" << std::endl;
+                ofs << "1 1 1 0 0 0" << std::endl;
+                ofs.close();
             }
         };
         this->add_item(item);

--- a/source/module_io/test_serial/CMakeLists.txt
+++ b/source/module_io/test_serial/CMakeLists.txt
@@ -33,7 +33,6 @@ AddTest(
 AddTest(
   TARGET io_read_item_serial
   LIBS parameter ${math_libs} base device io_input_serial 
-  LIBS parameter ${math_libs} base device io_input_serial 
   SOURCES read_input_item_test.cpp
 )
 

--- a/source/module_io/test_serial/read_input_item_test.cpp
+++ b/source/module_io/test_serial/read_input_item_test.cpp
@@ -811,8 +811,15 @@ TEST_F(InputTest, Item_test)
         auto it = find_label("gamma_only", readinput.input_lists);
         param.input.basis_type = "pw";
         param.input.gamma_only = true;
+        std::string filename = param.input.kpoint_file;
         it->second.reset_value(it->second, param);
         EXPECT_EQ(param.input.gamma_only, false);
+        std::ifstream ifs(filename);
+        std::string line;
+        std::getline(ifs, line);
+        ifs.close();
+        EXPECT_EQ(line, "K_POINTS");
+
     }
     { // out_mat_r
         auto it = find_label("out_mat_r", readinput.input_lists);


### PR DESCRIPTION
### Linked Issue
Fix #5119 

### What's changed?
- add the kpoint file when gamma_only =1 ,and basis_type = "pw".The pw model is not supported in gamma_only=1 now.
@pxlxingliang ,Can you test it?Please.
