### PR TITLE
Fix: Fix the warning triggered in error of `SCAN_END`.

### DIFF
--- a/source/module_cell/read_pp.cpp
+++ b/source/module_cell/read_pp.cpp
@@ -479,3 +479,12 @@ void Pseudopot_upf::setqfnew(const int& nqf,
         rho[ir] *= pow(r[ir], l + n);
     }
 }
+
+void Pseudopot_upf::skip_number(std::ifstream& ifs, bool mesh_changed)
+{
+	if (mesh_changed)
+	{
+		double temp = 0.;
+		ifs >> temp;
+	}
+}

--- a/source/module_cell/read_pp.h
+++ b/source/module_cell/read_pp.h
@@ -73,6 +73,7 @@ public:
 
   private:
     bool mesh_changed = false; // if the mesh is even, it will be changed to odd
+    void skip_number(std::ifstream& ifs, bool mesh_changed); // skip the last number if the mesh is even
 
     int set_pseudo_type(const std::string& fn, std::string& type);
     std::string& trim(std::string& in_str);

--- a/source/module_cell/read_pp_upf100.cpp
+++ b/source/module_cell/read_pp_upf100.cpp
@@ -236,6 +236,7 @@ void Pseudopot_upf::read_pseudo_mesh(std::ifstream &ifs, Atom_pseudo& pp)
 		{
 			ifs >> pp.r[ir];
 		}
+        this->skip_number(ifs, this->mesh_changed);
 		ModuleBase::GlobalFunc::SCAN_END(ifs, "</PP_R>");
 	}
 
@@ -245,6 +246,7 @@ void Pseudopot_upf::read_pseudo_mesh(std::ifstream &ifs, Atom_pseudo& pp)
 		{
 			ifs >> pp.rab[ir];
 		}
+        this->skip_number(ifs, this->mesh_changed);
 		ModuleBase::GlobalFunc::SCAN_END(ifs, "</PP_RAB>");
 	}
 	return;
@@ -258,6 +260,7 @@ void Pseudopot_upf::read_pseudo_nlcc(std::ifstream &ifs, Atom_pseudo& pp)
 	{
 		ifs >> pp.rho_atc[ir];
 	}
+    this->skip_number(ifs, this->mesh_changed);
 	return;
 }
 
@@ -270,7 +273,7 @@ void Pseudopot_upf::read_pseudo_local(std::ifstream &ifs, Atom_pseudo& pp)
 	{
 		ifs >> pp.vloc_at[ir];
 	}
-	
+    this->skip_number(ifs, this->mesh_changed);
 	return;
 }
 
@@ -406,6 +409,7 @@ void Pseudopot_upf::read_pseudo_nl(std::ifstream &ifs, Atom_pseudo& pp)
                             ifs >> qfunc(nmb, ir);
                         }
                     }
+                    this->skip_number(ifs, this->mesh_changed);
 
                     if (this->nqf > 0)
                     {
@@ -445,11 +449,7 @@ void Pseudopot_upf::read_pseudo_pswfc(std::ifstream &ifs, Atom_pseudo& pp)
 		{
 			ifs >> pp.chi(i, ir);
 		}
-        if (this->mesh_changed)
-        {
-            double temp = 0.0;
-            ifs >> temp;
-        }
+        this->skip_number(ifs, this->mesh_changed);
 	}
 	return;
 }
@@ -461,6 +461,7 @@ void Pseudopot_upf::read_pseudo_rhoatom(std::ifstream &ifs, Atom_pseudo& pp)
 	{
 		ifs >> pp.rho_at[ir];
 	}
+    this->skip_number(ifs, this->mesh_changed);
 	return;
 }
 

--- a/source/module_cell/read_pp_upf201.cpp
+++ b/source/module_cell/read_pp_upf201.cpp
@@ -32,6 +32,7 @@ int Pseudopot_upf::read_pseudo_upf201(std::ifstream &ifs, Atom_pseudo& pp)
         {
             ifs >> pp.rho_atc[ir];
         }
+        this->skip_number(ifs, this->mesh_changed);
         ModuleBase::GlobalFunc::SCAN_END(ifs, "</PP_NLCC>");
     }
 
@@ -53,6 +54,7 @@ int Pseudopot_upf::read_pseudo_upf201(std::ifstream &ifs, Atom_pseudo& pp)
         {
             ifs >> pp.vloc_at[ir];
         }
+        this->skip_number(ifs, this->mesh_changed);
         ModuleBase::GlobalFunc::SCAN_END(ifs, "</PP_LOCAL>");
     }
 
@@ -90,6 +92,7 @@ int Pseudopot_upf::read_pseudo_upf201(std::ifstream &ifs, Atom_pseudo& pp)
     {
         ifs >> pp.rho_at[ir];
     }
+    this->skip_number(ifs, this->mesh_changed);
     ModuleBase::GlobalFunc::SCAN_END(ifs, "</PP_RHOATOM>");
 
     //--------------------------------------
@@ -406,6 +409,7 @@ void Pseudopot_upf::read_pseudo_upf201_mesh(std::ifstream& ifs, Atom_pseudo& pp)
     {
         ifs >> pp.r[ir];
     }
+    this->skip_number(ifs, this->mesh_changed);
     ModuleBase::GlobalFunc::SCAN_END(ifs, "</PP_R>");
 
     if (ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_RAB", true, false))
@@ -420,6 +424,7 @@ void Pseudopot_upf::read_pseudo_upf201_mesh(std::ifstream& ifs, Atom_pseudo& pp)
     {
         ifs >> pp.rab[ir];
     }
+    this->skip_number(ifs, this->mesh_changed);
     ModuleBase::GlobalFunc::SCAN_END(ifs, "</PP_RAB>");
     ModuleBase::GlobalFunc::SCAN_END(ifs, "</PP_MESH>");
 }
@@ -497,6 +502,7 @@ void Pseudopot_upf::read_pseudo_upf201_nonlocal(std::ifstream& ifs, Atom_pseudo&
         {
             ifs >> pp.betar(ib, ir);
         }
+        this->skip_number(ifs, this->mesh_changed);
         word = "</PP_BETA." + std::to_string(ib + 1) + ">";
         ModuleBase::GlobalFunc::SCAN_END(ifs, word);
     }
@@ -639,6 +645,7 @@ void Pseudopot_upf::read_pseudo_upf201_nonlocal(std::ifstream& ifs, Atom_pseudo&
                         {
                             ifs >> pp.qfuncl(l, nmb, ir);
                         }
+                        this->skip_number(ifs, this->mesh_changed);
                         word = "</PP_QIJL." + std::to_string(nb + 1) + "." + std::to_string(mb + 1) + "."
                                + std::to_string(l) + ">";
                         ModuleBase::GlobalFunc::SCAN_END(ifs, word);
@@ -653,6 +660,7 @@ void Pseudopot_upf::read_pseudo_upf201_nonlocal(std::ifstream& ifs, Atom_pseudo&
                     {
                         ifs >> this->qfunc(nmb, ir);
                     }
+                    this->skip_number(ifs, this->mesh_changed);
                     word = "</PP_QIJ." + std::to_string(nb + 1) + "." + std::to_string(mb + 1) + ">";
                     ModuleBase::GlobalFunc::SCAN_END(ifs, word);
                 }
@@ -757,6 +765,7 @@ void Pseudopot_upf::read_pseudo_upf201_pswfc(std::ifstream& ifs, Atom_pseudo& pp
         {
             assert(pp.chi.c[iw * pp.mesh + ir] == pp.chi(iw, ir));
         }
+        this->skip_number(ifs, this->mesh_changed);
         word = "</PP_CHI." + std::to_string(iw + 1) + ">";
         ModuleBase::GlobalFunc::SCAN_END(ifs, word);
     }


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #5534 

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
