### PR TITLE
Refactor:Remove GlobalC::ucell

### DIFF
--- a/source/driver.cpp
+++ b/source/driver.cpp
@@ -43,9 +43,6 @@ void Driver::init()
     // (4) close all of the running logs
     ModuleBase::Global_File::close_all_log(GlobalV::MY_RANK, PARAM.inp.out_alllog,PARAM.inp.calculation);
 
-    // (5) output the json file
-    // Json::create_Json(&GlobalC::ucell.symm,GlobalC::ucell.atoms,&INPUT);
-    Json::create_Json(&GlobalC::ucell, PARAM);
 }
 
 void Driver::print_start_info()
@@ -180,7 +177,7 @@ void Driver::atomic_world()
     //--------------------------------------------------
 
     // where the actual stuff is done
-    this->driver_run(GlobalC::ucell);
+    this->driver_run();
 
     ModuleBase::timer::finish(GlobalV::ofs_running);
     ModuleBase::Memory::print_all(GlobalV::ofs_running);

--- a/source/driver.h
+++ b/source/driver.h
@@ -36,7 +36,7 @@ class Driver
     void atomic_world();
 
     // the actual calculations
-    void driver_run(UnitCell& ucell);
+    void driver_run();
 };
 
 #endif

--- a/source/driver_run.cpp
+++ b/source/driver_run.cpp
@@ -24,13 +24,12 @@
  * the configuration-changing subroutine takes force and stress and updates the
  * configuration
  */
-void Driver::driver_run(UnitCell& ucell)
+void Driver::driver_run()
 {
     ModuleBase::TITLE("Driver", "driver_line");
     ModuleBase::timer::tick("Driver", "driver_line");
 
     //! 1: setup cell and atom information
-
     // this warning should not be here, mohan 2024-05-22
 #ifndef __LCAO
     if (PARAM.inp.basis_type == "lcao_in_pw" || PARAM.inp.basis_type == "lcao") {
@@ -40,6 +39,13 @@ void Driver::driver_run(UnitCell& ucell)
 #endif
 
     // the life of ucell should begin here, mohan 2024-05-12
+    UnitCell ucell;
+    ucell.setup(PARAM.inp.latname,
+                    PARAM.inp.ntype,
+                    PARAM.inp.lmaxmax,
+                    PARAM.inp.init_vel,
+                    PARAM.inp.fixed_axes);
+
     ucell.setup_cell(PARAM.globalv.global_in_stru, GlobalV::ofs_running);
     Check_Atomic_Stru::check_atomic_stru(ucell, PARAM.inp.min_dist_coef);
 
@@ -86,6 +92,8 @@ void Driver::driver_run(UnitCell& ucell)
 
     ModuleESolver::clean_esolver(p_esolver);
 
+    //! 6: output the json file
+    Json::create_Json(&ucell, PARAM);
     ModuleBase::timer::tick("Driver", "driver_line");
     return;
 }

--- a/source/module_esolver/esolver_ks_lcao.cpp
+++ b/source/module_esolver/esolver_ks_lcao.cpp
@@ -302,11 +302,11 @@ void ESolver_KS_LCAO<TK, TR>::cal_force(UnitCell& ucell, ModuleBase::matrix& for
 
     Force_Stress_LCAO<TK> fsl(this->RA, ucell.nat);
 
-    fsl.getForceStress(PARAM.inp.cal_force,
+    fsl.getForceStress(ucell,
+                       PARAM.inp.cal_force,
                        PARAM.inp.cal_stress,
                        PARAM.inp.test_force,
                        PARAM.inp.test_stress,
-                       ucell,
                        this->gd,
                        this->pv,
                        this->pelec,

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
@@ -975,7 +975,7 @@ void Force_Stress_LCAO<std::complex<double>>::integral_part(const bool isGammaOn
 
 // vlocal, hartree, ewald, core correction, exchange-correlation terms in stress
 template <typename T>
-void Force_Stress_LCAO<T>::calStressPwPart(const UnitCell& ucell,
+void Force_Stress_LCAO<T>::calStressPwPart(UnitCell& ucell,
                                            ModuleBase::matrix& sigmadvl,
                                            ModuleBase::matrix& sigmahar,
                                            ModuleBase::matrix& sigmaewa,
@@ -1007,7 +1007,7 @@ void Force_Stress_LCAO<T>::calStressPwPart(const UnitCell& ucell,
     //--------------------------------------------------------
     // stress due to core correlation.
     //--------------------------------------------------------
-    sc_pw.stress_cc(sigmacc, rhopw, &sf, 0, nlpp.numeric, chr);
+    sc_pw.stress_cc(sigmacc, rhopw, ucell, &sf, 0, nlpp.numeric, chr);
 
     //--------------------------------------------------------
     // stress due to self-consistent charge.

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
@@ -31,11 +31,11 @@ Force_Stress_LCAO<T>::~Force_Stress_LCAO()
 {
 }
 template <typename T>
-void Force_Stress_LCAO<T>::getForceStress(const bool isforce,
+void Force_Stress_LCAO<T>::getForceStress(UnitCell& ucell,
+                                          const bool isforce,
                                           const bool isstress,
                                           const bool istestf,
                                           const bool istests,
-                                          const UnitCell& ucell,
                                           const Grid_Driver& gd,
                                           Parallel_Orbitals& pv,
                                           const elecstate::ElecState* pelec,
@@ -830,7 +830,7 @@ void Force_Stress_LCAO<T>::getForceStress(const bool isforce,
 
 // local pseudopotential, ewald, core correction, scc terms in force
 template <typename T>
-void Force_Stress_LCAO<T>::calForcePwPart(const UnitCell& ucell,
+void Force_Stress_LCAO<T>::calForcePwPart(UnitCell& ucell,
                                           ModuleBase::matrix& fvl_dvl,
                                           ModuleBase::matrix& fewalds,
                                           ModuleBase::matrix& fcc,
@@ -857,7 +857,7 @@ void Force_Stress_LCAO<T>::calForcePwPart(const UnitCell& ucell,
     //--------------------------------------------------------
     // force due to core correlation.
     //--------------------------------------------------------
-    f_pw.cal_force_cc(fcc, rhopw, chr, nlpp.numeric, GlobalC::ucell);
+    f_pw.cal_force_cc(fcc, rhopw, chr, nlpp.numeric, ucell);
     //--------------------------------------------------------
     // force due to self-consistent charge.
     //--------------------------------------------------------

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
@@ -29,11 +29,11 @@ class Force_Stress_LCAO
     Force_Stress_LCAO(Record_adj& ra, const int nat_in);
     ~Force_Stress_LCAO();
 
-    void getForceStress(const bool isforce,
+    void getForceStress(UnitCell& ucell,
+                        const bool isforce,
                         const bool isstress,
                         const bool istestf,
                         const bool istests,
-                        const UnitCell& ucell,
                         const Grid_Driver& gd,
                         Parallel_Orbitals& pv,
                         const elecstate::ElecState* pelec,
@@ -66,7 +66,7 @@ class Force_Stress_LCAO
                        ModuleBase::matrix& fcs, 
                        ModuleSymmetry::Symmetry* symm);
 
-    void calForcePwPart(const UnitCell& ucell,
+    void calForcePwPart(UnitCell& ucell,
                         ModuleBase::matrix& fvl_dvl,
                         ModuleBase::matrix& fewalds,
                         ModuleBase::matrix& fcc,

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
@@ -105,7 +105,7 @@ class Force_Stress_LCAO
                        const Parallel_Orbitals& pv,
                        const K_Vectors& kv);
 
-    void calStressPwPart(const UnitCell& ucell,
+    void calStressPwPart(UnitCell& ucell,
                          ModuleBase::matrix& sigmadvl,
                          ModuleBase::matrix& sigmahar,
                          ModuleBase::matrix& sigmaewa,

--- a/source/module_hamilt_lcao/module_dftu/dftu.cpp
+++ b/source/module_hamilt_lcao/module_dftu/dftu.cpp
@@ -59,6 +59,7 @@ void DFTU::init(UnitCell& cell, // unitcell class
     {
         orb_cutoff_ = orb->cutoffs();
     }
+    ucell = &cell;
 #endif
 
     // needs reconstructions in future

--- a/source/module_hamilt_lcao/module_dftu/dftu.h
+++ b/source/module_hamilt_lcao/module_dftu/dftu.h
@@ -300,6 +300,7 @@ private:
     void set_dmr(const elecstate::DensityMatrix<std::complex<double>, double>* dm_in_dftu_cd);
   
   private:
+    const UnitCell* ucell = nullptr;
     const elecstate::DensityMatrix<double, double>* dm_in_dftu_d = nullptr;
     const elecstate::DensityMatrix<std::complex<double>, double>* dm_in_dftu_cd = nullptr;
 #endif

--- a/source/module_hamilt_lcao/module_dftu/dftu_tools.cpp
+++ b/source/module_hamilt_lcao/module_dftu/dftu_tools.cpp
@@ -12,34 +12,38 @@ void DFTU::cal_VU_pot_mat_complex(const int spin, const bool newlocale, std::com
     ModuleBase::TITLE("DFTU", "cal_VU_pot_mat_complex");
     ModuleBase::GlobalFunc::ZEROS(VU, this->paraV->nloc);
 
-    for (int it = 0; it < GlobalC::ucell.ntype; ++it)
+    for (int it = 0; it < this->ucell->ntype; ++it)
     {
-        if (PARAM.inp.orbital_corr[it] == -1) {
-            continue;
-}
-        for (int ia = 0; ia < GlobalC::ucell.atoms[it].na; ia++)
+        if (PARAM.inp.orbital_corr[it] == -1) 
         {
-            const int iat = GlobalC::ucell.itia2iat(it, ia);
-            for (int L = 0; L <= GlobalC::ucell.atoms[it].nwl; L++)
+            continue;
+        }
+        for (int ia = 0; ia < this->ucell->atoms[it].na; ia++)
+        {
+            const int iat = this->ucell->itia2iat(it, ia);
+            for (int L = 0; L <= this->ucell->atoms[it].nwl; L++)
             {
-                if (L != PARAM.inp.orbital_corr[it]) {
-                    continue;
-}
-
-                for (int n = 0; n < GlobalC::ucell.atoms[it].l_nchi[L]; n++)
+                if (L != PARAM.inp.orbital_corr[it]) 
                 {
-                    if (n != 0) {
+                    continue;
+                }
+
+                for (int n = 0; n < this->ucell->atoms[it].l_nchi[L]; n++)
+                {
+                    if (n != 0) 
+                    {
                         continue;
-}
+                    }
 
                     for (int m1 = 0; m1 < 2 * L + 1; m1++)
                     {
                         for (int ipol1 = 0; ipol1 < PARAM.globalv.npol; ipol1++)
                         {
                             const int mu = this->paraV->global2local_row(this->iatlnmipol2iwt[iat][L][n][m1][ipol1]);
-                            if (mu < 0) {
+                            if (mu < 0) 
+                            {
                                 continue;
-}
+                            }
 
                             for (int m2 = 0; m2 < 2 * L + 1; m2++)
                             {
@@ -47,13 +51,12 @@ void DFTU::cal_VU_pot_mat_complex(const int spin, const bool newlocale, std::com
                                 {
                                     const int nu
                                         = this->paraV->global2local_col(this->iatlnmipol2iwt[iat][L][n][m2][ipol2]);
-                                    if (nu < 0) {
+                                    if (nu < 0) 
+                                    {
                                         continue;
-}
-
+                                    }
                                     int m1_all = m1 + (2 * L + 1) * ipol1;
                                     int m2_all = m2 + (2 * L + 1) * ipol2;
-
                                     double val = get_onebody_eff_pot(it, iat, L, n, spin, m1_all, m2_all, newlocale);
                                     VU[nu * this->paraV->nrow + mu] = std::complex<double>(val, 0.0);
                                 } // ipol2
@@ -73,43 +76,47 @@ void DFTU::cal_VU_pot_mat_real(const int spin, const bool newlocale, double* VU)
     ModuleBase::TITLE("DFTU", "cal_VU_pot_mat_real");
     ModuleBase::GlobalFunc::ZEROS(VU, this->paraV->nloc);
 
-    for (int it = 0; it < GlobalC::ucell.ntype; ++it)
+    for (int it = 0; it < this->ucell->ntype; ++it)
     {
-        if (PARAM.inp.orbital_corr[it] == -1) {
-            continue;
-}
-        for (int ia = 0; ia < GlobalC::ucell.atoms[it].na; ia++)
+        if (PARAM.inp.orbital_corr[it] == -1) 
         {
-            const int iat = GlobalC::ucell.itia2iat(it, ia);
-            for (int L = 0; L <= GlobalC::ucell.atoms[it].nwl; L++)
+            continue;
+        }
+        for (int ia = 0; ia < this->ucell->atoms[it].na; ia++)
+        {
+            const int iat = this->ucell->itia2iat(it, ia);
+            for (int L = 0; L <= this->ucell->atoms[it].nwl; L++)
             {
-                if (L != PARAM.inp.orbital_corr[it]) {
-                    continue;
-}
-
-                for (int n = 0; n < GlobalC::ucell.atoms[it].l_nchi[L]; n++)
+                if (L != PARAM.inp.orbital_corr[it]) 
                 {
-                    if (n != 0) {
-                        continue;
-}
+                    continue;
+                }
 
+                for (int n = 0; n < this->ucell->atoms[it].l_nchi[L]; n++)
+                {
+                    if (n != 0) 
+                    {
+                        continue;
+                    }
                     for (int m1 = 0; m1 < 2 * L + 1; m1++)
                     {
                         for (int ipol1 = 0; ipol1 < PARAM.globalv.npol; ipol1++)
                         {
                             const int mu = this->paraV->global2local_row(this->iatlnmipol2iwt[iat][L][n][m1][ipol1]);
-                            if (mu < 0) {
+                            if (mu < 0) 
+                            {
                                 continue;
-}
+                            }
                             for (int m2 = 0; m2 < 2 * L + 1; m2++)
                             {
                                 for (int ipol2 = 0; ipol2 < PARAM.globalv.npol; ipol2++)
                                 {
                                     const int nu
                                         = this->paraV->global2local_col(this->iatlnmipol2iwt[iat][L][n][m2][ipol2]);
-                                    if (nu < 0) {
+                                    if (nu < 0) 
+                                    {
                                         continue;
-}
+                                    }
 
                                     int m1_all = m1 + (2 * L + 1) * ipol1;
                                     int m2_all = m2 + (2 * L + 1) * ipol2;
@@ -157,12 +164,13 @@ double DFTU::get_onebody_eff_pot(const int T,
         {
             if (Yukawa)
             {
-                if (m0 == m1) {
+                if (m0 == m1) 
+                {
                     VU = (this->U_Yukawa[T][L][N] - this->J_Yukawa[T][L][N])
                          * (0.5 - this->locale[iat][L][N][spin](m0, m1));
                 } else {
                     VU = -(this->U_Yukawa[T][L][N] - this->J_Yukawa[T][L][N]) * this->locale[iat][L][N][spin](m0, m1);
-}
+                }
             }
             else
             {
@@ -170,7 +178,7 @@ double DFTU::get_onebody_eff_pot(const int T,
                     VU = (this->U[T]) * (0.5 - this->locale[iat][L][N][spin](m0, m1));
                 } else {
                     VU = -(this->U[T]) * this->locale[iat][L][N][spin](m0, m1);
-}
+                }
             }
         }
         else
@@ -183,7 +191,7 @@ double DFTU::get_onebody_eff_pot(const int T,
                 } else {
                     VU = -(this->U_Yukawa[T][L][N] - this->J_Yukawa[T][L][N])
                          * this->locale_save[iat][L][N][spin](m0, m1);
-}
+                }
             }
             else
             {
@@ -191,7 +199,7 @@ double DFTU::get_onebody_eff_pot(const int T,
                     VU = (this->U[T]) * (0.5 - this->locale_save[iat][L][N][spin](m0, m1));
                 } else {
                     VU = -(this->U[T]) * this->locale_save[iat][L][N][spin](m0, m1);
-}
+                }
             }
         }
 

--- a/source/module_hamilt_pw/hamilt_ofdft/of_stress_pw.cpp
+++ b/source/module_hamilt_pw/hamilt_ofdft/of_stress_pw.cpp
@@ -79,7 +79,7 @@ void OF_Stress_PW::cal_stress(ModuleBase::matrix& sigmatot,
     stress_loc(ucell,sigmaloc, this->rhopw, locpp.vloc, p_sf, true, pelec->charge);
 
     // nlcc
-    stress_cc(sigmaxcc, this->rhopw, p_sf, true, locpp.numeric, pelec->charge);
+    stress_cc(sigmaxcc, this->rhopw, ucell, p_sf, true, locpp.numeric, pelec->charge);
 
     // vdw term
     stress_vdw(sigmavdw, ucell);

--- a/source/module_hamilt_pw/hamilt_pwdft/forces.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/forces.cpp
@@ -24,7 +24,7 @@
 #endif
 
 template <typename FPTYPE, typename Device>
-void Forces<FPTYPE, Device>::cal_force(const UnitCell& ucell,
+void Forces<FPTYPE, Device>::cal_force(UnitCell& ucell,
                                        ModuleBase::matrix& force,
                                        const elecstate::ElecState& elec,
                                        ModulePW::PW_Basis* rho_basis,
@@ -161,7 +161,7 @@ void Forces<FPTYPE, Device>::cal_force(const UnitCell& ucell,
         // DFT+U and DeltaSpin
         if(PARAM.inp.dft_plus_u || PARAM.inp.sc_mag_switch)
         {
-            this->cal_force_onsite(forceonsite, wg, wfc_basis, GlobalC::ucell, psi_in);
+            this->cal_force_onsite(forceonsite, wg, wfc_basis, ucell, psi_in);
         }
     }
 
@@ -169,7 +169,7 @@ void Forces<FPTYPE, Device>::cal_force(const UnitCell& ucell,
     // not relevant for PAW
     if (!PARAM.inp.use_paw)
     {
-        Forces::cal_force_cc(forcecc, rho_basis, chr, locpp->numeric, GlobalC::ucell);
+        Forces::cal_force_cc(forcecc, rho_basis, chr, locpp->numeric, ucell);
     }
     else
     {

--- a/source/module_hamilt_pw/hamilt_pwdft/forces.h
+++ b/source/module_hamilt_pw/hamilt_pwdft/forces.h
@@ -33,7 +33,7 @@ class Forces
     Forces(const int nat_in) : nat(nat_in){};
     ~Forces(){};
 
-    void cal_force(const UnitCell& ucell,
+    void cal_force(UnitCell& ucell,
                    ModuleBase::matrix& force,
                    const elecstate::ElecState& elec,
                    ModulePW::PW_Basis* rho_basis,

--- a/source/module_hamilt_pw/hamilt_pwdft/global.h
+++ b/source/module_hamilt_pw/hamilt_pwdft/global.h
@@ -265,7 +265,6 @@ namespace GlobalC
 #include "module_hamilt_pw/hamilt_pwdft/parallel_grid.h"
 namespace GlobalC
 {
-extern UnitCell ucell;
 extern Parallel_Grid Pgrid;
 extern Parallel_Kpoints Pkpoints;
 extern Restart restart; // Peize Lin add 2020.04.04

--- a/source/module_hamilt_pw/hamilt_pwdft/hamilt_pw.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/hamilt_pw.cpp
@@ -118,7 +118,7 @@ HamiltPW<T, Device>::HamiltPW(elecstate::Potential* pot_in,
     if(PARAM.inp.sc_mag_switch || PARAM.inp.dft_plus_u)
     {
         Operator<T, Device>* onsite_proj
-            = new OnsiteProj<OperatorPW<T, Device>>(isk, &GlobalC::ucell, PARAM.inp.sc_mag_switch, (PARAM.inp.dft_plus_u>0));
+            = new OnsiteProj<OperatorPW<T, Device>>(isk, ucell, PARAM.inp.sc_mag_switch, (PARAM.inp.dft_plus_u>0));
         this->ops->add(onsite_proj);
     }
     return;

--- a/source/module_hamilt_pw/hamilt_pwdft/stress_func.h
+++ b/source/module_hamilt_pw/hamilt_pwdft/stress_func.h
@@ -114,12 +114,15 @@ class Stress_Func
     // 5) the stress from the non-linear core correction (if any)
     void stress_cc(ModuleBase::matrix& sigma,
                    ModulePW::PW_Basis* rho_basis,
+                   UnitCell& ucell,
                    const Structure_Factor* p_sf,
                    const bool is_pw,
                    const bool *numeric,
                    const Charge* const chr); // nonlinear core correction stress in PW or LCAO basis
 
     void deriv_drhoc(const bool& numeric,
+                     const double& omega,
+                     const double& tpiba2,
                      const int mesh,
                      const FPTYPE* r,
                      const FPTYPE* rab,

--- a/source/module_hamilt_pw/hamilt_pwdft/stress_pw.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/stress_pw.cpp
@@ -97,7 +97,7 @@ void Stress_PW<FPTYPE, Device>::cal_stress(ModuleBase::matrix& sigmatot,
     this->stress_loc(ucell,sigmaloc, rho_basis, nlpp.vloc, p_sf, 1, pelec->charge);
 
     // nlcc
-    this->stress_cc(sigmaxcc, rho_basis, p_sf, 1, nlpp.numeric, pelec->charge);
+    this->stress_cc(sigmaxcc, rho_basis, ucell, p_sf, 1, nlpp.numeric, pelec->charge);
 
     // nonlocal
     this->stress_nl(sigmanl, this->pelec->wg, this->pelec->ekb, p_sf, p_kv, p_symm, wfc_basis, d_psi_in, nlpp, ucell);

--- a/source/module_hamilt_pw/hamilt_stodft/sto_stress_pw.cpp
+++ b/source/module_hamilt_pw/hamilt_stodft/sto_stress_pw.cpp
@@ -20,7 +20,7 @@ void Sto_Stress_PW<FPTYPE, Device>::cal_stress(ModuleBase::matrix& sigmatot,
                                                const Stochastic_WF<std::complex<FPTYPE>, Device>& stowf,
                                                const Charge* const chr,
                                                pseudopot_cell_vnl* nlpp,
-                                               const UnitCell& ucell_in)
+                                               UnitCell& ucell_in)
 {
     ModuleBase::TITLE("Sto_Stress_PW", "cal_stress");
     ModuleBase::timer::tick("Sto_Stress_PW", "cal_stress");
@@ -55,7 +55,7 @@ void Sto_Stress_PW<FPTYPE, Device>::cal_stress(ModuleBase::matrix& sigmatot,
     this->stress_loc(ucell_in,sigmaloc, rho_basis, nlpp->vloc, p_sf, true, chr);
 
     // nlcc
-    this->stress_cc(sigmaxcc, rho_basis, p_sf, true, nlpp->numeric, chr);
+    this->stress_cc(sigmaxcc, rho_basis, ucell_in, p_sf, true, nlpp->numeric, chr);
 
     // nonlocal
     this->sto_stress_nl(sigmanl, wg, p_sf, p_symm, p_kv, wfc_basis, *nlpp, ucell_in, psi_in, stowf);

--- a/source/module_hamilt_pw/hamilt_stodft/sto_stress_pw.h
+++ b/source/module_hamilt_pw/hamilt_stodft/sto_stress_pw.h
@@ -26,7 +26,7 @@ class Sto_Stress_PW : public Stress_Func<FPTYPE, Device>
                     const Stochastic_WF<std::complex<FPTYPE>, Device>& stowf,
                     const Charge* const chr,
                     pseudopot_cell_vnl* nlpp_in,
-                    const UnitCell& ucell_in);
+                    UnitCell& ucell_in);
 
   private:
     void sto_stress_kin(ModuleBase::matrix& sigma,

--- a/source/module_io/input_conv.cpp
+++ b/source/module_io/input_conv.cpp
@@ -170,11 +170,6 @@ void Input_Conv::Convert()
     ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "pseudo_dir", PARAM.inp.pseudo_dir);
     ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "orbital_dir", PARAM.inp.orbital_dir);
     // GlobalV::global_pseudo_type = PARAM.inp.pseudo_type;
-    GlobalC::ucell.setup(PARAM.inp.latname,
-                         PARAM.inp.ntype,
-                         PARAM.inp.lmaxmax,
-                         PARAM.inp.init_vel,
-                         PARAM.inp.fixed_axes);
 
     if (PARAM.inp.calculation == "relax" || PARAM.inp.calculation == "cell-relax")
     {

--- a/source/module_rdmft/rdmft.h
+++ b/source/module_rdmft/rdmft.h
@@ -99,7 +99,7 @@ class RDMFT
 
     //! update in elec-step
     // Or we can use rdmft_solver.wfc/occ_number directly when optimizing, so that the update_elec() function does not require parameters.
-    void update_elec(const UnitCell& ucell, const ModuleBase::matrix& occ_number_in, const psi::Psi<TK>& wfc_in, const Charge* charge_in = nullptr);
+    void update_elec(UnitCell& ucell, const ModuleBase::matrix& occ_number_in, const psi::Psi<TK>& wfc_in, const Charge* charge_in = nullptr);
 
     //! obtain the gradient of total energy with respect to occupation number and wfc
     double cal_E_grad_wfc_occ_num();
@@ -131,7 +131,7 @@ class RDMFT
     //! get the total Hamilton in k-space
     void cal_Hk_Hpsi();
     
-    void update_charge();
+    void update_charge(UnitCell& ucell);
 
   private:
 

--- a/source/module_rdmft/rdmft_pot.cpp
+++ b/source/module_rdmft/rdmft_pot.cpp
@@ -54,7 +54,7 @@ void RDMFT<TK, TR>::cal_V_TV()
     V_ekinetic_potential = new hamilt::EkineticNew<hamilt::OperatorLCAO<TK, TR>>(hsk_TV,
                                                                                  kv->kvec_d,
                                                                                  HR_TV,
-                                                                                 &GlobalC::ucell,
+                                                                                 this->ucell,
                                                                                  orb->cutoffs(),
                                                                                  this->gd,
                                                                                  two_center_bundle->kinetic_orb.get());
@@ -62,7 +62,7 @@ void RDMFT<TK, TR>::cal_V_TV()
     V_nonlocal = new hamilt::NonlocalNew<hamilt::OperatorLCAO<TK, TR>>(hsk_TV,
                                                                        kv->kvec_d,
                                                                        HR_TV,
-                                                                       &GlobalC::ucell,
+                                                                       this->ucell,
                                                                        orb->cutoffs(),
                                                                        this->gd,
                                                                        two_center_bundle->overlap_orb_beta.get());
@@ -74,7 +74,7 @@ void RDMFT<TK, TR>::cal_V_TV()
                                                 kv->kvec_d,
                                                 this->pelec->pot,
                                                 HR_TV,
-                                                &GlobalC::ucell,
+                                                this->ucell,
                                                 orb->cutoffs(),
                                                 this->gd,
                                                 nspin,
@@ -91,7 +91,7 @@ void RDMFT<TK, TR>::cal_V_TV()
                                                 kv->kvec_d,
                                                 this->pelec->pot,
                                                 HR_TV,
-                                                &GlobalC::ucell,
+                                                this->ucell,
                                                 orb->cutoffs(),
                                                 this->gd,
                                                 nspin,
@@ -122,7 +122,7 @@ void RDMFT<TK, TR>::cal_V_hartree()
                                                   kv->kvec_d,
                                                   this->pelec->pot,
                                                   HR_hartree,
-                                                  &GlobalC::ucell,
+                                                  this->ucell,
                                                   orb->cutoffs(),
                                                   this->gd,
                                                   nspin,
@@ -140,7 +140,7 @@ void RDMFT<TK, TR>::cal_V_hartree()
                                                   kv->kvec_d,
                                                   this->pelec->pot,
                                                   HR_hartree,
-                                                  &GlobalC::ucell,
+                                                  this->ucell,
                                                   orb->cutoffs(),
                                                   this->gd,
                                                   nspin,
@@ -170,7 +170,7 @@ void RDMFT<TK, TR>::cal_V_XC(const UnitCell& ucell)
 
     // elecstate::DensityMatrix<TK, double> DM_test(ParaV, nspin, kv->kvec_d, nk_total);
     // elecstate::cal_dm_psi(ParaV, wg, wfc, DM_test);
-    // DM_test.init_DMR(this->gd, &GlobalC::ucell);
+    // DM_test.init_DMR(this->gd, this->ucell);
     // DM_test.cal_DMR();
 
     // // compare DM_XC and DM get in update_charge(or ABACUS)
@@ -202,7 +202,7 @@ void RDMFT<TK, TR>::cal_V_XC(const UnitCell& ucell)
                                                      kv->kvec_d,
                                                      this->pelec->pot,
                                                      HR_dft_XC,
-                                                     &GlobalC::ucell,
+                                                     this->ucell,
                                                      orb->cutoffs(),
                                                      this->gd,
                                                      nspin,
@@ -222,7 +222,7 @@ void RDMFT<TK, TR>::cal_V_XC(const UnitCell& ucell)
                                                      kv->kvec_d,
                                                      this->pelec->pot,
                                                      HR_dft_XC,
-                                                     &GlobalC::ucell,
+                                                     this->ucell,
                                                      orb->cutoffs(),
                                                      this->gd,
                                                      nspin,

--- a/source/module_rdmft/update_state_rdmft.cpp
+++ b/source/module_rdmft/update_state_rdmft.cpp
@@ -47,7 +47,7 @@ void RDMFT<TK, TR>::update_ion(UnitCell& ucell_in,
 
 
 template <typename TK, typename TR>
-void RDMFT<TK, TR>::update_elec(const UnitCell& ucell,
+void RDMFT<TK, TR>::update_elec(UnitCell& ucell,
                                 const ModuleBase::matrix& occ_number_in, 
                                 const psi::Psi<TK>& wfc_in, const Charge* charge_in)
 {
@@ -71,7 +71,7 @@ void RDMFT<TK, TR>::update_elec(const UnitCell& ucell,
 }
 
     // update charge
-    this->update_charge();
+    this->update_charge(ucell);
 
     // "default" = "pbe"
     // if(  !only_exx_type || this->cal_E_type != 1 )
@@ -91,14 +91,14 @@ void RDMFT<TK, TR>::update_elec(const UnitCell& ucell,
 
 // this code is copying from function ElecStateLCAO<TK>::psiToRho(), in elecstate_lcao.cpp
 template <typename TK, typename TR>
-void RDMFT<TK, TR>::update_charge()
+void RDMFT<TK, TR>::update_charge(UnitCell& ucell)
 {
     if( PARAM.inp.gamma_only )
     {
         // calculate DMK and DMR
         elecstate::DensityMatrix<TK, double> DM_gamma_only(ParaV, nspin);
         elecstate::cal_dm_psi(ParaV, wg, wfc, DM_gamma_only);
-        DM_gamma_only.init_DMR(this->gd, &GlobalC::ucell);
+        DM_gamma_only.init_DMR(this->gd, &ucell);
         DM_gamma_only.cal_DMR();
 
         for (int is = 0; is < nspin; is++)
@@ -128,7 +128,7 @@ void RDMFT<TK, TR>::update_charge()
         // calculate DMK and DMR
         elecstate::DensityMatrix<TK, double> DM(ParaV, nspin, kv->kvec_d, nk_total);
         elecstate::cal_dm_psi(ParaV, wg, wfc, DM);
-        DM.init_DMR(this->gd, &GlobalC::ucell);
+        DM.init_DMR(this->gd, &ucell);
         DM.cal_DMR();
 
         for (int is = 0; is < nspin; is++)
@@ -160,7 +160,7 @@ void RDMFT<TK, TR>::update_charge()
     Symmetry_rho srho;
     for (int is = 0; is < nspin; is++)
     {
-        srho.begin(is, *(this->charge), rho_basis, GlobalC::ucell.symm);
+        srho.begin(is, *(this->charge), rho_basis, ucell.symm);
     }
 
 }


### PR DESCRIPTION
### What's changed?
- Last PR of remove GlobalC::ucell.
- Remove all global classes GlobalC::ucell to increase program safety and address previously unresolved problemes.
- The Ucell had an uninitialized bug. Thanks to @Qianruipku for fixing the problem. Moving forward, I will set the UnitUcell in the atomic_world function, not in the drive_run function, to avoid initializing a risky ucell for the entire program.
