### PR TITLE
Feature: support the `default` as the value of `dft_functional` when initialize vdw

### DIFF
--- a/source/module_hamilt_general/module_vdw/test/vdw_test.cpp
+++ b/source/module_hamilt_general/module_vdw/test/vdw_test.cpp
@@ -377,7 +377,7 @@ class vdwd3Test: public testing::Test
 TEST_F(vdwd3Test, D30Default)
 {
     vdw::Vdwd3 vdwd3_test(ucell);
-    vdwd3_test.parameter().initial_parameters(input);
+    vdwd3_test.parameter().initial_parameters("pbe", input);
 
     EXPECT_EQ(vdwd3_test.parameter().s6(), 1.0);
     EXPECT_EQ(vdwd3_test.parameter().s18(), 0.7875);
@@ -396,7 +396,8 @@ TEST_F(vdwd3Test, D30UnitA)
     input.vdw_cn_thr_unit = "A";
     vdw::Vdwd3 vdwd3_test(ucell);
 
-    vdwd3_test.parameter().initial_parameters(input);
+    const std::string xc = "pbe";
+    vdwd3_test.parameter().initial_parameters(xc, input);
 
     EXPECT_EQ(vdwd3_test.parameter().rthr2(), std::pow(95/ModuleBase::BOHR_TO_A, 2));
     EXPECT_EQ(vdwd3_test.parameter().cn_thr2(), std::pow(40/ModuleBase::BOHR_TO_A, 2));   
@@ -407,7 +408,8 @@ TEST_F(vdwd3Test, D30Period)
     input.vdw_cutoff_type = "period";
     vdw::Vdwd3 vdwd3_test(ucell);
 
-    vdwd3_test.parameter().initial_parameters(input);
+    const std::string xc = "pbe";
+    vdwd3_test.parameter().initial_parameters(xc, input);
     vdwd3_test.init();
     std::vector<int> rep_vdw_ref = {input.vdw_cutoff_period.x, input.vdw_cutoff_period.y, input.vdw_cutoff_period.z};
 

--- a/source/module_hamilt_general/module_vdw/vdw.cpp
+++ b/source/module_hamilt_general/module_vdw/vdw.cpp
@@ -31,7 +31,7 @@ std::string parse_xcname(const std::string &xc_input,
         " in the pseudopotential files");
     }
     const std::string xc = xc_psp_uniq[0];
-    std::cout << "ModuleHamiltGeneral::ModuleVDW::parse_xcname: "
+    std::cout << " ***WARNING*** ModuleHamiltGeneral::ModuleVDW::parse_xcname: "
               << "XC name is automatically inferred from pseudopotential as `" 
               << xc << "`" << std::endl;
     return xc;

--- a/source/module_hamilt_general/module_vdw/vdw.cpp
+++ b/source/module_hamilt_general/module_vdw/vdw.cpp
@@ -1,7 +1,41 @@
+#include <algorithm>
+#include <cassert>
 
 #include "vdw.h"
 #include "vdwd2.h"
 #include "vdwd3.h"
+#include "module_base/tool_quit.h"
+
+std::string parse_xcname(const std::string &xc_input,
+                         const std::vector<std::string> &xc_psp)
+{
+    if (xc_input != "default")
+    {
+        return xc_input;
+    }
+
+    if (xc_psp.size() <= 0)
+    {
+        ModuleBase::WARNING_QUIT("ModuleHamiltGeneral::ModuleVDW::parse_xcname", 
+        "XC name automatic inference failed: no pseudopotential files are found");
+    }
+    std::vector<std::string> xc_psp_uniq = xc_psp;
+    std::sort(xc_psp_uniq.begin(), xc_psp_uniq.end());
+    auto last = std::unique(xc_psp_uniq.begin(), xc_psp_uniq.end());
+    xc_psp_uniq.erase(last, xc_psp_uniq.end());
+    
+    if (xc_psp_uniq.size() > 1)
+    {
+        ModuleBase::WARNING_QUIT("ModuleHamiltGeneral::ModuleVDW::parse_xcname", 
+        "XC name automatic inference failed: inconsistency in XC names is found"
+        " in the pseudopotential files");
+    }
+    const std::string xc = xc_psp_uniq[0];
+    std::cout << "ModuleHamiltGeneral::ModuleVDW::parse_xcname: "
+              << "XC name is automatically inferred from pseudopotential as `" 
+              << xc << "`" << std::endl;
+    return xc;
+}
 
 namespace vdw
 {
@@ -24,8 +58,13 @@ std::unique_ptr<Vdw> make_vdw(const UnitCell &ucell,
     }
     else if (input.vdw_method == "d3_0" || input.vdw_method == "d3_bj")
     {
+        std::vector<std::string> xc_psp(ucell.ntype);
+        for (int it = 0; it < ucell.ntype; it++)
+        {
+            xc_psp[it] = ucell.atoms[it].ncpp.xc_func;
+        }
         std::unique_ptr<Vdwd3> vdw_ptr = make_unique<Vdwd3>(ucell);
-        vdw_ptr->parameter().initial_parameters(input, plog);
+        vdw_ptr->parameter().initial_parameters(parse_xcname(input.dft_functional, xc_psp), input, plog);
         return vdw_ptr;
     }
     else if (input.vdw_method != "none")

--- a/source/module_hamilt_general/module_vdw/vdw.h
+++ b/source/module_hamilt_general/module_vdw/vdw.h
@@ -11,9 +11,10 @@
 namespace vdw
 {
 
-template<typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args &&... args) {
-    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+    template<typename T, typename... Args>
+    std::unique_ptr<T> make_unique(Args &&... args) {
+        return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+
 }
 
 class Vdw

--- a/source/module_hamilt_general/module_vdw/vdwd3_parameters.cpp
+++ b/source/module_hamilt_general/module_vdw/vdwd3_parameters.cpp
@@ -10,7 +10,9 @@
 namespace vdw
 {
 
-void Vdwd3Parameters::initial_parameters(const Input_para &input, std::ofstream* plog)
+void Vdwd3Parameters::initial_parameters(const std::string& xc,
+                                         const Input_para& input, 
+                                         std::ofstream* plog)
 {
     // initialize the dftd3 parameters
     mxc_.resize(max_elem_, 1);
@@ -23,7 +25,7 @@ void Vdwd3Parameters::initial_parameters(const Input_para &input, std::ofstream*
                          5,
                          std::vector<std::vector<double>>(max_elem_, std::vector<double>(max_elem_, 0.0)))));
     
-    _vdwd3_autoset_xcparam(input.dft_functional, input.vdw_method,
+    _vdwd3_autoset_xcparam(xc, input.vdw_method,
                            input.vdw_s6, input.vdw_s8, input.vdw_a1, input.vdw_a2,
                            s6_, s18_, rs6_, rs18_, /* rs6: a1, rs18: a2 */
                            plog);

--- a/source/module_hamilt_general/module_vdw/vdwd3_parameters.h
+++ b/source/module_hamilt_general/module_vdw/vdwd3_parameters.h
@@ -27,7 +27,8 @@ class Vdwd3Parameters : public VdwParameters
      * @param input Parameter instance
      * @param plog optional, for logging the parameter setting process
      */
-    void initial_parameters(const Input_para &input, 
+    void initial_parameters(const std::string& xc,
+                            const Input_para& input, 
                             std::ofstream* plog = nullptr); // for logging the parameter autoset
 
     inline const std::string &version() const { return version_; }


### PR DESCRIPTION
### Background
ABACUS supports the automatic inference of `dft_functional` from pseudopotential, but its value will not be changed even after the inference is sucessful, this does not matter for other modules, but brings trouble to vdw d3 module because its parameter is functional-specific. The vdw d3 module should search for correct set of parameters according to the name of xc. 
However, there are users may think it is harmful to the user-friendliness.

### What's changed
**This change needs some discussion**.
In this PR, ABACUS will pop a warning message like
![image](https://github.com/user-attachments/assets/b51bf45c-78ee-44bb-9d1a-1895f0d72433)

rather than warning_quit with error message, but I am not sure this is really a good idea (at least now users will not get a crash when leaving `dft_functional` unset explicitly). I need suggestion from other developers.

@mohanchen @QuantumMisaka @dyzheng @1041176461 

### Linked Issue
Fix #5944 