### PR TITLE
[Fix] Fix the issue that single precision caculation is not runable on CUDA version

### DIFF
--- a/source/module_basis/module_pw/module_fft/fft_bundle.cpp
+++ b/source/module_basis/module_pw/module_fft/fft_bundle.cpp
@@ -45,8 +45,15 @@ void FFT_Bundle::initfft(int nx_in,
 
     if (this->precision=="single")
     {
-        #ifndef __ENABLE_FLOAT_FFTW
-        float_define = false;
+        #if not defined (__ENABLE_FLOAT_FFTW)
+        if (this->device == "cpu"){
+            float_define = false;
+        }
+        #endif
+        #if defined(__CUDA) || defined (__ROCM)
+        if (this->device == "gpu"){
+            float_flag = float_define;
+        }
         #endif
         float_flag = float_define;
         double_flag = true;


### PR DESCRIPTION
Fix this issue https://github.com/deepmodeling/abacus-develop/issues/5679

Important!!!!!!!!!!!!!!!!!:

This only fix the problem that  single precision caculation is not runable on CUDA version. This is caused by a wrong macro definition in new fft, which caused the GPU single precision FFT not initializing at all.

But!!!!!!!!!!!!!!!!!!
According to this issue https://github.com/deepmodeling/abacus-develop/issues/5811
Current PW version does not support single precision at all. This is caused by some other incorrect codes. This pull request cannot fix this problem. If you try using GPU single precision caculation now, it will tell you that cusolver cannot invert matrix. This is the can problem as the https://github.com/deepmodeling/abacus-develop/issues/5811 problem. Before this pull request, ABACUS can not be launched correctly at all.