### PR TITLE
ignoring files/directories starting with Lib in the deps directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ time.json
 __pycache__
 abacus.json
 *.npy
+deps/Lib*


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

@mohanchen @PeizeLin 
Please reject this pull request if it is unreasonable to introduce the following change:
In an earlier commit (two weeks ago) the LibComm and LibRI directories in path/to/abacus/deps are discarded. So I told the .gitignore file to ignore files/directories starting with 'Lib' in deps.


### Linked Issue
Fix #...

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
