### PR TITLE
Fix: reinterpret_cast bug for c10::complex<double>.

### DIFF
--- a/source/module_hamilt_lcao/module_deepks/deepks_check.cpp
+++ b/source/module_hamilt_lcao/module_deepks/deepks_check.cpp
@@ -49,6 +49,7 @@ void DeePKS_domain::check_tensor(const torch::Tensor& tensor, const std::string&
     ofs.close();
 }
 
+template void DeePKS_domain::check_tensor<int>(const torch::Tensor& tensor, const std::string& filename, const int rank);
 template void DeePKS_domain::check_tensor<double>(const torch::Tensor& tensor, const std::string& filename, const int rank);
 template void DeePKS_domain::check_tensor<std::complex<double>>(const torch::Tensor& tensor, const std::string& filename, const int rank);
 


### PR DESCRIPTION
### Linked Issue
Fix #6315.

### What's changed?
- Fix a bug cause by reinterpret c10 data type in DeePKS.
- Add int support for tensor output in `check_tensor()`.