### PR TITLE
Perf: change default pw_seed=0

### DIFF
--- a/source/module_parameter/input_parameter.h
+++ b/source/module_parameter/input_parameter.h
@@ -47,7 +47,7 @@ struct Input_para
     bool diago_full_acc = false;        ///< all the empty states are diagonalized
     std::string init_wfc = "atomic";    ///< "file","atomic","random"
     bool psi_initializer = false;       ///< whether use psi_initializer to initialize wavefunctions
-    int pw_seed = 1;                    ///< random seed for initializing wave functions qianrui 2021-8-12
+    int pw_seed = 0;                    ///< random seed for initializing wave functions
     std::string init_chg = "atomic";    ///< "file","atomic"
     bool dm_to_rho = false;             ///< read density matrix from npz format and calculate charge density
     std::string chg_extrap = "default"; ///< xiaohui modify 2015-02-01

--- a/tests/integrate/101_PW_15_pseudopots_LibxcLDA/INPUT
+++ b/tests/integrate/101_PW_15_pseudopots_LibxcLDA/INPUT
@@ -28,3 +28,5 @@ dft_functional XC_LDA_X+XC_LDA_C_PZ
 
 cal_force 1
 cal_stress 1
+
+pw_seed 1

--- a/tests/integrate/101_PW_GTH_CF_CS_Si/INPUT
+++ b/tests/integrate/101_PW_GTH_CF_CS_Si/INPUT
@@ -20,3 +20,5 @@ mixing_beta     0.7
 mixing_gg0      1.5
 pseudo_dir	../../PP_ORB
 
+
+pw_seed 1

--- a/tests/integrate/101_PW_lps6_pseudopots/INPUT
+++ b/tests/integrate/101_PW_lps6_pseudopots/INPUT
@@ -25,3 +25,5 @@ dft_functional	pbe
 #Parameters (5.Mixing)
 mixing_type		broyden
 mixing_beta		0.7
+
+pw_seed 1

--- a/tests/integrate/101_PW_upf100_Rappe_Fe/INPUT
+++ b/tests/integrate/101_PW_upf100_Rappe_Fe/INPUT
@@ -27,3 +27,5 @@ mixing_gg0             1.0
 
 cal_force              1
 cal_stress             1
+
+pw_seed 1

--- a/tests/integrate/101_PW_upf100_uspp_Fe/INPUT
+++ b/tests/integrate/101_PW_upf100_uspp_Fe/INPUT
@@ -32,3 +32,5 @@ pseudo_rcut            10
 
 cal_force              1
 cal_stress             1
+
+pw_seed 1

--- a/tests/integrate/101_PW_upf201_uspp_Fe/INPUT
+++ b/tests/integrate/101_PW_upf201_uspp_Fe/INPUT
@@ -35,3 +35,5 @@ cal_force              1
 cal_stress             1
 
 kpar                   3
+
+pw_seed 1

--- a/tests/integrate/102_PW_BPCG_GPU/INPUT
+++ b/tests/integrate/102_PW_BPCG_GPU/INPUT
@@ -32,3 +32,5 @@ cal_stress          1
 mixing_type         broyden
 mixing_beta         0.4
 mixing_gg0          1.5
+
+pw_seed   1

--- a/tests/integrate/103_PW_15_CS_CF/INPUT
+++ b/tests/integrate/103_PW_15_CS_CF/INPUT
@@ -31,3 +31,5 @@ cal_stress               1
 mixing_type         broyden
 mixing_beta         0.4
 mixing_gg0          1.5
+
+pw_seed 1

--- a/tests/integrate/103_PW_15_CS_CF_bspline/INPUT
+++ b/tests/integrate/103_PW_15_CS_CF_bspline/INPUT
@@ -32,3 +32,5 @@ mixing_type         broyden
 mixing_beta         0.4
 mixing_gg0          1.5
 nbspline            20
+
+pw_seed 1

--- a/tests/integrate/103_PW_OU_CS_CF/INPUT
+++ b/tests/integrate/103_PW_OU_CS_CF/INPUT
@@ -33,3 +33,5 @@ cal_stress              1
 mixing_type         broyden
 mixing_beta         0.4
 mixing_gg0          1.5
+
+pw_seed 1

--- a/tests/integrate/104_PW_FM_magnetic/INPUT
+++ b/tests/integrate/104_PW_FM_magnetic/INPUT
@@ -26,3 +26,5 @@ basis_type    pw
 symmetry      1
 pseudo_dir	../../PP_ORB
 orbital_dir	../../PP_ORB
+
+pw_seed 1

--- a/tests/integrate/107_PW_OB_outputbands/INPUT
+++ b/tests/integrate/107_PW_OB_outputbands/INPUT
@@ -31,3 +31,5 @@ smearing_sigma			0.002
 mixing_type		plain
 mixing_beta		0.7
 
+
+pw_seed 1

--- a/tests/integrate/107_PW_W90/INPUT
+++ b/tests/integrate/107_PW_W90/INPUT
@@ -14,3 +14,5 @@ symmetry                0
 towannier90             1
 nnkpfile                diamond.nnkp
 read_file_dir		./
+
+pw_seed 1

--- a/tests/integrate/107_PW_outWfcPw/INPUT
+++ b/tests/integrate/107_PW_outWfcPw/INPUT
@@ -16,3 +16,5 @@ scf_nmax			100
 basis_type		pw
 
 out_wfc_pw 1
+
+pw_seed 1

--- a/tests/integrate/107_PW_outWfcR/INPUT
+++ b/tests/integrate/107_PW_outWfcR/INPUT
@@ -16,3 +16,7 @@ scf_nmax			100
 basis_type		pw
 
 out_wfc_r 1
+
+pw_seed 1
+
+pw_seed 1

--- a/tests/integrate/107_PW_outWfcR/INPUT
+++ b/tests/integrate/107_PW_outWfcR/INPUT
@@ -18,5 +18,3 @@ basis_type		pw
 out_wfc_r 1
 
 pw_seed 1
-
-pw_seed 1

--- a/tests/integrate/110_PW_SY/INPUT
+++ b/tests/integrate/110_PW_SY/INPUT
@@ -25,3 +25,5 @@ dft_functional  XC_GGA_X_PBE+XC_GGA_C_PBE
 
 cal_force 1
 cal_stress 1
+
+pw_seed 1

--- a/tests/integrate/112_PW_dipole/INPUT
+++ b/tests/integrate/112_PW_dipole/INPUT
@@ -29,3 +29,5 @@ efield_pos_dec      0.1
 efield_amp          0.01
 cal_force           1
 cal_stress          1
+
+pw_seed 1

--- a/tests/integrate/112_PW_efield/INPUT
+++ b/tests/integrate/112_PW_efield/INPUT
@@ -27,3 +27,5 @@ efield_flag         1
 dip_cor_flag        0
 cal_force           1
 cal_stress          1
+
+pw_seed 1

--- a/tests/integrate/113_PW_gatefield/INPUT
+++ b/tests/integrate/113_PW_gatefield/INPUT
@@ -33,3 +33,5 @@ cal_stress          1
 gate_flag           1
 zgate               0.2
 nelec               7
+
+pw_seed 1

--- a/tests/integrate/114_PW_BD_15/INPUT
+++ b/tests/integrate/114_PW_BD_15/INPUT
@@ -24,3 +24,5 @@ smearing_sigma			0.002
 mixing_type		broyden
 mixing_beta		0.7
 
+
+pw_seed 1

--- a/tests/integrate/115_PW_sol_H2O/INPUT
+++ b/tests/integrate/115_PW_sol_H2O/INPUT
@@ -18,3 +18,5 @@ eb_k                    80
 tau                     0.000010798
 sigma_k                 0.6
 nc_k                    0.00037
+
+pw_seed 1

--- a/tests/integrate/116_PW_scan_Si2/INPUT
+++ b/tests/integrate/116_PW_scan_Si2/INPUT
@@ -28,3 +28,5 @@ cal_force 1
 cal_stress 1
 
 mixing_tau 1
+
+pw_seed 1

--- a/tests/integrate/118_PW_CHG_BINARY/INPUT
+++ b/tests/integrate/118_PW_CHG_BINARY/INPUT
@@ -31,3 +31,5 @@ cal_stress             1
 
 init_chg               auto
 read_file_dir          .
+
+pw_seed 1

--- a/tests/integrate/120_PW_KP_MD_MSST/INPUT
+++ b/tests/integrate/120_PW_KP_MD_MSST/INPUT
@@ -32,3 +32,5 @@ init_vel         1
 
 msst_qmass       1
 msst_vel         10
+
+pw_seed 1

--- a/tests/integrate/127_PW_15_PK_AF/INPUT
+++ b/tests/integrate/127_PW_15_PK_AF/INPUT
@@ -33,5 +33,3 @@ pseudo_dir	../../PP_ORB
 orbital_dir	../../PP_ORB
 
 pw_seed 1
-
-pw_seed 1

--- a/tests/integrate/127_PW_15_PK_AF/INPUT
+++ b/tests/integrate/127_PW_15_PK_AF/INPUT
@@ -31,3 +31,7 @@ symmetry     0
 nspin        2
 pseudo_dir	../../PP_ORB
 orbital_dir	../../PP_ORB
+
+pw_seed 1
+
+pw_seed 1

--- a/tests/integrate/140_PW_15_SO/INPUT
+++ b/tests/integrate/140_PW_15_SO/INPUT
@@ -38,3 +38,5 @@ pw_diag_thr                0.00001
 mixing_type         broyden
 mixing_beta         0.4
 mixing_gg0 1.5
+
+pw_seed 1

--- a/tests/integrate/801_PW_LT_sc/INPUT
+++ b/tests/integrate/801_PW_LT_sc/INPUT
@@ -16,3 +16,5 @@ scf_thr			1e-10
 
 cal_force                   1
 cal_stress                  1
+
+pw_seed 1


### PR DESCRIPTION
Fix #5143 

### The list of Changes
1. The default value `pw_seed=0`
2. Since `pw_seed` determines the way to make the initial guess of Psi, different `pw_seed` may result in different results if `scf_thr` is not low enough. I fix `pw_seed=1` in these 26 cases:
```
"101_PW_15_pseudopots_LibxcLDA"
"101_PW_lps6_pseudopots"
"101_PW_upf100_uspp_Fe"
"101_PW_upf100_Rappe_Fe"
"101_PW_upf201_uspp_Fe"
"101_PW_GTH_CF_CS_Si"
"103_PW_15_CS_CF"
"103_PW_15_CS_CF_bspline"
"103_PW_OU_CS_CF"
"104_PW_FM_magnetic"
"107_PW_outWfcPw"
"107_PW_outWfcR"
"110_PW_SY"
"112_PW_dipole"
"112_PW_efield"
"113_PW_gatefield"
"114_PW_BD_15"
"115_PW_sol_H2O"
"116_PW_scan_Si2"
"118_PW_CHG_BINARY"
"120_PW_KP_MD_MSST"
"127_PW_15_PK_AF"
"140_PW_15_SO"
"801_PW_LT_sc"
"107_PW_OB_outputbands"
"107_PW_W90"
```