### PR TITLE
Fix: set zero for unused psi data for nspin4

### DIFF
--- a/source/module_hamilt_pw/hamilt_pwdft/wf_atomic.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/wf_atomic.cpp
@@ -643,6 +643,10 @@ void WF_atomic::random_t(std::complex<FPTYPE>* psi,
                     const FPTYPE gk2 = wfc_basis->getgk2(ik,ig);
                     ppsi[ig+startig] = std::complex<FPTYPE>(rr * cos(arg), rr * sin(arg)) / FPTYPE(gk2 + 1.0);
                 }
+                for(int ig=ng ;ig<npwx;++ig)
+                {
+                    ppsi[ig+startig] = std::complex<FPTYPE>(0.0, 0.0);
+                }
                 startig += npwx;
             }
         }
@@ -733,6 +737,10 @@ void WF_atomic::atomicrandom(ModuleBase::ComplexMatrix& psi,
                     const double rr = tmprr[wfc_basis->ig2isz[ig]];
                     const double arg= ModuleBase::TWO_PI * tmparg[wfc_basis->ig2isz[ig]];
                     psi(iw,startig+ig) *= (1.0 + 0.05 * std::complex<double>(rr * cos(arg), rr * sin(arg)));
+                }
+                for(int ig=ng ;ig<npwx;++ig)
+                {
+                    psi(iw,startig+ig) = std::complex<double>(0.0, 0.0);
                 }
                 startig += npwx;
             }


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #5522 

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
