### PR TITLE
Perf: modify openmp strategy in module_gint

### DIFF
--- a/source/module_hamilt_lcao/module_gint/gint_force_cpu_interface.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_force_cpu_interface.cpp
@@ -28,7 +28,7 @@ void Gint::gint_kernel_force(Gint_inout* inout) {
     std::vector<int> block_index(max_size+1,0);
     std::vector<int> block_size(max_size,0);
     std::vector<double> vldr3(this->bxyz,0.0);
-#pragma omp for
+#pragma omp for schedule(dynamic)
     for (int grid_index = 0; grid_index < this->nbxx; grid_index++) {
         const int na_grid = this->gridt->how_many_atoms[grid_index];
         if (na_grid == 0) {
@@ -153,7 +153,7 @@ void Gint::gint_kernel_force_meta(Gint_inout* inout) {
     std::vector<int> block_size(max_size,0);
     std::vector<double> vldr3(this->bxyz,0.0);
     std::vector<double> vkdr3(this->bxyz,0.0);
-#pragma omp for
+#pragma omp for schedule(dynamic)
     for (int grid_index = 0; grid_index < this->nbxx; grid_index++) {
         const int na_grid = this->gridt->how_many_atoms[grid_index];
         if (na_grid == 0) {

--- a/source/module_hamilt_lcao/module_gint/gint_rho_cpu_interface.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_rho_cpu_interface.cpp
@@ -16,7 +16,7 @@ void Gint::gint_kernel_rho(Gint_inout* inout) {
     std::vector<int> block_index(max_size+1, 0);
     std::vector<int> block_size(max_size, 0);
     std::vector<int> vindex(this->bxyz, 0);
-#pragma omp for
+#pragma omp for schedule(dynamic)
     for (int grid_index = 0; grid_index < this->nbxx; grid_index++)
     {
         const int na_grid = this->gridt->how_many_atoms[grid_index];
@@ -102,7 +102,7 @@ void Gint::gint_kernel_tau(Gint_inout* inout) {
     std::vector<int> block_index(max_size+1, 0);
     std::vector<int> block_size(max_size, 0);
     std::vector<int> vindex(bxyz, 0);
-#pragma omp for
+#pragma omp for schedule(dynamic)
     for (int grid_index = 0; grid_index < this->nbxx; grid_index++)
     {
         const int na_grid = this->gridt->how_many_atoms[grid_index];

--- a/source/module_hamilt_lcao/module_gint/gint_vl_cpu_interface.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_vl_cpu_interface.cpp
@@ -24,7 +24,7 @@ void Gint::gint_kernel_vlocal(Gint_inout* inout) {
         std::vector<int> block_index(max_size+1,0);
         std::vector<int> block_size(max_size,0);
         std::vector<double> vldr3(this->bxyz,0.0);
-        #pragma omp for
+        #pragma omp for schedule(dynamic)
         for (int grid_index = 0; grid_index < this->nbxx; grid_index++) {
             const int na_grid = this->gridt->how_many_atoms[grid_index];
             if (na_grid == 0) {
@@ -119,7 +119,7 @@ void Gint::gint_kernel_dvlocal(Gint_inout* inout) {
     std::vector<int> block_index(max_size+1,0);
     std::vector<int> block_size(max_size,0);
     std::vector<double> vldr3(this->bxyz,0.0);
-#pragma omp for
+#pragma omp for schedule(dynamic)
     for (int grid_index = 0; grid_index < this->nbxx; grid_index++) {
         const int na_grid = this->gridt->how_many_atoms[grid_index];
         if (na_grid == 0) {
@@ -217,7 +217,7 @@ void Gint::gint_kernel_vlocal_meta(Gint_inout* inout) {
     std::vector<double> vldr3(this->bxyz,0.0);
     std::vector<double> vkdr3(this->bxyz,0.0);
 
-#pragma omp for
+#pragma omp for schedule(dynamic)
     for (int grid_index = 0; grid_index < this->nbxx; grid_index++) {
         const int na_grid = this->gridt->how_many_atoms[grid_index];
         if (na_grid == 0) {


### PR DESCRIPTION
### Background
In some cases, the computational workload varies significantly across different grids. Setting the OpenMP strategy to 'dynamic' can effectively balance the computational load and improve computational efficiency. Below is a comparison of computation times for one iteration of 'cal_gint_vlocal' before and after making these changes in several test cases:
||before|after|
|---|---|---|
|001_C2H6O|0.14s|0.08s|
|002_4MoS2|0.30s|0.13s|
|003_12Pt111|0.63s|0.27s|


