### PR TITLE
Feature: add interface `Gint::psir_func`

### DIFF
--- a/source/module_base/array_pool.h
+++ b/source/module_base/array_pool.h
@@ -15,56 +15,51 @@ namespace ModuleBase
     class Array_Pool
     {
     public:
-        Array_Pool();
-        Array_Pool(const int nr, const int nc);
+        Array_Pool() = default;
+        Array_Pool(const int nr_in, const int nc_in);
         Array_Pool(Array_Pool<T>&& other);
         Array_Pool& operator=(Array_Pool<T>&& other);
         ~Array_Pool();
         Array_Pool(const Array_Pool<T>& other) = delete;
         Array_Pool& operator=(const Array_Pool& other) = delete;
 
-        T** get_ptr_2D() const { return ptr_2D; }
-        T* get_ptr_1D() const { return ptr_1D; }
-        int get_nr() const { return nr; }
-        int get_nc() const { return nc; }
-        T* operator[](const int ir) const { return ptr_2D[ir]; }
+        T** get_ptr_2D() const { return this->ptr_2D; }
+        T* get_ptr_1D() const { return this->ptr_1D; }
+        int get_nr() const { return this->nr; }
+        int get_nc() const { return this->nc; }
+        T* operator[](const int ir) const { return this->ptr_2D[ir]; }
     private:
-        T** ptr_2D;
-        T* ptr_1D;
-        int nr;
-        int nc;
+        T** ptr_2D = nullptr;
+        T* ptr_1D = nullptr;
+        int nr = 0;
+        int nc = 0;
     };
 
     template <typename T>
-    Array_Pool<T>::Array_Pool() : ptr_2D(nullptr), ptr_1D(nullptr), nr(0), nc(0)
+    Array_Pool<T>::Array_Pool(const int nr_in, const int nc_in) // Attention: uninitialized
+        : nr(nr_in),
+          nc(nc_in)
     {
-    }
-
-    template <typename T>
-    Array_Pool<T>::Array_Pool(const int nr, const int nc) // Attention: uninitialized
-    {
-        this->nr = nr;
-        this->nc = nc;
-        ptr_1D = new T[nr * nc];
-        ptr_2D = new T*[nr];
+        this->ptr_1D = new T[nr * nc];
+        this->ptr_2D = new T*[nr];
         for (int ir = 0; ir < nr; ++ir)
-            ptr_2D[ir] = &ptr_1D[ir * nc];
+            this->ptr_2D[ir] = &this->ptr_1D[ir * nc];
     }
 
     template <typename T>
     Array_Pool<T>::~Array_Pool()
     {
-        delete[] ptr_2D;
-        delete[] ptr_1D;
+        delete[] this->ptr_2D;
+        delete[] this->ptr_1D;
     }
 
     template <typename T>
     Array_Pool<T>::Array_Pool(Array_Pool<T>&& other)
+        : ptr_2D(other.ptr_2D),
+          ptr_1D(other.ptr_1D),
+          nr(other.nr),
+          nc(other.nc)
     {
-        ptr_2D = other.ptr_2D;
-        ptr_1D = other.ptr_1D;
-        nr = other.nr;
-        nc = other.nc;
         other.ptr_2D = nullptr;
         other.ptr_1D = nullptr;
         other.nr = 0;
@@ -76,12 +71,12 @@ namespace ModuleBase
     {
         if (this != &other)
         {
-            delete[] ptr_2D;
-            delete[] ptr_1D;
-            ptr_2D = other.ptr_2D;
-            ptr_1D = other.ptr_1D;
-            nr = other.nr;
-            nc = other.nc;
+            delete[] this->ptr_2D;
+            delete[] this->ptr_1D;
+            this->ptr_2D = other.ptr_2D;
+            this->ptr_1D = other.ptr_1D;
+            this->nr = other.nr;
+            this->nc = other.nc;
             other.ptr_2D = nullptr;
             other.ptr_1D = nullptr;
             other.nr = 0;

--- a/source/module_hamilt_lcao/module_gint/cal_psir_ylm.cpp
+++ b/source/module_hamilt_lcao/module_gint/cal_psir_ylm.cpp
@@ -3,7 +3,8 @@
 #include "module_base/ylm.h"
 namespace Gint_Tools{
 void cal_psir_ylm(
-    const Grid_Technique& gt, const int bxyz,
+    const Grid_Technique& gt,
+    const int bxyz,
     const int na_grid,            // number of atoms on this grid
     const int grid_index,         // 1d index of FFT index (i,j,k)
     const double delta_r,         // delta_r of the uniform FFT grid

--- a/source/module_hamilt_lcao/module_gint/gint.h
+++ b/source/module_hamilt_lcao/module_gint/gint.h
@@ -13,6 +13,9 @@
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
 #include "module_hamilt_lcao/module_gint/grid_technique.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
+
+#include <functional>
+
 class Gint {
   public:
     ~Gint();
@@ -63,6 +66,21 @@ class Gint {
 
     const Grid_Technique* gridt = nullptr;
     const UnitCell* ucell;
+
+    // psir_ylm_new = psir_func(psir_ylm)
+    // psir_func==nullptr means psir_ylm_new=psir_ylm
+    using T_psir_func = std::function<
+        const ModuleBase::Array_Pool<double>&(
+            const ModuleBase::Array_Pool<double> &psir_ylm,
+            const Grid_Technique &gt,
+            const int grid_index,
+            const int is,
+            const std::vector<int> &block_iw,
+            const std::vector<int> &block_size,
+            const std::vector<int> &block_index,
+            const ModuleBase::Array_Pool<bool> &cal_flag)>;
+    T_psir_func psir_func_1 = nullptr;
+    T_psir_func psir_func_2 = nullptr;
 
   protected:
     // variables related to FFT grid
@@ -152,17 +170,18 @@ class Gint {
         hamilt::HContainer<double>* hR); // HContainer for storing the <phi_0 |
                                          // V | phi_R> matrix element.
 
-    void cal_meshball_vlocal_k(int na_grid,
-                               const int LD_pool,
-                               int grid_index,
-                               int* block_size,
-                               int* block_index,
-                               int* block_iw,
-                               bool** cal_flag,
-                               double** psir_ylm,
-                               double** psir_vlbr3,
-                               double* pvpR,
-                               const UnitCell& ucell);
+    void cal_meshball_vlocal_k(
+        const int na_grid,
+        const int LD_pool,
+        const int grid_index,
+        const int*const block_size,
+        const int*const block_index,
+        const int*const block_iw,
+        const bool*const*const cal_flag,
+        const double*const*const psir_ylm,
+        const double*const*const psir_vlbr3,
+        double*const pvpR,
+        const UnitCell &ucell);
 
     //------------------------------------------------------
     // in gint_fvl.cpp
@@ -225,11 +244,11 @@ class Gint {
                          Gint_inout* inout);
 
     void cal_meshball_rho(const int na_grid,
-                          int* block_index,
-                          int* vindex,
-                          double** psir_ylm,
-                          double** psir_DMR,
-                          double* rho);
+                          const int*const block_index,
+                          const int*const vindex,
+                          const double*const*const psir_ylm,
+                          const double*const*const psir_DMR,
+                          double*const rho);
 
     void gint_kernel_tau(const int na_grid,
                          const int grid_index,

--- a/source/module_hamilt_lcao/module_gint/gint_rho.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_rho.cpp
@@ -11,17 +11,17 @@
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
 
 void Gint::cal_meshball_rho(const int na_grid,
-                            int* block_index,
-                            int* vindex,
-                            double** psir_ylm,
-                            double** psir_DMR,
-                            double* rho)
+                            const int*const block_index,
+                            const int*const vindex,
+                            const double*const*const psir_ylm,
+                            const double*const*const psir_DMR,
+                            double*const rho)
 {
     const int inc = 1;
     // sum over mu to get density on grid
     for (int ib = 0; ib < this->bxyz; ++ib)
     {
-        double r = ddot_(&block_index[na_grid], psir_ylm[ib], &inc, psir_DMR[ib], &inc);
+        const double r = ddot_(&block_index[na_grid], psir_ylm[ib], &inc, psir_DMR[ib], &inc);
         const int grid = vindex[ib];
         rho[grid] += r;
     }

--- a/source/module_hamilt_lcao/module_gint/gint_tools.h
+++ b/source/module_hamilt_lcao/module_gint/gint_tools.h
@@ -284,18 +284,19 @@ ModuleBase::Array_Pool<double> get_psir_vlbr3(
     const double* const* const psir_ylm); // psir_ylm[bxyz][LD_pool]
 
 // sum_nu,R rho_mu,nu(R) psi_nu, for multi-k and gamma point
-void mult_psi_DMR(const Grid_Technique& gt,
-                  const int bxyz,
-                  const int LD_pool,
-                  const int& grid_index,
-                  const int& na_grid,
-                  const int* const block_index,
-                  const int* const block_size,
-                  bool** cal_flag,
-                  double** psi,
-                  double** psi_DMR,
-                  const hamilt::HContainer<double>* DM,
-                  const bool if_symm);
+void mult_psi_DMR(
+    const Grid_Technique& gt,
+    const int bxyz,
+    const int LD_pool,
+    const int &grid_index,
+    const int &na_grid,
+    const int*const block_index,
+    const int*const block_size,
+    const bool*const*const cal_flag,
+    const double*const*const psi,
+    double*const*const psi_DMR,
+    const hamilt::HContainer<double>*const DM,
+    const bool if_symm);
 
 
 // pair.first is the first index of the meshcell which is inside atoms ia1 and ia2.

--- a/source/module_hamilt_lcao/module_gint/gint_vl.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_vl.cpp
@@ -66,8 +66,7 @@ void Gint::cal_meshball_vlocal_gamma(
                     }
                 }
                 const int ib_length = last_ib-first_ib;
-                if(ib_length<=0) { continue;
-}
+                if(ib_length<=0) { continue; }
 
 				// calculate the BaseMatrix of <iat1, iat2, R> atom-pair
 				hamilt::AtomPair<double>* tmp_ap = hR->find_pair(iat1, iat2);
@@ -81,14 +80,13 @@ void Gint::cal_meshball_vlocal_gamma(
                 }
 
                 const int n=block_size[ia2];
-				//std::cout<<__FILE__<<__LINE__<<" "<<n<<" "<<m<<" "<<tmp_ap->get_row_size()<<" "<<tmp_ap->get_col_size()<<std::endl;
                 if(cal_pair_num>ib_length/4)
                 {
                     dgemm_(&transa, &transb, &n, &m, &ib_length, &alpha,
                         &psir_vlbr3[first_ib][block_index[ia2]], &LD_pool,
                         &psir_ylm[first_ib][block_index[ia1]], &LD_pool,
                         &beta, tmp_ap->get_pointer(0), &n);
-						//&GridVlocal[iw1_lo*lgd_now+iw2_lo], &lgd_now);   
+						//&GridVlocal[iw1_lo*lgd_now+iw2_lo], &lgd_now);
                 }
                 else
                 {
@@ -96,32 +94,31 @@ void Gint::cal_meshball_vlocal_gamma(
                     {
                         if(cal_flag[ib][ia1] && cal_flag[ib][ia2])
                         {
-                            int k=1;                            
+                            int k=1;
                             dgemm_(&transa, &transb, &n, &m, &k, &alpha,
                                 &psir_vlbr3[ib][block_index[ia2]], &LD_pool,
                                 &psir_ylm[ib][block_index[ia1]], &LD_pool,
-                                &beta, tmp_ap->get_pointer(0), &n);                          
+                                &beta, tmp_ap->get_pointer(0), &n);
                         }
                     }
                 }
-				//std::cout<<__FILE__<<__LINE__<<" "<<tmp_ap->get_pointer(0)[2]<<std::endl;
 			}
 		}
 	}
 }
 
 void Gint::cal_meshball_vlocal_k(
-	int na_grid,
+	const int na_grid,
 	const int LD_pool,
-	int grid_index, 
-	int* block_size,
-	int* block_index,
-	int* block_iw,
-	bool** cal_flag,  
-	double** psir_ylm,
-	double** psir_vlbr3,
-	double* pvpR,
-	const UnitCell& ucell)
+	const int grid_index,
+	const int*const block_size,
+	const int*const block_index,
+	const int*const block_iw,
+	const bool*const*const cal_flag,
+	const double*const*const psir_ylm,
+	const double*const*const psir_vlbr3,
+	double*const pvpR,
+	const UnitCell &ucell)
 {
     char transa = 'N', transb = 'T';
 	double alpha=1, beta=1;
@@ -151,12 +148,11 @@ void Gint::cal_meshball_vlocal_k(
     			{
     				if(cal_flag[ib][ia1] && cal_flag[ib][ia2]) {
     				    ++cal_num;
-}
+					}
     			}
 
-    			if(cal_num==0) { continue;
-}
-    			
+    			if(cal_num==0) { continue; }
+
                 const int idx2=block_index[ia2];
         		int n=block_size[ia2];
 				//const int I2 = ucell.iat2ia[iat2];
@@ -165,13 +161,13 @@ void Gint::cal_meshball_vlocal_k(
 				int offset;
 				offset=this->gridt->find_offset(id1, id2, iat1, iat2);
 
-				const int iatw = DM_start + this->gridt->find_R2st[iat1][offset];	
+				const int iatw = DM_start + this->gridt->find_R2st[iat1][offset];
 
 			    if(cal_num>this->bxyz/4)
 			    {
 					k=this->bxyz;
 					dgemm_(&transa, &transb, &n, &m, &k, &alpha,
-						&psir_vlbr3[0][idx2], &LD_pool, 
+						&psir_vlbr3[0][idx2], &LD_pool,
 						&psir_ylm[0][idx1], &LD_pool,
 						&beta, &pvpR[iatw], &n);
 				}
@@ -183,9 +179,9 @@ void Gint::cal_meshball_vlocal_k(
 						{
 							k=1;
 							dgemm_(&transa, &transb, &n, &m, &k, &alpha,
-								&psir_vlbr3[ib][idx2], &LD_pool, 
+								&psir_vlbr3[ib][idx2], &LD_pool,
 								&psir_ylm[ib][idx1], &LD_pool,
-								&beta, &pvpR[iatw], &n);	
+								&beta, &pvpR[iatw], &n);
 						}
 					}
     			}

--- a/source/module_hamilt_lcao/module_gint/mult_psi_dmr.cpp
+++ b/source/module_hamilt_lcao/module_gint/mult_psi_dmr.cpp
@@ -2,9 +2,19 @@
 #include "module_base/timer.h"
 #include "module_base/ylm.h"
 namespace Gint_Tools{
-void mult_psi_DMR(const Grid_Technique& gt, const int bxyz, const int LD_pool, const int& grid_index, const int& na_grid,
-                  const int* const block_index, const int* const block_size, bool** cal_flag, double** psi,
-                  double** psi_DMR, const hamilt::HContainer<double>* DM, const bool if_symm)
+void mult_psi_DMR(
+    const Grid_Technique& gt,
+    const int bxyz,
+    const int LD_pool,
+    const int &grid_index,
+    const int &na_grid,
+    const int*const block_index,
+    const int*const block_size,
+    const bool*const*const cal_flag,
+    const double*const*const psi,
+    double*const*const psi_DMR,
+    const hamilt::HContainer<double>*const DM,
+    const bool if_symm)
 {
     const UnitCell& ucell = *gt.ucell;
 


### PR DESCRIPTION
Add two function objects `psir_func` in `Gint`, changing the NAO `psir_ylm` to `psir_ylm_new = psir_func (psir_ylm)` when calculate `gint_rho()` and `gint_vl()`.
It's an interface for the future development. To the existing codes, it's just `psir_ylm_new = psi_ylm` as default .