### PR TITLE
Fix: Segment Fault of PAW

### DIFF
--- a/source/module_cell/atom_spec.cpp
+++ b/source/module_cell/atom_spec.cpp
@@ -4,15 +4,6 @@
 
 Atom::Atom()
 {
-    na = 0;
-    label = "\0";
-    label_orb = "\0";
-    nw = 0;
-    nwl = 0;
-    Rcut = 0.0; // pengfei Li 16-2-29
-    type = 0;
-    stapos_wf = 0;
-    mass = 0.0;
 }
 
 Atom::~Atom()

--- a/source/module_cell/atom_spec.cpp
+++ b/source/module_cell/atom_spec.cpp
@@ -10,7 +10,7 @@ Atom::~Atom()
 {
 }
 
-void Atom::set_index(void)
+void Atom::set_index()
 {
     assert(nw != 0);
     this->iw2l.resize(nw, 0);
@@ -75,7 +75,7 @@ void Atom::print_Atom(std::ofstream& ofs)
 
 #include "module_base/parallel_common.h"
 #ifdef __MPI
-void Atom::bcast_atom(void)
+void Atom::bcast_atom()
 {
     Parallel_Common::bcast_int(type);
     Parallel_Common::bcast_int(na);

--- a/source/module_cell/atom_spec.h
+++ b/source/module_cell/atom_spec.h
@@ -1,63 +1,62 @@
 #ifndef ATOM_H
 #define ATOM_H
 
-#include "atom_pseudo.h"
 #include "../module_io/output.h"
+#include "atom_pseudo.h"
 class Atom
 {
-public:
-
+  public:
     // constructor and destructor
     Atom();
     ~Atom();
 
     Atom_pseudo ncpp;
-    double mass; // the mass of atom
+    double mass = 0.0;                         // the mass of atom
     std::vector<ModuleBase::Vector3<int>> mbl; // whether the atoms can move or not
-	bool flag_empty_element = false; // whether is the empty element for bsse.	Peize Lin add 2021.04.07
+    bool flag_empty_element = false;           // whether is the empty element for bsse.	Peize Lin add 2021.04.07
 
     std::vector<int> iw2m; // use iw to find m
     std::vector<int> iw2n; // use iw to find n
     std::vector<int> iw2l; // use iw to find L
-	std::vector<int> iw2_ylm;
-	std::vector<bool> iw2_new;
-    int nw; // number of local orbitals (l,n,m) of this type
+    std::vector<int> iw2_ylm;
+    std::vector<bool> iw2_new;
+    int nw = 0; // number of local orbitals (l,n,m) of this type
 
     void set_index(void);
 
-    int type; // Index of atom type
-    int na; // Number of atoms in this type.
+    int type = 0; // Index of atom type
+    int na = 0;   // Number of atoms in this type.
 
-    int nwl; // max L(Angular momentum) (for local basis)
-    double Rcut; //pengfei Li 16-2-29
+    int nwl = 0;             // max L(Angular momentum) (for local basis)
+    double Rcut = 0.0;       // pengfei Li 16-2-29
     std::vector<int> l_nchi; // number of chi for each L
-    int stapos_wf; // start position of wave functions
+    int stapos_wf = 0;       // start position of wave functions
 
-    std::string label; // atomic symbol
-    std::vector<ModuleBase::Vector3<double>> tau;// Cartesian coordinates of each atom in this type.
-    std::vector<ModuleBase::Vector3<double>> dis;// direct displacements of each atom in this type in current step  liuyu modift 2023-03-22
-	std::vector<ModuleBase::Vector3<double>> taud;// Direct coordinates of each atom in this type.
-    std::vector<ModuleBase::Vector3<double>> vel;// velocities of each atom in this type.
+    std::string label = "\0";                     // atomic symbol
+    std::vector<ModuleBase::Vector3<double>> tau; // Cartesian coordinates of each atom in this type.
+    std::vector<ModuleBase::Vector3<double>>
+        dis; // direct displacements of each atom in this type in current step  liuyu modift 2023-03-22
+    std::vector<ModuleBase::Vector3<double>> taud;  // Direct coordinates of each atom in this type.
+    std::vector<ModuleBase::Vector3<double>> vel;   // velocities of each atom in this type.
     std::vector<ModuleBase::Vector3<double>> force; // force acting on each atom in this type.
-    std::vector<ModuleBase::Vector3<double>> lambda; // Lagrange multiplier for each atom in this type. used in deltaspin
+    std::vector<ModuleBase::Vector3<double>>
+        lambda; // Lagrange multiplier for each atom in this type. used in deltaspin
     std::vector<ModuleBase::Vector3<int>> constrain; // constrain for each atom in this type. used in deltaspin
-    std::string label_orb; // atomic Element symbol in the orbital file of lcao
+    std::string label_orb = "\0";                    // atomic Element symbol in the orbital file of lcao
 
-	std::vector<double> mag;
-	std::vector<double> angle1;//spin angle, added by zhengdy-soc
-	std::vector<double> angle2;
+    std::vector<double> mag;
+    std::vector<double> angle1; // spin angle, added by zhengdy-soc
+    std::vector<double> angle2;
     std::vector<ModuleBase::Vector3<double>> m_loc_;
     // Coulomb potential v(r) = z/r
     // It is a local potentail, and has no non-local potential parts.
     bool coulomb_potential = false;
-    void print_Atom(std::ofstream &ofs);
-    void update_force(ModuleBase::matrix &fcs);
+    void print_Atom(std::ofstream& ofs);
+    void update_force(ModuleBase::matrix& fcs);
 #ifdef __MPI
     void bcast_atom(void);
     void bcast_atom2(void);
 #endif
-
 };
 
-#endif //Atomspec
-
+#endif // Atomspec

--- a/source/module_cell/test/support/mock_unitcell.cpp
+++ b/source/module_cell/test/support/mock_unitcell.cpp
@@ -10,42 +10,7 @@
 */
 void UnitCell::set_iat2iwt(const int& npol_in) {}
 UnitCell::UnitCell() {
-    Coordinate = "Direct";
-    latName = "none";
-    lat0 = 0.0;
-    lat0_angstrom = 0.0;
-
-    ntype = 0;
-    nat = 0;
-    namax = 0;
-    nwmax = 0;
-
-    iat2it = nullptr;
-    iat2ia = nullptr;
-    iwt2iat = nullptr;
-    iwt2iw = nullptr;
-
     itia2iat.create(1, 1);
-    lc = new int[3];
-
-    latvec = ModuleBase::Matrix3();
-    latvec_supercell = ModuleBase::Matrix3();
-    G = ModuleBase::Matrix3();
-    GT = ModuleBase::Matrix3();
-    GGT = ModuleBase::Matrix3();
-    invGGT = ModuleBase::Matrix3();
-
-    tpiba = 0.0;
-    tpiba2 = 0.0;
-    omega = 0.0;
-
-    atom_label = new std::string[1];
-    atom_mass = nullptr;
-    pseudo_fn = new std::string[1];
-    pseudo_type = new std::string[1];
-    orbital_fn = new std::string[1];
-
-    set_atom_flag = false;
 }
 UnitCell::~UnitCell() {
     delete[] atom_label;
@@ -53,11 +18,6 @@ UnitCell::~UnitCell() {
     delete[] pseudo_fn;
     delete[] pseudo_type;
     delete[] orbital_fn;
-    delete[] iat2it;
-    delete[] iat2ia;
-    delete[] iwt2iat;
-    delete[] iwt2iw;
-    delete[] lc;
     if (set_atom_flag) {
         delete[] atoms;
     }

--- a/source/module_cell/unitcell.cpp
+++ b/source/module_cell/unitcell.cpp
@@ -31,41 +31,7 @@ UnitCell::UnitCell() {
     if (test_unitcell) {
         ModuleBase::TITLE("unitcell", "Constructor");
 }
-    Coordinate = "Direct";
-    latName = "none";
-    lat0 = 0.0;
-    lat0_angstrom = 0.0;
-
-    ntype = 0;
-    nat = 0;
-    namax = 0;
-    nwmax = 0;
-
-    iat2it = nullptr;
-    iat2ia = nullptr;
-    iwt2iat = nullptr;
-    iwt2iw = nullptr;
-
     itia2iat.create(1, 1);
-    lc = new int[3];
-
-    latvec = ModuleBase::Matrix3();
-    latvec_supercell = ModuleBase::Matrix3();
-    G = ModuleBase::Matrix3();
-    GT = ModuleBase::Matrix3();
-    GGT = ModuleBase::Matrix3();
-    invGGT = ModuleBase::Matrix3();
-
-    tpiba = 0.0;
-    tpiba2 = 0.0;
-    omega = 0.0;
-
-    atom_label = new std::string[1];
-    atom_mass = nullptr;
-    pseudo_fn = new std::string[1];
-    pseudo_type = new std::string[1];
-
-    set_atom_flag = false;
 }
 
 UnitCell::~UnitCell() {
@@ -74,11 +40,6 @@ UnitCell::~UnitCell() {
     delete[] pseudo_fn;
     delete[] pseudo_type;
     delete[] orbital_fn;
-    delete[] iat2it;
-    delete[] iat2ia;
-    delete[] iwt2iat;
-    delete[] iwt2iw;
-    delete[] lc;
     if (set_atom_flag) {
         delete[] atoms;
     }

--- a/source/module_cell/unitcell.h
+++ b/source/module_cell/unitcell.h
@@ -15,13 +15,14 @@
 // provide the basic information about unitcell.
 class UnitCell {
   public:
-    Atom* atoms;
+    Atom* atoms = nullptr;
 
-    bool set_atom_flag; // added on 2009-3-8 by mohan
-    Magnetism magnet;   // magnetism Yu Liu 2021-07-03
+    bool set_atom_flag = false;                     // added on 2009-3-8 by mohan
+    Magnetism magnet;                               // magnetism Yu Liu 2021-07-03
     std::vector<std::vector<double>> atom_mulliken; //[nat][nspin]
-    int n_mag_at;
+    int n_mag_at = 0;
 
+    Lattice lat;
     std::string& Coordinate = lat.Coordinate;
     std::string& latName = lat.latName;
     double& lat0 = lat.lat0;
@@ -31,7 +32,6 @@ class UnitCell {
     double& omega = lat.omega;
     int*& lc = lat.lc;
 
-    Lattice lat;
     ModuleBase::Matrix3& latvec = lat.latvec;
     ModuleBase::Vector3<double>&a1 = lat.a1, &a2 = lat.a2, &a3 = lat.a3;
     ModuleBase::Vector3<double>& latcenter = lat.latcenter;
@@ -181,15 +181,15 @@ class UnitCell {
     // nelec : total number of electrons
     // lmaxmax : revert from INPUT
     //============================================================
-    int meshx;
-    int natomwfc;
-    int lmax;
-    int nmax;
-    int nmax_total; // mohan add 2009-09-10
-    int lmax_ppwf;
-    int lmaxmax;   // liuyu 2021-07-04
-    bool init_vel; // liuyu 2021-07-15
-                   // double nelec;
+    int meshx = 0;
+    int natomwfc = 0;
+    int lmax = 0;
+    int nmax = 0;
+    int nmax_total = 0; // mohan add 2009-09-10
+    int lmax_ppwf = 0;
+    int lmaxmax = 0;   // liuyu 2021-07-04
+    bool init_vel = 0; // liuyu 2021-07-15
+                       // double nelec;
 
   private:
     ModuleBase::Matrix3 stress; // calculate stress on the cell
@@ -211,11 +211,11 @@ class UnitCell {
     void update_stress(ModuleBase::matrix& scs); // updates stress
     void update_force(ModuleBase::matrix& fcs);  // updates force in Atom
 
-    double* atom_mass;
-    std::string* atom_label;
-    std::string* pseudo_fn;
-    std::string* pseudo_type; // pseudopotential types for each elements,
-                              // sunliang added 2022-09-15.
+    double* atom_mass = nullptr;
+    std::string* atom_label = new std::string[1];
+    std::string* pseudo_fn = new std::string[1];
+    std::string* pseudo_type = new std::string[1]; // pseudopotential types for each elements,
+                                                   // sunliang added 2022-09-15.
     std::string* orbital_fn = nullptr;  // filenames of orbitals, liuyu add 2022-10-19
     std::string
         descriptor_file; // filenames of descriptor_file, liuyu add 2023-04-06

--- a/source/module_cell/unitcell.h
+++ b/source/module_cell/unitcell.h
@@ -188,7 +188,7 @@ class UnitCell {
     int nmax_total = 0; // mohan add 2009-09-10
     int lmax_ppwf = 0;
     int lmaxmax = 0;   // liuyu 2021-07-04
-    bool init_vel = 0; // liuyu 2021-07-15
+    bool init_vel = false; // liuyu 2021-07-15
                        // double nelec;
 
   private:

--- a/source/module_cell/unitcell_data.h
+++ b/source/module_cell/unitcell_data.h
@@ -1,25 +1,30 @@
-#include "module_base/matrix3.h"
 #include "module_base/intarray.h"
-/// @brief info of lattice 
+#include "module_base/matrix3.h"
+/// @brief info of lattice
 struct Lattice
 {
-    std::string Coordinate; // "Direct" or "Cartesian" or "Cartesian_angstrom"
-    std::string latName; // Lattice name
-    double lat0; // Lattice constant(bohr)(a.u.)
-    double lat0_angstrom;// Lattice constant(angstrom)
-    double tpiba;// 2*pi / lat0;
-    double tpiba2; // tpiba ^ 2
-    double omega;// the volume of the unit cell
-    int* lc;  // Change the lattice vectors or not
+    std::string Coordinate = "Direct"; // "Direct" or "Cartesian" or "Cartesian_angstrom"
+    std::string latName = "none";      // Lattice name
+    double lat0 = 0.0;                 // Lattice constant(bohr)(a.u.)
+    double lat0_angstrom = 0.0;        // Lattice constant(angstrom)
+    double tpiba = 0.0;                // 2*pi / lat0;
+    double tpiba2 = 0.0;               // tpiba ^ 2
+    double omega = 0.0;                // the volume of the unit cell
+    int* lc = new int[3];              // Change the lattice vectors or not
 
-    ModuleBase::Matrix3 latvec; // Unitcell lattice vectors
-    ModuleBase::Vector3<double> a1, a2, a3; // Same as latvec, just at another form.
-    ModuleBase::Vector3<double> latcenter; // (a1+a2+a3)/2 the center of vector
-    ModuleBase::Matrix3 latvec_supercell; // Supercell lattice vectors
-    ModuleBase::Matrix3 G; // reciprocal lattice vector (2pi*inv(R) )
-    ModuleBase::Matrix3 GT; // traspose of G
-    ModuleBase::Matrix3 GGT; // GGT = G*GT
-    ModuleBase::Matrix3 invGGT; // inverse G
+    ModuleBase::Matrix3 latvec = ModuleBase::Matrix3();           // Unitcell lattice vectors
+    ModuleBase::Vector3<double> a1, a2, a3;                       // Same as latvec, just at another form.
+    ModuleBase::Vector3<double> latcenter;                        // (a1+a2+a3)/2 the center of vector
+    ModuleBase::Matrix3 latvec_supercell = ModuleBase::Matrix3(); // Supercell lattice vectors
+    ModuleBase::Matrix3 G = ModuleBase::Matrix3();                // reciprocal lattice vector (2pi*inv(R) )
+    ModuleBase::Matrix3 GT = ModuleBase::Matrix3();               // traspose of G
+    ModuleBase::Matrix3 GGT = ModuleBase::Matrix3();              // GGT = G*GT
+    ModuleBase::Matrix3 invGGT = ModuleBase::Matrix3();           // inverse G
+
+    ~Lattice()
+    {
+        delete[] lc;
+    }
 };
 
 //========================================================
@@ -37,13 +42,21 @@ struct Lattice
 /// @brief usefull data and index maps
 struct Statistics
 {
-    int ntype;// number of atom species in UnitCell
-    int nat; // total number of atoms of all species in unitcell
-    int* iat2it; //iat==>it, distinguish a atom belong to which type
-    int* iat2ia; //iat==>ia
-    int* iwt2iat; // iwt ==> iat.
-    int* iwt2iw; // iwt ==> iw, Peize Lin add 2018-07-02
-    ModuleBase::IntArray itia2iat;//(it, ia)==>iat, the index in nat, add 2009-3-2 by mohan
-    int namax;// the max na among all atom species
-    int nwmax;// the max nw among all atom species
+    int ntype = 0;                 // number of atom species in UnitCell
+    int nat = 0;                   // total number of atoms of all species in unitcell
+    int* iat2it = nullptr;         // iat==>it, distinguish a atom belong to which type
+    int* iat2ia = nullptr;         // iat==>ia
+    int* iwt2iat = nullptr;        // iwt ==> iat.
+    int* iwt2iw = nullptr;         // iwt ==> iw, Peize Lin add 2018-07-02
+    ModuleBase::IntArray itia2iat; //(it, ia)==>iat, the index in nat, add 2009-3-2 by mohan
+    int namax = 0;                 // the max na among all atom species
+    int nwmax = 0;                 // the max nw among all atom species
+
+    ~Statistics()
+    {
+        delete[] iat2it;
+        delete[] iat2ia;
+        delete[] iwt2iat;
+        delete[] iwt2iw;
+    }
 };

--- a/source/module_elecstate/module_dm/test/test_cal_dm_R.cpp
+++ b/source/module_elecstate/module_dm/test/test_cal_dm_R.cpp
@@ -78,8 +78,6 @@ class DMTest : public testing::Test
     {
         delete paraV;
         delete[] ucell.atoms;
-        delete[] ucell.iat2it;
-        delete[] ucell.iat2ia;
     }
 
 #ifdef __MPI

--- a/source/module_elecstate/module_dm/test/test_cal_dmk_psi.cpp
+++ b/source/module_elecstate/module_dm/test/test_cal_dmk_psi.cpp
@@ -74,8 +74,6 @@ class DMTest : public testing::Test
         delete[] ucell.atoms[0].iw2m;
         delete[] ucell.atoms[0].iw2n;
         delete[] ucell.atoms;
-        delete[] ucell.iat2it;
-        delete[] ucell.iat2ia;
     }
 
 #ifdef __MPI

--- a/source/module_elecstate/module_dm/test/test_dm_R_init.cpp
+++ b/source/module_elecstate/module_dm/test/test_dm_R_init.cpp
@@ -78,8 +78,6 @@ class DMTest : public testing::Test
     {
         delete paraV;
         delete[] ucell.atoms;
-        delete[] ucell.iat2it;
-        delete[] ucell.iat2ia;
     }
 
 #ifdef __MPI

--- a/source/module_elecstate/module_dm/test/test_dm_constructor.cpp
+++ b/source/module_elecstate/module_dm/test/test_dm_constructor.cpp
@@ -75,8 +75,6 @@ class DMTest : public testing::Test
     {
         delete paraV;
         delete[] ucell.atoms;
-        delete[] ucell.iat2it;
-        delete[] ucell.iat2ia;
     }
 
 #ifdef __MPI

--- a/source/module_esolver/test/esolver_dp_test.cpp
+++ b/source/module_esolver/test/esolver_dp_test.cpp
@@ -65,8 +65,6 @@ class ESolverDPTest : public ::testing::Test
     {
         // Clean up after each test
         delete esolver;
-        delete[] ucell.iat2it;
-        delete[] ucell.iat2ia;
         delete[] ucell.atoms;
         delete[] ucell.atom_label;
     }

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_T_NL_cd.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_T_NL_cd.cpp
@@ -92,8 +92,6 @@ class TNLTest : public ::testing::Test
         delete HR;
         delete paraV;
         delete[] ucell.atoms;
-        delete[] ucell.iat2it;
-        delete[] ucell.iat2ia;
         delete[] ucell.infoNL.Beta;
     }
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_dftu.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_dftu.cpp
@@ -106,8 +106,6 @@ class DFTUTest : public ::testing::Test
         delete DMR;
         delete paraV;
         delete[] ucell.atoms;
-        delete[] ucell.iat2it;
-        delete[] ucell.iat2ia;
     }
 
 #ifdef __MPI

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_ekineticnew.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_ekineticnew.cpp
@@ -66,8 +66,6 @@ class EkineticNewTest : public ::testing::Test
         delete HR;
         delete paraV;
         delete[] ucell.atoms;
-        delete[] ucell.iat2it;
-        delete[] ucell.iat2ia;
     }
 
 #ifdef __MPI

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_nonlocalnew.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_nonlocalnew.cpp
@@ -90,8 +90,6 @@ class NonlocalNewTest : public ::testing::Test
         delete HR;
         delete paraV;
         delete[] ucell.atoms;
-        delete[] ucell.iat2it;
-        delete[] ucell.iat2ia;
         delete[] ucell.infoNL.Beta;
     }
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_overlapnew.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_overlapnew.cpp
@@ -66,8 +66,6 @@ class OverlapNewTest : public ::testing::Test
         delete SR;
         delete paraV;
         delete[] ucell.atoms;
-        delete[] ucell.iat2it;
-        delete[] ucell.iat2ia;
     }
 
 #ifdef __MPI

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_overlapnew_cd.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/test_overlapnew_cd.cpp
@@ -65,8 +65,6 @@ class OverlapNewTest : public ::testing::Test
         delete SR;
         delete paraV;
         delete[] ucell.atoms;
-        delete[] ucell.iat2it;
-        delete[] ucell.iat2ia;
     }
 
 #ifdef __MPI

--- a/source/module_hamilt_lcao/module_hcontainer/test/test_func_folding.cpp
+++ b/source/module_hamilt_lcao/module_hcontainer/test/test_func_folding.cpp
@@ -36,7 +36,6 @@ class FoldingTest : public ::testing::Test
     void TearDown() override
     {
         delete[] ucell.atoms;
-        delete[] ucell.iat2it;
     }
 
     UnitCell ucell;

--- a/source/module_hamilt_lcao/module_hcontainer/test/test_hcontainer.cpp
+++ b/source/module_hamilt_lcao/module_hcontainer/test/test_hcontainer.cpp
@@ -40,7 +40,6 @@ class HContainerTest : public ::testing::Test
     {
         delete HR;
         delete[] ucell.atoms;
-        delete[] ucell.iat2it;
     }
 
     UnitCell ucell;

--- a/source/module_hamilt_lcao/module_hcontainer/test/test_hcontainer_complex.cpp
+++ b/source/module_hamilt_lcao/module_hcontainer/test/test_hcontainer_complex.cpp
@@ -40,7 +40,6 @@ class HContainerTest : public ::testing::Test
     {
         delete HR;
         delete[] ucell.atoms;
-        delete[] ucell.iat2it;
     }
 
     UnitCell ucell;

--- a/source/module_hamilt_lcao/module_hcontainer/test/test_hcontainer_output.cpp
+++ b/source/module_hamilt_lcao/module_hcontainer/test/test_hcontainer_output.cpp
@@ -56,10 +56,6 @@ class OutputHContainerTest : public testing::Test
     void TearDown() override
     {
         delete[] ucell.atoms;
-        delete[] ucell.iat2it;
-        delete[] ucell.iat2ia;
-        delete[] ucell.iwt2iat;
-        delete[] ucell.iwt2iw;
     }
 };
 

--- a/source/module_hamilt_lcao/module_hcontainer/test/test_hcontainer_time.cpp
+++ b/source/module_hamilt_lcao/module_hcontainer/test/test_hcontainer_time.cpp
@@ -1,6 +1,6 @@
 #include "gtest/gtest.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
-#include "time.h"
+#include <ctime>
 
 // test_size is the number of atoms in the unitcell
 // modify test_size to test different size of unitcell
@@ -52,7 +52,7 @@ TEST(single_test_hcontainer, insert_pair)
     // print current used memory of system
     auto memory_start = ModuleBase::GlobalFunc::MemAvailable() / 1024.0;
     // get random number between (0, 100000000) by rand()
-    srand((unsigned)time(NULL));
+    srand((unsigned)time(nullptr));
     hamilt::HContainer<double> HR_test(test_size);
     clock_t start, end;
     start = clock();
@@ -85,7 +85,7 @@ TEST(single_test_hcontainer, insert_pair)
 TEST(single_test_IJR, insert_pair)
 {
     // get random number between (0, 100000000) by rand()
-    srand((unsigned)time(NULL));
+    srand((unsigned)time(nullptr));
     hamilt::HContainer<double> HR_test(test_size);
     clock_t start, end;
     start = clock();
@@ -121,7 +121,7 @@ TEST(single_test_IJR, insert_pair)
 TEST_F(HContainerTest, find_pair)
 {
     // find_pair 1000000 times with random iat1 and iat2
-    srand((unsigned)time(NULL));
+    srand((unsigned)time(nullptr));
     clock_t start, end;
     start = clock();
     for (int i = 0; i < test_size * 100; i++)

--- a/source/module_hamilt_lcao/module_hcontainer/test/test_hcontainer_time.cpp
+++ b/source/module_hamilt_lcao/module_hcontainer/test/test_hcontainer_time.cpp
@@ -39,7 +39,6 @@ class HContainerTest : public ::testing::Test
     {
         delete HR;
         delete[] ucell.atoms;
-        delete[] ucell.iat2it;
     }
 
     UnitCell ucell;

--- a/source/module_hamilt_lcao/module_hcontainer/test/test_transfer.cpp
+++ b/source/module_hamilt_lcao/module_hcontainer/test/test_transfer.cpp
@@ -49,8 +49,6 @@ class TransferTest : public ::testing::Test
         delete HR_para;
         delete paraV;
         delete[] ucell.atoms;
-        delete[] ucell.iat2it;
-        delete[] ucell.iat2ia;
     }
 
 #ifdef __MPI

--- a/source/module_hamilt_pw/hamilt_pwdft/VNL_in_pw.h
+++ b/source/module_hamilt_pw/hamilt_pwdft/VNL_in_pw.h
@@ -29,23 +29,18 @@ class pseudopot_cell_vnl : public pseudopot_cell_vl
               const ModulePW::PW_Basis_K* wfc_basis = nullptr,
               const bool allocate_vkb = true);
 
-    double cell_factor; // LiuXh add 20180619
+    double cell_factor = 0.0; // LiuXh add 20180619
 
-    int nkb; // total number of beta functions considering all atoms
+    int nkb = 0; // total number of beta functions considering all atoms
 
-    int lmaxkb; // max angular momentum for non-local projectors
+    int lmaxkb = 0; // max angular momentum for non-local projectors
 
     void init_vnl(UnitCell& cell, const ModulePW::PW_Basis* rho_basis);
 
     template <typename FPTYPE, typename Device>
-    void getvnl(Device* ctx, 
-                const UnitCell& ucell,
-                const int& ik, 
-                std::complex<FPTYPE>* vkb_in) const;
+    void getvnl(Device* ctx, const UnitCell& ucell, const int& ik, std::complex<FPTYPE>* vkb_in) const;
 
-    void getvnl(const int& ik, 
-                const UnitCell& ucell,
-                ModuleBase::ComplexMatrix& vkb_in) const;
+    void getvnl(const int& ik, const UnitCell& ucell, ModuleBase::ComplexMatrix& vkb_in) const;
 
     // void getvnl_alpha(const int &ik);
 
@@ -53,8 +48,7 @@ class pseudopot_cell_vnl : public pseudopot_cell_vl
 
     void initgradq_vnl(const UnitCell& cell);
 
-    void getgradq_vnl(const UnitCell& ucell,
-                      const int ik);
+    void getgradq_vnl(const UnitCell& ucell, const int ik);
 
     //===============================================================
     // MEMBER VARIABLES :
@@ -66,10 +60,10 @@ class pseudopot_cell_vnl : public pseudopot_cell_vl
     //===============================================================
     // private:
 
-    int nhm;
-    int nbetam; // max number of beta functions
+    int nhm = 0;
+    int nbetam = 0; // max number of beta functions
 
-    int lmaxq;
+    int lmaxq = 0;
 
     ModuleBase::matrix indv;   // indes linking  atomic beta's to beta's in the solid
     ModuleBase::matrix nhtol;  // correspondence n <-> angular momentum l

--- a/source/module_io/test/for_testing_input_conv.h
+++ b/source/module_io/test/for_testing_input_conv.h
@@ -180,44 +180,7 @@ wavefunc::~wavefunc()
 }
 UnitCell::UnitCell()
 {
-    Coordinate = "Direct";
-    latName = "none";
-    lat0 = 0.0;
-    lat0_angstrom = 0.0;
-
-    bool init_vel;
-
-    ntype = 0;
-    nat = 0;
-    namax = 0;
-    nwmax = 0;
-
-    iat2it = nullptr;
-    iat2ia = nullptr;
-    iwt2iat = nullptr;
-    iwt2iw = nullptr;
-
     itia2iat.create(1, 1);
-    lc = new int[3];
-
-    latvec = ModuleBase::Matrix3();
-    latvec_supercell = ModuleBase::Matrix3();
-    G = ModuleBase::Matrix3();
-    GT = ModuleBase::Matrix3();
-    GGT = ModuleBase::Matrix3();
-    invGGT = ModuleBase::Matrix3();
-
-    tpiba = 0.0;
-    tpiba2 = 0.0;
-    omega = 0.0;
-
-    atom_label = new std::string[1];
-    atom_mass = nullptr;
-    pseudo_fn = new std::string[1];
-    pseudo_type = new std::string[1];
-    orbital_fn = new std::string[1];
-
-    set_atom_flag = false;
 }
 UnitCell::~UnitCell() {}
 #ifdef __LCAO

--- a/source/module_lr/ri_benchmark/test/ri_benchmark_test.cpp
+++ b/source/module_lr/ri_benchmark/test/ri_benchmark_test.cpp
@@ -24,8 +24,9 @@ TEST(RI_Benchmark, SlicePsi)
 {
     const int nk = 1, nbands = 2, nbasis = 3;
     psi::Psi<double> psi(nk, nbands, nbasis);
-    for (int i = 0; i < nk * nbands * nbasis; i++)
+    for (int i = 0; i < nk * nbands * nbasis; i++) {
         psi.get_pointer()[i] = i;
+}
     std::vector<double> psi_slice = RI_Benchmark::slice_psi(psi, 1, 1, 1, 2);
     EXPECT_DOUBLE_EQ(psi_slice[0], 4);
     EXPECT_DOUBLE_EQ(psi_slice[1], 5);
@@ -61,7 +62,7 @@ TEST(RI_Benchmark, CalCsMO)
 
 int main(int argc, char** argv)
 {
-    srand(time(NULL));  // for random number generator
+    srand(time(nullptr));  // for random number generator
     MPI_Init(&argc, &argv);
     testing::InitGoogleTest(&argc, argv);
     int result = RUN_ALL_TESTS();

--- a/source/module_lr/ri_benchmark/test/ri_benchmark_test.cpp
+++ b/source/module_lr/ri_benchmark/test/ri_benchmark_test.cpp
@@ -17,7 +17,6 @@ UnitCell::UnitCell() {
 }
 UnitCell::~UnitCell() {
     delete[] atoms;
-    delete[] iat2it;
 }
 // inline const int* UnitCell::get_iat2iwt(int iat) { return iat2iwt; }
 

--- a/source/version.h
+++ b/source/version.h
@@ -1,3 +1,3 @@
 #ifndef VERSION
-#define VERSION "v3.8.4"
+#define VERSION "v3.8.5"
 #endif


### PR DESCRIPTION
Some variables in ucell and VNL_in_pw are not initialized, which makes paw tests fail.