### PR TITLE
Feature: apply CG eigensolver to LR-TDDFT

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -3925,7 +3925,7 @@ Currently supported: `RPA`, `LDA`, `PBE`, `HSE`, `HF`.
 
 - **Type**: String
 - **Description**: The method to solve the Casida equation $AX=\Omega X$ in LR-TDDFT under Tamm-Dancoff approximation (TDA), where $A_{ai,bj}=(\epsilon_a-\epsilon_i)\delta_{ij}\delta_{ab}+(ai|f_{Hxc}|bj)+\alpha_{EX}(ab|ij)$ is the particle-hole excitation matrix and $X$ is the transition amplitude.
-  - `dav`: Construct $AX$ and diagonalize the Hamiltonian matrix iteratively with Davidson algorithm.
+  - `dav`/`dav_subspace`/ `cg`: Construct $AX$ and diagonalize the Hamiltonian matrix iteratively with Davidson/Non-ortho-Davidson/CG algorithm.
   - `lapack`: Construct the full $A$ matrix and directly diagonalize with LAPACK.
   - `spectrum`: Calculate absorption spectrum only without solving Casida equation. The `OUT.${suffix}/` directory should contain the
   files for LR-TDDFT eigenstates and eigenvalues, i.e. `Excitation_Energy.dat` and `Excitation_Amplitude_${processor_rank}.dat`

--- a/source/module_hsolver/diago_iter_assist.cpp
+++ b/source/module_hsolver/diago_iter_assist.cpp
@@ -20,7 +20,7 @@ namespace hsolver
 // Produces on output n_band eigenvectors (n_band <= nstart) in evc.
 //----------------------------------------------------------------------
 template <typename T, typename Device>
-void DiagoIterAssist<T, Device>::diagH_subspace(hamilt::Hamilt<T, Device>* pHamilt, // hamiltonian operator carrier
+void DiagoIterAssist<T, Device>::diagH_subspace(const hamilt::Hamilt<T, Device>* const pHamilt, // hamiltonian operator carrier
                                                 const psi::Psi<T, Device>& psi,     // [in] wavefunction
                                                 psi::Psi<T, Device>& evc,           // [out] wavefunction
                                                 Real* en,                           // [out] eigenvalues

--- a/source/module_hsolver/diago_iter_assist.h
+++ b/source/module_hsolver/diago_iter_assist.h
@@ -29,7 +29,7 @@ class DiagoIterAssist
     static int SCF_ITER;
 
     // for psi::Psi structure
-    static void diagH_subspace(hamilt::Hamilt<T, Device>* pHamilt,
+    static void diagH_subspace(const hamilt::Hamilt<T, Device>* const pHamilt,
                                const psi::Psi<T, Device>& psi,
                                psi::Psi<T, Device>& evc,
                                Real* en,

--- a/source/module_lr/esolver_lrtd_lcao.cpp
+++ b/source/module_lr/esolver_lrtd_lcao.cpp
@@ -86,7 +86,7 @@ inline int cal_nupdown_form_occ(const ModuleBase::matrix& wg)
 template<typename T, typename TR>
 void LR::ESolver_LR<T, TR>::parameter_check()const
 {
-    std::set<std::string> lr_solvers = { "dav", "lapack" , "spectrum", "dav_subspace" };
+    std::set<std::string> lr_solvers = { "dav", "lapack" , "spectrum", "dav_subspace", "cg" };
     std::set<std::string> xc_kernels = { "rpa", "lda", "pbe", "hf" , "hse" };
     if (lr_solvers.find(this->input.lr_solver) == lr_solvers.end()) {
         throw std::invalid_argument("ESolver_LR: unknown type of lr_solver");


### PR DESCRIPTION
Something to refactor later:
- `diagH_subspace`: use `hpsi_func` instead `Hamilt`
- `DiagoCG` 
  - Remove the dependence of `basis_type` 
  - Use something like "allow_notconv" to replace `calculation` (as an eigen problem can be neighter "scf" nor "nscf")