### PR TITLE
Rafactor:remove GlobalC::rhopw

### DIFF
--- a/source/module_base/kernels/math_ylm_op.h
+++ b/source/module_base/kernels/math_ylm_op.h
@@ -20,7 +20,7 @@ struct cal_ylm_real_op {
     /// @param PI_HALF - ModuleBase::PI_HALF
     /// @param FOUR_PI - ModuleBase::FOUR_PI,
     /// @param SQRT_INVERSE_FOUR_PI - ModuleBase::SQRT_INVERSE_FOUR_PI,
-    /// @param g - input array with size npw * 3, GlobalC::wf.get_1qvec_cartesian
+    /// @param g - input array with size npw * 3, wf.get_1qvec_cartesian
     /// @param p - intermediate array
     ///
     /// Output Parameters

--- a/source/module_basis/module_nao/two_center_bundle.h
+++ b/source/module_basis/module_nao/two_center_bundle.h
@@ -28,7 +28,7 @@ class TwoCenterBundle
     void tabulate(const double lcao_ecut, const double lcao_dk, const double lcao_dr, const double lcao_rmax);
 
     /**
-     * @brief Overwrites the content of a LCAO_Orbitals object (e.g. GlobalC::ORB)
+     * @brief Overwrites the content of a LCAO_Orbitals object (e.g. ORB)
      * with the current object.
      *
      * This function provides an interface to the corresponding object in the old module_ao.

--- a/source/module_cell/test/klist_test.cpp
+++ b/source/module_cell/test/klist_test.cpp
@@ -84,10 +84,6 @@ Fcoef::~Fcoef()
 {
 }
 
-namespace GlobalC
-{
-Parallel_Kpoints Pkpoints;
-} // namespace GlobalC
 
 /************************************************
  *  unit test of class K_Vectors

--- a/source/module_cell/test/klist_test_para.cpp
+++ b/source/module_cell/test/klist_test_para.cpp
@@ -87,11 +87,6 @@ Fcoef::~Fcoef()
 {
 }
 
-namespace GlobalC
-{
-Parallel_Kpoints Pkpoints;
-UnitCell ucell;
-} // namespace GlobalC
 
 /************************************************
  *  unit test of class K_Vectors

--- a/source/module_hamilt_general/module_surchem/test/cal_epsilon_test.cpp
+++ b/source/module_hamilt_general/module_surchem/test/cal_epsilon_test.cpp
@@ -45,8 +45,6 @@ TEST_F(cal_epsilon_test, cal_epsilon)
     device_flag = "cpu";
 
     ModulePW::PW_Basis pwtest(device_flag, precision_flag);
-    GlobalC::rhopw = &pwtest;
-
     ModuleBase::Matrix3 latvec;
     int nx, ny, nz; // f*G
     double wfcecut;
@@ -70,17 +68,17 @@ TEST_F(cal_epsilon_test, cal_epsilon)
 #endif
 
 #ifdef __MPI
-    GlobalC::rhopw->initmpi(1, 0, POOL_WORLD);
+    pwtest.initmpi(1, 0, POOL_WORLD);
 #endif
     // pwtest.initgrids(lat0,latvec,wfcecut);
-    GlobalC::rhopw->initgrids(lat0, latvec, wfcecut);
-    GlobalC::rhopw->initparameters(gamma_only, wfcecut, distribution_type, xprime);
-    GlobalC::rhopw->setuptransform();
-    GlobalC::rhopw->collect_local_pw();
+    pwtest.initgrids(lat0, latvec, wfcecut);
+    pwtest.initparameters(gamma_only, wfcecut, distribution_type, xprime);
+    pwtest.setuptransform();
+    pwtest.collect_local_pw();
 
-    GlobalC::rhopw->nrxx = 125000;
-    const int npw = GlobalC::rhopw->npw;
-    const int nrxx = GlobalC::rhopw->nrxx;
+    pwtest.nrxx = 125000;
+    const int npw = pwtest.npw;
+    const int nrxx = pwtest.nrxx;
 
     std::ifstream fin;
     fin.open("./support/PS_TOTN_real.in");
@@ -99,8 +97,7 @@ TEST_F(cal_epsilon_test, cal_epsilon)
     double* epsilon = new double[nrxx];
     double* epsilon0 = new double[nrxx];
 
-    GlobalC::rhopw = &pwtest;
-    solvent_model.cal_epsilon(GlobalC::rhopw, PS_TOTN_real, epsilon, epsilon0);
+    solvent_model.cal_epsilon(&pwtest, PS_TOTN_real, epsilon, epsilon0);
 
     EXPECT_EQ(PS_TOTN_real[0], 0.274231);
     EXPECT_EQ(epsilon[0], 1);

--- a/source/module_hamilt_general/module_surchem/test/cal_pseudo_test.cpp
+++ b/source/module_hamilt_general/module_surchem/test/cal_pseudo_test.cpp
@@ -37,7 +37,6 @@ TEST_F(cal_pseudo_test, gauss_charge)
     device_flag = "cpu";
 
     ModulePW::PW_Basis pwtest(device_flag, precision_flag);
-    GlobalC::rhopw = &pwtest;
     ModuleBase::Matrix3 latvec;
     int nx, ny, nz; // f*G
     double wfcecut;
@@ -58,26 +57,26 @@ TEST_F(cal_pseudo_test, gauss_charge)
 #endif
 
 #ifdef __MPI
-    GlobalC::rhopw->initmpi(1, 0, POOL_WORLD);
+    pwtest.initmpi(1, 0, POOL_WORLD);
 #endif
     // pwtest.initgrids(lat0,latvec,wfcecut);
 
-    GlobalC::rhopw->initgrids(ucell.lat0, ucell.latvec, wfcecut);
+    pwtest.initgrids(ucell.lat0, ucell.latvec, wfcecut);
 
-    GlobalC::rhopw->initparameters(gamma_only, wfcecut, distribution_type, xprime);
-    GlobalC::rhopw->setuptransform();
-    GlobalC::rhopw->collect_local_pw();
-    GlobalC::rhopw->collect_uniqgg();
+    pwtest.initparameters(gamma_only, wfcecut, distribution_type, xprime);
+    pwtest.setuptransform();
+    pwtest.collect_local_pw();
+    pwtest.collect_uniqgg();
 
-    const int npw = GlobalC::rhopw->npw;
-    const int nrxx = GlobalC::rhopw->nrxx;
+    const int npw = pwtest.npw;
+    const int nrxx = pwtest.nrxx;
     complex<double>* N = new complex<double>[npw];
     ModuleBase::GlobalFunc::ZEROS(N, npw);
 
     Structure_Factor sf;
     sf.nbspline = -1;
 
-    solvent_model.gauss_charge(ucell, pgrid, GlobalC::rhopw, N, &sf);
+    solvent_model.gauss_charge(ucell, pgrid, &pwtest, N, &sf);
 
     EXPECT_NEAR(N[14].real(), 0.002, 1e-9);
     EXPECT_NEAR(N[16].real(), -0.001573534, 1e-9);
@@ -92,7 +91,6 @@ TEST_F(cal_pseudo_test, cal_pseudo)
     device_flag = "cpu";
     Setcell::setupcell(ucell);
     ModulePW::PW_Basis pwtest(device_flag, precision_flag);
-    GlobalC::rhopw = &pwtest;
     ModuleBase::Matrix3 latvec;
     int nx, ny, nz; // f*G
     double wfcecut;
@@ -113,18 +111,18 @@ TEST_F(cal_pseudo_test, cal_pseudo)
 #endif
 
 #ifdef __MPI
-    GlobalC::rhopw->initmpi(1, 0, POOL_WORLD);
+    pwtest.initmpi(1, 0, POOL_WORLD);
 #endif
     // pwtest.initgrids(lat0,latvec,wfcecut);
 
-    GlobalC::rhopw->initgrids(ucell.lat0, ucell.latvec, wfcecut);
-    GlobalC::rhopw->initparameters(gamma_only, wfcecut, distribution_type, xprime);
-    GlobalC::rhopw->setuptransform();
-    GlobalC::rhopw->collect_local_pw();
-    GlobalC::rhopw->collect_uniqgg();
+    pwtest.initgrids(ucell.lat0, ucell.latvec, wfcecut);
+    pwtest.initparameters(gamma_only, wfcecut, distribution_type, xprime);
+    pwtest.setuptransform();
+    pwtest.collect_local_pw();
+    pwtest.collect_uniqgg();
 
-    const int npw = GlobalC::rhopw->npw;
-    const int nrxx = GlobalC::rhopw->nrxx;
+    const int npw = pwtest.npw;
+    const int nrxx = pwtest.nrxx;
 
     Structure_Factor sf;
     sf.nbspline = -1;
@@ -137,7 +135,7 @@ TEST_F(cal_pseudo_test, cal_pseudo)
     }
 
     complex<double>* PS_TOTN = new complex<double>[npw];
-    solvent_model.cal_pseudo(ucell, pgrid, GlobalC::rhopw, Porter_g, PS_TOTN, &sf);
+    solvent_model.cal_pseudo(ucell, pgrid, &pwtest, Porter_g, PS_TOTN, &sf);
 
     EXPECT_NEAR(PS_TOTN[16].real(), 0.098426466, 1e-9);
     EXPECT_NEAR(PS_TOTN[14].real(), 0.102, 1e-9);

--- a/source/module_hamilt_general/module_surchem/test/cal_totn_test.cpp
+++ b/source/module_hamilt_general/module_surchem/test/cal_totn_test.cpp
@@ -35,7 +35,6 @@ TEST_F(cal_totn_test, cal_totn)
     device_flag = "cpu";
 
     ModulePW::PW_Basis pwtest(device_flag, precision_flag);
-    GlobalC::rhopw = &pwtest;
     ModuleBase::Matrix3 latvec;
     int nx, ny, nz; // f*G
     double wfcecut;
@@ -56,19 +55,19 @@ TEST_F(cal_totn_test, cal_totn)
 #endif
 
 #ifdef __MPI
-    GlobalC::rhopw->initmpi(1, 0, POOL_WORLD);
+    pwtest.initmpi(1, 0, POOL_WORLD);
 #endif
     // pwtest.initgrids(lat0,latvec,wfcecut);
 
-    GlobalC::rhopw->initgrids(ucell.lat0, ucell.latvec, wfcecut);
+    pwtest.initgrids(ucell.lat0, ucell.latvec, wfcecut);
 
-    GlobalC::rhopw->initparameters(gamma_only, wfcecut, distribution_type, xprime);
-    GlobalC::rhopw->setuptransform();
-    GlobalC::rhopw->collect_local_pw();
-    GlobalC::rhopw->collect_uniqgg();
+    pwtest.initparameters(gamma_only, wfcecut, distribution_type, xprime);
+    pwtest.setuptransform();
+    pwtest.collect_local_pw();
+    pwtest.collect_uniqgg();
 
-    const int npw = GlobalC::rhopw->npw;
-    const int nrxx = GlobalC::rhopw->nrxx;
+    const int npw = pwtest.npw;
+    const int nrxx = pwtest.nrxx;
     complex<double>* N = new complex<double>[npw];
     ModuleBase::GlobalFunc::ZEROS(N, npw);
     complex<double>* TOTN = new complex<double>[npw];
@@ -88,7 +87,7 @@ TEST_F(cal_totn_test, cal_totn)
         vloc[i] = 0.1;
     }
 
-    solvent_model.cal_totn(ucell, GlobalC::rhopw, Porter_g, N, TOTN, vloc);
+    solvent_model.cal_totn(ucell, &pwtest, Porter_g, N, TOTN, vloc);
 
     EXPECT_NEAR(TOTN[0].real(), -0.0999496256, 1e-10);
     EXPECT_NEAR(TOTN[0].imag(), -1.299621928166352e-7, 1e-10);
@@ -107,7 +106,6 @@ TEST_F(cal_totn_test, induced_charge)
     Setcell::setupcell(ucell);
     
     ModulePW::PW_Basis pwtest(device_flag, precision_flag);
-    GlobalC::rhopw = &pwtest;
     ModuleBase::Matrix3 latvec;
     int nx, ny, nz; // f*G
     double wfcecut;
@@ -126,19 +124,19 @@ TEST_F(cal_totn_test, induced_charge)
 #endif
 
 #ifdef __MPI
-    GlobalC::rhopw->initmpi(1, 0, POOL_WORLD);
+    pwtest.initmpi(1, 0, POOL_WORLD);
 #endif
     // pwtest.initgrids(lat0,latvec,wfcecut);
 
-    GlobalC::rhopw->initgrids(ucell.lat0, ucell.latvec, wfcecut);
+    pwtest.initgrids(ucell.lat0, ucell.latvec, wfcecut);
 
-    GlobalC::rhopw->initparameters(gamma_only, wfcecut, distribution_type, xprime);
-    GlobalC::rhopw->setuptransform();
-    GlobalC::rhopw->collect_local_pw();
-    GlobalC::rhopw->collect_uniqgg();
+    pwtest.initparameters(gamma_only, wfcecut, distribution_type, xprime);
+    pwtest.setuptransform();
+    pwtest.collect_local_pw();
+    pwtest.collect_uniqgg();
 
     double fac;
-    fac = ModuleBase::e2 * ModuleBase::FOUR_PI / (ucell.tpiba2 * GlobalC::rhopw->gg[0]);
+    fac = ModuleBase::e2 * ModuleBase::FOUR_PI / (ucell.tpiba2 * pwtest.gg[0]);
     complex<double> delta_phi{-2.0347933860e-05, 4.5900395826e-07};
     complex<double> induced_charge;
     induced_charge = -delta_phi / fac;

--- a/source/module_hamilt_general/module_surchem/test/cal_vcav_test.cpp
+++ b/source/module_hamilt_general/module_surchem/test/cal_vcav_test.cpp
@@ -41,7 +41,7 @@ TEST_F(cal_vcav_test, lapl_rho)
     device_flag = "cpu";
 
     ModulePW::PW_Basis pwtest(device_flag, precision_flag);
-    GlobalC::rhopw = &pwtest;
+    
     ModuleBase::Matrix3 latvec;
     int nx, ny, nz; // f*G
     double wfcecut;
@@ -60,22 +60,22 @@ TEST_F(cal_vcav_test, lapl_rho)
 #endif
 
 #ifdef __MPI
-    GlobalC::rhopw->initmpi(1, 0, POOL_WORLD);
+    pwtest.initmpi(1, 0, POOL_WORLD);
 #endif
-    GlobalC::rhopw->initgrids(ucell.lat0, ucell.latvec, wfcecut);
+    pwtest.initgrids(ucell.lat0, ucell.latvec, wfcecut);
 
-    GlobalC::rhopw->initparameters(gamma_only, wfcecut, distribution_type, xprime);
-    GlobalC::rhopw->setuptransform();
-    GlobalC::rhopw->collect_local_pw();
-    GlobalC::rhopw->collect_uniqgg();
+    pwtest.initparameters(gamma_only, wfcecut, distribution_type, xprime);
+    pwtest.setuptransform();
+    pwtest.collect_local_pw();
+    pwtest.collect_uniqgg();
 
-    const int npw = GlobalC::rhopw->npw;
-    const int nrxx = GlobalC::rhopw->nrxx;
+    const int npw = pwtest.npw;
+    const int nrxx = pwtest.nrxx;
     std::complex<double>* gdrtmpg = new std::complex<double>[npw];
     double* lapn = new double[nrxx];
     ModuleBase::GlobalFunc::ZEROS(lapn, nrxx);
 
-    std::complex<double>* aux = new std::complex<double>[GlobalC::rhopw->nmaxgr];
+    std::complex<double>* aux = new std::complex<double>[pwtest.nmaxgr];
 
     gdrtmpg[0] = {2.431e-07, 4.760e-08};
     gdrtmpg[1] = {-7.335e-08, 9.826e-07};
@@ -89,9 +89,9 @@ TEST_F(cal_vcav_test, lapl_rho)
     {
         for (int ig = 0; ig < npw; ig++)
         {
-            aux[ig] = gdrtmpg[ig] * pow(GlobalC::rhopw->gcar[ig][i], 2);
+            aux[ig] = gdrtmpg[ig] * pow(pwtest.gcar[ig][i], 2);
         }
-        GlobalC::rhopw->recip2real(aux, aux);
+        pwtest.recip2real(aux, aux);
         for (int ir = 0; ir < nrxx; ir++)
         {
             lapn[ir] -= aux[ir].real() * ucell.tpiba2;
@@ -148,7 +148,7 @@ TEST_F(cal_vcav_test, createcavity)
     device_flag = "cpu";
 
     ModulePW::PW_Basis pwtest(device_flag, precision_flag);
-    GlobalC::rhopw = &pwtest;
+    
     ModuleBase::Matrix3 latvec;
     int nx, ny, nz; // f*G
     double wfcecut;
@@ -167,17 +167,17 @@ TEST_F(cal_vcav_test, createcavity)
 #endif
 
 #ifdef __MPI
-    GlobalC::rhopw->initmpi(1, 0, POOL_WORLD);
+    pwtest.initmpi(1, 0, POOL_WORLD);
 #endif
-    GlobalC::rhopw->initgrids(ucell.lat0, ucell.latvec, wfcecut);
+    pwtest.initgrids(ucell.lat0, ucell.latvec, wfcecut);
 
-    GlobalC::rhopw->initparameters(gamma_only, wfcecut, distribution_type, xprime);
-    GlobalC::rhopw->setuptransform();
-    GlobalC::rhopw->collect_local_pw();
-    GlobalC::rhopw->collect_uniqgg();
+    pwtest.initparameters(gamma_only, wfcecut, distribution_type, xprime);
+    pwtest.setuptransform();
+    pwtest.collect_local_pw();
+    pwtest.collect_uniqgg();
 
-    const int npw = GlobalC::rhopw->npw;
-    const int nrxx = GlobalC::rhopw->nrxx;
+    const int npw = pwtest.npw;
+    const int nrxx = pwtest.nrxx;
     std::complex<double>* PS_TOTN = new std::complex<double>[npw];
     double* vwork = new double[nrxx];
     ModuleBase::GlobalFunc::ZEROS(vwork, nrxx);
@@ -191,7 +191,7 @@ TEST_F(cal_vcav_test, createcavity)
         PS_TOTN[ig] = 1e-7;
     }
 
-    solvent_model.createcavity(ucell, GlobalC::rhopw, PS_TOTN, vwork);
+    solvent_model.createcavity(ucell, &pwtest, PS_TOTN, vwork);
 
     EXPECT_NEAR(vwork[0], 4.8556305312, 1e-10);
     EXPECT_NEAR(vwork[1], -2.1006480538, 1e-10);
@@ -209,7 +209,7 @@ TEST_F(cal_vcav_test, cal_vcav)
     device_flag = "cpu";
 
     ModulePW::PW_Basis pwtest(device_flag, precision_flag);
-    GlobalC::rhopw = &pwtest;
+    
     ModuleBase::Matrix3 latvec;
     int nx, ny, nz;
     double wfcecut;
@@ -228,17 +228,17 @@ TEST_F(cal_vcav_test, cal_vcav)
 #endif
 
 #ifdef __MPI
-    GlobalC::rhopw->initmpi(1, 0, POOL_WORLD);
+    pwtest.initmpi(1, 0, POOL_WORLD);
 #endif
-    GlobalC::rhopw->initgrids(ucell.lat0, ucell.latvec, wfcecut);
+    pwtest.initgrids(ucell.lat0, ucell.latvec, wfcecut);
 
-    GlobalC::rhopw->initparameters(gamma_only, wfcecut, distribution_type, xprime);
-    GlobalC::rhopw->setuptransform();
-    GlobalC::rhopw->collect_local_pw();
-    GlobalC::rhopw->collect_uniqgg();
+    pwtest.initparameters(gamma_only, wfcecut, distribution_type, xprime);
+    pwtest.setuptransform();
+    pwtest.collect_local_pw();
+    pwtest.collect_uniqgg();
 
-    const int npw = GlobalC::rhopw->npw;
-    const int nrxx = GlobalC::rhopw->nrxx;
+    const int npw = pwtest.npw;
+    const int nrxx = pwtest.nrxx;
     std::complex<double>* PS_TOTN = new std::complex<double>[npw];
 
     PS_TOTN[0] = {2.432e-07, 4.862e-08};
@@ -253,7 +253,7 @@ TEST_F(cal_vcav_test, cal_vcav)
     int nspin = 2;
     solvent_model.Vcav.create(nspin, nrxx);
 
-    solvent_model.cal_vcav(ucell, GlobalC::rhopw, PS_TOTN, nspin);
+    solvent_model.cal_vcav(ucell, &pwtest, PS_TOTN, nspin);
 
     EXPECT_NEAR(solvent_model.Vcav(0, 0), 4.8556305312, 1e-10);
     EXPECT_NEAR(solvent_model.Vcav(0, 1), -2.1006480538, 1e-10);

--- a/source/module_hamilt_general/module_surchem/test/cal_vel_test.cpp
+++ b/source/module_hamilt_general/module_surchem/test/cal_vel_test.cpp
@@ -77,7 +77,6 @@ TEST_F(cal_vel_test, eps_pot)
     device_flag = "cpu";
 
     ModulePW::PW_Basis pwtest(device_flag, precision_flag);
-    GlobalC::rhopw = &pwtest;
     ModuleBase::Matrix3 latvec;
     int nx, ny, nz; // f*G
     double wfcecut;
@@ -96,17 +95,17 @@ TEST_F(cal_vel_test, eps_pot)
 #endif
 
 #ifdef __MPI
-    GlobalC::rhopw->initmpi(1, 0, POOL_WORLD);
+    pwtest.initmpi(1, 0, POOL_WORLD);
 #endif
-    GlobalC::rhopw->initgrids(ucell.lat0, ucell.latvec, wfcecut);
+    pwtest.initgrids(ucell.lat0, ucell.latvec, wfcecut);
 
-    GlobalC::rhopw->initparameters(gamma_only, wfcecut, distribution_type, xprime);
-    GlobalC::rhopw->setuptransform();
-    GlobalC::rhopw->collect_local_pw();
-    GlobalC::rhopw->collect_uniqgg();
+    pwtest.initparameters(gamma_only, wfcecut, distribution_type, xprime);
+    pwtest.setuptransform();
+    pwtest.collect_local_pw();
+    pwtest.collect_uniqgg();
 
-    const int npw = GlobalC::rhopw->npw;
-    const int nrxx = GlobalC::rhopw->nrxx;
+    const int npw = pwtest.npw;
+    const int nrxx = pwtest.nrxx;
     double* vwork = new double[nrxx];
     double* eprime = new double[nrxx];
     double* PS_TOTN_real = new double[nrxx];
@@ -143,7 +142,7 @@ TEST_F(cal_vel_test, eps_pot)
     ModuleBase::Vector3<double>* nabla_phi = new ModuleBase::Vector3<double>[nrxx];
     double* phisq = new double[nrxx];
 
-    XC_Functional::grad_rho(phi, nabla_phi, GlobalC::rhopw, ucell.tpiba);
+    XC_Functional::grad_rho(phi, nabla_phi, &pwtest, ucell.tpiba);
 
     for (int ir = 0; ir < nrxx; ir++)
     {
@@ -175,7 +174,7 @@ TEST_F(cal_vel_test, cal_vel)
     device_flag = "cpu";
 
     ModulePW::PW_Basis pwtest(device_flag, precision_flag);
-    GlobalC::rhopw = &pwtest;
+    
     ModuleBase::Matrix3 latvec;
     int nx, ny, nz; // f*G
     double wfcecut;
@@ -194,17 +193,17 @@ TEST_F(cal_vel_test, cal_vel)
 #endif
 
 #ifdef __MPI
-    GlobalC::rhopw->initmpi(1, 0, POOL_WORLD);
+    pwtest.initmpi(1, 0, POOL_WORLD);
 #endif
-    GlobalC::rhopw->initgrids(ucell.lat0, ucell.latvec, wfcecut);
+    pwtest.initgrids(ucell.lat0, ucell.latvec, wfcecut);
 
-    GlobalC::rhopw->initparameters(gamma_only, wfcecut, distribution_type, xprime);
-    GlobalC::rhopw->setuptransform();
-    GlobalC::rhopw->collect_local_pw();
-    GlobalC::rhopw->collect_uniqgg();
+    pwtest.initparameters(gamma_only, wfcecut, distribution_type, xprime);
+    pwtest.setuptransform();
+    pwtest.collect_local_pw();
+    pwtest.collect_uniqgg();
 
-    const int npw = GlobalC::rhopw->npw;
-    const int nrxx = GlobalC::rhopw->nrxx;
+    const int npw = pwtest.npw;
+    const int nrxx = pwtest.nrxx;
 
     complex<double>* TOTN = new complex<double>[npw];
     complex<double>* PS_TOTN = new complex<double>[npw];
@@ -221,7 +220,7 @@ TEST_F(cal_vel_test, cal_vel)
     solvent_model.TOTN_real = new double[nrxx];
     solvent_model.delta_phi = new double[nrxx];
 
-    solvent_model.cal_vel(ucell, GlobalC::rhopw, TOTN, PS_TOTN, nspin);
+    solvent_model.cal_vel(ucell, &pwtest, TOTN, PS_TOTN, nspin);
 
     EXPECT_NEAR(solvent_model.Vel(0, 0), 0.0532168705, 1e-10);
     EXPECT_NEAR(solvent_model.Vel(0, 1), 0.0447818244, 1e-10);

--- a/source/module_hamilt_general/module_surchem/test/setcell.h
+++ b/source/module_hamilt_general/module_surchem/test/setcell.h
@@ -12,9 +12,7 @@
 
 namespace GlobalC
 {
-	  UnitCell ucell;
     ModulePW::PW_Basis* rhopw;
-    Parallel_Grid Pgrid;
 }
 
 UnitCell::UnitCell(){};

--- a/source/module_hamilt_lcao/module_dftu/dftu.h
+++ b/source/module_hamilt_lcao/module_dftu/dftu.h
@@ -318,8 +318,8 @@ void dftu_cal_occup_m(const int iter,
 
 } // namespace ModuleDFTU
 
-// namespace GlobalC
-// {
-// 	extern ModuleDFTU::DFTU dftu;
-// }
+namespace GlobalC
+{
+	extern ModuleDFTU::DFTU dftu;
+}
 #endif

--- a/source/module_hamilt_lcao/module_dftu/dftu.h
+++ b/source/module_hamilt_lcao/module_dftu/dftu.h
@@ -318,8 +318,8 @@ void dftu_cal_occup_m(const int iter,
 
 } // namespace ModuleDFTU
 
-namespace GlobalC
-{
-	extern ModuleDFTU::DFTU dftu;
-}
+// namespace GlobalC
+// {
+// 	extern ModuleDFTU::DFTU dftu;
+// }
 #endif

--- a/source/module_hamilt_pw/hamilt_pwdft/global.cpp
+++ b/source/module_hamilt_pw/hamilt_pwdft/global.cpp
@@ -7,8 +7,6 @@ namespace GlobalC
 #ifdef __EXX
     Exx_Info exx_info;
 #endif
-UnitCell ucell;
-Parallel_Kpoints Pkpoints; // mohan add 2010-06-07
 Restart restart; // Peize Lin add 2020.04.04
 }
 

--- a/source/module_hsolver/diago_david.cpp
+++ b/source/module_hsolver/diago_david.cpp
@@ -165,6 +165,11 @@ int DiagoDavid<T, Device>::diag_once(const HPsiFunc& hpsi_func,
     {
         if(this->use_paw)
         {
+#ifdef USE_PAW
+            GlobalC::paw_cell.paw_nl_psi(1,
+                                         reinterpret_cast<const std::complex<double>*>(psi_in + m * ld_psi),
+                                         reinterpret_cast<std::complex<double>*>(&this->spsi[m * dim]));
+#endif
         }
         else
         {
@@ -186,6 +191,11 @@ int DiagoDavid<T, Device>::diag_once(const HPsiFunc& hpsi_func,
                          pre_matrix_mv_m[m]);
         if(this->use_paw)
         {
+#ifdef USE_PAW
+            GlobalC::paw_cell.paw_nl_psi(1,
+                                         reinterpret_cast<const std::complex<double>*>(basis + dim * m),
+                                         reinterpret_cast<std::complex<double>*>(&this->spsi[m * dim]));
+#endif
         }
         else
         {

--- a/source/module_hsolver/diago_david.cpp
+++ b/source/module_hsolver/diago_david.cpp
@@ -165,10 +165,6 @@ int DiagoDavid<T, Device>::diag_once(const HPsiFunc& hpsi_func,
     {
         if(this->use_paw)
         {
-#ifdef USE_PAW
-            GlobalC::paw_cell.paw_nl_psi(1, reinterpret_cast<const std::complex<double>*> (psi_in + m*ld_psi),
-                reinterpret_cast<std::complex<double>*>(&this->spsi[m * dim]));
-#endif
         }
         else
         {
@@ -190,10 +186,6 @@ int DiagoDavid<T, Device>::diag_once(const HPsiFunc& hpsi_func,
                          pre_matrix_mv_m[m]);
         if(this->use_paw)
         {
-#ifdef USE_PAW
-            GlobalC::paw_cell.paw_nl_psi(1,reinterpret_cast<const std::complex<double>*> (basis + dim*m),
-                reinterpret_cast<std::complex<double>*>(&this->spsi[m * dim]));
-#endif
         }
         else
         {

--- a/source/module_io/test/for_testing_input_conv.h
+++ b/source/module_io/test/for_testing_input_conv.h
@@ -261,14 +261,8 @@ void current_md_info(const int& my_rank,
 } // namespace MD_func
 
 namespace GlobalC {
-UnitCell ucell;
-wavefunc wf;
-ModuleSymmetry::Symmetry symm;
-Structure_Factor sf;
 ModuleDFTU::DFTU dftu;
 Restart restart;
-pseudopot_cell_vnl ppcell;
-Charge_Mixing CHR_MIX;
 } // namespace GlobalC
 
 #ifdef __PEXSI

--- a/source/module_io/test/for_testing_klist.h
+++ b/source/module_io/test/for_testing_klist.h
@@ -43,10 +43,6 @@ Fcoef::~Fcoef()
 {
 }
 
-namespace GlobalC
-{
-	Parallel_Kpoints Pkpoints;
-	UnitCell ucell;
-}
+
 
 #endif

--- a/source/module_io/test/print_info_test.cpp
+++ b/source/module_io/test/print_info_test.cpp
@@ -26,11 +26,6 @@ Magnetism::~Magnetism(){}
 
 bool berryphase::berry_phase_flag=false;
 
-namespace GlobalC
-{
-	Parallel_Kpoints Pkpoints;
-	UnitCell ucell;
-}
 
 /************************************************
  *  unit test of print_info.cpp

--- a/source/module_relax/relax_new/test/relax_test.h
+++ b/source/module_relax/relax_new/test/relax_test.h
@@ -2,7 +2,6 @@
 
 namespace GlobalC
 {
-    Structure_Factor sf;
     ModulePW::PW_Basis* rhopw;
 }
 


### PR DESCRIPTION
### What's changed?
- Remove the namespace GlobalC except the paw_cell,exx_inf,restart,dftu
- Remove the GlobalC::rhopw in the gtest. 
