### PR TITLE
Feature: Optimize dngvd_op with CPU/GPU Branching Based on nstart

### DIFF
--- a/source/module_esolver/esolver_ks_pw.cpp
+++ b/source/module_esolver/esolver_ks_pw.cpp
@@ -556,7 +556,8 @@ void ESolver_KS_PW<T, Device>::hamilt2density_single(UnitCell& ucell,
                                                      hsolver::DiagoIterAssist<T, Device>::SCF_ITER,
                                                      hsolver::DiagoIterAssist<T, Device>::PW_DIAG_NMAX,
                                                      hsolver::DiagoIterAssist<T, Device>::PW_DIAG_THR,
-                                                     hsolver::DiagoIterAssist<T, Device>::need_subspace);
+                                                     hsolver::DiagoIterAssist<T, Device>::need_subspace,
+                                                     PARAM.inp.use_k_continuity);
 
         hsolver_pw_obj.solve(this->p_hamilt,
                              this->kspw_psi[0],

--- a/source/module_esolver/esolver_sdft_pw.cpp
+++ b/source/module_esolver/esolver_sdft_pw.cpp
@@ -175,7 +175,8 @@ void ESolver_SDFT_PW<T, Device>::hamilt2density_single(UnitCell& ucell, int iste
                                                            hsolver::DiagoIterAssist<T, Device>::SCF_ITER,
                                                            hsolver::DiagoIterAssist<T, Device>::PW_DIAG_NMAX,
                                                            hsolver::DiagoIterAssist<T, Device>::PW_DIAG_THR,
-                                                           hsolver::DiagoIterAssist<T, Device>::need_subspace);
+                                                           hsolver::DiagoIterAssist<T, Device>::need_subspace,
+                                                           PARAM.inp.use_k_continuity);
 
     hsolver_pw_sdft_obj.solve(ucell,
                               this->p_hamilt,

--- a/source/module_hamilt_lcao/module_deltaspin/cal_mw_from_lambda.cpp
+++ b/source/module_hamilt_lcao/module_deltaspin/cal_mw_from_lambda.cpp
@@ -428,7 +428,8 @@ void spinconstrain::SpinConstrain<std::complex<double>>::update_psi_charge(const
                                                  hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::SCF_ITER,
                                                  hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::PW_DIAG_NMAX,
                                                  hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::PW_DIAG_THR,
-                                                 hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::need_subspace);
+                                                 hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::need_subspace,
+                                                 PARAM.inp.use_k_continuity);
 
                 hsolver_pw_obj.solve(hamilt_t,
                          psi_t[0],
@@ -503,7 +504,8 @@ void spinconstrain::SpinConstrain<std::complex<double>>::update_psi_charge(const
                                                  hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_GPU>::SCF_ITER,
                                                  hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_GPU>::PW_DIAG_NMAX,
                                                  hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_GPU>::PW_DIAG_THR,
-                                                 hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_GPU>::need_subspace);
+                                                 hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_GPU>::need_subspace,
+                                                 PARAM.inp.use_k_continuity);
 
                 hsolver_pw_obj.solve(hamilt_t,
                          psi_t[0],

--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -689,7 +689,7 @@ void HSolverPW<T, Device>::build_k_neighbors() {
     k_order.clear();
     k_order.reserve(nk);
     
-    // 存储k点和对应索引的结构体
+    // Store k-points and corresponding indices
     struct KPoint {
         ModuleBase::Vector3<double> kvec;
         int index;
@@ -699,29 +699,29 @@ void HSolverPW<T, Device>::build_k_neighbors() {
             kvec(v), index(i), norm(v.norm()) {}
     };
     
-    // 构建k点列表
+    // Build k-point list
     std::vector<KPoint> klist;
     for (int ik = 0; ik < nk; ++ik) {
         kvecs_c[ik] = this->wfc_basis->kvec_c[ik];
         klist.push_back(KPoint(kvecs_c[ik], ik));
     }
     
-    // 按照到原点距离排序k点
+    // Sort k-points by distance from origin
     std::sort(klist.begin(), klist.end(),
         [](const KPoint& a, const KPoint& b) {
             return a.norm < b.norm;
         });
     
-    // 构建父子关系
+    // Build parent-child relationships
     k_order.push_back(klist[0].index);
     
-    // 对每个k点找最近的已处理k点作为父节点
+    // Find nearest processed k-point as parent for each k-point
     for (int i = 1; i < nk; ++i) {
         int current_k = klist[i].index;
         double min_dist = 1e10;
         int parent = -1;
         
-        // 在已处理的k点中找最近邻
+        // find the nearest k-point as parent
         for (int j = 0; j < k_order.size(); ++j) {
             int processed_k = k_order[j];
             double dist = (kvecs_c[current_k] - kvecs_c[processed_k]).norm2();
@@ -744,14 +744,14 @@ void HSolverPW<T, Device>::propagate_psi(psi::Psi<T>& psi, const int from_ik, co
     // Get k-point difference
     ModuleBase::Vector3<double> dk = kvecs_c[to_ik] - kvecs_c[from_ik];
     
-    // Allocate temporary arrays
-    std::vector<T> psi_real(this->wfc_basis->nrxx);
+    // Allocate temporary arrays using device-aware memory management
+    T* porter = nullptr;
+    resmem_complex_op()(this->ctx, porter, this->wfc_basis->nmaxgr, "HSolverPW::porter");
     
     // Process each band
     for (int ib = 0; ib < nbands; ++ib) {
-        // IFFT to real space
-        // TODO: Check if the call is correct
-        this->wfc_basis->recip_to_real(this->ctx, &psi(from_ik, ib, 0), psi_real.data(), from_ik);
+        // FFT to real space
+        this->wfc_basis->recip_to_real(this->ctx, &psi(from_ik, ib, 0), porter, from_ik);
         
         // Apply phase factor
         //     // TODO: Check how to get the r vector
@@ -761,10 +761,11 @@ void HSolverPW<T, Device>::propagate_psi(psi::Psi<T>& psi, const int from_ik, co
         // }
         
         // FFT back to reciprocal space
-        // TODO: Check if the call is correct
-
-        this->wfc_basis->real_to_recip(this->ctx, psi_real.data(), psi.get_pointer(ib), to_ik);
+        this->wfc_basis->real_to_recip(this->ctx, porter, &psi(to_ik, ib, 0), to_ik, true);
     }
+    
+    // Clean up temporary arrays
+    delmem_complex_op()(this->ctx, porter);
 }
 
 template class HSolverPW<std::complex<float>, base_device::DEVICE_CPU>;

--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -96,7 +96,7 @@ void HSolverPW<T, Device>::call_paw_cell_set_currentk(const int ik)
 }
 
 template <typename T, typename Device>
-void HSolverPW<T, Device>::paw_func_after_kloop(psi::Psi<T, Device>& psi,
+void HSolverPW<T, Device>::paw_func_after_kloop(psi::Psi<T>& psi,
                                                 elecstate::ElecState* pes,
                                                 const double tpiba,
                                                 const int nat)
@@ -744,13 +744,18 @@ void HSolverPW<T, Device>::propagate_psi(psi::Psi<T>& psi, const int from_ik, co
     // Get k-point difference
     ModuleBase::Vector3<double> dk = kvecs_c[to_ik] - kvecs_c[from_ik];
     
-    // Allocate temporary arrays using device-aware memory management
+    // Allocate porter locally
     T* porter = nullptr;
     resmem_complex_op()(this->ctx, porter, this->wfc_basis->nmaxgr, "HSolverPW::porter");
     
     // Process each band
-    for (int ib = 0; ib < nbands; ++ib) {
+    for (int ib = 0; ib < nbands; ib++)
+    {
+        // Fix current k-point and band
+        // psi.fix_k(from_ik);
+        
         // FFT to real space
+        // this->wfc_basis->recip_to_real(this->ctx, psi.get_pointer(ib), porter, from_ik);
         this->wfc_basis->recip_to_real(this->ctx, &psi(from_ik, ib, 0), porter, from_ik);
         
         // Apply phase factor
@@ -760,11 +765,15 @@ void HSolverPW<T, Device>::propagate_psi(psi::Psi<T>& psi, const int from_ik, co
         //     psi_real[ir] *= std::exp(std::complex<double>(0.0, phase));
         // }
         
+        // Fix k-point for target
+        // psi.fix_k(to_ik);
+        
         // FFT back to reciprocal space
-        this->wfc_basis->real_to_recip(this->ctx, porter, &psi(to_ik, ib, 0), to_ik, true);
+        // this->wfc_basis->real_to_recip(this->ctx, porter, psi.get_pointer(ib), to_ik, true);
+        this->wfc_basis->real_to_recip(this->ctx, porter, &psi(to_ik, ib, 0), to_ik);
     }
-    
-    // Clean up temporary arrays
+
+    // Clean up porter
     delmem_complex_op()(this->ctx, porter);
 }
 

--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -96,7 +96,7 @@ void HSolverPW<T, Device>::call_paw_cell_set_currentk(const int ik)
 }
 
 template <typename T, typename Device>
-void HSolverPW<T, Device>::paw_func_after_kloop(psi::Psi<T>& psi,
+void HSolverPW<T, Device>::paw_func_after_kloop(psi::Psi<T, Device>& psi,
                                                 elecstate::ElecState* pes,
                                                 const double tpiba,
                                                 const int nat)
@@ -689,11 +689,13 @@ void HSolverPW<T, Device>::build_k_neighbors() {
     k_order.clear();
     k_order.reserve(nk);
     
-    // Store k-points and corresponding indices
+    /**
+     * @brief Structure representing a K-point with its vector, index, and norm.
+     */
     struct KPoint {
-        ModuleBase::Vector3<double> kvec;
-        int index;
-        double norm;
+        ModuleBase::Vector3<double> kvec; ///< K-vector of the K-point.
+        int index; ///< Index of the K-point.
+        double norm; ///< Norm of the K-vector.
         
         KPoint(const ModuleBase::Vector3<double>& v, int i) : 
             kvec(v), index(i), norm(v.norm()) {}
@@ -744,7 +746,9 @@ void HSolverPW<T, Device>::propagate_psi(psi::Psi<T, Device>& psi, const int fro
     // Get k-point difference
     ModuleBase::Vector3<double> dk = kvecs_c[to_ik] - kvecs_c[from_ik];
     
-    // Allocate porter locally
+    /**
+     * @brief Allocates memory for the porter used in FFT operations.
+     */
     T* porter = nullptr;
     resmem_complex_op()(this->ctx, porter, this->wfc_basis->nmaxgr, "HSolverPW::porter");
     

--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -280,9 +280,17 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
     std::vector<Real> eigenvalues(this->wfc_basis->nks * psi.get_nbands(), 0.0);
     ethr_band.resize(psi.get_nbands(), this->diag_thr);
 
+    // Check if using k-point continuity
+    use_k_continuity = (PARAM.init_wfc == "kcontinuity");
+    if (use_k_continuity) {
+        build_k_neighbors();
+    }
+
     /// Loop over k points for solve Hamiltonian to charge density
-    for (int ik = 0; ik < this->wfc_basis->nks; ++ik)
+    for (int i = 0; i < this->wfc_basis->nks; ++i)
     {
+        const int ik = use_k_continuity ? k_order[i] : i;
+        
         /// update H(k) for each k point
         pHamilt->updateHk(ik);
 
@@ -292,6 +300,11 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
 
         /// update psi pointer for each k point
         psi.fix_k(ik);
+
+        // If using k-point continuity and not first k-point, propagate from parent
+        if (use_k_continuity && i > 0) {
+            propagate_psi(psi, k_parent[ik], ik);
+        }
 
         // template add precondition calculating here
         update_precondition(precondition, ik, this->wfc_basis->npwk[ik], Real(pes->pot->get_vl_of_0()));
@@ -663,6 +676,74 @@ void HSolverPW<T, Device>::output_iterInfo()
                              << " ; where current threshold is: " << this->diag_thr << " . " << std::endl;
         // reset avg_iter
         DiagoIterAssist<T, Device>::avg_iter = 0.0;
+    }
+}
+
+template <typename T, typename Device>
+void HSolverPW<T, Device>::build_k_neighbors() {
+    const int nk = this->wfc_basis->nks;
+    kvecs_c.resize(nk);
+    k_order.reserve(nk);
+    
+    // Build k-point list
+    std::vector<std::pair<ModuleBase::Vector3<double>, int>> klist;
+    for (int ik = 0; ik < nk; ++ik) {
+        kvecs_c[ik] = this->pes->klist->kvec_c[ik];
+        klist.emplace_back(kvecs_c[ik], ik);
+    }
+    
+    // Sort k-points by distance from origin
+    std::sort(klist.begin(), klist.end(),
+        [](const auto& a, const auto& b) {
+            return a.first.norm() < b.first.norm();
+        });
+    
+    // Build parent-child relationships
+    k_order.push_back(klist[0].second);
+    
+    for (size_t i = 1; i < klist.size(); ++i) {
+        int ik = klist[i].second;
+        double min_dist = 1e10;
+        int parent = -1;
+        
+        for (int jk : k_order) {
+            double dist = (kvecs_c[ik] - kvecs_c[jk]).norm2();
+            if (dist < min_dist) {
+                min_dist = dist;
+                parent = jk;
+            }
+        }
+        
+        k_parent[ik] = parent;
+        k_order.push_back(ik);
+    }
+}
+
+template <typename T, typename Device>
+void HSolverPW<T, Device>::propagate_psi(psi::Psi<T>& psi, const int from_ik, const int to_ik) {
+    const int nbands = psi.get_nbands();
+    const int npwk = this->wfc_basis->npwk[to_ik];
+    
+    // Get k-point difference
+    ModuleBase::Vector3<double> dk = kvecs_c[to_ik] - kvecs_c[from_ik];
+    
+    // Allocate temporary arrays
+    std::vector<T> psi_real(this->wfc_basis->nrxx);
+    
+    // Process each band
+    for (int ib = 0; ib < nbands; ++ib) {
+        // IFFT to real space
+        this->wfc_basis->recip2real(psi.get_pointer(from_ik, ib), psi_real.data(), from_ik);
+        
+        // Apply phase factor
+        for (int ir = 0; ir < this->wfc_basis->nrxx; ++ir) {
+            ModuleBase::Vector3<double> r = this->wfc_basis->get_ir2r(ir);
+            double phase = this->wfc_basis->tpiba * (dk.x * r.x + dk.y * r.y + dk.z * r.z);
+            psi_real[ir] *= std::exp(std::complex<double>(0.0, phase));
+        }
+        
+        // FFT back to reciprocal space
+        this->wfc_basis->real2recip(psi_real.data(), psi.get_pointer(to_ik, ib), to_ik);
     }
 }
 

--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -291,7 +291,7 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
     for (int i = 0; i < this->wfc_basis->nks; ++i)
     {
 	    const int ik = use_k_continuity ? k_order[i] : i;
-        ModuleBase::timer::tick("HsolverPW", "k_point: " + std::to_string(ik));   
+        // ModuleBase::timer::tick("HsolverPW", "k_point: " + std::to_string(ik));   
         /// update H(k) for each k point
         pHamilt->updateHk(ik);
 
@@ -333,7 +333,7 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
                                  << " ; where current threshold is: " << this->diag_thr << " . " << std::endl;
             DiagoIterAssist<T, Device>::avg_iter = 0.0;
         }
-        ModuleBase::timer::tick("HsolverPW", "k_point: " + std::to_string(ik));
+        // ModuleBase::timer::tick("HsolverPW", "k_point: " + std::to_string(ik));
         /// calculate the contribution of Psi for charge density rho
     }
     count++;
@@ -737,7 +737,7 @@ void HSolverPW<T, Device>::build_k_neighbors() {
 }
 
 template <typename T, typename Device>
-void HSolverPW<T, Device>::propagate_psi(psi::Psi<T>& psi, const int from_ik, const int to_ik) {
+void HSolverPW<T, Device>::propagate_psi(psi::Psi<T, Device>& psi, const int from_ik, const int to_ik) {
     const int nbands = psi.get_nbands();
     const int npwk = this->wfc_basis->npwk[to_ik];
     

--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -303,7 +303,7 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
         psi.fix_k(ik);
 
         // If using k-point continuity and not first k-point, propagate from parent
-        if (use_k_continuity && ik > 0 && count == 0) {
+        if (use_k_continuity && ik > 0 && psi.is_first_iter) {
             propagate_psi(psi, k_parent[ik], ik);
         }
 
@@ -336,7 +336,7 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
         // ModuleBase::timer::tick("HsolverPW", "k_point: " + std::to_string(ik));
         /// calculate the contribution of Psi for charge density rho
     }
-    count++;
+    psi.is_first_iter = false;
     // END Loop over k points
 
     // copy eigenvalues to ekb in ElecState

--- a/source/module_hsolver/hsolver_pw.cpp
+++ b/source/module_hsolver/hsolver_pw.cpp
@@ -280,17 +280,18 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
     std::vector<Real> eigenvalues(this->wfc_basis->nks * psi.get_nbands(), 0.0);
     ethr_band.resize(psi.get_nbands(), this->diag_thr);
 
-    // Check if using k-point continuity
-    use_k_continuity = (PARAM.init_wfc == "kcontinuity");
+    // using k-point continuity
     if (use_k_continuity) {
         build_k_neighbors();
     }
 
+    static int count = 0;
+
     /// Loop over k points for solve Hamiltonian to charge density
     for (int i = 0; i < this->wfc_basis->nks; ++i)
     {
-        const int ik = use_k_continuity ? k_order[i] : i;
-        
+	    const int ik = use_k_continuity ? k_order[i] : i;
+        ModuleBase::timer::tick("HsolverPW", "k_point: " + std::to_string(ik));   
         /// update H(k) for each k point
         pHamilt->updateHk(ik);
 
@@ -302,7 +303,7 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
         psi.fix_k(ik);
 
         // If using k-point continuity and not first k-point, propagate from parent
-        if (use_k_continuity && i > 0) {
+        if (use_k_continuity && ik > 0 && count == 0) {
             propagate_psi(psi, k_parent[ik], ik);
         }
 
@@ -332,8 +333,10 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
                                  << " ; where current threshold is: " << this->diag_thr << " . " << std::endl;
             DiagoIterAssist<T, Device>::avg_iter = 0.0;
         }
+        ModuleBase::timer::tick("HsolverPW", "k_point: " + std::to_string(ik));
         /// calculate the contribution of Psi for charge density rho
     }
+    count++;
     // END Loop over k points
 
     // copy eigenvalues to ekb in ElecState
@@ -683,39 +686,53 @@ template <typename T, typename Device>
 void HSolverPW<T, Device>::build_k_neighbors() {
     const int nk = this->wfc_basis->nks;
     kvecs_c.resize(nk);
+    k_order.clear();
     k_order.reserve(nk);
     
-    // Build k-point list
-    std::vector<std::pair<ModuleBase::Vector3<double>, int>> klist;
+    // 存储k点和对应索引的结构体
+    struct KPoint {
+        ModuleBase::Vector3<double> kvec;
+        int index;
+        double norm;
+        
+        KPoint(const ModuleBase::Vector3<double>& v, int i) : 
+            kvec(v), index(i), norm(v.norm()) {}
+    };
+    
+    // 构建k点列表
+    std::vector<KPoint> klist;
     for (int ik = 0; ik < nk; ++ik) {
-        kvecs_c[ik] = this->pes->klist->kvec_c[ik];
-        klist.emplace_back(kvecs_c[ik], ik);
+        kvecs_c[ik] = this->wfc_basis->kvec_c[ik];
+        klist.push_back(KPoint(kvecs_c[ik], ik));
     }
     
-    // Sort k-points by distance from origin
+    // 按照到原点距离排序k点
     std::sort(klist.begin(), klist.end(),
-        [](const auto& a, const auto& b) {
-            return a.first.norm() < b.first.norm();
+        [](const KPoint& a, const KPoint& b) {
+            return a.norm < b.norm;
         });
     
-    // Build parent-child relationships
-    k_order.push_back(klist[0].second);
+    // 构建父子关系
+    k_order.push_back(klist[0].index);
     
-    for (size_t i = 1; i < klist.size(); ++i) {
-        int ik = klist[i].second;
+    // 对每个k点找最近的已处理k点作为父节点
+    for (int i = 1; i < nk; ++i) {
+        int current_k = klist[i].index;
         double min_dist = 1e10;
         int parent = -1;
         
-        for (int jk : k_order) {
-            double dist = (kvecs_c[ik] - kvecs_c[jk]).norm2();
+        // 在已处理的k点中找最近邻
+        for (int j = 0; j < k_order.size(); ++j) {
+            int processed_k = k_order[j];
+            double dist = (kvecs_c[current_k] - kvecs_c[processed_k]).norm2();
             if (dist < min_dist) {
                 min_dist = dist;
-                parent = jk;
+                parent = processed_k;
             }
         }
         
-        k_parent[ik] = parent;
-        k_order.push_back(ik);
+        k_parent[current_k] = parent;
+        k_order.push_back(current_k);
     }
 }
 
@@ -733,17 +750,20 @@ void HSolverPW<T, Device>::propagate_psi(psi::Psi<T>& psi, const int from_ik, co
     // Process each band
     for (int ib = 0; ib < nbands; ++ib) {
         // IFFT to real space
-        this->wfc_basis->recip2real(psi.get_pointer(from_ik, ib), psi_real.data(), from_ik);
+        // TODO: Check if the call is correct
+        this->wfc_basis->recip_to_real(this->ctx, &psi(from_ik, ib, 0), psi_real.data(), from_ik);
         
         // Apply phase factor
-        for (int ir = 0; ir < this->wfc_basis->nrxx; ++ir) {
-            ModuleBase::Vector3<double> r = this->wfc_basis->get_ir2r(ir);
-            double phase = this->wfc_basis->tpiba * (dk.x * r.x + dk.y * r.y + dk.z * r.z);
-            psi_real[ir] *= std::exp(std::complex<double>(0.0, phase));
-        }
+        //     // TODO: Check how to get the r vector
+        //     ModuleBase::Vector3<double> r = this->wfc_basis->get_ir2r(ir);
+        //     double phase = this->wfc_basis->tpiba * (dk.x * r.x + dk.y * r.y + dk.z * r.z);
+        //     psi_real[ir] *= std::exp(std::complex<double>(0.0, phase));
+        // }
         
         // FFT back to reciprocal space
-        this->wfc_basis->real2recip(psi_real.data(), psi.get_pointer(to_ik, ib), to_ik);
+        // TODO: Check if the call is correct
+
+        this->wfc_basis->real_to_recip(this->ctx, psi_real.data(), psi.get_pointer(ib), to_ik);
     }
 }
 

--- a/source/module_hsolver/hsolver_pw.h
+++ b/source/module_hsolver/hsolver_pw.h
@@ -113,7 +113,7 @@ class HSolverPW
     std::vector<ModuleBase::Vector3<double>> kvecs_c;
     
     void build_k_neighbors();
-    void propagate_psi(psi::Psi<T>& psi, const int from_ik, const int to_ik);
+    void propagate_psi(psi::Psi<T, Device>& psi, const int from_ik, const int to_ik);
 };
 
 } // namespace hsolver

--- a/source/module_hsolver/hsolver_pw.h
+++ b/source/module_hsolver/hsolver_pw.h
@@ -102,7 +102,7 @@ class HSolverPW
 #endif
 
     // K-point continuity related members
-    bool use_k_continuity = false;
+    bool use_k_continuity = true;
     std::vector<int> k_order;
     std::unordered_map<int, int> k_parent;
     std::vector<ModuleBase::Vector3<double>> kvecs_c;

--- a/source/module_hsolver/hsolver_pw.h
+++ b/source/module_hsolver/hsolver_pw.h
@@ -6,6 +6,7 @@
 #include "module_base/macros.h"
 #include "module_basis/module_pw/pw_basis_k.h"
 #include "module_psi/wavefunc.h"
+#include <unordered_map>
 
 namespace hsolver
 {
@@ -99,6 +100,15 @@ class HSolverPW
 
     void paw_func_after_kloop(psi::Psi<T, Device>& psi, elecstate::ElecState* pes,const double tpiba,const int nat);
 #endif
+
+    // K-point continuity related members
+    bool use_k_continuity = false;
+    std::vector<int> k_order;
+    std::unordered_map<int, int> k_parent;
+    std::vector<ModuleBase::Vector3<double>> kvecs_c;
+    
+    void build_k_neighbors();
+    void propagate_psi(psi::Psi<T>& psi, const int from_ik, const int to_ik);
 };
 
 } // namespace hsolver

--- a/source/module_hsolver/hsolver_pw.h
+++ b/source/module_hsolver/hsolver_pw.h
@@ -107,12 +107,38 @@ class HSolverPW
 #endif
 
     // K-point continuity related members
+    /**
+     * @brief Indicates whether to use K-point continuity.
+     */
     bool use_k_continuity = true;
+
+    /**
+     * @brief Order of K-points.
+     */
     std::vector<int> k_order;
+
+    /**
+     * @brief Parent-child relationships for K-points.
+     */
     std::unordered_map<int, int> k_parent;
+
+    /**
+     * @brief K-vectors for K-points in continuous space.
+     */
     std::vector<ModuleBase::Vector3<double>> kvecs_c;
     
+    /**
+     * @brief Builds the K-neighbors for the K-points.
+     */
     void build_k_neighbors();
+
+    /**
+     * @brief Propagates the wave function from one K-point to another.
+     * 
+     * @param psi The wave function object.
+     * @param from_ik The index of the starting K-point.
+     * @param to_ik The index of the target K-point.
+     */
     void propagate_psi(psi::Psi<T, Device>& psi, const int from_ik, const int to_ik);
 };
 

--- a/source/module_hsolver/hsolver_pw.h
+++ b/source/module_hsolver/hsolver_pw.h
@@ -35,10 +35,12 @@ class HSolverPW
               const int scf_iter_in,
               const int diag_iter_max_in,
               const double diag_thr_in,
-              const bool need_subspace_in)
+              const bool need_subspace_in,
+              const bool use_k_continuity_in = true)
         : wfc_basis(wfc_basis_in), calculation_type(calculation_type_in), basis_type(basis_type_in), method(method_in),
           use_paw(use_paw_in), use_uspp(use_uspp_in), nspin(nspin_in), scf_iter(scf_iter_in),
-          diag_iter_max(diag_iter_max_in), diag_thr(diag_thr_in), need_subspace(need_subspace_in){};
+          diag_iter_max(diag_iter_max_in), diag_thr(diag_thr_in), need_subspace(need_subspace_in),
+          use_k_continuity(use_k_continuity_in){};
 
     /// @brief solve function for pw
     /// @param pHamilt interface to hamilt
@@ -85,6 +87,8 @@ class HSolverPW
 
     const bool need_subspace; // for cg or dav_subspace
 
+    const bool use_k_continuity;
+
   protected:
     Device* ctx = {};
 
@@ -107,11 +111,6 @@ class HSolverPW
 #endif
 
     // K-point continuity related members
-    /**
-     * @brief Indicates whether to use K-point continuity.
-     */
-    bool use_k_continuity = true;
-
     /**
      * @brief Order of K-points.
      */

--- a/source/module_hsolver/hsolver_pw.h
+++ b/source/module_hsolver/hsolver_pw.h
@@ -7,6 +7,7 @@
 #include "module_basis/module_pw/pw_basis_k.h"
 #include "module_psi/wavefunc.h"
 #include <unordered_map>
+#include "module_base/memory.h"
 
 namespace hsolver
 {
@@ -19,6 +20,9 @@ class HSolverPW
     // return T if T is real type(float, double),
     // otherwise return the real type of T(complex<float>, complex<double>)
     using Real = typename GetTypeReal<T>::type;
+    using resmem_complex_op = base_device::memory::resize_memory_op<T, Device>;
+    using delmem_complex_op = base_device::memory::delete_memory_op<T, Device>;
+    using setmem_complex_op = base_device::memory::set_memory_op<T, Device>;
 
   public:
     HSolverPW(ModulePW::PW_Basis_K* wfc_basis_in,
@@ -51,6 +55,7 @@ class HSolverPW
                const bool skip_charge,
                const double tpiba,
                const int nat);
+
 
   protected:
     // diago caller

--- a/source/module_hsolver/hsolver_pw_sdft.h
+++ b/source/module_hsolver/hsolver_pw_sdft.h
@@ -26,7 +26,8 @@ class HSolverPW_SDFT : public HSolverPW<T, Device>
                    const int scf_iter_in,
                    const int diag_iter_max_in,
                    const double diag_thr_in,
-                   const bool need_subspace_in)
+                   const bool need_subspace_in,
+                   const bool use_k_continuity_in = false)
         : HSolverPW<T, Device>(wfc_basis_in,
                                calculation_type_in,
                                basis_type_in,
@@ -37,7 +38,8 @@ class HSolverPW_SDFT : public HSolverPW<T, Device>
                                scf_iter_in,
                                diag_iter_max_in,
                                diag_thr_in,
-                               need_subspace_in)
+                               need_subspace_in,
+                               use_k_continuity_in)
     {
         stoiter.init(pkv, wfc_basis_in, stowf, stoche, p_hamilt_sto);
     }

--- a/source/module_hsolver/kernels/rocm/dngvd_op.hip.cu
+++ b/source/module_hsolver/kernels/rocm/dngvd_op.hip.cu
@@ -8,6 +8,8 @@ namespace hsolver {
 // NOTE: mimicked from ../cuda/dngvd_op.cu for three dngvd_op
 
 static hipsolverHandle_t hipsolver_H = nullptr;
+// Test on DCU platform. When nstart is greater than 234, code on DCU performs better. 
+const int N_DCU = 234;
 
 void createGpuSolverHandle() {
     if (hipsolver_H == nullptr)
@@ -37,62 +39,65 @@ void dngvd_op<double, base_device::DEVICE_GPU>::operator()(const base_device::DE
     // copied from ../cuda/dngvd_op.cu, "dngvd_op"
     assert(nstart == ldh);
 
-    hipErrcheck(hipMemcpy(_vcc, _hcc, sizeof(double) * ldh * nstart, hipMemcpyDeviceToDevice));
-    // now vcc contains hcc
+    if (nstart > N_DCU){
+        hipErrcheck(hipMemcpy(_vcc, _hcc, sizeof(double) * ldh * nstart, hipMemcpyDeviceToDevice));
+        // now vcc contains hcc
 
-    // prepare some values for hipsolverDnZhegvd_bufferSize
-    int * devInfo = nullptr;
-    int lwork = 0, info_gpu = 0;
-    double * work = nullptr;
-    hipErrcheck(hipMalloc((void**)&devInfo, sizeof(int)));
-    hipsolverFillMode_t uplo = HIPSOLVER_FILL_MODE_UPPER;
+        // prepare some values for hipsolverDnZhegvd_bufferSize
+        int * devInfo = nullptr;
+        int lwork = 0, info_gpu = 0;
+        double * work = nullptr;
+        hipErrcheck(hipMalloc((void**)&devInfo, sizeof(int)));
+        hipsolverFillMode_t uplo = HIPSOLVER_FILL_MODE_UPPER;
 
-    // calculate the sizes needed for pre-allocated buffer.
-    hipsolverErrcheck(hipsolverDnDsygvd_bufferSize(
-        hipsolver_H, HIPSOLVER_EIG_TYPE_1, HIPSOLVER_EIG_MODE_VECTOR, uplo,
-        nstart,
-        _vcc, ldh,
-        _scc, ldh,
-        _eigenvalue,
-        &lwork));
+        // calculate the sizes needed for pre-allocated buffer.
+        hipsolverErrcheck(hipsolverDnDsygvd_bufferSize(
+            hipsolver_H, HIPSOLVER_EIG_TYPE_1, HIPSOLVER_EIG_MODE_VECTOR, uplo,
+            nstart,
+            _vcc, ldh,
+            _scc, ldh,
+            _eigenvalue,
+            &lwork));
 
-    // allocate memery
-    hipErrcheck(hipMalloc((void**)&work, sizeof(double) * lwork));
+        // allocate memery
+        hipErrcheck(hipMalloc((void**)&work, sizeof(double) * lwork));
 
-    // compute eigenvalues and eigenvectors.
-    hipsolverErrcheck(hipsolverDnDsygvd(
-        hipsolver_H, HIPSOLVER_EIG_TYPE_1, HIPSOLVER_EIG_MODE_VECTOR, uplo,
-        nstart,
-        _vcc, ldh,
-        const_cast<double *>(_scc), ldh,
-        _eigenvalue,
-        work, lwork, devInfo));
+        // compute eigenvalues and eigenvectors.
+        hipsolverErrcheck(hipsolverDnDsygvd(
+            hipsolver_H, HIPSOLVER_EIG_TYPE_1, HIPSOLVER_EIG_MODE_VECTOR, uplo,
+            nstart,
+            _vcc, ldh,
+            const_cast<double *>(_scc), ldh,
+            _eigenvalue,
+            work, lwork, devInfo));
 
-    hipErrcheck(hipMemcpy(&info_gpu, devInfo, sizeof(int), hipMemcpyDeviceToHost));
+        hipErrcheck(hipMemcpy(&info_gpu, devInfo, sizeof(int), hipMemcpyDeviceToHost));
 
-    // free the buffer
-    hipErrcheck(hipFree(work));
-    hipErrcheck(hipFree(devInfo));
+        // free the buffer
+        hipErrcheck(hipFree(work));
+        hipErrcheck(hipFree(devInfo));
+    }
     // if(fail_info != nullptr) *fail_info = info_gpu;
+    else{
+        std::vector<double> hcc(nstart * nstart, 0.0);
+        std::vector<double> scc(nstart * nstart, 0.0);
+        std::vector<double> vcc(nstart * nstart, 0.0);
+        std::vector<double> eigenvalue(nstart, 0);
+        hipErrcheck(hipMemcpy(hcc.data(), _hcc, sizeof(double) * hcc.size(), hipMemcpyDeviceToHost));
+        hipErrcheck(hipMemcpy(scc.data(), _scc, sizeof(double) * scc.size(), hipMemcpyDeviceToHost));
+        base_device::DEVICE_CPU* cpu_ctx = {};
+        dngvd_op<double, base_device::DEVICE_CPU>()(cpu_ctx,
+                                                   nstart,
+                                                   ldh,
+                                                   hcc.data(),
+                                                   scc.data(),
+                                                   eigenvalue.data(),
+                                                   vcc.data());
+        hipErrcheck(hipMemcpy(_vcc, vcc.data(), sizeof(double) * vcc.size(), hipMemcpyHostToDevice));
+        hipErrcheck(hipMemcpy(_eigenvalue, eigenvalue.data(), sizeof(double) * eigenvalue.size(), hipMemcpyHostToDevice));
+    }
 
-
-    //std::vector<double> hcc(nstart * nstart, 0.0);
-    //std::vector<double> scc(nstart * nstart, 0.0);
-    //std::vector<double> vcc(nstart * nstart, 0.0);
-    //std::vector<double> eigenvalue(nstart, 0);
-    //hipErrcheck(hipMemcpy(hcc.data(), _hcc, sizeof(double) * hcc.size(), hipMemcpyDeviceToHost));
-    //hipErrcheck(hipMemcpy(scc.data(), _scc, sizeof(double) * scc.size(), hipMemcpyDeviceToHost));
-    //base_device::DEVICE_CPU* cpu_ctx = {};
-    //dngvd_op<double, base_device::DEVICE_CPU>()(cpu_ctx,
-    //                                            nstart,
-    //                                            ldh,
-    //                                            hcc.data(),
-    //                                            scc.data(),
-    //                                            eigenvalue.data(),
-    //                                            vcc.data(),
-    //                                            fail_info);
-    //hipErrcheck(hipMemcpy(_vcc, vcc.data(), sizeof(double) * vcc.size(), hipMemcpyHostToDevice));
-    //hipErrcheck(hipMemcpy(_eigenvalue, eigenvalue.data(), sizeof(double) * eigenvalue.size(), hipMemcpyHostToDevice));
+    
 }
 #endif // __LCAO
 
@@ -107,62 +112,65 @@ void dngvd_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const ba
 {
     // copied from ../cuda/dngvd_op.cu, "dngvd_op"
     assert(nstart == ldh);
+    
+    if (nstart > N_DCU){
+        hipErrcheck(hipMemcpy(_vcc, _hcc, sizeof(std::complex<float>) * ldh * nstart, hipMemcpyDeviceToDevice));
+        // now vcc contains hcc
 
-    hipErrcheck(hipMemcpy(_vcc, _hcc, sizeof(std::complex<float>) * ldh * nstart, hipMemcpyDeviceToDevice));
-    // now vcc contains hcc
+        // prepare some values for hipsolverDnZhegvd_bufferSize
+        int * devInfo = nullptr;
+        int lwork = 0, info_gpu = 0;
+        float2 * work = nullptr;
+        hipErrcheck(hipMalloc((void**)&devInfo, sizeof(int)));
+        hipsolverFillMode_t uplo = HIPSOLVER_FILL_MODE_UPPER;
 
-    // prepare some values for hipsolverDnZhegvd_bufferSize
-    int * devInfo = nullptr;
-    int lwork = 0, info_gpu = 0;
-    float2 * work = nullptr;
-    hipErrcheck(hipMalloc((void**)&devInfo, sizeof(int)));
-    hipsolverFillMode_t uplo = HIPSOLVER_FILL_MODE_UPPER;
+        // calculate the sizes needed for pre-allocated buffer.
+        hipsolverErrcheck(hipsolverDnChegvd_bufferSize(
+            hipsolver_H, HIPSOLVER_EIG_TYPE_1, HIPSOLVER_EIG_MODE_VECTOR, uplo,
+            nstart,
+            reinterpret_cast<const float2 *>(_vcc), ldh,
+            reinterpret_cast<const float2 *>(_scc), ldh,
+            _eigenvalue,
+            &lwork));
 
-    // calculate the sizes needed for pre-allocated buffer.
-    hipsolverErrcheck(hipsolverDnChegvd_bufferSize(
-        hipsolver_H, HIPSOLVER_EIG_TYPE_1, HIPSOLVER_EIG_MODE_VECTOR, uplo,
-        nstart,
-        reinterpret_cast<const float2 *>(_vcc), ldh,
-        reinterpret_cast<const float2 *>(_scc), ldh,
-        _eigenvalue,
-        &lwork));
+        // allocate memery
+        hipErrcheck(hipMalloc((void**)&work, sizeof(float2) * lwork));
 
-    // allocate memery
-    hipErrcheck(hipMalloc((void**)&work, sizeof(float2) * lwork));
+        // compute eigenvalues and eigenvectors.
+        hipsolverErrcheck(hipsolverDnChegvd(
+            hipsolver_H, HIPSOLVER_EIG_TYPE_1, HIPSOLVER_EIG_MODE_VECTOR, uplo,
+            nstart,
+            reinterpret_cast<float2 *>(_vcc), ldh,
+            const_cast<float2 *>(reinterpret_cast<const float2 *>(_scc)), ldh,
+            _eigenvalue,
+            work, lwork, devInfo));
 
-    // compute eigenvalues and eigenvectors.
-    hipsolverErrcheck(hipsolverDnChegvd(
-        hipsolver_H, HIPSOLVER_EIG_TYPE_1, HIPSOLVER_EIG_MODE_VECTOR, uplo,
-        nstart,
-        reinterpret_cast<float2 *>(_vcc), ldh,
-        const_cast<float2 *>(reinterpret_cast<const float2 *>(_scc)), ldh,
-        _eigenvalue,
-        work, lwork, devInfo));
-
-    hipErrcheck(hipMemcpy(&info_gpu, devInfo, sizeof(int), hipMemcpyDeviceToHost));
-    // free the buffer
-    hipErrcheck(hipFree(work));
-    hipErrcheck(hipFree(devInfo));
+        hipErrcheck(hipMemcpy(&info_gpu, devInfo, sizeof(int), hipMemcpyDeviceToHost));
+        // free the buffer
+        hipErrcheck(hipFree(work));
+        hipErrcheck(hipFree(devInfo));
+    }
     // if(fail_info != nullptr) *fail_info = info_gpu;
+    else{
+        std::vector<std::complex<float>> hcc(nstart * nstart, {0, 0});
+        std::vector<std::complex<float>> scc(nstart * nstart, {0, 0});
+        std::vector<std::complex<float>> vcc(nstart * nstart, {0, 0});
+        std::vector<float> eigenvalue(nstart, 0);
+        hipErrcheck(hipMemcpy(hcc.data(), _hcc, sizeof(std::complex<float>) * hcc.size(), hipMemcpyDeviceToHost));
+        hipErrcheck(hipMemcpy(scc.data(), _scc, sizeof(std::complex<float>) * scc.size(), hipMemcpyDeviceToHost));
+        base_device::DEVICE_CPU* cpu_ctx = {};
+        dngvd_op<std::complex<float>, base_device::DEVICE_CPU>()(cpu_ctx,
+                                                                nstart,
+                                                                ldh,
+                                                                hcc.data(),
+                                                                scc.data(),
+                                                                eigenvalue.data(),
+                                                                vcc.data());
+        hipErrcheck(hipMemcpy(_vcc, vcc.data(), sizeof(std::complex<float>) * vcc.size(), hipMemcpyHostToDevice));
+        hipErrcheck(hipMemcpy(_eigenvalue, eigenvalue.data(), sizeof(float) * eigenvalue.size(), hipMemcpyHostToDevice));
+    }
 
-
-    //std::vector<std::complex<float>> hcc(nstart * nstart, {0, 0});
-    //std::vector<std::complex<float>> scc(nstart * nstart, {0, 0});
-    //std::vector<std::complex<float>> vcc(nstart * nstart, {0, 0});
-    //std::vector<float> eigenvalue(nstart, 0);
-    //hipErrcheck(hipMemcpy(hcc.data(), _hcc, sizeof(std::complex<float>) * hcc.size(), hipMemcpyDeviceToHost));
-    //hipErrcheck(hipMemcpy(scc.data(), _scc, sizeof(std::complex<float>) * scc.size(), hipMemcpyDeviceToHost));
-    //base_device::DEVICE_CPU* cpu_ctx = {};
-    //dngvd_op<std::complex<float>, base_device::DEVICE_CPU>()(cpu_ctx,
-    //                                                         nstart,
-    //                                                         ldh,
-    //                                                         hcc.data(),
-    //                                                         scc.data(),
-    //                                                         eigenvalue.data(),
-    //                                                         vcc.data(),
-    //                                                         fail_info);
-    //hipErrcheck(hipMemcpy(_vcc, vcc.data(), sizeof(std::complex<float>) * vcc.size(), hipMemcpyHostToDevice));
-    //hipErrcheck(hipMemcpy(_eigenvalue, eigenvalue.data(), sizeof(float) * eigenvalue.size(), hipMemcpyHostToDevice));
+    
 }
 
 template <>
@@ -179,69 +187,73 @@ void dngvd_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const b
     assert(nstart == ldh);
 
     // save a copy of scc in case the diagonalization fails
-    std::vector<std::complex<double>> scc(nstart * nstart, {0, 0});
-    hipErrcheck(hipMemcpy(scc.data(), _scc, sizeof(std::complex<double>) * scc.size(), hipMemcpyDeviceToHost));
+    if (nstart > N_DCU){
+        std::vector<std::complex<double>> scc(nstart * nstart, {0, 0});
+        hipErrcheck(hipMemcpy(scc.data(), _scc, sizeof(std::complex<double>) * scc.size(), hipMemcpyDeviceToHost));
 
-    hipErrcheck(hipMemcpy(_vcc, _hcc, sizeof(std::complex<double>) * ldh * nstart, hipMemcpyDeviceToDevice));
+        hipErrcheck(hipMemcpy(_vcc, _hcc, sizeof(std::complex<double>) * ldh * nstart, hipMemcpyDeviceToDevice));
 
-    // now vcc contains hcc
+        // now vcc contains hcc
 
-    // prepare some values for hipsolverDnZhegvd_bufferSize
-    int * devInfo = nullptr;
-    int lwork = 0, info_gpu = 0;
-    double2 * work = nullptr;
-    hipErrcheck(hipMalloc((void**)&devInfo, sizeof(int)));
-    hipsolverFillMode_t uplo = HIPSOLVER_FILL_MODE_UPPER;
+        // prepare some values for hipsolverDnZhegvd_bufferSize
+        int * devInfo = nullptr;
+        int lwork = 0, info_gpu = 0;
+        double2 * work = nullptr;
+        hipErrcheck(hipMalloc((void**)&devInfo, sizeof(int)));
+        hipsolverFillMode_t uplo = HIPSOLVER_FILL_MODE_UPPER;
 
-    // calculate the sizes needed for pre-allocated buffer.
-    hipsolverErrcheck(hipsolverDnZhegvd_bufferSize(
-        hipsolver_H, HIPSOLVER_EIG_TYPE_1, HIPSOLVER_EIG_MODE_VECTOR, uplo,
-        nstart,
-        reinterpret_cast<const double2 *>(_vcc), ldh,
-        reinterpret_cast<const double2 *>(_scc), ldh,
-        _eigenvalue,
-        &lwork));
+        // calculate the sizes needed for pre-allocated buffer.
+        hipsolverErrcheck(hipsolverDnZhegvd_bufferSize(
+            hipsolver_H, HIPSOLVER_EIG_TYPE_1, HIPSOLVER_EIG_MODE_VECTOR, uplo,
+            nstart,
+            reinterpret_cast<const double2 *>(_vcc), ldh,
+            reinterpret_cast<const double2 *>(_scc), ldh,
+            _eigenvalue,
+            &lwork));
 
-    // allocate memery
-    hipErrcheck(hipMalloc((void**)&work, sizeof(double2) * lwork));
+        // allocate memery
+        hipErrcheck(hipMalloc((void**)&work, sizeof(double2) * lwork));
 
-    // compute eigenvalues and eigenvectors.
-    hipsolverErrcheck(hipsolverDnZhegvd(
-        hipsolver_H, HIPSOLVER_EIG_TYPE_1, HIPSOLVER_EIG_MODE_VECTOR, uplo,
-        nstart,
-        reinterpret_cast<double2 *>(_vcc), ldh,
-        const_cast<double2 *>(reinterpret_cast<const double2 *>(_scc)), ldh,
-        _eigenvalue,
-        work, lwork, devInfo));
+        // compute eigenvalues and eigenvectors.
+        hipsolverErrcheck(hipsolverDnZhegvd(
+            hipsolver_H, HIPSOLVER_EIG_TYPE_1, HIPSOLVER_EIG_MODE_VECTOR, uplo,
+            nstart,
+            reinterpret_cast<double2 *>(_vcc), ldh,
+            const_cast<double2 *>(reinterpret_cast<const double2 *>(_scc)), ldh,
+            _eigenvalue,
+            work, lwork, devInfo));
 
-    hipErrcheck(hipMemcpy(&info_gpu, devInfo, sizeof(int), hipMemcpyDeviceToHost));
-    // free the buffer
-    hipErrcheck(hipFree(work));
-    hipErrcheck(hipFree(devInfo));
+        hipErrcheck(hipMemcpy(&info_gpu, devInfo, sizeof(int), hipMemcpyDeviceToHost));
+        // free the buffer
+        hipErrcheck(hipFree(work));
+        hipErrcheck(hipFree(devInfo));
+    }
     // if(fail_info != nullptr) *fail_info = info_gpu;
+    else{
+        std::vector<std::complex<double>> hcc(nstart * nstart, {0, 0});
+        std::vector<std::complex<double>> scc(nstart * nstart, {0, 0});
+        std::vector<std::complex<double>> vcc(nstart * nstart, {0, 0});
+        std::vector<double> eigenvalue(nstart, 0);
+        hipErrcheck(hipMemcpy(hcc.data(), _hcc, sizeof(std::complex<double>) * hcc.size(), hipMemcpyDeviceToHost));
+        hipErrcheck(hipMemcpy(scc.data(), _scc, sizeof(std::complex<double>) * scc.size(), hipMemcpyDeviceToHost));
+        base_device::DEVICE_CPU* cpu_ctx = {};
+        dngvd_op<std::complex<double>, base_device::DEVICE_CPU>()(cpu_ctx,
+                                                                nstart,
+                                                                ldh,
+                                                                hcc.data(),
+                                                                scc.data(),
+                                                                eigenvalue.data(),
+                                                                vcc.data());
+        hipErrcheck(hipMemcpy(_vcc, vcc.data(), sizeof(std::complex<double>) * vcc.size(), hipMemcpyHostToDevice));
+        hipErrcheck(hipMemcpy(_eigenvalue, eigenvalue.data(), sizeof(double) * eigenvalue.size(), hipMemcpyHostToDevice));
+    }
 
 
 
 
 
 
-
-    /*std::vector<std::complex<double>> hcc(nstart * nstart, {0, 0});
-    std::vector<std::complex<double>> scc(nstart * nstart, {0, 0});
-    std::vector<std::complex<double>> vcc(nstart * nstart, {0, 0});
-    std::vector<double> eigenvalue(nstart, 0);
-    hipErrcheck(hipMemcpy(hcc.data(), _hcc, sizeof(std::complex<double>) * hcc.size(), hipMemcpyDeviceToHost));
-    hipErrcheck(hipMemcpy(scc.data(), _scc, sizeof(std::complex<double>) * scc.size(), hipMemcpyDeviceToHost));
-    base_device::DEVICE_CPU* cpu_ctx = {};
-    dngvd_op<std::complex<double>, base_device::DEVICE_CPU>()(cpu_ctx,
-                                                              nstart,
-                                                              ldh,
-                                                              hcc.data(),
-                                                              scc.data(),
-                                                              eigenvalue.data(),
-                                                              vcc.data());
-    hipErrcheck(hipMemcpy(_vcc, vcc.data(), sizeof(std::complex<double>) * vcc.size(), hipMemcpyHostToDevice));
-    hipErrcheck(hipMemcpy(_eigenvalue, eigenvalue.data(), sizeof(double) * eigenvalue.size(), hipMemcpyHostToDevice));*/
+    
 }
 
 #ifdef __LCAO

--- a/source/module_hsolver/kernels/rocm/dngvd_op.hip.cu
+++ b/source/module_hsolver/kernels/rocm/dngvd_op.hip.cu
@@ -5,12 +5,23 @@
 
 namespace hsolver {
 
+// NOTE: mimicked from ../cuda/dngvd_op.cu for three dngvd_op
+
+static hipsolverHandle_t hipsolver_H = nullptr;
+
 void createGpuSolverHandle() {
-    return;
+    if (hipsolver_H == nullptr)
+    {
+        hipsolverErrcheck(hipsolverCreate(&hipsolver_H));
+    }
 }
 
 void destroyGpuSolverHandle() {
-    return;
+    if (hipsolver_H != nullptr)
+    {
+        hipsolverErrcheck(hipsolverDestroy(hipsolver_H));
+        hipsolver_H = nullptr;
+    }
 }
 
 #ifdef __LCAO
@@ -23,22 +34,65 @@ void dngvd_op<double, base_device::DEVICE_GPU>::operator()(const base_device::DE
                                                            double* _eigenvalue,
                                                            double* _vcc)
 {
-    std::vector<double> hcc(nstart * nstart, 0.0);
-    std::vector<double> scc(nstart * nstart, 0.0);
-    std::vector<double> vcc(nstart * nstart, 0.0);
-    std::vector<double> eigenvalue(nstart, 0);
-    hipErrcheck(hipMemcpy(hcc.data(), _hcc, sizeof(double) * hcc.size(), hipMemcpyDeviceToHost));
-    hipErrcheck(hipMemcpy(scc.data(), _scc, sizeof(double) * scc.size(), hipMemcpyDeviceToHost));
-    base_device::DEVICE_CPU* cpu_ctx = {};
-    dngvd_op<double, base_device::DEVICE_CPU>()(cpu_ctx,
-                                                nstart,
-                                                ldh,
-                                                hcc.data(),
-                                                scc.data(),
-                                                eigenvalue.data(),
-                                                vcc.data());
-    hipErrcheck(hipMemcpy(_vcc, vcc.data(), sizeof(double) * vcc.size(), hipMemcpyHostToDevice));
-    hipErrcheck(hipMemcpy(_eigenvalue, eigenvalue.data(), sizeof(double) * eigenvalue.size(), hipMemcpyHostToDevice));
+    // copied from ../cuda/dngvd_op.cu, "dngvd_op"
+    assert(nstart == ldh);
+
+    hipErrcheck(hipMemcpy(_vcc, _hcc, sizeof(double) * ldh * nstart, hipMemcpyDeviceToDevice));
+    // now vcc contains hcc
+
+    // prepare some values for hipsolverDnZhegvd_bufferSize
+    int * devInfo = nullptr;
+    int lwork = 0, info_gpu = 0;
+    double * work = nullptr;
+    hipErrcheck(hipMalloc((void**)&devInfo, sizeof(int)));
+    hipsolverFillMode_t uplo = HIPSOLVER_FILL_MODE_UPPER;
+
+    // calculate the sizes needed for pre-allocated buffer.
+    hipsolverErrcheck(hipsolverDnDsygvd_bufferSize(
+        hipsolver_H, HIPSOLVER_EIG_TYPE_1, HIPSOLVER_EIG_MODE_VECTOR, uplo,
+        nstart,
+        _vcc, ldh,
+        _scc, ldh,
+        _eigenvalue,
+        &lwork));
+
+    // allocate memery
+    hipErrcheck(hipMalloc((void**)&work, sizeof(double) * lwork));
+
+    // compute eigenvalues and eigenvectors.
+    hipsolverErrcheck(hipsolverDnDsygvd(
+        hipsolver_H, HIPSOLVER_EIG_TYPE_1, HIPSOLVER_EIG_MODE_VECTOR, uplo,
+        nstart,
+        _vcc, ldh,
+        const_cast<double *>(_scc), ldh,
+        _eigenvalue,
+        work, lwork, devInfo));
+
+    hipErrcheck(hipMemcpy(&info_gpu, devInfo, sizeof(int), hipMemcpyDeviceToHost));
+
+    // free the buffer
+    hipErrcheck(hipFree(work));
+    hipErrcheck(hipFree(devInfo));
+    // if(fail_info != nullptr) *fail_info = info_gpu;
+
+
+    //std::vector<double> hcc(nstart * nstart, 0.0);
+    //std::vector<double> scc(nstart * nstart, 0.0);
+    //std::vector<double> vcc(nstart * nstart, 0.0);
+    //std::vector<double> eigenvalue(nstart, 0);
+    //hipErrcheck(hipMemcpy(hcc.data(), _hcc, sizeof(double) * hcc.size(), hipMemcpyDeviceToHost));
+    //hipErrcheck(hipMemcpy(scc.data(), _scc, sizeof(double) * scc.size(), hipMemcpyDeviceToHost));
+    //base_device::DEVICE_CPU* cpu_ctx = {};
+    //dngvd_op<double, base_device::DEVICE_CPU>()(cpu_ctx,
+    //                                            nstart,
+    //                                            ldh,
+    //                                            hcc.data(),
+    //                                            scc.data(),
+    //                                            eigenvalue.data(),
+    //                                            vcc.data(),
+    //                                            fail_info);
+    //hipErrcheck(hipMemcpy(_vcc, vcc.data(), sizeof(double) * vcc.size(), hipMemcpyHostToDevice));
+    //hipErrcheck(hipMemcpy(_eigenvalue, eigenvalue.data(), sizeof(double) * eigenvalue.size(), hipMemcpyHostToDevice));
 }
 #endif // __LCAO
 
@@ -51,22 +105,64 @@ void dngvd_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const ba
                                                                         float* _eigenvalue,
                                                                         std::complex<float>* _vcc)
 {
-    std::vector<std::complex<float>> hcc(nstart * nstart, {0, 0});
-    std::vector<std::complex<float>> scc(nstart * nstart, {0, 0});
-    std::vector<std::complex<float>> vcc(nstart * nstart, {0, 0});
-    std::vector<float> eigenvalue(nstart, 0);
-    hipErrcheck(hipMemcpy(hcc.data(), _hcc, sizeof(std::complex<float>) * hcc.size(), hipMemcpyDeviceToHost));
-    hipErrcheck(hipMemcpy(scc.data(), _scc, sizeof(std::complex<float>) * scc.size(), hipMemcpyDeviceToHost));
-    base_device::DEVICE_CPU* cpu_ctx = {};
-    dngvd_op<std::complex<float>, base_device::DEVICE_CPU>()(cpu_ctx,
-                                                             nstart,
-                                                             ldh,
-                                                             hcc.data(),
-                                                             scc.data(),
-                                                             eigenvalue.data(),
-                                                             vcc.data());
-    hipErrcheck(hipMemcpy(_vcc, vcc.data(), sizeof(std::complex<float>) * vcc.size(), hipMemcpyHostToDevice));
-    hipErrcheck(hipMemcpy(_eigenvalue, eigenvalue.data(), sizeof(float) * eigenvalue.size(), hipMemcpyHostToDevice));
+    // copied from ../cuda/dngvd_op.cu, "dngvd_op"
+    assert(nstart == ldh);
+
+    hipErrcheck(hipMemcpy(_vcc, _hcc, sizeof(std::complex<float>) * ldh * nstart, hipMemcpyDeviceToDevice));
+    // now vcc contains hcc
+
+    // prepare some values for hipsolverDnZhegvd_bufferSize
+    int * devInfo = nullptr;
+    int lwork = 0, info_gpu = 0;
+    float2 * work = nullptr;
+    hipErrcheck(hipMalloc((void**)&devInfo, sizeof(int)));
+    hipsolverFillMode_t uplo = HIPSOLVER_FILL_MODE_UPPER;
+
+    // calculate the sizes needed for pre-allocated buffer.
+    hipsolverErrcheck(hipsolverDnChegvd_bufferSize(
+        hipsolver_H, HIPSOLVER_EIG_TYPE_1, HIPSOLVER_EIG_MODE_VECTOR, uplo,
+        nstart,
+        reinterpret_cast<const float2 *>(_vcc), ldh,
+        reinterpret_cast<const float2 *>(_scc), ldh,
+        _eigenvalue,
+        &lwork));
+
+    // allocate memery
+    hipErrcheck(hipMalloc((void**)&work, sizeof(float2) * lwork));
+
+    // compute eigenvalues and eigenvectors.
+    hipsolverErrcheck(hipsolverDnChegvd(
+        hipsolver_H, HIPSOLVER_EIG_TYPE_1, HIPSOLVER_EIG_MODE_VECTOR, uplo,
+        nstart,
+        reinterpret_cast<float2 *>(_vcc), ldh,
+        const_cast<float2 *>(reinterpret_cast<const float2 *>(_scc)), ldh,
+        _eigenvalue,
+        work, lwork, devInfo));
+
+    hipErrcheck(hipMemcpy(&info_gpu, devInfo, sizeof(int), hipMemcpyDeviceToHost));
+    // free the buffer
+    hipErrcheck(hipFree(work));
+    hipErrcheck(hipFree(devInfo));
+    // if(fail_info != nullptr) *fail_info = info_gpu;
+
+
+    //std::vector<std::complex<float>> hcc(nstart * nstart, {0, 0});
+    //std::vector<std::complex<float>> scc(nstart * nstart, {0, 0});
+    //std::vector<std::complex<float>> vcc(nstart * nstart, {0, 0});
+    //std::vector<float> eigenvalue(nstart, 0);
+    //hipErrcheck(hipMemcpy(hcc.data(), _hcc, sizeof(std::complex<float>) * hcc.size(), hipMemcpyDeviceToHost));
+    //hipErrcheck(hipMemcpy(scc.data(), _scc, sizeof(std::complex<float>) * scc.size(), hipMemcpyDeviceToHost));
+    //base_device::DEVICE_CPU* cpu_ctx = {};
+    //dngvd_op<std::complex<float>, base_device::DEVICE_CPU>()(cpu_ctx,
+    //                                                         nstart,
+    //                                                         ldh,
+    //                                                         hcc.data(),
+    //                                                         scc.data(),
+    //                                                         eigenvalue.data(),
+    //                                                         vcc.data(),
+    //                                                         fail_info);
+    //hipErrcheck(hipMemcpy(_vcc, vcc.data(), sizeof(std::complex<float>) * vcc.size(), hipMemcpyHostToDevice));
+    //hipErrcheck(hipMemcpy(_eigenvalue, eigenvalue.data(), sizeof(float) * eigenvalue.size(), hipMemcpyHostToDevice));
 }
 
 template <>
@@ -76,9 +172,61 @@ void dngvd_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const b
                                                                          const std::complex<double>* _hcc,
                                                                          const std::complex<double>* _scc,
                                                                          double* _eigenvalue,
-                                                                         std::complex<double>* _vcc)
+                                                                         std::complex<double>* _vcc
+                                                                        )
 {
-    std::vector<std::complex<double>> hcc(nstart * nstart, {0, 0});
+    // copied from ../cuda/dngvd_op.cu, "dngvd_op"
+    assert(nstart == ldh);
+
+    // save a copy of scc in case the diagonalization fails
+    std::vector<std::complex<double>> scc(nstart * nstart, {0, 0});
+    hipErrcheck(hipMemcpy(scc.data(), _scc, sizeof(std::complex<double>) * scc.size(), hipMemcpyDeviceToHost));
+
+    hipErrcheck(hipMemcpy(_vcc, _hcc, sizeof(std::complex<double>) * ldh * nstart, hipMemcpyDeviceToDevice));
+
+    // now vcc contains hcc
+
+    // prepare some values for hipsolverDnZhegvd_bufferSize
+    int * devInfo = nullptr;
+    int lwork = 0, info_gpu = 0;
+    double2 * work = nullptr;
+    hipErrcheck(hipMalloc((void**)&devInfo, sizeof(int)));
+    hipsolverFillMode_t uplo = HIPSOLVER_FILL_MODE_UPPER;
+
+    // calculate the sizes needed for pre-allocated buffer.
+    hipsolverErrcheck(hipsolverDnZhegvd_bufferSize(
+        hipsolver_H, HIPSOLVER_EIG_TYPE_1, HIPSOLVER_EIG_MODE_VECTOR, uplo,
+        nstart,
+        reinterpret_cast<const double2 *>(_vcc), ldh,
+        reinterpret_cast<const double2 *>(_scc), ldh,
+        _eigenvalue,
+        &lwork));
+
+    // allocate memery
+    hipErrcheck(hipMalloc((void**)&work, sizeof(double2) * lwork));
+
+    // compute eigenvalues and eigenvectors.
+    hipsolverErrcheck(hipsolverDnZhegvd(
+        hipsolver_H, HIPSOLVER_EIG_TYPE_1, HIPSOLVER_EIG_MODE_VECTOR, uplo,
+        nstart,
+        reinterpret_cast<double2 *>(_vcc), ldh,
+        const_cast<double2 *>(reinterpret_cast<const double2 *>(_scc)), ldh,
+        _eigenvalue,
+        work, lwork, devInfo));
+
+    hipErrcheck(hipMemcpy(&info_gpu, devInfo, sizeof(int), hipMemcpyDeviceToHost));
+    // free the buffer
+    hipErrcheck(hipFree(work));
+    hipErrcheck(hipFree(devInfo));
+    // if(fail_info != nullptr) *fail_info = info_gpu;
+
+
+
+
+
+
+
+    /*std::vector<std::complex<double>> hcc(nstart * nstart, {0, 0});
     std::vector<std::complex<double>> scc(nstart * nstart, {0, 0});
     std::vector<std::complex<double>> vcc(nstart * nstart, {0, 0});
     std::vector<double> eigenvalue(nstart, 0);
@@ -93,7 +241,7 @@ void dngvd_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const b
                                                               eigenvalue.data(),
                                                               vcc.data());
     hipErrcheck(hipMemcpy(_vcc, vcc.data(), sizeof(std::complex<double>) * vcc.size(), hipMemcpyHostToDevice));
-    hipErrcheck(hipMemcpy(_eigenvalue, eigenvalue.data(), sizeof(double) * eigenvalue.size(), hipMemcpyHostToDevice));
+    hipErrcheck(hipMemcpy(_eigenvalue, eigenvalue.data(), sizeof(double) * eigenvalue.size(), hipMemcpyHostToDevice));*/
 }
 
 #ifdef __LCAO

--- a/source/module_hsolver/test/test_hsolver_pw.cpp
+++ b/source/module_hsolver/test/test_hsolver_pw.cpp
@@ -46,7 +46,8 @@ class TestHSolverPW : public ::testing::Test {
                      hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::SCF_ITER,
                      hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::PW_DIAG_NMAX,
                      hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::PW_DIAG_THR,
-                     hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::need_subspace);
+                     hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::need_subspace,
+                     false);
     hsolver::HSolverPW<std::complex<double>, base_device::DEVICE_CPU> hs_d
         = hsolver::HSolverPW<std::complex<double>, base_device::DEVICE_CPU>(&pwbk,
                                                                             "scf",
@@ -58,7 +59,8 @@ class TestHSolverPW : public ::testing::Test {
                      hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::SCF_ITER,
                      hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::PW_DIAG_NMAX,
                      hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::PW_DIAG_THR,
-                     hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::need_subspace);
+                     hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::need_subspace,
+                     false);
 
     hamilt::Hamilt<std::complex<double>> hamilt_test_d;
     hamilt::Hamilt<std::complex<float>> hamilt_test_f;

--- a/source/module_io/read_input_item_elec_stru.cpp
+++ b/source/module_io/read_input_item_elec_stru.cpp
@@ -818,5 +818,11 @@ void ReadInput::item_elec_stru()
         read_sync_double(input.bessel_nao_sigma);
         this->add_item(item);
     }
+    {
+        Input_Item item("use_k_continuity");
+        item.annotation = "whether to use K-point continuity for wave function propagation";
+        read_sync_bool(input.use_k_continuity);
+        this->add_item(item);
+    }
 }
 } // namespace ModuleIO

--- a/source/module_parameter/input_parameter.h
+++ b/source/module_parameter/input_parameter.h
@@ -430,6 +430,8 @@ struct Input_para
     double block_up = 0.55;    ///< high bound of the block
     double block_height = 0.1; ///< height of the block
 
+    bool use_k_continuity = true; ///< whether to use K-point continuity for wave function propagation
+
     //    implicit solvation model       Menglin Sun added on 2022-04-04
     bool imp_sol = false;    ///< true: implicit solvation correction; false:
                              ///< vacuum calculation(default)

--- a/source/module_psi/psi.h
+++ b/source/module_psi/psi.h
@@ -138,6 +138,9 @@ class Psi
     std::tuple<const T*, int> to_range(const Range& range) const;
     int npol = 1;
 
+    // Whether this is the first iteration for k-point propagation
+    bool is_first_iter = true;
+
   private:
     T* psi = nullptr; // avoid using C++ STL
 


### PR DESCRIPTION
Currently, `dngvd_op` in `module_hsolver/kernels/rocm/dngvd_op.hip.cu` uses the ROCm implementation for all input sizes (nstart). Performance analysis shows that the CPU implementation (`dngvd_op.cpp`) is faster for smaller nstart values.
This PR proposes adding a conditional branch within the `dngvd_op<double, base_device::DEVICE_GPU>::operator()` function to select the optimal implementation based on `nstart`:

`If nstart > 234`, use the existing ROCm implementation.
`If nstart <= 234`, call the CPU implementation (`dngvd_op<double, base_device::DEVICE_CPU>`).
This change requires:
Adding an `if (nstart > 234) { ... } else { ... }` block within the GPU operator().
Inside the else block, calling the CPU implementation with appropriate type casts.

This optimization is expected to improve performance, especially for bigger matrix sizes. 