### PR TITLE
refactor `Exx_Info::coulomb_param` for RI

### DIFF
--- a/source/module_base/global_function.h
+++ b/source/module_base/global_function.h
@@ -236,10 +236,10 @@ static inline const T* VECTOR_TO_PTR(const std::valarray<T>& v)
 // Peize Lin add 2016-07-18
 //==========================================================
 template <typename T>
-std::string TO_STRING(const T& n)
+std::string TO_STRING(const T& t, const int n=20)		// n=20 since LDBL_EPSILON is 1E-16 or 1E-19
 {
     std::stringstream newstr;
-    newstr << n;
+    newstr << std::setprecision(n) << t;
     return newstr.str();
 }
 

--- a/source/module_base/gram_schmidt_orth-inl.h
+++ b/source/module_base/gram_schmidt_orth-inl.h
@@ -95,7 +95,7 @@ Func_Type Gram_Schmidt_Orth<Func_Type,R_Type>::cal_norm( const std::vector<Func_
 		}
 		default:
 		{
-			throw std::invalid_argument("coordinate must be Cartesian or Sphere "+ModuleBase::GlobalFunc::TO_STRING(__FILE__)+" line "+ModuleBase::GlobalFunc::TO_STRING(__LINE__));
+			throw std::invalid_argument("coordinate must be Cartesian or Sphere "+std::string(__FILE__)+" line "+std::to_string(__LINE__));
 			break;
 		}
 	}

--- a/source/module_base/mathzone_add1.cpp
+++ b/source/module_base/mathzone_add1.cpp
@@ -194,7 +194,7 @@ double Mathzone_Add1::Uni_RadialF
 
   	if (newr < 0.0)
   	{  
-		throw std::runtime_error("newr should >= 0. "+ModuleBase::GlobalFunc::TO_STRING(__FILE__)+" line "+ModuleBase::GlobalFunc::TO_STRING(__LINE__));
+		throw std::runtime_error("newr should >= 0. "+std::string(__FILE__)+" line "+std::to_string(__LINE__));
 
   	}
   	else if ( rmax <= newr	) 

--- a/source/module_base/random.h
+++ b/source/module_base/random.h
@@ -32,7 +32,7 @@ class Random
 		const int a = std::rand() % 2;
 		if(a==0) return between0and1();
 		else if(a==1) return betweenMinus1and0();
-		else throw(ModuleBase::GlobalFunc::TO_STRING(__FILE__)+" line "+ModuleBase::GlobalFunc::TO_STRING(__LINE__));	// Peize Lin add to fix warning 2019-05-01
+		else throw(std::string(__FILE__)+" line "+std::to_string(__LINE__));	// Peize Lin add to fix warning 2019-05-01
 	}
 
 	static double between0and1(void)

--- a/source/module_basis/module_ao/ORB_atomic_lm.cpp
+++ b/source/module_basis/module_ao/ORB_atomic_lm.cpp
@@ -97,7 +97,7 @@ void Numerical_Orbital_Lm::set_orbital_info
 				this->psik2[ik] = psi_in[ik];
 			break;
 		default:
-			throw std::domain_error(ModuleBase::GlobalFunc::TO_STRING(__FILE__)+" line "+ModuleBase::GlobalFunc::TO_STRING(__LINE__));
+			throw std::domain_error(std::string(__FILE__)+" line "+std::to_string(__LINE__));
 	}
 
 	switch(psi_type)
@@ -111,7 +111,7 @@ void Numerical_Orbital_Lm::set_orbital_info
 			}
 			else
 			{
-				throw std::domain_error("flag_sbpool false not finished in Numerical_Orbital_Lm::set_orbital_info_k. "+ModuleBase::GlobalFunc::TO_STRING(__FILE__)+" line "+ModuleBase::GlobalFunc::TO_STRING(__LINE__));
+				throw std::domain_error("flag_sbpool false not finished in Numerical_Orbital_Lm::set_orbital_info_k. "+std::string(__FILE__)+" line "+std::to_string(__LINE__));
 			}
 			break;
 		default:	break;

--- a/source/module_hamilt_general/module_xc/exx_info.h
+++ b/source/module_hamilt_general/module_xc/exx_info.h
@@ -4,11 +4,28 @@
 #include "module_ri/conv_coulomb_pot_k.h"
 #include "xc_functional.h"
 
+#include <vector>
+#include <map>
+#include <unordered_map>
+#include <string>
+
 struct Exx_Info
 {
     struct Exx_Info_Global
     {
         bool cal_exx = false;
+
+        std::unordered_map<Conv_Coulomb_Pot_K::Coulomb_Type, std::vector<std::map<std::string,std::string>>> coulomb_param;
+		// Fock:
+		//		"alpha":		"0"
+		//		"Rcut_type":	"limits" / "spencer"
+		//		"lambda":		"0.3"
+		//		//"Rcut"
+		// Erfc:
+		//		"alpha":		"0"
+		//		"omega":		"0.11"
+		//		"Rcut_type":	"limits"
+		//		//"Rcut"
 
         Conv_Coulomb_Pot_K::Ccp_Type ccp_type;
         double hybrid_alpha = 0.25;
@@ -35,8 +52,7 @@ struct Exx_Info
 
     struct Exx_Info_RI
     {
-        const Conv_Coulomb_Pot_K::Ccp_Type& ccp_type;
-        const double& hse_omega;
+        const std::unordered_map<Conv_Coulomb_Pot_K::Coulomb_Type, std::vector<std::map<std::string,std::string>>> &coulomb_param;
 
         bool real_number = false;
 
@@ -58,7 +74,7 @@ struct Exx_Info
         int abfs_Lmax = 0; // tmp
 
         Exx_Info_RI(const Exx_Info::Exx_Info_Global& info_global)
-            : ccp_type(info_global.ccp_type), hse_omega(info_global.hse_omega)
+            : coulomb_param(info_global.coulomb_param)
         {
         }
     };

--- a/source/module_hamilt_general/module_xc/xc_functional_libxc.cpp
+++ b/source/module_hamilt_general/module_xc/xc_functional_libxc.cpp
@@ -149,44 +149,52 @@ XC_Functional_Libxc::set_xc_type_libxc(const std::string& xc_func_in)
 
 const std::vector<double> in_built_xc_func_ext_params(const int id)
 {
-	const std::map<int, std::vector<double>> mymap = {
+	switch(id)
+	{
 		// finite temperature XC functionals
-		{XC_LDA_XC_KSDT, 	 {PARAM.inp.xc_temperature * 0.5}},
-		{XC_LDA_XC_CORRKSDT, {PARAM.inp.xc_temperature * 0.5}},
-		{XC_LDA_XC_GDSMFB,   {PARAM.inp.xc_temperature * 0.5}},
-		// hybrid functionals
+		case XC_LDA_XC_KSDT:
+			return {PARAM.inp.xc_temperature * 0.5};
+		case XC_LDA_XC_CORRKSDT:
+			return {PARAM.inp.xc_temperature * 0.5};
+		case XC_LDA_XC_GDSMFB:
+			return {PARAM.inp.xc_temperature * 0.5};
 #ifdef __EXX
-		{XC_HYB_GGA_XC_PBEH,  {GlobalC::exx_info.info_global.hybrid_alpha,
-							   GlobalC::exx_info.info_global.hse_omega, 
-							   GlobalC::exx_info.info_global.hse_omega}},
-		{XC_HYB_GGA_XC_HSE06, {GlobalC::exx_info.info_global.hybrid_alpha,
-							   GlobalC::exx_info.info_global.hse_omega, 
-							   GlobalC::exx_info.info_global.hse_omega}},
+		// hybrid functionals
+		case XC_HYB_GGA_XC_PBEH:
+			return {GlobalC::exx_info.info_global.hybrid_alpha,
+					GlobalC::exx_info.info_global.hse_omega, 
+					GlobalC::exx_info.info_global.hse_omega};
+		case XC_HYB_GGA_XC_HSE06:
+			return {GlobalC::exx_info.info_global.hybrid_alpha,
+					GlobalC::exx_info.info_global.hse_omega, 
+					GlobalC::exx_info.info_global.hse_omega};
 		// short-range of B88_X
-		{XC_GGA_X_ITYH, {PARAM.inp.exx_hse_omega}},
+		case XC_GGA_X_ITYH:
+			return {PARAM.inp.exx_hse_omega};
 		// short-range of LYP_C
-		{XC_GGA_C_LYPR, {0.04918, 0.132, 0.2533, 0.349, 
-						 0.35/2.29, 2.0/2.29, PARAM.inp.exx_hse_omega}},
+		case XC_GGA_C_LYPR:
+			return {0.04918, 0.132, 0.2533, 0.349, 
+					0.35/2.29, 2.0/2.29, PARAM.inp.exx_hse_omega};
 #endif
-	};
-	auto it = mymap.find(id);
-	return (it != mymap.end()) ? it->second : std::vector<double>{};
+		default:
+			return std::vector<double>{};
+	}
 }
 
 const std::vector<double> external_xc_func_ext_params(const int id)
 {
 	const std::map<int, std::vector<double>> mymap = {
-        {
-			PARAM.inp.xc_exch_ext[0], 
+		{
+			PARAM.inp.xc_exch_ext[0],
 			std::vector<double>(PARAM.inp.xc_exch_ext.begin()+1,
-							    PARAM.inp.xc_exch_ext.end())
+								PARAM.inp.xc_exch_ext.end())
 		},
-        {
-			PARAM.inp.xc_corr_ext[0], 
+		{
+			PARAM.inp.xc_corr_ext[0],
 			std::vector<double>(PARAM.inp.xc_corr_ext.begin()+1,
-            				    PARAM.inp.xc_corr_ext.end())
+								PARAM.inp.xc_corr_ext.end())
 		}
-    };
+ 	};
 	auto it = mymap.find(id);
 	return (it != mymap.end()) ? it->second : std::vector<double>{};
 }

--- a/source/module_hamilt_general/module_xc/xc_functional_wrapper_gcxc.cpp
+++ b/source/module_hamilt_general/module_xc/xc_functional_wrapper_gcxc.cpp
@@ -94,7 +94,7 @@ void XC_Functional::gcxc(const double &rho, const double &grho, double &sxc,
                 v2 = v2x + v2c;
                 break;
             default: //SCAN_X,SCAN_C,HSE, and so on
-                throw std::domain_error("functional unfinished in "+ModuleBase::GlobalFunc::TO_STRING(__FILE__)+" line "+ModuleBase::GlobalFunc::TO_STRING(__LINE__));
+                throw std::domain_error("functional unfinished in "+std::string(__FILE__)+" line "+std::to_string(__LINE__));
         }
         sxc += s;
         v1xc += v1;

--- a/source/module_hamilt_general/module_xc/xc_functional_wrapper_xc.cpp
+++ b/source/module_hamilt_general/module_xc/xc_functional_wrapper_xc.cpp
@@ -117,7 +117,7 @@ void XC_Functional::xc_spin(const double &rho, const double &zeta,
 
             // Cases that are only realized in LIBXC
             default:
-                throw std::domain_error("functional unfinished in "+ModuleBase::GlobalFunc::TO_STRING(__FILE__)+" line "+ModuleBase::GlobalFunc::TO_STRING(__LINE__));	break;
+                throw std::domain_error("functional unfinished in "+std::string(__FILE__)+" line "+std::to_string(__LINE__));	break;
 
         }
         exc += e;

--- a/source/module_hsolver/diago_lapack.cpp
+++ b/source/module_hsolver/diago_lapack.cpp
@@ -112,8 +112,8 @@ int DiagoLapack<T>::dsygvx_once(const int ncol,
     // Throw error if it returns info
     if (info)
         throw std::runtime_error("info = " + ModuleBase::GlobalFunc::TO_STRING(info) + ".\n"
-                                 + ModuleBase::GlobalFunc::TO_STRING(__FILE__) + " line "
-                                 + ModuleBase::GlobalFunc::TO_STRING(__LINE__));
+                                 + std::string(__FILE__) + " line "
+                                 + std::to_string(__LINE__));
     //lwork = work[0];
     //work.resize(std::max(lwork, 3), 0);
     //iwork.resize(iwork[0], 0);
@@ -205,8 +205,8 @@ int DiagoLapack<T>::zhegvx_once(const int ncol,
 
     if (info)
         throw std::runtime_error("info=" + ModuleBase::GlobalFunc::TO_STRING(info) + ". "
-                                 + ModuleBase::GlobalFunc::TO_STRING(__FILE__) + " line "
-                                 + ModuleBase::GlobalFunc::TO_STRING(__LINE__));
+                                 + std::string(__FILE__) + " line "
+                                 + std::to_string(__LINE__));
 
     //	GlobalV::ofs_running<<"lwork="<<work[0]<<"\t"<<"lrwork="<<rwork[0]<<"\t"<<"liwork="<<iwork[0]<<std::endl;
 
@@ -290,7 +290,7 @@ void DiagoLapack<T>::post_processing(const int info, const std::vector<int>& vec
 {
     const std::string str_info = "info = " + ModuleBase::GlobalFunc::TO_STRING(info) + ".\n";
     const std::string str_FILE
-        = ModuleBase::GlobalFunc::TO_STRING(__FILE__) + " line " + ModuleBase::GlobalFunc::TO_STRING(__LINE__) + ".\n";
+        = std::string(__FILE__) + " line " + std::to_string(__LINE__) + ".\n";
     const std::string str_info_FILE = str_info + str_FILE;
 
     if (info == 0)

--- a/source/module_hsolver/diago_scalapack.cpp
+++ b/source/module_hsolver/diago_scalapack.cpp
@@ -138,8 +138,8 @@ namespace hsolver
              &info);
     if (info) {
         throw std::runtime_error("info = " + ModuleBase::GlobalFunc::TO_STRING(info) + ".\n"
-                                 + ModuleBase::GlobalFunc::TO_STRING(__FILE__) + " line "
-                                 + ModuleBase::GlobalFunc::TO_STRING(__LINE__));
+                                 + std::string(__FILE__) + " line "
+                                 + std::to_string(__LINE__));
 }
 
     //	GlobalV::ofs_running<<"lwork="<<work[0]<<"\t"<<"liwork="<<iwork[0]<<std::endl;
@@ -198,8 +198,8 @@ namespace hsolver
         return std::make_pair(info, ifail);
     } else {
         throw std::runtime_error("info = " + ModuleBase::GlobalFunc::TO_STRING(info) + ".\n"
-                                 + ModuleBase::GlobalFunc::TO_STRING(__FILE__) + " line "
-                                 + ModuleBase::GlobalFunc::TO_STRING(__LINE__));
+                                 + std::string(__FILE__) + " line "
+                                 + std::to_string(__LINE__));
 }
 }
     template<typename T>
@@ -269,8 +269,8 @@ namespace hsolver
              &info);
     if (info) {
         throw std::runtime_error("info=" + ModuleBase::GlobalFunc::TO_STRING(info) + ". "
-                                 + ModuleBase::GlobalFunc::TO_STRING(__FILE__) + " line "
-                                 + ModuleBase::GlobalFunc::TO_STRING(__LINE__));
+                                 + std::string(__FILE__) + " line "
+                                 + std::to_string(__LINE__));
 }
 
     //	GlobalV::ofs_running<<"lwork="<<work[0]<<"\t"<<"lrwork="<<rwork[0]<<"\t"<<"liwork="<<iwork[0]<<std::endl;
@@ -334,8 +334,8 @@ namespace hsolver
         return std::make_pair(info, ifail);
     } else {
         throw std::runtime_error("info = " + ModuleBase::GlobalFunc::TO_STRING(info) + ".\n"
-                                 + ModuleBase::GlobalFunc::TO_STRING(__FILE__) + " line "
-                                 + ModuleBase::GlobalFunc::TO_STRING(__LINE__));
+                                 + std::string(__FILE__) + " line "
+                                 + std::to_string(__LINE__));
 }
 }
     template<typename T>
@@ -381,7 +381,7 @@ namespace hsolver
 {
     const std::string str_info = "info = " + ModuleBase::GlobalFunc::TO_STRING(info) + ".\n";
     const std::string str_FILE
-        = ModuleBase::GlobalFunc::TO_STRING(__FILE__) + " line " + ModuleBase::GlobalFunc::TO_STRING(__LINE__) + ".\n";
+        = std::string(__FILE__) + " line " + std::to_string(__LINE__) + ".\n";
     const std::string str_info_FILE = str_info + str_FILE;
 
     if (info == 0)

--- a/source/module_io/read_input_item_exx_dftu.cpp
+++ b/source/module_io/read_input_item_exx_dftu.cpp
@@ -11,9 +11,9 @@ void ReadInput::item_exx()
         Input_Item item("exx_hybrid_alpha");
         item.annotation = "fraction of Fock exchange in hybrid functionals";
         read_sync_string(input.exx_hybrid_alpha);
-		item.reset_value = [](const Input_Item& item, Parameter& para) 
-		{
-			if (para.input.exx_hybrid_alpha == "default")
+        item.reset_value = [](const Input_Item& item, Parameter& para) 
+        {
+            if (para.input.exx_hybrid_alpha == "default")
             {
                 std::string& dft_functional = para.input.dft_functional;
                 std::string dft_functional_lower = dft_functional;
@@ -72,9 +72,9 @@ void ReadInput::item_exx()
         item.annotation = "the maximal electronic iteration number in the "
                           "evaluation of Fock exchange";
         read_sync_int(input.exx_hybrid_step);
-		item.check_value = [](const Input_Item& item, const Parameter& para) 
-		{
-			if (para.input.exx_hybrid_step <= 0)
+        item.check_value = [](const Input_Item& item, const Parameter& para) 
+        {
+            if (para.input.exx_hybrid_step <= 0)
             {
                 ModuleBase::WARNING_QUIT("ReadInput", "exx_hybrid_step must > 0");
             }

--- a/source/module_io/restart.cpp
+++ b/source/module_io/restart.cpp
@@ -25,7 +25,7 @@ bool Restart::write_file2(const std::string& file_name, const void* const ptr, c
 	const int file = open(file_name.c_str(), O_WRONLY|O_CREAT|O_TRUNC, S_IRUSR|S_IWUSR);
     if (-1 == file){
         if (error_quit){
-            throw std::runtime_error("can't open restart save file. \nerrno=" + ModuleBase::GlobalFunc::TO_STRING(errno) + ".\n" + ModuleBase::GlobalFunc::TO_STRING(__FILE__) + " line " + ModuleBase::GlobalFunc::TO_STRING(__LINE__));
+            throw std::runtime_error("can't open restart save file. \nerrno=" + ModuleBase::GlobalFunc::TO_STRING(errno) + ".\n" + std::string(__FILE__) + " line " + std::to_string(__LINE__));
         } else {
             return false;
         }
@@ -33,7 +33,7 @@ bool Restart::write_file2(const std::string& file_name, const void* const ptr, c
     auto error = write(file, ptr, size);
     if (-1 == error) {
         if (error_quit) {
-            throw std::runtime_error("can't write restart save file. \nerrno=" + ModuleBase::GlobalFunc::TO_STRING(errno) + ".\n" + ModuleBase::GlobalFunc::TO_STRING(__FILE__) + " line " + ModuleBase::GlobalFunc::TO_STRING(__LINE__));
+            throw std::runtime_error("can't write restart save file. \nerrno=" + ModuleBase::GlobalFunc::TO_STRING(errno) + ".\n" + std::string(__FILE__) + " line " + std::to_string(__LINE__));
         } else {
             return false;
         }
@@ -47,7 +47,7 @@ bool Restart::read_file2(const std::string& file_name, void* const ptr, const si
 	const int file = open(file_name.c_str(), O_RDONLY);
     if (-1 == file) {
         if (error_quit) {
-            throw std::runtime_error("can't open restart load file. \nerrno=" + ModuleBase::GlobalFunc::TO_STRING(errno) + ".\n" + ModuleBase::GlobalFunc::TO_STRING(__FILE__) + " line " + ModuleBase::GlobalFunc::TO_STRING(__LINE__));
+            throw std::runtime_error("can't open restart load file. \nerrno=" + ModuleBase::GlobalFunc::TO_STRING(errno) + ".\n" + std::string(__FILE__) + " line " + std::to_string(__LINE__));
         } else {
             return false;
         }
@@ -55,7 +55,7 @@ bool Restart::read_file2(const std::string& file_name, void* const ptr, const si
     auto error = read(file, ptr, size);
     if (-1 == error) {
         if (error_quit) {
-            throw std::runtime_error("can't read restart load file. \nerrno=" + ModuleBase::GlobalFunc::TO_STRING(errno) + ".\n" + ModuleBase::GlobalFunc::TO_STRING(__FILE__) + " line " + ModuleBase::GlobalFunc::TO_STRING(__LINE__));
+            throw std::runtime_error("can't read restart load file. \nerrno=" + ModuleBase::GlobalFunc::TO_STRING(errno) + ".\n" + std::string(__FILE__) + " line " + std::to_string(__LINE__));
         } else {
             return false;
         }

--- a/source/module_io/to_wannier90.cpp
+++ b/source/module_io/to_wannier90.cpp
@@ -426,8 +426,8 @@ bool toWannier90::try_read_nnkp(const UnitCell& ucell, const K_Vectors& kv)
             }
             else
             {
-                throw std::runtime_error("numkpt_nnkp uninitialized in " + ModuleBase::GlobalFunc::TO_STRING(__FILE__)
-                                         + " line " + ModuleBase::GlobalFunc::TO_STRING(__LINE__));
+                throw std::runtime_error("numkpt_nnkp uninitialized in " + std::string(__FILE__)
+                                         + " line " + std::to_string(__LINE__));
             }
 
             for (int ik = 0; ik < numkpt_nnkp; ik++)

--- a/source/module_ri/Exx_LRI.hpp
+++ b/source/module_ri/Exx_LRI.hpp
@@ -48,8 +48,9 @@ void Exx_LRI<Tdata>::init(const MPI_Comm &mpi_comm_in,
 		{ this->abfs = Exx_Abfs::IO::construct_abfs( abfs_same_atom, orb, this->info.files_abfs, this->info.kmesh_times ); 	}
 	Exx_Abfs::Construct_Orbs::print_orbs_size(ucell, this->abfs, GlobalV::ofs_running);
 
-	const std::map<std::string,double> ccp_parameter = RI_Util::get_ccp_parameter(this->info, ucell.omega, this->p_kv->get_nkstot_full());
-	this->abfs_ccp = Conv_Coulomb_Pot_K::cal_orbs_ccp(this->abfs, this->info.ccp_type, ccp_parameter, this->info.ccp_rmesh_times);
+	const std::unordered_map<Conv_Coulomb_Pot_K::Coulomb_Type, std::vector<std::map<std::string,std::string>>>
+		coulomb_param_updated = RI_Util::update_coulomb_param(this->info.coulomb_param, ucell.omega, this->p_kv->get_nkstot_full());
+	this->abfs_ccp = Conv_Coulomb_Pot_K::cal_orbs_ccp(this->abfs, coulomb_param_updated, this->info.ccp_rmesh_times);
 
 	for( size_t T=0; T!=this->abfs.size(); ++T )
 		{ GlobalC::exx_info.info_ri.abfs_Lmax = std::max( GlobalC::exx_info.info_ri.abfs_Lmax, static_cast<int>(this->abfs[T].size())-1 ); }

--- a/source/module_ri/RI_Util.h
+++ b/source/module_ri/RI_Util.h
@@ -10,9 +10,13 @@
 
 #include <RI/global/Array_Operator.h>
 #include <RI/global/Global_Func-2.h>
+#include <RI/global/Tensor.h>
 
 #include <array>
-#include <RI/global/Tensor.h>
+#include <vector>
+#include <map>
+#include <unordered_map>
+#include <string>
 
 namespace RI_Util
 {
@@ -59,8 +63,9 @@ namespace RI_Util
         return m_new;
     }
 
-	std::map<std::string,double> get_ccp_parameter(
-		const Exx_Info::Exx_Info_RI &info,
+	std::unordered_map<Conv_Coulomb_Pot_K::Coulomb_Type, std::vector<std::map<std::string,std::string>>>
+	update_coulomb_param(
+		const std::unordered_map<Conv_Coulomb_Pot_K::Coulomb_Type, std::vector<std::map<std::string,std::string>>> &coulomb_param,
 		const double volumn,
 		const int nkstot);
 }

--- a/source/module_ri/RI_Util.hpp
+++ b/source/module_ri/RI_Util.hpp
@@ -66,27 +66,26 @@ namespace RI_Util
 	}
 	*/
 
-	inline std::map<std::string,double> get_ccp_parameter(
-		const Exx_Info::Exx_Info_RI &info,
+	inline std::unordered_map<Conv_Coulomb_Pot_K::Coulomb_Type, std::vector<std::map<std::string,std::string>>>
+	update_coulomb_param(
+		const std::unordered_map<Conv_Coulomb_Pot_K::Coulomb_Type, std::vector<std::map<std::string,std::string>>> &coulomb_param,
 		const double volumn,
 		const int nkstot)
 	{
-		switch(info.ccp_type)
+		std::unordered_map<Conv_Coulomb_Pot_K::Coulomb_Type, std::vector<std::map<std::string,std::string>>> coulomb_param_updated = coulomb_param;
+		for(auto &param_list : coulomb_param_updated)
 		{
-			case Conv_Coulomb_Pot_K::Ccp_Type::Ccp:
-				return {};
-			case Conv_Coulomb_Pot_K::Ccp_Type::Hf:
+			for(auto &param : param_list.second)
 			{
-				// 4/3 * pi * Rcut^3 = V_{supercell} = V_{unitcell} * Nk
-				const int nspin0 = (PARAM.inp.nspin==2) ? 2 : 1;
-				const double hf_Rcut = std::pow(0.75 * nkstot/nspin0 * volumn / (ModuleBase::PI), 1.0/3.0);
-				return {{"hf_Rcut", hf_Rcut}};
+				if(param.at("Rcut_type") == "spencer")
+				{
+					// 4/3 * pi * Rcut^3 = V_{supercell} = V_{unitcell} * Nk
+					const int nspin0 = (PARAM.inp.nspin==2) ? 2 : 1;
+					param["Rcut"] = std::to_string(std::pow(0.75 * nkstot/nspin0 * volumn / (ModuleBase::PI), 1.0/3.0));
+				}
 			}
-			case Conv_Coulomb_Pot_K::Ccp_Type::Erfc:
-				return {{"hse_omega", info.hse_omega}};
-			default:
-				throw std::domain_error(std::string(__FILE__)+" line "+std::to_string(__LINE__));	break;
 		}
+		return coulomb_param_updated;
 	}
 }
 

--- a/source/module_ri/RI_Util.hpp
+++ b/source/module_ri/RI_Util.hpp
@@ -8,6 +8,7 @@
 
 #include "RI_Util.h"
 #include "module_hamilt_pw/hamilt_pwdft/global.h"
+#include "module_base/global_function.h"
 
 namespace RI_Util
 {
@@ -81,7 +82,8 @@ namespace RI_Util
 				{
 					// 4/3 * pi * Rcut^3 = V_{supercell} = V_{unitcell} * Nk
 					const int nspin0 = (PARAM.inp.nspin==2) ? 2 : 1;
-					param["Rcut"] = std::to_string(std::pow(0.75 * nkstot/nspin0 * volumn / (ModuleBase::PI), 1.0/3.0));
+					const double Rcut = std::pow(0.75 * nkstot/nspin0 * volumn / (ModuleBase::PI), 1.0/3.0);
+					param["Rcut"] = ModuleBase::GlobalFunc::TO_STRING(Rcut);
 				}
 			}
 		}

--- a/source/module_ri/conv_coulomb_pot_k.h
+++ b/source/module_ri/conv_coulomb_pot_k.h
@@ -3,44 +3,39 @@
 
 #include <vector>
 #include <map>
+#include <unordered_map>
 #include <string>
 
 namespace Conv_Coulomb_Pot_K
 {
+	enum class Coulomb_Type{Fock, Erfc};
 	enum class Ccp_Type{		//	parameter:
 		Ccp,					//
 		Hf,						//		"hf_Rcut"
 		Erfc,					//		"hse_omega"
 		Erf};					//		"hse_omega", "hf_Rcut"
 
-	template<typename T> T cal_orbs_ccp(
+	template<typename T> extern T cal_orbs_ccp(
 		const T &orbs,
-		const Ccp_Type &ccp_type,
-		const std::map<std::string,double> &parameter,
-        const double rmesh_times);
+		const std::unordered_map<Conv_Coulomb_Pot_K::Coulomb_Type, std::vector<std::map<std::string,std::string>>> &coulomb_param,
+		const double rmesh_times);
 
   //private:
-	template< typename T > double get_rmesh_proportion(
+	template< typename T > extern double get_rmesh_proportion(
 		const T &orbs,
 		const double psi_threshold);
 
   //private:
-	std::vector<double> cal_psi_ccp(
+	extern std::vector<double> cal_psi_fock_limits(
 		const std::vector<double> & psif);
-	std::vector<double> cal_psi_hf(
+	extern std::vector<double> cal_psi_fock_spencer(
 		const std::vector<double> &psif,
 		const std::vector<double> &k_radial,
 		const double hf_Rcut);
-	std::vector<double> cal_psi_hse(
+	extern std::vector<double> cal_psi_erfc_limits(
 		const std::vector<double> & psif,
 		const std::vector<double> & k_radial,
-		const double hse_omega);
-	// added by jghan, 2024-07-06
-	std::vector<double> cal_psi_erf(
-		const std::vector<double> & psif,
-		const std::vector<double> & k_radial,
-		const double hse_omega,
-		const double hf_Rcut);
+		const double erfc_omega);
 }
 
 #include "conv_coulomb_pot_k.hpp"

--- a/source/module_ri/conv_coulomb_pot_k.hpp
+++ b/source/module_ri/conv_coulomb_pot_k.hpp
@@ -2,8 +2,8 @@
 #define CONV_COULOMB_POT_K_HPP
 
 #include "conv_coulomb_pot_k.h"
-#include <vector>
 #include <cmath>
+#include <cassert>
 
 namespace Conv_Coulomb_Pot_K
 {
@@ -11,13 +11,12 @@ namespace Conv_Coulomb_Pot_K
 	template< typename T >
 	std::vector<T> cal_orbs_ccp(
 		const std::vector<T> & orbs,
-		const Ccp_Type &ccp_type,
-		const std::map<std::string,double> &parameter,
+		const std::unordered_map<Conv_Coulomb_Pot_K::Coulomb_Type, std::vector<std::map<std::string,std::string>>> &coulomb_param,
 		const double rmesh_times)
 	{
 		std::vector<T> orbs_ccp(orbs.size());
 		for( size_t i=0; i!=orbs.size(); ++i )
-			orbs_ccp[i] = cal_orbs_ccp(orbs[i], ccp_type, parameter, rmesh_times);
+			orbs_ccp[i] = cal_orbs_ccp(orbs[i], coulomb_param, rmesh_times);
 		return orbs_ccp;
 	}
 
@@ -32,6 +31,24 @@ namespace Conv_Coulomb_Pot_K
 		return rmesh_proportion;
 	}
 
+	// for cal_orbs_ccp()
+	template<typename T>
+	std::vector<T> operator*(const T &s, const std::vector<T> &v_in)
+	{
+		std::vector<T> v(v_in.size());
+		for(std::size_t i=0; i<v.size(); ++i)
+			{ v[i] = s * v_in[i]; }
+		return v;
+	}
+	template<typename T>
+	std::vector<T> operator+ (const std::vector<T> &v1, const std::vector<T> &v2)
+	{
+		assert(v1.size()==v2.size());
+		std::vector<T> v(v1.size());
+		for(std::size_t i=0; i<v.size(); ++i)
+			{ v[i] = v1[i] + v2[i]; }
+		return v;
+	}
 }
 
 #endif

--- a/source/module_ri/exx_abfs-construct_orbs.cpp
+++ b/source/module_ri/exx_abfs-construct_orbs.cpp
@@ -320,7 +320,7 @@ std::vector<std::vector<std::vector<std::vector<double>>>> Exx_Abfs::Construct_O
 		}
 		else
 		{
-			ModuleBase::WARNING(ModuleBase::GlobalFunc::TO_STRING(__FILE__),
+			ModuleBase::WARNING(std::string(__FILE__),
 				"Element "+ModuleBase::GlobalFunc::TO_STRING(T)+" , all training data (lcao[i]*lcao[j]) are all the same. So PCA randomly choose an abf as the result.");
 			psis_new[T].resize( psis[T].size() );
 			for( size_t L=0; L!=psis[T].size(); ++L )


### PR DESCRIPTION
Add `Coulomb_Type` to replace `Ccp_Type` in `Exx_Info`.
Change parameters in `Exx_Info_RI` to `coulomb_param`.
Now the data structure supports Coulomb type for any $ \sum_i a_i 1/r + \sum_j a_j erfc(w_j r)/r $ in RI.

INPUT and libxc remains unchanged in this PR.