### PR TITLE
Fix: Fix calculation type inconsistency across MPI ranks, so that the log file names are correct when `out_alllog = 1`

### DIFF
--- a/source/source_io/read_set_globalv.cpp
+++ b/source/source_io/read_set_globalv.cpp
@@ -126,17 +126,22 @@ void ReadInput::set_global_dir(const Input_para& inp, System_para& sys)
 
     // set the global log file
     bool out_alllog = inp.out_alllog;
+    // set the global calculation type
+    std::string cal_type = inp.calculation;
 #ifdef __MPI
     // because log_file is different for each rank, so we need to bcast the out_alllog
     Parallel_Common::bcast_bool(out_alllog);
+    // In `ReadInput::read_parameters`, `bcastfunc(param)` is after `set_global_dir`,
+    // so `cal_type` must be synchronized here manually
+    Parallel_Common::bcast_string(cal_type);
 #endif
     if (out_alllog)
     {
-        PARAM.sys.log_file = "running_" + PARAM.inp.calculation + "_" + std::to_string(PARAM.sys.myrank + 1) + ".log";
+        PARAM.sys.log_file = "running_" + cal_type + "_" + std::to_string(PARAM.sys.myrank + 1) + ".log";
     }
     else
     {
-        PARAM.sys.log_file = "running_" + PARAM.inp.calculation + ".log";
+        PARAM.sys.log_file = "running_" + cal_type + ".log";
     }
 #ifdef __MPI
     Parallel_Common::bcast_string(sys.global_in_card);


### PR DESCRIPTION
### Linked Issue
Fix #6352.

Added a manual broadcast for calculation type to ensure it is synchronized across MPI ranks, as it is required before the `bcastfunc(param)` call in `ReadInput::read_parameters` to create log files.