### PR TITLE
Refactor: Standardize OFDFT screen output to match KSDFT format

### DIFF
--- a/source/module_esolver/esolver_fp.h
+++ b/source/module_esolver/esolver_fp.h
@@ -98,6 +98,12 @@ class ESolver_FP: public ESolver
 
     int pw_rho_flag  = false; ///< flag for pw_rho, 0: not initialized, 1: initialized
 
+    //! the start time of scf iteration
+    #ifdef __MPI
+        double iter_time;
+    #else
+        std::chrono::system_clock::time_point iter_time;
+    #endif
 };
 } // namespace ModuleESolver
 

--- a/source/module_esolver/esolver_fp.h
+++ b/source/module_esolver/esolver_fp.h
@@ -3,6 +3,10 @@
 
 #include "esolver.h"
 
+#ifndef __MPI
+#include <chrono>
+#endif
+
 //! plane wave basis
 #include "module_basis/module_pw/pw_basis.h"
 

--- a/source/module_esolver/esolver_ks.h
+++ b/source/module_esolver/esolver_ks.h
@@ -1,12 +1,6 @@
 #ifndef ESOLVER_KS_H
 #define ESOLVER_KS_H
 
-#ifdef __MPI
-#include <mpi.h>
-#else
-#include <chrono>
-#endif
-
 #include <cstring>
 //#include <fstream>
 

--- a/source/module_esolver/esolver_ks.h
+++ b/source/module_esolver/esolver_ks.h
@@ -79,13 +79,6 @@ class ESolver_KS : public ESolver_FP
     //! Electronic wavefunctions
     psi::Psi<T>* psi = nullptr;
 
-    //! the start time of scf iteration
-#ifdef __MPI
-    double iter_time;
-#else
-    std::chrono::system_clock::time_point iter_time;
-#endif
-
     std::string basisname;      //! esolver_ks_lcao.cpp
     double esolver_KS_ne = 0.0; //! number of electrons
     double diag_ethr;           //! the threshold for diagonalization

--- a/source/module_esolver/esolver_of.cpp
+++ b/source/module_esolver/esolver_of.cpp
@@ -164,8 +164,12 @@ void ESolver_OF::runner(UnitCell& ucell, const int istep)
     if (PARAM.inp.of_ml_local_test) this->ml_->localTest(this->chr.rho, this->pw_rho);
 #endif
 
-
     bool conv_esolver = false; // this conv_esolver is added by mohan 20250302 
+#ifdef __MPI
+    this->iter_time = MPI_Wtime();
+#else
+    this->iter_time = std::chrono::system_clock::now();
+#endif
 
     while (true)
     {

--- a/source/module_esolver/esolver_of_tool.cpp
+++ b/source/module_esolver/esolver_of_tool.cpp
@@ -410,8 +410,8 @@ void ESolver_OF::print_info(const bool conv_esolver)
         = (std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - this->iter_time)).count()
           / static_cast<double>(1e6);
 #endif
-    std::cout << " " << std::setw(8) << iteration << std::setw(18) << std::scientific << std::setprecision(8)
-              << this->energy_current_ * ModuleBase::Ry_to_eV
+    std::cout << " " << std::setw(8) << iteration
+              << std::setw(18) << std::scientific << std::setprecision(8) << this->energy_current_ * ModuleBase::Ry_to_eV
               << std::setw(18) << (this->energy_current_ - this->energy_last_) * ModuleBase::Ry_to_eV
               << std::setw(13) << std::setprecision(4) << this->pelec->eferm.get_efval(0) * ModuleBase::Ry_to_eV
               << std::setw(13) << std::setprecision(4) << this->normdLdphi_

--- a/source/module_esolver/esolver_of_tool.cpp
+++ b/source/module_esolver/esolver_of_tool.cpp
@@ -390,38 +390,32 @@ void ESolver_OF::print_info(const bool conv_esolver)
 {
     if (this->iter_ == 0)
     {
-        std::cout << "============================== Running OFDFT "
+        std::cout << " ============================= Running OFDFT "
                      "=============================="
                   << std::endl;
-        std::cout << "Iter        Etot(Ha)          Mu(Ha)      Theta      "
-                     "PotNorm     deltaE(Ha)"
+        std::cout << " ITER       ETOT/eV           EDIFF/eV        EFERMI/eV    POTNORM   TIME/s"
                   << std::endl;
-        // cout << "======================================== Running OFDFT
-        // ========================================" << endl; cout << "Iter
-        // Etot(Ha)          Theta       PotNorm        min/max(den)
-        // min/max(dE/dPhi)" << endl;
     }
-    // ============ used to compare with PROFESS3.0 ================
-    // double minDen = this->chr.rho[0][0];
-    // double maxDen = this->chr.rho[0][0];
-    // double minPot = this->pdEdphi_[0][0];
-    // double maxPot = this->pdEdphi_[0][0];
-    // for (int i = 0; i < this->pw_rho->nrxx; ++i)
-    // {
-    //     if (this->chr.rho[0][i] < minDen) minDen =
-    //     this->chr.rho[0][i]; if (this->chr.rho[0][i] > maxDen)
-    //     maxDen = this->chr.rho[0][i]; if (this->pdEdphi_[0][i] < minPot)
-    //     minPot = this->pdEdphi_[0][i]; if (this->pdEdphi_[0][i] > maxPot)
-    //     maxPot = this->pdEdphi_[0][i];
-    // }
-    std::cout << std::setw(6) << this->iter_ << std::setw(22) << std::scientific << std::setprecision(12)
-              << this->energy_current_ / 2. << std::setw(12) << std::setprecision(3) << this->pelec->eferm.get_efval(0) / 2.
-              << std::setw(12) << this->theta_[0] << std::setw(12) << this->normdLdphi_ << std::setw(12)
-              << (this->energy_current_ - this->energy_last_) / 2. << std::endl;
-    // ============ used to compare with PROFESS3.0 ================
-    // << setw(10) << minDen << "/ " << setw(12) << maxDen
-    // << setw(10) << minPot << "/ " << setw(10) << maxPot << endl;
-    // =============================================================
+
+    std::map<std::string, std::string> prefix_map = {
+        {"cg1", "CG"},
+        {"cg2", "CG"},
+        {"tn", "TN"}
+    };
+    std::string iteration = prefix_map[PARAM.inp.of_method] + std::to_string(this->iter_);
+#ifdef __MPI
+    double duration = (double)(MPI_Wtime() - this->iter_time);
+#else
+    double duration
+        = (std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - this->iter_time)).count()
+          / static_cast<double>(1e6);
+#endif
+    std::cout << " " << std::setw(8) << iteration << std::setw(18) << std::scientific << std::setprecision(8)
+              << this->energy_current_ * ModuleBase::Ry_to_eV
+              << std::setw(18) << (this->energy_current_ - this->energy_last_) * ModuleBase::Ry_to_eV
+              << std::setw(13) << std::setprecision(4) << this->pelec->eferm.get_efval(0) * ModuleBase::Ry_to_eV
+              << std::setw(13) << std::setprecision(4) << this->normdLdphi_
+              << std::setw(6) << std::fixed << std::setprecision(2) << duration << std::endl;
 
     GlobalV::ofs_running << std::setprecision(12);
     GlobalV::ofs_running << std::setiosflags(std::ios::right);
@@ -533,5 +527,12 @@ void ESolver_OF::print_info(const bool conv_esolver)
                    /*formats=*/{"%20s", "%20.12f", "%20.12f"}, 0);
     table << titles << energies_Ry << energies_eV;
     GlobalV::ofs_running << table.str() << std::endl;
+
+    // reset the iter_time for the next iteration
+#ifdef __MPI
+    this->iter_time = MPI_Wtime();
+#else
+    this->iter_time = std::chrono::system_clock::now();
+#endif
 }
 } // namespace ModuleESolver


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Standardize OFDFT screen output to match KSDFT format
    - Before:
![image](https://github.com/user-attachments/assets/2a67b8df-b6e0-473b-b0e8-283560f5d76b)
    - Now:
![image](https://github.com/user-attachments/assets/98ee43be-bd9f-48fb-8769-c62308834579)
    - KSDFT:
![image](https://github.com/user-attachments/assets/ccf309b7-a2dc-493a-b064-238a4f34c12f)
- Move `iter_time` from `ESolver_KS` to `ESolver_FP`.

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
