### PR TITLE
Refactor class `DensityMatrix`: remove the dependence on `K_Vectors` and the ambiguity of `_nks`

### DIFF
--- a/source/module_elecstate/elecstate_lcao.cpp
+++ b/source/module_elecstate/elecstate_lcao.cpp
@@ -131,7 +131,8 @@ void ElecStateLCAO<double>::psiToRho(const psi::Psi<double>& psi)
 template <typename TK>
 void ElecStateLCAO<TK>::init_DM(const K_Vectors* kv, const Parallel_Orbitals* paraV, const int nspin)
 {
-    this->DM = new DensityMatrix<TK, double>(kv, paraV, nspin);
+    const int nspin_dm = std::map<int, int>({ {1, 1}, {2, 2}, {4, 1} })[nspin];
+    this->DM = new DensityMatrix<TK, double>(paraV, nspin_dm, kv->kvec_d, kv->get_nks() / nspin_dm);
 }
 
 template <>

--- a/source/module_elecstate/elecstate_lcao.cpp
+++ b/source/module_elecstate/elecstate_lcao.cpp
@@ -131,7 +131,7 @@ void ElecStateLCAO<double>::psiToRho(const psi::Psi<double>& psi)
 template <typename TK>
 void ElecStateLCAO<TK>::init_DM(const K_Vectors* kv, const Parallel_Orbitals* paraV, const int nspin)
 {
-    const int nspin_dm = std::map<int, int>({ {1, 1}, {2, 2}, {4, 1} })[nspin];
+    const int nspin_dm = nspin == 2 ? 2 : 1;
     this->DM = new DensityMatrix<TK, double>(paraV, nspin_dm, kv->kvec_d, kv->get_nks() / nspin_dm);
 }
 

--- a/source/module_elecstate/module_dm/density_matrix.h
+++ b/source/module_elecstate/module_dm/density_matrix.h
@@ -243,8 +243,8 @@ class DensityMatrix
 
     /**
      * @brief density matrix in k space, which is a vector[ik]
-     * DMK should be a [_nspin][_nks][i][j] matrix,
-     * whose size is _nspin * _nks * _paraV->get_nrow() * _paraV->get_ncol()
+     * DMK should be a [_nspin][_nk][i][j] matrix,
+     * whose size is _nspin * _nk * _paraV->get_nrow() * _paraV->get_ncol()
      */
     // std::vector<ModuleBase::ComplexMatrix> _DMK;
     std::vector<std::vector<TK>> _DMK;
@@ -268,10 +268,10 @@ class DensityMatrix
 
     /**
      * @brief real number of k-points
-     * _nks is not equal to _kv->get_nks() when spin-polarization is considered
-     * _nks = kv->_nks / nspin
+     * _nk is not equal to _kv->get_nks() when spin-polarization is considered
+     * _nk = kv->get_nks() / nspin when nspin=2
      */
-    int _nks = 0;   // comment by lunasea: I want to rename it as nk
+    int _nk = 0;
 
 
 };

--- a/source/module_elecstate/module_dm/density_matrix.h
+++ b/source/module_elecstate/module_dm/density_matrix.h
@@ -49,9 +49,9 @@ class DensityMatrix
      *  (usually {nspin_global -> nspin_dm} = {1->1, 2->2, 4->1}, but sometimes 2->1 like in LR-TDDFT)
      * @param kvec_d direct coordinates of kpoints
      * @param nk number of k-points, not always equal to K_Vectors::get_nks()/nspin_dm.
-     * if remains default or large than kvec_d.size(), it will be set to kvec_d.size()
+     *               it will be set to kvec_d.size() if the value is invalid
      */
-    DensityMatrix(const Parallel_Orbitals* _paraV, const int nspin, const std::vector<ModuleBase::Vector3<double>>& kvec_d, const int nk = -1);
+    DensityMatrix(const Parallel_Orbitals* _paraV, const int nspin, const std::vector<ModuleBase::Vector3<double>>& kvec_d, const int nk);
 
     /**
      * @brief Constructor of class DensityMatrix for gamma-only calculation, where kvector is not required

--- a/source/module_elecstate/module_dm/density_matrix.h
+++ b/source/module_elecstate/module_dm/density_matrix.h
@@ -3,7 +3,6 @@
 
 #include <string>
 
-#include "module_cell/klist.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/record_adj.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
@@ -45,16 +44,20 @@ class DensityMatrix
 
     /**
      * @brief Constructor of class DensityMatrix for multi-k calculation
-     * @param _kv pointer of K_Vectors object
      * @param _paraV pointer of Parallel_Orbitals object
-     * @param nspin spin setting (1 - none spin; 2 - spin; 4 - SOC)
+     * @param nspin number of spin of the density matrix, set by user according to global nspin
+     *  (usually {nspin_global -> nspin_dm} = {1->1, 2->2, 4->1}, but sometimes 2->1 like in LR-TDDFT)
+     * @param kvec_d direct coordinates of kpoints
+     * @param nk number of k-points, not always equal to K_Vectors::get_nks()/nspin_dm.
+     * if remains default or large than kvec_d.size(), it will be set to kvec_d.size()
      */
-    DensityMatrix(const K_Vectors* _kv, const Parallel_Orbitals* _paraV, const int nspin);
+    DensityMatrix(const Parallel_Orbitals* _paraV, const int nspin, const std::vector<ModuleBase::Vector3<double>>& kvec_d, const int nk = -1);
 
     /**
      * @brief Constructor of class DensityMatrix for gamma-only calculation, where kvector is not required
      * @param _paraV pointer of Parallel_Orbitals object
-     * @param nspin spin setting (1 - none spin; 2 - spin; 4 - SOC)
+     * @param nspin number of spin of the density matrix, set by user according to global nspin
+     *  (usually {nspin_global -> nspin_dm} = {1->1, 2->2, 4->1}, but sometimes 2->1 like in LR-TDDFT)
      */
     DensityMatrix(const Parallel_Orbitals* _paraV, const int nspin);
 
@@ -169,7 +172,7 @@ class DensityMatrix
      */
     const Parallel_Orbitals* get_paraV_pointer() const {return this->_paraV;}
 
-    const K_Vectors* get_kv_pointer() const {return this->_kv;}
+    const std::vector<ModuleBase::Vector3<double>>& get_kvec_d() const { return this->_kvec_d; }
 
     /**
      * @brief calculate density matrix DMR from dm(k) using blas::axpy
@@ -249,7 +252,7 @@ class DensityMatrix
     /**
      * @brief K_Vectors object, which is used to get k-point information
      */
-    const K_Vectors* _kv;
+    const std::vector<ModuleBase::Vector3<double>> _kvec_d;
 
     /**
      * @brief Parallel_Orbitals object, which contain all information of 2D block cyclic distribution
@@ -268,7 +271,7 @@ class DensityMatrix
      * _nks is not equal to _kv->get_nks() when spin-polarization is considered
      * _nks = kv->_nks / nspin
      */
-    int _nks = 0;
+    int _nks = 0;   // comment by lunasea: I want to rename it as nk
 
 
 };

--- a/source/module_elecstate/module_dm/test/test_cal_dm_R.cpp
+++ b/source/module_elecstate/module_dm/test/test_cal_dm_R.cpp
@@ -74,7 +74,7 @@ class DMTest : public testing::Test
         init_parav();
     }
 
-    void TearDown()
+    void TearDown() override
     {
         delete paraV;
         delete[] ucell.atoms[0].tau;
@@ -129,7 +129,7 @@ TEST_F(DMTest, cal_DMR_test)
     kv->set_nks(nks);
     kv->kvec_d.resize(nks);
     // construct DM
-    elecstate::DensityMatrix<double, double> DM(kv, paraV, nspin);
+    elecstate::DensityMatrix<double, double> DM(paraV, nspin, kv->kvec_d, kv->get_nks() / nspin);
     // set this->_DMK
     for (int is = 1; is <= nspin; is++)
     {
@@ -198,7 +198,7 @@ TEST_F(DMTest, cal_DMR_blas_double)
     kv->set_nks(nks);
     kv->kvec_d.resize(nks);
     // construct DM
-    elecstate::DensityMatrix<double, double> DM(kv, paraV, nspin);
+    elecstate::DensityMatrix<double, double> DM(paraV, nspin, kv->kvec_d, kv->get_nks() / nspin);
     // set this->_DMK
     for (int is = 1; is <= nspin; is++)
     {
@@ -269,7 +269,7 @@ TEST_F(DMTest, cal_DMR_blas_complex)
     kv->kvec_d[1].x = 0.5;
     kv->kvec_d[3].x = 0.5;
     // construct DM
-    elecstate::DensityMatrix<std::complex<double>, double> DM(kv, paraV, nspin);
+    elecstate::DensityMatrix<std::complex<double>, double> DM(paraV, nspin, kv->kvec_d, kv->get_nks() / nspin);
     // set this->_DMK
     for (int is = 1; is <= nspin; is++)
     {

--- a/source/module_elecstate/module_dm/test/test_dm_R_init.cpp
+++ b/source/module_elecstate/module_dm/test/test_dm_R_init.cpp
@@ -118,7 +118,7 @@ TEST_F(DMTest, DMInit1)
     // construct DM
     std::cout << "dim0: " << paraV->dim0 << "    dim1:" << paraV->dim1 << std::endl;
     std::cout << "nrow: " << paraV->nrow << "    ncol:" << paraV->ncol << std::endl;
-    elecstate::DensityMatrix<double, double> DM(paraV, nspin, kv->kvec_d);
+    elecstate::DensityMatrix<double, double> DM(paraV, nspin, kv->kvec_d, nks);
     // initialize this->_DMR
     Grid_Driver gd(0,0);
     DM.init_DMR(&gd, &ucell);
@@ -145,7 +145,7 @@ TEST_F(DMTest, DMInit2)
     // construct DM
     std::cout << "dim0: " << paraV->dim0 << "    dim1:" << paraV->dim1 << std::endl;
     std::cout << "nrow: " << paraV->nrow << "    ncol:" << paraV->ncol << std::endl;
-    elecstate::DensityMatrix<double, double> DM(paraV, nspin, kv->kvec_d);
+    elecstate::DensityMatrix<double, double> DM(paraV, nspin, kv->kvec_d, nks);
     // initialize Record_adj using Grid_Driver
     Grid_Driver gd(0,0);
     Record_adj ra;

--- a/source/module_elecstate/module_dm/test/test_dm_R_init.cpp
+++ b/source/module_elecstate/module_dm/test/test_dm_R_init.cpp
@@ -74,7 +74,7 @@ class DMTest : public testing::Test
         init_parav();
     }
 
-    void TearDown()
+    void TearDown() override
     {
         delete paraV;
         delete[] ucell.atoms[0].tau;
@@ -118,7 +118,7 @@ TEST_F(DMTest, DMInit1)
     // construct DM
     std::cout << "dim0: " << paraV->dim0 << "    dim1:" << paraV->dim1 << std::endl;
     std::cout << "nrow: " << paraV->nrow << "    ncol:" << paraV->ncol << std::endl;
-    elecstate::DensityMatrix<double, double> DM(kv, paraV, nspin);
+    elecstate::DensityMatrix<double, double> DM(paraV, nspin, kv->kvec_d);
     // initialize this->_DMR
     Grid_Driver gd(0,0);
     DM.init_DMR(&gd, &ucell);
@@ -145,7 +145,7 @@ TEST_F(DMTest, DMInit2)
     // construct DM
     std::cout << "dim0: " << paraV->dim0 << "    dim1:" << paraV->dim1 << std::endl;
     std::cout << "nrow: " << paraV->nrow << "    ncol:" << paraV->ncol << std::endl;
-    elecstate::DensityMatrix<double, double> DM(kv, paraV, nspin);
+    elecstate::DensityMatrix<double, double> DM(paraV, nspin, kv->kvec_d);
     // initialize Record_adj using Grid_Driver
     Grid_Driver gd(0,0);
     Record_adj ra;
@@ -208,12 +208,12 @@ TEST_F(DMTest, DMInit3)
     kv->kvec_d[1].x = 0.5;
     kv->kvec_d[3].x = 0.5;
     // construct a DM
-    elecstate::DensityMatrix<std::complex<double>, double> DM(kv, paraV, nspin);
+    elecstate::DensityMatrix<std::complex<double>, double> DM(paraV, nspin, kv->kvec_d, kv->get_nks() / nspin);
     Grid_Driver gd(0, 0);
     DM.init_DMR(&gd, &ucell);
     std::cout << "dim0: " << paraV->dim0 << "    dim1:" << paraV->dim1 << std::endl;
     // construct another DM
-    elecstate::DensityMatrix<std::complex<double>, double> DM1(kv, paraV, nspin);
+    elecstate::DensityMatrix<std::complex<double>, double> DM1(paraV, nspin, kv->kvec_d, kv->get_nks() / nspin);
     DM1.init_DMR(*DM.get_DMR_pointer(1));
     // compare
     EXPECT_EQ(DM1.get_DMR_pointer(2)->size_atom_pairs(), test_size * test_size);
@@ -266,7 +266,7 @@ TEST_F(DMTest, DMInit4)
         }
     }
     // construct a DM from this HContainer
-    elecstate::DensityMatrix<std::complex<double>, double> DM(kv, paraV, nspin);
+    elecstate::DensityMatrix<std::complex<double>, double> DM(paraV, nspin, kv->kvec_d, kv->get_nks() / nspin);
     DM.init_DMR(*tmp_DMR);
     std::cout << "dim0: " << paraV->dim0 << "    dim1:" << paraV->dim1 << std::endl;
     // compare
@@ -292,11 +292,11 @@ TEST_F(DMTest, saveDMR)
     kv->kvec_d[1].x = 0.5;
     kv->kvec_d[3].x = 0.5;
     // construct a DM
-    elecstate::DensityMatrix<std::complex<double>, double> DM(kv, paraV, nspin);
+    elecstate::DensityMatrix<std::complex<double>, double> DM(paraV, nspin, kv->kvec_d, kv->get_nks() / nspin);
     Grid_Driver gd(0, 0);
     DM.init_DMR(&gd, &ucell);
     // construct another DM
-    elecstate::DensityMatrix<std::complex<double>, double> DM_test(kv, paraV, nspin);
+    elecstate::DensityMatrix<std::complex<double>, double> DM_test(paraV, nspin, kv->kvec_d, kv->get_nks() / nspin);
     DM_test.init_DMR(*DM.get_DMR_pointer(1));
     DM_test.save_DMR();
     EXPECT_EQ(DM_test.get_DMR_pointer(1)->get_nnr(), DM.get_DMR_pointer(1)->get_nnr());

--- a/source/module_elecstate/module_dm/test/test_dm_constructor.cpp
+++ b/source/module_elecstate/module_dm/test/test_dm_constructor.cpp
@@ -127,7 +127,7 @@ TEST_F(DMTest, DMConstructor_nspin1)
     std::cout << "dim0: " << paraV->dim0 << "    dim1:" << paraV->dim1 << std::endl;
     std::cout << "nrow: " << paraV->nrow << "    ncol:" << paraV->ncol << std::endl;
     int nspin = 1;
-    elecstate::DensityMatrix<double, double> DM(kv, paraV, nspin);
+    elecstate::DensityMatrix<double, double> DM(paraV, nspin, kv->kvec_d);
     // compare
     EXPECT_EQ(DM.get_DMK_nks(), kv->get_nks());
     EXPECT_EQ(DM.get_DMK_nrow(), paraV->nrow);
@@ -196,7 +196,7 @@ TEST_F(DMTest, DMConstructor_nspin2)
     // construct DM
     std::cout << "dim0: " << paraV->dim0 << "    dim1:" << paraV->dim1 << std::endl;
     std::cout << "nrow: " << paraV->nrow << "    ncol:" << paraV->ncol << std::endl;
-    elecstate::DensityMatrix<double, double> DM(kv, paraV, nspin);
+    elecstate::DensityMatrix<double, double> DM(paraV, nspin, kv->kvec_d, kv->get_nks() / nspin);
     // compare
     EXPECT_EQ(DM.get_DMK_nks(), kv->get_nks());
     EXPECT_EQ(DM.get_DMK_nrow(), paraV->nrow);

--- a/source/module_elecstate/module_dm/test/test_dm_constructor.cpp
+++ b/source/module_elecstate/module_dm/test/test_dm_constructor.cpp
@@ -127,7 +127,7 @@ TEST_F(DMTest, DMConstructor_nspin1)
     std::cout << "dim0: " << paraV->dim0 << "    dim1:" << paraV->dim1 << std::endl;
     std::cout << "nrow: " << paraV->nrow << "    ncol:" << paraV->ncol << std::endl;
     int nspin = 1;
-    elecstate::DensityMatrix<double, double> DM(paraV, nspin, kv->kvec_d);
+    elecstate::DensityMatrix<double, double> DM(paraV, nspin, kv->kvec_d, nks);
     // compare
     EXPECT_EQ(DM.get_DMK_nks(), kv->get_nks());
     EXPECT_EQ(DM.get_DMK_nrow(), paraV->nrow);

--- a/source/module_elecstate/module_dm/test/test_dm_io.cpp
+++ b/source/module_elecstate/module_dm/test/test_dm_io.cpp
@@ -142,7 +142,7 @@ TEST_F(DMTest, DMConstructor1)
     int nspin = 1;
     // construct DM
     std::cout << paraV->nrow << paraV->ncol << std::endl;
-    elecstate::DensityMatrix<double, double> DM(kv, paraV, nspin);
+    elecstate::DensityMatrix<double, double> DM(paraV, nspin, kv->kvec_d);
     // read DMK
     std::string directory = "./support/";
     for (int is = 1; is <= nspin; ++is)
@@ -162,7 +162,7 @@ TEST_F(DMTest, DMConstructor1)
         }
     }
     // construct a new DM
-    elecstate::DensityMatrix<double, double> DM1(kv, paraV, nspin);
+    elecstate::DensityMatrix<double, double> DM1(paraV, nspin, kv->kvec_d);
     directory = "./support/output";
     for (int is = 1; is <= nspin; ++is)
     {

--- a/source/module_elecstate/module_dm/test/test_dm_io.cpp
+++ b/source/module_elecstate/module_dm/test/test_dm_io.cpp
@@ -142,7 +142,7 @@ TEST_F(DMTest, DMConstructor1)
     int nspin = 1;
     // construct DM
     std::cout << paraV->nrow << paraV->ncol << std::endl;
-    elecstate::DensityMatrix<double, double> DM(paraV, nspin, kv->kvec_d);
+    elecstate::DensityMatrix<double, double> DM(paraV, nspin, kv->kvec_d, kv->get_nks());
     // read DMK
     std::string directory = "./support/";
     for (int is = 1; is <= nspin; ++is)
@@ -162,7 +162,7 @@ TEST_F(DMTest, DMConstructor1)
         }
     }
     // construct a new DM
-    elecstate::DensityMatrix<double, double> DM1(paraV, nspin, kv->kvec_d);
+    elecstate::DensityMatrix<double, double> DM1(paraV, nspin, kv->kvec_d, kv->get_nks());
     directory = "./support/output";
     for (int is = 1; is <= nspin; ++is)
     {

--- a/source/module_hamilt_lcao/hamilt_lcaodft/edm.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/edm.cpp
@@ -58,7 +58,8 @@ elecstate::DensityMatrix<std::complex<double>, double> Force_LCAO<std::complex<d
 {
 
     // construct a DensityMatrix object
-    elecstate::DensityMatrix<std::complex<double>, double> edm(&kv, &pv, nspin);
+    const int nspin_dm = nspin == 2 ? 2 : 1;
+    elecstate::DensityMatrix<std::complex<double>, double> edm(&pv, nspin_dm, kv.kvec_d, kv.get_nks() / nspin_dm);
 
     //--------------------------------------------
     // calculate the energy density matrix here.

--- a/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h
@@ -2,6 +2,7 @@
 #define W_ABACUS_DEVELOP_ABACUS_DEVELOP_SOURCE_MODULE_HAMILT_LCAO_HAMILT_LCAODFT_HAMILT_LCAO_H
 
 #include "module_basis/module_nao/two_center_bundle.h"
+#include "module_cell/klist.h"
 #include "module_elecstate/module_dm/density_matrix.h"
 #include "module_elecstate/potentials/potential_new.h"
 #include "module_hamilt_general/hamilt.h"

--- a/source/module_io/get_pchg_lcao.cpp
+++ b/source/module_io/get_pchg_lcao.cpp
@@ -219,7 +219,8 @@ void IState_Charge::begin(Gint_k& gk,
         if (bands_picked_[ib])
         {
             // Using new density matrix inplementation (multi-k)
-            elecstate::DensityMatrix<std::complex<double>, double> DM(&kv, this->ParaV, nspin);
+            const int nspin_dm = std::map<int, int>({ {1,1},{2,2},{4,1} })[nspin];
+            elecstate::DensityMatrix<std::complex<double>, double> DM(this->ParaV, nspin_dm, kv.kvec_d, kv.get_nks() / nspin_dm);
 
 #ifdef __MPI
             this->idmatrix(ib, nspin, nelec, nlocal, wg, DM, kv, if_separate_k);

--- a/source/module_io/get_pchg_lcao.h
+++ b/source/module_io/get_pchg_lcao.h
@@ -1,6 +1,7 @@
 #ifndef ISTATE_CHARGE_H
 #define ISTATE_CHARGE_H
 #include "module_basis/module_pw/pw_basis.h"
+#include "module_cell/klist.h"
 #include "module_elecstate/module_dm/density_matrix.h"
 #include "module_hamilt_lcao/module_gint/gint.h"
 #include "module_hamilt_lcao/module_gint/gint_gamma.h"

--- a/source/module_io/td_current_io.cpp
+++ b/source/module_io/td_current_io.cpp
@@ -64,7 +64,7 @@ void ModuleIO::cal_tmp_DM(elecstate::DensityMatrix<std::complex<double>, double>
                 // cal k_phase
                 // if TK==std::complex<double>, kphase is e^{ikR}
                 const ModuleBase::Vector3<double> dR(r_index.x, r_index.y, r_index.z);
-                const double arg = (DM_real.get_kv_pointer()->kvec_d[ik] * dR) * ModuleBase::TWO_PI;
+                const double arg = (DM_real.get_kvec_d()[ik] * dR) * ModuleBase::TWO_PI;
                 double sinp, cosp;
                 ModuleBase::libm::sincos(arg, &sinp, &cosp);
                 std::complex<double> kphase = std::complex<double>(cosp, sinp);
@@ -156,8 +156,9 @@ void ModuleIO::write_current(const int istep,
     // construct a DensityMatrix object
     // Since the function cal_dm_psi do not suport DMR in complex type, I replace it with two DMR in double type. Should
     // be refactored in the future.
-    elecstate::DensityMatrix<std::complex<double>, double> DM_real(&kv, pv, PARAM.inp.nspin);
-    elecstate::DensityMatrix<std::complex<double>, double> DM_imag(&kv, pv, PARAM.inp.nspin);
+    const int nspin_dm = std::map<int, int>({ {1,1},{2,2},{4,1} })[PARAM.inp.nspin];
+    elecstate::DensityMatrix<std::complex<double>, double> DM_real(pv, nspin_dm, kv.kvec_d, kv.get_nks() / nspin_dm);
+    elecstate::DensityMatrix<std::complex<double>, double> DM_imag(pv, nspin_dm, kv.kvec_d, kv.get_nks() / nspin_dm);
     // calculate DMK
     elecstate::cal_dm_psi(DM_real.get_paraV_pointer(), pelec->wg, psi[0], DM_real);
 

--- a/source/module_io/td_current_io.cpp
+++ b/source/module_io/td_current_io.cpp
@@ -28,7 +28,7 @@ void ModuleIO::cal_tmp_DM(elecstate::DensityMatrix<std::complex<double>, double>
     int ld_hk = DM_real.get_paraV_pointer()->nrow;
     int ld_hk2 = 2 * ld_hk;
     // tmp for is
-    int ik_begin = DM_real.get_DMK_nks() / nspin * (is - 1); // jump this->_nks for spin_down if nspin==2
+    int ik_begin = DM_real.get_DMK_nks() / nspin * (is - 1); // jump nk for spin_down if nspin==2
 
     hamilt::HContainer<double>* tmp_DMR_real = DM_real.get_DMR_vector()[is - 1];
     hamilt::HContainer<double>* tmp_DMR_imag = DM_imag.get_DMR_vector()[is - 1];

--- a/source/module_lr/dm_trans/dmr_complex.cpp
+++ b/source/module_lr/dm_trans/dmr_complex.cpp
@@ -48,7 +48,7 @@ namespace elecstate
                             // cal k_phase
                             // if TK==std::complex<double>, kphase is e^{ikR}
                             const ModuleBase::Vector3<double> dR(r_index[0], r_index[1], r_index[2]);
-                            const double arg = (this->_kv->kvec_d[ik] * dR) * ModuleBase::TWO_PI;
+                            const double arg = (this->_kvec_d[ik] * dR) * ModuleBase::TWO_PI;
                             double sinp, cosp;
                             ModuleBase::libm::sincos(arg, &sinp, &cosp);
                             std::complex<double> kphase = std::complex<double>(cosp, sinp);

--- a/source/module_lr/dm_trans/dmr_complex.cpp
+++ b/source/module_lr/dm_trans/dmr_complex.cpp
@@ -11,7 +11,7 @@ namespace elecstate
         ModuleBase::timer::tick("DensityMatrix", "cal_DMR");
         for (int is = 1; is <= this->_nspin; ++is)
         {
-            int ik_begin = this->_nks * (is - 1); // jump this->_nks for spin_down if nspin==2
+            int ik_begin = this->_nk * (is - 1); // jump this->_nk for spin_down if nspin==2
             hamilt::HContainer<std::complex<double>>* tmp_DMR = this->_DMR[is - 1];
             // set zero since this function is called in every scf step
             tmp_DMR->set_zero();
@@ -43,7 +43,7 @@ namespace elecstate
 #endif
                     // loop over k-points
                     if (PARAM.inp.nspin != 4)
-                        for (int ik = 0; ik < this->_nks; ++ik)
+                        for (int ik = 0; ik < this->_nk; ++ik)
                         {
                             // cal k_phase
                             // if TK==std::complex<double>, kphase is e^{ikR}

--- a/source/module_lr/dm_trans/dmr_complex.cpp
+++ b/source/module_lr/dm_trans/dmr_complex.cpp
@@ -42,7 +42,7 @@ namespace elecstate
                     }
 #endif
                     // loop over k-points
-                    if (PARAM.inp.nspin != 4)
+                    if (PARAM.inp.nspin != 4) {
                         for (int ik = 0; ik < this->_nk; ++ik)
                         {
                             // cal k_phase
@@ -70,9 +70,11 @@ namespace elecstate
                                 tmp_DMR_pointer += this->_paraV->get_col_size(iat2);
                             }
                         }
+}
                     // treat DMR as pauli matrix when NSPIN=4
-                    if (PARAM.inp.nspin == 4)
+                    if (PARAM.inp.nspin == 4) {
                         throw std::runtime_error("complex DM(R) with NSPIN=4 is not implemented yet");
+}
                 }
             }
         }

--- a/source/module_lr/hamilt_casida.h
+++ b/source/module_lr/hamilt_casida.h
@@ -44,7 +44,7 @@ namespace LR
             if (ri_hartree_benchmark != "aims") { assert(aims_nbasis.empty()); }
             this->classname = "HamiltCasidaLR";
             this->DM_trans.resize(1);
-            this->DM_trans[0] = LR_Util::make_unique<elecstate::DensityMatrix<T, T>>(&kv_in, pmat_in, nspin);
+            this->DM_trans[0] = LR_Util::make_unique<elecstate::DensityMatrix<T, T>>(pmat_in, nspin, kv_in.kvec_d, nk);
             // add the diag operator  (the first one)
             this->ops = new OperatorLRDiag<T>(eig_ks, pX_in, nk, nocc, nvirt);
             //add Hxc operator

--- a/source/module_lr/lr_spectrum.cpp
+++ b/source/module_lr/lr_spectrum.cpp
@@ -33,7 +33,7 @@ void LR::LR_Spectrum<double>::oscillator_strength()
     osc.resize(X.get_nbands(), 0.0);
     // const int nspin0 = (this->nspin == 2) ? 2 : 1;   use this in NSPIN=4 implementation
     double osc_tot = 0.0;
-    elecstate::DensityMatrix<double, double> DM_trans(&this->kv, &this->pmat, this->nspin);
+    elecstate::DensityMatrix<double, double> DM_trans(&this->pmat, this->nspin, this->kv.kvec_d, this->nk);
     DM_trans.init_DMR(&GlobalC::GridD, &this->ucell);
     this->transition_dipole_.resize(X.get_nbands(), ModuleBase::Vector3<double>(0.0, 0.0, 0.0));
     for (int istate = 0;istate < X.get_nbands();++istate)
@@ -90,9 +90,9 @@ void LR::LR_Spectrum<std::complex<double>>::oscillator_strength()
     osc.resize(X.get_nbands(), 0.0);
     // const int nspin0 = (this->nspin == 2) ? 2 : 1;   use this in NSPIN=4 implementation
     double osc_tot = 0.0;
-    elecstate::DensityMatrix<std::complex<double>, std::complex<double>> DM_trans(&this->kv, &this->pmat, this->nspin);
+    elecstate::DensityMatrix<std::complex<double>, std::complex<double>> DM_trans(&this->pmat, this->nspin, this->kv.kvec_d, this->nk);
     DM_trans.init_DMR(&GlobalC::GridD, &this->ucell);
-    elecstate::DensityMatrix<std::complex<double>, double> DM_trans_real_imag(&this->kv, &this->pmat, this->nspin);
+    elecstate::DensityMatrix<std::complex<double>, double> DM_trans_real_imag(&this->pmat, this->nspin, this->kv.kvec_d, this->nk);
     DM_trans_real_imag.init_DMR(&GlobalC::GridD, &this->ucell);
 
     this->transition_dipole_.resize(X.get_nbands(), ModuleBase::Vector3<std::complex<double>>(0.0, 0.0, 0.0));

--- a/source/module_lr/lr_spectrum.h
+++ b/source/module_lr/lr_spectrum.h
@@ -1,3 +1,4 @@
+#include "module_cell/klist.h"
 #include "module_lr/utils/gint_template.h"
 #include "module_psi/psi.h"
 #include "module_elecstate/module_dm/density_matrix.h"

--- a/source/module_lr/operator_casida/operator_lr_hxc.cpp
+++ b/source/module_lr/operator_casida/operator_lr_hxc.cpp
@@ -131,7 +131,7 @@ namespace LR
         ModuleBase::TITLE("OperatorLRHxc", "grid_calculation(complex)");
         ModuleBase::timer::tick("OperatorLRHxc", "grid_calculation");
 
-        elecstate::DensityMatrix<std::complex<double>, double> DM_trans_real_imag(&kv, pmat, nspin);
+        elecstate::DensityMatrix<std::complex<double>, double> DM_trans_real_imag(pmat, nspin, kv.kvec_d, kv.get_nks() / nspin);
         DM_trans_real_imag.init_DMR(*this->hR);
         hamilt::HContainer<double> HR_real_imag(GlobalC::ucell, this->pmat);
         this->initialize_HR(HR_real_imag, ucell, gd, this->pmat);

--- a/source/module_lr/operator_casida/operator_lr_hxc.h
+++ b/source/module_lr/operator_casida/operator_lr_hxc.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "module_cell/klist.h"
 #include "module_hamilt_general/operator.h"
 #include "module_lr/utils/gint_template.h"
 #include "module_hamilt_lcao/module_gint/grid_technique.h"
@@ -87,7 +88,7 @@ namespace LR
                 for (int ib = prev_size;ib < nbands;++ib)
                 {
                     // the first dimenstion of DensityMatrix is nk=nks/nspin 
-                    DM_trans[ib] = LR_Util::make_unique<elecstate::DensityMatrix<T, TR>>(&this->kv, this->pmat, this->nspin);
+                    DM_trans[ib] = LR_Util::make_unique<elecstate::DensityMatrix<T, TR>>(this->pmat, this->nspin, this->kv.kvec_d, this->kv.get_nks() / nspin);
                     DM_trans[ib]->init_DMR(*this->hR);
                 }
             }


### PR DESCRIPTION
The map {global nspin -> dm nspin} is not always {1->1, 2->2, 4->1}. I will use 2->1 in openshell-LR-TDDFT, where `kv->get_nks()/nspin` is not equal to the real number of k-points. I renamed the latter (`_nks`) as `_nk` in class `DensityMatrix` and decouple it from `kv`, leaving the flexibility to the user to set `nspin` and `nk` independently. 