### PR TITLE
Tests: remove mock of print func in md/esolver tests

### DIFF
--- a/source/module_esolver/test/CMakeLists.txt
+++ b/source/module_esolver/test/CMakeLists.txt
@@ -6,5 +6,5 @@ install(DIRECTORY support DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 AddTest(
   TARGET esolver_dp_test
   LIBS parameter ${math_libs} base device 
-  SOURCES esolver_dp_test.cpp ../esolver_dp.cpp ../../module_io/cif_io.cpp
+  SOURCES esolver_dp_test.cpp ../esolver_dp.cpp ../../module_io/cif_io.cpp ../../module_io/output_log.cpp
 )

--- a/source/module_esolver/test/esolver_dp_test.cpp
+++ b/source/module_esolver/test/esolver_dp_test.cpp
@@ -20,19 +20,6 @@
  *   - ESolver_DP::post_process()
  *   - ESolver_DP::type_map()
  */
-namespace ModuleIO
-{
-void print_force(std::ofstream& ofs_running,
-                 const UnitCell& cell,
-                 const std::string& name,
-                 const ModuleBase::matrix& force,
-                 bool ry = true)
-{
-}
-void print_stress(const std::string& name, const ModuleBase::matrix& scs, const bool screen, const bool ry)
-{
-}
-} // namespace ModuleIO
 
 class ESolverDPTest : public ::testing::Test
 {
@@ -178,8 +165,9 @@ TEST_F(ESolverDPTest, Postprocess)
     esolver->after_all_runners(ucell);
     GlobalV::ofs_running.close();
 
-    std::string expected_output = "\n\n --------------------------------------------\n !FINAL_ETOT_IS 133.3358404 eV\n "
-                                  "--------------------------------------------\n\n\n";
+    std::string expected_output
+        = "\n\n --------------------------------------------\n !FINAL_ETOT_IS 133.3358404000000235 eV\n "
+          "--------------------------------------------\n\n\n";
     std::ifstream ifs("log");
     std::string output((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
     ifs.close();

--- a/source/module_md/test/CMakeLists.txt
+++ b/source/module_md/test/CMakeLists.txt
@@ -44,6 +44,7 @@ list(APPEND depend_files
   ../../module_cell/module_neighbor/sltk_grid.cpp
   ../../module_cell/module_neighbor/sltk_grid_driver.cpp
   ../../module_io/output.cpp
+  ../../module_io/output_log.cpp
   ../../module_io/print_info.cpp
   ../../module_io/cif_io.cpp
   ../../module_esolver/esolver_lj.cpp

--- a/source/module_md/test/setcell.h
+++ b/source/module_md/test/setcell.h
@@ -20,20 +20,6 @@ Magnetism::~Magnetism()
     delete[] this->start_magnetization;
 }
 
-namespace ModuleIO
-{
-void print_force(std::ofstream& ofs_running,
-                 const UnitCell& cell,
-                 const std::string& name,
-                 const ModuleBase::matrix& force,
-                 bool ry = true)
-{
-}
-void print_stress(const std::string& name, const ModuleBase::matrix& scs, const bool screen, const bool ry)
-{
-}
-} // namespace ModuleIO
-
 class Setcell
 {
   public:


### PR DESCRIPTION
### What's changed?
- remove mock of print func `print_force` and `print_stress` in md/esolver tests
