### PR TITLE
Clean dependency: remove headers scalapack_connector that are not actually referenced

### DIFF
--- a/source/source_hsolver/diago_elpa.cpp
+++ b/source/source_hsolver/diago_elpa.cpp
@@ -5,7 +5,6 @@
 #include "source_base/module_external/blacs_connector.h"
 #include "source_base/global_variable.h"
 #include "source_base/module_external/lapack_connector.h"
-#include "source_base/module_external/scalapack_connector.h"
 #include "source_base/timer.h"
 #include "source_base/tool_quit.h"
 

--- a/source/source_hsolver/diago_elpa_native.cpp
+++ b/source/source_hsolver/diago_elpa_native.cpp
@@ -4,7 +4,6 @@
 #include "source_base/global_variable.h"
 #include "source_io/module_parameter/parameter.h"
 #include "source_base/module_external/lapack_connector.h"
-#include "source_base/module_external/scalapack_connector.h"
 #include "source_base/timer.h"
 #include "source_base/tool_quit.h"
 #include "source_hsolver/module_genelpa/elpa_new.h"

--- a/source/source_hsolver/test/diago_elpa_utils.h
+++ b/source/source_hsolver/test/diago_elpa_utils.h
@@ -1,6 +1,5 @@
 #include "source_base/module_external/blacs_connector.h"
 #include "source_base/module_external/lapack_connector.h"
-#include "source_base/module_external/scalapack_connector.h"
 #include "mpi.h"
 
 #include <complex>

--- a/source/source_hsolver/test/diago_lcao_cusolver_test.cpp
+++ b/source/source_hsolver/test/diago_lcao_cusolver_test.cpp
@@ -14,6 +14,7 @@
 #ifdef __CUDA
 #include "source_hsolver/diago_cusolver.h"
 #endif
+#include "source_base/module_external/scalapack_connector.h"
 
 #define PASSTHRESHOLD 1e-10
 #define DETAILINFO false

--- a/source/source_hsolver/test/diago_lcao_test.cpp
+++ b/source/source_hsolver/test/diago_lcao_test.cpp
@@ -11,6 +11,7 @@
 #ifdef __ELPA
 #include "source_hsolver/diago_elpa.h"
 #endif
+#include "source_base/module_external/scalapack_connector.h"
 
 #define PASSTHRESHOLD 1e-10
 #define DETAILINFO false

--- a/source/source_io/write_vxc_r.hpp
+++ b/source/source_io/write_vxc_r.hpp
@@ -1,7 +1,6 @@
 #ifndef __WRITE_VXC_R_H_
 #define __WRITE_VXC_R_H_
 #include "source_io/module_parameter/parameter.h"
-#include "source_base/module_external/scalapack_connector.h"
 #include "source_lcao/module_operator_lcao/op_dftu_lcao.h"
 #include "source_lcao/module_operator_lcao/veff_lcao.h"
 #include "source_lcao/spar_hsr.h"

--- a/source/source_lcao/module_deltaspin/cal_mw.cpp
+++ b/source/source_lcao/module_deltaspin/cal_mw.cpp
@@ -2,7 +2,6 @@
 
 #include "source_base/matrix.h"
 #include "source_base/name_angular.h"
-#include "source_base/module_external/scalapack_connector.h"
 #include "source_base/tool_title.h"
 #include "source_base/timer.h"
 #include "source_pw/module_pwdft/onsite_projector.h"

--- a/source/source_lcao/module_dftu/dftu.cpp
+++ b/source/source_lcao/module_dftu/dftu.cpp
@@ -5,7 +5,6 @@
 #include "source_base/global_function.h"
 #include "source_base/inverse_matrix.h"
 #include "source_base/memory.h"
-#include "source_base/module_external/scalapack_connector.h"
 #include "source_base/timer.h"
 #include "source_estate/magnetism.h"
 #include "source_estate/module_charge/charge.h"

--- a/source/source_lcao/module_rt/evolve_psi.cpp
+++ b/source/source_lcao/module_rt/evolve_psi.cpp
@@ -8,7 +8,6 @@
 #include "source_base/module_external/lapack_connector.h"
 #include "source_base/module_container/ATen/kernels/blas.h"   // cuBLAS handle
 #include "source_base/module_container/ATen/kernels/lapack.h" // cuSOLVER handle
-#include "source_base/module_external/scalapack_connector.h"
 #include "source_esolver/esolver_ks_lcao_tddft.h" // use gatherMatrix
 #include "source_io/module_parameter/parameter.h"
 #include "source_lcao/hamilt_lcao.h"

--- a/source/source_lcao/module_rt/propagator.cpp
+++ b/source/source_lcao/module_rt/propagator.cpp
@@ -5,7 +5,6 @@
 #include "source_base/module_container/ATen/kernels/lapack.h"
 #include "source_base/module_container/ATen/kernels/memory.h" // memory operations (Tensor)
 #include "source_base/module_device/memory_op.h"              // memory operations
-#include "source_base/module_external/scalapack_connector.h"
 #include "source_io/module_parameter/parameter.h"
 
 #include <complex>


### PR DESCRIPTION
Remove `source_base/module_external/scalapack_connector.h` that are included but not used.
Including:
- source_lcao/module_rt
- source_lcao/module_lr
- source_io
- source_esolver
- source_estate
- source_hsolver

