### PR TITLE
Fix: Fix Consts memory leak by directly removing custome consts

### DIFF
--- a/source/module_hsolver/diago_dav_subspace.cpp
+++ b/source/module_hsolver/diago_dav_subspace.cpp
@@ -25,10 +25,6 @@ Diago_DavSubspace<T, Device>::Diago_DavSubspace(const std::vector<Real>& precond
 {
     this->device = base_device::get_device_type<Device>(this->ctx);
 
-    this->one = this->cs.one;
-    this->zero = this->cs.zero;
-    this->neg_one = this->cs.neg_one;
-
     assert(david_ndim_in > 1);
     assert(david_ndim_in * nband_in < nbasis_in * this->diag_comm.nproc);
 
@@ -559,8 +555,8 @@ void Diago_DavSubspace<T, Device>::diag_zhegvx(const int& nbase,
         }
         else
         {
-            std::vector<std::vector<T>> h_diag(nbase, std::vector<T>(nbase, cs.zero[0]));
-            std::vector<std::vector<T>> s_diag(nbase, std::vector<T>(nbase, cs.zero[0]));
+            std::vector<std::vector<T>> h_diag(nbase, std::vector<T>(nbase, *this->zero));
+            std::vector<std::vector<T>> s_diag(nbase, std::vector<T>(nbase, *this->zero));
 
             for (size_t i = 0; i < nbase; i++)
             {
@@ -589,10 +585,10 @@ void Diago_DavSubspace<T, Device>::diag_zhegvx(const int& nbase,
 
                 for (size_t j = nbase; j < this->nbase_x; j++)
                 {
-                    hcc[i * this->nbase_x + j] = cs.zero[0];
-                    hcc[j * this->nbase_x + i] = cs.zero[0];
-                    scc[i * this->nbase_x + j] = cs.zero[0];
-                    scc[j * this->nbase_x + i] = cs.zero[0];
+                    hcc[i * this->nbase_x + j] = *this->zero;
+                    hcc[j * this->nbase_x + i] = *this->zero;
+                    scc[i * this->nbase_x + j] = *this->zero;
+                    scc[j * this->nbase_x + i] = *this->zero;
                 }
             }
         }

--- a/source/module_hsolver/diago_dav_subspace.cpp
+++ b/source/module_hsolver/diago_dav_subspace.cpp
@@ -193,7 +193,7 @@ int Diago_DavSubspace<T, Device>::diag_once(const HPsiFunc& hpsi_func,
                                  this->dim,
                                  this->vcc,
                                  this->nbase_x,
-                                 this->zero,
+                                 *this->zero,
                                  psi_in,
                                  psi_in_dmax);
 
@@ -279,7 +279,7 @@ void Diago_DavSubspace<T, Device>::cal_grad(const HPsiFunc& hpsi_func,
                          this->dim,
                          vcc,
                          this->nbase_x,
-                         this->zero,
+                         *this->zero,
                          psi_iter + (nbase) * this->dim,
                          this->dim);
 
@@ -413,7 +413,7 @@ void Diago_DavSubspace<T, Device>::cal_elem(const int& dim,
                          this->dim,
                          &hphi[nbase * this->dim],
                          this->dim,
-                         this->zero,
+                         *this->zero,
                          &hcc[nbase * this->nbase_x],
                          this->nbase_x);
 
@@ -433,7 +433,7 @@ void Diago_DavSubspace<T, Device>::cal_elem(const int& dim,
                          this->dim,
                          psi_iter + nbase * this->dim,
                          this->dim,
-                         this->zero,
+                         *this->zero,
                          &scc[nbase * this->nbase_x],
                          this->nbase_x);
 
@@ -640,7 +640,7 @@ void Diago_DavSubspace<T, Device>::refresh(const int& dim,
                          this->dim,
                          this->vcc,
                          this->nbase_x,
-                         this->zero,
+                         *this->zero,
                          psi_iter + nband * this->dim,
                          this->dim);
 

--- a/source/module_hsolver/diago_dav_subspace.cpp
+++ b/source/module_hsolver/diago_dav_subspace.cpp
@@ -25,6 +25,10 @@ Diago_DavSubspace<T, Device>::Diago_DavSubspace(const std::vector<Real>& precond
 {
     this->device = base_device::get_device_type<Device>(this->ctx);
 
+    this->one = &one_;
+    this->zero = &zero_;
+    this->neg_one = &neg_one_;
+
     assert(david_ndim_in > 1);
     assert(david_ndim_in * nband_in < nbasis_in * this->diag_comm.nproc);
 
@@ -193,7 +197,7 @@ int Diago_DavSubspace<T, Device>::diag_once(const HPsiFunc& hpsi_func,
                                  this->dim,
                                  this->vcc,
                                  this->nbase_x,
-                                 *this->zero,
+                                 this->zero,
                                  psi_in,
                                  psi_in_dmax);
 
@@ -279,7 +283,7 @@ void Diago_DavSubspace<T, Device>::cal_grad(const HPsiFunc& hpsi_func,
                          this->dim,
                          vcc,
                          this->nbase_x,
-                         *this->zero,
+                         this->zero,
                          psi_iter + (nbase) * this->dim,
                          this->dim);
 
@@ -413,7 +417,7 @@ void Diago_DavSubspace<T, Device>::cal_elem(const int& dim,
                          this->dim,
                          &hphi[nbase * this->dim],
                          this->dim,
-                         *this->zero,
+                         this->zero,
                          &hcc[nbase * this->nbase_x],
                          this->nbase_x);
 
@@ -433,7 +437,7 @@ void Diago_DavSubspace<T, Device>::cal_elem(const int& dim,
                          this->dim,
                          psi_iter + nbase * this->dim,
                          this->dim,
-                         *this->zero,
+                         this->zero,
                          &scc[nbase * this->nbase_x],
                          this->nbase_x);
 
@@ -640,7 +644,7 @@ void Diago_DavSubspace<T, Device>::refresh(const int& dim,
                          this->dim,
                          this->vcc,
                          this->nbase_x,
-                         *this->zero,
+                         this->zero,
                          psi_iter + nband * this->dim,
                          this->dim);
 

--- a/source/module_hsolver/diago_dav_subspace.h
+++ b/source/module_hsolver/diago_dav_subspace.h
@@ -158,8 +158,8 @@ class Diago_DavSubspace
     using syncmem_h2d_op = base_device::memory::synchronize_memory_op<T, Device, base_device::DEVICE_CPU>;
     using syncmem_d2h_op = base_device::memory::synchronize_memory_op<T, base_device::DEVICE_CPU, Device>;
 
-    const_nums<T> cs;
     const T *one = nullptr, *zero = nullptr, *neg_one = nullptr;
+    const T one_ = static_cast<T>(1.0), zero_ = static_cast<T>(0.0), neg_one_ = static_cast<T>(-1.0);
 };
 
 } // namespace hsolver


### PR DESCRIPTION
Fix issue #5343
In fact I dont exactly know what is the necessity of custom consts... So just directly remove this is david_subspace to get rid of its bug. @Cstandardlib has removed it from other solvers.