### PR TITLE
Refactor: Remove LCAO_Deepks from GlobalC.

### DIFF
--- a/source/module_elecstate/elecstate.h
+++ b/source/module_elecstate/elecstate.h
@@ -1,10 +1,9 @@
 #ifndef ELECSTATE_H
 #define ELECSTATE_H
-#include "module_parameter/parameter.h"
-
 #include "fp_energy.h"
 #include "module_cell/klist.h"
 #include "module_elecstate/module_charge/charge.h"
+#include "module_parameter/parameter.h"
 #include "module_psi/psi.h"
 #include "potentials/potential_new.h"
 
@@ -14,10 +13,10 @@ namespace elecstate
 class ElecState
 {
   public:
-    ElecState(){}
-    ElecState(Charge* charge_in,
-              ModulePW::PW_Basis* rhopw_in,
-              ModulePW::PW_Basis_Big* bigpw_in)
+    ElecState()
+    {
+    }
+    ElecState(Charge* charge_in, ModulePW::PW_Basis* rhopw_in, ModulePW::PW_Basis_Big* bigpw_in)
     {
         this->charge = charge_in;
         this->charge->set_rhopw(rhopw_in);
@@ -26,20 +25,20 @@ class ElecState
     }
     virtual ~ElecState()
     {
-        if(this->pot != nullptr) 
+        if (this->pot != nullptr)
         {
             delete this->pot;
             this->pot = nullptr;
         }
     }
-    void init_ks(Charge *chg_in, // pointer for class Charge
-                      const K_Vectors *klist_in,
-                      int nk_in, // number of k points
-                      ModulePW::PW_Basis* rhopw_in,
-                      const ModulePW::PW_Basis_Big* bigpw_in); 
+    void init_ks(Charge* chg_in, // pointer for class Charge
+                 const K_Vectors* klist_in,
+                 int nk_in, // number of k points
+                 ModulePW::PW_Basis* rhopw_in,
+                 const ModulePW::PW_Basis_Big* bigpw_in);
 
     // return current electronic density rho, as a input for constructing Hamiltonian
-    virtual const double *getRho(int spin) const;
+    virtual const double* getRho(int spin) const;
 
     // calculate electronic charge density on grid points or density matrix in real space
     // the consequence charge density rho saved into rho_out, preparing for charge mixing.
@@ -78,17 +77,14 @@ class ElecState
 
     // use occupied weights from INPUT and skip calculate_weights
     // mohan updated on 2024-06-08
-	void fixed_weights(
-			const std::vector<double>& ocp_kb,
-			const int &nbands,
-			const double &nelec);
+    void fixed_weights(const std::vector<double>& ocp_kb, const int& nbands, const double& nelec);
 
-    // if nupdown is not 0(TWO_EFERMI case), 
-    // nelec_spin will be fixed and weights will be constrained 
+    // if nupdown is not 0(TWO_EFERMI case),
+    // nelec_spin will be fixed and weights will be constrained
     void init_nelec_spin();
-    //used to record number of electrons per spin index
-    //for NSPIN=2, it will record number of spin up and number of spin down
-    //for NSPIN=4, it will record total number, magnetization for x, y, z direction  
+    // used to record number of electrons per spin index
+    // for NSPIN=2, it will record number of spin up and number of spin down
+    // for NSPIN=4, it will record total number, magnetization for x, y, z direction
     std::vector<double> nelec_spin;
 
     virtual void print_psi(const psi::Psi<double>& psi_in, const int istep = -1)
@@ -102,7 +98,7 @@ class ElecState
 
     /**
      * @brief Init rho_core, init rho, renormalize rho, init pot
-     * 
+     *
      * @param istep i-th step
      * @param ucell unit cell
      * @param strucfac structure factor
@@ -142,7 +138,7 @@ class ElecState
     void set_exx(const std::complex<double>& Eexx);
 #endif //__LCAO
 #endif //__EXX
- 
+
     double get_hartree_energy();
     double get_etot_efield();
     double get_etot_gatefield();
@@ -150,20 +146,16 @@ class ElecState
     double get_solvent_model_Ael();
     double get_solvent_model_Acav();
 
-    virtual double get_spin_constrain_energy() {
+    virtual double get_spin_constrain_energy()
+    {
         return 0.0;
     }
 
     double get_dftu_energy();
     double get_local_pp_energy();
 
-#ifdef __DEEPKS
-    double get_deepks_E_delta();
-    double get_deepks_E_delta_band();
-#endif
-
-    fenergy f_en;                                  ///< energies contribute to the total free energy
-    efermi eferm;                                  ///< fermi energies
+    fenergy f_en; ///< energies contribute to the total free energy
+    efermi eferm; ///< fermi energies
 
     // below defines the bandgap:
 

--- a/source/module_elecstate/elecstate_energy.cpp
+++ b/source/module_elecstate/elecstate_energy.cpp
@@ -1,10 +1,10 @@
-#include <cmath>
-
 #include "elecstate.h"
 #include "elecstate_getters.h"
 #include "module_base/global_variable.h"
 #include "module_base/parallel_reduce.h"
 #include "module_parameter/parameter.h"
+
+#include <cmath>
 #ifdef USE_PAW
 #include "module_hamilt_general/module_xc/xc_functional.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
@@ -103,10 +103,9 @@ double ElecState::cal_delta_eband(const UnitCell& ucell) const
     const double* v_eff = this->pot->get_effective_v(0);
     const double* v_fixed = this->pot->get_fixed_v();
     const double* v_ofk = nullptr;
-    const bool v_ofk_flag =(get_xc_func_type() == 3 
-                            || get_xc_func_type() == 5);
+    const bool v_ofk_flag = (get_xc_func_type() == 3 || get_xc_func_type() == 5);
 #ifdef USE_PAW
-    if(PARAM.inp.use_paw)
+    if (PARAM.inp.use_paw)
     {
         ModuleBase::matrix v_xc;
         const std::tuple<double, double, ModuleBase::matrix> etxc_vtxc_v
@@ -115,19 +114,19 @@ double ElecState::cal_delta_eband(const UnitCell& ucell) const
 
         for (int ir = 0; ir < this->charge->rhopw->nrxx; ir++)
         {
-            deband_aux -= this->charge->rho[0][ir] * v_xc(0,ir);
+            deband_aux -= this->charge->rho[0][ir] * v_xc(0, ir);
         }
         if (PARAM.inp.nspin == 2)
         {
             for (int ir = 0; ir < this->charge->rhopw->nrxx; ir++)
             {
-                deband_aux -= this->charge->rho[1][ir] * v_xc(1,ir);
+                deband_aux -= this->charge->rho[1][ir] * v_xc(1, ir);
             }
         }
     }
 #endif
 
-    if(!PARAM.inp.use_paw)
+    if (!PARAM.inp.use_paw)
     {
         for (int ir = 0; ir < this->charge->rhopw->nrxx; ir++)
         {
@@ -137,16 +136,16 @@ double ElecState::cal_delta_eband(const UnitCell& ucell) const
         {
             v_ofk = this->pot->get_effective_vofk(0);
             // cause in the get_effective_vofk, the func will return nullptr
-            if(v_ofk==nullptr && this->charge->rhopw->nrxx>0)
+            if (v_ofk == nullptr && this->charge->rhopw->nrxx > 0)
             {
-                ModuleBase::WARNING_QUIT("ElecState::cal_delta_eband","v_ofk is nullptr");
+                ModuleBase::WARNING_QUIT("ElecState::cal_delta_eband", "v_ofk is nullptr");
             }
             for (int ir = 0; ir < this->charge->rhopw->nrxx; ir++)
             {
                 deband_aux -= this->charge->kin_r[0][ir] * v_ofk[ir];
             }
         }
-        
+
         if (PARAM.inp.nspin == 2)
         {
             v_eff = this->pot->get_effective_v(1);
@@ -157,9 +156,9 @@ double ElecState::cal_delta_eband(const UnitCell& ucell) const
             if (v_ofk_flag)
             {
                 v_ofk = this->pot->get_effective_vofk(1);
-                if(v_ofk==nullptr && this->charge->rhopw->nrxx>0)
+                if (v_ofk == nullptr && this->charge->rhopw->nrxx > 0)
                 {
-                    ModuleBase::WARNING_QUIT("ElecState::cal_delta_eband","v_ofk is nullptr");
+                    ModuleBase::WARNING_QUIT("ElecState::cal_delta_eband", "v_ofk is nullptr");
                 }
                 for (int ir = 0; ir < this->charge->rhopw->nrxx; ir++)
                 {
@@ -219,7 +218,7 @@ double ElecState::cal_delta_escf() const
         if (get_xc_func_type() == 3 || get_xc_func_type() == 5)
         {
             // cause in the get_effective_vofk, the func will return nullptr
-            assert(v_ofk!=nullptr);
+            assert(v_ofk != nullptr);
             descf -= (this->charge->kin_r[0][ir] - this->charge->kin_r_save[0][ir]) * v_ofk[ir];
         }
     }
@@ -278,7 +277,7 @@ void ElecState::cal_converged()
 /**
  * @brief calculate energies
  *
- * @param type: 1 means Harris-Foulkes functinoal; 
+ * @param type: 1 means Harris-Foulkes functinoal;
  * @param type: 2 means Kohn-Sham functional;
  */
 void ElecState::cal_energies(const int type)
@@ -292,7 +291,7 @@ void ElecState::cal_energies(const int type)
     //! energy from gate-field
     this->f_en.gatefield = get_etot_gatefield();
 
-    //! energy from implicit solvation model 
+    //! energy from implicit solvation model
     if (PARAM.inp.imp_sol)
     {
         this->f_en.esol_el = get_solvent_model_Ael();
@@ -305,7 +304,7 @@ void ElecState::cal_energies(const int type)
         this->f_en.escon = get_spin_constrain_energy();
     }
 
-     // energy from DFT+U
+    // energy from DFT+U
     if (PARAM.inp.dft_plus_u)
     {
         this->f_en.edftu = get_dftu_energy();
@@ -313,19 +312,11 @@ void ElecState::cal_energies(const int type)
 
     this->f_en.e_local_pp = get_local_pp_energy();
 
-#ifdef __DEEPKS
-    // energy from deepks
-    if (PARAM.inp.deepks_scf)
-    {
-        this->f_en.edeepks_scf = get_deepks_E_delta() - get_deepks_E_delta_band();
-    }
-#endif
-
     if (type == 1) // Harris-Foulkes functional
     {
         this->f_en.calculate_harris();
     }
-    else if (type == 2)// Kohn-Sham functional
+    else if (type == 2) // Kohn-Sham functional
     {
         this->f_en.calculate_etot();
     }

--- a/source/module_elecstate/elecstate_energy_terms.cpp
+++ b/source/module_elecstate/elecstate_energy_terms.cpp
@@ -3,8 +3,8 @@
 #include "module_elecstate/potentials/efield.h"
 #include "module_elecstate/potentials/gatefield.h"
 #include "module_hamilt_lcao/module_deepks/LCAO_deepks.h"
-#include "module_hamilt_lcao/module_dftu/dftu.h"
 #include "module_hamilt_lcao/module_deltaspin/spin_constrain.h"
+#include "module_hamilt_lcao/module_dftu/dftu.h"
 
 namespace elecstate
 {
@@ -41,25 +41,15 @@ double ElecState::get_dftu_energy()
 
 double ElecState::get_local_pp_energy()
 {
-    double local_pseudopot_energy = 0.;                   // electron-ion interaction energy from local pseudopotential
+    double local_pseudopot_energy = 0.; // electron-ion interaction energy from local pseudopotential
     for (int is = 0; is < PARAM.inp.nspin; ++is)
     {
-        local_pseudopot_energy += BlasConnector::dot(this->charge->rhopw->nrxx, this->pot->get_fixed_v(), 1, this->charge->rho[is], 1)
-                                * this->charge->rhopw->omega / this->charge->rhopw->nxyz;
+        local_pseudopot_energy
+            += BlasConnector::dot(this->charge->rhopw->nrxx, this->pot->get_fixed_v(), 1, this->charge->rho[is], 1)
+               * this->charge->rhopw->omega / this->charge->rhopw->nxyz;
     }
     Parallel_Reduce::reduce_all(local_pseudopot_energy);
     return local_pseudopot_energy;
 }
-
-#ifdef __DEEPKS
-double ElecState::get_deepks_E_delta()
-{
-    return GlobalC::ld.E_delta;
-}
-double ElecState::get_deepks_E_delta_band()
-{
-    return GlobalC::ld.e_delta_band;
-}
-#endif
 
 } // namespace elecstate

--- a/source/module_elecstate/elecstate_print.cpp
+++ b/source/module_elecstate/elecstate_print.cpp
@@ -1,6 +1,5 @@
 #include "elecstate.h"
 #include "elecstate_getters.h"
-#include "module_parameter/parameter.h"
 #include "module_base/formatter.h"
 #include "module_base/global_variable.h"
 #include "module_elecstate/potentials/H_Hartree_pw.h"
@@ -8,6 +7,7 @@
 #include "module_elecstate/potentials/gatefield.h"
 #include "module_hamilt_general/module_xc/xc_functional.h"
 #include "module_hamilt_lcao/module_deepks/LCAO_deepks.h"
+#include "module_parameter/parameter.h"
 #include "occupy.h"
 namespace elecstate
 {
@@ -311,9 +311,10 @@ void ElecState::print_etot(const Magnetism& magnet,
 
     GlobalV::ofs_running << "\n Density error is " << scf_thr << std::endl;
 
-    if (PARAM.inp.basis_type == "pw") {
+    if (PARAM.inp.basis_type == "pw")
+    {
         ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "Error Threshold", pw_diag_thr); // xiaohui add 2013-09-02
-}
+    }
 
     std::vector<std::string> titles;
     std::vector<double> energies_Ry;
@@ -378,7 +379,7 @@ void ElecState::print_etot(const Magnetism& magnet,
         if (PARAM.inp.deepks_scf) // caoyu add 2021-08-10
         {
             titles.push_back("E_DeePKS");
-            energies_Ry.push_back(GlobalC::ld.E_delta);
+            energies_Ry.push_back(this->f_en.edeepks_delta);
         }
 #endif
     }

--- a/source/module_elecstate/fp_energy.h
+++ b/source/module_elecstate/fp_energy.h
@@ -39,12 +39,13 @@ struct fenergy
     double esol_el = 0.0;  ///< the implicit solvation energy Ael
     double esol_cav = 0.0; ///< the implicit solvation energy Acav
 
-    double edftu = 0.0;       ///< DFT+U energy
-    double edeepks_scf = 0.0; /// DeePKS energy
+    double edftu = 0.0;         ///< DFT+U energy
+    double edeepks_scf = 0.0;   /// DeePKS energy difference
+    double edeepks_delta = 0.0; /// DeePKS energy
 
     double escon = 0.0; ///< spin constraint energy
 
-    double ekinetic = 0.0;  /// kinetic energy, used in OFDFT
+    double ekinetic = 0.0;   /// kinetic energy, used in OFDFT
     double e_local_pp = 0.0; /// ion-electron interaction energy contributed by local pp, used in OFDFT
 
     double calculate_etot();

--- a/source/module_esolver/esolver_ks_lcao.h
+++ b/source/module_esolver/esolver_ks_lcao.h
@@ -5,6 +5,9 @@
 // for grid integration
 #include "module_hamilt_lcao/module_gint/gint_gamma.h"
 #include "module_hamilt_lcao/module_gint/gint_k.h"
+#ifdef __DEEPKS
+#include "module_hamilt_lcao/module_deepks/LCAO_deepks.h"
+#endif
 #ifdef __EXX
 #include "module_ri/Exx_LRI_interface.h"
 #include "module_ri/Mix_DMk_2D.h"
@@ -19,13 +22,14 @@
 
 namespace LR
 {
-    template<typename T, typename TR>
-    class ESolver_LR;
+template <typename T, typename TR>
+class ESolver_LR;
 }
 namespace ModuleESolver
 {
 template <typename TK, typename TR>
-class ESolver_KS_LCAO : public ESolver_KS<TK> {
+class ESolver_KS_LCAO : public ESolver_KS<TK>
+{
   public:
     ESolver_KS_LCAO();
     ~ESolver_KS_LCAO();
@@ -73,7 +77,7 @@ class ESolver_KS_LCAO : public ESolver_KS<TK> {
 
     TwoCenterBundle two_center_bundle_;
 
-    rdmft::RDMFT<TK, TR> rdmft_solver;  // added by jghan for rdmft calculation, 2024-03-16
+    rdmft::RDMFT<TK, TR> rdmft_solver; // added by jghan for rdmft calculation, 2024-03-16
 
     // temporary introduced during removing GlobalC::ORB
     LCAO_Orbitals orb_;
@@ -91,6 +95,10 @@ class ESolver_KS_LCAO : public ESolver_KS<TK> {
 
     void beforesolver(const int istep);
     //---------------------------------------------------------------------
+
+#ifdef __DEEPKS
+    LCAO_Deepks ld;
+#endif
 
 #ifdef __EXX
     std::shared_ptr<Exx_LRI_Interface<TK, double>> exd = nullptr;

--- a/source/module_esolver/esolver_ks_lcao_tddft.cpp
+++ b/source/module_esolver/esolver_ks_lcao_tddft.cpp
@@ -17,19 +17,18 @@
 #include "module_elecstate/module_dm/cal_edm_tddft.h"
 #include "module_elecstate/module_dm/density_matrix.h"
 #include "module_elecstate/occupy.h"
-#include "module_hamilt_lcao/hamilt_lcaodft/LCAO_domain.h" // need divide_HS_in_frag
 #include "module_hamilt_lcao/module_tddft/evolve_elec.h"
 #include "module_hamilt_lcao/module_tddft/td_velocity.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
 #include "module_io/print_info.h"
 
 //-----HSolver ElecState Hamilt--------
+#include "module_elecstate/cal_ux.h"
 #include "module_elecstate/elecstate_lcao.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h"
 #include "module_hsolver/hsolver_lcao.h"
 #include "module_parameter/parameter.h"
 #include "module_psi/psi.h"
-#include "module_elecstate/cal_ux.h"
 
 //-----force& stress-------------------
 #include "module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h"
@@ -290,7 +289,12 @@ void ESolver_KS_LCAO_TDDFT::after_scf(UnitCell& ucell, const int istep)
         {
             std::stringstream ss_dipole;
             ss_dipole << PARAM.globalv.global_out_dir << "SPIN" << is + 1 << "_DIPOLE";
-            ModuleIO::write_dipole(ucell,pelec->charge->rho_save[is], pelec->charge->rhopw, is, istep, ss_dipole.str());
+            ModuleIO::write_dipole(ucell,
+                                   pelec->charge->rho_save[is],
+                                   pelec->charge->rhopw,
+                                   is,
+                                   istep,
+                                   ss_dipole.str());
         }
     }
     if (TD_Velocity::out_current == true)

--- a/source/module_esolver/lcao_before_scf.cpp
+++ b/source/module_esolver/lcao_before_scf.cpp
@@ -193,7 +193,10 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(UnitCell& ucell, const int istep)
             this->kv,
             two_center_bundle_,
             orb_,
-            DM
+            DM,
+#ifdef __DEEPKS
+            &this->ld
+#endif
 #ifdef __EXX
             ,
             istep,
@@ -211,7 +214,7 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(UnitCell& ucell, const int istep)
     {
         const Parallel_Orbitals* pv = &this->pv;
         // allocate <phi(0)|alpha(R)>, phialpha is different every ion step, so it is allocated here
-        DeePKS_domain::allocate_phialpha(PARAM.inp.cal_force, ucell, orb_, this->gd, pv, GlobalC::ld.phialpha);
+        DeePKS_domain::allocate_phialpha(PARAM.inp.cal_force, ucell, orb_, this->gd, pv, this->ld.phialpha);
         // build and save <phi(0)|alpha(R)> at beginning
         DeePKS_domain::build_phialpha(PARAM.inp.cal_force,
                                       ucell,
@@ -219,11 +222,11 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(UnitCell& ucell, const int istep)
                                       this->gd,
                                       pv,
                                       *(two_center_bundle_.overlap_orb_alpha),
-                                      GlobalC::ld.phialpha);
+                                      this->ld.phialpha);
 
         if (PARAM.inp.deepks_out_unittest)
         {
-            DeePKS_domain::check_phialpha(PARAM.inp.cal_force, ucell, orb_, this->gd, pv, GlobalC::ld.phialpha);
+            DeePKS_domain::check_phialpha(PARAM.inp.cal_force, ucell, orb_, this->gd, pv, this->ld.phialpha);
         }
     }
 #endif

--- a/source/module_esolver/lcao_before_scf.cpp
+++ b/source/module_esolver/lcao_before_scf.cpp
@@ -193,8 +193,9 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(UnitCell& ucell, const int istep)
             this->kv,
             two_center_bundle_,
             orb_,
-            DM,
+            DM
 #ifdef __DEEPKS
+            ,
             &this->ld
 #endif
 #ifdef __EXX

--- a/source/module_esolver/lcao_others.cpp
+++ b/source/module_esolver/lcao_others.cpp
@@ -199,8 +199,9 @@ void ESolver_KS_LCAO<TK, TR>::others(UnitCell& ucell, const int istep)
             this->kv,
             two_center_bundle_,
             orb_,
-            DM,
+            DM
 #ifdef __DEEPKS
+            ,
             &this->ld
 #endif
 #ifdef __EXX

--- a/source/module_esolver/lcao_others.cpp
+++ b/source/module_esolver/lcao_others.cpp
@@ -199,7 +199,10 @@ void ESolver_KS_LCAO<TK, TR>::others(UnitCell& ucell, const int istep)
             this->kv,
             two_center_bundle_,
             orb_,
-            DM
+            DM,
+#ifdef __DEEPKS
+            &this->ld
+#endif
 #ifdef __EXX
             ,
             istep,
@@ -217,7 +220,7 @@ void ESolver_KS_LCAO<TK, TR>::others(UnitCell& ucell, const int istep)
     {
         const Parallel_Orbitals* pv = &this->pv;
         // allocate <phi(0)|alpha(R)>, phialpha is different every ion step, so it is allocated here
-        DeePKS_domain::allocate_phialpha(PARAM.inp.cal_force, ucell, orb_, this->gd, pv, GlobalC::ld.phialpha);
+        DeePKS_domain::allocate_phialpha(PARAM.inp.cal_force, ucell, orb_, this->gd, pv, this->ld.phialpha);
         // build and save <phi(0)|alpha(R)> at beginning
         DeePKS_domain::build_phialpha(PARAM.inp.cal_force,
                                       ucell,
@@ -225,11 +228,11 @@ void ESolver_KS_LCAO<TK, TR>::others(UnitCell& ucell, const int istep)
                                       this->gd,
                                       pv,
                                       *(two_center_bundle_.overlap_orb_alpha),
-                                      GlobalC::ld.phialpha);
+                                      this->ld.phialpha);
 
         if (PARAM.inp.deepks_out_unittest)
         {
-            DeePKS_domain::check_phialpha(PARAM.inp.cal_force, ucell, orb_, this->gd, pv, GlobalC::ld.phialpha);
+            DeePKS_domain::check_phialpha(PARAM.inp.cal_force, ucell, orb_, this->gd, pv, this->ld.phialpha);
         }
     }
 #endif

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE.h
@@ -5,13 +5,14 @@
 #include "module_base/global_variable.h"
 #include "module_base/matrix.h"
 #include "module_basis/module_nao/two_center_bundle.h"
+#include "module_elecstate/elecstate.h"
 #include "module_elecstate/module_dm/density_matrix.h"
+#include "module_elecstate/potentials/potential_new.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/force_stress_arrays.h"
+#include "module_hamilt_lcao/module_deepks/LCAO_deepks.h"
 #include "module_hamilt_lcao/module_gint/gint_gamma.h"
 #include "module_hamilt_lcao/module_gint/gint_k.h"
 #include "module_psi/psi.h"
-#include "module_elecstate/potentials/potential_new.h"
-#include "module_elecstate/elecstate.h"
 
 #ifndef TGINT_H
 #define TGINT_H
@@ -65,6 +66,7 @@ class Force_LCAO
 #ifdef __DEEPKS
                 ModuleBase::matrix& fvnl_dalpha,
                 ModuleBase::matrix& svnl_dalpha,
+                LCAO_Deepks& ld,
 #endif
                 typename TGint<T>::type& gint,
                 const TwoCenterBundle& two_center_bundle,
@@ -87,7 +89,7 @@ class Force_LCAO
 
     void average_force(double* fm);
 
-    //void test(Parallel_Orbitals& pv, double* mm, const std::string& name);
+    // void test(Parallel_Orbitals& pv, double* mm, const std::string& name);
 
     //-------------------------------------------------------------
     // forces reated to overlap matrix
@@ -131,14 +133,14 @@ class Force_LCAO
                       ModuleBase::matrix& svl_dphi);
 
     elecstate::DensityMatrix<T, double> cal_edm(const elecstate::ElecState* pelec,
-        const psi::Psi<T>& psi,
-        const elecstate::DensityMatrix<T, double>& dm,
-        const K_Vectors& kv,
-        const Parallel_Orbitals& pv,
-        const int& nspin, 
-        const int& nbands,
-        const UnitCell& ucell,
-        Record_adj& ra) const;
+                                                const psi::Psi<T>& psi,
+                                                const elecstate::DensityMatrix<T, double>& dm,
+                                                const K_Vectors& kv,
+                                                const Parallel_Orbitals& pv,
+                                                const int& nspin,
+                                                const int& nbands,
+                                                const UnitCell& ucell,
+                                                Record_adj& ra) const;
 };
 
 #endif

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.cpp
@@ -50,6 +50,9 @@ void Force_Stress_LCAO<T>::getForceStress(UnitCell& ucell,
                                           const K_Vectors& kv,
                                           ModulePW::PW_Basis* rhopw,
                                           surchem& solvent,
+#ifdef __DEEPKS
+                                          LCAO_Deepks& ld,
+#endif
 #ifdef __EXX
                                           Exx_LRI<double>& exx_lri_double,
                                           Exx_LRI<std::complex<double>>& exx_lri_complex,
@@ -180,6 +183,7 @@ void Force_Stress_LCAO<T>::getForceStress(UnitCell& ucell,
 #ifdef __DEEPKS
                         fvnl_dalpha,
                         svnl_dalpha,
+                        ld,
 #endif
                         gint_gamma,
                         gint_k,
@@ -500,16 +504,16 @@ void Force_Stress_LCAO<T>::getForceStress(UnitCell& ucell,
         if (PARAM.inp.deepks_out_labels) // not parallelized yet
         {
             const std::string file_ftot = PARAM.globalv.global_out_dir + "deepks_ftot.npy";
-            LCAO_deepks_io::save_npy_f(fcs, file_ftot, GlobalV::MY_RANK); // Ry/Bohr, F_tot
+            LCAO_deepks_io::save_matrix2npy(file_ftot, fcs, GlobalV::MY_RANK); // Ry/Bohr, F_tot
 
             const std::string file_fbase = PARAM.globalv.global_out_dir + "deepks_fbase.npy";
             if (PARAM.inp.deepks_scf)
             {
-                LCAO_deepks_io::save_npy_f(fcs - fvnl_dalpha, file_fbase, GlobalV::MY_RANK); // Ry/Bohr, F_base
+                LCAO_deepks_io::save_matrix2npy(file_fbase, fcs - fvnl_dalpha, GlobalV::MY_RANK); // Ry/Bohr, F_base
             }
             else
             {
-                LCAO_deepks_io::save_npy_f(fcs, file_fbase, GlobalV::MY_RANK); // no scf, F_base=F_tot
+                LCAO_deepks_io::save_matrix2npy(file_fbase, fcs, GlobalV::MY_RANK); // no scf, F_base=F_tot
             }
         }
 #endif
@@ -682,23 +686,24 @@ void Force_Stress_LCAO<T>::getForceStress(UnitCell& ucell,
         if (PARAM.inp.deepks_out_labels) // not parallelized yet
         {
             const std::string file_stot = PARAM.globalv.global_out_dir + "deepks_stot.npy";
-            LCAO_deepks_io::save_npy_s(scs,
-                                       file_stot,
-                                       ucell.omega,
-                                       GlobalV::MY_RANK); // change to energy unit Ry when printing, S_tot, w/ model
+            LCAO_deepks_io::save_matrix2npy(file_stot,
+                                            scs,
+                                            GlobalV::MY_RANK,
+                                            ucell.omega,
+                                            'U'); // change to energy unit Ry when printing, S_tot;
 
             const std::string file_sbase = PARAM.globalv.global_out_dir + "deepks_sbase.npy";
             if (PARAM.inp.deepks_scf)
             {
-                LCAO_deepks_io::save_npy_s(scs - svnl_dalpha,
-                                           file_sbase,
-                                           ucell.omega,
-                                           GlobalV::MY_RANK); // change to energy unit Ry when printing, S_base;
+                LCAO_deepks_io::save_matrix2npy(file_sbase,
+                                                scs - svnl_dalpha,
+                                                GlobalV::MY_RANK,
+                                                ucell.omega,
+                                                'U'); // change to energy unit Ry when printing, S_base;
             }
             else
             {
-                LCAO_deepks_io::save_npy_s(scs, file_sbase, ucell.omega,
-                                           GlobalV::MY_RANK); // sbase = stot
+                LCAO_deepks_io::save_matrix2npy(file_sbase, scs, GlobalV::MY_RANK, ucell.omega, 'U'); // sbase = stot
             }
         }
 #endif
@@ -832,6 +837,7 @@ void Force_Stress_LCAO<double>::integral_part(const bool isGammaOnly,
 #if __DEEPKS
                                               ModuleBase::matrix& fvnl_dalpha,
                                               ModuleBase::matrix& svnl_dalpha,
+                                              LCAO_Deepks& ld,
 #endif
                                               Gint_Gamma& gint_gamma, // mohan add 2024-04-01
                                               Gint_k& gint_k,         // mohan add 2024-04-01
@@ -859,6 +865,7 @@ void Force_Stress_LCAO<double>::integral_part(const bool isGammaOnly,
 #if __DEEPKS
                fvnl_dalpha,
                svnl_dalpha,
+               ld,
 #endif
                gint_gamma,
                two_center_bundle,
@@ -887,6 +894,7 @@ void Force_Stress_LCAO<std::complex<double>>::integral_part(const bool isGammaOn
 #if __DEEPKS
                                                             ModuleBase::matrix& fvnl_dalpha,
                                                             ModuleBase::matrix& svnl_dalpha,
+                                                            LCAO_Deepks& ld,
 #endif
                                                             Gint_Gamma& gint_gamma,
                                                             Gint_k& gint_k,
@@ -913,6 +921,7 @@ void Force_Stress_LCAO<std::complex<double>>::integral_part(const bool isGammaOn
 #if __DEEPKS
                fvnl_dalpha,
                svnl_dalpha,
+               ld,
 #endif
                gint_k,
                two_center_bundle,

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_STRESS.h
@@ -49,6 +49,9 @@ class Force_Stress_LCAO
                         const K_Vectors& kv,
                         ModulePW::PW_Basis* rhopw,
                         surchem& solvent,
+#ifdef __DEEPKS
+                        LCAO_Deepks& ld,
+#endif
 #ifdef __EXX
                         Exx_LRI<double>& exx_lri_double,
                         Exx_LRI<std::complex<double>>& exx_lri_complex,
@@ -62,9 +65,7 @@ class Force_Stress_LCAO
     Stress_Func<double> sc_pw;
     Forces<double> f_pw;
 
-    void forceSymmetry(const UnitCell& ucell, 
-                       ModuleBase::matrix& fcs, 
-                       ModuleSymmetry::Symmetry* symm);
+    void forceSymmetry(const UnitCell& ucell, ModuleBase::matrix& fcs, ModuleSymmetry::Symmetry* symm);
 
     void calForcePwPart(UnitCell& ucell,
                         ModuleBase::matrix& fvl_dvl,
@@ -98,6 +99,7 @@ class Force_Stress_LCAO
 #if __DEEPKS
                        ModuleBase::matrix& fvnl_dalpha,
                        ModuleBase::matrix& svnl_dalpha,
+                       LCAO_Deepks& ld,
 #endif
                        Gint_Gamma& gint_gamma,
                        Gint_k& gint_k,

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_gamma.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_gamma.cpp
@@ -190,6 +190,7 @@ void Force_LCAO<double>::ftable(const bool isforce,
 #ifdef __DEEPKS
                                 ModuleBase::matrix& fvnl_dalpha,
                                 ModuleBase::matrix& svnl_dalpha,
+                                LCAO_Deepks& ld,
 #endif
                                 TGint<double>::type& gint,
                                 const TwoCenterBundle& two_center_bundle,
@@ -247,28 +248,23 @@ void Force_LCAO<double>::ftable(const bool isforce,
                                    false /*reset dm to gint*/);
 
 #ifdef __DEEPKS
-    const std::vector<std::vector<double>>& dm_gamma = dm->get_DMK_vector();
-    std::vector<torch::Tensor> descriptor;
     if (PARAM.inp.deepks_scf)
     {
+        const std::vector<std::vector<double>>& dm_gamma = dm->get_DMK_vector();
+        std::vector<torch::Tensor> descriptor;
         // when deepks_scf is on, the init pdm should be same as the out pdm, so we should not recalculate the pdm
-        DeePKS_domain::cal_descriptor(ucell.nat,
-                                      GlobalC::ld.inlmax,
-                                      GlobalC::ld.inl_l,
-                                      GlobalC::ld.pdm,
-                                      descriptor,
-                                      GlobalC::ld.des_per_atom);
+        DeePKS_domain::cal_descriptor(ucell.nat, ld.inlmax, ld.inl_l, ld.pdm, descriptor, ld.des_per_atom);
         DeePKS_domain::cal_gedm(ucell.nat,
-                                GlobalC::ld.lmaxd,
-                                GlobalC::ld.nmaxd,
-                                GlobalC::ld.inlmax,
-                                GlobalC::ld.des_per_atom,
-                                GlobalC::ld.inl_l,
+                                ld.lmaxd,
+                                ld.nmaxd,
+                                ld.inlmax,
+                                ld.des_per_atom,
+                                ld.inl_l,
                                 descriptor,
-                                GlobalC::ld.pdm,
-                                GlobalC::ld.model_deepks,
-                                GlobalC::ld.gedm,
-                                GlobalC::ld.E_delta);
+                                ld.pdm,
+                                ld.model_deepks,
+                                ld.gedm,
+                                ld.E_delta);
 
         const int nks = 1;
         DeePKS_domain::cal_f_delta<double>(dm_gamma,
@@ -276,12 +272,11 @@ void Force_LCAO<double>::ftable(const bool isforce,
                                            orb,
                                            gd,
                                            *this->ParaV,
-                                           GlobalC::ld.lmaxd,
                                            nks,
                                            kv->kvec_d,
-                                           GlobalC::ld.phialpha,
-                                           GlobalC::ld.gedm,
-                                           GlobalC::ld.inl_index,
+                                           ld.phialpha,
+                                           ld.gedm,
+                                           ld.inl_index,
                                            fvnl_dalpha,
                                            isstress,
                                            svnl_dalpha);

--- a/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_k.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/FORCE_k.cpp
@@ -284,6 +284,7 @@ void Force_LCAO<std::complex<double>>::ftable(const bool isforce,
 #ifdef __DEEPKS
                                               ModuleBase::matrix& fvnl_dalpha,
                                               ModuleBase::matrix& svnl_dalpha,
+                                              LCAO_Deepks& ld,
 #endif
                                               TGint<std::complex<double>>::type& gint,
                                               const TwoCenterBundle& two_center_bundle,
@@ -345,38 +346,31 @@ void Force_LCAO<std::complex<double>>::ftable(const bool isforce,
     if (PARAM.inp.deepks_scf)
     {
         const std::vector<std::vector<std::complex<double>>>& dm_k = dm->get_DMK_vector();
-
-        // when deepks_scf is on, the init pdm should be same as the out pdm, so we should not recalculate the pdm
         std::vector<torch::Tensor> descriptor;
-        DeePKS_domain::cal_descriptor(ucell.nat,
-                                      GlobalC::ld.inlmax,
-                                      GlobalC::ld.inl_l,
-                                      GlobalC::ld.pdm,
-                                      descriptor,
-                                      GlobalC::ld.des_per_atom);
+        // when deepks_scf is on, the init pdm should be same as the out pdm, so we should not recalculate the pdm
+        DeePKS_domain::cal_descriptor(ucell.nat, ld.inlmax, ld.inl_l, ld.pdm, descriptor, ld.des_per_atom);
         DeePKS_domain::cal_gedm(ucell.nat,
-                                GlobalC::ld.lmaxd,
-                                GlobalC::ld.nmaxd,
-                                GlobalC::ld.inlmax,
-                                GlobalC::ld.des_per_atom,
-                                GlobalC::ld.inl_l,
+                                ld.lmaxd,
+                                ld.nmaxd,
+                                ld.inlmax,
+                                ld.des_per_atom,
+                                ld.inl_l,
                                 descriptor,
-                                GlobalC::ld.pdm,
-                                GlobalC::ld.model_deepks,
-                                GlobalC::ld.gedm,
-                                GlobalC::ld.E_delta);
+                                ld.pdm,
+                                ld.model_deepks,
+                                ld.gedm,
+                                ld.E_delta);
 
         DeePKS_domain::cal_f_delta<std::complex<double>>(dm_k,
                                                          ucell,
                                                          orb,
                                                          gd,
                                                          pv,
-                                                         GlobalC::ld.lmaxd,
                                                          kv->get_nks(),
                                                          kv->kvec_d,
-                                                         GlobalC::ld.phialpha,
-                                                         GlobalC::ld.gedm,
-                                                         GlobalC::ld.inl_index,
+                                                         ld.phialpha,
+                                                         ld.gedm,
+                                                         ld.inl_index,
                                                          fvnl_dalpha,
                                                          isstress,
                                                          svnl_dalpha);

--- a/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_allocate.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_allocate.cpp
@@ -6,6 +6,7 @@
 
 namespace LCAO_domain
 {
+#ifdef __DEEPKS
 // It seems it is only related to DeePKS, so maybe we should move it to DeeKS_domain
 void DeePKS_init(const UnitCell& ucell,
                  Parallel_Orbitals& pv,
@@ -14,7 +15,6 @@ void DeePKS_init(const UnitCell& ucell,
                  LCAO_Deepks& ld)
 {
     ModuleBase::TITLE("LCAO_domain", "DeePKS_init");
-#ifdef __DEEPKS
     // preparation for DeePKS
     if (PARAM.inp.deepks_out_labels || PARAM.inp.deepks_scf)
     {
@@ -33,8 +33,7 @@ void DeePKS_init(const UnitCell& ucell,
             ld.allocate_V_delta(ucell.nat, nks);
         }
     }
-#endif
     return;
 }
-
+#endif
 } // namespace LCAO_domain

--- a/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_allocate.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_allocate.cpp
@@ -1,46 +1,40 @@
-#include "module_hamilt_lcao/hamilt_lcaodft/LCAO_domain.h"
 #include "module_base/timer.h"
-#include "module_parameter/parameter.h"
-#include "module_hamilt_pw/hamilt_pwdft/global.h"
+#include "module_hamilt_lcao/hamilt_lcaodft/LCAO_domain.h"
 #include "module_hamilt_lcao/module_deepks/LCAO_deepks.h"
+#include "module_hamilt_pw/hamilt_pwdft/global.h"
+#include "module_parameter/parameter.h"
 
 namespace LCAO_domain
 {
-
-void divide_HS_in_frag(const bool isGamma, const UnitCell& ucell, Parallel_Orbitals& pv,const int& nks, const LCAO_Orbitals& orb) {
-    ModuleBase::TITLE("LCAO_domain", "divide_HS_in_frag");
-
-    //(1), (2): set up matrix division have been moved into ESolver_KS_LCAO::init_basis_lcao
-    // just pass `ParaV` as pointer is enough
+// It seems it is only related to DeePKS, so maybe we should move it to DeeKS_domain
+void DeePKS_init(const UnitCell& ucell,
+                 Parallel_Orbitals& pv,
+                 const int& nks,
+                 const LCAO_Orbitals& orb,
+                 LCAO_Deepks& ld)
+{
+    ModuleBase::TITLE("LCAO_domain", "DeePKS_init");
 #ifdef __DEEPKS
-    // wenfei 2021-12-19
     // preparation for DeePKS
-
-    if (PARAM.inp.deepks_out_labels || PARAM.inp.deepks_scf) {
+    if (PARAM.inp.deepks_out_labels || PARAM.inp.deepks_scf)
+    {
         // allocate relevant data structures for calculating descriptors
         std::vector<int> na;
         na.resize(ucell.ntype);
-        for (int it = 0; it < ucell.ntype; it++) {
+        for (int it = 0; it < ucell.ntype; it++)
+        {
             na[it] = ucell.atoms[it].na;
         }
 
-        GlobalC::ld.init(orb,
-                         ucell.nat,
-                         ucell.ntype,
-                         nks,
-                         pv,
-                         na);
+        ld.init(orb, ucell.nat, ucell.ntype, nks, pv, na);
 
-        if (PARAM.inp.deepks_scf) {
-            if (isGamma) {
-                GlobalC::ld.allocate_V_delta(ucell.nat);
-            } else {
-                GlobalC::ld.allocate_V_delta(ucell.nat, nks);
-            }
+        if (PARAM.inp.deepks_scf)
+        {
+            ld.allocate_V_delta(ucell.nat, nks);
         }
     }
 #endif
     return;
 }
 
-}
+} // namespace LCAO_domain

--- a/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_domain.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_domain.h
@@ -174,11 +174,13 @@ void build_ST_new(ForceStressArrays& fsr,
  */
 void zeros_HSR(const char& mtype, LCAO_HS_Arrays& HS_arrays);
 
+#ifdef __DEEPKS
 void DeePKS_init(const UnitCell& ucell,
                  Parallel_Orbitals& pv,
                  const int& nks,
                  const LCAO_Orbitals& orb,
                  LCAO_Deepks& ld);
+#endif
 
 template <typename T>
 void set_mat2d(const int& global_ir, const int& global_ic, const T& v, const Parallel_Orbitals& pv, T* mat);

--- a/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_domain.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/LCAO_domain.h
@@ -8,6 +8,7 @@
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
 #include "module_hamilt_lcao/hamilt_lcaodft/LCAO_HS_arrays.hpp"
 #include "module_hamilt_lcao/hamilt_lcaodft/force_stress_arrays.h"
+#include "module_hamilt_lcao/module_deepks/LCAO_deepks.h"
 #include "module_hamilt_lcao/module_gint/gint_gamma.h"
 #include "module_hamilt_lcao/module_gint/gint_k.h"
 #include "module_hamilt_lcao/module_gint/grid_technique.h"
@@ -16,14 +17,14 @@ namespace LCAO_domain
 {
 
 void init_basis_lcao(Parallel_Orbitals& pv,
-        const double &onsite_radius,
-        const double &lcao_ecut,
-        const double &lcao_dk,
-        const double &lcao_dr,
-        const double &lcao_rmax,
-		UnitCell& ucell,
-        TwoCenterBundle& two_center_bundle,
-        LCAO_Orbitals& orb);
+                     const double& onsite_radius,
+                     const double& lcao_ecut,
+                     const double& lcao_dk,
+                     const double& lcao_dr,
+                     const double& lcao_rmax,
+                     UnitCell& ucell,
+                     TwoCenterBundle& two_center_bundle,
+                     LCAO_Orbitals& orb);
 
 void build_Nonlocal_mu_new(const Parallel_Orbitals& pv,
                            ForceStressArrays& fsr, // mohan 2024-06-16
@@ -173,14 +174,14 @@ void build_ST_new(ForceStressArrays& fsr,
  */
 void zeros_HSR(const char& mtype, LCAO_HS_Arrays& HS_arrays);
 
-void divide_HS_in_frag(const bool isGamma, const UnitCell& ucell, Parallel_Orbitals& pv, const int& nks, const LCAO_Orbitals& orb);
+void DeePKS_init(const UnitCell& ucell,
+                 Parallel_Orbitals& pv,
+                 const int& nks,
+                 const LCAO_Orbitals& orb,
+                 LCAO_Deepks& ld);
 
 template <typename T>
-void set_mat2d(const int& global_ir,
-                const int& global_ic,
-                const T& v,
-                const Parallel_Orbitals& pv,
-                T* mat);
+void set_mat2d(const int& global_ir, const int& global_ic, const T& v, const Parallel_Orbitals& pv, T* mat);
 
 } // namespace LCAO_domain
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.cpp
@@ -80,8 +80,9 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                const K_Vectors& kv_in,
                                const TwoCenterBundle& two_center_bundle,
                                const LCAO_Orbitals& orb,
-                               elecstate::DensityMatrix<TK, double>* DM_in,
+                               elecstate::DensityMatrix<TK, double>* DM_in
 #ifdef __DEEPKS
+                               ,
                                LCAO_Deepks* ld_in
 #endif
 #ifdef __EXX

--- a/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.cpp
@@ -80,7 +80,10 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                const K_Vectors& kv_in,
                                const TwoCenterBundle& two_center_bundle,
                                const LCAO_Orbitals& orb,
-                               elecstate::DensityMatrix<TK, double>* DM_in
+                               elecstate::DensityMatrix<TK, double>* DM_in,
+#ifdef __DEEPKS
+                               LCAO_Deepks* ld_in
+#endif
 #ifdef __EXX
                                ,
                                const int istep,
@@ -209,7 +212,8 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                     two_center_bundle.overlap_orb_alpha.get(),
                                                                     &orb,
                                                                     this->kv->get_nks(),
-                                                                    DM_in);
+                                                                    DM_in,
+                                                                    ld_in);
             this->getOperator()->add(deepks);
         }
 #endif
@@ -262,7 +266,6 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                      orb.cutoffs(),
                                                                      &grid_d,
                                                                      PARAM.inp.nspin);
-
             }
         }
 
@@ -333,7 +336,8 @@ HamiltLCAO<TK, TR>::HamiltLCAO(Gint_Gamma* GG_in,
                                                                     two_center_bundle.overlap_orb_alpha.get(),
                                                                     &orb,
                                                                     this->kv->get_nks(),
-                                                                    DM_in);
+                                                                    DM_in,
+                                                                    ld_in);
             this->getOperator()->add(deepks);
         }
 #endif

--- a/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h
@@ -39,8 +39,9 @@ class HamiltLCAO : public Hamilt<TK>
                const K_Vectors& kv_in,
                const TwoCenterBundle& two_center_bundle,
                const LCAO_Orbitals& orb,
-               elecstate::DensityMatrix<TK, double>* DM_in,
+               elecstate::DensityMatrix<TK, double>* DM_in
 #ifdef __DEEPKS
+               ,
                LCAO_Deepks* ld_in
 #endif
 #ifdef __EXX

--- a/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.h
@@ -39,7 +39,10 @@ class HamiltLCAO : public Hamilt<TK>
                const K_Vectors& kv_in,
                const TwoCenterBundle& two_center_bundle,
                const LCAO_Orbitals& orb,
-               elecstate::DensityMatrix<TK, double>* DM_in
+               elecstate::DensityMatrix<TK, double>* DM_in,
+#ifdef __DEEPKS
+               LCAO_Deepks* ld_in
+#endif
 #ifdef __EXX
                ,
                const int istep,

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.cpp
@@ -22,8 +22,12 @@ DeePKS<OperatorLCAO<TK, TR>>::DeePKS(HS_Matrix_K<TK>* hsk_in,
                                      const TwoCenterIntegrator* intor_orb_alpha,
                                      const LCAO_Orbitals* ptr_orb,
                                      const int& nks_in,
-                                     elecstate::DensityMatrix<TK, double>* DM_in,
-                                     LCAO_Deepks* ld_in)
+                                     elecstate::DensityMatrix<TK, double>* DM_in
+#ifdef __DEEPKS
+                                     ,
+                                     LCAO_Deepks* ld_in
+#endif
+                                     )
     : OperatorLCAO<TK, TR>(hsk_in, kvec_d_in, hR_in), DM(DM_in), ucell(ucell_in), intor_orb_alpha_(intor_orb_alpha),
       ptr_orb_(ptr_orb), nks(nks_in)
 {

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.cpp
@@ -2,12 +2,10 @@
 
 #include "module_base/timer.h"
 #include "module_base/tool_title.h"
-#include "module_parameter/parameter.h"
-#ifdef __DEEPKS
-#include "module_hamilt_lcao/module_deepks/LCAO_deepks.h"
-#endif
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
+#include "module_hamilt_lcao/module_deepks/LCAO_deepks.h"
 #include "module_hamilt_lcao/module_hcontainer/hcontainer_funcs.h"
+#include "module_parameter/parameter.h"
 #ifdef _OPENMP
 #include <unordered_set>
 #endif
@@ -24,13 +22,15 @@ DeePKS<OperatorLCAO<TK, TR>>::DeePKS(HS_Matrix_K<TK>* hsk_in,
                                      const TwoCenterIntegrator* intor_orb_alpha,
                                      const LCAO_Orbitals* ptr_orb,
                                      const int& nks_in,
-                                     elecstate::DensityMatrix<TK, double>* DM_in)
+                                     elecstate::DensityMatrix<TK, double>* DM_in,
+                                     LCAO_Deepks* ld_in)
     : OperatorLCAO<TK, TR>(hsk_in, kvec_d_in, hR_in), DM(DM_in), ucell(ucell_in), intor_orb_alpha_(intor_orb_alpha),
       ptr_orb_(ptr_orb), nks(nks_in)
 {
     this->cal_type = calculation_type::lcao_deepks;
     this->gd = GridD_in;
 #ifdef __DEEPKS
+    this->ld = ld_in;
     this->initialize_HR(GridD_in);
 #endif
 }
@@ -154,43 +154,45 @@ void hamilt::DeePKS<hamilt::OperatorLCAO<TK, TR>>::contributeHR()
 #ifdef __DEEPKS
     ModuleBase::TITLE("DeePKS", "contributeHR");
     // if DM changed, HR of DeePKS need to refresh.
-    // the judgement is based on the status of HR in GlobalC::ld
+    // the judgement is based on the status of HR in ld
     // this operator should be informed that DM has changed and HR need to recalculate.
-    if (GlobalC::ld.get_hr_cal())
+    if (this->ld->get_hr_cal())
     {
         ModuleBase::timer::tick("DeePKS", "contributeHR");
 
-        DeePKS_domain::cal_pdm<TK>(GlobalC::ld.init_pdm,
-                                   GlobalC::ld.inlmax,
-                                   GlobalC::ld.lmaxd,
-                                   GlobalC::ld.inl_l,
-                                   GlobalC::ld.inl_index,
+        const int inlmax = ptr_orb_->Alpha[0].getTotal_nchi() * this->ucell->nat;
+
+        DeePKS_domain::cal_pdm<TK>(this->ld->init_pdm,
+                                   inlmax,
+                                   this->ld->lmaxd,
+                                   this->ld->inl_l,
+                                   this->ld->inl_index,
                                    this->DM,
-                                   GlobalC::ld.phialpha,
+                                   this->ld->phialpha,
                                    *this->ucell,
                                    *ptr_orb_,
                                    *(this->gd),
                                    *(this->hR->get_paraV()),
-                                   GlobalC::ld.pdm);
+                                   this->ld->pdm);
 
         std::vector<torch::Tensor> descriptor;
         DeePKS_domain::cal_descriptor(this->ucell->nat,
-                                      GlobalC::ld.inlmax,
-                                      GlobalC::ld.inl_l,
-                                      GlobalC::ld.pdm,
+                                      inlmax,
+                                      this->ld->inl_l,
+                                      this->ld->pdm,
                                       descriptor,
-                                      GlobalC::ld.des_per_atom);
+                                      this->ld->des_per_atom);
         DeePKS_domain::cal_gedm(this->ucell->nat,
-                                GlobalC::ld.lmaxd,
-                                GlobalC::ld.nmaxd,
-                                GlobalC::ld.inlmax,
-                                GlobalC::ld.des_per_atom,
-                                GlobalC::ld.inl_l,
+                                this->ld->lmaxd,
+                                this->ld->nmaxd,
+                                inlmax,
+                                this->ld->des_per_atom,
+                                this->ld->inl_l,
                                 descriptor,
-                                GlobalC::ld.pdm,
-                                GlobalC::ld.model_deepks,
-                                GlobalC::ld.gedm,
-                                GlobalC::ld.E_delta);
+                                this->ld->pdm,
+                                this->ld->model_deepks,
+                                this->ld->gedm,
+                                this->ld->E_delta);
 
         // // recalculate the H_V_delta
         // if (this->H_V_delta == nullptr)
@@ -200,7 +202,7 @@ void hamilt::DeePKS<hamilt::OperatorLCAO<TK, TR>>::contributeHR()
         this->H_V_delta->set_zero();
         this->calculate_HR();
 
-        GlobalC::ld.set_hr_cal(false);
+        this->ld->set_hr_cal(false);
 
         ModuleBase::timer::tick("DeePKS", "contributeHR");
     }
@@ -297,8 +299,8 @@ void hamilt::DeePKS<hamilt::OperatorLCAO<TK, TR>>::calculate_HR()
             {
                 for (int N0 = 0; N0 < ptr_orb_->Alpha[0].getNchi(L0); ++N0)
                 {
-                    const int inl = GlobalC::ld.get_inl(T0, I0, L0, N0);
-                    const double* pgedm = GlobalC::ld.get_gedms(inl);
+                    const int inl = this->ld->inl_index[T0](I0, L0, N0);
+                    const double* pgedm = this->ld->gedm[inl];
                     const int nm = 2 * L0 + 1;
 
                     for (int m1 = 0; m1 < nm; ++m1) // m1 = 1 for s, 3 for p, 5 for d
@@ -316,9 +318,9 @@ void hamilt::DeePKS<hamilt::OperatorLCAO<TK, TR>>::calculate_HR()
         }
         else
         {
-            const double* pgedm = GlobalC::ld.get_gedms(iat0);
+            const double* pgedm = this->ld->gedm[iat0];
             int nproj = 0;
-            for (int il = 0; il < GlobalC::ld.get_lmaxd() + 1; il++)
+            for (int il = 0; il < this->ld->lmaxd + 1; il++)
             {
                 nproj += (2 * il + 1) * ptr_orb_->Alpha[0].getNchi(il);
             }
@@ -466,15 +468,15 @@ void hamilt::DeePKS<hamilt::OperatorLCAO<TK, TR>>::cal_HR_IJR(const double* hr_i
 }
 
 template <typename TK>
-inline void get_h_delta_k(int ik, TK*& h_delta_k)
+inline void get_h_delta_k(int ik, TK*& h_delta_k, LCAO_Deepks* ld_in)
 {
     if constexpr (std::is_same<TK, double>::value)
     {
-        h_delta_k = GlobalC::ld.H_V_delta[ik].data();
+        h_delta_k = ld_in->H_V_delta[ik].data();
     }
     else
     {
-        h_delta_k = GlobalC::ld.H_V_delta_k[ik].data();
+        h_delta_k = ld_in->H_V_delta_k[ik].data();
     }
     return;
 }
@@ -487,7 +489,7 @@ void hamilt::DeePKS<hamilt::OperatorLCAO<TK, TR>>::contributeHk(int ik)
     ModuleBase::timer::tick("DeePKS", "contributeHk");
 
     TK* h_delta_k = nullptr;
-    get_h_delta_k<TK>(ik, h_delta_k);
+    get_h_delta_k<TK>(ik, h_delta_k, this->ld);
     // set SK to zero and then calculate SK for each k vector
     ModuleBase::GlobalFunc::ZEROS(h_delta_k, this->hsk->get_size());
 

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.h
@@ -4,8 +4,8 @@
 #include "module_basis/module_nao/two_center_integrator.h"
 #include "module_cell/module_neighbor/sltk_grid_driver.h"
 #include "module_elecstate/module_dm/density_matrix.h"
-#include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
 #include "module_hamilt_lcao/module_deepks/LCAO_deepks.h"
+#include "module_hamilt_lcao/module_hcontainer/hcontainer.h"
 #include "operator_lcao.h"
 
 namespace hamilt
@@ -38,7 +38,8 @@ class DeePKS<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                                  const TwoCenterIntegrator* intor_orb_alpha,
                                  const LCAO_Orbitals* ptr_orb,
                                  const int& nks_in,
-                                 elecstate::DensityMatrix<TK, double>* DM_in);
+                                 elecstate::DensityMatrix<TK, double>* DM_in,
+                                 LCAO_Deepks* ld_in);
     ~DeePKS();
 
     /**

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.h
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/deepks_lcao.h
@@ -38,8 +38,12 @@ class DeePKS<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                                  const TwoCenterIntegrator* intor_orb_alpha,
                                  const LCAO_Orbitals* ptr_orb,
                                  const int& nks_in,
-                                 elecstate::DensityMatrix<TK, double>* DM_in,
-                                 LCAO_Deepks* ld_in);
+                                 elecstate::DensityMatrix<TK, double>* DM_in
+#ifdef __DEEPKS
+                                 ,
+                                 LCAO_Deepks* ld_in
+#endif
+                                 );
     ~DeePKS();
 
     /**

--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks.cpp
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks.cpp
@@ -15,15 +15,9 @@
 #include "LCAO_deepks.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
 
-namespace GlobalC
-{
-LCAO_Deepks ld;
-}
-
 // Constructor of the class
 LCAO_Deepks::LCAO_Deepks()
 {
-    alpha_index = new ModuleBase::IntArray[1];
     inl_index = new ModuleBase::IntArray[1];
     inl_l = nullptr;
     gedm = nullptr;
@@ -33,7 +27,6 @@ LCAO_Deepks::LCAO_Deepks()
 // Desctructor of the class
 LCAO_Deepks::~LCAO_Deepks()
 {
-    delete[] alpha_index;
     delete[] inl_index;
     delete[] inl_l;
 
@@ -139,8 +132,6 @@ void LCAO_Deepks::init_index(const int ntype,
                              const int Total_nchi,
                              const LCAO_Orbitals& orb)
 {
-    delete[] this->alpha_index;
-    this->alpha_index = new ModuleBase::IntArray[ntype];
     delete[] this->inl_index;
     this->inl_index = new ModuleBase::IntArray[ntype];
     delete[] this->inl_l;
@@ -151,11 +142,6 @@ void LCAO_Deepks::init_index(const int ntype,
     int alpha = 0;
     for (int it = 0; it < ntype; it++)
     {
-        this->alpha_index[it].create(na[it],
-                                     this->lmaxd + 1, // l starts from 0
-                                     this->nmaxd,
-                                     2 * this->lmaxd + 1); // m ==> 2*l+1
-
         this->inl_index[it].create(na[it], this->lmaxd + 1, this->nmaxd);
 
         GlobalV::ofs_running << " Type " << it + 1 << " number_of_atoms " << na[it] << std::endl;
@@ -167,11 +153,6 @@ void LCAO_Deepks::init_index(const int ntype,
             {
                 for (int n = 0; n < orb.Alpha[0].getNchi(l); n++)
                 {
-                    for (int m = 0; m < 2 * l + 1; m++)
-                    {
-                        this->alpha_index[it](ia, l, n, m) = alpha;
-                        alpha++;
-                    }
                     this->inl_index[it](ia, l, n) = inl;
                     this->inl_l[inl] = l;
                     inl++;
@@ -179,7 +160,6 @@ void LCAO_Deepks::init_index(const int ntype,
             }
         } // end ia
     }     // end it
-    assert(this->n_descriptor == alpha);
     assert(Total_nchi == inl);
     GlobalV::ofs_running << " descriptors_per_atom " << this->des_per_atom << std::endl;
     GlobalV::ofs_running << " total_descriptors " << this->n_descriptor << std::endl;

--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks.h
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks.h
@@ -64,43 +64,18 @@ class LCAO_Deepks
     /// Correction term to Hamiltonian, for multi-k
     std::vector<std::vector<std::complex<double>>> H_V_delta_k;
 
-    // functions for hr status: 1. get value; 2. set value;
-    int get_hr_cal()
-    {
-        return this->hr_cal;
-    }
-    void set_hr_cal(bool cal)
-    {
-        this->hr_cal = cal;
-    }
-
-    // temporary add two getters for inl_index and gedm
-    int get_inl(const int& T0, const int& I0, const int& L0, const int& N0)
-    {
-        return inl_index[T0](I0, L0, N0);
-    }
-    const double* get_gedms(const int& inl)
-    {
-        return gedm[inl];
-    }
-
-    int get_lmaxd()
-    {
-        return lmaxd;
-    }
     //-------------------
     // private variables
     //-------------------
     //  private:
-  public:                              // change to public to reconstuct the code, 2024-07-22 by mohan
-    int lmaxd = 0;                     // max l of descirptors
-    int nmaxd = 0;                     //#. descriptors per l
-    int inlmax = 0;                    // tot. number {i,n,l} - atom, n, l
-    int n_descriptor;                  // natoms * des_per_atom, size of descriptor(projector) basis set
-    int des_per_atom;                  // \sum_L{Nchi(L)*(2L+1)}
-    int* inl_l;                        // inl_l[inl_index] = l of descriptor with inl_index
-    ModuleBase::IntArray* alpha_index; // seems not used in the code
-    ModuleBase::IntArray* inl_index;   // caoyu add 2021-05-07
+  public:                            // change to public to reconstuct the code, 2024-07-22 by mohan
+    int lmaxd = 0;                   // max l of descirptors
+    int nmaxd = 0;                   //#. descriptors per l
+    int inlmax = 0;                  // tot. number {i,n,l} - atom, n, l
+    int n_descriptor;                // natoms * des_per_atom, size of descriptor(projector) basis set
+    int des_per_atom;                // \sum_L{Nchi(L)*(2L+1)}
+    int* inl_l;                      // inl_l[inl_index] = l of descriptor with inl_index
+    ModuleBase::IntArray* inl_index; // caoyu add 2021-05-07
 
     bool init_pdm = false; // for DeePKS NSCF calculation, set init_pdm to skip the calculation of pdm in SCF iteration
 
@@ -120,14 +95,15 @@ class LCAO_Deepks
     /// dE/dD, autograd from loaded model(E: Ry)
     double** gedm; //[tot_Inl][(2l+1)*(2l+1)]
 
-    // HR status,
-    // true : HR should be calculated
-    // false : HR has been calculated
-    bool hr_cal = true;
-
-    //-------------------
-    // subroutines, grouped according to the file they are in:
-    //-------------------
+    // functions for hr status: 1. get value; 2. set value;
+    int get_hr_cal()
+    {
+        return this->hr_cal;
+    }
+    void set_hr_cal(bool cal)
+    {
+        this->hr_cal = cal;
+    }
 
     //-------------------
     // LCAO_deepks.cpp
@@ -164,16 +140,16 @@ class LCAO_Deepks
     void dpks_cal_e_delta_band(const std::vector<std::vector<TK>>& dm, const int nks);
 
   private:
+    // flag of HR status,
+    // true : HR should be calculated
+    // false : HR has been calculated
+    bool hr_cal = true;
+
     // arrange index of descriptor in all atoms
     void init_index(const int ntype, const int nat, std::vector<int> na, const int tot_inl, const LCAO_Orbitals& orb);
 
     const Parallel_Orbitals* pv;
 };
-
-namespace GlobalC
-{
-extern LCAO_Deepks ld;
-}
 
 #endif
 #endif

--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks_io.h
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks_io.h
@@ -28,12 +28,9 @@ namespace LCAO_deepks_io
 
 /// 1. save_npy_d : descriptor -> deepks_dm_eig.npy
 /// 2. save_npy_e : energy
-/// 3. save_npy_f : force
-/// 4. save_npy_s : stress
-/// 5. save_npy_o: orbital
-/// 6. save_npy_h : Hamiltonian
-/// 7. save_matrix2npy : ModuleBase::matrix -> .npy
-/// 8. save_tensor2npy : torch::Tensor -> .npy
+/// 3. save_npy_h : Hamiltonian
+/// 4. save_matrix2npy : ModuleBase::matrix -> .npy, for force, stress and orbital
+/// 5. save_tensor2npy : torch::Tensor -> .npy, for precalculation variables
 
 /// print density matrices
 template <typename TK>
@@ -56,24 +53,7 @@ void save_npy_e(const double& e, /**<[in] \f$E_{base}\f$ or \f$E_{tot}\f$, in Ry
                 const std::string& e_file,
                 const int rank);
 
-// save force
-void save_npy_f(const ModuleBase::matrix& f, /**<[in] \f$F_{base}\f$ or \f$F_{tot}\f$, in Ry/Bohr*/
-                const std::string& f_file,
-                const int rank);
-
-// save stress
-void save_npy_s(const ModuleBase::matrix& stress, /**<[in] \f$S_{base}\f$ or \f$S_{tot}\f$, in Ry/Bohr^3*/
-                const std::string& s_file,
-                const double& omega,
-                const int rank);
-
-/// save orbital
-void save_npy_o(const std::vector<double>& bandgap, /**<[in] \f$E_{base}\f$ or \f$E_{tot}\f$, in Ry*/
-                const std::string& o_file,
-                const int nks,
-                const int rank);
-
-// save Hamiltonian and v_delta_precalc(for deepks_v_delta==1)/phialpha+gevdm(for deepks_v_delta==2)
+// save Hamiltonian
 template <typename TK, typename TH>
 void save_npy_h(const std::vector<TH>& hamilt,
                 const std::string& h_file,
@@ -84,7 +64,8 @@ void save_npy_h(const std::vector<TH>& hamilt,
 void save_matrix2npy(const std::string& file_name,
                      const ModuleBase::matrix& matrix,
                      const int rank,
-                     const double& scale = 1.0);
+                     const double& scale = 1.0,
+                     const char mode = 'N');
 
 template <typename T>
 void save_tensor2npy(const std::string& file_name, const torch::Tensor& tensor, const int rank);

--- a/source/module_hamilt_lcao/module_deepks/deepks_force.cpp
+++ b/source/module_hamilt_lcao/module_deepks/deepks_force.cpp
@@ -15,7 +15,6 @@ void DeePKS_domain::cal_f_delta(const std::vector<std::vector<TK>>& dm,
                                 const LCAO_Orbitals& orb,
                                 const Grid_Driver& GridD,
                                 const Parallel_Orbitals& pv,
-                                const int lmaxd,
                                 const int nks,
                                 const std::vector<ModuleBase::Vector3<double>>& kvec_d,
                                 std::vector<hamilt::HContainer<double>*> phialpha,
@@ -30,7 +29,7 @@ void DeePKS_domain::cal_f_delta(const std::vector<std::vector<TK>>& dm,
     f_delta.zero_out();
 
     const double Rcut_Alpha = orb.Alpha[0].getRcut();
-
+    const int lmaxd = orb.get_lmax_d();
     const int nrow = pv.nrow;
 
     for (int T0 = 0; T0 < ucell.ntype; T0++)
@@ -346,7 +345,6 @@ template void DeePKS_domain::cal_f_delta<double>(const std::vector<std::vector<d
                                                  const LCAO_Orbitals& orb,
                                                  const Grid_Driver& GridD,
                                                  const Parallel_Orbitals& pv,
-                                                 const int lmaxd,
                                                  const int nks,
                                                  const std::vector<ModuleBase::Vector3<double>>& kvec_d,
                                                  std::vector<hamilt::HContainer<double>*> phialpha,
@@ -361,7 +359,6 @@ template void DeePKS_domain::cal_f_delta<std::complex<double>>(const std::vector
                                                                const LCAO_Orbitals& orb,
                                                                const Grid_Driver& GridD,
                                                                const Parallel_Orbitals& pv,
-                                                               const int lmaxd,
                                                                const int nks,
                                                                const std::vector<ModuleBase::Vector3<double>>& kvec_d,
                                                                std::vector<hamilt::HContainer<double>*> phialpha,

--- a/source/module_hamilt_lcao/module_deepks/deepks_force.h
+++ b/source/module_hamilt_lcao/module_deepks/deepks_force.h
@@ -1,5 +1,5 @@
-#ifndef DEEPKS_FORCE_H 
-#define DEEPKS_FORCE_H 
+#ifndef DEEPKS_FORCE_H
+#define DEEPKS_FORCE_H
 
 #ifdef __DEEPKS
 
@@ -14,36 +14,34 @@
 
 namespace DeePKS_domain
 {
-    //------------------------
-    // deepks_force.cpp
-    //------------------------
+//------------------------
+// deepks_force.cpp
+//------------------------
 
-    // This file contains subroutines for calculating F_delta,
-    // which is defind as sum_mu,nu rho_mu,nu d/dX (<chi_mu|alpha>V(D)<alpha|chi_nu>)
+// This file contains subroutines for calculating F_delta,
+// which is defind as sum_mu,nu rho_mu,nu d/dX (<chi_mu|alpha>V(D)<alpha|chi_nu>)
 
-    // There are 2 subroutines in this file:
-    // 1. cal_f_delta, which is used for F_delta calculation
-    // 2. check_f_delta, which prints F_delta into F_delta.dat for checking
+// There are 2 subroutines in this file:
+// 1. cal_f_delta, which is used for F_delta calculation
+// 2. check_f_delta, which prints F_delta into F_delta.dat for checking
 
 template <typename TK>
-void cal_f_delta(
-    const std::vector<std::vector<TK>>& dm,
-    const UnitCell& ucell,
-    const LCAO_Orbitals& orb,
-    const Grid_Driver& GridD,
-    const Parallel_Orbitals& pv,
-    const int lmaxd,
-    const int nks,
-    const std::vector<ModuleBase::Vector3<double>>& kvec_d,
-    std::vector<hamilt::HContainer<double>*> phialpha,
-    double** gedm,
-    ModuleBase::IntArray* inl_index,
-    ModuleBase::matrix& f_delta,
-    const bool isstress,
-    ModuleBase::matrix& svnl_dalpha);
+void cal_f_delta(const std::vector<std::vector<TK>>& dm,
+                 const UnitCell& ucell,
+                 const LCAO_Orbitals& orb,
+                 const Grid_Driver& GridD,
+                 const Parallel_Orbitals& pv,
+                 const int nks,
+                 const std::vector<ModuleBase::Vector3<double>>& kvec_d,
+                 std::vector<hamilt::HContainer<double>*> phialpha,
+                 double** gedm,
+                 ModuleBase::IntArray* inl_index,
+                 ModuleBase::matrix& f_delta,
+                 const bool isstress,
+                 ModuleBase::matrix& svnl_dalpha);
 
 void check_f_delta(const int nat, ModuleBase::matrix& f_delta, ModuleBase::matrix& svnl_dalpha);
-}
+} // namespace DeePKS_domain
 
 #endif
 #endif

--- a/source/module_hamilt_lcao/module_deepks/deepks_orbital.cpp
+++ b/source/module_hamilt_lcao/module_deepks/deepks_orbital.cpp
@@ -9,7 +9,8 @@
 template <typename TK, typename TH>
 void DeePKS_domain::cal_o_delta(const std::vector<TH>& dm_hl,
                                 const std::vector<std::vector<TK>>& h_delta,
-                                std::vector<double>& o_delta,
+                                // std::vector<double>& o_delta,
+                                ModuleBase::matrix& o_delta,
                                 const Parallel_Orbitals& pv,
                                 const int nks)
 {
@@ -54,11 +55,13 @@ void DeePKS_domain::cal_o_delta(const std::vector<TH>& dm_hl,
         Parallel_Reduce::reduce_all(o_delta_tmp);
         if constexpr (std::is_same<TK, double>::value)
         {
-            o_delta[ik] = o_delta_tmp;
+            // o_delta[ik] = o_delta_tmp;
+            o_delta(ik, 0) = o_delta_tmp;
         }
         else
         {
-            o_delta[ik] = o_delta_tmp.real();
+            // o_delta[ik] = o_delta_tmp.real();
+            o_delta(ik, 0) = o_delta_tmp.real();
         }
     }
     return;
@@ -66,14 +69,16 @@ void DeePKS_domain::cal_o_delta(const std::vector<TH>& dm_hl,
 
 template void DeePKS_domain::cal_o_delta<double, ModuleBase::matrix>(const std::vector<ModuleBase::matrix>& dm_hl,
                                                                      const std::vector<std::vector<double>>& h_delta,
-                                                                     std::vector<double>& o_delta,
+                                                                     //  std::vector<double>& o_delta,
+                                                                     ModuleBase::matrix& o_delta,
                                                                      const Parallel_Orbitals& pv,
                                                                      const int nks);
 
 template void DeePKS_domain::cal_o_delta<std::complex<double>, ModuleBase::ComplexMatrix>(
     const std::vector<ModuleBase::ComplexMatrix>& dm_hl,
     const std::vector<std::vector<std::complex<double>>>& h_delta,
-    std::vector<double>& o_delta,
+    // std::vector<double>& o_delta,
+    ModuleBase::matrix& o_delta,
     const Parallel_Orbitals& pv,
     const int nks);
 

--- a/source/module_hamilt_lcao/module_deepks/deepks_orbital.h
+++ b/source/module_hamilt_lcao/module_deepks/deepks_orbital.h
@@ -26,7 +26,8 @@ namespace DeePKS_domain
 template <typename TK, typename TH>
 void cal_o_delta(const std::vector<TH>& dm_hl,
                  const std::vector<std::vector<TK>>& h_delta,
-                 std::vector<double>& o_delta,
+                 //  std::vector<double>& o_delta,
+                 ModuleBase::matrix& o_delta,
                  const Parallel_Orbitals& pv,
                  const int nks);
 } // namespace DeePKS_domain

--- a/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test.cpp
+++ b/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test.cpp
@@ -34,14 +34,9 @@ void test_deepks::check_phialpha()
     {
         na[it] = ucell.atoms[it].na;
     }
-    GlobalC::ld.init(ORB, ucell.nat, ucell.ntype, kv.nkstot, ParaO, na);
+    this->ld.init(ORB, ucell.nat, ucell.ntype, kv.nkstot, ParaO, na);
 
-    DeePKS_domain::allocate_phialpha(PARAM.input.cal_force,
-                                     ucell,
-                                     ORB,
-                                     Test_Deepks::GridD,
-                                     &ParaO,
-                                     GlobalC::ld.phialpha);
+    DeePKS_domain::allocate_phialpha(PARAM.input.cal_force, ucell, ORB, Test_Deepks::GridD, &ParaO, this->ld.phialpha);
 
     DeePKS_domain::build_phialpha(PARAM.input.cal_force,
                                   ucell,
@@ -49,9 +44,9 @@ void test_deepks::check_phialpha()
                                   Test_Deepks::GridD,
                                   &ParaO,
                                   overlap_orb_alpha_,
-                                  GlobalC::ld.phialpha);
+                                  this->ld.phialpha);
 
-    DeePKS_domain::check_phialpha(PARAM.input.cal_force, ucell, ORB, Test_Deepks::GridD, &ParaO, GlobalC::ld.phialpha);
+    DeePKS_domain::check_phialpha(PARAM.input.cal_force, ucell, ORB, Test_Deepks::GridD, &ParaO, this->ld.phialpha);
 
     this->compare_with_ref("phialpha.dat", "phialpha_ref.dat");
     this->compare_with_ref("dphialpha_x.dat", "dphialpha_x_ref.dat");
@@ -156,38 +151,38 @@ void test_deepks::check_pdm()
         this->read_dm();
         this->set_dm_new();
         this->set_p_elec_DM();
-        DeePKS_domain::cal_pdm(GlobalC::ld.init_pdm,
-                               GlobalC::ld.inlmax,
-                               GlobalC::ld.lmaxd,
-                               GlobalC::ld.inl_l,
-                               GlobalC::ld.inl_index,
+        DeePKS_domain::cal_pdm(this->ld.init_pdm,
+                               this->ld.inlmax,
+                               this->ld.lmaxd,
+                               this->ld.inl_l,
+                               this->ld.inl_index,
                                p_elec_DM,
-                               GlobalC::ld.phialpha,
+                               this->ld.phialpha,
                                ucell,
                                ORB,
                                Test_Deepks::GridD,
                                ParaO,
-                               GlobalC::ld.pdm);
+                               this->ld.pdm);
     }
     else
     {
         this->read_dm_k(kv.nkstot);
         this->set_dm_k_new();
         this->set_p_elec_DM_k();
-        DeePKS_domain::cal_pdm(GlobalC::ld.init_pdm,
-                               GlobalC::ld.inlmax,
-                               GlobalC::ld.lmaxd,
-                               GlobalC::ld.inl_l,
-                               GlobalC::ld.inl_index,
+        DeePKS_domain::cal_pdm(this->ld.init_pdm,
+                               this->ld.inlmax,
+                               this->ld.lmaxd,
+                               this->ld.inl_l,
+                               this->ld.inl_index,
                                p_elec_DM_k,
-                               GlobalC::ld.phialpha,
+                               this->ld.phialpha,
                                ucell,
                                ORB,
                                Test_Deepks::GridD,
                                ParaO,
-                               GlobalC::ld.pdm);
+                               this->ld.pdm);
     }
-    DeePKS_domain::check_pdm(GlobalC::ld.inlmax, GlobalC::ld.inl_l, GlobalC::ld.pdm);
+    DeePKS_domain::check_pdm(this->ld.inlmax, this->ld.inl_l, this->ld.pdm);
     this->compare_with_ref("pdm.dat", "pdm_ref.dat");
 }
 
@@ -195,12 +190,12 @@ void test_deepks::check_gdmx(torch::Tensor& gdmx)
 {
     if (PARAM.sys.gamma_only_local)
     {
-        DeePKS_domain::cal_gdmx(GlobalC::ld.lmaxd,
-                                GlobalC::ld.inlmax,
+        DeePKS_domain::cal_gdmx(this->ld.lmaxd,
+                                this->ld.inlmax,
                                 kv.nkstot,
                                 kv.kvec_d,
-                                GlobalC::ld.phialpha,
-                                GlobalC::ld.inl_index,
+                                this->ld.phialpha,
+                                this->ld.inl_index,
                                 dm_new,
                                 ucell,
                                 ORB,
@@ -210,12 +205,12 @@ void test_deepks::check_gdmx(torch::Tensor& gdmx)
     }
     else
     {
-        DeePKS_domain::cal_gdmx(GlobalC::ld.lmaxd,
-                                GlobalC::ld.inlmax,
+        DeePKS_domain::cal_gdmx(this->ld.lmaxd,
+                                this->ld.inlmax,
                                 kv.nkstot,
                                 kv.kvec_d,
-                                GlobalC::ld.phialpha,
-                                GlobalC::ld.inl_index,
+                                this->ld.phialpha,
+                                this->ld.inl_index,
                                 dm_k_new,
                                 ucell,
                                 ORB,
@@ -254,12 +249,12 @@ void test_deepks::check_gdmepsl(torch::Tensor& gdmepsl)
 {
     if (PARAM.sys.gamma_only_local)
     {
-        DeePKS_domain::cal_gdmepsl(GlobalC::ld.lmaxd,
-                                   GlobalC::ld.inlmax,
+        DeePKS_domain::cal_gdmepsl(this->ld.lmaxd,
+                                   this->ld.inlmax,
                                    kv.nkstot,
                                    kv.kvec_d,
-                                   GlobalC::ld.phialpha,
-                                   GlobalC::ld.inl_index,
+                                   this->ld.phialpha,
+                                   this->ld.inl_index,
                                    dm_new,
                                    ucell,
                                    ORB,
@@ -269,12 +264,12 @@ void test_deepks::check_gdmepsl(torch::Tensor& gdmepsl)
     }
     else
     {
-        DeePKS_domain::cal_gdmepsl(GlobalC::ld.lmaxd,
-                                   GlobalC::ld.inlmax,
+        DeePKS_domain::cal_gdmepsl(this->ld.lmaxd,
+                                   this->ld.inlmax,
                                    kv.nkstot,
                                    kv.kvec_d,
-                                   GlobalC::ld.phialpha,
-                                   GlobalC::ld.inl_index,
+                                   this->ld.phialpha,
+                                   this->ld.inl_index,
                                    dm_k_new,
                                    ucell,
                                    ORB,
@@ -299,32 +294,21 @@ void test_deepks::check_gdmepsl(torch::Tensor& gdmepsl)
 void test_deepks::check_descriptor(std::vector<torch::Tensor>& descriptor)
 {
     DeePKS_domain::cal_descriptor(ucell.nat,
-                                  GlobalC::ld.inlmax,
-                                  GlobalC::ld.inl_l,
-                                  GlobalC::ld.pdm,
+                                  this->ld.inlmax,
+                                  this->ld.inl_l,
+                                  this->ld.pdm,
                                   descriptor,
-                                  GlobalC::ld.des_per_atom);
-    DeePKS_domain::check_descriptor(GlobalC::ld.inlmax,
-                                    GlobalC::ld.des_per_atom,
-                                    GlobalC::ld.inl_l,
-                                    ucell,
-                                    "./",
-                                    descriptor);
+                                  this->ld.des_per_atom);
+    DeePKS_domain::check_descriptor(this->ld.inlmax, this->ld.des_per_atom, this->ld.inl_l, ucell, "./", descriptor);
     this->compare_with_ref("deepks_desc.dat", "descriptor_ref.dat");
 }
 
 void test_deepks::check_gvx(torch::Tensor& gdmx)
 {
     std::vector<torch::Tensor> gevdm;
-    DeePKS_domain::cal_gevdm(ucell.nat, GlobalC::ld.inlmax, GlobalC::ld.inl_l, GlobalC::ld.pdm, gevdm);
+    DeePKS_domain::cal_gevdm(ucell.nat, this->ld.inlmax, this->ld.inl_l, this->ld.pdm, gevdm);
     torch::Tensor gvx;
-    DeePKS_domain::cal_gvx(ucell.nat,
-                           GlobalC::ld.inlmax,
-                           GlobalC::ld.des_per_atom,
-                           GlobalC::ld.inl_l,
-                           gevdm,
-                           gdmx,
-                           gvx);
+    DeePKS_domain::cal_gvx(ucell.nat, this->ld.inlmax, this->ld.des_per_atom, this->ld.inl_l, gevdm, gdmx, gvx);
     DeePKS_domain::check_gvx(gvx);
 
     for (int ia = 0; ia < ucell.nat; ia++)
@@ -354,12 +338,12 @@ void test_deepks::check_gvx(torch::Tensor& gdmx)
 void test_deepks::check_gvepsl(torch::Tensor& gdmepsl)
 {
     std::vector<torch::Tensor> gevdm;
-    DeePKS_domain::cal_gevdm(ucell.nat, GlobalC::ld.inlmax, GlobalC::ld.inl_l, GlobalC::ld.pdm, gevdm);
+    DeePKS_domain::cal_gevdm(ucell.nat, this->ld.inlmax, this->ld.inl_l, this->ld.pdm, gevdm);
     torch::Tensor gvepsl;
     DeePKS_domain::cal_gvepsl(ucell.nat,
-                              GlobalC::ld.inlmax,
-                              GlobalC::ld.des_per_atom,
-                              GlobalC::ld.inl_l,
+                              this->ld.inlmax,
+                              this->ld.des_per_atom,
+                              this->ld.inl_l,
                               gevdm,
                               gdmepsl,
                               gvepsl);
@@ -379,33 +363,33 @@ void test_deepks::check_gvepsl(torch::Tensor& gdmepsl)
 
 void test_deepks::check_edelta(std::vector<torch::Tensor>& descriptor)
 {
-    DeePKS_domain::load_model("model.ptg", GlobalC::ld.model_deepks);
+    DeePKS_domain::load_model("model.ptg", ld.model_deepks);
     if (PARAM.sys.gamma_only_local)
     {
-        GlobalC::ld.allocate_V_delta(ucell.nat, 1); // 1 for gamma-only
+        ld.allocate_V_delta(ucell.nat, 1); // 1 for gamma-only
     }
     else
     {
-        GlobalC::ld.allocate_V_delta(ucell.nat, kv.nkstot);
+        ld.allocate_V_delta(ucell.nat, kv.nkstot);
     }
     DeePKS_domain::cal_gedm(ucell.nat,
-                            GlobalC::ld.lmaxd,
-                            GlobalC::ld.nmaxd,
-                            GlobalC::ld.inlmax,
-                            GlobalC::ld.des_per_atom,
-                            GlobalC::ld.inl_l,
+                            this->ld.lmaxd,
+                            this->ld.nmaxd,
+                            this->ld.inlmax,
+                            this->ld.des_per_atom,
+                            this->ld.inl_l,
                             descriptor,
-                            GlobalC::ld.pdm,
-                            GlobalC::ld.model_deepks,
-                            GlobalC::ld.gedm,
-                            GlobalC::ld.E_delta);
+                            this->ld.pdm,
+                            this->ld.model_deepks,
+                            this->ld.gedm,
+                            this->ld.E_delta);
 
     std::ofstream ofs("E_delta.dat");
-    ofs << std::setprecision(10) << GlobalC::ld.E_delta << std::endl;
+    ofs << std::setprecision(10) << this->ld.E_delta << std::endl;
     ofs.close();
     this->compare_with_ref("E_delta.dat", "E_delta_ref.dat");
 
-    DeePKS_domain::check_gedm(GlobalC::ld.inlmax, GlobalC::ld.inl_l, GlobalC::ld.gedm);
+    DeePKS_domain::check_gedm(this->ld.inlmax, this->ld.inl_l, this->ld.gedm);
     this->compare_with_ref("gedm.dat", "gedm_ref.dat");
 }
 
@@ -422,7 +406,8 @@ void test_deepks::cal_H_V_delta()
                                                                    &overlap_orb_alpha_,
                                                                    &ORB,
                                                                    kv.nkstot,
-                                                                   p_elec_DM);
+                                                                   p_elec_DM,
+                                                                   &this->ld);
     for (int ik = 0; ik < kv.nkstot; ++ik)
     {
         op_deepks->init(ik);
@@ -443,7 +428,8 @@ void test_deepks::cal_H_V_delta_k()
                                                                                  &overlap_orb_alpha_,
                                                                                  &ORB,
                                                                                  kv.nkstot,
-                                                                                 p_elec_DM_k);
+                                                                                 p_elec_DM_k,
+                                                                                 &this->ld);
     for (int ik = 0; ik < kv.nkstot; ++ik)
     {
         op_deepks->init(ik);
@@ -455,16 +441,16 @@ void test_deepks::check_e_deltabands()
     if (PARAM.sys.gamma_only_local)
     {
         this->cal_H_V_delta();
-        GlobalC::ld.dpks_cal_e_delta_band(dm_new, 1);
+        this->ld.dpks_cal_e_delta_band(dm_new, 1);
     }
     else
     {
         this->cal_H_V_delta_k();
-        GlobalC::ld.dpks_cal_e_delta_band(dm_k_new, kv.nkstot);
+        this->ld.dpks_cal_e_delta_band(dm_k_new, kv.nkstot);
     }
 
     std::ofstream ofs("E_delta_bands.dat");
-    ofs << std::setprecision(10) << GlobalC::ld.e_delta_band << std::endl;
+    ofs << std::setprecision(10) << this->ld.e_delta_band << std::endl;
     ofs.close();
     this->compare_with_ref("E_delta_bands.dat", "E_delta_bands_ref.dat");
 }
@@ -485,12 +471,11 @@ void test_deepks::check_f_delta_and_stress_delta()
                                            ORB,
                                            Test_Deepks::GridD,
                                            ParaO,
-                                           GlobalC::ld.lmaxd,
                                            nks,
                                            kv.kvec_d,
-                                           GlobalC::ld.phialpha,
-                                           GlobalC::ld.gedm,
-                                           GlobalC::ld.inl_index,
+                                           this->ld.phialpha,
+                                           this->ld.gedm,
+                                           this->ld.inl_index,
                                            fvnl_dalpha,
                                            cal_stress,
                                            svnl_dalpha);
@@ -503,12 +488,11 @@ void test_deepks::check_f_delta_and_stress_delta()
                                                          ORB,
                                                          Test_Deepks::GridD,
                                                          ParaO,
-                                                         GlobalC::ld.lmaxd,
                                                          nks,
                                                          kv.kvec_d,
-                                                         GlobalC::ld.phialpha,
-                                                         GlobalC::ld.gedm,
-                                                         GlobalC::ld.inl_index,
+                                                         this->ld.phialpha,
+                                                         this->ld.gedm,
+                                                         this->ld.inl_index,
                                                          fvnl_dalpha,
                                                          cal_stress,
                                                          svnl_dalpha);

--- a/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test.h
+++ b/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test.h
@@ -21,11 +21,6 @@ namespace Test_Deepks
 extern Grid_Driver GridD;
 }
 
-namespace GlobalC
-{
-extern LCAO_Deepks ld;
-}
-
 class test_deepks
 {
 
@@ -43,7 +38,7 @@ class test_deepks
 
     Parallel_Orbitals ParaO;
     Test_Deepks::K_Vectors kv;
-    // LCAO_Deepks ld;
+    LCAO_Deepks ld;
 
     int failed_check = 0;
     int total_check = 0;


### PR DESCRIPTION
### What's changed?
- Move LCAO_Deepks from GlobalC to ESOLVER_KS_LCAO.
- Combile `save_npy_f()` `save_npy_s()` and `save_npy_o()` by `save_matrix2npy()`.