### PR TITLE
Fix: Fix periodic boundary condition search issue by enforcing `search_pbc=true`

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -52,7 +52,6 @@
     - [lcao\_dr](#lcao_dr)
     - [lcao\_rmax](#lcao_rmax)
     - [search\_radius](#search_radius)
-    - [search\_pbc](#search_pbc)
     - [bx, by, bz](#bx-by-bz)
     - [elpa\_num\_thread](#elpa_num_thread)
     - [num\_stream](#num_stream)
@@ -923,12 +922,6 @@ These variables are used to control the numerical atomic orbitals related parame
 - **Description**: Searching radius in finding the neighbouring atoms. By default the radius will be automatically determined by the cutoffs of orbitals and nonlocal beta projectors.
 - **Default**: -1
 - **Unit**: Bohr
-
-### search_pbc
-
-- **Type**: Boolean
-- **Description**: If True, periodic images will be included in searching for the neighbouring atoms. If False, periodic images will be ignored.
-- **Default**: True
 
 ### bx, by, bz
 
@@ -3586,9 +3579,11 @@ These variables are used to control berry phase and wannier90 interface paramete
 - **Type**: Real
 - **Description**:
   `td_lcut1` is the lower bound of the interval in the length gauge RT-TDDFT, where $x$ is the fractional coordinate:
+
   $$
     E(x)=\begin{cases}E_0, & \mathtt{cut1}\leqslant x \leqslant \mathtt{cut2} \\-E_0\left(\dfrac{1}{\mathtt{cut1}+1-\mathtt{cut2}}-1\right), & 0 < x < \mathtt{cut1~~or~~cut2} < x < 1 \end{cases}
   $$
+
 - **Default**: 0.05
 
 ### td_lcut2
@@ -3596,9 +3591,11 @@ These variables are used to control berry phase and wannier90 interface paramete
 - **Type**: Real
 - **Description**:
   `td_lcut2` is the upper bound of the interval in the length gauge RT-TDDFT, where $x$ is the fractional coordinate:
+
   $$
     E(x)=\begin{cases}E_0, & \mathtt{cut1}\leqslant x \leqslant \mathtt{cut2} \\-E_0\left(\dfrac{1}{\mathtt{cut1}+1-\mathtt{cut2}}-1\right), & 0 < x < \mathtt{cut1~~or~~cut2} < x < 1 \end{cases}
   $$
+
 - **Default**: 0.95
 
 ### td_gauss_freq

--- a/source/module_esolver/esolver_gets.cpp
+++ b/source/module_esolver/esolver_gets.cpp
@@ -90,7 +90,7 @@ void ESolver_GetS::runner(UnitCell& ucell, const int istep)
 
     Grid_Driver gd;
 
-    atom_arrange::search(PARAM.inp.search_pbc,
+    atom_arrange::search(PARAM.globalv.search_pbc,
                          GlobalV::ofs_running,
                          gd,
                          ucell,
@@ -133,7 +133,7 @@ void ESolver_GetS::runner(UnitCell& ucell, const int istep)
     if (PARAM.inp.out_mat_r)
     {
         cal_r_overlap_R r_matrix;
-        r_matrix.init(ucell,pv, orb_);
+        r_matrix.init(ucell, pv, orb_);
         r_matrix.out_rR(ucell, gd, istep);
     }
 
@@ -142,20 +142,23 @@ void ESolver_GetS::runner(UnitCell& ucell, const int istep)
         LCAO_HS_Arrays HS_Arrays; // store sparse arrays
         //! Print out sparse matrix
         ModuleIO::output_dSR(istep,
-            ucell,
-            this->pv,
-            HS_Arrays,
-            gd, // mohan add 2024-04-06
-            two_center_bundle_,
-            orb_,
-            kv);
+                             ucell,
+                             this->pv,
+                             HS_Arrays,
+                             gd, // mohan add 2024-04-06
+                             two_center_bundle_,
+                             orb_,
+                             kv);
     }
 
     ModuleBase::timer::tick("ESolver_GetS", "runner");
 }
 
 void ESolver_GetS::after_all_runners(UnitCell& ucell) {};
-double ESolver_GetS::cal_energy() { return 0.0; };
+double ESolver_GetS::cal_energy()
+{
+    return 0.0;
+};
 void ESolver_GetS::cal_force(UnitCell& ucell, ModuleBase::matrix& force) {};
 void ESolver_GetS::cal_stress(UnitCell& ucell, ModuleBase::matrix& stress) {};
 

--- a/source/module_esolver/esolver_lj.cpp
+++ b/source/module_esolver/esolver_lj.cpp
@@ -33,7 +33,7 @@ void ESolver_LJ::before_all_runners(UnitCell& ucell, const Input_para& inp)
 void ESolver_LJ::runner(UnitCell& ucell, const int istep)
 {
     Grid_Driver grid_neigh(PARAM.inp.test_deconstructor, PARAM.inp.test_grid);
-    atom_arrange::search(PARAM.inp.search_pbc,
+    atom_arrange::search(PARAM.globalv.search_pbc,
                          GlobalV::ofs_running,
                          grid_neigh,
                          ucell,

--- a/source/module_esolver/lcao_after_scf.cpp
+++ b/source/module_esolver/lcao_after_scf.cpp
@@ -476,7 +476,7 @@ void ESolver_KS_LCAO<TK, TR>::after_scf(UnitCell& ucell, const int istep, const 
             /*test_deconstructor=*/PARAM.inp.test_deconstructor,
             /*test_grid=*/PARAM.inp.test_grid,
             /*test_atom_input=*/PARAM.inp.test_atom_input,
-            /*search_pbc=*/PARAM.inp.search_pbc,
+            /*search_pbc=*/PARAM.globalv.search_pbc,
             /*ofs=*/&GlobalV::ofs_running,
             /*rank=*/GlobalV::MY_RANK
         );

--- a/source/module_esolver/lcao_before_scf.cpp
+++ b/source/module_esolver/lcao_before_scf.cpp
@@ -53,7 +53,7 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(UnitCell& ucell, const int istep)
                                                    PARAM.globalv.gamma_only_local);
 
     //! 3) use search_radius to search adj atoms
-    atom_arrange::search(PARAM.inp.search_pbc,
+    atom_arrange::search(PARAM.globalv.search_pbc,
                          GlobalV::ofs_running,
                          this->gd,
                          ucell,

--- a/source/module_esolver/lcao_others.cpp
+++ b/source/module_esolver/lcao_others.cpp
@@ -67,7 +67,7 @@ void ESolver_KS_LCAO<TK, TR>::others(UnitCell& ucell, const int istep)
         // test_search_neighbor();
         std::cout << FmtCore::format("\n * * * * * *\n << Start %s.\n", "testing neighbour");
         double search_radius = PARAM.inp.search_radius;
-        atom_arrange::search(PARAM.inp.search_pbc,
+        atom_arrange::search(PARAM.globalv.search_pbc,
                              GlobalV::ofs_running,
                              this->gd,
                              ucell,
@@ -86,7 +86,7 @@ void ESolver_KS_LCAO<TK, TR>::others(UnitCell& ucell, const int istep)
                                                    ucell.infoNL.get_rcutmax_Beta(),
                                                    PARAM.globalv.gamma_only_local);
 
-    atom_arrange::search(PARAM.inp.search_pbc,
+    atom_arrange::search(PARAM.globalv.search_pbc,
                          GlobalV::ofs_running,
                          this->gd,
                          ucell,

--- a/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test_prep.cpp
+++ b/source/module_hamilt_lcao/module_deepks/test/LCAO_deepks_test_prep.cpp
@@ -171,7 +171,7 @@ void test_deepks<T>::prep_neighbour()
                                                    ucell.infoNL.get_rcutmax_Beta(),
                                                    PARAM.sys.gamma_only_local);
 
-    atom_arrange::search(PARAM.inp.search_pbc,
+    atom_arrange::search(PARAM.globalv.search_pbc,
                          GlobalV::ofs_running,
                          Test_Deepks::GridD,
                          ucell,

--- a/source/module_io/read_input_item_elec_stru.cpp
+++ b/source/module_io/read_input_item_elec_stru.cpp
@@ -713,12 +713,6 @@ void ReadInput::item_elec_stru()
         this->add_item(item);
     }
     {
-        Input_Item item("search_pbc");
-        item.annotation = "input periodic boundary condition";
-        read_sync_bool(input.search_pbc);
-        this->add_item(item);
-    }
-    {
         Input_Item item("bx");
         item.annotation = "division of an element grid in FFT grid along x";
         read_sync_int(input.bx);

--- a/source/module_io/test/read_input_ptest.cpp
+++ b/source/module_io/test/read_input_ptest.cpp
@@ -101,7 +101,6 @@ TEST_F(InputParaTest, ParaRead)
     EXPECT_EQ(param.inp.basis_type, "lcao");
     EXPECT_EQ(param.inp.ks_solver, "genelpa");
     EXPECT_DOUBLE_EQ(param.inp.search_radius, -1.0);
-    EXPECT_TRUE(param.inp.search_pbc);
     EXPECT_EQ(param.inp.symmetry, "1");
     EXPECT_FALSE(param.inp.init_vel);
     EXPECT_DOUBLE_EQ(param.inp.symmetry_prec, 1.0e-6);

--- a/source/module_io/test/support/INPUT
+++ b/source/module_io/test/support/INPUT
@@ -134,7 +134,6 @@ basis_type                     lcao #PW; LCAO in pw; LCAO
 nb2d                           0 #2d distribution of atoms
 gamma_only                     T #Only for localized orbitals set and gamma point. If set to 1, a fast algorithm is used
 search_radius                  -1 #input search radius (Bohr)
-search_pbc                     1 #input periodic boundary condition
 lcao_ecut                      20 #energy cutoff for LCAO
 lcao_dk                        0.01 #delta k for 1D integration in LCAO
 lcao_dr                        0.01 #delta r for 1D integration in LCAO

--- a/source/module_lr/esolver_lrtd_lcao.cpp
+++ b/source/module_lr/esolver_lrtd_lcao.cpp
@@ -352,7 +352,7 @@ LR::ESolver_LR<T, TR>::ESolver_LR(const Input_para& inp, UnitCell& ucell) : inpu
         orb.get_rcutmax_Phi(),
         ucell.infoNL.get_rcutmax_Beta(),
         PARAM.globalv.gamma_only_local);
-    atom_arrange::search(PARAM.inp.search_pbc,
+    atom_arrange::search(PARAM.globalv.search_pbc,
                          GlobalV::ofs_running,
                          this->gd,
                          this->ucell,

--- a/source/module_parameter/input_parameter.h
+++ b/source/module_parameter/input_parameter.h
@@ -134,7 +134,6 @@ struct Input_para
     double lcao_dr = 0.01;                     ///< dr used in two center integral
     double lcao_rmax = 30.0;                   ///< rmax(a.u.) to make table.
     double search_radius = -1.0;               ///< 11.1
-    bool search_pbc = true;                    ///< 11.2
     int bx = 0, by = 0, bz = 0;                ///< big mesh ball. 0: auto set bx/by/bz
     int elpa_num_thread = -1;                  ///< Number of threads need to use in elpa
     int nstream = 4;                           ///< Number of streams in CUDA as per input data

--- a/source/module_parameter/system_parameter.h
+++ b/source/module_parameter/system_parameter.h
@@ -58,8 +58,9 @@ struct System_para
     bool ks_run = false;                    ///< true if current process runs KS calculation
     bool all_ks_run = true;                 ///< true if only all processes run KS calculation
 
-    bool has_double_data = true;           ///< hamiltonian has double data
-    bool has_float_data = false;           ///< hamiltonian has float data
+    bool has_double_data = true;            ///< hamiltonian has double data
+    bool has_float_data = false;            ///< hamiltonian has float data
 
+    bool search_pbc = true;                 ///< whether to search for periodic boundary conditions, force set to true
 };
 #endif


### PR DESCRIPTION
### Linked Issue
Fix #6151

### What's changed?
We now enforce `search_pbc=true` by:

1. Moving the parameter from `input_parameter.h` to `system_parameter.h`
2. Updating all references from `PARAM.inp.search_pbc` to `PARAM.globalv.search_pbc`
3. Removing related documentation in `input-main.md`
4. Adjusting unit tests accordingly

These changes prevent users from modifying this parameter while ensuring physically correct behavior.