### PR TITLE
Fix: nupdown = 0 for spin-unpolarized calculation

### DIFF
--- a/source/module_io/read_input_item_elec_stru.cpp
+++ b/source/module_io/read_input_item_elec_stru.cpp
@@ -235,7 +235,18 @@ void ReadInput::item_elec_stru()
             para.input.nupdown = doublevalue;
             para.sys.two_fermi = true;
         };
-
+        item.reset_value = [](const Input_Item&, Parameter& para) {
+            if (para.input.nspin == 1)
+            {
+                para.sys.two_fermi = false;
+            }
+        };
+        item.check_value = [](const Input_Item&, const Parameter& para) {
+            if (para.input.nspin == 1 && para.input.nupdown != 0.0)
+            {
+                ModuleBase::WARNING_QUIT("ReadInput", "nupdown mustn't have a non-zero value for spin-unpolarized calculations.");
+            }
+        };
         sync_double(input.nupdown);
         this->add_item(item);
     }


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #5297 
