### PR TITLE
Fix: Enhance the warning message when the XC name cannot be recognized.

### DIFF
--- a/source/module_hamilt_general/module_xc/xc_functional.cpp
+++ b/source/module_hamilt_general/module_xc/xc_functional.cpp
@@ -263,7 +263,11 @@ void XC_Functional::set_xc_type(const std::string xc_func_in)
         func_id = std::get<1>(type_id);
         use_libxc = true;
 #else
-        ModuleBase::WARNING_QUIT("xc_functional.cpp","functional name not recognized!");
+        std::string message = "Unrecognized exchange-correlation functional '"+ xc_func +"'.\n"
+                              " Possible source: Pseudopotential file or dft_functional parameter.\n"
+                              " Please explicitly set dft_functional in INPUT,\n"
+                              " or verify the functional name is supported.";
+        ModuleBase::WARNING_QUIT("xc_functional.cpp",message);
 #endif
     }
 

--- a/source/module_hamilt_general/module_xc/xc_functional_libxc.cpp
+++ b/source/module_hamilt_general/module_xc/xc_functional_libxc.cpp
@@ -82,13 +82,27 @@ std::pair<int,std::vector<int>> XC_Functional_Libxc::set_xc_type_libxc(std::stri
         token = xc_func_in.substr(0, pos);
         int id = xc_functional_get_number(token.c_str());
         std::cout << "func,id" << token << " " << id << std::endl;
-        if (id == -1) { ModuleBase::WARNING_QUIT("XC_Functional::set_xc_type_libxc","functional name not recognized!"); }
+        if (id == -1) 
+		{
+			std::string message = "Unrecognized exchange-correlation functional '"+ xc_func_in +"'.\n"
+								  " Possible source: Pseudopotential file or dft_functional parameter.\n"
+								  " Please explicitly set dft_functional in INPUT,\n"
+								  " or verify the functional name is supported.";
+			ModuleBase::WARNING_QUIT("XC_Functional::set_xc_type_libxc",message);
+		}
         func_id.push_back(id);
         xc_func_in.erase(0, pos + delimiter.length());
     }
     int id = xc_functional_get_number(xc_func_in.c_str());
     std::cout << "func,id" << xc_func_in << " " << id << std::endl;
-    if (id == -1) { ModuleBase::WARNING_QUIT("XC_Functional::set_xc_type_libxc","functional name not recognized!"); }
+    if (id == -1)
+	{ 
+		std::string message = "Unrecognized exchange-correlation functional '"+ xc_func_in +"'.\n"
+							  " Possible source: Pseudopotential file or dft_functional parameter.\n"
+							  " Please explicitly set dft_functional in INPUT,\n"
+							  " or verify the functional name is supported.";
+		ModuleBase::WARNING_QUIT("XC_Functional::set_xc_type_libxc",message);
+	}
     func_id.push_back(id);
 
     return std::make_pair(func_type, func_id);


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #5005 

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
