### PR TITLE
Fix: TDDFT now can use `ks_solver=cusolver`, and velocity gauge is able to use Heaviside external field

### DIFF
--- a/source/module_elecstate/elecstate_lcao_tddft.cpp
+++ b/source/module_elecstate/elecstate_lcao_tddft.cpp
@@ -22,13 +22,8 @@ void ElecStateLCAO_TDDFT::psiToRho_td(const psi::Psi<std::complex<double>>& psi)
 
     // this part for calculating DMK in 2d-block format, not used for charge now
     //    psi::Psi<std::complex<double>> dm_k_2d();
-
-    if (PARAM.inp.ks_solver == "genelpa" || PARAM.inp.ks_solver == "scalapack_gvx"
-        || PARAM.inp.ks_solver == "lapack") // Peize Lin test 2019-05-15
-    {
-        elecstate::cal_dm_psi(this->DM->get_paraV_pointer(), this->wg, psi, *(this->DM));
-        this->DM->cal_DMR();
-    }
+    elecstate::cal_dm_psi(this->DM->get_paraV_pointer(), this->wg, psi, *(this->DM));
+    this->DM->cal_DMR();
 
     for (int is = 0; is < PARAM.inp.nspin; is++)
     {

--- a/source/module_elecstate/potentials/H_TDDFT_pw.cpp
+++ b/source/module_elecstate/potentials/H_TDDFT_pw.cpp
@@ -227,7 +227,7 @@ int H_TDDFT_pw::check_ncut(int t_type)
         break;
 
     case 3:
-        ncut = 1;
+        ncut = 2;
         break;
 
         // case 4:


### PR DESCRIPTION
### Linked Issue
Fix #5230, fix #5237, fix #5108.