### PR TITLE
Tests: add checks for opening data files by hsolver tests

### DIFF
--- a/source/module_hsolver/test/diago_bpcg_test.cpp
+++ b/source/module_hsolver/test/diago_bpcg_test.cpp
@@ -248,7 +248,14 @@ TEST(DiagoBPCGTest, readH)
     // read Hamilt matrix from file data-H
     std::vector<std::complex<double>> hm;
     std::ifstream ifs;
-    ifs.open("H-KPoints-Si64.dat");
+    std::string filename = "H-KPoints-Si64.dat";
+    ifs.open(filename);
+    // open file and check status
+    if (!ifs.is_open())
+    {
+        std::cout << "Error opening file " << filename << std::endl;
+        exit(1);
+    }
     DIAGOTEST::readh(ifs, hm);
     ifs.close();
     int dim = DIAGOTEST::npw;

--- a/source/module_hsolver/test/diago_bpcg_test.cpp
+++ b/source/module_hsolver/test/diago_bpcg_test.cpp
@@ -46,8 +46,9 @@ void lapackEigen(int &npw, std::vector<std::complex<double>> &hm, double *e, boo
     char tmp_c1 = 'V', tmp_c2 = 'U';
     zheev_(&tmp_c1, &tmp_c2, &npw, hm.data(), &npw, e, work2, &lwork, rwork, &info);
     end = clock();
-    if (outtime)
+    if (outtime) {
         std::cout << "Lapack Run time: " << (double)(end - start) / CLOCKS_PER_SEC << " S" << std::endl;
+}
     delete[] rwork;
     delete[] work2;
 }
@@ -78,7 +79,8 @@ class DiagoBPCGPrepare
         // calculate eigenvalues by LAPACK;
         double *e_lapack = new double[npw];
         auto ev = DIAGOTEST::hmatrix;
-        if(mypnum == 0)  lapackEigen(npw, ev, e_lapack, false);
+        if(mypnum == 0) {  lapackEigen(npw, ev, e_lapack, false);
+}
         // initial guess of psi by perturbing lapack psi
         ModuleBase::ComplexMatrix psiguess(nband, npw);
         std::default_random_engine p(1);
@@ -287,7 +289,8 @@ int main(int argc, char **argv)
 
     testing::InitGoogleTest(&argc, argv);
     ::testing::TestEventListeners &listeners = ::testing::UnitTest::GetInstance()->listeners();
-    if (myrank != 0) delete listeners.Release(listeners.default_result_printer());
+    if (myrank != 0) { delete listeners.Release(listeners.default_result_printer());
+}
 
     int result = RUN_ALL_TESTS();
     if (myrank == 0 && result != 0)

--- a/source/module_hsolver/test/diago_cg_float_test.cpp
+++ b/source/module_hsolver/test/diago_cg_float_test.cpp
@@ -314,7 +314,14 @@ TEST(DiagoCGFloatTest, readH)
     // read Hamilt matrix from file data-H
     std::vector<std::complex<float>> hm;
     std::ifstream ifs;
-    ifs.open("H-KPoints-Si64.dat");
+    std::string filename = "H-KPoints-Si64.dat";
+    // open file and check status
+    ifs.open(filename);
+    if (!ifs.is_open())
+    {
+        std::cout << "Error opening file " << filename << std::endl;
+        exit(1);
+    }
     DIAGOTEST::readh(ifs, hm);
     ifs.close();
     int dim = DIAGOTEST::npw;

--- a/source/module_hsolver/test/diago_cg_real_test.cpp
+++ b/source/module_hsolver/test/diago_cg_real_test.cpp
@@ -289,7 +289,14 @@ TEST(DiagoCGTest, readH)
     // read Hamilt matrix from file data-H
     std::vector<double> hm;
     std::ifstream ifs;
-    ifs.open("H-GammaOnly-Si64.dat");
+    std::string filename = "H-GammaOnly-Si64.dat";
+    ifs.open(filename);
+    // open file and check status
+    if (!ifs.is_open())
+    {
+        std::cout << "Error opening file " << filename << std::endl;
+        exit(1);
+    }
     DIAGOTEST::readh(ifs, hm);
     ifs.close();
     int dim = DIAGOTEST::npw;

--- a/source/module_hsolver/test/diago_cg_test.cpp
+++ b/source/module_hsolver/test/diago_cg_test.cpp
@@ -309,7 +309,14 @@ TEST(DiagoCGTest, readH)
     // read Hamilt matrix from file data-H
     std::vector<std::complex<double>> hm;
     std::ifstream ifs;
-    ifs.open("H-KPoints-Si64.dat");
+    std::string filename = "H-KPoints-Si64.dat";
+    ifs.open(filename);
+    // open file and check status
+    if (!ifs.is_open())
+    {
+        std::cout << "Error opening file " << filename << std::endl;
+        exit(1);
+    }
     DIAGOTEST::readh(ifs, hm);
     ifs.close();
     int dim = DIAGOTEST::npw;

--- a/source/module_hsolver/test/diago_david_float_test.cpp
+++ b/source/module_hsolver/test/diago_david_float_test.cpp
@@ -196,7 +196,15 @@ INSTANTIATE_TEST_SUITE_P(VerifyDiag,DiagoDavTest,::testing::Values(
 TEST(DiagoDavRealSystemTest,dataH)
 {
 	std::vector<std::complex<float>> hmatrix;
-	std::ifstream ifs("H-KPoints-Si64.dat");
+	std::ifstream ifs;
+	std::string filename = "H-KPoints-Si64.dat";
+	ifs.open(filename);
+    // open file and check status
+    if (!ifs.is_open())
+    {
+        std::cout << "Error opening file " << filename << std::endl;
+        exit(1);
+    }
 	DIAGOTEST::readh(ifs,hmatrix);
 	ifs.close();
 	DIAGOTEST::hmatrix_f = hmatrix;

--- a/source/module_hsolver/test/diago_david_real_test.cpp
+++ b/source/module_hsolver/test/diago_david_real_test.cpp
@@ -194,7 +194,15 @@ INSTANTIATE_TEST_SUITE_P(VerifyDiag, DiagoDavTest, ::testing::Values(
 TEST(DiagoDavRealSystemTest, dataH)
 {
     std::vector<double> hmatrix;
-    std::ifstream ifs("H-GammaOnly-Si64.dat");
+    std::ifstream ifs;
+    std::string filename = "H-GammaOnly-Si64.dat";
+    ifs.open(filename);
+    // open file and check status
+    if (!ifs.is_open())
+    {
+        std::cout << "Error opening file " << filename << std::endl;
+        exit(1);
+    }
     DIAGOTEST::readh(ifs, hmatrix);
     ifs.close();
     DIAGOTEST::hmatrix_d = hmatrix;

--- a/source/module_hsolver/test/diago_david_test.cpp
+++ b/source/module_hsolver/test/diago_david_test.cpp
@@ -198,7 +198,15 @@ INSTANTIATE_TEST_SUITE_P(VerifyDiag,DiagoDavTest,::testing::Values(
 TEST(DiagoDavRealSystemTest, dataH)
 {
 	std::vector<std::complex<double>> hmatrix;
-	std::ifstream ifs("H-KPoints-Si64.dat");
+	std::ifstream ifs;
+	std::string filename = "H-KPoints-Si64.dat";
+	ifs.open(filename);
+    // open file and check status
+    if (!ifs.is_open())
+    {
+        std::cout << "Error opening file " << filename << std::endl;
+        exit(1);
+    }
 	DIAGOTEST::readh(ifs,hmatrix);
 	ifs.close();
 	DIAGOTEST::hmatrix = hmatrix;


### PR DESCRIPTION
### Unit Tests and/or Case Tests for my changes
- Add checks for hsolver tests so that it will pop a warning and quit if data files cannot be opened normally. Current test will stuck if the data file required by `ifstream` does not exist in working directory.
