### PR TITLE
Fix: forbit setting of nspin=4 without noncolin and lspinorb

### DIFF
--- a/source/module_io/read_input_item_elec_stru.cpp
+++ b/source/module_io/read_input_item_elec_stru.cpp
@@ -290,6 +290,10 @@ void ReadInput::item_elec_stru()
             {
                 ModuleBase::WARNING_QUIT("ReadInput", "nspin should be 1, 2 or 4.");
             }
+            else if(para.input.nspin == 4 && !para.input.noncolin && !para.input.lspinorb)
+            {
+                ModuleBase::WARNING_QUIT("ReadInput", "nspin should be 4 only when noncolin or lspinorb is true.");
+            }
         };
         this->add_item(item);
     }


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #5021 

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
