### PR TITLE
Feature: move `scf_ene_thr` before `mix_rho`

### DIFF
--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -547,13 +547,15 @@ void ESolver_KS<T, Device>::runner(const int istep, UnitCell& ucell)
 
             this->conv_esolver = (drho < this->scf_thr && not_restart_step && is_U_converged);
 
+            // calculate energy of output charge density
+            this->pelec->cal_energies(2); // 2 means Kohn-Sham functional
+            // now, etot_old is the energy of input density, while etot is the energy of output density
+            this->pelec->f_en.etot_delta = this->pelec->f_en.etot - this->pelec->f_en.etot_old;
+            // output etot_delta
+            GlobalV::ofs_running << " DeltaE_womix = " << this->pelec->f_en.etot_delta * ModuleBase::Ry_to_eV << " eV" << std::endl;
             // add energy threshold for SCF convergence
             if (this->scf_ene_thr > 0.0 && iter > 1 && this->conv_esolver == 1) // only check when density is converged
             {
-                // only calculate energy when density is converged to reduce the time cost
-                this->pelec->cal_energies(2); // 2 means Kohn-Sham functional
-                // now, etot_old is the energy of input density, while etot is the energy of output density
-                this->pelec->f_en.etot_delta = this->pelec->f_en.etot - this->pelec->f_en.etot_old;
                 // update the convergence flag
                 this->conv_esolver
                     = (std::abs(this->pelec->f_en.etot_delta * ModuleBase::Ry_to_eV) < this->scf_ene_thr);

--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -681,13 +681,6 @@ void ESolver_KS<T, Device>::iter_finish(int& iter)
     }
     this->pelec->f_en.etot_delta = this->pelec->f_en.etot - this->pelec->f_en.etot_old;
     this->pelec->f_en.etot_old = this->pelec->f_en.etot;
-
-    // add a energy threshold for SCF convergence
-    if (this->scf_ene_thr > 0.0 && this->conv_esolver == 1) // only check when density is converged
-    {
-        this->conv_esolver
-            = (std::abs(this->pelec->f_en.etot_delta * ModuleBase::Ry_to_eV) < this->scf_ene_thr);
-    }
 }
 
 //! Something to do after SCF iterations when SCF is converged or comes to the max iter step.

--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -547,6 +547,18 @@ void ESolver_KS<T, Device>::runner(const int istep, UnitCell& ucell)
 
             this->conv_esolver = (drho < this->scf_thr && not_restart_step && is_U_converged);
 
+            // add energy threshold for SCF convergence
+            if (this->scf_ene_thr > 0.0 && iter > 1 && this->conv_esolver == 1) // only check when density is converged
+            {
+                // only calculate energy when density is converged to reduce the time cost
+                this->pelec->cal_energies(2); // 2 means Kohn-Sham functional
+                // now, etot_old is the energy of input density, while etot is the energy of output density
+                this->pelec->f_en.etot_delta = this->pelec->f_en.etot - this->pelec->f_en.etot_old;
+                // update the convergence flag
+                this->conv_esolver
+                    = (std::abs(this->pelec->f_en.etot_delta * ModuleBase::Ry_to_eV) < this->scf_ene_thr);
+            }
+
             // If drho < hsolver_error in the first iter or drho < scf_thr, we
             // do not change rho.
             if (drho < hsolver_error || this->conv_esolver)

--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -547,18 +547,22 @@ void ESolver_KS<T, Device>::runner(const int istep, UnitCell& ucell)
 
             this->conv_esolver = (drho < this->scf_thr && not_restart_step && is_U_converged);
 
-            // calculate energy of output charge density
-            this->pelec->cal_energies(2); // 2 means Kohn-Sham functional
-            // now, etot_old is the energy of input density, while etot is the energy of output density
-            this->pelec->f_en.etot_delta = this->pelec->f_en.etot - this->pelec->f_en.etot_old;
-            // output etot_delta
-            GlobalV::ofs_running << " DeltaE_womix = " << this->pelec->f_en.etot_delta * ModuleBase::Ry_to_eV << " eV" << std::endl;
             // add energy threshold for SCF convergence
-            if (this->scf_ene_thr > 0.0 && iter > 1 && this->conv_esolver == 1) // only check when density is converged
+            if (this->scf_ene_thr > 0.0)
             {
-                // update the convergence flag
-                this->conv_esolver
-                    = (std::abs(this->pelec->f_en.etot_delta * ModuleBase::Ry_to_eV) < this->scf_ene_thr);
+                // calculate energy of output charge density
+                this->update_pot(istep, iter);
+                this->pelec->cal_energies(2); // 2 means Kohn-Sham functional
+                // now, etot_old is the energy of input density, while etot is the energy of output density
+                this->pelec->f_en.etot_delta = this->pelec->f_en.etot - this->pelec->f_en.etot_old;
+                // output etot_delta
+                GlobalV::ofs_running << " DeltaE_womix = " << this->pelec->f_en.etot_delta * ModuleBase::Ry_to_eV << " eV" << std::endl;
+                if (iter > 1 && this->conv_esolver == 1) // only check when density is converged
+                {
+                    // update the convergence flag
+                    this->conv_esolver
+                        = (std::abs(this->pelec->f_en.etot_delta * ModuleBase::Ry_to_eV) < this->scf_ene_thr);
+                }
             }
 
             // If drho < hsolver_error in the first iter or drho < scf_thr, we


### PR DESCRIPTION
Fix #5011

In previous PR #5357, I add the energy threshold in `iter_finish`. We find it may result in some problems for 
`scf_ene_thr` converges while `scf_thr` does not converge. In that case, the output density is mixed, while the output energy is not mixed. This PR fixes it.