### PR TITLE
Fix: init_mixing before `beforescf`

### DIFF
--- a/source/module_esolver/esolver_ks.cpp
+++ b/source/module_esolver/esolver_ks.cpp
@@ -109,6 +109,7 @@ void ESolver_KS<T, Device>::before_all_runners(UnitCell& ucell, const Input_para
                          PARAM.inp.mixing_gg0_min,
                          PARAM.inp.mixing_angle,
                          PARAM.inp.mixing_dmr);
+    p_chgmix->init_mixing();
 
     /// PAW Section
 #ifdef USE_PAW

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -511,7 +511,7 @@ void ESolver_KS_LCAO<TK, TR>::iter_init(UnitCell& ucell, const int istep, const 
 
     if (iter == 1)
     {
-        this->p_chgmix->init_mixing(); // init mixing
+        this->p_chgmix->mix_reset(); // init mixing
         this->p_chgmix->mixing_restart_step = PARAM.inp.scf_nmax + 1;
         this->p_chgmix->mixing_restart_count = 0;
         // this output will be removed once the feeature is stable

--- a/tests/integrate/384_NO_GO_S1_HSE_loop0_PU/result.ref
+++ b/tests/integrate/384_NO_GO_S1_HSE_loop0_PU/result.ref
@@ -1,3 +1,3 @@
-etotref -465.9048077363179
-etotperatomref -155.3016025788
-totaltimeref 49.53
+etotref -465.9048164318562
+etotperatomref -155.3016054773
+totaltimeref 8.29


### PR DESCRIPTION
Fix #5640 