### PR TITLE
Fix: let only one rank do file I/O in unittest of orb_io

### DIFF
--- a/source/module_io/orb_io.cpp
+++ b/source/module_io/orb_io.cpp
@@ -128,12 +128,13 @@ void ModuleIO::write_abacus_orb(std::ofstream& ofs,
                                 const int rank)
 {
     const std::vector<std::string> spec = {"S", "P", "D", "F", "G", "H", "I", "J", "K"};
-    if (!ofs.good())
-    {
-        ModuleBase::WARNING_QUIT("AtomicRadials::write_abacus_orb", "Couldn't open orbital file.");
-    }
+
     if (rank == 0)
     {
+        if (!ofs.is_open())
+        {
+            ModuleBase::WARNING_QUIT("AtomicRadials::write_abacus_orb", "Couldn't open orbital file.");
+        }
         const int lmax = nzeta.size() - 1;
 
         for (int i = 0; i < 75; ++i)

--- a/source/module_io/test/orb_io_test.cpp
+++ b/source/module_io/test/orb_io_test.cpp
@@ -89,6 +89,9 @@ TEST_F(OrbIOTest, WriteAbacusOrb)
     std::vector<int> nzeta1;
     std::vector<std::vector<double>> radials1;
     ModuleIO::read_abacus_orb(ifs1, elem1, ecut1, nr1, dr1, nzeta1, radials1, GlobalV::MY_RANK);
+#ifdef __MPI // make sure all processes have finished reading
+    MPI_Barrier(MPI_COMM_WORLD);
+#endif
     EXPECT_EQ(elem, elem1);
     EXPECT_DOUBLE_EQ(ecut, ecut1);
     EXPECT_EQ(nr, nr1);

--- a/source/module_io/test/orb_io_test.cpp
+++ b/source/module_io/test/orb_io_test.cpp
@@ -27,13 +27,21 @@ void OrbIOTest::SetUp()
 
 TEST_F(OrbIOTest, ReadAbacusOrb)
 {
-    std::ifstream ifs(file);
+    std::ifstream ifs;
     std::string elem;
     double ecut, dr;
     int nr;
     std::vector<int> nzeta;
     std::vector<std::vector<double>> radials;
+    if (GlobalV::MY_RANK == 0)
+    {
+        ifs.open(file);
+    }
     ModuleIO::read_abacus_orb(ifs, elem, ecut, nr, dr, nzeta, radials, GlobalV::MY_RANK);
+    if (GlobalV::MY_RANK == 0)
+    {
+        ifs.close();
+    }
     EXPECT_EQ(elem, "Ti");
     EXPECT_DOUBLE_EQ(ecut, 100.0);
     EXPECT_EQ(nr, 1001);
@@ -60,38 +68,58 @@ TEST_F(OrbIOTest, ReadAbacusOrb)
     EXPECT_EQ(radials[8][4], 3.744878535962e-05);
     EXPECT_EQ(radials[8][996], 7.495357740660e-05);
     EXPECT_EQ(radials[8][1000], 0);
-    ifs.close();
 }
 
 TEST_F(OrbIOTest, WriteAbacusOrb)
 {
-    std::ifstream ifs(file);
+    std::ifstream ifs;
     std::string elem;
     double ecut, dr;
     int nr;
     std::vector<int> nzeta;
     std::vector<std::vector<double>> radials;
+    if (GlobalV::MY_RANK == 0)
+    {
+        ifs.open(file);
+    }
     ModuleIO::read_abacus_orb(ifs, elem, ecut, nr, dr, nzeta, radials, GlobalV::MY_RANK);
-#ifdef __MPI
-    MPI_Barrier(MPI_COMM_WORLD);
-#endif
+    if (GlobalV::MY_RANK == 0)
+    {
+        ifs.close();
+    }
+
     const std::string ftmp = "tmp.orb";
-    std::ofstream ofs(ftmp, std::ios::out);
+    std::ofstream ofs;
+    if (GlobalV::MY_RANK == 0)
+    {
+        ofs.open(ftmp);
+    }
     ModuleIO::write_abacus_orb(ofs, elem, ecut, nr, dr, nzeta, radials, GlobalV::MY_RANK);
-    ofs.close();
+    if (GlobalV::MY_RANK == 0)
+    {
+        ofs.close();
+    }
 #ifdef __MPI
     MPI_Barrier(MPI_COMM_WORLD);
 #endif
-    std::ifstream ifs1(ftmp);
+
+    std::ifstream ifs1;
+
     std::string elem1;
     double ecut1, dr1;
     int nr1;
     std::vector<int> nzeta1;
     std::vector<std::vector<double>> radials1;
+    if (GlobalV::MY_RANK == 0)
+    {
+        ifs1.open(ftmp);
+    }
     ModuleIO::read_abacus_orb(ifs1, elem1, ecut1, nr1, dr1, nzeta1, radials1, GlobalV::MY_RANK);
-#ifdef __MPI // make sure all processes have finished reading
-    MPI_Barrier(MPI_COMM_WORLD);
-#endif
+    if (GlobalV::MY_RANK == 0)
+    {
+        ifs1.close();
+    }
+
     EXPECT_EQ(elem, elem1);
     EXPECT_DOUBLE_EQ(ecut, ecut1);
     EXPECT_EQ(nr, nr1);
@@ -110,11 +138,10 @@ TEST_F(OrbIOTest, WriteAbacusOrb)
             EXPECT_NEAR(radials[i][j], radials1[i][j], tol);
         }
     }
-    ifs1.close();
-#ifdef __MPI
-    MPI_Barrier(MPI_COMM_WORLD);
-#endif
-    remove(ftmp.c_str());
+    if (GlobalV::MY_RANK == 0)
+    {
+        remove(ftmp.c_str());
+    }
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #5184 

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
