### PR TITLE
Feature: add smooth ethr for all iter methods

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -37,6 +37,7 @@
     - [ndx, ndy, ndz](#ndx-ndy-ndz)
     - [pw\_seed](#pw_seed)
     - [pw\_diag\_thr](#pw_diag_thr)
+    - [diag\_smooth\_ethr](#diag_smooth_ethr)
     - [pw\_diag\_nmax](#pw_diag_nmax)
     - [pw\_diag\_ndim](#pw_diag_ndim)
     - [erf\_ecut](#erf_ecut)
@@ -776,6 +777,12 @@ These variables are used to control the plane wave related parameters.
 - **Type**: Real
 - **Description**: Only used when you use `ks_solver = cg/dav/dav_subspace/bpcg`. It indicates the threshold for the first electronic iteration, from the second iteration the pw_diag_thr will be updated automatically. **For nscf calculations with planewave basis set, pw_diag_thr should be <= 1e-3.**
 - **Default**: 0.01
+
+### diago_smooth_ethr
+
+- **Type**: bool
+- **Description**: If `FALSE`, all the empty states are diagonalized at the same level of accuracy of the occupied ones. If `TRUE` the empty states are diagonalized using a larger threshold (10-5) (this should not affect total energy, forces, and other ground-state properties, but computational efficiency will be improved.).
+- **Default**: false
 
 ### pw_diag_nmax
 

--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -781,7 +781,7 @@ These variables are used to control the plane wave related parameters.
 ### diago_smooth_ethr
 
 - **Type**: bool
-- **Description**: If `FALSE`, all the empty states are diagonalized at the same level of accuracy of the occupied ones. If `TRUE` the empty states are diagonalized using a larger threshold (10-5) (this should not affect total energy, forces, and other ground-state properties, but computational efficiency will be improved.).
+- **Description**: If `TRUE`, the smooth threshold strategy, which applies a larger threshold (10e-5) for the empty states, will be implemented in the diagonalization methods. (This strategy should not affect total energy, forces, and other ground-state properties, but computational efficiency will be improved.) If `FALSE`, the smooth threshold strategy will not be applied.
 - **Default**: false
 
 ### pw_diag_nmax

--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -37,7 +37,7 @@
     - [ndx, ndy, ndz](#ndx-ndy-ndz)
     - [pw\_seed](#pw_seed)
     - [pw\_diag\_thr](#pw_diag_thr)
-    - [diag\_smooth\_ethr](#diag_smooth_ethr)
+    - [diago\_smooth\_ethr](#diago_smooth_ethr)
     - [pw\_diag\_nmax](#pw_diag_nmax)
     - [pw\_diag\_ndim](#pw_diag_ndim)
     - [erf\_ecut](#erf_ecut)

--- a/source/module_hsolver/hsolver_pw.h
+++ b/source/module_hsolver/hsolver_pw.h
@@ -88,7 +88,7 @@ class HSolverPW
 
   private:
     /// @brief calculate the threshold for iterative-diagonalization for each band
-    void cal_ethr_band(const double& wk, const double* wg, const double& ethr, std::vector<double>& ethrs);
+    void cal_smooth_ethr(const double& wk, const double* wg, const double& ethr, std::vector<double>& ethrs);
 
 #ifdef USE_PAW
     void paw_func_in_kloop(const int ik,

--- a/source/module_io/read_input_item_elec_stru.cpp
+++ b/source/module_io/read_input_item_elec_stru.cpp
@@ -315,6 +315,12 @@ void ReadInput::item_elec_stru()
         this->add_item(item);
     }
     {
+        Input_Item item("diago_smooth_ethr");
+        item.annotation = "smooth ethr for iter methods";
+        read_sync_bool(input.diago_smooth_ethr);
+        this->add_item(item);
+    }
+    {
         Input_Item item("pw_diag_ndim");
         item.annotation = "dimension of workspace for Davidson diagonalization";
         read_sync_int(input.pw_diag_ndim);

--- a/source/module_io/test/read_input_ptest.cpp
+++ b/source/module_io/test/read_input_ptest.cpp
@@ -154,6 +154,7 @@ TEST_F(InputParaTest, ParaRead)
     EXPECT_EQ(param.inp.diago_cg_prec, 1);
     EXPECT_EQ(param.inp.pw_diag_ndim, 4);
     EXPECT_DOUBLE_EQ(param.inp.pw_diag_thr, 1.0e-2);
+    EXPECT_FALSE(param.inp.diago_smooth_ethr);
     EXPECT_EQ(param.inp.nb2d, 0);
     EXPECT_EQ(param.inp.nurse, 0);
     EXPECT_EQ(param.inp.t_in_h, 1);

--- a/source/module_io/test/support/INPUT
+++ b/source/module_io/test/support/INPUT
@@ -50,6 +50,7 @@ erf_height                     20 #the height of the energy step for reciprocal 
 erf_sigma                      4 #the width of the energy step for reciprocal vectors
 fft_mode                       0 #mode of FFTW
 pw_diag_thr                    0.01 #threshold for eigenvalues is cg electron iterations
+diago_smooth_ethr              false #smooth ethr for iter methods
 scf_thr                        1e-08 #charge density error
 scf_ene_thr                    1e-06 #total energy error threshold
 scf_os_stop                    1 #whether to stop scf when oscillation is detected

--- a/source/module_parameter/input_parameter.h
+++ b/source/module_parameter/input_parameter.h
@@ -86,6 +86,7 @@ struct Input_para
     int nspin = 1;                          ///< LDA ; LSDA ; non-linear spin
     int pw_diag_nmax = 50;
     double pw_diag_thr = 0.01; ///< used in cg method
+    bool diago_smooth_ethr = false; ///< smooth ethr for iter methods
     int pw_diag_ndim = 4;      ///< dimension of workspace for Davidson diagonalization
     int diago_cg_prec = 1;     ///< mohan add 2012-03-31
 

--- a/tests/integrate/104_PW_NC_magnetic/INPUT
+++ b/tests/integrate/104_PW_NC_magnetic/INPUT
@@ -22,6 +22,7 @@ mixing_beta    0.2
 mixing_ndim 10
 
 ks_solver     dav_subspace
+diago_smooth_ethr true
 pw_diag_ndim  2
 basis_type    pw
 symmetry      0

--- a/tests/integrate/140_PW_15_SO/INPUT
+++ b/tests/integrate/140_PW_15_SO/INPUT
@@ -34,6 +34,7 @@ lspinorb            1
 
 basis_type          pw
 ks_solver           dav_subspace
+diago_smooth_ethr true
 pw_diag_ndim        2
 chg_extrap       second-order
 out_dm              0

--- a/tests/integrate/160_PW_DJ_PK_PU_SO/INPUT
+++ b/tests/integrate/160_PW_DJ_PK_PU_SO/INPUT
@@ -27,6 +27,7 @@ mixing_dmr     1
 mixing_gg0    1.1
 
 ks_solver    dav_subspace
+diago_smooth_ethr true
 pw_diag_ndim  2
 basis_type    pw
 gamma_only    0


### PR DESCRIPTION
Added a new input parameter, `diago_smooth_ethr`, to control the use of the smooth threshold strategy in iterative methods. 

* By default, `diago_smooth_ethr` is set to false, meaning the feature is disabled.
* When enabled, `diago_smooth_ethr` enhances the efficiency of calculations without impacting total energy, forces, or other ground-state properties.