### PR TITLE
Feature: enable ABACUS can finish SCF if charge density oscillation is found

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -88,6 +88,8 @@
     - [scf\_thr](#scf_thr)
     - [scf\_ene\_thr](#scf_ene_thr)
     - [scf\_thr\_type](#scf_thr_type)
+    - [scf\_thr\_os](#scf_thr_os)
+    - [scf\_os\_ndim](#scf_os_ndim)
     - [chg\_extrap](#chg_extrap)
     - [lspinorb](#lspinorb)
     - [noncolin](#noncolin)
@@ -1204,6 +1206,21 @@ Note: In new angle mixing, you should set `mixing_beta_mag >> mixing_beta`. The 
   Note: This parameter is still under testing and the default setting is usually sufficient.
 
 - **Default**: 1 (plane-wave basis), or 2 (localized atomic orbital basis).
+
+### scf_thr_os
+
+- **Type**: double
+- **Description**: The slope threshold to determine if the SCF is stuck in a charge density oscillation. To this end, Least Squares Method is used to calculate the slope of the logarithmically taken drho for the previous `scf_os_ndim` iterations. If the calculated slope is larger than `scf_thr_os`, stop the SCF.
+  - **>=0**: The SCF will continue to run regardless of whether there is oscillation or not. 
+  - **<0**: If the calculated slope is larger than `scf_thr_os`, stop the SCF.
+
+- **Default**: 0
+
+### scf_os_ndim
+
+- **Type**: int
+- **Description**: To determine the number of old iterations' `drho` used in slope calculations.
+- **Default**: `mixing_ndim`
 
 ### chg_extrap
 

--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -1211,7 +1211,7 @@ Note: In new angle mixing, you should set `mixing_beta_mag >> mixing_beta`. The 
 ### scf_os_stop
 
 - **Type**: bool
-- **Description**: The slope threshold to determine if the SCF is stuck in a charge density oscillation. To this end, Least Squares Method is used to calculate the slope of the logarithmically taken drho for the previous `scf_os_ndim` iterations. If the calculated slope is larger than `scf_os_thr`, stop the SCF.
+- **Description**: For systems that are difficult to converge, the SCF process may exhibit oscillations in charge density, preventing further progress toward the specified convergence criteria and resulting in continuous oscillation until the maximum number of steps is reached; this greatly wastes computational resources. To address this issue, this function allows ABACUS to terminate the SCF process early upon detecting oscillations, thus reducing subsequent meaningless calculations. The detection of oscillations is based on the slope of the logarithm of historical drho values.. To this end, Least Squares Method is used to calculate the slope of the logarithmically taken drho for the previous `scf_os_ndim` iterations. If the calculated slope is larger than `scf_os_thr`, stop the SCF.
 
   - **0**: The SCF will continue to run regardless of whether there is oscillation or not. 
   - **1**: If the calculated slope is larger than `scf_os_thr`, stop the SCF.
@@ -1221,11 +1221,9 @@ Note: In new angle mixing, you should set `mixing_beta_mag >> mixing_beta`. The 
 ### scf_os_thr
 
 - **Type**: double
-- **Description**: The slope threshold to determine if the SCF is stuck in a charge density oscillation. To this end, Least Squares Method is used to calculate the slope of the logarithmically taken drho for the previous `scf_os_ndim` iterations. If the calculated slope is larger than `scf_os_thr`, stop the SCF.
-  - **>=0**: The SCF will continue to run regardless of whether there is oscillation or not. 
-  - **<0**: If the calculated slope is larger than `scf_os_thr`, stop the SCF.
+- **Description**: The slope threshold to determine if the SCF is stuck in a charge density oscillation. If the calculated slope is larger than `scf_os_thr`, stop the SCF.
 
-- **Default**: 0
+- **Default**: -0.01
 
 ### scf_os_ndim
 

--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -88,6 +88,7 @@
     - [scf\_thr](#scf_thr)
     - [scf\_ene\_thr](#scf_ene_thr)
     - [scf\_thr\_type](#scf_thr_type)
+    - [scf\_os\_stop](#scf_os_stop)
     - [scf\_thr\_os](#scf_thr_os)
     - [scf\_os\_ndim](#scf_os_ndim)
     - [chg\_extrap](#chg_extrap)
@@ -1206,6 +1207,16 @@ Note: In new angle mixing, you should set `mixing_beta_mag >> mixing_beta`. The 
   Note: This parameter is still under testing and the default setting is usually sufficient.
 
 - **Default**: 1 (plane-wave basis), or 2 (localized atomic orbital basis).
+
+### scf_os_stop
+
+- **Type**: bool
+- **Description**: The slope threshold to determine if the SCF is stuck in a charge density oscillation. To this end, Least Squares Method is used to calculate the slope of the logarithmically taken drho for the previous `scf_os_ndim` iterations. If the calculated slope is larger than `scf_thr_os`, stop the SCF.
+
+  - **0**: The SCF will continue to run regardless of whether there is oscillation or not. 
+  - **1**: If the calculated slope is larger than `scf_thr_os`, stop the SCF.
+
+- **Default**: false
 
 ### scf_thr_os
 

--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -89,7 +89,7 @@
     - [scf\_ene\_thr](#scf_ene_thr)
     - [scf\_thr\_type](#scf_thr_type)
     - [scf\_os\_stop](#scf_os_stop)
-    - [scf\_thr\_os](#scf_thr_os)
+    - [scf\_os\_thr](#scf_os_thr)
     - [scf\_os\_ndim](#scf_os_ndim)
     - [chg\_extrap](#chg_extrap)
     - [lspinorb](#lspinorb)
@@ -1211,19 +1211,19 @@ Note: In new angle mixing, you should set `mixing_beta_mag >> mixing_beta`. The 
 ### scf_os_stop
 
 - **Type**: bool
-- **Description**: The slope threshold to determine if the SCF is stuck in a charge density oscillation. To this end, Least Squares Method is used to calculate the slope of the logarithmically taken drho for the previous `scf_os_ndim` iterations. If the calculated slope is larger than `scf_thr_os`, stop the SCF.
+- **Description**: The slope threshold to determine if the SCF is stuck in a charge density oscillation. To this end, Least Squares Method is used to calculate the slope of the logarithmically taken drho for the previous `scf_os_ndim` iterations. If the calculated slope is larger than `scf_os_thr`, stop the SCF.
 
   - **0**: The SCF will continue to run regardless of whether there is oscillation or not. 
-  - **1**: If the calculated slope is larger than `scf_thr_os`, stop the SCF.
+  - **1**: If the calculated slope is larger than `scf_os_thr`, stop the SCF.
 
 - **Default**: false
 
-### scf_thr_os
+### scf_os_thr
 
 - **Type**: double
-- **Description**: The slope threshold to determine if the SCF is stuck in a charge density oscillation. To this end, Least Squares Method is used to calculate the slope of the logarithmically taken drho for the previous `scf_os_ndim` iterations. If the calculated slope is larger than `scf_thr_os`, stop the SCF.
+- **Description**: The slope threshold to determine if the SCF is stuck in a charge density oscillation. To this end, Least Squares Method is used to calculate the slope of the logarithmically taken drho for the previous `scf_os_ndim` iterations. If the calculated slope is larger than `scf_os_thr`, stop the SCF.
   - **>=0**: The SCF will continue to run regardless of whether there is oscillation or not. 
-  - **<0**: If the calculated slope is larger than `scf_thr_os`, stop the SCF.
+  - **<0**: If the calculated slope is larger than `scf_os_thr`, stop the SCF.
 
 - **Default**: 0
 

--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -1731,6 +1731,7 @@ bool Charge_Mixing::if_scf_oscillate(const int iteration, const double drho, con
     double slope = 0.0;
 
     // Least Squares Method
+    // this part is too short, so I do not design it as a free function in principle
     double sumX = 0, sumY = 0, sumXY = 0, sumXX = 0;
     for (int i = iteration - iternum_used; i < iteration; i++)
     {

--- a/source/module_elecstate/module_charge/charge_mixing.cpp
+++ b/source/module_elecstate/module_charge/charge_mixing.cpp
@@ -1702,3 +1702,58 @@ void Charge_Mixing::clean_data(std::complex<double>*& data_s, std::complex<doubl
         data_hf = nullptr;
     }
 }
+
+bool Charge_Mixing::if_scf_oscillate(const int iteration, const double drho, const int iternum_used, const double threshold)
+{
+    ModuleBase::TITLE("Charge_Mixing", "if_scf_oscillate");
+    ModuleBase::timer::tick("Charge_Mixing", "if_scf_oscillate");
+
+    if(threshold >= 0) // close the function
+    {
+        return false;
+    }
+
+    if(this->_drho_history.size() == 0)
+    {
+        this->_drho_history.resize(PARAM.inp.scf_nmax);
+    }
+
+    // add drho into history
+    this->_drho_history[iteration - 1] = drho;
+
+    // check if the history is long enough
+    if(iteration < iternum_used)
+    {
+        return false;
+    }
+
+    // calculate the slope of the last iternum_used iterations' drho
+    double slope = 0.0;
+
+    // Least Squares Method
+    double sumX = 0, sumY = 0, sumXY = 0, sumXX = 0;
+    for (int i = iteration - iternum_used; i < iteration; i++)
+    {
+        sumX += i;
+        sumY += std::log10(this->_drho_history[i]);
+        sumXY += i * std::log10(this->_drho_history[i]);
+        sumXX += i * i;
+    }
+    double numerator = iternum_used * sumXY - sumX * sumY;
+    double denominator = iternum_used * sumXX - sumX * sumX;
+    if (denominator == 0) {
+        return false;
+    }
+    slope =  numerator / denominator;
+
+    // if the slope is less than the threshold, return true
+    if(slope > threshold)
+    {
+        return true;
+    }
+
+    return false;
+
+    ModuleBase::timer::tick("Charge_Mixing", "if_scf_oscillate");
+  
+}

--- a/source/module_elecstate/module_charge/charge_mixing.h
+++ b/source/module_elecstate/module_charge/charge_mixing.h
@@ -105,6 +105,9 @@ class Charge_Mixing
     int mixing_restart_step = 0; //which step to restart mixing during SCF
     int mixing_restart_count = 0; // the number of restart mixing during SCF. Do not set mixing_restart_count as bool since I want to keep some flexibility in the future
 
+    // to calculate the slope of drho curve during SCF, which is used to determine if SCF oscillate
+    bool if_scf_oscillate(const int iteration, const double drho, const int iternum_used, const double threshold);
+    
   private:
   
     // mixing_data
@@ -129,6 +132,8 @@ class Charge_Mixing
     double mixing_angle = 0.0;           ///< mixing angle for nspin=4
     bool mixing_dmr = false;             ///< whether to mixing real space density matrix
 
+    std::vector<double> _drho_history; ///< history of drho used to determine the oscillation, size is scf_nmax
+    
     bool new_e_iteration = true;
 
     ModulePW::PW_Basis* rhopw = nullptr;  ///< smooth grid

--- a/source/module_elecstate/test/charge_mixing_test.cpp
+++ b/source/module_elecstate/test/charge_mixing_test.cpp
@@ -1030,7 +1030,7 @@ TEST_F(ChargeMixingTest, SCFOscillationTest)
     Charge_Mixing CMtest;
     int scf_nmax = 20;
     int scf_os_ndim = 3;
-    double scf_thr_os = -0.05;
+    double scf_os_thr = -0.05;
     bool scf_oscillate = false;
     std::vector<double> drho(scf_nmax, 0.0);
     std::vector<bool> scf_oscillate_ref(scf_nmax, false);
@@ -1058,7 +1058,7 @@ TEST_F(ChargeMixingTest, SCFOscillationTest)
                         false,false,true,false,false,true,true,true,true,true};
     for (int i = 1; i <= scf_nmax; ++i)
     {
-        scf_oscillate = CMtest.if_scf_oscillate(i,drho[i-1],scf_os_ndim,scf_thr_os);
+        scf_oscillate = CMtest.if_scf_oscillate(i,drho[i-1],scf_os_ndim,scf_os_thr);
         EXPECT_EQ(scf_oscillate, scf_oscillate_ref[i-1]);
     } 
 }

--- a/source/module_elecstate/test/charge_mixing_test.cpp
+++ b/source/module_elecstate/test/charge_mixing_test.cpp
@@ -1024,3 +1024,41 @@ TEST_F(ChargeMixingTest, MixDivCombTest)
     EXPECT_EQ(datas2, nullptr);
     EXPECT_EQ(datahf2, nullptr);
 }
+
+TEST_F(ChargeMixingTest, SCFOscillationTest)
+{
+    Charge_Mixing CMtest;
+    int scf_nmax = 20;
+    int scf_os_ndim = 3;
+    double scf_thr_os = -0.05;
+    bool scf_oscillate = false;
+    std::vector<double> drho(scf_nmax, 0.0);
+    std::vector<bool> scf_oscillate_ref(scf_nmax, false);
+    drho = {6.83639633652e-05,
+            4.93523029235e-05,
+            3.59230097735e-05,
+            2.68356403913e-05,
+            2.17490806464e-05,
+            2.14231642508e-05,
+            1.67507494811e-05,
+            1.53575889539e-05,
+            1.26504511554e-05,
+            1.04762016224e-05,
+            8.10000162918e-06,
+            7.66427917682e-06,
+            6.70112820094e-06,
+            5.68594436664e-06,
+            4.80120233733e-06,
+            4.86519757184e-06,
+            4.37855804356e-06,
+            4.29922703412e-06,
+            4.36398486331e-06,
+            4.94224615955e-06};
+    scf_oscillate_ref = {false,false,false,false,false,true,false,false,false,false,
+                        false,false,true,false,false,true,true,true,true,true};
+    for (int i = 1; i <= scf_nmax; ++i)
+    {
+        scf_oscillate = CMtest.if_scf_oscillate(i,drho[i-1],scf_os_ndim,scf_thr_os);
+        EXPECT_EQ(scf_oscillate, scf_oscillate_ref[i-1]);
+    } 
+}

--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -532,7 +532,10 @@ void ESolver_KS<T, Device>::runner(const int istep, UnitCell& ucell)
                 this->p_chgmix->mixing_restart_step = iter + 1;
             }
 
-            this->oscillate_esolver = this->p_chgmix->if_scf_oscillate(iter, drho, PARAM.inp.scf_os_ndim, PARAM.inp.scf_thr_os);
+            if (PARAM.inp.scf_os_stop) // if oscillation is detected, SCF will stop
+            {
+                this->oscillate_esolver = this->p_chgmix->if_scf_oscillate(iter, drho, PARAM.inp.scf_os_ndim, PARAM.inp.scf_thr_os);
+            }
 
             // drho will be 0 at this->p_chgmix->mixing_restart step, which is
             // not ground state

--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -532,6 +532,8 @@ void ESolver_KS<T, Device>::runner(const int istep, UnitCell& ucell)
                 this->p_chgmix->mixing_restart_step = iter + 1;
             }
 
+            this->oscillate_esolver = this->p_chgmix->if_scf_oscillate(iter, drho, PARAM.inp.mixing_ndim, PARAM.inp.scf_thr_os);
+
             // drho will be 0 at this->p_chgmix->mixing_restart step, which is
             // not ground state
             bool not_restart_step = !(iter == this->p_chgmix->mixing_restart_step && PARAM.inp.mixing_restart > 0.0);
@@ -640,9 +642,13 @@ void ESolver_KS<T, Device>::runner(const int istep, UnitCell& ucell)
 #endif //__RAPIDJSON
 
         // 13) check convergence
-        if (this->conv_esolver)
+        if (this->conv_esolver || this->oscillate_esolver)
         {
             this->niter = iter;
+            if (this->oscillate_esolver)
+            {
+                std::cout << " !! Density oscillation is found, STOP HERE !!" << std::endl;
+            }
             break;
         }
 

--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -532,7 +532,7 @@ void ESolver_KS<T, Device>::runner(const int istep, UnitCell& ucell)
                 this->p_chgmix->mixing_restart_step = iter + 1;
             }
 
-            this->oscillate_esolver = this->p_chgmix->if_scf_oscillate(iter, drho, PARAM.inp.mixing_ndim, PARAM.inp.scf_thr_os);
+            this->oscillate_esolver = this->p_chgmix->if_scf_oscillate(iter, drho, PARAM.inp.scf_os_ndim, PARAM.inp.scf_thr_os);
 
             // drho will be 0 at this->p_chgmix->mixing_restart step, which is
             // not ground state

--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -534,7 +534,7 @@ void ESolver_KS<T, Device>::runner(const int istep, UnitCell& ucell)
 
             if (PARAM.inp.scf_os_stop) // if oscillation is detected, SCF will stop
             {
-                this->oscillate_esolver = this->p_chgmix->if_scf_oscillate(iter, drho, PARAM.inp.scf_os_ndim, PARAM.inp.scf_thr_os);
+                this->oscillate_esolver = this->p_chgmix->if_scf_oscillate(iter, drho, PARAM.inp.scf_os_ndim, PARAM.inp.scf_os_thr);
             }
 
             // drho will be 0 at this->p_chgmix->mixing_restart step, which is

--- a/source/module_esolver/esolver_ks.h
+++ b/source/module_esolver/esolver_ks.h
@@ -100,6 +100,7 @@ class ESolver_KS : public ESolver_FP
       protected:
         std::string basisname; // PW or LCAO
         double esolver_KS_ne = 0.0;
+		bool oscillate_esolver = false; // whether esolver is oscillated
 };	
 } // end of namespace
 #endif

--- a/source/module_io/read_input_item_elec_stru.cpp
+++ b/source/module_io/read_input_item_elec_stru.cpp
@@ -538,6 +538,12 @@ void ReadInput::item_elec_stru()
         Input_Item item("scf_os_thr");
         item.annotation = "charge density threshold for oscillation";
         read_sync_double(input.scf_os_thr);
+        item.check_value = [](const Input_Item& item, const Parameter& para) {
+            if (para.input.scf_os_thr >= 0)
+            {
+                ModuleBase::WARNING_QUIT("ReadInput", "scf_os_thr should be negative");
+            }
+        };
         this->add_item(item);
     }
     {

--- a/source/module_io/read_input_item_elec_stru.cpp
+++ b/source/module_io/read_input_item_elec_stru.cpp
@@ -529,6 +529,12 @@ void ReadInput::item_elec_stru()
         this->add_item(item);
     }
     {
+        Input_Item item("scf_thr_os");
+        item.annotation = "charge density threshold for oscillation";
+        read_sync_double(input.scf_thr_os);
+        this->add_item(item);
+    }
+    {
         Input_Item item("scf_thr_type");
         item.annotation = "type of the criterion of scf_thr, 1: reci drho for "
                           "pw, 2: real drho for lcao";

--- a/source/module_io/read_input_item_elec_stru.cpp
+++ b/source/module_io/read_input_item_elec_stru.cpp
@@ -529,6 +529,12 @@ void ReadInput::item_elec_stru()
         this->add_item(item);
     }
     {
+        Input_Item item("scf_os_stop");
+        item.annotation = "whether to stop scf when oscillation is detected";
+        read_sync_bool(input.scf_os_stop);
+        this->add_item(item);
+    }
+    {
         Input_Item item("scf_thr_os");
         item.annotation = "charge density threshold for oscillation";
         read_sync_double(input.scf_thr_os);

--- a/source/module_io/read_input_item_elec_stru.cpp
+++ b/source/module_io/read_input_item_elec_stru.cpp
@@ -535,9 +535,9 @@ void ReadInput::item_elec_stru()
         this->add_item(item);
     }
     {
-        Input_Item item("scf_thr_os");
+        Input_Item item("scf_os_thr");
         item.annotation = "charge density threshold for oscillation";
-        read_sync_double(input.scf_thr_os);
+        read_sync_double(input.scf_os_thr);
         this->add_item(item);
     }
     {

--- a/source/module_io/read_input_item_elec_stru.cpp
+++ b/source/module_io/read_input_item_elec_stru.cpp
@@ -535,6 +535,12 @@ void ReadInput::item_elec_stru()
         this->add_item(item);
     }
     {
+        Input_Item item("scf_os_ndim");
+        item.annotation = "number of old iterations used for oscillation detection";
+        read_sync_int(input.scf_os_ndim);
+        this->add_item(item);
+    }
+    {
         Input_Item item("scf_thr_type");
         item.annotation = "type of the criterion of scf_thr, 1: reci drho for "
                           "pw, 2: real drho for lcao";

--- a/source/module_io/read_input_item_elec_stru.cpp
+++ b/source/module_io/read_input_item_elec_stru.cpp
@@ -538,6 +538,12 @@ void ReadInput::item_elec_stru()
         Input_Item item("scf_os_ndim");
         item.annotation = "number of old iterations used for oscillation detection";
         read_sync_int(input.scf_os_ndim);
+        item.reset_value = [](const Input_Item& item, Parameter& para) {
+            if (para.input.scf_os_ndim <= 0) // default value
+            {
+                para.input.scf_os_ndim = para.input.mixing_ndim;
+            }
+        };
         this->add_item(item);
     }
     {

--- a/source/module_io/test/read_input_ptest.cpp
+++ b/source/module_io/test/read_input_ptest.cpp
@@ -164,6 +164,7 @@ TEST_F(InputParaTest, ParaRead)
     EXPECT_EQ(PARAM.inp.test_force, 0);
     EXPECT_EQ(param.inp.test_stress, 0);
     EXPECT_NEAR(param.inp.scf_thr, 1.0e-8, 1.0e-15);
+    EXPECT_NEAR(param.inp.scf_thr_os, -0.02, 1.0e-15);
     EXPECT_NEAR(param.inp.scf_ene_thr, -1.0, 1.0e-15);
     EXPECT_EQ(param.inp.scf_nmax, 50);
     EXPECT_EQ(param.inp.relax_nmax, 1);

--- a/source/module_io/test/read_input_ptest.cpp
+++ b/source/module_io/test/read_input_ptest.cpp
@@ -165,6 +165,7 @@ TEST_F(InputParaTest, ParaRead)
     EXPECT_EQ(param.inp.test_stress, 0);
     EXPECT_NEAR(param.inp.scf_thr, 1.0e-8, 1.0e-15);
     EXPECT_NEAR(param.inp.scf_thr_os, -0.02, 1.0e-15);
+    EXPECT_EQ(param.inp.scf_os_ndim, 10);
     EXPECT_NEAR(param.inp.scf_ene_thr, 1.0e-6, 1.0e-15);
     EXPECT_EQ(param.inp.scf_nmax, 50);
     EXPECT_EQ(param.inp.relax_nmax, 1);

--- a/source/module_io/test/read_input_ptest.cpp
+++ b/source/module_io/test/read_input_ptest.cpp
@@ -165,7 +165,7 @@ TEST_F(InputParaTest, ParaRead)
     EXPECT_EQ(param.inp.test_stress, 0);
     EXPECT_NEAR(param.inp.scf_thr, 1.0e-8, 1.0e-15);
     EXPECT_EQ(param.inp.scf_os_stop, 1);
-    EXPECT_NEAR(param.inp.scf_thr_os, -0.02, 1.0e-15);
+    EXPECT_NEAR(param.inp.scf_os_thr, -0.02, 1.0e-15);
     EXPECT_EQ(param.inp.scf_os_ndim, 10);
     EXPECT_NEAR(param.inp.scf_ene_thr, 1.0e-6, 1.0e-15);
     EXPECT_EQ(param.inp.scf_nmax, 50);

--- a/source/module_io/test/read_input_ptest.cpp
+++ b/source/module_io/test/read_input_ptest.cpp
@@ -165,7 +165,7 @@ TEST_F(InputParaTest, ParaRead)
     EXPECT_EQ(param.inp.test_stress, 0);
     EXPECT_NEAR(param.inp.scf_thr, 1.0e-8, 1.0e-15);
     EXPECT_NEAR(param.inp.scf_thr_os, -0.02, 1.0e-15);
-    EXPECT_NEAR(param.inp.scf_ene_thr, -1.0, 1.0e-15);
+    EXPECT_NEAR(param.inp.scf_ene_thr, 1.0e-6, 1.0e-15);
     EXPECT_EQ(param.inp.scf_nmax, 50);
     EXPECT_EQ(param.inp.relax_nmax, 1);
     EXPECT_EQ(param.inp.out_stru, 0);

--- a/source/module_io/test/read_input_ptest.cpp
+++ b/source/module_io/test/read_input_ptest.cpp
@@ -164,6 +164,7 @@ TEST_F(InputParaTest, ParaRead)
     EXPECT_EQ(PARAM.inp.test_force, 0);
     EXPECT_EQ(param.inp.test_stress, 0);
     EXPECT_NEAR(param.inp.scf_thr, 1.0e-8, 1.0e-15);
+    EXPECT_EQ(param.inp.scf_os_stop, 1);
     EXPECT_NEAR(param.inp.scf_thr_os, -0.02, 1.0e-15);
     EXPECT_EQ(param.inp.scf_os_ndim, 10);
     EXPECT_NEAR(param.inp.scf_ene_thr, 1.0e-6, 1.0e-15);

--- a/source/module_io/test/support/INPUT
+++ b/source/module_io/test/support/INPUT
@@ -51,6 +51,7 @@ erf_sigma                      4 #the width of the energy step for reciprocal ve
 fft_mode                       0 #mode of FFTW
 pw_diag_thr                    0.01 #threshold for eigenvalues is cg electron iterations
 scf_thr                        1e-08 #charge density error
+scf_thr_os                     -0.02 #charge density threshold for oscillation
 scf_thr_type                   2 #type of the criterion of scf_thr, 1: reci drho for pw, 2: real drho for lcao
 init_wfc                       atomic #start wave functions are from 'atomic', 'atomic+random', 'random' or 'file'
 init_chg                       atomic #start charge is from 'atomic' or file

--- a/source/module_io/test/support/INPUT
+++ b/source/module_io/test/support/INPUT
@@ -51,6 +51,7 @@ erf_sigma                      4 #the width of the energy step for reciprocal ve
 fft_mode                       0 #mode of FFTW
 pw_diag_thr                    0.01 #threshold for eigenvalues is cg electron iterations
 scf_thr                        1e-08 #charge density error
+scf_ene_thr                    1e-06 #total energy error threshold
 scf_thr_os                     -0.02 #charge density threshold for oscillation
 scf_thr_type                   2 #type of the criterion of scf_thr, 1: reci drho for pw, 2: real drho for lcao
 init_wfc                       atomic #start wave functions are from 'atomic', 'atomic+random', 'random' or 'file'

--- a/source/module_io/test/support/INPUT
+++ b/source/module_io/test/support/INPUT
@@ -52,6 +52,7 @@ fft_mode                       0 #mode of FFTW
 pw_diag_thr                    0.01 #threshold for eigenvalues is cg electron iterations
 scf_thr                        1e-08 #charge density error
 scf_ene_thr                    1e-06 #total energy error threshold
+scf_os_stop                    1 #whether to stop scf when oscillation is detected
 scf_thr_os                     -0.02 #charge density threshold for oscillation
 scf_os_ndim                    10 #number of old iterations used for oscillation detection
 scf_thr_type                   2 #type of the criterion of scf_thr, 1: reci drho for pw, 2: real drho for lcao

--- a/source/module_io/test/support/INPUT
+++ b/source/module_io/test/support/INPUT
@@ -53,7 +53,7 @@ pw_diag_thr                    0.01 #threshold for eigenvalues is cg electron it
 scf_thr                        1e-08 #charge density error
 scf_ene_thr                    1e-06 #total energy error threshold
 scf_os_stop                    1 #whether to stop scf when oscillation is detected
-scf_thr_os                     -0.02 #charge density threshold for oscillation
+scf_os_thr                     -0.02 #charge density threshold for oscillation
 scf_os_ndim                    10 #number of old iterations used for oscillation detection
 scf_thr_type                   2 #type of the criterion of scf_thr, 1: reci drho for pw, 2: real drho for lcao
 init_wfc                       atomic #start wave functions are from 'atomic', 'atomic+random', 'random' or 'file'

--- a/source/module_io/test/support/INPUT
+++ b/source/module_io/test/support/INPUT
@@ -53,6 +53,7 @@ pw_diag_thr                    0.01 #threshold for eigenvalues is cg electron it
 scf_thr                        1e-08 #charge density error
 scf_ene_thr                    1e-06 #total energy error threshold
 scf_thr_os                     -0.02 #charge density threshold for oscillation
+scf_os_ndim                    10 #number of old iterations used for oscillation detection
 scf_thr_type                   2 #type of the criterion of scf_thr, 1: reci drho for pw, 2: real drho for lcao
 init_wfc                       atomic #start wave functions are from 'atomic', 'atomic+random', 'random' or 'file'
 init_chg                       atomic #start charge is from 'atomic' or file

--- a/source/module_parameter/input_parameter.h
+++ b/source/module_parameter/input_parameter.h
@@ -115,6 +115,7 @@ struct Input_para
     double scf_ene_thr = -1.0; ///< energy threshold for scf convergence, in eV
     int scf_thr_type = -1;     ///< type of the criterion of scf_thr, 1: reci drho, 2: real drho
     bool final_scf = false;    ///< whether to do final scf
+    double scf_thr_os = -0.01;  ///< drho threshold for oscillation
 
     bool lspinorb = false;   ///< consider the spin-orbit interaction
     bool noncolin = false;   ///< using non-collinear-spin

--- a/source/module_parameter/input_parameter.h
+++ b/source/module_parameter/input_parameter.h
@@ -116,7 +116,7 @@ struct Input_para
     int scf_thr_type = -1;     ///< type of the criterion of scf_thr, 1: reci drho, 2: real drho
     bool final_scf = false;    ///< whether to do final scf
     bool scf_os_stop = false;  ///< whether to stop scf when oscillation is detected
-    double scf_thr_os = -0.01;  ///< drho threshold for oscillation
+    double scf_os_thr = -0.01;  ///< drho threshold for oscillation
     int scf_os_ndim = 0;       ///< number of old iterations used for oscillation detection
 
     bool lspinorb = false;   ///< consider the spin-orbit interaction

--- a/source/module_parameter/input_parameter.h
+++ b/source/module_parameter/input_parameter.h
@@ -116,6 +116,7 @@ struct Input_para
     int scf_thr_type = -1;     ///< type of the criterion of scf_thr, 1: reci drho, 2: real drho
     bool final_scf = false;    ///< whether to do final scf
     double scf_thr_os = -0.01;  ///< drho threshold for oscillation
+    int scf_os_ndim = 0;       ///< number of old iterations used for oscillation detection
 
     bool lspinorb = false;   ///< consider the spin-orbit interaction
     bool noncolin = false;   ///< using non-collinear-spin

--- a/source/module_parameter/input_parameter.h
+++ b/source/module_parameter/input_parameter.h
@@ -115,6 +115,7 @@ struct Input_para
     double scf_ene_thr = -1.0; ///< energy threshold for scf convergence, in eV
     int scf_thr_type = -1;     ///< type of the criterion of scf_thr, 1: reci drho, 2: real drho
     bool final_scf = false;    ///< whether to do final scf
+    bool scf_os_stop = false;  ///< whether to stop scf when oscillation is detected
     double scf_thr_os = -0.01;  ///< drho threshold for oscillation
     int scf_os_ndim = 0;       ///< number of old iterations used for oscillation detection
 


### PR DESCRIPTION
Fix #5406 

### Motivation
For systems that are difficult to converge, the SCF process may exhibit oscillations in charge density, preventing further progress toward the specified convergence criteria and resulting in continuous oscillation until the maximum number of steps is reached; this greatly wastes computational resources. To address this issue, I have designed a new feature that allows ABACUS to terminate the SCF process early upon detecting oscillations, thus reducing subsequent meaningless calculations. The detection of oscillations is based on the slope of the logarithm of historical `drho` values.

### What's Changed?
1. add a new parameter `scf_os_stop`. If `true`, SCF will stop if charge density oscillation is found. The default is `false`
2. add a new parameter to control the slope threshold `scf_os_thr`. The default value is -0.01
3. add a new parameter `scf_os_ndim` to control the number of past iterations used in slope calculation. Generally speaking, if the number of oscillation steps persists beyond the steps considered for charge density mixing `mixing_ndim`, the SCF is unlikely to break free from oscillations. So, I set the default value as the same as `mixing_ndim`, you can change it.
4. add a new function `Charge_Mixing::if_scf_oscillate` to determine if oscillation happens.
5. add a new member `oscillate_esolver`, similar to `conv_esolver`.
6. add some docs and comments for users.