### PR TITLE
Test: Fix tests to work without MPI

### DIFF
--- a/source/module_hsolver/test/CMakeLists.txt
+++ b/source/module_hsolver/test/CMakeLists.txt
@@ -5,6 +5,11 @@ remove_definitions(-D__EXX)
 
 if (ENABLE_MPI)
   AddTest(
+    TARGET hsolver_parak2d_test
+    LIBS parameter  ${math_libs} base device MPI::MPI_CXX
+    SOURCES parallel_k2d_test.cpp ../parallel_k2d.cpp ../../module_cell/parallel_kpoints.cpp  ../../module_basis/module_ao/parallel_2d.cpp
+  )
+  AddTest(
     TARGET HSolver_bpcg
     LIBS parameter  ${math_libs} base psi device container
     SOURCES diago_bpcg_test.cpp ../diago_bpcg.cpp  ../diago_iter_assist.cpp  
@@ -147,11 +152,7 @@ install(FILES PEXSI-DM-GammaOnly-Si2.dat DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
 install(FILES diago_pexsi_parallel_test.sh DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 install(FILES parallel_k2d_test.sh DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-AddTest(
-  TARGET hsolver_parak2d_test
-  LIBS parameter  ${math_libs} base device MPI::MPI_CXX
-  SOURCES parallel_k2d_test.cpp ../parallel_k2d.cpp ../../module_cell/parallel_kpoints.cpp  ../../module_basis/module_ao/parallel_2d.cpp
-)
+
 
 find_program(BASH bash)
 if (ENABLE_MPI)

--- a/source/module_hsolver/test/diago_lapack_test.cpp
+++ b/source/module_hsolver/test/diago_lapack_test.cpp
@@ -1,8 +1,8 @@
 // Author: Zhang Xiaoyang
 // A modified version of diago_lcao_test.cpp
-#define private public
+// #define private public
 #include "module_parameter/parameter.h"
-#undef private
+// #undef private
 // Remove some useless functions and dependencies. Serialized the full code
 // and refactored some function.
 
@@ -187,8 +187,10 @@ class DiagoLapackPrepare
 
     void set_env()
     {
-        PARAM.sys.nlocal = nlocal;
-        PARAM.input.nbands = nbands;
+        // PARAM.sys.nlocal = nlocal;
+        PARAM.set_sys_nlocal(nlocal);
+        // PARAM.input.nbands = nbands;
+        PARAM.set_input_nbands(nbands);
     }
 
     void diago()

--- a/source/module_lr/AX/test/AX_test.cpp
+++ b/source/module_lr/AX/test/AX_test.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
+#ifdef __MPI
 #include "mpi.h"
+#endif
 #include "../AX.h"
 
 #include "module_lr/utils/lr_util.h"
@@ -206,9 +208,13 @@ TEST_F(AXTest, ComplexParallel)
 int main(int argc, char** argv)
 {
     srand(time(nullptr));  // for random number generator
+#ifdef __MPI
     MPI_Init(&argc, &argv);
+#endif
     testing::InitGoogleTest(&argc, argv);
     int result = RUN_ALL_TESTS();
+#ifdef __MPI
     MPI_Finalize();
+#endif
     return result;
 }

--- a/source/module_lr/dm_trans/test/dm_trans_test.cpp
+++ b/source/module_lr/dm_trans/test/dm_trans_test.cpp
@@ -1,7 +1,8 @@
 #include <gtest/gtest.h>
-#include "mpi.h"
+#include <fstream>
 #include "../dm_trans.h"
 #ifdef __MPI
+#include "mpi.h"
 #include "module_lr/utils/lr_util.h"
 #endif
 struct matsize
@@ -226,9 +227,13 @@ TEST_F(DMTransTest, ComplexParallel)
 int main(int argc, char** argv)
 {
     srand(time(NULL));  // for random number generator
+#ifdef __MPI
     MPI_Init(&argc, &argv);
+#endif
     testing::InitGoogleTest(&argc, argv);
     int result = RUN_ALL_TESTS();
+#ifdef __MPI
     MPI_Finalize();
+#endif
     return result;
 }

--- a/source/module_parameter/parameter.cpp
+++ b/source/module_parameter/parameter.cpp
@@ -14,3 +14,13 @@ void Parameter::set_start_time(const std::time_t& start_time)
 {
     sys.start_time = start_time;
 }
+
+void Parameter::set_input_nbands(const int& nbands)
+{
+    input.nbands = nbands;
+}
+
+void Parameter::set_sys_nlocal(const int& nlocal)
+{
+    sys.nlocal = nlocal;
+}

--- a/source/module_parameter/parameter.h
+++ b/source/module_parameter/parameter.h
@@ -33,6 +33,11 @@ class Parameter
     // Set the start time
     void set_start_time(const std::time_t& start_time);
 
+    // set input.nbands 
+    void set_input_nbands(const int& nbands);
+    // set sys.nlocal
+    void set_sys_nlocal(const int& nlocal);
+
   private:
     // Only ReadInput and CalAtomInfo can modify the value of Parameter.
     // Do not add extra friend class here!!!


### PR DESCRIPTION
### Linked Issue
Fix #5627 

### Unit Tests and/or Case Tests for my changes
- Unit tests and CMakeLists are changed to run without MPI.

What is the proper way to access `PARAM` private members?
