### PR TITLE
Fix: Avoid hexadecimal output during relax process of HSE

### DIFF
--- a/source/module_ri/Exx_LRI_interface.hpp
+++ b/source/module_ri/Exx_LRI_interface.hpp
@@ -370,6 +370,7 @@ bool Exx_LRI_Interface<T, Tdata>::exx_after_converge(
 
                 timeval t_end;       gettimeofday(&t_end, nullptr);
                 std::cout << "and rerun SCF\t"
+                    << std::defaultfloat
                     << std::setprecision(3) << std::setiosflags(std::ios::scientific)
                     << (double)(t_end.tv_sec-t_start.tv_sec) + (double)(t_end.tv_usec-t_start.tv_usec)/1000000.0 
                     << std::defaultfloat << " (s)" << std::endl;


### PR DESCRIPTION
### Linked Issue
Fix #5066 
