### PR TITLE
Refactor: remove useless warning for dp

### DIFF
--- a/source/module_base/global_file.cpp
+++ b/source/module_base/global_file.cpp
@@ -274,30 +274,4 @@ void ModuleBase::Global_File::close_all_log(const int rank, const bool out_alllo
 #endif
     return;
 }
-
-void ModuleBase::Global_File::delete_tmp_files()
-{
-    if (GlobalV::MY_RANK == 0)
-    {
-        for (int is = 0; is < PARAM.inp.nspin; ++is)
-        {
-            std::string tmp_chg_1 = PARAM.globalv.global_out_dir + "NOW_SPIN" + std::to_string(is + 1) + "_CHG.cube";
-            std::string tmp_chg_2 = PARAM.globalv.global_out_dir + "OLD1_SPIN" + std::to_string(is + 1) + "_CHG.cube";
-            std::string tmp_chg_3 = PARAM.globalv.global_out_dir + "OLD2_SPIN" + std::to_string(is + 1) + "_CHG.cube";
-
-            if (access(tmp_chg_1.c_str(), 0) == 0)
-            {
-                std::remove(tmp_chg_1.c_str());
-            }
-            if (access(tmp_chg_2.c_str(), 0) == 0)
-            {
-                std::remove(tmp_chg_2.c_str());
-            }
-            if (access(tmp_chg_3.c_str(), 0) == 0)
-            {
-                std::remove(tmp_chg_3.c_str());
-            }
-        }
-    }
-}
 }

--- a/source/module_base/global_file.h
+++ b/source/module_base/global_file.h
@@ -30,13 +30,7 @@ namespace Global_File
 	void make_dir_atom(const std::string &label);
 	void open_log ( std::ofstream &ofs, const std::string &fn, const std::string &calculation, const bool &restart);
 	void close_log( std::ofstream &ofs, const std::string &fn);
-	void close_all_log(const int rank, const bool out_alllog = false,const std::string &calculation = "md");
-
-    /**
-     * @brief delete tmperary files
-     *
-     */
-    void delete_tmp_files();
+    void close_all_log(const int rank, const bool out_alllog = false, const std::string& calculation = "md");
 }
 }
 #endif

--- a/source/module_base/test/global_file_test.cpp
+++ b/source/module_base/test/global_file_test.cpp
@@ -158,25 +158,3 @@ TEST_F(GlobalFile,closealllog)
 		remove("running.log");
 		remove("warning.log");
 }
-
-TEST_F(GlobalFile, DeleteTmpFiles)
-{
-
-    std::string tmp_chg_1 = PARAM.sys.global_out_dir + "NOW_SPIN1_CHG.cube";
-    std::string tmp_chg_2 = PARAM.sys.global_out_dir + "OLD1_SPIN1_CHG.cube";
-    std::string tmp_chg_3 = PARAM.sys.global_out_dir + "OLD2_SPIN1_CHG.cube";
-    std::ofstream ofs1(tmp_chg_1.c_str());
-    std::ofstream ofs2(tmp_chg_2.c_str());
-    std::ofstream ofs3(tmp_chg_3.c_str());
-    ofs1.close();
-    ofs2.close();
-    ofs3.close();
-    EXPECT_TRUE(access(tmp_chg_1.c_str(), 0) == 0);
-    EXPECT_TRUE(access(tmp_chg_2.c_str(), 0) == 0);
-    EXPECT_TRUE(access(tmp_chg_3.c_str(), 0) == 0);
-
-    ModuleBase::Global_File::delete_tmp_files();
-    EXPECT_TRUE(access(tmp_chg_1.c_str(), 0) == -1);
-    EXPECT_TRUE(access(tmp_chg_2.c_str(), 0) == -1);
-    EXPECT_TRUE(access(tmp_chg_3.c_str(), 0) == -1);
-}

--- a/source/module_esolver/esolver.h
+++ b/source/module_esolver/esolver.h
@@ -61,7 +61,7 @@ class ESolver
     // get conv_elec used in current scf
     virtual bool get_conv_elec()
     {
-        return false;
+        return true;
     }
     std::string classname;
 };

--- a/source/module_esolver/esolver_fp.cpp
+++ b/source/module_esolver/esolver_fp.cpp
@@ -117,6 +117,15 @@ void ESolver_FP::before_all_runners(const Input_para& inp, UnitCell& cell)
     return;
 }
 
+//------------------------------------------------------------------------------
+//! the 12th function of ESolver_KS: get_conv_elec
+//! tqzhao add 2024-05-15
+//------------------------------------------------------------------------------
+bool ESolver_FP::get_conv_elec()
+{
+    return this->conv_elec;
+}
+
 //! Something to do after SCF iterations when SCF is converged or comes to the max iter step.
 void ESolver_FP::after_scf(const int istep)
 {

--- a/source/module_esolver/esolver_fp.h
+++ b/source/module_esolver/esolver_fp.h
@@ -44,6 +44,9 @@ namespace ModuleESolver
         //! Initialize of the first-principels energy solver
         virtual void before_all_runners(const Input_para& inp, UnitCell& cell) override;
 
+        // get conv_elec used in current scf
+        virtual bool get_conv_elec() override;
+
         virtual void init_after_vc(const Input_para& inp, UnitCell& cell);    // liuyu add 2023-03-09
 
         //! Electronic states

--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -760,16 +760,6 @@ int ESolver_KS<T, Device>::get_maxniter()
 }
 
 //------------------------------------------------------------------------------
-//! the 12th function of ESolver_KS: get_conv_elec
-//! tqzhao add 2024-05-15
-//------------------------------------------------------------------------------
-template <typename T, typename Device>
-bool ESolver_KS<T, Device>::get_conv_elec()
-{
-    return this->conv_elec;
-}
-
-//------------------------------------------------------------------------------
 //! the 16th-20th functions of ESolver_KS
 //! mohan add 2024-05-12
 //------------------------------------------------------------------------------

--- a/source/module_esolver/esolver_ks.h
+++ b/source/module_esolver/esolver_ks.h
@@ -56,11 +56,8 @@ class ESolver_KS : public ESolver_FP
 		// get maxniter used in current scf
 		virtual int get_maxniter() override;
 
-		// get conv_elec used in current scf
-		virtual bool get_conv_elec() override;
-
-	protected:
-		//! Something to do before SCF iterations.
+      protected:
+        //! Something to do before SCF iterations.
 		virtual void before_scf(const int istep) {};
 
 		//! Something to do before hamilt2density function in each iter loop.

--- a/source/module_io/output_log.cpp
+++ b/source/module_io/output_log.cpp
@@ -21,6 +21,28 @@ void output_convergence_after_scf(bool& convergence, double& energy, std::ofstre
     }
 }
 
+void output_after_relax(bool conv_ion, bool conv_elec, std::ofstream& ofs_running)
+{
+    if (conv_ion && !conv_elec)
+    {
+        std::cout << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
+        std::cout << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
+        std::cout << " Relaxation is converged, but the SCF is unconverged! The results are unreliable. " << std::endl;
+        std::cout << " It is suggested to increase the maximum SCF step and/or perform the relaxation again."
+                  << std::endl;
+        std::cout << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
+        std::cout << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
+        ofs_running << "\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
+        ofs_running << "\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
+        ofs_running << "\n Relaxation is converged, but the SCF is unconverged! The results are unreliable.. "
+                    << std::endl;
+        ofs_running << "\n It is suggested to increase the maximum SCF step and/or perform the relaxation again. "
+                    << std::endl;
+        ofs_running << "\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
+        ofs_running << "\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
+    }
+}
+
 void output_efermi(bool& convergence, double& efermi, std::ofstream& ofs_running)
 {
     if (convergence && PARAM.inp.out_level != "m")

--- a/source/module_io/output_log.h
+++ b/source/module_io/output_log.h
@@ -16,6 +16,12 @@ namespace ModuleIO
 /// @param ofs_running the output stream
 void output_convergence_after_scf(bool& convergence, double& energy, std::ofstream& ofs_running = GlobalV::ofs_running);
 
+/// @brief output after relaxation
+/// @param conv_ion if is convergence for ions
+/// @param conv_elec if is convergence for electrons
+/// @param ofs_running the output stream
+void output_after_relax(bool conv_ion, bool conv_elec, std::ofstream& ofs_running = GlobalV::ofs_running);
+
 /// @brief output the fermi energy
 /// @param convergence if is convergence
 /// @param efermi

--- a/source/module_io/test/outputlog_test.cpp
+++ b/source/module_io/test/outputlog_test.cpp
@@ -86,6 +86,33 @@ TEST(OutputEfermiTest, TestConvergence) {
     std::remove("test_output_efermi.txt");
 }
 
+// Test the output_efermi function
+TEST(OutputAfterRelaxTest, TestConvergence)
+{
+    bool conv_ion = true;
+    bool conv_elec = false;
+    std::ofstream ofs_running("test_output_after_relax.txt");
+    ModuleIO::output_after_relax(conv_ion, conv_elec, ofs_running);
+    ofs_running.close();
+
+    std::ifstream ifs_running("test_output_after_relax.txt");
+    std::stringstream ss;
+    ss << ifs_running.rdbuf();
+    std::string file_content = ss.str();
+    ifs_running.close();
+
+    std::string expected_content
+        = "\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
+          "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n\n Relaxation is converged, but the SCF is unconverged! The "
+          "results are unreliable.. \n\n It is suggested to increase the maximum SCF step and/or perform the "
+          "relaxation again. "
+          "\n\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n\n%%%%%%%%%%%%%%%%%%%%%%%%%%"
+          "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
+
+    EXPECT_EQ(file_content, expected_content);
+    std::remove("test_output_after_relax.txt");
+}
+
 TEST(OutputEfermiTest, TestNotConvergence) {
     bool convergence = false;
     double efermi = 1.0;

--- a/source/module_md/run_md.cpp
+++ b/source/module_md/run_md.cpp
@@ -122,8 +122,6 @@ void md_line(UnitCell& unit_in, ModuleESolver::ESolver* p_esolver, const Paramet
         mdrun->step_++;
     }
 
-    ModuleBase::Global_File::delete_tmp_files();
-
     delete mdrun;
     ModuleBase::timer::tick("Run_MD", "md_line");
     return;

--- a/source/module_relax/relax_driver.cpp
+++ b/source/module_relax/relax_driver.cpp
@@ -159,11 +159,6 @@ void Relax_Driver::relax_driver(ModuleESolver::ESolver* p_esolver)
         std::cout << " ION DYNAMICS FINISHED :)" << std::endl;
     }
 
-    if (PARAM.inp.calculation == "relax" || PARAM.inp.calculation == "cell-relax")
-    {
-        ModuleBase::Global_File::delete_tmp_files();
-    }
-
     ModuleBase::timer::tick("Ions", "opt_ions");
     return;
 }

--- a/source/module_relax/relax_driver.cpp
+++ b/source/module_relax/relax_driver.cpp
@@ -2,12 +2,13 @@
 
 #include "module_base/global_file.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h" // use chr.
+#include "module_io/cif_io.h"
 #include "module_io/json_output/output_info.h"
+#include "module_io/output_log.h"
 #include "module_io/print_info.h"
 #include "module_io/read_exit_file.h"
 #include "module_io/write_wfc_r.h"
 #include "module_parameter/parameter.h"
-#include "module_io/cif_io.h"
 void Relax_Driver::relax_driver(ModuleESolver::ESolver* p_esolver)
 {
     ModuleBase::TITLE("Ions", "opt_ions");
@@ -128,37 +129,7 @@ void Relax_Driver::relax_driver(ModuleESolver::ESolver* p_esolver)
                                                "data_?");
                 }
 
-                if (p_esolver && stop && p_esolver->get_maxniter() == p_esolver->get_niter()
-                    && !(p_esolver->get_conv_elec()))
-                {
-                    std::cout << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
-                              << std::endl;
-                    std::cout << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
-                              << std::endl;
-                    std::cout << " Relaxation is converged, but the SCF is unconverged! The results are unreliable. "
-                              << std::endl;
-                    std::cout
-                        << " It is suggested to increase the maximum SCF step and/or perform the relaxation again."
-                        << std::endl;
-                    std::cout << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
-                              << std::endl;
-                    std::cout << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
-                              << std::endl;
-                    GlobalV::ofs_running
-                        << "\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
-                    GlobalV::ofs_running
-                        << "\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
-                    GlobalV::ofs_running
-                        << "\n Relaxation is converged, but the SCF is unconverged! The results are unreliable.. "
-                        << std::endl;
-                    GlobalV::ofs_running
-                        << "\n It is suggested to increase the maximum SCF step and/or perform the relaxation again. "
-                        << std::endl;
-                    GlobalV::ofs_running
-                        << "\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
-                    GlobalV::ofs_running
-                        << "\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
-                }
+                ModuleIO::output_after_relax(stop, p_esolver->get_conv_elec(), GlobalV::ofs_running);
             }
 
 #ifdef __RAPIDJSON


### PR DESCRIPTION
### Linked Issue
Fix #5106 

### Unit Tests and/or Case Tests for my changes
- A unit test is added for output_after_relax()

### What's changed?
- remove useless relax warning for dp/lj
- remove useless delete_tmp_file() 
