### PR TITLE
Fix: Fix the Segmentation fault caused by zero atom case with LCAO basis.

### DIFF
--- a/source/module_cell/module_neighbor/sltk_grid.cpp
+++ b/source/module_cell/module_neighbor/sltk_grid.cpp
@@ -152,12 +152,19 @@ void Grid::setMemberVariables(std::ofstream& ofs_in, //  output data to ofs
     this->clear_atoms();
 
     // random selection, in order to estimate again.
-    this->x_min = ucell.atoms[0].tau[0].x;
-    this->y_min = ucell.atoms[0].tau[0].y;
-    this->z_min = ucell.atoms[0].tau[0].z;
-    this->x_max = ucell.atoms[0].tau[0].x;
-    this->y_max = ucell.atoms[0].tau[0].y;
-    this->z_max = ucell.atoms[0].tau[0].z;
+    for (int it = 0; it < ucell.ntype; it++)
+    {
+        if (ucell.atoms[it].na > 0)
+        {
+            this->x_min = ucell.atoms[it].tau[0].x;
+            this->y_min = ucell.atoms[it].tau[0].y;
+            this->z_min = ucell.atoms[it].tau[0].z;
+            this->x_max = ucell.atoms[it].tau[0].x;
+            this->y_max = ucell.atoms[it].tau[0].y;
+            this->z_max = ucell.atoms[it].tau[0].z;
+            break;
+        }
+    }
 
     ModuleBase::Vector3<double> vec1(ucell.latvec.e11, ucell.latvec.e12, ucell.latvec.e13);
     ModuleBase::Vector3<double> vec2(ucell.latvec.e21, ucell.latvec.e22, ucell.latvec.e23);

--- a/tests/integrate/223_NO_zero_atom/INPUT
+++ b/tests/integrate/223_NO_zero_atom/INPUT
@@ -1,0 +1,27 @@
+INPUT_PARAMETERS
+#Parameters (1.General)
+suffix			autotest
+calculation     	scf
+
+nbands			6
+symmetry		0
+pseudo_dir      	../../PP_ORB/
+orbital_dir     	../../PP_ORB/
+
+#Parameters (2.Iteration)
+ecutwfc			20
+
+#Parameters (3.Basis)
+basis_type		lcao
+
+#Parameters (4.Smearing)
+smearing_method		gauss
+smearing_sigma		0.0002
+
+#Parameters (5.Mixing)
+mixing_type		broyden
+mixing_beta		0.7
+cal_force		1
+test_force		1
+cal_stress		1
+test_stress		1

--- a/tests/integrate/223_NO_zero_atom/KPT
+++ b/tests/integrate/223_NO_zero_atom/KPT
@@ -1,0 +1,4 @@
+K_POINTS
+0
+Gamma
+2 2 2 0 0 0

--- a/tests/integrate/223_NO_zero_atom/STRU
+++ b/tests/integrate/223_NO_zero_atom/STRU
@@ -1,0 +1,27 @@
+ATOMIC_SPECIES
+Al 13 Al_ONCV_PBE-1.0.upf upf201
+Si 14 Si_ONCV_PBE-1.0.upf upf201
+
+NUMERICAL_ORBITAL
+Al_gga_8au_100Ry_4s4p1d.orb
+Si_gga_8au_100Ry_2s2p1d.orb
+
+LATTICE_CONSTANT
+10.2  // add lattice constant
+
+LATTICE_VECTORS
+0.5 0.5 0.0
+0.5 0.0 0.5
+0.0 0.5 0.5
+
+ATOMIC_POSITIONS
+Direct 
+
+Al
+0.0
+0
+Si      // Element type
+0.0     // magnetism
+2
+0.00 0.00 0.00 1 1 1
+0.25 0.25 0.25 1 1 1

--- a/tests/integrate/223_NO_zero_atom/jd
+++ b/tests/integrate/223_NO_zero_atom/jd
@@ -1,0 +1,1 @@
+test calculation when atom number is zero with LCAO.

--- a/tests/integrate/223_NO_zero_atom/result.ref
+++ b/tests/integrate/223_NO_zero_atom/result.ref
@@ -1,0 +1,5 @@
+etotref -211.4490868003635171
+etotperatomref -105.7245434002
+totalforceref 0.000000
+totalstressref 366.791415
+totaltimeref 2.69

--- a/tests/integrate/CASES_CPU.txt
+++ b/tests/integrate/CASES_CPU.txt
@@ -188,6 +188,7 @@
 #220_NO_KP_MD_MSST_level2
 220_NO_KP_MD_NVT
 220_NO_KP_MD_wfc_out
+223_NO_zero_atom
 #230_NO_KP_MD_TD
 240_NO_KP_15_SO
 240_NO_KP_15_SO_average


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #5711 

### Unit Tests and/or Case Tests for my changes
- An integrate test 223_NO_zero_atom has been added.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
