### PR TITLE
Fix:modify cheaktau type and add unittest

### DIFF
--- a/source/module_cell/read_stru.cpp
+++ b/source/module_cell/read_stru.cpp
@@ -5,8 +5,8 @@
 namespace unitcell
 {
     bool check_tau(const Atom* atoms,
-                   const int ntype,
-                   const int lat0) 
+                   const int& ntype,
+                   const double& lat0) 
     {
         ModuleBase::TITLE("UnitCell","check_tau");
         ModuleBase::timer::tick("UnitCell","check_tau");

--- a/source/module_cell/read_stru.h
+++ b/source/module_cell/read_stru.h
@@ -6,8 +6,8 @@
 namespace unitcell
 {
     bool check_tau(const Atom* atoms,
-                   const int ntype,
-                   const int lat0);
+                   const int& ntype,
+                   const double& lat0);
                    
     bool read_atom_species(std::ifstream& ifa,
                           std::ofstream& ofs_running,

--- a/source/module_cell/test/unitcell_test.cpp
+++ b/source/module_cell/test/unitcell_test.cpp
@@ -776,6 +776,9 @@ TEST_F(UcellTest, CheckTauTrue)
     ucell = utp.SetUcellInfo();
     GlobalV::ofs_warning.open("checktau_warning");
     int atom=0;
+    //cause the ucell->lat0 is 0.5,if the type of the check_tau has 
+    //an int type,it will set to zero,and it will not pass the unittest
+    ucell->lat0=0.5;
     ucell->nat=3;
     for (int it=0;it<ucell->ntype;it++)
     {
@@ -785,7 +788,6 @@ TEST_F(UcellTest, CheckTauTrue)
             for (int i=0;i<3;i++)
             {
                 ucell->atoms[it].tau[ia][i]=((atom+i)/(ucell->nat*3.0));
-                std::cout<<"the tau is "<<ucell->atoms[it].tau[ia][i];
             }
             atom+=3;
         }

--- a/source/module_cell/test/unitcell_test.cpp
+++ b/source/module_cell/test/unitcell_test.cpp
@@ -753,7 +753,7 @@ TEST_F(UcellTest, CheckDTau)
     }
 }
 
-TEST_F(UcellTest, CheckTau)
+TEST_F(UcellTest, CheckTauFalse)
 {
     UcellTestPrepare utp = UcellTestLib["C1H2-CheckTau"];
     PARAM.input.relax_new = utp.relax_new;
@@ -767,6 +767,31 @@ TEST_F(UcellTest, CheckTau)
     EXPECT_THAT(str, testing::HasSubstr("two atoms are too close!"));
     ifs.close();
     remove("checktau_warning");
+}
+
+TEST_F(UcellTest, CheckTauTrue)
+{
+    UcellTestPrepare utp = UcellTestLib["C1H2-CheckTau"];
+    PARAM.input.relax_new = utp.relax_new;
+    ucell = utp.SetUcellInfo();
+    GlobalV::ofs_warning.open("checktau_warning");
+    int atom=0;
+    ucell->nat=3;
+    for (int it=0;it<ucell->ntype;it++)
+    {
+        for(int ia=0; ia<ucell->atoms[it].na; ++ia)
+        {
+            
+            for (int i=0;i<3;i++)
+            {
+                ucell->atoms[it].tau[ia][i]=((atom+i)/(ucell->nat*3.0));
+                std::cout<<"the tau is "<<ucell->atoms[it].tau[ia][i];
+            }
+            atom+=3;
+        }
+    }
+    EXPECT_EQ(unitcell::check_tau(ucell->atoms ,ucell->ntype, ucell->lat0),true);
+    GlobalV::ofs_warning.close();
 }
 
 TEST_F(UcellTest, SelectiveDynamics)


### PR DESCRIPTION
### Linked Issue
Fix #5860 

### Unit Tests and/or Case Tests for my changes
- The current unit tests do not cover the scenario where cheaktau is set to true. As a result, when I modified the type of lat, the changes could not be validated through existing tests  
- when i set the type of lat in check_tau,it will be wrong in the new test
![图片](https://github.com/user-attachments/assets/40c9fb55-284a-4b8e-99f9-39dd4a4aba2a)

### What's changed?
- Fixed a bug related to the type of checktau. I had incorrectly specified the type for lat0.
- Special thanks to @dzzz2001 for identifying the error in test/performance within the P102_si64_lcao test case.
- The result is as below.
![图片](https://github.com/user-attachments/assets/267636a5-b4e2-4f00-8d60-21375f01ab63)


