### PR TITLE
Fix: compile cuda without openmp

### DIFF
--- a/source/module_hamilt_lcao/module_gint/gint_force_gpu.cu
+++ b/source/module_hamilt_lcao/module_gint/gint_force_gpu.cu
@@ -1,4 +1,6 @@
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 
 #include "gint_force_gpu.h"
 #include "kernels/cuda/cuda_tools.cuh"
@@ -87,8 +89,9 @@ void gint_fvl_gpu(const hamilt::HContainer<double>* dm,
                          dm->get_wrapper(),
                          dm->get_nnr() * sizeof(double),
                          cudaMemcpyHostToDevice));
-
+#ifdef _OPENMP
     #pragma omp parallel for num_threads(num_streams) collapse(2)
+#endif
     for (int i = 0; i < gridt.nbx; i++)
     {
         for (int j = 0; j < gridt.nby; j++)
@@ -96,7 +99,11 @@ void gint_fvl_gpu(const hamilt::HContainer<double>* dm,
             // 20240620 Note that it must be set again here because 
             // cuda's device is not safe in a multi-threaded environment.
             checkCuda(cudaSetDevice(gridt.dev_id));
+#ifdef _OPENMP
             const int sid = omp_get_thread_num();
+#else
+            const int sid = 0;
+#endif
 
             int max_m = 0;
             int max_n = 0;

--- a/source/module_hamilt_lcao/module_gint/gint_rho_gpu.cu
+++ b/source/module_hamilt_lcao/module_gint/gint_rho_gpu.cu
@@ -4,7 +4,9 @@
 #include "gint_tools.h"
 #include "kernels/cuda/gint_rho.cuh"
 
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 
 namespace GintKernel
 {
@@ -68,7 +70,9 @@ void gint_rho_gpu(const hamilt::HContainer<double>* dm,
                          cudaMemcpyHostToDevice));
 
 // calculate the rho for every nbzp bigcells
+#ifdef _OPENMP
 #pragma omp parallel for num_threads(num_streams) collapse(2)
+#endif
     for (int i = 0; i < gridt.nbx; i++)
     {
         for (int j = 0; j < gridt.nby; j++)
@@ -78,7 +82,11 @@ void gint_rho_gpu(const hamilt::HContainer<double>* dm,
 
             checkCuda(cudaSetDevice(gridt.dev_id));
             // get stream id
+#ifdef _OPENMP
             const int sid = omp_get_thread_num();
+#else
+            const int sid = 0;
+#endif
 
             int max_m = 0;
             int max_n = 0;

--- a/source/module_hamilt_lcao/module_gint/gint_vl_gpu.cu
+++ b/source/module_hamilt_lcao/module_gint/gint_vl_gpu.cu
@@ -1,4 +1,6 @@
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 
 #include "kernels/cuda/cuda_tools.cuh"
 #include "module_base/ylm.h"
@@ -71,7 +73,9 @@ void gint_vl_gpu(hamilt::HContainer<double>* hRGint,
     Cuda_Mem_Wrapper<double*> gemm_B(max_atompair_per_z, num_streams, true);
     Cuda_Mem_Wrapper<double*> gemm_C(max_atompair_per_z, num_streams, true);
 
+#ifdef _OPENMP
 #pragma omp parallel for num_threads(num_streams) collapse(2)
+#endif
     for (int i = 0; i < gridt.nbx; i++)
     {
         for (int j = 0; j < gridt.nby; j++)
@@ -79,7 +83,11 @@ void gint_vl_gpu(hamilt::HContainer<double>* hRGint,
             // 20240620 Note that it must be set again here because 
             // cuda's device is not safe in a multi-threaded environment.
             checkCuda(cudaSetDevice(gridt.dev_id));
+#ifdef _OPENMP
             const int sid = omp_get_thread_num();
+#else
+            const int sid = 0;
+#endif
 
             int max_m = 0;
             int max_n = 0;


### PR DESCRIPTION
Add #ifdef _OPENMP to compile cuda without openmp