### PR TITLE
Refactor: Remove some redundant variables and global dependence in DeePKS.

### DIFF
--- a/source/Makefile.Objects
+++ b/source/Makefile.Objects
@@ -200,7 +200,7 @@ OBJS_DEEPKS=LCAO_deepks.o\
         LCAO_deepks_vdelta.o\
         deepks_hmat.o\
         LCAO_deepks_interface.o\
-        orbital_precalc.o\
+        deepks_orbpre.o\
         cal_gdmx.o\
         cal_gedm.o\
         cal_gvx.o\

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
@@ -7,12 +7,12 @@
 // new
 #include "module_base/timer.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
+#include "module_elecstate/elecstate_lcao.h"
 #include "module_elecstate/potentials/efield.h"           // liuyu add 2022-05-18
 #include "module_elecstate/potentials/gatefield.h"        // liuyu add 2022-09-13
 #include "module_hamilt_general/module_surchem/surchem.h" //sunml add 2022-08-10
 #include "module_hamilt_general/module_vdw/vdw.h"
 #include "module_parameter/parameter.h"
-#include "module_elecstate/elecstate_lcao.h"
 #ifdef __DEEPKS
 #include "module_hamilt_lcao/module_deepks/LCAO_deepks.h"    //caoyu add for deepks 2021-06-03
 #include "module_hamilt_lcao/module_deepks/LCAO_deepks_io.h" // mohan add 2024-07-22

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
@@ -540,7 +540,9 @@ void Force_Stress_LCAO<T>::getForceStress(UnitCell& ucell,
                     {
                         GlobalC::ld.check_gdmx(ucell.nat);
                     }
-                    GlobalC::ld.cal_gvx(ucell.nat);
+                    std::vector<torch::Tensor> gevdm;
+                    GlobalC::ld.cal_gevdm(ucell.nat, gevdm);
+                    GlobalC::ld.cal_gvx(ucell.nat, gevdm);
 
                     if (PARAM.inp.deepks_out_unittest)
                     {
@@ -758,7 +760,9 @@ void Force_Stress_LCAO<T>::getForceStress(UnitCell& ucell,
 
                 if (!PARAM.inp.deepks_equiv) // training with stress label not supported by equivariant version now
                 {
-                    GlobalC::ld.cal_gvepsl(ucell.nat);
+                    std::vector<torch::Tensor> gevdm;
+                    GlobalC::ld.cal_gevdm(ucell.nat, gevdm);
+                    GlobalC::ld.cal_gvepsl(ucell.nat, gevdm);
 
                     LCAO_deepks_io::save_npy_gvepsl(ucell.nat,
                                                     GlobalC::ld.des_per_atom,

--- a/source/module_hamilt_lcao/module_deepks/CMakeLists.txt
+++ b/source/module_hamilt_lcao/module_deepks/CMakeLists.txt
@@ -11,7 +11,7 @@ if(ENABLE_DEEPKS)
       LCAO_deepks_vdelta.cpp
       deepks_hmat.cpp
       LCAO_deepks_interface.cpp
-      orbital_precalc.cpp
+      deepks_orbpre.cpp
       cal_gdmx.cpp
       cal_gedm.cpp
       cal_gvx.cpp      

--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks_interface.cpp
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks_interface.cpp
@@ -113,14 +113,18 @@ void LCAO_Deepks_Interface<TK, TR>::out_deepks_labels(const double& etot,
 
                 std::vector<double> o_delta(nks, 0.0);
 
-                ld->cal_orbital_precalc<TK, TH>(dm_bandgap, ld->lmaxd, ld->inlmax, nat, nks, ld->inl_l, kvec_d, ld->phialpha, ld->inl_index, ucell, orb, *ParaV, GridD);
+                // calculate and save orbital_precalc: [nks,NAt,NDscrpt]
+                torch::Tensor orbital_precalc;
+                std::vector<torch::Tensor> gevdm;
+                ld->cal_gevdm(nat, gevdm);
+                DeePKS_domain::cal_orbital_precalc<TK, TH>(dm_bandgap, ld->lmaxd, ld->inlmax, nat, nks, ld->inl_l, kvec_d, ld->phialpha, gevdm, ld->inl_index, ucell, orb, *ParaV, GridD, orbital_precalc);
                 DeePKS_domain::cal_o_delta<TK, TH>(dm_bandgap, *h_delta, o_delta, *ParaV, nks);
 
                 // save obase and orbital_precalc
                 LCAO_deepks_io::save_npy_orbital_precalc(nat,
                                                          nks,
                                                          ld->des_per_atom,
-                                                         ld->orbital_precalc_tensor,
+                                                         orbital_precalc,
                                                          PARAM.globalv.global_out_dir,
                                                          my_rank);
                 const std::string file_obase = PARAM.globalv.global_out_dir + "deepks_obase.npy";

--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks_interface.cpp
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks_interface.cpp
@@ -117,7 +117,21 @@ void LCAO_Deepks_Interface<TK, TR>::out_deepks_labels(const double& etot,
                 torch::Tensor orbital_precalc;
                 std::vector<torch::Tensor> gevdm;
                 ld->cal_gevdm(nat, gevdm);
-                DeePKS_domain::cal_orbital_precalc<TK, TH>(dm_bandgap, ld->lmaxd, ld->inlmax, nat, nks, ld->inl_l, kvec_d, ld->phialpha, gevdm, ld->inl_index, ucell, orb, *ParaV, GridD, orbital_precalc);
+                DeePKS_domain::cal_orbital_precalc<TK, TH>(dm_bandgap,
+                                                           ld->lmaxd,
+                                                           ld->inlmax,
+                                                           nat,
+                                                           nks,
+                                                           ld->inl_l,
+                                                           kvec_d,
+                                                           ld->phialpha,
+                                                           gevdm,
+                                                           ld->inl_index,
+                                                           ucell,
+                                                           orb,
+                                                           *ParaV,
+                                                           GridD,
+                                                           orbital_precalc);
                 DeePKS_domain::cal_o_delta<TK, TH>(dm_bandgap, *h_delta, o_delta, *ParaV, nks);
 
                 // save obase and orbital_precalc
@@ -139,8 +153,8 @@ void LCAO_Deepks_Interface<TK, TR>::out_deepks_labels(const double& etot,
             {
                 const std::string file_obase = PARAM.globalv.global_out_dir + "deepks_obase.npy";
                 LCAO_deepks_io::save_npy_o(o_tot, file_obase, nks, my_rank); // no scf, o_tot=o_base
-            }                                                                       // end deepks_scf == 0
-        }                                                                           // end bandgap label
+            }                                                                // end deepks_scf == 0
+        }                                                                    // end bandgap label
 
         // save H(R) matrix
         if (true) // should be modified later!

--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks_io.cpp
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks_io.cpp
@@ -346,7 +346,7 @@ void LCAO_deepks_io::save_npy_o(const std::vector<double>& bandgap,
 void LCAO_deepks_io::save_npy_orbital_precalc(const int nat, 
                                               const int nks, 
                                               const int des_per_atom,
-                                              const torch::Tensor& orbital_precalc_tensor,
+                                              const torch::Tensor& orbital_precalc,
                                               const std::string& out_dir,
                                               const int rank)
 {
@@ -369,7 +369,7 @@ void LCAO_deepks_io::save_npy_orbital_precalc(const int nat,
         {
             for(int p=0; p<des_per_atom; ++p)
             {
-                npy_orbital_precalc.push_back(orbital_precalc_tensor.index({iks, iat, p}).item().toDouble());
+                npy_orbital_precalc.push_back(orbital_precalc.index({iks, iat, p}).item().toDouble());
             }
         }
     }

--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks_io.cpp
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks_io.cpp
@@ -1,50 +1,48 @@
-//wenfei 2022-1-11
-//This file contains subroutines that contains interface with libnpy
+// wenfei 2022-1-11
+// This file contains subroutines that contains interface with libnpy
 #include "module_parameter/parameter.h"
-//since many arrays must be saved in numpy format
-//It also contains subroutines for printing density matrices
-//which is used in unit tests
+// since many arrays must be saved in numpy format
+// It also contains subroutines for printing density matrices
+// which is used in unit tests
 
-//There are 2 subroutines for printing density matrices:
-//1. print_dm : for gamma only
-//2. print_dm_k : for multi-k
+// There are 2 subroutines for printing density matrices:
+// 1. print_dm : for gamma only
+// 2. print_dm_k : for multi-k
 
-//There are 4 subroutines in this file that prints to npy file:
-//1. save_npy_d : descriptor ->dm_eig.npy
-//2. save_npy_gvx : gvx ->grad_vx.npy
-//3. save_npy_e : energy
-//4. save_npy_f : force
-//5. save_npy_s : stress
-//6. save_npy_o : bandgap
-//7. save_npy_orbital_precalc : orbital_precalc
-//8. save_npy_h : Hamiltonian
-//9. save_npy_v_delta_precalc : v_delta_precalc
-//10. save_npy_phialpha : phialpha
-//11. save_npy_gevdm : grav_evdm , can use phialpha and gevdm to calculate v_delta_precalc
+// There are 4 subroutines in this file that prints to npy file:
+// 1. save_npy_d : descriptor ->dm_eig.npy
+// 2. save_npy_gvx : gvx ->grad_vx.npy
+// 3. save_npy_e : energy
+// 4. save_npy_f : force
+// 5. save_npy_s : stress
+// 6. save_npy_o : bandgap
+// 7. save_npy_orbital_precalc : orbital_precalc
+// 8. save_npy_h : Hamiltonian
+// 9. save_npy_v_delta_precalc : v_delta_precalc
+// 10. save_npy_phialpha : phialpha
+// 11. save_npy_gevdm : grav_evdm , can use phialpha and gevdm to calculate v_delta_precalc
 
 #ifdef __DEEPKS
 
-#include <mpi.h>
 #include "LCAO_deepks_io.h"
 #include "npy.hpp"
 
+#include <mpi.h>
+
 template <typename TK>
-void LCAO_deepks_io::print_dm(const int nks, 
-                                const int nlocal,
-                                const int nrow,
-                                const std::vector<std::vector<TK>>& dm)
+void LCAO_deepks_io::print_dm(const int nks, const int nlocal, const int nrow, const std::vector<std::vector<TK>>& dm)
 {
     std::stringstream ss;
-    for(int ik=0;ik<nks;ik++)
+    for (int ik = 0; ik < nks; ik++)
     {
         ss.str("");
-        ss<<"dm_"<<ik;
+        ss << "dm_" << ik;
         std::ofstream ofs(ss.str().c_str());
         ofs << std::setprecision(15);
 
-        for (int mu=0;mu<nlocal;mu++)
+        for (int mu = 0; mu < nlocal; mu++)
         {
-            for (int nu=0;nu<nlocal;nu++)
+            for (int nu = 0; nu < nlocal; nu++)
             {
                 ofs << dm[ik][mu * nrow + nu] << " ";
             }
@@ -53,8 +51,7 @@ void LCAO_deepks_io::print_dm(const int nks,
     }
 }
 
-
-void LCAO_deepks_io::load_npy_gedm(const int nat, 
+void LCAO_deepks_io::load_npy_gedm(const int nat,
                                    const int des_per_atom,
                                    double** gedm,
                                    double& e_delta,
@@ -62,12 +59,11 @@ void LCAO_deepks_io::load_npy_gedm(const int nat,
 {
     ModuleBase::TITLE("LCAO_deepks_io", "load_npy_gedm");
 
-    if(rank==0)
+    if (rank == 0)
     {
-        //load gedm.npy
+        // load gedm.npy
         std::vector<double> npy_gedm;
-        std::vector<unsigned long> dshape = {static_cast<unsigned long>(nat), 
-                                             static_cast<unsigned long>(des_per_atom)};
+        std::vector<unsigned long> dshape = {static_cast<unsigned long>(nat), static_cast<unsigned long>(des_per_atom)};
 
         std::string gedm_file = "gedm.npy";
 
@@ -75,57 +71,55 @@ void LCAO_deepks_io::load_npy_gedm(const int nat,
 
         for (int iat = 0; iat < nat; iat++)
         {
-            for(int ides = 0; ides < des_per_atom; ides++)
+            for (int ides = 0; ides < des_per_atom; ides++)
             {
-                gedm[iat][ides] = npy_gedm[iat*des_per_atom + ides] * 2.0; //Ha to Ry
+                gedm[iat][ides] = npy_gedm[iat * des_per_atom + ides] * 2.0; // Ha to Ry
             }
         }
 
-        //load ec.npy
+        // load ec.npy
         std::vector<double> npy_ec;
-        std::vector<unsigned long> eshape = { 1ul };
+        std::vector<unsigned long> eshape = {1ul};
         std::string ec_file = "ec.npy";
         npy::LoadArrayFromNumpy(ec_file, eshape, npy_ec);
-        e_delta = npy_ec[0] * 2.0; //Ha to Ry
+        e_delta = npy_ec[0] * 2.0; // Ha to Ry
     }
 
 #ifdef __MPI
-    for(int iat = 0; iat < nat; iat++)
+    for (int iat = 0; iat < nat; iat++)
     {
         MPI_Bcast(gedm[iat], des_per_atom, MPI_DOUBLE, 0, MPI_COMM_WORLD);
     }
     MPI_Bcast(&e_delta, 1, MPI_DOUBLE, 0, MPI_COMM_WORLD);
 #endif
-
 }
 
-
-//saves descriptor into dm_eig.npy
-void LCAO_deepks_io::save_npy_d(const int nat, 
+// saves descriptor into dm_eig.npy
+void LCAO_deepks_io::save_npy_d(const int nat,
                                 const int des_per_atom,
                                 const int inlmax,
-                                const int *inl_l,
+                                const int* inl_l,
                                 const bool deepks_equiv,
-                                const std::vector<torch::Tensor> &d_tensor,
+                                const std::vector<torch::Tensor>& d_tensor,
                                 const std::string& out_dir,
                                 const int rank)
 {
     ModuleBase::TITLE("LCAO_deepks_io", "save_npy_d");
 
-	if(rank!=0) 
-	{ 
-		return;
-	}
+    if (rank != 0)
+    {
+        return;
+    }
 
-    //save descriptor in .npy format
-    // deepks_equiv was PARAM.inp.deepks_equiv
-    if(!deepks_equiv)
+    // save descriptor in .npy format
+    //  deepks_equiv was PARAM.inp.deepks_equiv
+    if (!deepks_equiv)
     {
         std::vector<double> npy_des;
-        for (int inl = 0;inl < inlmax;++inl)
+        for (int inl = 0; inl < inlmax; ++inl)
         {
-            int nm = 2*inl_l[inl] + 1;
-            for(int im=0;im<nm;im++)
+            int nm = 2 * inl_l[inl] + 1;
+            for (int im = 0; im < nm; im++)
             {
                 npy_des.push_back(d_tensor[inl].index({im}).item().toDouble());
             }
@@ -134,7 +128,7 @@ void LCAO_deepks_io::save_npy_d(const int nat,
         if (rank == 0)
         {
             std::string file_dm_eig = out_dir + "deepks_dm_eig.npy";
-            //std::string file_dm_eig = "dm_eig.npy";
+            // std::string file_dm_eig = "dm_eig.npy";
             npy::SaveArrayAsNumpy(file_dm_eig, false, 2, dshape, npy_des);
         }
     }
@@ -142,9 +136,9 @@ void LCAO_deepks_io::save_npy_d(const int nat,
     {
         // a rather unnecessary way of writing this, but I'll do it for now
         std::vector<double> npy_des;
-        for(int iat = 0; iat < nat; iat ++)
+        for (int iat = 0; iat < nat; iat++)
         {
-            for(int i = 0; i < des_per_atom; i++)
+            for (int i = 0; i < des_per_atom; i++)
             {
                 npy_des.push_back(d_tensor[iat].index({i}).item().toDouble());
             }
@@ -153,90 +147,85 @@ void LCAO_deepks_io::save_npy_d(const int nat,
         if (rank == 0)
         {
             std::string file_dm_eig = out_dir + "deepks_dm_eig.npy";
-            //std::string file_dm_eig = "dm_eig.npy";
+            // std::string file_dm_eig = "dm_eig.npy";
             npy::SaveArrayAsNumpy(file_dm_eig, false, 2, dshape, npy_des);
-        }        
+        }
     }
     return;
 }
 
-
-//saves gvx into grad_vx.npy
-void LCAO_deepks_io::save_npy_gvx(const int nat, 
+// saves gvx into grad_vx.npy
+void LCAO_deepks_io::save_npy_gvx(const int nat,
                                   const int des_per_atom,
-                                  const torch::Tensor &gvx_tensor,
-                                  const std::string &out_dir,
+                                  const torch::Tensor& gvx_tensor,
+                                  const std::string& out_dir,
                                   const int rank)
 {
     ModuleBase::TITLE("LCAO_deepks_io", "save_npy_gvx");
 
-	if(rank!=0)
-	{
-		return;
-	}
+    if (rank != 0)
+    {
+        return;
+    }
 
-    assert(nat>0);
+    assert(nat > 0);
 
-    //save grad_vx.npy (when  force label is in use)
-    //unit: /Bohr
-    const long unsigned gshape[]
-        = {static_cast<unsigned long>(nat), 
-           3UL, 
-           static_cast<unsigned long>(nat), 
-           static_cast<unsigned long>(des_per_atom)};
+    // save grad_vx.npy (when  force label is in use)
+    // unit: /Bohr
+    const long unsigned gshape[] = {static_cast<unsigned long>(nat),
+                                    3UL,
+                                    static_cast<unsigned long>(nat),
+                                    static_cast<unsigned long>(des_per_atom)};
 
     std::vector<double> npy_gvx;
-    for (int ibt = 0;ibt < nat;++ibt)
+    for (int ibt = 0; ibt < nat; ++ibt)
     {
-        for (int i = 0;i < 3;i++)
+        for (int i = 0; i < 3; i++)
         {
-            for (int iat = 0;iat < nat;++iat)
+            for (int iat = 0; iat < nat; ++iat)
             {
-                for(int p=0;p<des_per_atom;++p)
+                for (int p = 0; p < des_per_atom; ++p)
                 {
-                    npy_gvx.push_back(gvx_tensor.index({ ibt, i, iat, p }).item().toDouble());
+                    npy_gvx.push_back(gvx_tensor.index({ibt, i, iat, p}).item().toDouble());
                 }
             }
         }
     }
-    
+
     std::string file_gradvx = out_dir + "deepks_gradvx.npy";
     npy::SaveArrayAsNumpy(file_gradvx, false, 4, gshape, npy_gvx);
     return;
 }
 
-//saves gvx into grad_vepsl.npy
+// saves gvx into grad_vepsl.npy
 void LCAO_deepks_io::save_npy_gvepsl(const int nat,
                                      const int des_per_atom,
-                                     const torch::Tensor &gvepsl_tensor,
+                                     const torch::Tensor& gvepsl_tensor,
                                      const std::string& out_dir,
                                      const int rank)
 {
     ModuleBase::TITLE("LCAO_deepks_io", "save_npy_gvepsl");
 
-	if(rank!=0) 
-	{ 
-		return;
-	}
+    if (rank != 0)
+    {
+        return;
+    }
 
-    //save grad_vepsl.npy (when  stress label is in use)
-    //unit: none
-    const long unsigned gshape[] = {6UL, 
-                                    static_cast<unsigned long>(nat), 
-                                    static_cast<unsigned long>(des_per_atom)};
- 
+    // save grad_vepsl.npy (when  stress label is in use)
+    // unit: none
+    const long unsigned gshape[] = {6UL, static_cast<unsigned long>(nat), static_cast<unsigned long>(des_per_atom)};
+
     std::vector<double> npy_gvepsl;
 
-    for (int i = 0;i < 6;i++)
+    for (int i = 0; i < 6; i++)
     {
-        for (int ibt = 0;ibt < nat;++ibt)
+        for (int ibt = 0; ibt < nat; ++ibt)
         {
 
-            for(int p=0;p<des_per_atom;++p)
+            for (int p = 0; p < des_per_atom; ++p)
             {
-                npy_gvepsl.push_back(gvepsl_tensor.index({ i, ibt, p }).item().toDouble());
+                npy_gvepsl.push_back(gvepsl_tensor.index({i, ibt, p}).item().toDouble());
             }
-
         }
     }
 
@@ -246,49 +235,42 @@ void LCAO_deepks_io::save_npy_gvepsl(const int nat,
     return;
 }
 
-
-//saves energy in numpy format
-void LCAO_deepks_io::save_npy_e(const double &e, 
-                                const std::string &e_file,
-                                const int rank)
+// saves energy in numpy format
+void LCAO_deepks_io::save_npy_e(const double& e, const std::string& e_file, const int rank)
 {
     ModuleBase::TITLE("LCAO_deepks_io", "save_npy_e");
-	if(rank!=0) 
-	{ 
-		return;
-	}
+    if (rank != 0)
+    {
+        return;
+    }
 
-	//save e_base
-    const long unsigned eshape[] = { 1 };
+    // save e_base
+    const long unsigned eshape[] = {1};
     std::vector<double> npy_e;
     npy_e.push_back(e);
     npy::SaveArrayAsNumpy(e_file, false, 1, eshape, npy_e);
     return;
 }
 
-
-//saves force in numpy format
-void LCAO_deepks_io::save_npy_f(const ModuleBase::matrix &f, 
-                                const std::string &f_file, 
-                                const int nat,
-                                const int rank)
+// saves force in numpy format
+void LCAO_deepks_io::save_npy_f(const ModuleBase::matrix& f, const std::string& f_file, const int nat, const int rank)
 {
     ModuleBase::TITLE("LCAO_deepks_io", "save_npy_f");
 
-	if(rank!=0) 
-	{ 
-		return;
-	}
+    if (rank != 0)
+    {
+        return;
+    }
 
-    assert(nat>0);
+    assert(nat > 0);
 
-	//save f_base
-    //caution: unit: Rydberg/Bohr
+    // save f_base
+    // caution: unit: Rydberg/Bohr
     const long unsigned fshape[] = {static_cast<unsigned long>(nat), 3};
     std::vector<double> npy_f;
-    for (int iat = 0;iat < nat;++iat)
+    for (int iat = 0; iat < nat; ++iat)
     {
-        for (int i = 0;i < 3;i++)
+        for (int i = 0; i < 3; i++)
         {
             npy_f.push_back(f(iat, i));
         }
@@ -297,77 +279,73 @@ void LCAO_deepks_io::save_npy_f(const ModuleBase::matrix &f,
     return;
 }
 
-
-//saves stress in numpy format
-void LCAO_deepks_io::save_npy_s(const ModuleBase::matrix &stress, 
-                                const std::string &s_file, 
-                                const double &omega,
+// saves stress in numpy format
+void LCAO_deepks_io::save_npy_s(const ModuleBase::matrix& stress,
+                                const std::string& s_file,
+                                const double& omega,
                                 const int rank)
 {
     ModuleBase::TITLE("LCAO_deepks_io", "save_npy_s");
-	if(rank!=0) 
-	{
-		return;
-	}
+    if (rank != 0)
+    {
+        return;
+    }
 
-    const long unsigned sshape[] = { 6 };
+    const long unsigned sshape[] = {6};
     std::vector<double> npy_s;
 
-    for (int ipol = 0;ipol < 3;++ipol)
+    for (int ipol = 0; ipol < 3; ++ipol)
     {
-        for (int jpol = ipol;jpol < 3;jpol++)
+        for (int jpol = ipol; jpol < 3; jpol++)
         {
-            npy_s.push_back(stress(ipol, jpol)*omega);
+            npy_s.push_back(stress(ipol, jpol) * omega);
         }
     }
     npy::SaveArrayAsNumpy(s_file, false, 1, sshape, npy_s);
     return;
 }
 
-
-void LCAO_deepks_io::save_npy_o(const std::vector<double>& bandgap, 
-                                const std::string& o_file, 
+void LCAO_deepks_io::save_npy_o(const std::vector<double>& bandgap,
+                                const std::string& o_file,
                                 const int nks,
                                 const int rank)
 {
-	ModuleBase::TITLE("LCAO_deepks_io", "save_npy_o");
-	if(rank!=0) 
-	{ 
-		return;
-	}
+    ModuleBase::TITLE("LCAO_deepks_io", "save_npy_o");
+    if (rank != 0)
+    {
+        return;
+    }
 
-    //save o_base
-    const long unsigned oshape[] = {static_cast<unsigned long>(nks), 1 };
+    // save o_base
+    const long unsigned oshape[] = {static_cast<unsigned long>(nks), 1};
     npy::SaveArrayAsNumpy(o_file, false, 2, oshape, bandgap);
     return;
 }
 
-
-void LCAO_deepks_io::save_npy_orbital_precalc(const int nat, 
-                                              const int nks, 
+void LCAO_deepks_io::save_npy_orbital_precalc(const int nat,
+                                              const int nks,
                                               const int des_per_atom,
                                               const torch::Tensor& orbital_precalc,
                                               const std::string& out_dir,
                                               const int rank)
 {
     ModuleBase::TITLE("LCAO_deepks_io", "save_npy_orbital_precalc");
-	if(rank!=0) 
-	{ 
-		return;
-	}
+    if (rank != 0)
+    {
+        return;
+    }
 
-    //save orbital_precalc.npy (when bandgap label is in use)
-    //unit: a.u.
-    const long unsigned gshape[] = {static_cast<unsigned long>(nks),
-                                    static_cast<unsigned long>(nat),
-                                    static_cast<unsigned long>(des_per_atom)};
+    // save orbital_precalc.npy (when bandgap label is in use)
+    // unit: a.u.
+    const long unsigned gshape[]
+        = {static_cast<unsigned long>(nks), static_cast<unsigned long>(nat), static_cast<unsigned long>(des_per_atom)};
 
     std::vector<double> npy_orbital_precalc;
     for (int iks = 0; iks < nks; ++iks)
     {
-        for (int iat = 0;iat < nat;++iat)
+        for (int iat = 0; iat < nat; ++iat)
         {
-            for(int p=0; p<des_per_atom; ++p)
+            for (int p = 0; p < des_per_atom; ++p)
             {
                 npy_orbital_precalc.push_back(orbital_precalc.index({iks, iat, p}).item().toDouble());
             }
@@ -380,86 +358,87 @@ void LCAO_deepks_io::save_npy_orbital_precalc(const int nat,
 }
 
 template <typename TK, typename TH>
-void LCAO_deepks_io::save_npy_h(const std::vector<TH> &hamilt,
-                                const std::string &h_file,
+void LCAO_deepks_io::save_npy_h(const std::vector<TH>& hamilt,
+                                const std::string& h_file,
                                 const int nlocal,
                                 const int nks,
                                 const int rank)
 {
     ModuleBase::TITLE("LCAO_deepks_io", "save_npy_h");
-	if(rank!=0)
-	{
-		return;
-	}
+    if (rank != 0)
+    {
+        return;
+    }
 
-    const long unsigned hshape[] = {static_cast<unsigned long>(nks),
-                                    static_cast<unsigned long>(nlocal), 
-                                    static_cast<unsigned long>(nlocal) };
+    const long unsigned hshape[]
+        = {static_cast<unsigned long>(nks), static_cast<unsigned long>(nlocal), static_cast<unsigned long>(nlocal)};
 
     std::vector<TK> npy_h;
-    for(int k=0; k<nks; k++)
+    for (int k = 0; k < nks; k++)
     {
-        for (int i=0; i<nlocal; i++)
+        for (int i = 0; i < nlocal; i++)
         {
-            for (int j=0; j<nlocal; j++)
+            for (int j = 0; j < nlocal; j++)
             {
-                npy_h.push_back(hamilt[k](i,j));
+                npy_h.push_back(hamilt[k](i, j));
             }
-        }         
+        }
     }
 
     npy::SaveArrayAsNumpy(h_file, false, 3, hshape, npy_h);
-    return;    
+    return;
 }
 
 template <typename TK>
-void LCAO_deepks_io::save_npy_v_delta_precalc(const int nat, 
+void LCAO_deepks_io::save_npy_v_delta_precalc(const int nat,
                                               const int nks,
-                                              const int nlocal, 
+                                              const int nlocal,
                                               const int des_per_atom,
                                               const torch::Tensor& v_delta_precalc_tensor,
                                               const std::string& out_dir,
                                               const int rank)
 {
     ModuleBase::TITLE("LCAO_deepks_io", "save_npy_v_delta_precalc");
-	if(rank!=0)
-	{
-		return;
-	}
+    if (rank != 0)
+    {
+        return;
+    }
 
-	// timeval t_start;
+    // timeval t_start;
     // gettimeofday(&t_start,NULL);
-    //save v_delta_precalc.npy (when v_delta label is in use)
-    //unit: a.u.
+    // save v_delta_precalc.npy (when v_delta label is in use)
+    // unit: a.u.
     const long unsigned gshape[] = {static_cast<unsigned long>(nks),
                                     static_cast<unsigned long>(nlocal),
                                     static_cast<unsigned long>(nlocal),
                                     static_cast<unsigned long>(nat),
                                     static_cast<unsigned long>(des_per_atom)};
 
-    std::vector<TK> npy_v_delta_precalc;    
+    std::vector<TK> npy_v_delta_precalc;
     for (int iks = 0; iks < nks; ++iks)
     {
         for (int mu = 0; mu < nlocal; ++mu)
         {
             for (int nu = 0; nu < nlocal; ++nu)
             {
-                for (int iat = 0;iat < nat;++iat)
+                for (int iat = 0; iat < nat; ++iat)
                 {
-                    for(int p=0; p<des_per_atom; ++p)
+                    for (int p = 0; p < des_per_atom; ++p)
                     {
                         if constexpr (std::is_same<TK, double>::value)
                         {
-                            npy_v_delta_precalc.push_back(v_delta_precalc_tensor.index({iks, mu, nu, iat, p }).item().toDouble());
+                            npy_v_delta_precalc.push_back(
+                                v_delta_precalc_tensor.index({iks, mu, nu, iat, p}).item().toDouble());
                         }
                         else
                         {
-                            std::complex<double> value(torch::real(v_delta_precalc_tensor.index({iks, mu, nu, iat, p})).item<double>(),
-                                                        torch::imag(v_delta_precalc_tensor.index({iks, mu, nu, iat, p})).item<double>());
+                            std::complex<double> value(
+                                torch::real(v_delta_precalc_tensor.index({iks, mu, nu, iat, p})).item<double>(),
+                                torch::imag(v_delta_precalc_tensor.index({iks, mu, nu, iat, p})).item<double>());
                             npy_v_delta_precalc.push_back(value);
                         }
                     }
-                }                
+                }
             }
         }
     }
@@ -469,53 +448,54 @@ void LCAO_deepks_io::save_npy_v_delta_precalc(const int nat,
 }
 
 template <typename TK>
-void LCAO_deepks_io::save_npy_phialpha(const int nat, 
+void LCAO_deepks_io::save_npy_phialpha(const int nat,
                                        const int nks,
                                        const int nlocal,
                                        const int inlmax,
                                        const int lmaxd,
-                                       const torch::Tensor &phialpha_tensor,
+                                       const torch::Tensor& phialpha_tensor,
                                        const std::string& out_dir,
                                        const int rank)
 {
     ModuleBase::TITLE("LCAO_deepks_io", "save_npy_phialpha");
-	if(rank!=0)
-	{ 
-		return;
-	}
+    if (rank != 0)
+    {
+        return;
+    }
 
-    //save phialpha.npy (when v_delta label == 2)
-    //unit: a.u.
-    const int nlmax = inlmax/nat;
-    const int mmax = 2*lmaxd+1;
+    // save phialpha.npy (when v_delta label == 2)
+    // unit: a.u.
+    const int nlmax = inlmax / nat;
+    const int mmax = 2 * lmaxd + 1;
     const long unsigned gshape[] = {static_cast<unsigned long>(nat),
                                     static_cast<unsigned long>(nlmax),
                                     static_cast<unsigned long>(nks),
                                     static_cast<unsigned long>(nlocal),
                                     static_cast<unsigned long>(mmax)};
     std::vector<TK> npy_phialpha;
-    for(int iat=0; iat< nat ; iat++) 
+    for (int iat = 0; iat < nat; iat++)
     {
-        for(int nl = 0; nl < nlmax; nl++)
+        for (int nl = 0; nl < nlmax; nl++)
         {
-            for (int iks = 0; iks < nks ; iks++)
+            for (int iks = 0; iks < nks; iks++)
             {
-                for(int mu = 0; mu < nlocal ; mu++)
+                for (int mu = 0; mu < nlocal; mu++)
                 {
-                    for(int m=0; m< mmax; m++)
+                    for (int m = 0; m < mmax; m++)
                     {
                         if constexpr (std::is_same<TK, double>::value)
                         {
-                            npy_phialpha.push_back(phialpha_tensor.index({ iat,nl, iks, mu, m }).item().toDouble());
+                            npy_phialpha.push_back(phialpha_tensor.index({iat, nl, iks, mu, m}).item().toDouble());
                         }
                         else
                         {
-                            std::complex<double> value(torch::real(phialpha_tensor.index({ iat, nl, iks, mu, m })).item<double>(), 
-                                                       torch::imag(phialpha_tensor.index({ iat, nl, iks, mu, m })).item<double>());
+                            std::complex<double> value(
+                                torch::real(phialpha_tensor.index({iat, nl, iks, mu, m})).item<double>(),
+                                torch::imag(phialpha_tensor.index({iat, nl, iks, mu, m})).item<double>());
                             npy_phialpha.push_back(value);
                         }
                     }
-                }                
+                }
             }
         }
     }
@@ -523,7 +503,6 @@ void LCAO_deepks_io::save_npy_phialpha(const int nat,
     npy::SaveArrayAsNumpy(file_phialpha, false, 5, gshape, npy_phialpha);
     return;
 }
-
 
 void LCAO_deepks_io::save_npy_gevdm(const int nat,
                                     const int inlmax,
@@ -533,37 +512,37 @@ void LCAO_deepks_io::save_npy_gevdm(const int nat,
                                     const int rank)
 {
     ModuleBase::TITLE("LCAO_deepks_io", "save_npy_gevdm");
-	if(rank!=0) 
-	{ 
-		return;
-	}
+    if (rank != 0)
+    {
+        return;
+    }
 
-    assert(nat>0);
+    assert(nat > 0);
 
-	//save grad_evdm.npy (when v_delta label == 2)
-    //unit: a.u.
-    const int nlmax = inlmax/nat;
-    const int mmax = 2*lmaxd+1;
+    // save grad_evdm.npy (when v_delta label == 2)
+    // unit: a.u.
+    const int nlmax = inlmax / nat;
+    const int mmax = 2 * lmaxd + 1;
     const long unsigned gshape[] = {static_cast<unsigned long>(nat),
                                     static_cast<unsigned long>(nlmax),
                                     static_cast<unsigned long>(mmax),
                                     static_cast<unsigned long>(mmax),
                                     static_cast<unsigned long>(mmax)};
     std::vector<double> npy_gevdm;
-    for(int iat=0; iat< nat ; iat++)
+    for (int iat = 0; iat < nat; iat++)
     {
-        for(int nl = 0; nl < nlmax; nl++)
+        for (int nl = 0; nl < nlmax; nl++)
         {
-            for(int v=0; v< mmax; v++)
+            for (int v = 0; v < mmax; v++)
             {
-                for(int m=0; m< mmax; m++)
+                for (int m = 0; m < mmax; m++)
                 {
-                    for(int n=0; n< mmax; n++)
+                    for (int n = 0; n < mmax; n++)
                     {
-                        npy_gevdm.push_back(gevdm_tensor.index({ iat, nl, v, m, n}).item().toDouble());
-                    }         
+                        npy_gevdm.push_back(gevdm_tensor.index({iat, nl, v, m, n}).item().toDouble());
+                    }
                 }
-            }                
+            }
         }
     }
     const std::string file_gevdm = out_dir + "deepks_gevdm.npy";
@@ -571,51 +550,51 @@ void LCAO_deepks_io::save_npy_gevdm(const int nat,
     return;
 }
 
-
-template void LCAO_deepks_io::print_dm<double>(const int nks, 
+template void LCAO_deepks_io::print_dm<double>(const int nks,
                                                const int nlocal,
                                                const int nrow,
                                                const std::vector<std::vector<double>>& dm);
 
-template void LCAO_deepks_io::print_dm<std::complex<double>>(const int nks, 
+template void LCAO_deepks_io::print_dm<std::complex<double>>(const int nks,
                                                              const int nlocal,
                                                              const int nrow,
                                                              const std::vector<std::vector<std::complex<double>>>& dm);
 
-template void LCAO_deepks_io::save_npy_h<double>(const std::vector<ModuleBase::matrix> &hamilt,
-                                                 const std::string &h_file,
+template void LCAO_deepks_io::save_npy_h<double>(const std::vector<ModuleBase::matrix>& hamilt,
+                                                 const std::string& h_file,
                                                  const int nlocal,
                                                  const int nks,
                                                  const int rank);
 
-template void LCAO_deepks_io::save_npy_h<std::complex<double>>(const std::vector<ModuleBase::ComplexMatrix> &hamilt,
-                                                               const std::string &h_file,
+template void LCAO_deepks_io::save_npy_h<std::complex<double>>(const std::vector<ModuleBase::ComplexMatrix>& hamilt,
+                                                               const std::string& h_file,
                                                                const int nlocal,
                                                                const int nks,
                                                                const int rank);
 
-template void LCAO_deepks_io::save_npy_v_delta_precalc<double>(const int nat, 
+template void LCAO_deepks_io::save_npy_v_delta_precalc<double>(const int nat,
                                                                const int nks,
-                                                               const int nlocal, 
+                                                               const int nlocal,
                                                                const int des_per_atom,
                                                                const torch::Tensor& v_delta_precalc_tensor,
                                                                const std::string& out_dir,
                                                                const int rank);
 
-template void LCAO_deepks_io::save_npy_v_delta_precalc<std::complex<double>>(const int nat, 
-                                                                             const int nks,
-                                                                             const int nlocal, 
-                                                                             const int des_per_atom,
-                                                                             const torch::Tensor& v_delta_precalc_tensor,
-                                                                             const std::string& out_dir,
-                                                                             const int rank);
+template void LCAO_deepks_io::save_npy_v_delta_precalc<std::complex<double>>(
+    const int nat,
+    const int nks,
+    const int nlocal,
+    const int des_per_atom,
+    const torch::Tensor& v_delta_precalc_tensor,
+    const std::string& out_dir,
+    const int rank);
 
 template void LCAO_deepks_io::save_npy_phialpha<double>(const int nat,
                                                         const int nks,
                                                         const int nlocal,
                                                         const int inlmax,
                                                         const int lmaxd,
-                                                        const torch::Tensor &phialpha_tensor,
+                                                        const torch::Tensor& phialpha_tensor,
                                                         const std::string& out_dir,
                                                         const int rank);
 
@@ -624,7 +603,7 @@ template void LCAO_deepks_io::save_npy_phialpha<std::complex<double>>(const int 
                                                                       const int nlocal,
                                                                       const int inlmax,
                                                                       const int lmaxd,
-                                                                      const torch::Tensor &phialpha_tensor,
+                                                                      const torch::Tensor& phialpha_tensor,
                                                                       const std::string& out_dir,
                                                                       const int rank);
 

--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks_io.h
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks_io.h
@@ -1,144 +1,137 @@
-#ifndef LCAO_DEEPKS_IO_H 
+#ifndef LCAO_DEEPKS_IO_H
 #define LCAO_DEEPKS_IO_H
 
 #ifdef __DEEPKS
 
-#include <string>
-#include <vector>
-#include "module_base/tool_title.h"
-#include "module_base/matrix.h"
 #include "module_base/complexmatrix.h"
+#include "module_base/matrix.h"
+#include "module_base/tool_title.h"
 
+#include <string>
 #include <torch/script.h>
 #include <torch/torch.h>
+#include <vector>
 
 namespace LCAO_deepks_io
 {
 
-    /// This file contains subroutines that contains interface with libnpy
-    /// since many arrays must be saved in numpy format
-    /// It also contains subroutines for printing density matrices
-    /// which is used in unit tests
+/// This file contains subroutines that contains interface with libnpy
+/// since many arrays must be saved in numpy format
+/// It also contains subroutines for printing density matrices
+/// which is used in unit tests
 
-    /// There are 2 subroutines for printing and loading .npy file:
-    /// 1. print_dm : print density matrices
-    /// 2. load_npy_gedm : load gedm from .npy file
+/// There are 2 subroutines for printing and loading .npy file:
+/// 1. print_dm : print density matrices
+/// 2. load_npy_gedm : load gedm from .npy file
 
-    /// others print quantities in .npy format
+/// others print quantities in .npy format
 
-    /// 3. save_npy_d : descriptor -> deepks_dm_eig.npy
-    /// 4. save_npy_e : energy
-    /// 5. save_npy_f : force 
-    /// 6. save_npy_gvx : gvx -> deepks_gradvx.npy
-    /// 7. save_npy_s : stress
-    /// 8. save_npy_gvepsl : gvepsl -> deepks_gvepsl.npy
-    /// 9. save_npy_o: orbital
-    /// 10. save_npy_orbital_precalc: orbital_precalc -> deepks_orbpre.npy
-    /// 11. save_npy_h : Hamiltonian
-    /// 12. save_npy_v_delta_precalc : v_delta_precalc -> deepks_vdpre.npy
-    /// 13. save_npy_phialpha : phialpha -> deepks_phialpha.npy
-    /// 14. save_npy_gevdm : grav_evdm -> deepks_gevdm.npy, can use phialpha and gevdm to calculate v_delta_precalc
+/// 3. save_npy_d : descriptor -> deepks_dm_eig.npy
+/// 4. save_npy_e : energy
+/// 5. save_npy_f : force
+/// 6. save_npy_gvx : gvx -> deepks_gradvx.npy
+/// 7. save_npy_s : stress
+/// 8. save_npy_gvepsl : gvepsl -> deepks_gvepsl.npy
+/// 9. save_npy_o: orbital
+/// 10. save_npy_orbital_precalc: orbital_precalc -> deepks_orbpre.npy
+/// 11. save_npy_h : Hamiltonian
+/// 12. save_npy_v_delta_precalc : v_delta_precalc -> deepks_vdpre.npy
+/// 13. save_npy_phialpha : phialpha -> deepks_phialpha.npy
+/// 14. save_npy_gevdm : grav_evdm -> deepks_gevdm.npy, can use phialpha and gevdm to calculate v_delta_precalc
 
 /// print density matrices
 template <typename TK>
-void print_dm(const int nks,
-		const int nlocal,
-		const int nrow,
-		const std::vector<std::vector<TK>>& dm);
+void print_dm(const int nks, const int nlocal, const int nrow, const std::vector<std::vector<TK>>& dm);
 
-void load_npy_gedm(const int nat,
-		const int des_per_atom,
-		double** gedm,
-		double& e_delta,
-		const int rank);
+void load_npy_gedm(const int nat, const int des_per_atom, double** gedm, double& e_delta, const int rank);
 
 /// save descriptor
 void save_npy_d(const int nat,
-		const int des_per_atom,
-		const int inlmax,
-        const int* inl_l,
-		const bool deepks_equiv,
-		const std::vector<torch::Tensor> &d_tensor,
-		const std::string& out_dir,
-		const int rank);
+                const int des_per_atom,
+                const int inlmax,
+                const int* inl_l,
+                const bool deepks_equiv,
+                const std::vector<torch::Tensor>& d_tensor,
+                const std::string& out_dir,
+                const int rank);
 
 // save energy
-void save_npy_e(const double &e,  /**<[in] \f$E_{base}\f$ or \f$E_{tot}\f$, in Ry*/
-		const std::string &e_file,
-		const int rank);
+void save_npy_e(const double& e, /**<[in] \f$E_{base}\f$ or \f$E_{tot}\f$, in Ry*/
+                const std::string& e_file,
+                const int rank);
 
 // save force and gvx
-void save_npy_f(const ModuleBase::matrix &f, /**<[in] \f$F_{base}\f$ or \f$F_{tot}\f$, in Ry/Bohr*/
-		const std::string &f_file,
-		const int nat,
-		const int rank);
+void save_npy_f(const ModuleBase::matrix& f, /**<[in] \f$F_{base}\f$ or \f$F_{tot}\f$, in Ry/Bohr*/
+                const std::string& f_file,
+                const int nat,
+                const int rank);
 
 void save_npy_gvx(const int nat,
-		const int des_per_atom,
-		const torch::Tensor &gvx_tensor,
-        const std::string& out_dir,
-		const int rank);
+                  const int des_per_atom,
+                  const torch::Tensor& gvx_tensor,
+                  const std::string& out_dir,
+                  const int rank);
 
 // save stress and gvepsl
-void save_npy_s(const ModuleBase::matrix &stress, /**<[in] \f$S_{base}\f$ or \f$S_{tot}\f$, in Ry/Bohr^3*/
-		const std::string &s_file,
-		const double &omega,
-		const int rank);
+void save_npy_s(const ModuleBase::matrix& stress, /**<[in] \f$S_{base}\f$ or \f$S_{tot}\f$, in Ry/Bohr^3*/
+                const std::string& s_file,
+                const double& omega,
+                const int rank);
 
 void save_npy_gvepsl(const int nat,
-		const int des_per_atom,
-		const torch::Tensor &gvepsl_tensor,
-		const std::string& out_dir,
-		const int rank);
+                     const int des_per_atom,
+                     const torch::Tensor& gvepsl_tensor,
+                     const std::string& out_dir,
+                     const int rank);
 
 /// save orbital and orbital_precalc
 void save_npy_o(const std::vector<double>& bandgap, /**<[in] \f$E_{base}\f$ or \f$E_{tot}\f$, in Ry*/
-		const std::string &o_file,
-		const int nks,
-		const int rank);
+                const std::string& o_file,
+                const int nks,
+                const int rank);
 
-void save_npy_orbital_precalc(const int nat, 
-		const int nks,
-		const int des_per_atom,
-		const torch::Tensor& orbital_precalc,
-        const std::string& out_dir,
-		const int rank);
+void save_npy_orbital_precalc(const int nat,
+                              const int nks,
+                              const int des_per_atom,
+                              const torch::Tensor& orbital_precalc,
+                              const std::string& out_dir,
+                              const int rank);
 
 // save Hamiltonian and v_delta_precalc(for deepks_v_delta==1)/phialpha+gevdm(for deepks_v_delta==2)
 template <typename TK, typename TH>
-void save_npy_h(const std::vector<TH> &hamilt,
-		const std::string &h_file,
-		const int nlocal,
-        const int nks,
-		const int rank);
+void save_npy_h(const std::vector<TH>& hamilt,
+                const std::string& h_file,
+                const int nlocal,
+                const int nks,
+                const int rank);
 
 template <typename TK>
 void save_npy_v_delta_precalc(const int nat,
-		const int nks,
-		const int nlocal,
-		const int des_per_atom,
-		const torch::Tensor& v_delta_precalc_tensor,
-		const std::string& out_dir,
-		const int rank);
+                              const int nks,
+                              const int nlocal,
+                              const int des_per_atom,
+                              const torch::Tensor& v_delta_precalc_tensor,
+                              const std::string& out_dir,
+                              const int rank);
 
 template <typename TK>
 void save_npy_phialpha(const int nat,
-		const int nks,
-		const int nlocal,
-		const int inlmax,
-		const int lmaxd,
-		const torch::Tensor &phialpha_tensor,
-		const std::string& out_dir,
-		const int rank);
+                       const int nks,
+                       const int nlocal,
+                       const int inlmax,
+                       const int lmaxd,
+                       const torch::Tensor& phialpha_tensor,
+                       const std::string& out_dir,
+                       const int rank);
 
 // Always real, no need for template now
 void save_npy_gevdm(const int nat,
-		const int inlmax,
-		const int lmaxd,
-		const torch::Tensor& gevdm_tensor,
-		const std::string& out_dir,
-		const int rank);
-};
+                    const int inlmax,
+                    const int lmaxd,
+                    const torch::Tensor& gevdm_tensor,
+                    const std::string& out_dir,
+                    const int rank);
+}; // namespace LCAO_deepks_io
 
 #endif
 #endif

--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks_io.h
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks_io.h
@@ -100,7 +100,7 @@ void save_npy_o(const std::vector<double>& bandgap, /**<[in] \f$E_{base}\f$ or \
 void save_npy_orbital_precalc(const int nat, 
 		const int nks,
 		const int des_per_atom,
-		const torch::Tensor& orbital_precalc_tensor,
+		const torch::Tensor& orbital_precalc,
         const std::string& out_dir,
 		const int rank);
 

--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks_pdm.cpp
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks_pdm.cpp
@@ -21,26 +21,14 @@
 #include "module_base/timer.h"
 #include "module_base/vector3.h"
 #include "module_hamilt_lcao/module_hcontainer/atom_pair.h"
+#ifdef __MPI
+#include "module_base/parallel_reduce.h"
+#endif
 
 void LCAO_Deepks::read_projected_DM(bool read_pdm_file, bool is_equiv, const Numerical_Orbital& alpha)
 {
     if (read_pdm_file && !this->init_pdm) // for DeePKS NSCF calculation
     {
-        int pdm_size = 0;
-        if (!is_equiv)
-        {
-            pdm_size = (this->lmaxd * 2 + 1) * (this->lmaxd * 2 + 1);
-        }
-        else
-        {
-            int nproj = 0;
-            for (int il = 0; il < this->lmaxd + 1; il++)
-            {
-                nproj += (2 * il + 1) * alpha.getNchi(il);
-            }
-            pdm_size = nproj * nproj;
-        }
-
         const std::string file_projdm = PARAM.globalv.global_out_dir + "deepks_projdm.dat";
         std::ifstream ifs(file_projdm.c_str());
 
@@ -48,15 +36,42 @@ void LCAO_Deepks::read_projected_DM(bool read_pdm_file, bool is_equiv, const Num
         {
             ModuleBase::WARNING_QUIT("LCAO_Deepks::read_projected_DM", "Cannot find the file deepks_projdm.dat");
         }
-        for (int inl = 0; inl < this->inlmax; inl++)
+        if (!is_equiv)
         {
-            for (int ind = 0; ind < pdm_size; ind++)
+            for (int inl = 0; inl < this->inlmax; inl++)
             {
-                double c;
-                ifs >> c;
-                pdm[inl][ind] = c;
+                int nm = this->inl_l[inl] * 2 + 1;
+                for (int m1 = 0; m1 < nm; m1++)
+                {
+                    for (int m2 = 0; m2 < nm; m2++)
+                    {
+                        double c;
+                        ifs >> c;
+                        this->pdm[inl][m1][m2] = c;
+                    }
+                }
             }
         }
+        else
+        {
+            int pdm_size = 0;
+            int nproj = 0;
+            for (int il = 0; il < this->lmaxd + 1; il++)
+            {
+                nproj += (2 * il + 1) * alpha.getNchi(il);
+            }
+            pdm_size = nproj * nproj;
+            for (int inl = 0; inl < this->inlmax; inl++)
+            {
+                for (int ind = 0; ind < pdm_size; ind++)
+                {
+                    double c;
+                    ifs >> c;
+                    this->pdm[inl][ind] = c;
+                }
+            }
+        }
+        
         this->init_pdm = true;
     }
 }
@@ -78,31 +93,31 @@ void LCAO_Deepks::cal_projected_DM(const elecstate::DensityMatrix<TK, double>* d
         this->init_pdm = false;
         return;
     }
-    int pdm_size = 0;
+
     if (!PARAM.inp.deepks_equiv)
     {
-        pdm_size = (this->lmaxd * 2 + 1) * (this->lmaxd * 2 + 1);
+        for (int inl = 0; inl < this->inlmax; inl++)
+        {
+            int nm = this->inl_l[inl] * 2 + 1;
+            this->pdm[inl] = torch::zeros({nm, nm}, torch::kFloat64);
+        }
     }
     else
     {
+        int pdm_size = 0;
         int nproj = 0;
         for (int il = 0; il < this->lmaxd + 1; il++)
         {
             nproj += (2 * il + 1) * orb.Alpha[0].getNchi(il);
         }
         pdm_size = nproj * nproj;
+        for (int inl = 0; inl < inlmax; inl++)
+        {
+            this->pdm[inl] = torch::zeros({pdm_size}, torch::kFloat64);
+        }
     }
 
-    // if(dm.size() == 0 || dm[0].size() == 0)
-    //{
-    //     return;
-    // }
     ModuleBase::timer::tick("LCAO_Deepks", "cal_projected_DM");
-
-    for (int inl = 0; inl < inlmax; inl++)
-    {
-        ModuleBase::GlobalFunc::ZEROS(pdm[inl], pdm_size);
-    }
 
     const double Rcut_Alpha = orb.Alpha[0].getRcut();
     for (int T0 = 0; T0 < ucell.ntype; T0++)
@@ -299,7 +314,6 @@ void LCAO_Deepks::cal_projected_DM(const elecstate::DensityMatrix<TK, double>* d
                            g_1dmt.data(),
                            &row_size);
                 } // ad2
-                // do dot of g_1dmt and s_1t to get orbital_pdm_shell
                 if (!PARAM.inp.deepks_equiv)
                 {
                     int ib = 0, index = 0, inc = 1;
@@ -315,11 +329,11 @@ void LCAO_Deepks::cal_projected_DM(const elecstate::DensityMatrix<TK, double>* d
                                 for (int m2 = 0; m2 < nm; ++m2) // m1 = 1 for s, 3 for p, 5 for d
                                 {
                                     int ind = m1 * nm + m2;
-                                    pdm[inl][ind] += ddot_(&row_size,
-                                                           g_1dmt.data() + index * row_size,
-                                                           &inc,
-                                                           s_1t.data() + index * row_size,
-                                                           &inc);
+                                    pdm[inl][m1][m2] += ddot_(&row_size,
+                                                                     g_1dmt.data() + index * row_size,
+                                                                     &inc,
+                                                                     s_1t.data() + index * row_size,
+                                                                     &inc);
                                     index++;
                                 }
                             }
@@ -340,10 +354,10 @@ void LCAO_Deepks::cal_projected_DM(const elecstate::DensityMatrix<TK, double>* d
                         for (int jproj = 0; jproj < nproj; jproj++)
                         {
                             pdm[iat][iproj * nproj + jproj] += ddot_(&row_size,
-                                                                     g_1dmt.data() + index * row_size,
-                                                                     &inc,
-                                                                     s_1t.data() + index * row_size,
-                                                                     &inc);
+                                                                            g_1dmt.data() + index * row_size,
+                                                                            &inc,
+                                                                            s_1t.data() + index * row_size,
+                                                                            &inc);
                             index++;
                         }
                     }
@@ -353,7 +367,11 @@ void LCAO_Deepks::cal_projected_DM(const elecstate::DensityMatrix<TK, double>* d
     }         // T0
 
 #ifdef __MPI
-    allsum_deepks(this->inlmax, pdm_size, this->pdm);
+    for(int inl=0; inl<inlmax; inl++)
+    {
+        int pdm_size = (2 * inl_l[inl] + 1) * (2 * inl_l[inl] + 1);
+        Parallel_Reduce::reduce_all(pdm[inl].data_ptr<double>(), pdm_size);
+    }
 #endif
     ModuleBase::timer::tick("LCAO_Deepks", "cal_projected_DM");
     return;
@@ -364,13 +382,16 @@ void LCAO_Deepks::check_projected_dm()
     const std::string file_projdm = PARAM.globalv.global_out_dir + "deepks_projdm.dat";
     std::ofstream ofs(file_projdm.c_str());
 
-    const int pdm_size = (this->lmaxd * 2 + 1) * (this->lmaxd * 2 + 1);
     ofs << std::setprecision(10);
     for (int inl = 0; inl < inlmax; inl++)
     {
-        for (int ind = 0; ind < pdm_size; ind++)
+        const int nm = 2 * this->inl_l[inl] + 1;
+        for (int m1 = 0; m1 < nm; m1++)
         {
-            ofs << pdm[inl][ind] << " ";
+            for (int m2 = 0; m2 < nm; m2++)
+            {
+                ofs << pdm[inl][m1][m2].item<double>() << " ";
+            }
         }
         ofs << std::endl;
     }

--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks_pdm.cpp
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks_pdm.cpp
@@ -71,7 +71,7 @@ void LCAO_Deepks::read_projected_DM(bool read_pdm_file, bool is_equiv, const Num
                 }
             }
         }
-        
+
         this->init_pdm = true;
     }
 }
@@ -330,10 +330,10 @@ void LCAO_Deepks::cal_projected_DM(const elecstate::DensityMatrix<TK, double>* d
                                 {
                                     int ind = m1 * nm + m2;
                                     pdm[inl][m1][m2] += ddot_(&row_size,
-                                                                     g_1dmt.data() + index * row_size,
-                                                                     &inc,
-                                                                     s_1t.data() + index * row_size,
-                                                                     &inc);
+                                                              g_1dmt.data() + index * row_size,
+                                                              &inc,
+                                                              s_1t.data() + index * row_size,
+                                                              &inc);
                                     index++;
                                 }
                             }
@@ -354,10 +354,10 @@ void LCAO_Deepks::cal_projected_DM(const elecstate::DensityMatrix<TK, double>* d
                         for (int jproj = 0; jproj < nproj; jproj++)
                         {
                             pdm[iat][iproj * nproj + jproj] += ddot_(&row_size,
-                                                                            g_1dmt.data() + index * row_size,
-                                                                            &inc,
-                                                                            s_1t.data() + index * row_size,
-                                                                            &inc);
+                                                                     g_1dmt.data() + index * row_size,
+                                                                     &inc,
+                                                                     s_1t.data() + index * row_size,
+                                                                     &inc);
                             index++;
                         }
                     }
@@ -367,7 +367,7 @@ void LCAO_Deepks::cal_projected_DM(const elecstate::DensityMatrix<TK, double>* d
     }         // T0
 
 #ifdef __MPI
-    for(int inl=0; inl<inlmax; inl++)
+    for (int inl = 0; inl < inlmax; inl++)
     {
         int pdm_size = (2 * inl_l[inl] + 1) * (2 * inl_l[inl] + 1);
         Parallel_Reduce::reduce_all(pdm[inl].data_ptr<double>(), pdm_size);

--- a/source/module_hamilt_lcao/module_deepks/cal_descriptor.cpp
+++ b/source/module_hamilt_lcao/module_deepks/cal_descriptor.cpp
@@ -27,7 +27,7 @@ void LCAO_Deepks::cal_descriptor_equiv(const int nat)
     for (int iat = 0; iat < nat; iat++) 
     {
         auto tmp = torch::zeros(des_per_atom, torch::kFloat64);
-        std::memcpy(tmp.data_ptr(), pdm[iat], sizeof(double) * tmp.numel());
+        std::memcpy(tmp.data_ptr(), pdm[iat].data_ptr<double>(), sizeof(double) * tmp.numel());
         this->d_tensor.push_back(tmp);
     }
 
@@ -45,40 +45,17 @@ void LCAO_Deepks::cal_descriptor(const int nat) {
         return;
     }
 
-    // init pdm_tensor and d_tensor
-    torch::Tensor tmp;
-
-    // if pdm_tensor and d_tensor is not empty, clear it !!
+    // init d_tensor
+    // if d_tensor is not empty, clear it !!
     if (!this->d_tensor.empty()) 
     {
         this->d_tensor.erase(this->d_tensor.begin(), this->d_tensor.end());
     }
 
-    if (!this->pdm_tensor.empty()) 
-    {
-        this->pdm_tensor.erase(this->pdm_tensor.begin(),
-                               this->pdm_tensor.end());
-    }
-
     for (int inl = 0; inl < this->inlmax; ++inl) 
     {
         const int nm = 2 * inl_l[inl] + 1;
-        tmp = torch::ones({nm, nm},
-                          torch::TensorOptions().dtype(torch::kFloat64));
-
-        for (int m1 = 0; m1 < nm; ++m1) 
-        {
-            for (int m2 = 0; m2 < nm; ++m2) 
-            {
-                tmp.index_put_({m1, m2}, this->pdm[inl][m1 * nm + m2]);
-            }
-        }
-
-        // torch::Tensor tmp = torch::from_blob(this->pdm[inl], { nm, nm },
-        // torch::requires_grad());
-
-        tmp.requires_grad_(true);
-        this->pdm_tensor.push_back(tmp);
+        this->pdm[inl].requires_grad_(true);
         this->d_tensor.push_back(torch::ones({nm}, torch::requires_grad(true)));
     }
 
@@ -87,9 +64,9 @@ void LCAO_Deepks::cal_descriptor(const int nat) {
     {
         torch::Tensor vd;
         std::tuple<torch::Tensor, torch::Tensor> d_v(this->d_tensor[inl], vd);
-        // d_v = torch::symeig(pdm_tensor[inl], /*eigenvalues=*/true,
+        // d_v = torch::symeig(pdm[inl], /*eigenvalues=*/true,
         // /*upper=*/true);
-        d_v = torch::linalg::eigh(pdm_tensor[inl], /*uplo*/ "U");
+        d_v = torch::linalg::eigh(pdm[inl], /*uplo*/ "U");
         d_tensor[inl] = std::get<0>(d_v);
     }
     ModuleBase::timer::tick("LCAO_Deepks", "cal_descriptor");
@@ -149,7 +126,7 @@ void LCAO_Deepks::check_descriptor(const UnitCell& ucell, const std::string& out
                 << " n_descriptor " << this->des_per_atom << std::endl;
             for (int i = 0; i < this->des_per_atom; i++) 
             {
-                ofs << this->pdm[iat][i] << " ";
+                ofs << this->pdm[iat][i].item<double>() << " ";
 				if (i % 8 == 7) 
 				{
 					ofs << std::endl;

--- a/source/module_hamilt_lcao/module_deepks/cal_descriptor.cpp
+++ b/source/module_hamilt_lcao/module_deepks/cal_descriptor.cpp
@@ -1,6 +1,6 @@
-///1. cal_descriptor : obtains descriptors which are eigenvalues of pdm
-///      by calling torch::linalg::eigh
-///2. check_descriptor : prints descriptor for checking
+/// 1. cal_descriptor : obtains descriptors which are eigenvalues of pdm
+///       by calling torch::linalg::eigh
+/// 2. check_descriptor : prints descriptor for checking
 
 #ifdef __DEEPKS
 
@@ -13,18 +13,18 @@
 #include "module_hamilt_lcao/module_hcontainer/atom_pair.h"
 #include "module_parameter/parameter.h"
 
-void LCAO_Deepks::cal_descriptor_equiv(const int nat) 
+void LCAO_Deepks::cal_descriptor_equiv(const int nat)
 {
     ModuleBase::TITLE("LCAO_Deepks", "cal_descriptor_equiv");
     ModuleBase::timer::tick("LCAO_Deepks", "cal_descriptor_equiv");
 
     // a rather unnecessary way of writing this, but I'll do it for now
-    if (!this->d_tensor.empty()) 
+    if (!this->d_tensor.empty())
     {
         this->d_tensor.erase(this->d_tensor.begin(), this->d_tensor.end());
     }
 
-    for (int iat = 0; iat < nat; iat++) 
+    for (int iat = 0; iat < nat; iat++)
     {
         auto tmp = torch::zeros(des_per_atom, torch::kFloat64);
         std::memcpy(tmp.data_ptr(), pdm[iat].data_ptr<double>(), sizeof(double) * tmp.numel());
@@ -35,11 +35,12 @@ void LCAO_Deepks::cal_descriptor_equiv(const int nat)
 }
 
 // calculates descriptors from projected density matrices
-void LCAO_Deepks::cal_descriptor(const int nat) {
+void LCAO_Deepks::cal_descriptor(const int nat)
+{
     ModuleBase::TITLE("LCAO_Deepks", "cal_descriptor");
     ModuleBase::timer::tick("LCAO_Deepks", "cal_descriptor");
 
-    if (PARAM.inp.deepks_equiv) 
+    if (PARAM.inp.deepks_equiv)
     {
         this->cal_descriptor_equiv(nat);
         return;
@@ -47,12 +48,12 @@ void LCAO_Deepks::cal_descriptor(const int nat) {
 
     // init d_tensor
     // if d_tensor is not empty, clear it !!
-    if (!this->d_tensor.empty()) 
+    if (!this->d_tensor.empty())
     {
         this->d_tensor.erase(this->d_tensor.begin(), this->d_tensor.end());
     }
 
-    for (int inl = 0; inl < this->inlmax; ++inl) 
+    for (int inl = 0; inl < this->inlmax; ++inl)
     {
         const int nm = 2 * inl_l[inl] + 1;
         this->pdm[inl].requires_grad_(true);
@@ -60,7 +61,7 @@ void LCAO_Deepks::cal_descriptor(const int nat) {
     }
 
     // cal d_tensor
-    for (int inl = 0; inl < inlmax; ++inl) 
+    for (int inl = 0; inl < inlmax; ++inl)
     {
         torch::Tensor vd;
         std::tuple<torch::Tensor, torch::Tensor> d_v(this->d_tensor[inl], vd);
@@ -73,65 +74,64 @@ void LCAO_Deepks::cal_descriptor(const int nat) {
     return;
 }
 
-
-void LCAO_Deepks::check_descriptor(const UnitCell& ucell, const std::string& out_dir) {
+void LCAO_Deepks::check_descriptor(const UnitCell& ucell, const std::string& out_dir)
+{
     ModuleBase::TITLE("LCAO_Deepks", "check_descriptor");
 
-    if (GlobalV::MY_RANK != 0) 
+    if (GlobalV::MY_RANK != 0)
     {
         return;
     }
 
     // mohan updated 2024-07-25
     std::string file = out_dir + "deepks_desc.dat";
-    
-    std::ofstream ofs(file.c_str());
-	ofs << std::setprecision(10);
-	if (!PARAM.inp.deepks_equiv) 
-	{
-		for (int it = 0; it < ucell.ntype; it++) 
-		{
-			for (int ia = 0; ia < ucell.atoms[it].na; ia++) 
-			{
-				int iat = ucell.itia2iat(it, ia);
-				ofs << ucell.atoms[it].label << " atom_index " << ia + 1
-					<< " n_descriptor " << this->des_per_atom << std::endl;
-				int id = 0;
-				for (int inl = 0; inl < inlmax / ucell.nat; inl++) 
-				{
-					int nm = 2 * inl_l[inl] + 1;
-					for (int im = 0; im < nm; im++) 
-					{
-						const int ind = iat * inlmax / ucell.nat + inl;
-						ofs << d_tensor[ind].index({im}).item().toDouble()
-							<< " ";
 
-						if (id % 8 == 7) 
-						{
-							ofs << std::endl;
-						}
-						id++;
-					}
-				}
-				ofs << std::endl << std::endl;
-			}
-		}
-	} 
-	else 
-	{
-		for (int iat = 0; iat < ucell.nat; iat++) 
-		{
-			const int it = ucell.iat2it[iat];
-            ofs << ucell.atoms[it].label << " atom_index " << iat + 1
-                << " n_descriptor " << this->des_per_atom << std::endl;
-            for (int i = 0; i < this->des_per_atom; i++) 
+    std::ofstream ofs(file.c_str());
+    ofs << std::setprecision(10);
+    if (!PARAM.inp.deepks_equiv)
+    {
+        for (int it = 0; it < ucell.ntype; it++)
+        {
+            for (int ia = 0; ia < ucell.atoms[it].na; ia++)
+            {
+                int iat = ucell.itia2iat(it, ia);
+                ofs << ucell.atoms[it].label << " atom_index " << ia + 1 << " n_descriptor " << this->des_per_atom
+                    << std::endl;
+                int id = 0;
+                for (int inl = 0; inl < inlmax / ucell.nat; inl++)
+                {
+                    int nm = 2 * inl_l[inl] + 1;
+                    for (int im = 0; im < nm; im++)
+                    {
+                        const int ind = iat * inlmax / ucell.nat + inl;
+                        ofs << d_tensor[ind].index({im}).item().toDouble() << " ";
+
+                        if (id % 8 == 7)
+                        {
+                            ofs << std::endl;
+                        }
+                        id++;
+                    }
+                }
+                ofs << std::endl << std::endl;
+            }
+        }
+    }
+    else
+    {
+        for (int iat = 0; iat < ucell.nat; iat++)
+        {
+            const int it = ucell.iat2it[iat];
+            ofs << ucell.atoms[it].label << " atom_index " << iat + 1 << " n_descriptor " << this->des_per_atom
+                << std::endl;
+            for (int i = 0; i < this->des_per_atom; i++)
             {
                 ofs << this->pdm[iat][i].item<double>() << " ";
-				if (i % 8 == 7) 
-				{
-					ofs << std::endl;
-				}
-			}
+                if (i % 8 == 7)
+                {
+                    ofs << std::endl;
+                }
+            }
             ofs << std::endl << std::endl;
         }
     }

--- a/source/module_hamilt_lcao/module_deepks/cal_gedm.cpp
+++ b/source/module_hamilt_lcao/module_deepks/cal_gedm.cpp
@@ -14,13 +14,13 @@
 #include "module_hamilt_lcao/module_hcontainer/atom_pair.h"
 #include "module_parameter/parameter.h"
 
+inline void generate_py_files(const int lmaxd, const int nmaxd, const std::string& out_dir)
+{
 
-inline void generate_py_files(const int lmaxd, const int nmaxd, const std::string &out_dir) {
-
-	if (GlobalV::MY_RANK != 0) 
-	{
-		return;
-	}
+    if (GlobalV::MY_RANK != 0)
+    {
+        return;
+    }
 
     std::ofstream ofs("cal_gedm.py");
     ofs << "import torch" << std::endl;
@@ -52,12 +52,15 @@ inline void generate_py_files(const int lmaxd, const int nmaxd, const std::strin
 
     ofs.open("basis.yaml");
     ofs << "proj_basis:" << std::endl;
-    for (int l = 0; l < lmaxd + 1; l++) {
+    for (int l = 0; l < lmaxd + 1; l++)
+    {
         ofs << "  - - " << l << std::endl;
         ofs << "    - [";
-        for (int i = 0; i < nmaxd + 1; i++) {
+        for (int i = 0; i < nmaxd + 1; i++)
+        {
             ofs << "0";
-            if (i != nmaxd) {
+            if (i != nmaxd)
+            {
                 ofs << ", ";
             }
         }
@@ -65,22 +68,23 @@ inline void generate_py_files(const int lmaxd, const int nmaxd, const std::strin
     }
 }
 
-void LCAO_Deepks::cal_gedm_equiv(const int nat) {
+void LCAO_Deepks::cal_gedm_equiv(const int nat)
+{
     ModuleBase::TITLE("LCAO_Deepks", "cal_gedm_equiv");
 
-	LCAO_deepks_io::save_npy_d(
-			nat, 
-			this->des_per_atom, 
-			this->inlmax, 
-			this->inl_l,
-			PARAM.inp.deepks_equiv, 
-			this->d_tensor, 
-            PARAM.globalv.global_out_dir,
-			GlobalV::MY_RANK); // libnpy needed
+    LCAO_deepks_io::save_npy_d(nat,
+                               this->des_per_atom,
+                               this->inlmax,
+                               this->inl_l,
+                               PARAM.inp.deepks_equiv,
+                               this->d_tensor,
+                               PARAM.globalv.global_out_dir,
+                               GlobalV::MY_RANK); // libnpy needed
 
     generate_py_files(this->lmaxd, this->nmaxd, PARAM.globalv.global_out_dir);
 
-    if (GlobalV::MY_RANK == 0) {
+    if (GlobalV::MY_RANK == 0)
+    {
         std::string cmd = "python cal_gedm.py " + PARAM.inp.deepks_model;
         int stat = std::system(cmd.c_str());
         assert(stat == 0);
@@ -88,21 +92,17 @@ void LCAO_Deepks::cal_gedm_equiv(const int nat) {
 
     MPI_Barrier(MPI_COMM_WORLD);
 
-	LCAO_deepks_io::load_npy_gedm(
-			nat,
-			this->des_per_atom,
-			this->gedm,
-			this->E_delta,
-			GlobalV::MY_RANK);
+    LCAO_deepks_io::load_npy_gedm(nat, this->des_per_atom, this->gedm, this->E_delta, GlobalV::MY_RANK);
 
     std::string cmd = "rm -f cal_gedm.py basis.yaml ec.npy gedm.npy";
     std::system(cmd.c_str());
 }
 
 // obtain from the machine learning model dE_delta/dDescriptor
-void LCAO_Deepks::cal_gedm(const int nat) {
+void LCAO_Deepks::cal_gedm(const int nat)
+{
 
-    if (PARAM.inp.deepks_equiv) 
+    if (PARAM.inp.deepks_equiv)
     {
         this->cal_gedm_equiv(nat);
         return;
@@ -114,11 +114,10 @@ void LCAO_Deepks::cal_gedm(const int nat) {
     std::vector<torch::jit::IValue> inputs;
 
     // input_dim:(natom, des_per_atom)
-    inputs.push_back(
-        torch::cat(this->d_tensor, 0).reshape({1, nat, this->des_per_atom}));
+    inputs.push_back(torch::cat(this->d_tensor, 0).reshape({1, nat, this->des_per_atom}));
     std::vector<torch::Tensor> ec;
     ec.push_back(module.forward(inputs).toTensor()); // Hartree
-    this->E_delta = ec[0].item().toDouble() * 2; // Ry; *2 is for Hartree to Ry
+    this->E_delta = ec[0].item().toDouble() * 2;     // Ry; *2 is for Hartree to Ry
 
     // cal gedm
     std::vector<torch::Tensor> gedm_shell;
@@ -131,39 +130,40 @@ void LCAO_Deepks::cal_gedm(const int nat) {
                                               /*allow_unused=*/true);
 
     // gedm_tensor(Hartree) to gedm(Ry)
-    for (int inl = 0; inl < inlmax; ++inl) {
+    for (int inl = 0; inl < inlmax; ++inl)
+    {
         int nm = 2 * inl_l[inl] + 1;
-        for (int m1 = 0; m1 < nm; ++m1) {
-            for (int m2 = 0; m2 < nm; ++m2) {
+        for (int m1 = 0; m1 < nm; ++m1)
+        {
+            for (int m2 = 0; m2 < nm; ++m2)
+            {
                 int index = m1 * nm + m2;
                 //*2 is for Hartree to Ry
-                this->gedm[inl][index]
-                    = this->gedm_tensor[inl].index({m1, m2}).item().toDouble()
-                      * 2;
+                this->gedm[inl][index] = this->gedm_tensor[inl].index({m1, m2}).item().toDouble() * 2;
             }
         }
     }
     return;
 }
 
-void LCAO_Deepks::check_gedm() 
+void LCAO_Deepks::check_gedm()
 {
     std::ofstream ofs("gedm.dat");
 
-	for (int inl = 0; inl < inlmax; inl++) 
-	{
-		int nm = 2 * inl_l[inl] + 1;
-		for (int m1 = 0; m1 < nm; ++m1) 
-		{
-			for (int m2 = 0; m2 < nm; ++m2) 
-			{
-				int index = m1 * nm + m2;
-				//*2 is for Hartree to Ry
-				ofs << this->gedm[inl][index] << " ";
-			}
-		}
-		ofs << std::endl;
-	}
+    for (int inl = 0; inl < inlmax; inl++)
+    {
+        int nm = 2 * inl_l[inl] + 1;
+        for (int m1 = 0; m1 < nm; ++m1)
+        {
+            for (int m2 = 0; m2 < nm; ++m2)
+            {
+                int index = m1 * nm + m2;
+                //*2 is for Hartree to Ry
+                ofs << this->gedm[inl][index] << " ";
+            }
+        }
+        ofs << std::endl;
+    }
 }
 
 #endif

--- a/source/module_hamilt_lcao/module_deepks/cal_gedm.cpp
+++ b/source/module_hamilt_lcao/module_deepks/cal_gedm.cpp
@@ -108,7 +108,6 @@ void LCAO_Deepks::cal_gedm(const int nat) {
         return;
     }
 
-    // using this->pdm_tensor
     ModuleBase::TITLE("LCAO_Deepks", "cal_gedm");
 
     // forward
@@ -125,7 +124,7 @@ void LCAO_Deepks::cal_gedm(const int nat) {
     std::vector<torch::Tensor> gedm_shell;
     gedm_shell.push_back(torch::ones_like(ec[0]));
     this->gedm_tensor = torch::autograd::grad(ec,
-                                              this->pdm_tensor,
+                                              this->pdm,
                                               gedm_shell,
                                               /*retain_grad=*/true,
                                               /*create_graph=*/false,

--- a/source/module_hamilt_lcao/module_deepks/cal_gvx.cpp
+++ b/source/module_hamilt_lcao/module_deepks/cal_gvx.cpp
@@ -1,4 +1,4 @@
-/// 1. cal_gvx : gvx is used for training with force label, which is gradient of descriptors, 
+/// 1. cal_gvx : gvx is used for training with force label, which is gradient of descriptors,
 ///      calculated by d(des)/dX = d(pdm)/dX * d(des)/d(pdm) = gdmx * gvdm
 ///      using einsum
 /// 2. check_gvx : prints gvx into gvx.dat for checking
@@ -16,59 +16,54 @@
 
 // calculates gradient of descriptors from gradient of projected density
 // matrices
-void LCAO_Deepks::cal_gvx(const int nat, const std::vector<torch::Tensor>& gevdm) 
+void LCAO_Deepks::cal_gvx(const int nat, const std::vector<torch::Tensor>& gevdm)
 {
     ModuleBase::TITLE("LCAO_Deepks", "cal_gvx");
 
-    if (!gdmr_vector.empty()) 
+    if (!gdmr_vector.empty())
     {
         gdmr_vector.erase(gdmr_vector.begin(), gdmr_vector.end());
     }
 
     // gdmr_vector : nat(derivative) * 3 * inl(projector) * nm * nm
-    if (GlobalV::MY_RANK == 0) 
+    if (GlobalV::MY_RANK == 0)
     {
         // make gdmx as tensor
         int nlmax = this->inlmax / nat;
-        for (int nl = 0; nl < nlmax; ++nl) 
+        for (int nl = 0; nl < nlmax; ++nl)
         {
             std::vector<torch::Tensor> bmmv;
-            for (int ibt = 0; ibt < nat; ++ibt) 
+            for (int ibt = 0; ibt < nat; ++ibt)
             {
                 std::vector<torch::Tensor> xmmv;
-                for (int i = 0; i < 3; ++i) 
+                for (int i = 0; i < 3; ++i)
                 {
                     std::vector<torch::Tensor> ammv;
-                    for (int iat = 0; iat < nat; ++iat) 
+                    for (int iat = 0; iat < nat; ++iat)
                     {
                         int inl = iat * nlmax + nl;
                         int nm = 2 * this->inl_l[inl] + 1;
                         std::vector<double> mmv;
-                        for (int m1 = 0; m1 < nm; ++m1) 
+                        for (int m1 = 0; m1 < nm; ++m1)
                         {
-                            for (int m2 = 0; m2 < nm; ++m2) 
+                            for (int m2 = 0; m2 < nm; ++m2)
                             {
-                                if (i == 0) 
-								{
-									mmv.push_back(
-											this->gdmx[ibt][inl][m1 * nm + m2]);
-								}
-								if (i == 1) 
-								{
-									mmv.push_back(
-											this->gdmy[ibt][inl][m1 * nm + m2]);
-								}
-								if (i == 2) 
-								{
-									mmv.push_back(
-											this->gdmz[ibt][inl][m1 * nm + m2]);
-								}
+                                if (i == 0)
+                                {
+                                    mmv.push_back(this->gdmx[ibt][inl][m1 * nm + m2]);
+                                }
+                                if (i == 1)
+                                {
+                                    mmv.push_back(this->gdmy[ibt][inl][m1 * nm + m2]);
+                                }
+                                if (i == 2)
+                                {
+                                    mmv.push_back(this->gdmz[ibt][inl][m1 * nm + m2]);
+                                }
                             }
                         } // nm^2
-                        torch::Tensor mm
-                            = torch::tensor(
-                                  mmv,
-                                  torch::TensorOptions().dtype(torch::kFloat64)).reshape({nm, nm}); // nm*nm
+                        torch::Tensor mm = torch::tensor(mmv, torch::TensorOptions().dtype(torch::kFloat64))
+                                               .reshape({nm, nm}); // nm*nm
                         ammv.push_back(mm);
                     }
                     torch::Tensor amm = torch::stack(ammv, 0); // nat*nm*nm
@@ -88,10 +83,9 @@ void LCAO_Deepks::cal_gvx(const int nat, const std::vector<torch::Tensor>& gevdm
         // n:nm (pdm, dim2) gvx_vector : b:nat(derivative) * x:3 *
         // a:inl(projector) * m:nm(descriptor)
         std::vector<torch::Tensor> gvx_vector;
-        for (int nl = 0; nl < nlmax; ++nl) {
-            gvx_vector.push_back(
-                at::einsum("bxamn, avmn->bxav",
-                           {this->gdmr_vector[nl], gevdm[nl]}));
+        for (int nl = 0; nl < nlmax; ++nl)
+        {
+            gvx_vector.push_back(at::einsum("bxamn, avmn->bxav", {this->gdmr_vector[nl], gevdm[nl]}));
         }
 
         // cat nv-> \sum_nl(nv) = \sum_nl(nm_nl)=des_per_atom
@@ -107,7 +101,8 @@ void LCAO_Deepks::cal_gvx(const int nat, const std::vector<torch::Tensor>& gevdm
     return;
 }
 
-void LCAO_Deepks::check_gvx(const int nat) {
+void LCAO_Deepks::check_gvx(const int nat)
+{
     std::stringstream ss;
     std::ofstream ofs_x;
     std::ofstream ofs_y;
@@ -117,7 +112,8 @@ void LCAO_Deepks::check_gvx(const int nat) {
     ofs_y << std::setprecision(12);
     ofs_z << std::setprecision(12);
 
-    for (int ia = 0; ia < nat; ia++) {
+    for (int ia = 0; ia < nat; ia++)
+    {
         ss.str("");
         ss << "gvx_" << ia << ".dat";
         ofs_x.open(ss.str().c_str());
@@ -132,20 +128,16 @@ void LCAO_Deepks::check_gvx(const int nat) {
         ofs_y << std::setprecision(10);
         ofs_z << std::setprecision(10);
 
-        for (int ib = 0; ib < nat; ib++) {
-            for (int inl = 0; inl < inlmax / nat; inl++) {
+        for (int ib = 0; ib < nat; ib++)
+        {
+            for (int inl = 0; inl < inlmax / nat; inl++)
+            {
                 int nm = 2 * inl_l[inl] + 1;
                 {
                     const int ind = ib * inlmax / nat + inl;
-                    ofs_x
-                        << gvx_tensor.index({ia, 0, ib, inl}).item().toDouble()
-                        << " ";
-                    ofs_y
-                        << gvx_tensor.index({ia, 1, ib, inl}).item().toDouble()
-                        << " ";
-                    ofs_z
-                        << gvx_tensor.index({ia, 2, ib, inl}).item().toDouble()
-                        << " ";
+                    ofs_x << gvx_tensor.index({ia, 0, ib, inl}).item().toDouble() << " ";
+                    ofs_y << gvx_tensor.index({ia, 1, ib, inl}).item().toDouble() << " ";
+                    ofs_z << gvx_tensor.index({ia, 2, ib, inl}).item().toDouble() << " ";
                 }
             }
             ofs_x << std::endl;

--- a/source/module_hamilt_lcao/module_deepks/cal_gvx.cpp
+++ b/source/module_hamilt_lcao/module_deepks/cal_gvx.cpp
@@ -16,10 +16,9 @@
 
 // calculates gradient of descriptors from gradient of projected density
 // matrices
-void LCAO_Deepks::cal_gvx(const int nat) {
+void LCAO_Deepks::cal_gvx(const int nat, const std::vector<torch::Tensor>& gevdm) 
+{
     ModuleBase::TITLE("LCAO_Deepks", "cal_gvx");
-    // preconditions
-    this->cal_gvdm(nat);
 
     if (!gdmr_vector.empty()) 
     {
@@ -85,14 +84,14 @@ void LCAO_Deepks::cal_gvx(const int nat) {
 
         // einsum for each inl:
         // gdmr_vector : b:nat(derivative) * x:3 * a:inl(projector) * m:nm *
-        // n:nm gevdm_vector : a:inl * v:nm (descriptor) * m:nm (pdm, dim1) *
+        // n:nm gevdm : a:inl * v:nm (descriptor) * m:nm (pdm, dim1) *
         // n:nm (pdm, dim2) gvx_vector : b:nat(derivative) * x:3 *
         // a:inl(projector) * m:nm(descriptor)
         std::vector<torch::Tensor> gvx_vector;
         for (int nl = 0; nl < nlmax; ++nl) {
             gvx_vector.push_back(
                 at::einsum("bxamn, avmn->bxav",
-                           {this->gdmr_vector[nl], this->gevdm_vector[nl]}));
+                           {this->gdmr_vector[nl], gevdm[nl]}));
         }
 
         // cat nv-> \sum_nl(nv) = \sum_nl(nm_nl)=des_per_atom

--- a/source/module_hamilt_lcao/module_deepks/deepks_orbpre.cpp
+++ b/source/module_hamilt_lcao/module_deepks/deepks_orbpre.cpp
@@ -1,10 +1,10 @@
 #ifdef __DEEPKS
 
-/// cal_orbital_precalc : orbital_precalc is usted for training with orbital label,
-///                          which equals gvdm * orbital_pdm_shell,
-///                          orbital_pdm_shell[Inl,nm*nm] = dm_hl * overlap * overlap
+/// cal_orbital_precalc : orbital_precalc is used for training with orbital label,
+///                       which equals gvdm * orbital_pdm,
+///                       orbital_pdm[nks,Inl,nm,nm] = dm_hl * overlap * overlap
 
-#include "LCAO_deepks.h"
+#include "deepks_orbpre.h"
 #include "LCAO_deepks_io.h" // mohan add 2024-07-22
 #include "module_base/blas_connector.h"
 #include "module_base/constants.h"
@@ -13,31 +13,31 @@
 #include "module_hamilt_lcao/module_hcontainer/atom_pair.h"
 #include "module_parameter/parameter.h"
 
-// calculates orbital_precalc[1,NAt,NDscrpt] = gvdm * orbital_pdm_shell;
-// orbital_pdm_shell[Inl,nm*nm] = dm_hl * overlap * overlap;
+// calculates orbital_precalc[nks,NAt,NDscrpt] = gvdm * orbital_pdm;
+// orbital_pdm[nks,Inl,nm,nm] = dm_hl * overlap * overlap;
 template <typename TK, typename TH>
-void LCAO_Deepks::cal_orbital_precalc(const std::vector<TH>& dm_hl,
-                                      const int lmaxd,
-                                      const int inlmax,
-                                      const int nat,
-                                      const int nks,
-                                      const int* inl_l,
-                                      const std::vector<ModuleBase::Vector3<double>>& kvec_d,
-                                      const std::vector<hamilt::HContainer<double>*> phialpha,
-                                      const ModuleBase::IntArray* inl_index,
-                                      const UnitCell& ucell,
-                                      const LCAO_Orbitals& orb,
-                                      const Parallel_Orbitals& pv,
-                                      const Grid_Driver& GridD)
+void DeePKS_domain::cal_orbital_precalc(const std::vector<TH>& dm_hl,
+                                        const int lmaxd,
+                                        const int inlmax,
+                                        const int nat,
+                                        const int nks,
+                                        const int* inl_l,
+                                        const std::vector<ModuleBase::Vector3<double>>& kvec_d,
+                                        const std::vector<hamilt::HContainer<double>*> phialpha,
+                                        const std::vector<torch::Tensor> gevdm,
+                                        const ModuleBase::IntArray* inl_index,
+                                        const UnitCell& ucell,
+                                        const LCAO_Orbitals& orb,
+                                        const Parallel_Orbitals& pv,
+                                        const Grid_Driver& GridD,
+                                        torch::Tensor& orbital_precalc)
 {
-    ModuleBase::TITLE("LCAO_Deepks", "cal_orbital_precalc");
-    ModuleBase::timer::tick("LCAO_Deepks", "calc_orbital_precalc");
-
-    this->cal_gvdm(nat);
+    ModuleBase::TITLE("DeePKS_domain", "cal_orbital_precalc");
+    ModuleBase::timer::tick("DeePKS_domain", "calc_orbital_precalc");
 
     const double Rcut_Alpha = orb.Alpha[0].getRcut();
 
-    this->init_orbital_pdm_shell(nks);
+    torch::Tensor orbital_pdm = torch::zeros({nks, inlmax, (2 * lmaxd + 1) , (2 * lmaxd + 1)}, torch::dtype(torch::kFloat64));
 
     for (int T0 = 0; T0 < ucell.ntype; T0++)
     {
@@ -256,7 +256,8 @@ void LCAO_Deepks::cal_orbital_precalc(const std::vector<TH>& dm_hl,
 
                 for (int ik = 0; ik < nks; ik++)
                 {
-                    // do dot of g_1dmt and s_1t to get orbital_pdm_shell
+                    // do dot of g_1dmt and s_1t to get orbital_pdm
+                    
                     const double* p_g1dmt = g_1dmt.data() + ik * row_size;
 
                     int ib = 0, index = 0, inc = 1;
@@ -272,7 +273,7 @@ void LCAO_Deepks::cal_orbital_precalc(const std::vector<TH>& dm_hl,
                             {
                                 for (int m2 = 0; m2 < nm; ++m2) // m1 = 1 for s, 3 for p, 5 for d
                                 {
-                                    orbital_pdm_shell[ik][inl][m1 * nm + m2]
+                                    orbital_pdm[ik][inl][m1][m2]
                                         += ddot_(&row_size,
                                                  p_g1dmt + index * row_size * nks,
                                                  &inc,
@@ -293,17 +294,17 @@ void LCAO_Deepks::cal_orbital_precalc(const std::vector<TH>& dm_hl,
     {
         for (int inl = 0; inl < inlmax; inl++)
         {
-            Parallel_Reduce::reduce_all(this->orbital_pdm_shell[iks][inl],
+            auto tensor_slice = orbital_pdm[iks][inl];
+            Parallel_Reduce::reduce_all(tensor_slice.data_ptr<double>(),
                                         (2 * lmaxd + 1) * (2 * lmaxd + 1));
         }
     }
 #endif
 
-    // transfer orbital_pdm_shell to orbital_pdm_shell_vector
-
+    // transfer orbital_pdm [nks,inl,nm,nm] to orbital_pdm_vector [nl,[nks,nat,nm,nm]]
     int nlmax = inlmax / nat;
 
-    std::vector<torch::Tensor> orbital_pdm_shell_vector;
+    std::vector<torch::Tensor> orbital_pdm_vector;
     for (int nl = 0; nl < nlmax; ++nl)
     {
         std::vector<torch::Tensor> kammv;
@@ -320,7 +321,7 @@ void LCAO_Deepks::cal_orbital_precalc(const std::vector<TH>& dm_hl,
                 {
                     for (int m2 = 0; m2 < nm; ++m2) // m1 = 1 for s, 3 for p, 5 for d
                     {
-                        mmv.push_back(this->orbital_pdm_shell[iks][inl][m1 * nm + m2]);
+                        mmv.push_back(orbital_pdm[iks][inl][m1][m2].item<double>());
                     }
                 }
                 torch::Tensor mm
@@ -332,26 +333,25 @@ void LCAO_Deepks::cal_orbital_precalc(const std::vector<TH>& dm_hl,
             kammv.push_back(amm);
         }
         torch::Tensor kamm = torch::stack(kammv, 0);
-        orbital_pdm_shell_vector.push_back(kamm);
+        orbital_pdm_vector.push_back(kamm);
     }
 
-    assert(orbital_pdm_shell_vector.size() == nlmax);
+    assert(orbital_pdm_vector.size() == nlmax);
 
     // einsum for each nl:
     std::vector<torch::Tensor> orbital_precalc_vector;
     for (int nl = 0; nl < nlmax; ++nl)
     {
         orbital_precalc_vector.push_back(
-            at::einsum("kamn, avmn->kav", {orbital_pdm_shell_vector[nl], this->gevdm_vector[nl]}));
+            at::einsum("kamn, avmn->kav", {orbital_pdm_vector[nl], gevdm[nl]}));
     }
 
-    this->orbital_precalc_tensor = torch::cat(orbital_precalc_vector, -1);
-    this->del_orbital_pdm_shell(nks);
+    orbital_precalc = torch::cat(orbital_precalc_vector, -1);
     ModuleBase::timer::tick("LCAO_Deepks", "calc_orbital_precalc");
     return;
 }
 
-template void LCAO_Deepks::cal_orbital_precalc<double, ModuleBase::matrix>(
+template void DeePKS_domain::cal_orbital_precalc<double, ModuleBase::matrix>(
     const std::vector<ModuleBase::matrix>& dm_hl,
     const int lmaxd,
     const int inlmax,
@@ -360,13 +360,15 @@ template void LCAO_Deepks::cal_orbital_precalc<double, ModuleBase::matrix>(
     const int* inl_l,
     const std::vector<ModuleBase::Vector3<double>>& kvec_d,
     const std::vector<hamilt::HContainer<double>*> phialpha,
+    const std::vector<torch::Tensor> gevdm,
     const ModuleBase::IntArray* inl_index,
     const UnitCell& ucell,
     const LCAO_Orbitals& orb,
     const Parallel_Orbitals& pv,
-    const Grid_Driver& GridD);
+    const Grid_Driver& GridD,
+    torch::Tensor& orbital_precalc);
 
-template void LCAO_Deepks::cal_orbital_precalc<std::complex<double>, ModuleBase::ComplexMatrix>(
+template void DeePKS_domain::cal_orbital_precalc<std::complex<double>, ModuleBase::ComplexMatrix>(
     const std::vector<ModuleBase::ComplexMatrix>& dm_hl,
     const int lmaxd,
     const int inlmax,
@@ -375,9 +377,11 @@ template void LCAO_Deepks::cal_orbital_precalc<std::complex<double>, ModuleBase:
     const int* inl_l,
     const std::vector<ModuleBase::Vector3<double>>& kvec_d,
     const std::vector<hamilt::HContainer<double>*> phialpha,
+    const std::vector<torch::Tensor> gevdm,
     const ModuleBase::IntArray* inl_index,
     const UnitCell& ucell,
     const LCAO_Orbitals& orb,
     const Parallel_Orbitals& pv,
-    const Grid_Driver& GridD);
+    const Grid_Driver& GridD,
+    torch::Tensor& orbital_precalc);
 #endif

--- a/source/module_hamilt_lcao/module_deepks/deepks_orbpre.cpp
+++ b/source/module_hamilt_lcao/module_deepks/deepks_orbpre.cpp
@@ -5,6 +5,7 @@
 ///                       orbital_pdm[nks,Inl,nm,nm] = dm_hl * overlap * overlap
 
 #include "deepks_orbpre.h"
+
 #include "LCAO_deepks_io.h" // mohan add 2024-07-22
 #include "module_base/blas_connector.h"
 #include "module_base/constants.h"
@@ -37,7 +38,8 @@ void DeePKS_domain::cal_orbital_precalc(const std::vector<TH>& dm_hl,
 
     const double Rcut_Alpha = orb.Alpha[0].getRcut();
 
-    torch::Tensor orbital_pdm = torch::zeros({nks, inlmax, (2 * lmaxd + 1) , (2 * lmaxd + 1)}, torch::dtype(torch::kFloat64));
+    torch::Tensor orbital_pdm
+        = torch::zeros({nks, inlmax, (2 * lmaxd + 1), (2 * lmaxd + 1)}, torch::dtype(torch::kFloat64));
 
     for (int T0 = 0; T0 < ucell.ntype; T0++)
     {
@@ -257,7 +259,7 @@ void DeePKS_domain::cal_orbital_precalc(const std::vector<TH>& dm_hl,
                 for (int ik = 0; ik < nks; ik++)
                 {
                     // do dot of g_1dmt and s_1t to get orbital_pdm
-                    
+
                     const double* p_g1dmt = g_1dmt.data() + ik * row_size;
 
                     int ib = 0, index = 0, inc = 1;
@@ -273,12 +275,11 @@ void DeePKS_domain::cal_orbital_precalc(const std::vector<TH>& dm_hl,
                             {
                                 for (int m2 = 0; m2 < nm; ++m2) // m1 = 1 for s, 3 for p, 5 for d
                                 {
-                                    orbital_pdm[ik][inl][m1][m2]
-                                        += ddot_(&row_size,
-                                                 p_g1dmt + index * row_size * nks,
-                                                 &inc,
-                                                 s_1t.data() + index * row_size,
-                                                 &inc);
+                                    orbital_pdm[ik][inl][m1][m2] += ddot_(&row_size,
+                                                                          p_g1dmt + index * row_size * nks,
+                                                                          &inc,
+                                                                          s_1t.data() + index * row_size,
+                                                                          &inc);
                                     index++;
                                 }
                             }
@@ -295,8 +296,7 @@ void DeePKS_domain::cal_orbital_precalc(const std::vector<TH>& dm_hl,
         for (int inl = 0; inl < inlmax; inl++)
         {
             auto tensor_slice = orbital_pdm[iks][inl];
-            Parallel_Reduce::reduce_all(tensor_slice.data_ptr<double>(),
-                                        (2 * lmaxd + 1) * (2 * lmaxd + 1));
+            Parallel_Reduce::reduce_all(tensor_slice.data_ptr<double>(), (2 * lmaxd + 1) * (2 * lmaxd + 1));
         }
     }
 #endif
@@ -342,8 +342,7 @@ void DeePKS_domain::cal_orbital_precalc(const std::vector<TH>& dm_hl,
     std::vector<torch::Tensor> orbital_precalc_vector;
     for (int nl = 0; nl < nlmax; ++nl)
     {
-        orbital_precalc_vector.push_back(
-            at::einsum("kamn, avmn->kav", {orbital_pdm_vector[nl], gevdm[nl]}));
+        orbital_precalc_vector.push_back(at::einsum("kamn, avmn->kav", {orbital_pdm_vector[nl], gevdm[nl]}));
     }
 
     orbital_precalc = torch::cat(orbital_precalc_vector, -1);

--- a/source/module_hamilt_lcao/module_deepks/deepks_orbpre.h
+++ b/source/module_hamilt_lcao/module_deepks/deepks_orbpre.h
@@ -1,5 +1,5 @@
-#ifndef DEEPKS_ORBPRE_H 
-#define DEEPKS_ORBPRE_H 
+#ifndef DEEPKS_ORBPRE_H
+#define DEEPKS_ORBPRE_H
 
 #ifdef __DEEPKS
 
@@ -18,12 +18,12 @@
 
 namespace DeePKS_domain
 {
-    //------------------------
-    // deepks_orbpre.cpp
-    //------------------------
+//------------------------
+// deepks_orbpre.cpp
+//------------------------
 
-    // This file contains one subroutine for calculating orbital_precalc,
-    // which is defind as gvdm * dm_hl * overlap * overlap
+// This file contains one subroutine for calculating orbital_precalc,
+// which is defind as gvdm * dm_hl * overlap * overlap
 
 template <typename TK, typename TH>
 void cal_orbital_precalc(const std::vector<TH>& dm_hl,
@@ -41,6 +41,6 @@ void cal_orbital_precalc(const std::vector<TH>& dm_hl,
                          const Parallel_Orbitals& pv,
                          const Grid_Driver& GridD,
                          torch::Tensor& orbital_precalc);
-}
+} // namespace DeePKS_domain
 #endif
 #endif

--- a/source/module_hamilt_lcao/module_deepks/deepks_orbpre.h
+++ b/source/module_hamilt_lcao/module_deepks/deepks_orbpre.h
@@ -1,0 +1,46 @@
+#ifndef DEEPKS_ORBPRE_H 
+#define DEEPKS_ORBPRE_H 
+
+#ifdef __DEEPKS
+
+#include "module_base/complexmatrix.h"
+#include "module_base/intarray.h"
+#include "module_base/matrix.h"
+#include "module_base/timer.h"
+#include "module_basis/module_ao/parallel_orbitals.h"
+#include "module_basis/module_nao/two_center_integrator.h"
+#include "module_cell/module_neighbor/sltk_grid_driver.h"
+#include "module_elecstate/module_dm/density_matrix.h"
+#include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
+
+#include <torch/script.h>
+#include <torch/torch.h>
+
+namespace DeePKS_domain
+{
+    //------------------------
+    // deepks_orbpre.cpp
+    //------------------------
+
+    // This file contains one subroutine for calculating orbital_precalc,
+    // which is defind as gvdm * dm_hl * overlap * overlap
+
+template <typename TK, typename TH>
+void cal_orbital_precalc(const std::vector<TH>& dm_hl,
+                         const int lmaxd,
+                         const int inlmax,
+                         const int nat,
+                         const int nks,
+                         const int* inl_l,
+                         const std::vector<ModuleBase::Vector3<double>>& kvec_d,
+                         const std::vector<hamilt::HContainer<double>*> phialpha,
+                         const std::vector<torch::Tensor> gevdm,
+                         const ModuleBase::IntArray* inl_index,
+                         const UnitCell& ucell,
+                         const LCAO_Orbitals& orb,
+                         const Parallel_Orbitals& pv,
+                         const Grid_Driver& GridD,
+                         torch::Tensor& orbital_precalc);
+}
+#endif
+#endif

--- a/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test.cpp
+++ b/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test.cpp
@@ -1,8 +1,9 @@
 #include "LCAO_deepks_test.h"
 #define private public
 #include "module_parameter/parameter.h"
-#include <torch/torch.h>
+
 #include <torch/script.h>
+#include <torch/torch.h>
 #undef private
 namespace Test_Deepks
 {

--- a/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test.cpp
+++ b/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test.cpp
@@ -1,6 +1,8 @@
 #include "LCAO_deepks_test.h"
 #define private public
 #include "module_parameter/parameter.h"
+#include <torch/torch.h>
+#include <torch/script.h>
 #undef private
 namespace Test_Deepks
 {
@@ -170,7 +172,9 @@ void test_deepks::check_descriptor()
 
 void test_deepks::check_gvx()
 {
-    this->ld.cal_gvx(ucell.nat);
+    std::vector<torch::Tensor> gevdm;
+    this->ld.cal_gevdm(ucell.nat, gevdm);
+    this->ld.cal_gvx(ucell.nat, gevdm);
     this->ld.check_gvx(ucell.nat);
 
     for (int ia = 0; ia < ucell.nat; ia++)

--- a/source/module_hamilt_lcao/module_deepks/v_delta_precalc.cpp
+++ b/source/module_hamilt_lcao/module_deepks/v_delta_precalc.cpp
@@ -30,7 +30,8 @@ void LCAO_Deepks::cal_v_delta_precalc(const int nlocal,
     // timeval t_start;
     // gettimeofday(&t_start,NULL);
 
-    this->cal_gvdm(nat);
+    std::vector<torch::Tensor> gevdm;
+    this->cal_gevdm(nat, gevdm);
     const double Rcut_Alpha = orb.Alpha[0].getRcut();
     this->init_v_delta_pdm_shell(nks, nlocal);
 
@@ -266,13 +267,13 @@ void LCAO_Deepks::cal_v_delta_precalc(const int nlocal,
         if constexpr (std::is_same<TK, double>::value)
         {
             v_delta_precalc_vector.push_back(
-                at::einsum("kxyamn, avmn->kxyav", {v_delta_pdm_shell_vector[nl], this->gevdm_vector[nl]}));
+                at::einsum("kxyamn, avmn->kxyav", {v_delta_pdm_shell_vector[nl], gevdm[nl]}));
         }
         else
         {
-            torch::Tensor gevdm_vector_complex = this->gevdm_vector[nl].to(torch::kComplexDouble);
+            torch::Tensor gevdm_complex = gevdm[nl].to(torch::kComplexDouble);
             v_delta_precalc_vector.push_back(
-                at::einsum("kxyamn, avmn->kxyav", {v_delta_pdm_shell_vector[nl], gevdm_vector_complex}));
+                at::einsum("kxyamn, avmn->kxyav", {v_delta_pdm_shell_vector[nl], gevdm_complex}));
         }
     }
 


### PR DESCRIPTION
### What's changed?
- Move `cal_orbital_precalc()` from LCAO_Deepks to DeePKS_domain to remove the dependence of GlobalC. Remove `orbital_pdm_shell` variable. Change orbital_precalc.cpp into deepks_orbpre.cpp with corresponding head file.
- Change `cal_gvdm()` into `cal_gevdm()` and remove the dependence of variable gvdm_tensor. Change some other related functions from directly call `cal_gevdm()` to accept input variable `gevdm`.
- Remove the double pointer variable `pdm` and rename the `pdm_tensor` to `pdm`.
