### PR TITLE
[Test] Remove pre-commit bot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,13 +33,16 @@ jobs:
         run: |
           cmake -B build -DBUILD_TESTING=ON -DENABLE_DEEPKS=ON -DENABLE_MLKEDF=ON -DENABLE_LIBXC=ON -DENABLE_LIBRI=ON -DENABLE_PAW=ON -DENABLE_GOOGLEBENCH=ON -DENABLE_RAPIDJSON=ON  -DCMAKE_EXPORT_COMPILE_COMMANDS=1
 
-      - uses: pre-commit/action@v3.0.1
-        with:
-          extra_args:
-            --from-ref ${{ github.event.pull_request.base.sha }}
-              --to-ref ${{ github.event.pull_request.head.sha }}
-        continue-on-error: true
-      - uses: pre-commit-ci/lite-action@v1.0.3
+# Temporarily removed because no one maintains this now.
+# And it will break the CI test workflow.
+
+#      - uses: pre-commit/action@v3.0.1
+#        with:
+#          extra_args:
+#            --from-ref ${{ github.event.pull_request.base.sha }}
+#              --to-ref ${{ github.event.pull_request.head.sha }}
+#        continue-on-error: true
+#      - uses: pre-commit-ci/lite-action@v1.0.3
 
       - name: Build
         run: |


### PR DESCRIPTION
Because no one maintains this pre-commit bot now and it will break the CI test, so it is removed temporarily.