### PR TITLE
Fix: not build useless library without ENABLE_LCAO

### DIFF
--- a/source/module_hamilt_lcao/module_gint/CMakeLists.txt
+++ b/source/module_hamilt_lcao/module_gint/CMakeLists.txt
@@ -1,4 +1,5 @@
 #add_subdirectory(kernels/cuda)
+if(ENABLE_LCAO)
 
 list(APPEND objects
     gint.cpp
@@ -69,4 +70,6 @@ IF (BUILD_TESTING)
   if(ENABLE_MPI)
     add_subdirectory(test)
   endif()
+endif()
+
 endif()

--- a/source/module_hamilt_lcao/module_hcontainer/CMakeLists.txt
+++ b/source/module_hamilt_lcao/module_hcontainer/CMakeLists.txt
@@ -1,3 +1,5 @@
+if(ENABLE_LCAO)
+
 list(APPEND objects
     base_matrix.cpp
     atom_pair.cpp
@@ -22,4 +24,6 @@ IF (BUILD_TESTING)
   if(ENABLE_MPI)
     add_subdirectory(test)
   endif()
+endif()
+
 endif()

--- a/source/module_hamilt_pw/hamilt_pwdft/operator_pw/CMakeLists.txt
+++ b/source/module_hamilt_pw/hamilt_pwdft/operator_pw/CMakeLists.txt
@@ -7,12 +7,13 @@ list(APPEND operator_ks_pw_srcs
     velocity_pw.cpp
 )
 
-add_library(
-    operator_ks_pw
-    OBJECT
-    ${operator_ks_pw_srcs}
-)
+# this library is included in hamilt_pwdft now
+#add_library(
+#    operator_ks_pw
+#    OBJECT
+#    ${operator_ks_pw_srcs}
+#)
 
-if(ENABLE_COVERAGE)
-  add_coverage(operator_ks_pw)
-endif()
+#if(ENABLE_COVERAGE)
+#  add_coverage(operator_ks_pw)
+#endif()


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #4354 

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
