### PR TITLE
Fix R-index mismatch in lr_util_hcontainer

### DIFF
--- a/source/module_lr/utils/lr_util_hcontainer.cpp
+++ b/source/module_lr/utils/lr_util_hcontainer.cpp
@@ -21,8 +21,10 @@ namespace LR_Util
                     auto ap_real = dr_real->find_pair(ia, ja);
                     for (int iR = 0;iR < ap->get_R_size();++iR)
                     {
+                        // R index may be different between the two HContainers, find by R value instead of R-index
+                        auto dR = ap->get_R_index(iR);
                         auto ptr = ap->get_HR_values(iR).get_pointer();
-                        auto ptr_real = ap_real->get_HR_values(iR).get_pointer();
+                        auto ptr_real = ap_real->get_HR_values(dR.x, dR.y, dR.z).get_pointer();
                         for (int i = 0;i < ap->get_size();++i)  ptr_real[i] = (get_imag ? ptr[i].imag() : ptr[i].real());
                     }
                 }
@@ -42,8 +44,10 @@ namespace LR_Util
                 auto ap_real = HR_real.find_pair(ia, ja);
                 for (int iR = 0;iR < ap->get_R_size();++iR)
                 {
+                    // R index may be different between the two HContainers, find by R value instead of R-index
+                    auto dR = ap->get_R_index(iR);
                     auto ptr = ap->get_HR_values(iR).get_pointer();
-                    auto ptr_real = ap_real->get_HR_values(iR).get_pointer();
+                    auto ptr_real = ap_real->get_HR_values(dR.x, dR.y, dR.z).get_pointer();
                     for (int i = 0;i < ap->get_size();++i)  get_imag ? ptr[i].imag(ptr_real[i]) : ptr[i].real(ptr_real[i]);
                 }
             }

--- a/source/module_lr/utils/lr_util_hcontainer.cpp
+++ b/source/module_lr/utils/lr_util_hcontainer.cpp
@@ -14,7 +14,7 @@ namespace LR_Util
             auto dr_real = DMR_real.get_DMR_vector()[is];
             assert(dr != nullptr);
             assert(dr_real != nullptr);
-            for (int ia = 0;ia < nat;ia++)
+            for (int ia = 0;ia < nat;ia++) {
                 for (int ja = 0;ja < nat;ja++)
                 {
                     auto ap = dr->find_pair(ia, ja);
@@ -25,9 +25,10 @@ namespace LR_Util
                         auto dR = ap->get_R_index(iR);
                         auto ptr = ap->get_HR_values(iR).get_pointer();
                         auto ptr_real = ap_real->get_HR_values(dR.x, dR.y, dR.z).get_pointer();
-                        for (int i = 0;i < ap->get_size();++i)  ptr_real[i] = (get_imag ? ptr[i].imag() : ptr[i].real());
+                        for (int i = 0;i < ap->get_size();++i) { ptr_real[i] = (get_imag ? ptr[i].imag() : ptr[i].real()); }
                     }
                 }
+            }
         }
     }
 
@@ -37,7 +38,7 @@ namespace LR_Util
         const char& type)
     {
         bool get_imag = (type == 'I' || type == 'i');
-        for (int ia = 0;ia < nat;ia++)
+        for (int ia = 0;ia < nat;ia++) {
             for (int ja = 0;ja < nat;ja++)
             {
                 auto ap = HR.find_pair(ia, ja);
@@ -48,8 +49,9 @@ namespace LR_Util
                     auto dR = ap->get_R_index(iR);
                     auto ptr = ap->get_HR_values(iR).get_pointer();
                     auto ptr_real = ap_real->get_HR_values(dR.x, dR.y, dR.z).get_pointer();
-                    for (int i = 0;i < ap->get_size();++i)  get_imag ? ptr[i].imag(ptr_real[i]) : ptr[i].real(ptr_real[i]);
+                    for (int i = 0;i < ap->get_size();++i) { get_imag ? ptr[i].imag(ptr_real[i]) : ptr[i].real(ptr_real[i]); }
                 }
             }
+        }
     }
 }

--- a/tests/integrate/291_NO_KP_LR/result.ref
+++ b/tests/integrate/291_NO_KP_LR/result.ref
@@ -1,1 +1,1 @@
-totexcitationenergyref 0.784963
+totexcitationenergyref 0.784471


### PR DESCRIPTION
This bug leads to the non-hermitian of LR-TDDFT A matrix between k-points, which is the causes of problem 2 in #5376.
(Davidson itself still has other problems, so this issue cannot be closed.)