### PR TITLE
Fix: make EXX symmetry consistent with the fixed irreducible k-points

### DIFF
--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -203,10 +203,12 @@ void ESolver_KS_LCAO<TK, TR>::before_all_runners(const Input_para& inp, UnitCell
             if (GlobalC::exx_info.info_ri.real_number)
             {
                 this->exx_lri_double->init(MPI_COMM_WORLD, this->kv, orb_);
+                this->exd->exx_before_all_runners(this->kv, GlobalC::ucell, this->pv);
             }
             else
             {
                 this->exx_lri_complex->init(MPI_COMM_WORLD, this->kv, orb_);
+                this->exc->exx_before_all_runners(this->kv, GlobalC::ucell, this->pv);
             }
         }
     }

--- a/source/module_esolver/lcao_before_scf.cpp
+++ b/source/module_esolver/lcao_before_scf.cpp
@@ -210,11 +210,11 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(const int istep)
 #ifdef __EXX // set xc type before the first cal of xc in pelec->init_scf
     if (GlobalC::exx_info.info_ri.real_number)
     {
-        this->exd->exx_beforescf(this->kv, *this->p_chgmix, GlobalC::ucell, this->pv, orb_);
+        this->exd->exx_beforescf(this->kv, *this->p_chgmix, GlobalC::ucell, orb_);
     }
     else
     {
-        this->exc->exx_beforescf(this->kv, *this->p_chgmix, GlobalC::ucell, this->pv, orb_);
+        this->exc->exx_beforescf(this->kv, *this->p_chgmix, GlobalC::ucell, orb_);
     }
 #endif // __EXX
 

--- a/source/module_ri/Exx_LRI_interface.h
+++ b/source/module_ri/Exx_LRI_interface.h
@@ -48,8 +48,13 @@ public:
     double& get_Eexx() const { return this->exx_ptr->Eexx; }
 
     // Processes in ESolver_KS_LCAO
+    /// @brief in before_all_runners: set symmetry according to irreducible k-points
+    /// since k-points are not reduced again after the variation of the cell and exx-symmetry must be consistent with k-points. 
+    /// In the future, we will reduce k-points again during cell-relax, then this setting can be moved to `exx_beforescf`.
+    void exx_before_all_runners(const K_Vectors& kv, const UnitCell& ucell, const Parallel_2D& pv);
+
     /// @brief in beforescf: set xc type, opt_orb, do DM mixing
-    void exx_beforescf(const K_Vectors& kv, const Charge_Mixing& chgmix, const UnitCell& ucell, const Parallel_2D& pv, const LCAO_Orbitals& orb);
+    void exx_beforescf(const K_Vectors& kv, const Charge_Mixing& chgmix, const UnitCell& ucell, const LCAO_Orbitals& orb);
 
     /// @brief in eachiterinit:  do DM mixing and calculate Hexx when entering 2nd SCF
     void exx_eachiterinit(const elecstate::DensityMatrix<T, double>& dm/**< double should be Tdata if complex-PBE-DM is supported*/,

--- a/source/module_ri/module_exx_symmetry/irreducible_sector.cpp
+++ b/source/module_ri/module_exx_symmetry/irreducible_sector.cpp
@@ -86,9 +86,9 @@ namespace ModuleSymmetry
         return TCdouble(std::round(return_lattice_double.x), std::round(return_lattice_double.y), std::round(return_lattice_double.z));
     }
 
-    void Irreducible_Sector::get_return_lattice_all(const Symmetry& symm, const Atom* atoms, const Statistics& st)
+    void Irreducible_Sector::cal_return_lattice_all(const Symmetry& symm, const Atom* atoms, const Statistics& st)
     {
-        ModuleBase::TITLE("Symmetry_rotation", "get_return_lattice_all");
+        ModuleBase::TITLE("Symmetry_rotation", "cal_return_lattice_all");
         this->return_lattice_.resize(st.nat, std::vector<TCdouble>(symm.nrotk));
         for (int iat1 = 0;iat1 < st.nat;++iat1)
         {
@@ -163,7 +163,7 @@ namespace ModuleSymmetry
         this->irreducible_sector_.clear();
         this->sector_stars_.clear();
 
-        if (this->return_lattice_.empty()) this->get_return_lattice_all(symm, atoms, st);
+        if (this->return_lattice_.empty()) this->cal_return_lattice_all(symm, atoms, st);
         // if (this->atompair_stars_.empty()) this->find_irreducible_atom_pairs(symm);
 
         // contruct {atom pair, R} set

--- a/source/module_ri/module_exx_symmetry/irreducible_sector.h
+++ b/source/module_ri/module_exx_symmetry/irreducible_sector.h
@@ -67,9 +67,10 @@ namespace ModuleSymmetry
         TCdouble get_return_lattice(const Symmetry& symm,
             const ModuleBase::Matrix3& gmatd, const TCdouble gtransd,
             const TCdouble& posd_a1, const TCdouble& posd_a2)const;
-        void get_return_lattice_all(const Symmetry& symm, const Atom* atoms, const Statistics& st);
 
     protected:
+        void cal_return_lattice_all(const Symmetry& symm, const Atom* atoms, const Statistics& st);
+
         //--------------------------------------------------------------------------------
         /// The sub functions to find irreducible sector: {abR}
 

--- a/source/module_ri/module_exx_symmetry/symmetry_rotation.cpp
+++ b/source/module_ri/module_exx_symmetry/symmetry_rotation.cpp
@@ -95,8 +95,7 @@ namespace ModuleSymmetry
         auto  vec_conj = [](const std::vector<std::complex<double>>& z, const double scal = 1.0) -> std::vector<std::complex<double>>
             {
                 std::vector<std::complex<double>> z_conj(z.size());
-                for (int i = 0;i < z.size();++i) { z_conj[i] = std::conj(z[i]) * scal;
-}
+                for (int i = 0;i < z.size();++i) { z_conj[i] = std::conj(z[i]) * scal; }
                 return z_conj;
             };
         std::vector<std::vector<std::complex<double>>> dm_k_full;
@@ -110,8 +109,7 @@ namespace ModuleSymmetry
                     {
                         double factor = 1.0 / static_cast<double>(kv.kstars[ik_ibz].size());
                         std::vector<std::complex<double>> dm_scaled(pv.get_local_size());
-                        for (int i = 0;i < pv.get_local_size();++i) { dm_scaled[i] = factor * dm_k_ibz[ik_ibz + is * nk][i];
-}
+                        for (int i = 0;i < pv.get_local_size();++i) { dm_scaled[i] = factor * dm_k_ibz[ik_ibz + is * nk][i]; }
                         dm_k_full.push_back(dm_scaled);
                     }
                     else if (vec3_eq(isym_kvd.second, -kv.kvec_d[ik_ibz], this->eps_) && this->TRS_first_) {

--- a/source/module_ri/module_exx_symmetry/symmetry_rotation.h
+++ b/source/module_ri/module_exx_symmetry/symmetry_rotation.h
@@ -21,11 +21,6 @@ namespace ModuleSymmetry
         //--------------------------------------------------------------------------------
         // getters
         const std::map<Tap, std::set<TC>>& get_irreducible_sector()const { return this->irs_.get_irreducible_sector(); }
-        void find_irreducible_sector(const Symmetry& symm, const Atom* atoms, const Statistics& st,
-            const std::vector<TC>& Rs, const TC& period, const Lattice& lat)
-        {
-            this->irs_.find_irreducible_sector(symm, atoms, st, Rs, period, lat);
-        }
         TCdouble get_return_lattice(const Symmetry& symm,
             const ModuleBase::Matrix3& gmatd, const TCdouble gtransd,
             const TCdouble& posd_a1, const TCdouble& posd_a2)const
@@ -34,6 +29,11 @@ namespace ModuleSymmetry
         }
         //--------------------------------------------------------------------------------
         // setters
+        void find_irreducible_sector(const Symmetry& symm, const Atom* atoms, const Statistics& st,
+            const std::vector<TC>& Rs, const TC& period, const Lattice& lat)
+        {
+            this->irs_.find_irreducible_sector(symm, atoms, st, Rs, period, lat);
+        }
         void set_Cs_rotation(const std::vector<std::vector<int>>& abfs_l_nchi);
         //--------------------------------------------------------------------------------
         /// functions  to contruct rotation matrix in AO-representation


### PR DESCRIPTION
To rotate the density matrices correctly, module_exx_symmetry must be consistent with `kv.kstars` set in `ibz_kpoint`.
However, during cell-relax, k-points are not reduced again when the symmetry changes. Such inconsistency make it impossible to rotate the density matrices using the changed symmetry. 

As a temporary solution, I move the initialization of EXX symmetry into `before_all_runners`. It will be called only once after `ibz_kpoints`.

If the irreducible k-points can change with symmetry during cell-relax, it can be moved back to `before_scf`.