### PR TITLE
Fix: v_delta_precalc error in DeePKS.

### DIFF
--- a/source/module_hamilt_lcao/module_deepks/deepks_vdpre.cpp
+++ b/source/module_hamilt_lcao/module_deepks/deepks_vdpre.cpp
@@ -122,7 +122,7 @@ void DeePKS_domain::cal_v_delta_precalc(const int nlocal,
                                     {
                                         TK_tensor tmp = overlap_1->get_value(iw1, ib + m1)
                                                         * overlap_2->get_value(iw2, ib + m2) * *kpase_ptr;
-                                        accessor[ik][iw1][iw2][inl][m1][m2] += tmp;
+                                        accessor[ik][iw1_all][iw2_all][inl][m1][m2] += tmp;
                                     }
                                 }
                                 ib += nm;
@@ -282,7 +282,7 @@ void DeePKS_domain::prepare_phialpha(const int nlocal,
                             for (int m1 = 0; m1 < nm; ++m1) // nm = 1 for s, 3 for p, 5 for d
                             {
                                 TK_tensor tmp = overlap->get_value(iw1, ib + m1) * *kpase_ptr;
-                                accessor[iat][nl][ik][iw1_local][m1] += tmp;
+                                accessor[iat][nl][ik][iw1_all][m1] += tmp;
                             }
                             ib += nm;
                             nl++;

--- a/source/module_hamilt_lcao/module_deepks/deepks_vdpre.cpp
+++ b/source/module_hamilt_lcao/module_deepks/deepks_vdpre.cpp
@@ -106,7 +106,7 @@ void DeePKS_domain::cal_v_delta_precalc(const int nlocal,
                         if (std::is_same<TK, std::complex<double>>::value)
                         {
                             const double arg
-                                = -(kvec_d[ik] * ModuleBase::Vector3<double>(dR1 - dR2)) * ModuleBase::TWO_PI;
+                                = (kvec_d[ik] * ModuleBase::Vector3<double>(dR1 - dR2)) * ModuleBase::TWO_PI;
                             kphase = std::complex<double>(cos(arg), sin(arg));
                         }
                         TK_tensor* kpase_ptr = reinterpret_cast<TK_tensor*>(&kphase);
@@ -268,7 +268,7 @@ void DeePKS_domain::prepare_phialpha(const int nlocal,
                     std::complex<double> kphase = std::complex<double>(1.0, 0.0);
                     if (std::is_same<TK, std::complex<double>>::value)
                     {
-                        const double arg = -(kvec_d[ik] * ModuleBase::Vector3<double>(dR)) * ModuleBase::TWO_PI;
+                        const double arg = (kvec_d[ik] * ModuleBase::Vector3<double>(dR)) * ModuleBase::TWO_PI;
                         kphase = std::complex<double>(cos(arg), sin(arg));
                     }
                     TK_tensor* kpase_ptr = reinterpret_cast<TK_tensor*>(&kphase);

--- a/source/module_hamilt_lcao/module_deepks/deepks_vdpre.cpp
+++ b/source/module_hamilt_lcao/module_deepks/deepks_vdpre.cpp
@@ -268,7 +268,7 @@ void DeePKS_domain::prepare_phialpha(const int nlocal,
                     std::complex<double> kphase = std::complex<double>(1.0, 0.0);
                     if (std::is_same<TK, std::complex<double>>::value)
                     {
-                        const double arg = (kvec_d[ik] * ModuleBase::Vector3<double>(dR)) * ModuleBase::TWO_PI;
+                        const double arg = -(kvec_d[ik] * ModuleBase::Vector3<double>(dR)) * ModuleBase::TWO_PI;
                         kphase = std::complex<double>(cos(arg), sin(arg));
                     }
                     TK_tensor* kpase_ptr = reinterpret_cast<TK_tensor*>(&kphase);


### PR DESCRIPTION
### Linked Issue
Fix #6105 

### What's changed?
- Usage for orbitals index should be iw_all instead of iw. See #6105.
