### PR TITLE
Fix: skip mix_dmr after the last iteration

### DIFF
--- a/source/source_esolver/esolver_ks_lcao.cpp
+++ b/source/source_esolver/esolver_ks_lcao.cpp
@@ -821,11 +821,14 @@ void ESolver_KS_LCAO<TK, TR>::iter_finish(UnitCell& ucell, const int istep, int&
     ESolver_KS<TK>::iter_finish(ucell, istep, iter, conv_esolver);
 
     // 5) mix density matrix if mixing_restart + mixing_dmr + not first
-    // mixing_restart at every iter
-    if (PARAM.inp.mixing_restart > 0 && this->p_chgmix->mixing_restart_count > 0 && PARAM.inp.mixing_dmr)
+    // mixing_restart at every iter except the last iter
+    if(iter != PARAM.inp.scf_nmax && !conv_esolver)
     {
-        elecstate::DensityMatrix<TK, double>* dm = dynamic_cast<elecstate::ElecStateLCAO<TK>*>(this->pelec)->get_DM();
-        this->p_chgmix->mix_dmr(dm);
+        if (PARAM.inp.mixing_restart > 0 && this->p_chgmix->mixing_restart_count > 0 && PARAM.inp.mixing_dmr)
+        {
+            elecstate::DensityMatrix<TK, double>* dm = dynamic_cast<elecstate::ElecStateLCAO<TK>*>(this->pelec)->get_DM();
+            this->p_chgmix->mix_dmr(dm);
+        }
     }
 
     // 6) save charge density

--- a/tests/03_NAO_multik/53_NO_PK_URAMP/result.ref
+++ b/tests/03_NAO_multik/53_NO_PK_URAMP/result.ref
@@ -1,5 +1,5 @@
 etotref -3376.2723454300949015
 etotperatomref -1688.1361727150
 totalforceref 36.032716
-totalstressref 12211.003288
+totalstressref 12211.003182
 totaltimeref 2.21

--- a/tests/03_NAO_multik/54_NO_PK_PU/result.ref
+++ b/tests/03_NAO_multik/54_NO_PK_PU/result.ref
@@ -1,5 +1,5 @@
 etotref -7661.7030524582096405
 etotperatomref -1915.4257631146
-totalforceref 24.669066
-totalstressref 7358.093426
+totalforceref 24.663512
+totalstressref 7359.638478
 totaltimeref 27.05

--- a/tests/03_NAO_multik/55_NO_PK_PU_S1/result.ref
+++ b/tests/03_NAO_multik/55_NO_PK_PU_S1/result.ref
@@ -1,5 +1,5 @@
 etotref -5909.5419790928954171
 etotperatomref -1969.8473263643
-totalforceref 955.111693
-totalstressref 46844.269362
+totalforceref 955.111630
+totalstressref 46844.260877
 totaltimeref 1.25

--- a/tests/03_NAO_multik/56_NO_PK_PU_SO/result.ref
+++ b/tests/03_NAO_multik/56_NO_PK_PU_SO/result.ref
@@ -1,5 +1,5 @@
 etotref -6789.2817503491569369
 etotperatomref -3394.6408751746
-totalforceref 11.329526
-totalstressref 4894.902744
+totalforceref 11.335196
+totalstressref 4892.274915
 totaltimeref 4.70


### PR DESCRIPTION
### Linked Issue
Fix issue #6323 

### What's changed?
- cancel the `mix_dmr`operation after last iteration, and some reference values related to `mix_dmr` feature in the tests are modified. 

