### PR TITLE
Fix cal_edm_tddft

### DIFF
--- a/source/module_esolver/cal_edm_tddft.cpp
+++ b/source/module_esolver/cal_edm_tddft.cpp
@@ -2,7 +2,6 @@
 
 #include "module_io/cal_r_overlap_R.h"
 #include "module_io/dipole_io.h"
-#include "module_io/rho_io.h"
 #include "module_io/td_current_io.h"
 #include "module_io/write_HS.h"
 #include "module_io/write_HS_R.h"
@@ -42,7 +41,7 @@ namespace ModuleESolver
 void ESolver_KS_LCAO_TDDFT::cal_edm_tddft()
 {
     // mohan add 2024-03-27
-    const int nlocal = GlobalV::NLOCAL;
+    const int nlocal = PARAM.globalv.nlocal;
     assert(nlocal >= 0);
 
     dynamic_cast<elecstate::ElecStateLCAO<std::complex<double>>*>(this->pelec)

--- a/tests/integrate/601_NO_TDDFT_H2_kpoint/result.ref
+++ b/tests/integrate/601_NO_TDDFT_H2_kpoint/result.ref
@@ -1,5 +1,5 @@
 etotref -18.05466171990316
 etotperatomref -9.0273308600
-totalforceref 44.887962
-totalstressref 79.547659
+totalforceref 44.85505600
+totalstressref 79.48569300
 totaltimeref 1.51

--- a/tests/integrate/601_NO_TDDFT_H2_len_gauss/result.ref
+++ b/tests/integrate/601_NO_TDDFT_H2_len_gauss/result.ref
@@ -1,5 +1,5 @@
 etotref -30.45477750879012
 etotperatomref -15.2273887544
-totalforceref 0.574814
+totalforceref 0.57576800
 totalstressref 4.287440
 totaltimeref 1.57

--- a/tests/integrate/601_NO_TDDFT_H2_len_gauss_dire/result.ref
+++ b/tests/integrate/601_NO_TDDFT_H2_len_gauss_dire/result.ref
@@ -1,5 +1,5 @@
 etotref -30.45466274119030
 etotperatomref -15.2273313706
-totalforceref 0.573436
+totalforceref 0.57439400
 totalstressref 4.285714
 totaltimeref 1.55

--- a/tests/integrate/601_NO_TDDFT_H2_len_heavi/result.ref
+++ b/tests/integrate/601_NO_TDDFT_H2_len_heavi/result.ref
@@ -1,5 +1,5 @@
 etotref -22.97718184915547
 etotperatomref -11.4885909246
-totalforceref 0.564908
+totalforceref 0.56587600
 totalstressref 76.073961
 totaltimeref 1.56

--- a/tests/integrate/601_NO_TDDFT_H2_len_hhg/result.ref
+++ b/tests/integrate/601_NO_TDDFT_H2_len_hhg/result.ref
@@ -1,5 +1,5 @@
 etotref 20.38731422853930
 etotperatomref 10.1936571143
-totalforceref 0.738256
+totalforceref 0.73949000
 totalstressref 489.377111
 totaltimeref 1.56

--- a/tests/integrate/601_NO_TDDFT_H2_len_trape/result.ref
+++ b/tests/integrate/601_NO_TDDFT_H2_len_trape/result.ref
@@ -1,5 +1,5 @@
 etotref -30.89965242483882
 etotperatomref -15.4498262124
-totalforceref 0.574662
-totalstressref 1.034216
+totalforceref 0.57561800
+totalstressref 1.03619000
 totaltimeref 1.44

--- a/tests/integrate/601_NO_TDDFT_H2_len_trigo/result.ref
+++ b/tests/integrate/601_NO_TDDFT_H2_len_trigo/result.ref
@@ -1,5 +1,5 @@
 etotref -30.90912142263002
 etotperatomref -15.4545607113
-totalforceref 0.574662
-totalstressref 1.108904
+totalforceref 0.57561800
+totalstressref 1.11089700
 totaltimeref 1.43

--- a/tests/integrate/601_NO_TDDFT_H2_oldedm/INPUT
+++ b/tests/integrate/601_NO_TDDFT_H2_oldedm/INPUT
@@ -32,4 +32,4 @@ md_dt			0.05
 init_vel                1
 ocp			1
 ocp_set			1*0.5 1*0.5 3*0 1*0.5 1*0.5 3*0	
-td_edm			0
+td_edm			1

--- a/tests/integrate/601_NO_TDDFT_H2_oldedm/result.ref
+++ b/tests/integrate/601_NO_TDDFT_H2_oldedm/result.ref
@@ -1,5 +1,5 @@
 etotref -18.05466171990316
 etotperatomref -9.0273308600
-totalforceref 44.887962
-totalstressref 79.547659
+totalforceref 43.10812600
+totalstressref 76.35413900
 totaltimeref 1.53

--- a/tests/integrate/601_NO_TDDFT_graphene_kpoint/result.ref
+++ b/tests/integrate/601_NO_TDDFT_graphene_kpoint/result.ref
@@ -1,5 +1,5 @@
 etotref -321.2089497177532
 etotperatomref -107.0696499059
-totalforceref 14.639754
-totalstressref 1803.570000
+totalforceref 2.10083100
+totalstressref 198.29401300
 totaltimeref 14.01


### PR DESCRIPTION
The force calculations in rt-TDDFT for periodic systems are incorrect and inconsistent with the results of AIMD. This problem was first discovered by @dyzheng  in PR #4879 .This issue is caused by the incorrect implementation of the cal_edm_tddft function, which does not update the HS matrix for each k-point and does not use the correct matrix indices. For ground state calculations, rt-TDDFT should yield results that are expected to be consistent with AIMD. Below is a display of the results before and after this fix.
AIMD:
<img width="899" alt="屏幕截图 2024-11-02 115635" src="https://github.com/user-attachments/assets/71c97532-2111-4663-8936-13203e799caa">
rt-TDDFT(before fix):
<img width="899" alt="屏幕截图 2024-11-02 115654" src="https://github.com/user-attachments/assets/afc26080-dbe2-4908-97e8-bfa3749495ac">
The forces in this case is completely unreasonable.
rt-tddft(after fix):
<img width="900" alt="屏幕截图 2024-11-02 115711" src="https://github.com/user-attachments/assets/0bfe863a-8f84-46fe-bbed-2e4be9542475">
There is still a very small numerical error, but the results are good enough to demonstrate that the fix is correct.

### Linked Issue
Fix #5333 