### PR TITLE
Performance: change the position of open mp

### DIFF
--- a/source/module_hamilt_pw/hamilt_pwdft/kernels/ekinetic_op.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/kernels/ekinetic_op.cpp
@@ -17,39 +17,34 @@ struct ekinetic_pw_op<FPTYPE, base_device::DEVICE_CPU>
     {
         if (is_first_node)
         {
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
             for (int ib = 0; ib < nband; ++ib)
             {
-#ifdef _OPENMP
-#pragma omp parallel for
-#endif
+                const int ig0 = ib * max_npw;
                 for (int ig = 0; ig < npw; ++ig)
                 {
-                    tmhpsi[ig] = gk2_ik[ig] * tpiba2 * tmpsi_in[ig];
+                    tmhpsi[ig + ig0] = gk2_ik[ig] * tpiba2 * tmpsi_in[ig + ig0];
                 }
-#ifdef _OPENMP
-#pragma omp parallel for
-#endif
                 for (int ig = npw; ig < max_npw; ++ig)
                 {
-                    tmhpsi[ig] = 0.0;
+                    tmhpsi[ig + ig0] = 0.0;
                 }
-                tmpsi_in += max_npw;
-                tmhpsi += max_npw;
             }
         }
         else
         {
-            for (int ib = 0; ib < nband; ++ib)
-            {
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
+            for (int ib = 0; ib < nband; ++ib)
+            {
+                const int ig0 = ib * max_npw;
                 for (int ig = 0; ig < npw; ++ig)
                 {
-                    tmhpsi[ig] += gk2_ik[ig] * tpiba2 * tmpsi_in[ig];
+                    tmhpsi[ig + ig0] += gk2_ik[ig] * tpiba2 * tmpsi_in[ig + ig0];
                 }
-                tmpsi_in += max_npw;
-                tmhpsi += max_npw;
             }
         }
     }

--- a/source/module_hamilt_pw/hamilt_stodft/hamilt_sdft_pw.cpp
+++ b/source/module_hamilt_pw/hamilt_stodft/hamilt_sdft_pw.cpp
@@ -55,14 +55,17 @@ void HamiltSdftPW<T, Device>::hPsi_norm(const T* psi_in, T* hpsi_norm, const int
     const Real emax = *this->emax;
     const Real Ebar = (emin + emax) / 2;
     const Real DeltaE = (emax - emin) / 2;
+
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
     for (int ib = 0; ib < nbands; ++ib)
     {
+        const int ig0 = ib * npwk_max;
         for (int ig = 0; ig < npwk; ++ig)
         {
-            hpsi_norm[ig] = (hpsi_norm[ig] - Ebar * psi_in[ig]) / DeltaE;
+            hpsi_norm[ig + ig0] = (hpsi_norm[ig + ig0] - Ebar * psi_in[ig + ig0]) / DeltaE;
         }
-        hpsi_norm += npwk_max;
-        psi_in += npwk_max;
     }
     ModuleBase::timer::tick("HamiltSdftPW", "hPsi_norm");
 }


### PR DESCRIPTION
In PR #5298 , we found after replacing sto_hchi by hamilt_sdft_pw, the time is increase.
In fact, it is caused by openmp collapse(2). In this case, collapse(2) will be 10 times slower than collapse(1).
In PR #5298, we place openmp inside the for loop, but it will be nonefficient when npw is small. So，in this PR we move it outside the for loop. The time will not change if npw is large.