### PR TITLE
Fix: make the symmetry condition in RPA consistent with EXX

### DIFF
--- a/source/module_ri/RPA_LRI.hpp
+++ b/source/module_ri/RPA_LRI.hpp
@@ -108,7 +108,7 @@ void RPA_LRI<T, Tdata>::cal_postSCF_exx(const elecstate::DensityMatrix<T, Tdata>
     exx_lri_rpa.init(mpi_comm_in, kv, orb);
     exx_lri_rpa.cal_exx_ions(PARAM.inp.out_ri_cv);
 
-    if (exx_spacegroup_symmetry) {
+    if (exx_spacegroup_symmetry && PARAM.inp.exx_symmetry_realspace) {
         exx_lri_rpa.cal_exx_elec(Ds, *dm.get_paraV_pointer(), &symrot);
     } else {
         exx_lri_rpa.cal_exx_elec(Ds, *dm.get_paraV_pointer());


### PR DESCRIPTION
Thanks @JGHan7 for pointing it out.