### PR TITLE
Fix: Fixed a bug in RT-TDDFT where the electric field was not applied starting from the restart step

### DIFF
--- a/source/module_elecstate/potentials/H_TDDFT_pw.cpp
+++ b/source/module_elecstate/potentials/H_TDDFT_pw.cpp
@@ -12,6 +12,7 @@ namespace elecstate
 {
 
 int H_TDDFT_pw::istep = -1;
+bool H_TDDFT_pw::is_initialized = false;
 
 double H_TDDFT_pw::amp;
 double H_TDDFT_pw::bmod;
@@ -75,6 +76,21 @@ std::vector<int> H_TDDFT_pw::trigo_ncut;   // cut for integral
 int H_TDDFT_pw::heavi_count;
 std::vector<double> H_TDDFT_pw::heavi_t0;
 std::vector<double> H_TDDFT_pw::heavi_amp; // Ry/bohr
+
+void H_TDDFT_pw::current_step_info(const std::string& file_dir, int& istep)
+{
+    std::stringstream ssc;
+    ssc << file_dir << "Restart_md.dat";
+    std::ifstream file(ssc.str().c_str());
+
+    if (!file)
+    {
+        ModuleBase::WARNING_QUIT("H_TDDFT_pw::current_step_info", "No Restart_md.dat!");
+    }
+
+    file >> istep;
+    file.close();
+}
 
 void H_TDDFT_pw::cal_fixed_v(double* vl_pseudo)
 {

--- a/source/module_io/read_set_globalv.cpp
+++ b/source/module_io/read_set_globalv.cpp
@@ -23,7 +23,7 @@ void ReadInput::set_globalv(Parameter& para)
         para.sys.global_matrix_dir = to_dir(para.sys.global_matrix_dir);
 
         /// get the global readin directory
-        para.sys.global_readin_dir = para.inp.read_file_dir + '/';
+        para.sys.global_readin_dir = para.inp.read_file_dir;
         para.sys.global_readin_dir = to_dir(para.sys.global_readin_dir);
 
         /// get the stru file for md restart case


### PR DESCRIPTION
### Linked Issue
Fix #4833, fix #4736.

### What's changed?

Now, for RT-TDDFT with an external electric field, the restart process no longer requires modifying the electric field parameters. The program automatically reads the step at which the calculation was interrupted and applies the electric field starting from the restart MD step.

Below is a benchmark: a Heaviside step electric field is applied, which turns off at the 12th MD step. The _blue_ line represents the complete 20-step simulation, the _orange_ line represents the simulation interrupted at the 10th step, and the _green_ line represents the simulation restarted from the 10th step. Their energy curves perfectly overlap, and no changes were made to the electric field parameters in the INPUT file.
![combined_energy](https://github.com/user-attachments/assets/cd68e501-32bd-4c21-bb92-54e3fb5ef7a5)
