### PR TITLE
Refactor: remove the redundant macro in source file of VDW module

### DIFF
--- a/source/module_hamilt_general/module_vdw/vdwd3_autoset_xcname.cpp
+++ b/source/module_hamilt_general/module_vdw/vdwd3_autoset_xcname.cpp
@@ -1,5 +1,3 @@
-#ifndef DFTD3_XC_NAME_H
-#define DFTD3_XC_NAME_H
 /**
  * Intro
  * -----
@@ -606,4 +604,3 @@ if __name__ == '__main__':
     # print_xc(others)
     print(paired_xc_to_stdmap(special))
  */
-#endif // DFTD3_XCNAME_H_


### PR DESCRIPTION
### What's changed?
After the PR#5517, all free functions defined in header files are moved into source file to avoid voilating the One Definition Rule (ODR). However, there is a macro previously defined is not removed. Although it will not affect anything (due to the source file only needs to be compiled for once), it is better to remove it for a correct  programming habit.
