### PR TITLE
CI & CD : Trigger devcontainer build for LTS branches and tags

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches:
       - develop
+      - LTS
     tags:
       - 'v*'
+      - 'LTSv*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This commit updates the devcontainer workflow to correctly trigger builds for LTS branches and tags prefixed with 'LTSv*'.