### PR TITLE
Fix: A bug caused by the incorrect update of DMR for deepks_out_labels>0 but deepks_scf=0

### DIFF
--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks_interface.cpp
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks_interface.cpp
@@ -64,6 +64,8 @@ void LCAO_Deepks_Interface<TK, TR>::out_deepks_labels(const double& etot,
     {
         // this part is for integrated test of deepks
         // so it is printed no matter even if deepks_out_labels is not used
+        DeePKS_domain::update_dmr(kvec_d, dm->get_DMK_vector(), ucell, orb, *ParaV, GridD, dmr);
+        
         DeePKS_domain::cal_pdm<
             TK>(init_pdm, inlmax, lmaxd, inl2l, inl_index, kvec_d, dmr, phialpha, ucell, orb, GridD, *ParaV, pdm);
 


### PR DESCRIPTION
### What's changed?
- Add the step for updating DMR in DeePKS to avoid incorrect results when setting `deepks_out_labels>0` and `deepks_scf=0`. This bug may cause the non-convergence when running scf.