### PR TITLE
Refactor: remove nspin dependence form Gint

### DIFF
--- a/source/module_elecstate/elecstate_lcao.cpp
+++ b/source/module_elecstate/elecstate_lcao.cpp
@@ -62,7 +62,7 @@ void ElecStateLCAO<std::complex<double>>::psiToRho(const psi::Psi<std::complex<d
 
     ModuleBase::GlobalFunc::NOTE("Calculate the charge on real space grid!");
     this->gint_k->transfer_DM2DtoGrid(this->DM->get_DMR_vector()); // transfer DM2D to DM_grid in gint
-    Gint_inout inout(this->charge->rho, Gint_Tools::job_type::rho);
+    Gint_inout inout(this->charge->rho, Gint_Tools::job_type::rho, PARAM.inp.nspin);
     this->gint_k->cal_gint(&inout);
 
     if (XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5)
@@ -113,7 +113,7 @@ void ElecStateLCAO<double>::psiToRho(const psi::Psi<double>& psi)
 
     this->gint_gamma->transfer_DM2DtoGrid(this->DM->get_DMR_vector()); // transfer DM2D to DM_grid in gint
 
-    Gint_inout inout(this->charge->rho, Gint_Tools::job_type::rho);
+    Gint_inout inout(this->charge->rho, Gint_Tools::job_type::rho, PARAM.inp.nspin);
 
     this->gint_gamma->cal_gint(&inout);
 
@@ -178,7 +178,7 @@ void ElecStateLCAO<double>::dmToRho(std::vector<double*> pexsi_DM, std::vector<d
 
     ModuleBase::GlobalFunc::NOTE("Calculate the charge on real space grid!");
     this->gint_gamma->transfer_DM2DtoGrid(this->DM->get_DMR_vector()); // transfer DM2D to DM_grid in gint
-    Gint_inout inout(this->charge->rho, Gint_Tools::job_type::rho);
+    Gint_inout inout(this->charge->rho, Gint_Tools::job_type::rho, PARAM.inp.nspin);
     this->gint_gamma->cal_gint(&inout);
     if (XC_Functional::get_func_type() == 3 || XC_Functional::get_func_type() == 5)
     {

--- a/source/module_elecstate/elecstate_lcao_cal_tau.cpp
+++ b/source/module_elecstate/elecstate_lcao_cal_tau.cpp
@@ -15,7 +15,7 @@ void ElecStateLCAO<std::complex<double>>::cal_tau(const psi::Psi<std::complex<do
     {
         ModuleBase::GlobalFunc::ZEROS(this->charge->kin_r[is], this->charge->nrxx);
     }
-    Gint_inout inout1(this->charge->kin_r, Gint_Tools::job_type::tau);
+    Gint_inout inout1(this->charge->kin_r, Gint_Tools::job_type::tau, PARAM.inp.nspin);
     this->gint_k->cal_gint(&inout1);
 
     ModuleBase::timer::tick("ElecStateLCAO", "cal_tau");
@@ -32,7 +32,7 @@ void ElecStateLCAO<double>::cal_tau(const psi::Psi<double>& psi)
     {
         ModuleBase::GlobalFunc::ZEROS(this->charge->kin_r[is], this->charge->nrxx);
     }
-    Gint_inout inout1(this->charge->kin_r, Gint_Tools::job_type::tau);
+    Gint_inout inout1(this->charge->kin_r, Gint_Tools::job_type::tau, PARAM.inp.nspin);
     this->gint_gamma->cal_gint(&inout1);
 
     ModuleBase::timer::tick("ElecStateLCAO", "cal_tau");

--- a/source/module_elecstate/elecstate_lcao_tddft.cpp
+++ b/source/module_elecstate/elecstate_lcao_tddft.cpp
@@ -36,7 +36,7 @@ void ElecStateLCAO_TDDFT::psiToRho_td(const psi::Psi<std::complex<double>>& psi)
 
     ModuleBase::GlobalFunc::NOTE("Calculate the charge on real space grid!");
     this->gint_k->transfer_DM2DtoGrid(this->DM->get_DMR_vector());  // transfer DM2D to DM_grid in gint
-    Gint_inout inout(this->charge->rho, Gint_Tools::job_type::rho); // rho calculation
+    Gint_inout inout(this->charge->rho, Gint_Tools::job_type::rho, PARAM.inp.nspin); // rho calculation
     this->gint_k->cal_gint(&inout);
 
     this->charge->renormalize_rho();

--- a/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.cpp
@@ -174,13 +174,14 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                 pot_in->pot_register(pot_register_in);
                 // effective potential term
                 Operator<TK>* veff = new Veff<OperatorLCAO<TK, TR>>(GG_in,
-                                                                    this->hsk,
-                                                                    this->kv->kvec_d,
-                                                                    pot_in,
-                                                                    this->hR, // no explicit call yet
-                                                                    &GlobalC::ucell,
-                                                                    orb.cutoffs(),
-                                                                    &GlobalC::GridD
+                    this->hsk,
+                    this->kv->kvec_d,
+                    pot_in,
+                    this->hR, // no explicit call yet
+                    &GlobalC::ucell,
+                    orb.cutoffs(),
+                    &GlobalC::GridD,
+                    PARAM.inp.nspin
                 );
                 this->getOperator()->add(veff);
             }
@@ -242,13 +243,14 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                 pot_in->pot_register(pot_register_in);
                 // Veff term
                 this->getOperator() = new Veff<OperatorLCAO<TK, TR>>(GK_in,
-                                                                     this->hsk,
-                                                                     kv->kvec_d,
-                                                                     pot_in,
-                                                                     this->hR,
-                                                                     &GlobalC::ucell,
-                                                                     orb.cutoffs(),
-                                                                     &GlobalC::GridD);
+                    this->hsk,
+                    kv->kvec_d,
+                    pot_in,
+                    this->hR,
+                    &GlobalC::ucell,
+                    orb.cutoffs(),
+                    &GlobalC::GridD,
+                    PARAM.inp.nspin);
                 // reset spin index and real space Hamiltonian matrix
                 int start_spin = -1;
                 GK_in->reset_spin(start_spin);

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/veff_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/veff_lcao.h
@@ -36,39 +36,41 @@ class Veff<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
      * @param GK_in: the pointer of Gint_k object, used for grid integration
     */
     Veff<OperatorLCAO<TK, TR>>(Gint_k* GK_in,
-                               HS_Matrix_K<TK>* hsk_in,
-                               const std::vector<ModuleBase::Vector3<double>>& kvec_d_in,
-                               elecstate::Potential* pot_in,
-                               hamilt::HContainer<TR>* hR_in,
-                               const UnitCell* ucell_in,
-                               const std::vector<double>& orb_cutoff,
-                               Grid_Driver* GridD_in)
+        HS_Matrix_K<TK>* hsk_in,
+        const std::vector<ModuleBase::Vector3<double>>& kvec_d_in,
+        elecstate::Potential* pot_in,
+        hamilt::HContainer<TR>* hR_in,
+        const UnitCell* ucell_in,
+        const std::vector<double>& orb_cutoff,
+        Grid_Driver* GridD_in,
+        const int& nspin)
         : GK(GK_in), orb_cutoff_(orb_cutoff), pot(pot_in), ucell(ucell_in),
           gd(GridD_in), OperatorLCAO<TK, TR>(hsk_in, kvec_d_in, hR_in)
     {
         this->cal_type = calculation_type::lcao_gint;
 
         this->initialize_HR(ucell_in, GridD_in);
-        GK_in->initialize_pvpR(*ucell_in, GridD_in);
+        GK_in->initialize_pvpR(*ucell_in, GridD_in, nspin);
     }
     /**
      * @brief Construct a new Veff object for Gamma-only calculation
      * @param GG_in: the pointer of Gint_Gamma object, used for grid integration
     */
     Veff<OperatorLCAO<TK, TR>>(Gint_Gamma* GG_in,
-                               HS_Matrix_K<TK>* hsk_in,
-                               const std::vector<ModuleBase::Vector3<double>>& kvec_d_in,
-                               elecstate::Potential* pot_in,
-                               hamilt::HContainer<TR>* hR_in,
-                               const UnitCell* ucell_in,
-                               const std::vector<double>& orb_cutoff,
-                               Grid_Driver* GridD_in)
+        HS_Matrix_K<TK>* hsk_in,
+        const std::vector<ModuleBase::Vector3<double>>& kvec_d_in,
+        elecstate::Potential* pot_in,
+        hamilt::HContainer<TR>* hR_in,
+        const UnitCell* ucell_in,
+        const std::vector<double>& orb_cutoff,
+        Grid_Driver* GridD_in,
+        const int& nspin)
         : GG(GG_in), orb_cutoff_(orb_cutoff), pot(pot_in), OperatorLCAO<TK, TR>(hsk_in, kvec_d_in, hR_in)
     {
         this->cal_type = calculation_type::lcao_gint;
         this->initialize_HR(ucell_in, GridD_in);
 
-        GG_in->initialize_pvpR(*ucell_in, GridD_in);
+        GG_in->initialize_pvpR(*ucell_in, GridD_in, nspin);
     }
 
     ~Veff<OperatorLCAO<TK, TR>>(){};

--- a/source/module_hamilt_lcao/module_gint/gint.h
+++ b/source/module_hamilt_lcao/module_gint/gint.h
@@ -49,7 +49,12 @@ class Gint {
      * @brief calculate the neighbor atoms of each atom in this processor
      * size of BaseMatrix with be the non-parallel version
      */
-    void initialize_pvpR(const UnitCell& unitcell, Grid_Driver* gd);
+    void initialize_pvpR(const UnitCell& unitcell, Grid_Driver* gd, const int& nspin);
+
+    /**
+     * @brief resize DMRGint to nspin and reallocate the memory
+     */
+    void reset_DMRGint(const int& nspin);
 
     /**
      * @brief transfer DMR (2D para) to DMR (Grid para) in elecstate_lcao.cpp

--- a/source/module_hamilt_lcao/module_gint/gint_rho_cpu_interface.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_rho_cpu_interface.cpp
@@ -54,7 +54,7 @@ void Gint::gint_kernel_rho(Gint_inout* inout) {
                                 cal_flag.get_ptr_2D(),
                                 psir_ylm.get_ptr_2D());
 
-        for (int is = 0; is < PARAM.inp.nspin; ++is)
+        for (int is = 0; is < inout->nspin_rho; ++is)
         {
             ModuleBase::Array_Pool<double> psir_DM(this->bxyz, LD_pool);
             ModuleBase::GlobalFunc::ZEROS(psir_DM.get_ptr_1D(), this->bxyz * LD_pool);

--- a/source/module_hamilt_lcao/module_gint/gint_tools.h
+++ b/source/module_hamilt_lcao/module_gint/gint_tools.h
@@ -39,6 +39,7 @@ class Gint_inout
     bool isforce;
     bool isstress;
     int ispin;
+    int nspin_rho;  // usually, but not always, equal to global nspin
     bool if_symm = false; // if true, use dsymv in gint_kernel_rho; if false, use dgemv.
 
     // output
@@ -48,10 +49,11 @@ class Gint_inout
     Gint_Tools::job_type job;
 
     // electron density and kin_r, multi-k
-    Gint_inout(double** rho_in, Gint_Tools::job_type job_in, bool if_symm_in = true)
+    Gint_inout(double** rho_in, Gint_Tools::job_type job_in, const int& nspin_rho_in, bool if_symm_in = true)
     {
         rho = rho_in;
         job = job_in;
+        nspin_rho = nspin_rho_in;
         if_symm = if_symm_in;
     }
 
@@ -108,15 +110,6 @@ class Gint_inout
         vofk = vofk_in;
         ispin = ispin_in;
         job = job_in;
-    }
-
-    // electron density and kin_r, gamma point
-    Gint_inout(double*** DM_in, double** rho_in, Gint_Tools::job_type job_in, bool if_symm_in = true)
-    {
-        DM = DM_in;
-        rho = rho_in;
-        job = job_in;
-        if_symm = if_symm_in;
     }
 
     // vlocal, gamma point

--- a/source/module_io/get_pchg_lcao.cpp
+++ b/source/module_io/get_pchg_lcao.cpp
@@ -104,9 +104,9 @@ void IState_Charge::begin(Gint_Gamma& gg,
 
             DM.init_DMR(GridD_in, ucell_in);
             DM.cal_DMR();
-            gg.initialize_pvpR(*ucell_in, GridD_in);
+            gg.initialize_pvpR(*ucell_in, GridD_in, PARAM.inp.nspin);
             gg.transfer_DM2DtoGrid(DM.get_DMR_vector());
-            Gint_inout inout((double***)nullptr, rho, Gint_Tools::job_type::rho);
+            Gint_inout inout(rho, Gint_Tools::job_type::rho, PARAM.inp.nspin);
             gg.cal_gint(&inout);
 
             // A solution to replace the original implementation of the following code:
@@ -243,9 +243,9 @@ void IState_Charge::begin(Gint_k& gk,
 
                     DM.init_DMR(GridD_in, ucell_in);
                     DM.cal_DMR(ik);
-                    gk.initialize_pvpR(*ucell_in, GridD_in);
+                    gk.initialize_pvpR(*ucell_in, GridD_in, PARAM.inp.nspin);
                     gk.transfer_DM2DtoGrid(DM.get_DMR_vector());
-                    Gint_inout inout(rho, Gint_Tools::job_type::rho);
+                    Gint_inout inout(rho, Gint_Tools::job_type::rho, PARAM.inp.nspin);
                     gk.cal_gint(&inout);
 
                     // Using std::vector to replace the original double** rho_save
@@ -298,9 +298,9 @@ void IState_Charge::begin(Gint_k& gk,
 
                 DM.init_DMR(GridD_in, ucell_in);
                 DM.cal_DMR();
-                gk.initialize_pvpR(*ucell_in, GridD_in);
+                gk.initialize_pvpR(*ucell_in, GridD_in, PARAM.inp.nspin);
                 gk.transfer_DM2DtoGrid(DM.get_DMR_vector());
-                Gint_inout inout(rho, Gint_Tools::job_type::rho);
+                Gint_inout inout(rho, Gint_Tools::job_type::rho, PARAM.inp.nspin);
                 gk.cal_gint(&inout);
 
                 // Using std::vector to replace the original double** rho_save

--- a/source/module_io/write_eband_terms.hpp
+++ b/source/module_io/write_eband_terms.hpp
@@ -87,7 +87,7 @@ namespace ModuleIO
             hamilt::HContainer<TR> v_pp_local_R_ao(pv);
             if_gamma_fix(v_pp_local_R_ao);
             std::vector<std::vector<double>> e_orb_pp_local;
-            hamilt::Veff<hamilt::OperatorLCAO<TK, TR>> v_pp_local_op(gint, &v_pp_local_k_ao, kv.kvec_d, &pot_local, &v_pp_local_R_ao, &ucell, orb_cutoff, &gd);
+            hamilt::Veff<hamilt::OperatorLCAO<TK, TR>> v_pp_local_op(gint, &v_pp_local_k_ao, kv.kvec_d, &pot_local, &v_pp_local_R_ao, &ucell, orb_cutoff, &gd, nspin);
             v_pp_local_op.contributeHR();
             for (int ik = 0;ik < kv.get_nks();++ik)
             {
@@ -142,7 +142,7 @@ namespace ModuleIO
             for (int is = 0; is < nspin0; ++is)
             {
                 v_hartree_op[is] = new hamilt::Veff<hamilt::OperatorLCAO<TK, TR>>(gint,
-                    &v_hartree_k_ao, kv.kvec_d, &pot_hartree, &v_hartree_R_ao[is], &ucell, orb_cutoff, &gd);
+                    &v_hartree_k_ao, kv.kvec_d, &pot_hartree, &v_hartree_R_ao[is], &ucell, orb_cutoff, &gd, nspin);
                 v_hartree_op[is]->contributeHR();
             }
             std::vector<std::vector<double>> e_orb_hartree;

--- a/source/module_io/write_vxc.hpp
+++ b/source/module_io/write_vxc.hpp
@@ -238,13 +238,7 @@ void write_Vxc(const int nspin,
     for (int is = 0; is < nspin0; ++is)
     {
         vxcs_op_ao[is] = new hamilt::Veff<hamilt::OperatorLCAO<TK, TR>>(gint,
-                                                                        &vxc_k_ao,
-                                                                        kv.kvec_d,
-                                                                        potxc,
-                                                                        &vxcs_R_ao[is],
-                                                                        &ucell,
-                                                                        orb_cutoff,
-                                                                        &gd);
+            &vxc_k_ao, kv.kvec_d, potxc, &vxcs_R_ao[is], &ucell, orb_cutoff, &gd, nspin);
 
         vxcs_op_ao[is]->contributeHR();
     }

--- a/source/module_lr/esolver_lrtd_lcao.cpp
+++ b/source/module_lr/esolver_lrtd_lcao.cpp
@@ -313,6 +313,7 @@ LR::ESolver_LR<T, TR>::ESolver_LR(const Input_para& inp, UnitCell& ucell) : inpu
         PARAM.inp.test_atom_input);
     this->set_gint();
     this->gint_->gridt = &this->gt_;
+    this->gint_->reset_DMRGint(1);
 
     // (3) Periodic condition search for each grid.
     double dr_uniform = 0.001;
@@ -372,7 +373,7 @@ LR::ESolver_LR<T, TR>::ESolver_LR(const Input_para& inp, UnitCell& ucell) : inpu
         this->pw_rho->startz_current,
         &ucell,
         &orb);
-    this->gint_->initialize_pvpR(ucell, &GlobalC::GridD);
+    this->gint_->initialize_pvpR(ucell, &GlobalC::GridD, 1);    // always use nspin=1 for transition density
 
     // if EXX from scratch, init 2-center integral and calculate Cs, Vs 
 #ifdef __EXX

--- a/source/module_lr/hamilt_casida.h
+++ b/source/module_lr/hamilt_casida.h
@@ -44,7 +44,7 @@ namespace LR
             if (ri_hartree_benchmark != "aims") { assert(aims_nbasis.empty()); }
             this->classname = "HamiltCasidaLR";
             this->DM_trans.resize(1);
-            this->DM_trans[0] = LR_Util::make_unique<elecstate::DensityMatrix<T, T>>(pmat_in, nspin, kv_in.kvec_d, nk);
+            this->DM_trans[0] = LR_Util::make_unique<elecstate::DensityMatrix<T, T>>(pmat_in, 1, kv_in.kvec_d, nk);
             // add the diag operator  (the first one)
             this->ops = new OperatorLRDiag<T>(eig_ks, pX_in, nk, nocc, nvirt);
             //add Hxc operator

--- a/source/module_lr/lr_spectrum.cpp
+++ b/source/module_lr/lr_spectrum.cpp
@@ -12,7 +12,7 @@ void LR::LR_Spectrum<T>::cal_gint_rho(double** rho, const int& nspin_solve, cons
     for (int is = 0;is < nspin_solve;++is) {
         ModuleBase::GlobalFunc::ZEROS(rho[is], nrxx);
 }
-    Gint_inout inout_rho(rho, Gint_Tools::job_type::rho, false);
+    Gint_inout inout_rho(rho, Gint_Tools::job_type::rho, 1, false);
     this->gint->cal_gint(&inout_rho);
 }
 
@@ -33,7 +33,7 @@ void LR::LR_Spectrum<double>::oscillator_strength()
     osc.resize(X.get_nbands(), 0.0);
     // const int nspin0 = (this->nspin == 2) ? 2 : 1;   use this in NSPIN=4 implementation
     double osc_tot = 0.0;
-    elecstate::DensityMatrix<double, double> DM_trans(&this->pmat, this->nspin, this->kv.kvec_d, this->nk);
+    elecstate::DensityMatrix<double, double> DM_trans(&this->pmat, 1, this->kv.kvec_d, this->nk);
     DM_trans.init_DMR(&GlobalC::GridD, &this->ucell);
     this->transition_dipole_.resize(X.get_nbands(), ModuleBase::Vector3<double>(0.0, 0.0, 0.0));
     for (int istate = 0;istate < X.get_nbands();++istate)
@@ -90,9 +90,9 @@ void LR::LR_Spectrum<std::complex<double>>::oscillator_strength()
     osc.resize(X.get_nbands(), 0.0);
     // const int nspin0 = (this->nspin == 2) ? 2 : 1;   use this in NSPIN=4 implementation
     double osc_tot = 0.0;
-    elecstate::DensityMatrix<std::complex<double>, std::complex<double>> DM_trans(&this->pmat, this->nspin, this->kv.kvec_d, this->nk);
+    elecstate::DensityMatrix<std::complex<double>, std::complex<double>> DM_trans(&this->pmat, 1, this->kv.kvec_d, this->nk);
     DM_trans.init_DMR(&GlobalC::GridD, &this->ucell);
-    elecstate::DensityMatrix<std::complex<double>, double> DM_trans_real_imag(&this->pmat, this->nspin, this->kv.kvec_d, this->nk);
+    elecstate::DensityMatrix<std::complex<double>, double> DM_trans_real_imag(&this->pmat, 1, this->kv.kvec_d, this->nk);
     DM_trans_real_imag.init_DMR(&GlobalC::GridD, &this->ucell);
 
     this->transition_dipole_.resize(X.get_nbands(), ModuleBase::Vector3<std::complex<double>>(0.0, 0.0, 0.0));

--- a/source/module_lr/operator_casida/operator_lr_hxc.cpp
+++ b/source/module_lr/operator_casida/operator_lr_hxc.cpp
@@ -101,9 +101,9 @@ namespace LR
         double** rho_trans;
         const int& nrxx = this->pot.lock()->nrxx;
         // LR_Util::new_p2(rho_trans, nspin_solve, nrxx);
-        LR_Util::new_p2(rho_trans, nspin, nrxx); // currently gint_kernel_rho uses PARAM.inp.nspin, it needs refactor
+        LR_Util::new_p2(rho_trans, 1, nrxx); // currently gint_kernel_rho uses PARAM.inp.nspin, it needs refactor
         for (int is = 0;is < nspin_solve;++is)ModuleBase::GlobalFunc::ZEROS(rho_trans[is], nrxx);
-        Gint_inout inout_rho(rho_trans, Gint_Tools::job_type::rho, false);
+        Gint_inout inout_rho(rho_trans, Gint_Tools::job_type::rho, 1, false);
         this->gint->cal_gint(&inout_rho);
 
         // 3. v_hxc = f_hxc * rho_trans
@@ -131,7 +131,7 @@ namespace LR
         ModuleBase::TITLE("OperatorLRHxc", "grid_calculation(complex)");
         ModuleBase::timer::tick("OperatorLRHxc", "grid_calculation");
 
-        elecstate::DensityMatrix<std::complex<double>, double> DM_trans_real_imag(pmat, nspin, kv.kvec_d, kv.get_nks() / nspin);
+        elecstate::DensityMatrix<std::complex<double>, double> DM_trans_real_imag(pmat, 1, kv.kvec_d, kv.get_nks() / nspin);
         DM_trans_real_imag.init_DMR(*this->hR);
         hamilt::HContainer<double> HR_real_imag(GlobalC::ucell, this->pmat);
         this->initialize_HR(HR_real_imag, ucell, gd, this->pmat);
@@ -150,7 +150,7 @@ namespace LR
                 // LR_Util::new_p2(rho_trans, nspin_solve, nrxx);
                 LR_Util::new_p2(rho_trans, nspin, nrxx); // currently gint_kernel_rho uses PARAM.inp.nspin, it needs refactor
                 for (int is = 0;is < nspin_solve;++is)ModuleBase::GlobalFunc::ZEROS(rho_trans[is], nrxx);
-                Gint_inout inout_rho(rho_trans, Gint_Tools::job_type::rho, false);
+                Gint_inout inout_rho(rho_trans, Gint_Tools::job_type::rho, 1, false);
                 this->gint->cal_gint(&inout_rho);
                 // print_grid_nonzero(rho_trans[0], nrxx, 10, "rho_trans");
 

--- a/source/module_lr/operator_casida/operator_lr_hxc.h
+++ b/source/module_lr/operator_casida/operator_lr_hxc.h
@@ -88,7 +88,7 @@ namespace LR
                 for (int ib = prev_size;ib < nbands;++ib)
                 {
                     // the first dimenstion of DensityMatrix is nk=nks/nspin 
-                    DM_trans[ib] = LR_Util::make_unique<elecstate::DensityMatrix<T, TR>>(this->pmat, this->nspin, this->kv.kvec_d, this->kv.get_nks() / nspin);
+                    DM_trans[ib] = LR_Util::make_unique<elecstate::DensityMatrix<T, TR>>(this->pmat, 1, this->kv.kvec_d, this->kv.get_nks() / nspin);
                     DM_trans[ib]->init_DMR(*this->hR);
                 }
             }


### PR DESCRIPTION
then LR-TDDFT can always use nspin=1 for transition density matrix, no matter what `PARAM.inp.nspin` is.