### PR TITLE
Feature: make SCF converges only if drho and dene is smaller than threshold

### DIFF
--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -673,10 +673,10 @@ void ESolver_KS<T, Device>::iter_finish(int& iter)
     this->pelec->f_en.etot_old = this->pelec->f_en.etot;
 
     // add a energy threshold for SCF convergence
-    if (this->conv_esolver == 0) // only check when density is not converged
+    if (this->scf_ene_thr > 0.0 && this->conv_esolver == 1) // only check when density is not converged
     {
         this->conv_esolver
-            = (iter != 1 && std::abs(this->pelec->f_en.etot_delta * ModuleBase::Ry_to_eV) < this->scf_ene_thr);
+            = (std::abs(this->pelec->f_en.etot_delta * ModuleBase::Ry_to_eV) < this->scf_ene_thr);
     }
 }
 

--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -673,7 +673,7 @@ void ESolver_KS<T, Device>::iter_finish(int& iter)
     this->pelec->f_en.etot_old = this->pelec->f_en.etot;
 
     // add a energy threshold for SCF convergence
-    if (this->scf_ene_thr > 0.0 && this->conv_esolver == 1) // only check when density is not converged
+    if (this->scf_ene_thr > 0.0 && this->conv_esolver == 1) // only check when density is converged
     {
         this->conv_esolver
             = (std::abs(this->pelec->f_en.etot_delta * ModuleBase::Ry_to_eV) < this->scf_ene_thr);


### PR DESCRIPTION
Fix #5011 

### The List of Change
1. Before this PR, SCF converges for `drho < scf_thr || dene < scf_ene_thr`. After this PR, SCF converges for `drho < scf_thr && dene < scf_ene_thr`.