### PR TITLE
Feature: change the default value of `printe` from `100` to `scf_nmax`

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -1176,7 +1176,7 @@ Note: In new angle mixing, you should set `mixing_beta_mag >> mixing_beta`. The 
 
 - **Type**: Integer
 - **Description**: Print out energy for each band for every printe step
-- **Default**: 100
+- **Default**: `scf_nmax`
 
 ### scf_nmax
 

--- a/source/module_elecstate/test/elecstate_print_test.cpp
+++ b/source/module_elecstate/test/elecstate_print_test.cpp
@@ -391,36 +391,3 @@ TEST_F(ElecStatePrintTest, PrintEtotColorS4)
     GlobalV::MY_RANK = 0;
     elecstate.print_etot(converged, iter, scf_thr, scf_thr_kin, duration, printe, pw_diag_thr, avg_iter, print);
 }
-
-// TEST_F(ElecStatePrintTest, PrintEtotWarning)
-// {
-//     GlobalV::ofs_running.open("test.dat", std::ios::out);
-//     bool converged = false;
-//     int iter = 1;
-//     double scf_thr = 0.1;
-//     double scf_thr_kin = 0.0;
-//     double duration = 2.0;
-//     int printe = 0;
-//     double pw_diag_thr = 0.1;
-//     int avg_iter = 2;
-//     bool print = true;
-//     elecstate.charge = new Charge;
-//     elecstate.charge->nrxx = 100;
-//     elecstate.charge->nxyz = 1000;
-//     PARAM.input.imp_sol = true;
-//     PARAM.input.efield_flag = true;
-//     PARAM.input.gate_flag = true;
-//     PARAM.sys.two_fermi = false;
-//     PARAM.input.out_bandgap = true;
-//     GlobalV::MY_RANK = 0;
-//     PARAM.input.basis_type = "pw";
-//     PARAM.input.scf_nmax = 100;
-//     elecstate::tmp_ks_solver = "unknown";
-//     testing::internal::CaptureStdout();
-//     EXPECT_EXIT(elecstate.print_etot(converged, iter, scf_thr, scf_thr_kin, duration, printe, pw_diag_thr, avg_iter, print), ::testing::ExitedWithCode(0), "");
-//     output = testing::internal::GetCapturedStdout();
-//     EXPECT_THAT(output, testing::HasSubstr("print_etot found unknown ks_solver_type"));
-//     GlobalV::ofs_running.close();
-//     delete elecstate.charge;
-//     std::remove("test.dat");
-// }

--- a/source/module_io/read_input_item_output.cpp
+++ b/source/module_io/read_input_item_output.cpp
@@ -83,6 +83,12 @@ void ReadInput::item_output()
     {
         Input_Item item("printe");
         item.annotation = "Print out energy for each band for every printe steps";
+        item.reset_value = [](const Input_Item& item, Parameter& para) {
+            if (para.input.printe <= 0) // default is scf_nmax
+            {
+                para.input.printe = para.input.scf_nmax;
+            }
+        };
         read_sync_int(input.printe);
         this->add_item(item);
     }

--- a/source/module_parameter/input_parameter.h
+++ b/source/module_parameter/input_parameter.h
@@ -320,7 +320,7 @@ struct Input_para
     int out_pot = 0;                      ///< yes or no
     int out_wfc_pw = 0;                   ///< 0: no; 1: txt; 2: dat
     bool out_wfc_r = false;               ///< 0: no; 1: yes
-    int printe = 100;                     ///< mohan add 2011-03-16
+    int printe = 0;                       ///< Print out energy for each band for every printe step, default is scf_nmax
     std::vector<int> out_band = {0, 8};   ///< band calculation pengfei 2014-10-13
     int out_dos = 0;                      ///< dos calculation. mohan add 20090909
     bool out_mul = false;                 ///< qifeng add 2019-9-10


### PR DESCRIPTION
fix #5354 