### PR TITLE
Fix GPU memory recorder's memory leak

### DIFF
--- a/source/module_base/memory.cpp
+++ b/source/module_base/memory.cpp
@@ -23,7 +23,7 @@ int Memory::short_memory = sizeof(short); // 2.0 Byte
 
 int Memory::n_memory = 1000;
 int Memory::n_now = 0;
-bool Memory::init_flag =  false;
+bool Memory::init_flag = false;
 
 #if defined(__CUDA) || defined(__ROCM)
 
@@ -234,10 +234,10 @@ double Memory::record_gpu
 {
 	if(!Memory::init_flag_gpu)
 	{
-		name_gpu = new std::string[n_memory];
-		class_name_gpu = new std::string[n_memory];
-		consume_gpu = new double[n_memory];
-		for(int i=0;i<n_memory;i++)
+		name_gpu = new std::string[n_memory + 2];
+		class_name_gpu = new std::string[n_memory + 2];
+		consume_gpu = new double[n_memory + 2];
+		for(int i=0;i<n_memory + 2;i++)
 		{
 			consume_gpu[i] = 0.0;
 		}
@@ -365,6 +365,7 @@ void Memory::finish(std::ofstream &ofs)
 		delete[] name_gpu;
 		delete[] class_name_gpu;
 		delete[] consume_gpu;
+		init_flag_gpu = false;
 	}
 #endif
 	return;
@@ -372,11 +373,7 @@ void Memory::finish(std::ofstream &ofs)
 
 void Memory::print_all(std::ofstream &ofs)
 {
-	if(!init_flag
-#if defined(__CUDA) || defined(__ROCM)
-	&& !init_flag_gpu
-#endif
-	) 
+	if(!init_flag) 
 	{
 		return;
 	}
@@ -437,6 +434,11 @@ void Memory::print_all(std::ofstream &ofs)
 	}
 
 #if defined(__CUDA) || defined(__ROCM)
+	if(!init_flag_gpu) 
+	{
+		return;
+	}
+
 	ofs <<"\n NAME-------------------------|GPU MEMORY(MB)----" << std::endl;
 	ofs <<std::setw(30)<< "total" << std::setw(15) <<std::setprecision(4)<< Memory::total_gpu << std::endl;
     

--- a/source/module_base/memory.cpp
+++ b/source/module_base/memory.cpp
@@ -234,10 +234,10 @@ double Memory::record_gpu
 {
 	if(!Memory::init_flag_gpu)
 	{
-		name_gpu = new std::string[n_memory + 2];
-		class_name_gpu = new std::string[n_memory + 2];
-		consume_gpu = new double[n_memory + 2];
-		for(int i=0;i<n_memory + 2;i++)
+		name_gpu = new std::string[n_memory];
+		class_name_gpu = new std::string[n_memory];
+		consume_gpu = new double[n_memory];
+		for(int i=0;i<n_memory;i++)
 		{
 			consume_gpu[i] = 0.0;
 		}


### PR DESCRIPTION
If you are running cpu examples using ABACUS compiled for GPU, then it will cause memory leak and crash the application. But it passed the CI test because CI test will not do tests like this.

Thanks for @dzzz2001 for finding this bug
![img_v3_02gk_bad01767-7d06-4fc0-a13e-5db49ff5eafg](https://github.com/user-attachments/assets/d4b875d4-a59f-4bf3-a3bc-7100e0d32de9)
