### PR TITLE
exclude toolchain/install/ in `.gitignore` after toolchain run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ __pycache__
 abacus.json
 *.npy
 toolchain/install/
+toolchain/abacus_env.sh

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ time.json
 __pycache__
 abacus.json
 *.npy
+toolchain/install/


### PR DESCRIPTION

### What's changed?
- After a toolchain run, the directory toolchain/install is filled up with ~4000 files. They surely should not be tracked. To avoid possible mistake, I exclude them in the `.gitignore` file. 
- Should it be close to the top, after `/build*` or `obj`? Currently, it is the last line.