### PR TITLE
Improve md calculation stress output in running log

### DIFF
--- a/source/source_io/output_log.cpp
+++ b/source/source_io/output_log.cpp
@@ -285,8 +285,8 @@ void print_stress(const std::string& name, const ModuleBase::matrix& scs,
     }
     else
     {
-        title += " (KBAR)";
-        unit = " KBAR";
+        title += " (kbar)";
+        unit = " kbar";
         unit_transform = ModuleBase::RYDBERG_SI / pow(ModuleBase::BOHR_RADIUS_SI, 3) * 1.0e-8;
     }
     std::vector<double> stress_x;
@@ -317,7 +317,7 @@ void print_stress(const std::string& name, const ModuleBase::matrix& scs,
     fmt << stress_x << stress_y << stress_z;
     table = fmt.str();
     ofs << table;
-    if (name == "TOTAL-STRESS")
+    if (name == "TOTAL-STRESS" && PARAM.inp.calculation != "md")
     {
         ofs << " #TOTAL-PRESSURE# (EXCLUDE KINETIC PART OF IONS): " << std::fixed 
                              << std::setprecision(6) << pressure << unit

--- a/source/source_io/test/outputlog_test.cpp
+++ b/source/source_io/test/outputlog_test.cpp
@@ -292,7 +292,7 @@ TEST(PrintStress, PrintStress)
     std::string output_str;
     getline(ifs, output_str);
     getline(ifs, output_str); // mohan add 2025-06-22
-    EXPECT_THAT(output_str, testing::HasSubstr(" #TOTAL-STRESS (KBAR)#"));
+    EXPECT_THAT(output_str, testing::HasSubstr(" #TOTAL-STRESS (kbar)#"));
 
     getline(ifs, output_str);
     EXPECT_THAT(output_str, testing::HasSubstr("----------------------------------------------------------------"));
@@ -316,7 +316,7 @@ TEST(PrintStress, PrintStress)
     EXPECT_THAT(output_str, testing::HasSubstr("----------------------------------------------------------------"));
 
     getline(ifs, output_str);
-    EXPECT_THAT(output_str, testing::HasSubstr(" #TOTAL-PRESSURE# (EXCLUDE KINETIC PART OF IONS): 49035.075992 KBAR"));
+    EXPECT_THAT(output_str, testing::HasSubstr(" #TOTAL-PRESSURE# (EXCLUDE KINETIC PART OF IONS): 49035.075992 kbar"));
     ifs.close();
     std::remove("running_stress.txt");
 }

--- a/source/source_md/md_base.cpp
+++ b/source/source_md/md_base.cpp
@@ -184,15 +184,15 @@ void MD_base::print_md(std::ofstream& ofs, const bool& cal_stress)
               << std::endl;
 
     // running_log output
-    
+    ofs.unsetf(std::ios::fixed);
+    ofs << std::setprecision(8);
+
     if (cal_stress)
     {
         MD_func::print_stress(ofs, virial, stress);
-	ofs << std::endl;
+	    ofs << std::endl;
     }
 
-    ofs.unsetf(std::ios::fixed);
-    ofs << std::setprecision(8);
     ofs << " ------------------------------------------------------------------------------------------------"
         << std::endl;
     ofs << " " << std::left << std::setw(20) << "Energy (Ry)" << std::left << std::setw(20) << "Potential (Ry)"

--- a/source/source_md/md_base.cpp
+++ b/source/source_md/md_base.cpp
@@ -184,6 +184,13 @@ void MD_base::print_md(std::ofstream& ofs, const bool& cal_stress)
               << std::endl;
 
     // running_log output
+    
+    if (cal_stress)
+    {
+        MD_func::print_stress(ofs, virial, stress);
+	ofs << std::endl;
+    }
+
     ofs.unsetf(std::ios::fixed);
     ofs << std::setprecision(8);
     ofs << " ------------------------------------------------------------------------------------------------"
@@ -209,12 +216,7 @@ void MD_base::print_md(std::ofstream& ofs, const bool& cal_stress)
     ofs << std::endl;
     ofs << " ------------------------------------------------------------------------------------------------"
         << std::endl;
-
-    if (cal_stress)
-    {
-        MD_func::print_stress(ofs, virial, stress);
-    }
-
+    ofs << std::endl;
     return;
 }
 

--- a/source/source_md/md_func.cpp
+++ b/source/source_md/md_func.cpp
@@ -300,9 +300,10 @@ void print_stress(std::ofstream& ofs, const ModuleBase::matrix& virial, const Mo
 
     const double unit_transform = ModuleBase::HARTREE_SI / pow(ModuleBase::BOHR_RADIUS_SI, 3) * 1.0e-8;
 
-    ofs << " MD PRESSURE (ELECTRONS+IONS)  : " << stress_scalar * unit_transform << " kbar" << std::endl;
+    
     ofs << " ELECTRONIC      PART OF STRESS: " << virial_scalar * unit_transform << " kbar" << std::endl;
     ofs << " IONIC (KINETIC) PART OF STRESS: " << (stress_scalar - virial_scalar) * unit_transform << " kbar" << std::endl;
+    ofs << " MD PRESSURE (ELECTRONS+IONS)  : " << stress_scalar * unit_transform << " kbar" << std::endl;
 
     // one should use 'print_stress' function in ../source/source_io/output_log.cpp
 /*

--- a/source/source_md/test/fire_test.cpp
+++ b/source/source_md/test/fire_test.cpp
@@ -185,11 +185,11 @@ TEST_F(FIREtest, PrintMD)
     std::string output_str;
 
     getline(ifs, output_str);
-	EXPECT_THAT(output_str, testing::HasSubstr(" ELECTRONIC      PART OF STRESS: 0.2461 kbar"));
+	EXPECT_THAT(output_str, testing::HasSubstr(" ELECTRONIC      PART OF STRESS: 0.24609992 kbar"));
     getline(ifs, output_str);
-	EXPECT_THAT(output_str, testing::HasSubstr(" IONIC (KINETIC) PART OF STRESS: 0.838539 kbar"));
+	EXPECT_THAT(output_str, testing::HasSubstr(" IONIC (KINETIC) PART OF STRESS: 0.83853919 kbar"));
     getline(ifs, output_str);
-	EXPECT_THAT(output_str, testing::HasSubstr(" MD PRESSURE (ELECTRONS+IONS)  : 1.08464 kbar"));
+	EXPECT_THAT(output_str, testing::HasSubstr(" MD PRESSURE (ELECTRONS+IONS)  : 1.0846391 kbar"));
     getline(ifs, output_str);
     getline(ifs, output_str);
     EXPECT_THAT(output_str,

--- a/source/source_md/test/fire_test.cpp
+++ b/source/source_md/test/fire_test.cpp
@@ -184,47 +184,31 @@ TEST_F(FIREtest, PrintMD)
     std::ifstream ifs("running_fire.log");
     std::string output_str;
 
-    // Line 6
     getline(ifs, output_str);
 	EXPECT_THAT(output_str, testing::HasSubstr(" ELECTRONIC      PART OF STRESS: 0.2461 kbar"));
-
-    // Line 7
     getline(ifs, output_str);
 	EXPECT_THAT(output_str, testing::HasSubstr(" IONIC (KINETIC) PART OF STRESS: 0.838539 kbar"));
-
-    // Line 5
     getline(ifs, output_str);
 	EXPECT_THAT(output_str, testing::HasSubstr(" MD PRESSURE (ELECTRONS+IONS)  : 1.08464 kbar"));
-    
     getline(ifs, output_str);
-    // Line 1
     getline(ifs, output_str);
     EXPECT_THAT(output_str,
         testing::HasSubstr(
             " ------------------------------------------------------------------------------------------------"));
-
-    // Line 2
     getline(ifs, output_str);
     EXPECT_THAT(output_str,
         testing::HasSubstr(
             " Energy (Ry)         Potential (Ry)      Kinetic (Ry)        Temperature (K)     Pressure (kbar)     "));
-
-    // Line 3
     getline(ifs, output_str);
     EXPECT_THAT(output_str,
         testing::HasSubstr(
             " -0.015365236        -0.023915637        0.0085504016        300                 1.0846391           "));
-
-    // Line 4
     getline(ifs, output_str);
     EXPECT_THAT(
         output_str,
         testing::HasSubstr(
             " ------------------------------------------------------------------------------------------------"));
-
     getline(ifs, output_str);
-
-    // Line 8
 	getline(ifs, output_str);
 	EXPECT_THAT(output_str, testing::HasSubstr(" LARGEST FORCE (eV/A)      : 0.049479926"));
 

--- a/source/source_md/test/fire_test.cpp
+++ b/source/source_md/test/fire_test.cpp
@@ -184,6 +184,19 @@ TEST_F(FIREtest, PrintMD)
     std::ifstream ifs("running_fire.log");
     std::string output_str;
 
+    // Line 6
+    getline(ifs, output_str);
+	EXPECT_THAT(output_str, testing::HasSubstr(" ELECTRONIC      PART OF STRESS: 0.2461 kbar"));
+
+    // Line 7
+    getline(ifs, output_str);
+	EXPECT_THAT(output_str, testing::HasSubstr(" IONIC (KINETIC) PART OF STRESS: 0.838539 kbar"));
+
+    // Line 5
+    getline(ifs, output_str);
+	EXPECT_THAT(output_str, testing::HasSubstr(" MD PRESSURE (ELECTRONS+IONS)  : 1.08464 kbar"));
+    
+    getline(ifs, output_str);
     // Line 1
     getline(ifs, output_str);
     EXPECT_THAT(output_str,
@@ -209,17 +222,7 @@ TEST_F(FIREtest, PrintMD)
         testing::HasSubstr(
             " ------------------------------------------------------------------------------------------------"));
 
-    // Line 5
     getline(ifs, output_str);
-	EXPECT_THAT(output_str, testing::HasSubstr(" MD PRESSURE (ELECTRONS+IONS)  : 1.0846391 kbar"));
-
-    // Line 6
-    getline(ifs, output_str);
-	EXPECT_THAT(output_str, testing::HasSubstr(" ELECTRONIC      PART OF STRESS: 0.24609992 kbar"));
-
-    // Line 7
-    getline(ifs, output_str);
-	EXPECT_THAT(output_str, testing::HasSubstr(" IONIC (KINETIC) PART OF STRESS: 0.83853919 kbar"));
 
     // Line 8
 	getline(ifs, output_str);

--- a/source/source_md/test/langevin_test.cpp
+++ b/source/source_md/test/langevin_test.cpp
@@ -173,6 +173,25 @@ TEST_F(Langevin_test, print_md)
     EXPECT_THAT(
         output_str,
         testing::HasSubstr(
+            " ELECTRONIC      PART OF STRESS: 0.2461 kbar"
+        ));
+    getline(ifs, output_str);
+    EXPECT_THAT(
+        output_str,
+        testing::HasSubstr(
+            " IONIC (KINETIC) PART OF STRESS: 0.838539 kbar"
+        ));
+        getline(ifs, output_str);
+    EXPECT_THAT(
+        output_str,
+        testing::HasSubstr(
+            " MD PRESSURE (ELECTRONS+IONS)  : 1.08464 kbar"
+        ));
+    getline(ifs, output_str);
+    getline(ifs, output_str);
+    EXPECT_THAT(
+        output_str,
+        testing::HasSubstr(
             " ------------------------------------------------------------------------------------------------"));
     getline(ifs, output_str);
     EXPECT_THAT(

--- a/source/source_md/test/langevin_test.cpp
+++ b/source/source_md/test/langevin_test.cpp
@@ -170,23 +170,11 @@ TEST_F(Langevin_test, print_md)
     std::ifstream ifs("running_langevin.log");
     std::string output_str;
     getline(ifs, output_str);
-    EXPECT_THAT(
-        output_str,
-        testing::HasSubstr(
-            " ELECTRONIC      PART OF STRESS: 0.2461 kbar"
-        ));
+	EXPECT_THAT(output_str, testing::HasSubstr(" ELECTRONIC      PART OF STRESS: 0.24609992 kbar"));
     getline(ifs, output_str);
-    EXPECT_THAT(
-        output_str,
-        testing::HasSubstr(
-            " IONIC (KINETIC) PART OF STRESS: 0.838539 kbar"
-        ));
-        getline(ifs, output_str);
-    EXPECT_THAT(
-        output_str,
-        testing::HasSubstr(
-            " MD PRESSURE (ELECTRONS+IONS)  : 1.08464 kbar"
-        ));
+	EXPECT_THAT(output_str, testing::HasSubstr(" IONIC (KINETIC) PART OF STRESS: 0.83853919 kbar"));
+    getline(ifs, output_str);
+	EXPECT_THAT(output_str, testing::HasSubstr(" MD PRESSURE (ELECTRONS+IONS)  : 1.0846391 kbar"));
     getline(ifs, output_str);
     getline(ifs, output_str);
     EXPECT_THAT(

--- a/source/source_md/test/md_func_test.cpp
+++ b/source/source_md/test/md_func_test.cpp
@@ -385,11 +385,11 @@ TEST_F(MD_func_test, print_stress)
     std::ifstream ifs("running.log");
     std::string output_str;
     getline(ifs, output_str);
-    EXPECT_THAT(output_str, testing::HasSubstr("MD PRESSURE (ELECTRONS+IONS)  : 0 kbar"));
-    getline(ifs, output_str);
     EXPECT_THAT(output_str, testing::HasSubstr("ELECTRONIC      PART OF STRESS: 0 kbar"));
     getline(ifs, output_str);
     EXPECT_THAT(output_str, testing::HasSubstr("IONIC (KINETIC) PART OF STRESS: 0 kbar"));
+    getline(ifs, output_str);
+    EXPECT_THAT(output_str, testing::HasSubstr("MD PRESSURE (ELECTRONS+IONS)  : 0 kbar"));
 /*
     getline(ifs, output_str);
     getline(ifs, output_str);

--- a/source/source_md/test/msst_test.cpp
+++ b/source/source_md/test/msst_test.cpp
@@ -229,6 +229,25 @@ TEST_F(MSST_test, print_md)
     EXPECT_THAT(
         output_str,
         testing::HasSubstr(
+            " ELECTRONIC      PART OF STRESS: 0.2461 kbar"
+        ));
+    getline(ifs, output_str);
+    EXPECT_THAT(
+        output_str,
+        testing::HasSubstr(
+            " IONIC (KINETIC) PART OF STRESS: 0.830154 kbar"
+        ));
+    getline(ifs, output_str);
+    EXPECT_THAT(
+        output_str,
+        testing::HasSubstr(
+            " MD PRESSURE (ELECTRONS+IONS)  : 1.07625 kbar"
+        ));
+    getline(ifs, output_str);    
+    getline(ifs, output_str);
+    EXPECT_THAT(
+        output_str,
+        testing::HasSubstr(
             " ------------------------------------------------------------------------------------------------"));
     getline(ifs, output_str);
     EXPECT_THAT(

--- a/source/source_md/test/msst_test.cpp
+++ b/source/source_md/test/msst_test.cpp
@@ -226,23 +226,11 @@ TEST_F(MSST_test, print_md)
     std::ifstream ifs("running_msst.log");
     std::string output_str;
     getline(ifs, output_str);
-    EXPECT_THAT(
-        output_str,
-        testing::HasSubstr(
-            " ELECTRONIC      PART OF STRESS: 0.2461 kbar"
-        ));
+	EXPECT_THAT(output_str, testing::HasSubstr(" ELECTRONIC      PART OF STRESS: 0.24609992 kbar"));
     getline(ifs, output_str);
-    EXPECT_THAT(
-        output_str,
-        testing::HasSubstr(
-            " IONIC (KINETIC) PART OF STRESS: 0.830154 kbar"
-        ));
+	EXPECT_THAT(output_str, testing::HasSubstr(" IONIC (KINETIC) PART OF STRESS: 0.8301538 kbar")); // result different from other MD methods
     getline(ifs, output_str);
-    EXPECT_THAT(
-        output_str,
-        testing::HasSubstr(
-            " MD PRESSURE (ELECTRONS+IONS)  : 1.07625 kbar"
-        ));
+	EXPECT_THAT(output_str, testing::HasSubstr(" MD PRESSURE (ELECTRONS+IONS)  : 1.0762537 kbar")); // result different from other MD methods
     getline(ifs, output_str);    
     getline(ifs, output_str);
     EXPECT_THAT(

--- a/source/source_md/test/nhchain_test.cpp
+++ b/source/source_md/test/nhchain_test.cpp
@@ -216,20 +216,11 @@ TEST_F(NHC_test, print_md)
     std::ifstream ifs("running_nhchain.log");
     std::string output_str;
     getline(ifs, output_str);
-    EXPECT_THAT(
-        output_str,
-        testing::HasSubstr(
-            " ELECTRONIC      PART OF STRESS: 0.2461 kbar"));
+	EXPECT_THAT(output_str, testing::HasSubstr(" ELECTRONIC      PART OF STRESS: 0.24609992 kbar"));
     getline(ifs, output_str);
-    EXPECT_THAT(
-        output_str,
-        testing::HasSubstr(
-            " IONIC (KINETIC) PART OF STRESS: 0.838539 kbar"));
+	EXPECT_THAT(output_str, testing::HasSubstr(" IONIC (KINETIC) PART OF STRESS: 0.83853919 kbar"));
     getline(ifs, output_str);
-    EXPECT_THAT(
-        output_str,
-        testing::HasSubstr(
-            " MD PRESSURE (ELECTRONS+IONS)  : 1.08464 kbar"));
+	EXPECT_THAT(output_str, testing::HasSubstr(" MD PRESSURE (ELECTRONS+IONS)  : 1.0846391 kbar"));
     getline(ifs, output_str);
     getline(ifs, output_str);
     EXPECT_THAT(

--- a/source/source_md/test/nhchain_test.cpp
+++ b/source/source_md/test/nhchain_test.cpp
@@ -219,6 +219,22 @@ TEST_F(NHC_test, print_md)
     EXPECT_THAT(
         output_str,
         testing::HasSubstr(
+            " ELECTRONIC      PART OF STRESS: 0.2461 kbar"));
+    getline(ifs, output_str);
+    EXPECT_THAT(
+        output_str,
+        testing::HasSubstr(
+            " IONIC (KINETIC) PART OF STRESS: 0.838539 kbar"));
+    getline(ifs, output_str);
+    EXPECT_THAT(
+        output_str,
+        testing::HasSubstr(
+            " MD PRESSURE (ELECTRONS+IONS)  : 1.08464 kbar"));
+    getline(ifs, output_str);
+    getline(ifs, output_str);
+    EXPECT_THAT(
+        output_str,
+        testing::HasSubstr(
             " ------------------------------------------------------------------------------------------------"));
     getline(ifs, output_str);
     EXPECT_THAT(

--- a/source/source_md/test/verlet_test.cpp
+++ b/source/source_md/test/verlet_test.cpp
@@ -311,26 +311,11 @@ TEST_F(Verlet_test, print_md)
     std::ifstream ifs("running_verlet.log");
     std::string output_str;
     getline(ifs, output_str);
-    EXPECT_THAT(
-        output_str,
-        testing::HasSubstr(
-            " ELECTRONIC      PART OF STRESS: 0.2461 kbar"
-        )
-    );
+	EXPECT_THAT(output_str, testing::HasSubstr(" ELECTRONIC      PART OF STRESS: 0.24609992 kbar"));
     getline(ifs, output_str);
-    EXPECT_THAT(
-        output_str,
-        testing::HasSubstr(
-            " IONIC (KINETIC) PART OF STRESS: 0.838539 kbar"
-        )
-    );
+	EXPECT_THAT(output_str, testing::HasSubstr(" IONIC (KINETIC) PART OF STRESS: 0.83853919 kbar"));
     getline(ifs, output_str);
-    EXPECT_THAT(
-        output_str,
-        testing::HasSubstr(
-            " MD PRESSURE (ELECTRONS+IONS)  : 1.08464 kbar"
-        )
-    );
+	EXPECT_THAT(output_str, testing::HasSubstr(" MD PRESSURE (ELECTRONS+IONS)  : 1.0846391 kbar"));
     getline(ifs, output_str);
     getline(ifs, output_str);
     EXPECT_THAT(

--- a/source/source_md/test/verlet_test.cpp
+++ b/source/source_md/test/verlet_test.cpp
@@ -314,6 +314,28 @@ TEST_F(Verlet_test, print_md)
     EXPECT_THAT(
         output_str,
         testing::HasSubstr(
+            " ELECTRONIC      PART OF STRESS: 0.2461 kbar"
+        )
+    );
+    getline(ifs, output_str);
+    EXPECT_THAT(
+        output_str,
+        testing::HasSubstr(
+            " IONIC (KINETIC) PART OF STRESS: 0.838539 kbar"
+        )
+    );
+    getline(ifs, output_str);
+    EXPECT_THAT(
+        output_str,
+        testing::HasSubstr(
+            " MD PRESSURE (ELECTRONS+IONS)  : 1.08464 kbar"
+        )
+    );
+    getline(ifs, output_str);
+    getline(ifs, output_str);
+    EXPECT_THAT(
+        output_str,
+        testing::HasSubstr(
             " ------------------------------------------------------------------------------------------------"));
     getline(ifs, output_str);
     EXPECT_THAT(


### PR DESCRIPTION
### Linked Issue
Fix #6343 

running log output format in examples/18_md/lcao_gammaonly_Si8/, INPUT1, cal_stress=1
BEFORE:
![image](https://github.com/user-attachments/assets/838d597d-384a-4146-8313-fa03e88d458f)
AFTER:
![image](https://github.com/user-attachments/assets/19869792-27a9-4cfc-8fd9-32bd7a59dfcd)


