### PR TITLE
[Test] Now integrated test will run after other tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,9 +48,16 @@ jobs:
         run: |
           cmake --build build -j8
           cmake --install build
-      - name: Test
+      - name: Unit Test
         env:
           GTEST_COLOR: 'yes'
           OMP_NUM_THREADS: '2'
         run: |
-          cmake --build build --target test ARGS="-V --timeout 1700"
+          cmake --build build --target test ARGS="-V --timeout 1700 -E integrated_test"
+      - name: Integrated Test
+        env:
+          GTEST_COLOR: 'yes'
+          OMP_NUM_THREADS: '2'
+        run: |
+          cmake --build build --target test ARGS="-V --timeout 1700 -R integrated_test"
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -705,7 +705,6 @@ if(BUILD_TESTING)
   endif()
   # TODO: Try the GoogleTest module.
   # https://cmake.org/cmake/help/latest/module/GoogleTest.html
-  add_subdirectory(tests) # Contains integration tests
 
   function(AddTest) # function for UT
     cmake_parse_arguments(UT "DYN" "TARGET"
@@ -797,4 +796,8 @@ install(PROGRAMS ${ABACUS_BIN_PATH}
 
 if(ENABLE_COVERAGE)
   coverage_evaluate()
+endif()
+
+if(BUILD_TESTING)
+  add_subdirectory(tests) # Contains integration tests
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -704,7 +704,8 @@ if(BUILD_TESTING)
     FetchContent_MakeAvailable(googletest)
   endif()
   # TODO: Try the GoogleTest module.
-  # https://cmake.org/cmake/help/latest/module/GoogleTest.html
+  # https://cmake.org/cmake/help/latest/module/GoogleTest.html\
+  add_subdirectory(tests) # Contains integration tests
 
   function(AddTest) # function for UT
     cmake_parse_arguments(UT "DYN" "TARGET"
@@ -796,8 +797,4 @@ install(PROGRAMS ${ABACUS_BIN_PATH}
 
 if(ENABLE_COVERAGE)
   coverage_evaluate()
-endif()
-
-if(BUILD_TESTING)
-  add_subdirectory(tests) # Contains integration tests
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -704,7 +704,7 @@ if(BUILD_TESTING)
     FetchContent_MakeAvailable(googletest)
   endif()
   # TODO: Try the GoogleTest module.
-  # https://cmake.org/cmake/help/latest/module/GoogleTest.html\
+  # https://cmake.org/cmake/help/latest/module/GoogleTest.html
   add_subdirectory(tests) # Contains integration tests
 
   function(AddTest) # function for UT


### PR DESCRIPTION
Integrated tests always take too long to finish running, so they are separated from the test workflow and will be running after other unit tests are finished.
