### PR TITLE
Refactor Interface of hpsi_func in hsolver

### DIFF
--- a/python/pyabacus/src/py_diago_dav_subspace.hpp
+++ b/python/pyabacus/src/py_diago_dav_subspace.hpp
@@ -129,7 +129,7 @@ public:
 
             py::buffer_info hpsi_buf = hpsi.request();
             std::complex<double>* hpsi_ptr = static_cast<std::complex<double>*>(hpsi_buf.ptr);
-            std::copy(hpsi_ptr, hpsi_ptr + (band_index2 - band_index1 + 1) * nbasis_in, hpsi_out);
+            std::copy(hpsi_ptr + band_index1 * nbasis_i, hpsi_ptr + (band_index2 + 1) * nbasis_in, hpsi_out);
         };
 
         obj = std::make_unique<hsolver::Diago_DavSubspace<std::complex<double>, base_device::DEVICE_CPU>>(

--- a/python/pyabacus/src/py_diago_dav_subspace.hpp
+++ b/python/pyabacus/src/py_diago_dav_subspace.hpp
@@ -129,7 +129,7 @@ public:
 
             py::buffer_info hpsi_buf = hpsi.request();
             std::complex<double>* hpsi_ptr = static_cast<std::complex<double>*>(hpsi_buf.ptr);
-            std::copy(hpsi_ptr + band_index1 * nbasis_in, hpsi_ptr + (band_index2 + 1) * nbasis_in, hpsi_out);
+            std::copy(hpsi_ptr, hpsi_ptr + (band_index2 + 1) * nbasis_in, hpsi_out);
         };
 
         obj = std::make_unique<hsolver::Diago_DavSubspace<std::complex<double>, base_device::DEVICE_CPU>>(

--- a/python/pyabacus/src/py_diago_dav_subspace.hpp
+++ b/python/pyabacus/src/py_diago_dav_subspace.hpp
@@ -129,7 +129,7 @@ public:
 
             py::buffer_info hpsi_buf = hpsi.request();
             std::complex<double>* hpsi_ptr = static_cast<std::complex<double>*>(hpsi_buf.ptr);
-            std::copy(hpsi_ptr + band_index1 * nbasis_i, hpsi_ptr + (band_index2 + 1) * nbasis_in, hpsi_out);
+            std::copy(hpsi_ptr + band_index1 * nbasis_in, hpsi_ptr + (band_index2 + 1) * nbasis_in, hpsi_out);
         };
 
         obj = std::make_unique<hsolver::Diago_DavSubspace<std::complex<double>, base_device::DEVICE_CPU>>(

--- a/python/pyabacus/src/py_diago_david.hpp
+++ b/python/pyabacus/src/py_diago_david.hpp
@@ -127,7 +127,7 @@ public:
 
             py::buffer_info hpsi_buf = hpsi.request();
             std::complex<double>* hpsi_ptr = static_cast<std::complex<double>*>(hpsi_buf.ptr);
-            std::copy(hpsi_ptr, hpsi_ptr + (band_index2 - band_index1 + 1) * nbasis_in, hpsi_out);
+            std::copy(hpsi_ptr + band_index1 * nbasis_in, hpsi_ptr + (band_index2 + 1) * nbasis_in, hpsi_out);
         };
 
         auto spsi_func = [this] (

--- a/python/pyabacus/src/py_diago_david.hpp
+++ b/python/pyabacus/src/py_diago_david.hpp
@@ -127,7 +127,7 @@ public:
 
             py::buffer_info hpsi_buf = hpsi.request();
             std::complex<double>* hpsi_ptr = static_cast<std::complex<double>*>(hpsi_buf.ptr);
-            std::copy(hpsi_ptr + band_index1 * nbasis_in, hpsi_ptr + (band_index2 + 1) * nbasis_in, hpsi_out);
+            std::copy(hpsi_ptr, hpsi_ptr + (band_index2 + 1) * nbasis_in, hpsi_out);
         };
 
         auto spsi_func = [this] (

--- a/source/module_hsolver/diago_dav_subspace.cpp
+++ b/source/module_hsolver/diago_dav_subspace.cpp
@@ -421,7 +421,7 @@ void Diago_DavSubspace<T, Device>::cal_grad(const HPsiFunc& hpsi_func,
     }
 
     // update hpsi[:, nbase:nbase+notconv]
-    hpsi_func(psi_iter, &hphi[nbase * this->dim], this->nbase_x, this->dim, nbase, nbase + notconv - 1);
+    hpsi_func(psi_iter, hphi, this->nbase_x, this->dim, nbase, nbase + notconv - 1);
 
     ModuleBase::timer::tick("Diago_DavSubspace", "cal_grad");
     return;

--- a/source/module_hsolver/diago_david.cpp
+++ b/source/module_hsolver/diago_david.cpp
@@ -601,7 +601,7 @@ void DiagoDavid<T, Device>::cal_grad(const HPsiFunc& hpsi_func,
     //                       psi::Range(true, 0, nbase, nbase + notconv - 1),
     //                       &hpsi[nbase * dim]); // &hp(nbase, 0)
     // phm_in->ops->hPsi(dav_hpsi_in);
-    hpsi_func(basis, &hpsi[nbase * dim], nbase_x, dim, nbase, nbase + notconv - 1);
+    hpsi_func(basis, hpsi, nbase_x, dim, nbase, nbase + notconv - 1);
 
     delmem_complex_op()(this->ctx, lagrange);
     delmem_complex_op()(this->ctx, vc_ev_vector);

--- a/source/module_hsolver/diago_david.h
+++ b/source/module_hsolver/diago_david.h
@@ -36,6 +36,7 @@ class DiagoDavid : public DiagH<T, Device>
      * This function type is used to define a matrix-blockvector operator H.
      * For eigenvalue problem HX = λX or generalized eigenvalue problem HX = λSX,
      * this function computes the product of the Hamiltonian matrix H and a blockvector X.
+     * The result will be: HX[id_start:id_end] = H(X[id_start:id_end]).
      *
      * @param[out] X      Pointer to input blockvector of type `T*`.
      * @param[in]  HX     Pointer to output blockvector of type `T*`.

--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -448,7 +448,7 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm,
             psi::Range bands_range(true, 0, band_index1, band_index2);
 
             using hpsi_info = typename hamilt::Operator<T, Device>::hpsi_info;
-            hpsi_info info(&psi_iter_wrapper, bands_range, hpsi_out);
+            hpsi_info info(&psi_iter_wrapper, bands_range, hpsi_out + band_index1*nbasis_in);
             hm->ops->hPsi(info);
 
             ModuleBase::timer::tick("DavSubspace", "hpsi_func");
@@ -507,7 +507,7 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm,
             psi::Range bands_range(true, 0, band_index1, band_index2);
 
             using hpsi_info = typename hamilt::Operator<T, Device>::hpsi_info;
-            hpsi_info info(&psi_iter_wrapper, bands_range, hpsi_out);
+            hpsi_info info(&psi_iter_wrapper, bands_range, hpsi_out + band_index1*nbasis_in);
             hm->ops->hPsi(info);
 
             ModuleBase::timer::tick("David", "hpsi_func");

--- a/source/module_hsolver/test/diago_david_float_test.cpp
+++ b/source/module_hsolver/test/diago_david_float_test.cpp
@@ -114,7 +114,7 @@ public:
                         auto psi_iter_wrapper = psi::Psi<std::complex<float>>(psi_in, 1, nband_in, nbasis_in, nullptr);
                         psi::Range bands_range(1, 0, band_index1, band_index2);
                         using hpsi_info = typename hamilt::Operator<std::complex<float>>::hpsi_info;
-                        hpsi_info info(&psi_iter_wrapper, bands_range, hpsi_out);
+                        hpsi_info info(&psi_iter_wrapper, bands_range, hpsi_out + band_index1 * nbasis_in);
                         phm->ops->hPsi(info);
                     };
 		auto spsi_func = [phm](const std::complex<float>* psi_in, std::complex<float>* spsi_out,const int nrow, const int npw,  const int nbands){

--- a/source/module_hsolver/test/diago_david_real_test.cpp
+++ b/source/module_hsolver/test/diago_david_real_test.cpp
@@ -113,7 +113,7 @@ public:
                         auto psi_iter_wrapper = psi::Psi<double>(psi_in, 1, nband_in, nbasis_in, nullptr);
                         psi::Range bands_range(1, 0, band_index1, band_index2);
                         using hpsi_info = typename hamilt::Operator<double>::hpsi_info;
-                        hpsi_info info(&psi_iter_wrapper, bands_range, hpsi_out);
+                        hpsi_info info(&psi_iter_wrapper, bands_range, hpsi_out + band_index1 * nbasis_in);
                         phm->ops->hPsi(info);
                     };
         auto spsi_func = [phm](const double* psi_in, double* spsi_out,const int nrow, const int npw,  const int nbands){

--- a/source/module_hsolver/test/diago_david_real_test.cpp
+++ b/source/module_hsolver/test/diago_david_real_test.cpp
@@ -48,8 +48,10 @@ void lapackEigen(int& npw, std::vector<double>& hm, double* e, bool outtime = fa
     double* work2 = new double[lwork];
     dsyev_(&tmp_c1, &tmp_c2, &npw, tmp.data(), &npw, e, work2, &lwork, &info);
     end = clock();
-    if (info) std::cout << "ERROR: Lapack solver, info=" << info << std::endl;
-    if (outtime) std::cout << "Lapack Run time: " << (double)(end - start) / CLOCKS_PER_SEC << " S" << std::endl;
+    if (info) { std::cout << "ERROR: Lapack solver, info=" << info << std::endl;
+}
+    if (outtime) { std::cout << "Lapack Run time: " << (double)(end - start) / CLOCKS_PER_SEC << " S" << std::endl;
+}
     delete[] work2;
 }
 class DiagoDavPrepare
@@ -73,7 +75,8 @@ public:
         //calculate eigenvalues by LAPACK;
         double* e_lapack = new double[npw];
         double* ev;
-        if (mypnum == 0) lapackEigen(npw, DIAGOTEST::hmatrix_d, e_lapack, DETAILINFO);
+        if (mypnum == 0) { lapackEigen(npw, DIAGOTEST::hmatrix_d, e_lapack, DETAILINFO);
+}
 
         //do Diago_David::diag()
         double* en = new double[npw];
@@ -111,7 +114,7 @@ public:
                     const int band_index1, const int band_index2)
                     {
                         auto psi_iter_wrapper = psi::Psi<double>(psi_in, 1, nband_in, nbasis_in, nullptr);
-                        psi::Range bands_range(1, 0, band_index1, band_index2);
+                        psi::Range bands_range(true, 0, band_index1, band_index2);
                         using hpsi_info = typename hamilt::Operator<double>::hpsi_info;
                         hpsi_info info(&psi_iter_wrapper, bands_range, hpsi_out + band_index1 * nbasis_in);
                         phm->ops->hPsi(info);
@@ -131,7 +134,8 @@ public:
 
         if (mypnum == 0)
         {
-            if (DETAILINFO) std::cout << "diag Run time: " << use_time << std::endl;
+            if (DETAILINFO) { std::cout << "diag Run time: " << use_time << std::endl;
+}
             for (int i = 0;i < nband;i++)
             {
                 EXPECT_NEAR(en[i], e_lapack[i], CONVTHRESHOLD);
@@ -148,8 +152,9 @@ class DiagoDavTest : public ::testing::TestWithParam<DiagoDavPrepare> {};
 TEST_P(DiagoDavTest, RandomHamilt)
 {
     DiagoDavPrepare ddp = GetParam();
-    if (DETAILINFO && ddp.mypnum == 0) std::cout << "npw=" << ddp.npw << ", nband=" << ddp.nband << ", sparsity="
+    if (DETAILINFO && ddp.mypnum == 0) { std::cout << "npw=" << ddp.npw << ", nband=" << ddp.nband << ", sparsity="
         << ddp.sparsity << ", eps=" << ddp.eps << std::endl;
+}
 
     HPsi<double> hpsi(ddp.nband, ddp.npw, ddp.sparsity);
     DIAGOTEST::hmatrix_d = hpsi.hamilt();
@@ -236,7 +241,8 @@ int main(int argc, char** argv)
 
     testing::InitGoogleTest(&argc, argv);
     ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
-    if (myrank != 0) delete listeners.Release(listeners.default_result_printer());
+    if (myrank != 0) { delete listeners.Release(listeners.default_result_printer());
+}
 
     int result = RUN_ALL_TESTS();
     if (myrank == 0 && result != 0)

--- a/source/module_hsolver/test/diago_david_test.cpp
+++ b/source/module_hsolver/test/diago_david_test.cpp
@@ -116,7 +116,7 @@ public:
                         auto psi_iter_wrapper = psi::Psi<std::complex<double>>(psi_in, 1, nband_in, nbasis_in, nullptr);
                         psi::Range bands_range(1, 0, band_index1, band_index2);
                         using hpsi_info = typename hamilt::Operator<std::complex<double>>::hpsi_info;
-                        hpsi_info info(&psi_iter_wrapper, bands_range, hpsi_out);
+                        hpsi_info info(&psi_iter_wrapper, bands_range, hpsi_out + band_index1 * nbasis_in);
                         phm->ops->hPsi(info);
                     };
 		auto spsi_func = [phm](const std::complex<double>* psi_in, std::complex<double>* spsi_out,const int nrow, const int npw,  const int nbands){

--- a/source/module_hsolver/test/diago_david_test.cpp
+++ b/source/module_hsolver/test/diago_david_test.cpp
@@ -48,8 +48,10 @@ void lapackEigen(int& npw, std::vector<std::complex<double>>& hm, double* e, boo
 	char tmp_c1 = 'V', tmp_c2 = 'U';
 	zheev_(&tmp_c1, &tmp_c2, &npw, tmp.data(), &npw, e, work2, &lwork, rwork, &info);
 	end = clock();
-	if(info) std::cout << "ERROR: Lapack solver, info=" << info <<std::endl;
-	if (outtime) std::cout<<"Lapack Run time: "<<(double)(end - start) / CLOCKS_PER_SEC<<" S"<<std::endl;
+	if(info) { std::cout << "ERROR: Lapack solver, info=" << info <<std::endl;
+}
+	if (outtime) { std::cout<<"Lapack Run time: "<<(double)(end - start) / CLOCKS_PER_SEC<<" S"<<std::endl;
+}
 
 	delete [] rwork;
 	delete [] work2;
@@ -76,7 +78,8 @@ public:
 		//calculate eigenvalues by LAPACK;
 		double* e_lapack = new double[npw];
 		double* ev;
-		if(mypnum == 0) lapackEigen(npw, DIAGOTEST::hmatrix, e_lapack,DETAILINFO);
+		if(mypnum == 0) { lapackEigen(npw, DIAGOTEST::hmatrix, e_lapack,DETAILINFO);
+}
 
 		//do Diago_David::diag()
 		double* en = new double[npw];		
@@ -114,7 +117,7 @@ public:
                     const int band_index1, const int band_index2)
                     {
                         auto psi_iter_wrapper = psi::Psi<std::complex<double>>(psi_in, 1, nband_in, nbasis_in, nullptr);
-                        psi::Range bands_range(1, 0, band_index1, band_index2);
+                        psi::Range bands_range(true, 0, band_index1, band_index2);
                         using hpsi_info = typename hamilt::Operator<std::complex<double>>::hpsi_info;
                         hpsi_info info(&psi_iter_wrapper, bands_range, hpsi_out + band_index1 * nbasis_in);
                         phm->ops->hPsi(info);
@@ -134,7 +137,8 @@ public:
 
 		if(mypnum == 0)
 		{
-			if (DETAILINFO) std::cout<<"diag Run time: "<< use_time << std::endl;
+			if (DETAILINFO) { std::cout<<"diag Run time: "<< use_time << std::endl;
+}
 			for(int i=0;i<nband;i++)
 			{
 				EXPECT_NEAR(en[i],e_lapack[i],CONVTHRESHOLD);
@@ -151,8 +155,9 @@ class DiagoDavTest : public ::testing::TestWithParam<DiagoDavPrepare> {};
 TEST_P(DiagoDavTest,RandomHamilt)
 {
 	DiagoDavPrepare ddp = GetParam();
-	if (DETAILINFO&&ddp.mypnum==0) std::cout << "npw=" << ddp.npw << ", nband=" << ddp.nband << ", sparsity=" 
+	if (DETAILINFO&&ddp.mypnum==0) { std::cout << "npw=" << ddp.npw << ", nband=" << ddp.nband << ", sparsity=" 
 			  << ddp.sparsity << ", eps=" << ddp.eps << std::endl;
+}
 
     HPsi<std::complex<double>> hpsi(ddp.nband, ddp.npw, ddp.sparsity);
 	DIAGOTEST::hmatrix = hpsi.hamilt();
@@ -239,7 +244,8 @@ int main(int argc, char **argv)
 
     testing::InitGoogleTest(&argc, argv);
     ::testing::TestEventListeners &listeners = ::testing::UnitTest::GetInstance()->listeners();
-    if (myrank != 0) delete listeners.Release(listeners.default_result_printer());
+    if (myrank != 0) { delete listeners.Release(listeners.default_result_printer());
+}
 
     int result = RUN_ALL_TESTS();
     if (myrank == 0 && result != 0)

--- a/source/module_lr/hsolver_lrtd.cpp
+++ b/source/module_lr/hsolver_lrtd.cpp
@@ -92,7 +92,7 @@ namespace LR
                         auto psi_iter_wrapper = psi::Psi<T, Device>(psi_in, 1, nband_in, nbasis_in, nullptr);
                         psi::Range bands_range(true, 0, band_index1, band_index2);
                         using hpsi_info = typename hamilt::Operator<T, Device>::hpsi_info;
-                        hpsi_info info(&psi_iter_wrapper, bands_range, hpsi_out);
+                        hpsi_info info(&psi_iter_wrapper, bands_range, hpsi_out+ band_index1*nbasis_in);
                         pHamilt->ops->hPsi(info);
                     };
                 auto spsi_func = [pHamilt](const T* psi_in, T* spsi_out,
@@ -129,7 +129,7 @@ namespace LR
                         auto psi_iter_wrapper = psi::Psi<T, Device>(psi_in, 1, nband_in, nbasis_in, nullptr);
                         psi::Range bands_range(true, 0, band_index1, band_index2);
                         using hpsi_info = typename hamilt::Operator<T, Device>::hpsi_info;
-                        hpsi_info info(&psi_iter_wrapper, bands_range, hpsi_out);
+                        hpsi_info info(&psi_iter_wrapper, bands_range, hpsi_out + band_index1 * nbasis_in);
                         pHamilt->ops->hPsi(info);
                     };
                 auto subspace_func = [pHamilt](T* psi_out,


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #5178 

### What's changed?
- `hpsi_func` used by dav/dav_subspace will take parameters in `(in, out, id_start, id_end)` manner.
- Consequently, the code (including tests) responsible for calling davidson&dav_subspace and 'hpsi_func' construction are also updated to align with these changes.

### Note
- This change does not affect `hpsi_func` about cg method, taking `Tensor`-typed parameters. 