### PR TITLE
Remove unreferenced blas_connector.h header

### DIFF
--- a/source/source_base/kernels/math_kernel_op.cpp
+++ b/source/source_base/kernels/math_kernel_op.cpp
@@ -1,4 +1,5 @@
 #include "source_base/kernels/math_kernel_op.h"
+#include "source_base/module_external/blas_connector.h"
 
 #include <iomanip>
 #include <iostream>

--- a/source/source_base/kernels/math_kernel_op.h
+++ b/source/source_base/kernels/math_kernel_op.h
@@ -5,7 +5,6 @@
 
 #include "source_base/macros.h"
 
-#include "source_base/module_external/blas_connector.h"
 #include "source_base/parallel_reduce.h"
 
 #include "source_base/module_device/memory_op.h"

--- a/source/source_base/kernels/math_kernel_op_vec.cpp
+++ b/source/source_base/kernels/math_kernel_op_vec.cpp
@@ -1,4 +1,6 @@
 #include "source_base/kernels/math_kernel_op.h"
+#include "source_base/module_external/blas_connector.h"
+
 
 namespace ModuleBase
 {

--- a/source/source_base/module_grid/batch.cpp
+++ b/source/source_base/module_grid/batch.cpp
@@ -4,7 +4,6 @@
 #include <cassert>
 #include <iterator>
 
-#include "source_base/module_external/blas_connector.h"
 #include "source_base/module_external/lapack_connector.h"
 
 namespace {

--- a/source/source_hsolver/diago_bpcg.cpp
+++ b/source/source_hsolver/diago_bpcg.cpp
@@ -1,7 +1,6 @@
 #include "source_hsolver/diago_bpcg.h"
 
 #include "diago_iter_assist.h"
-#include "source_base/module_external/blas_connector.h"
 #include "source_base/global_function.h"
 #include "source_base/kernels/math_kernel_op.h"
 #include "source_base/parallel_comm.h" // different MPI worlds

--- a/source/source_hsolver/diago_iter_assist.cpp
+++ b/source/source_hsolver/diago_iter_assist.cpp
@@ -1,6 +1,5 @@
 #include "diago_iter_assist.h"
 #include "source_io/module_parameter/parameter.h"
-#include "source_base/module_external/blas_connector.h"
 #include "source_base/complexmatrix.h"
 #include "source_base/constants.h"
 #include "source_base/global_variable.h"

--- a/source/source_lcao/module_gint/gint_gamma_vl.cpp
+++ b/source/source_lcao/module_gint/gint_gamma_vl.cpp
@@ -4,7 +4,6 @@
 #include "gint_gamma.h"
 #include "gint_tools.h"
 #include "grid_technique.h"
-#include "source_base/module_external/blas_connector.h"
 #include "source_base/memory.h"
 #include "source_base/timer.h"
 #include "source_basis/module_ao/ORB_read.h"

--- a/source/source_lcao/module_gint/gint_rho_old.cpp
+++ b/source/source_lcao/module_gint/gint_rho_old.cpp
@@ -1,7 +1,6 @@
 #include "gint_k.h"
 #include "gint_tools.h"
 #include "grid_technique.h"
-#include "source_base/module_external/blas_connector.h"
 #include "source_base/global_function.h"
 #include "source_base/global_variable.h"
 #include "source_base/timer.h"

--- a/source/source_lcao/module_gint/gint_vl_old.cpp
+++ b/source/source_lcao/module_gint/gint_vl_old.cpp
@@ -5,7 +5,6 @@
 #include "grid_technique.h"
 #include "source_base/ylm.h"
 #include "source_pw/module_pwdft/global.h"
-#include "source_base/module_external/blas_connector.h"
 #include "source_base/timer.h"
 #include "source_base/array_pool.h"
 #include "source_base/vector3.h"

--- a/source/source_lcao/module_gint/temp_gint/gint_vl.cpp
+++ b/source/source_lcao/module_gint/temp_gint/gint_vl.cpp
@@ -1,4 +1,3 @@
-#include "source_base/module_external/blas_connector.h"
 #include "gint_common.h"
 #include "gint_vl.h"
 #include "phi_operator.h"

--- a/source/source_lcao/module_gint/temp_gint/gint_vl_metagga.cpp
+++ b/source/source_lcao/module_gint/temp_gint/gint_vl_metagga.cpp
@@ -1,4 +1,3 @@
-#include "source_base/module_external/blas_connector.h"
 #include "gint_common.h"
 #include "gint_vl_metagga.h"
 #include "phi_operator.h"

--- a/source/source_lcao/module_gint/temp_gint/gint_vl_metagga_nspin4.cpp
+++ b/source/source_lcao/module_gint/temp_gint/gint_vl_metagga_nspin4.cpp
@@ -1,6 +1,5 @@
 #include "source_base/global_function.h"
 #include "source_lcao/module_hcontainer/hcontainer.h"
-#include "source_base/module_external/blas_connector.h"
 #include "gint_common.h"
 #include "gint_vl_metagga_nspin4.h"
 #include "phi_operator.h"

--- a/source/source_lcao/module_gint/temp_gint/gint_vl_nspin4.cpp
+++ b/source/source_lcao/module_gint/temp_gint/gint_vl_nspin4.cpp
@@ -1,6 +1,5 @@
 #include "source_base/global_function.h"
 #include "source_lcao/module_hcontainer/hcontainer.h"
-#include "source_base/module_external/blas_connector.h"
 #include "gint_common.h"
 #include "gint_vl_nspin4.h"
 #include "phi_operator.h"

--- a/source/source_lcao/module_lr/operator_casida/operator_lr_hxc.cpp
+++ b/source/source_lcao/module_lr/operator_casida/operator_lr_hxc.cpp
@@ -1,7 +1,6 @@
 #include "operator_lr_hxc.h"
 #include <vector>
 #include "source_io/module_parameter/parameter.h"
-#include "source_base/module_external/blas_connector.h"
 #include "source_base/timer.h"
 #include "source_lcao/module_lr/utils/lr_util.h"
 #include "source_lcao/module_lr/utils/lr_util_hcontainer.h"

--- a/source/source_lcao/module_operator_lcao/dspin_lcao.cpp
+++ b/source/source_lcao/module_operator_lcao/dspin_lcao.cpp
@@ -1,6 +1,5 @@
 #include "dspin_lcao.h"
 #include "source_lcao/module_deltaspin/spin_constrain.h"
-#include "source_base/module_external/blas_connector.h"
 #include "source_base/timer.h"
 #include "source_base/memory.h"
 #include "source_base/tool_title.h"

--- a/source/source_lcao/module_ri/module_exx_symmetry/symmetry_rotation_R.hpp
+++ b/source/source_lcao/module_ri/module_exx_symmetry/symmetry_rotation_R.hpp
@@ -1,6 +1,5 @@
 #include "symmetry_rotation.h"
 #include "source_lcao/module_ri/RI_Util.h"
-#include "source_base/module_external/blas_connector.h"
 #include "source_base/timer.h"
 #include <array>
 #include <RI/global/Global_Func-2.h>

--- a/source/source_pw/module_pwdft/hamilt_pw.cpp
+++ b/source/source_pw/module_pwdft/hamilt_pw.cpp
@@ -1,7 +1,6 @@
 #include "hamilt_pw.h"
 
 #include "source_io/module_parameter/parameter.h"
-#include "source_base/module_external/blas_connector.h"
 #include "source_base/global_function.h"
 #include "source_base/global_variable.h"
 #include "source_pw/module_pwdft/global.h"

--- a/source/source_pw/module_pwdft/onsite_projector.cpp
+++ b/source/source_pw/module_pwdft/onsite_projector.cpp
@@ -7,7 +7,6 @@
 #include "source_pw/module_pwdft/onsite_projector.h"
 
 #include "source_base/projgen.h"
-#include "source_base/module_external/blas_connector.h"
 #include "source_base/kernels/math_kernel_op.h"
 #ifdef __MPI
 #include "source_base/parallel_reduce.h"

--- a/source/source_pw/module_pwdft/operator_pw/nonlocal_pw.cpp
+++ b/source/source_pw/module_pwdft/operator_pw/nonlocal_pw.cpp
@@ -1,7 +1,6 @@
 #include "nonlocal_pw.h"
 
 #include "source_io/module_parameter/parameter.h"
-#include "source_base/module_external/blas_connector.h"
 #include "source_base/timer.h"
 #include "source_base/parallel_reduce.h"
 #include "source_base/tool_quit.h"

--- a/source/source_pw/module_pwdft/operator_pw/onsite_proj_pw.cpp
+++ b/source/source_pw/module_pwdft/operator_pw/onsite_proj_pw.cpp
@@ -1,6 +1,5 @@
 #include "onsite_proj_pw.h"
 
-#include "source_base/module_external/blas_connector.h"
 #include "source_base/timer.h"
 #include "source_base/parallel_reduce.h"
 #include "source_base/tool_quit.h"

--- a/source/source_pw/module_pwdft/operator_pw/op_exx_pw.h
+++ b/source/source_pw/module_pwdft/operator_pw/op_exx_pw.h
@@ -2,7 +2,6 @@
 #define OPEXXPW_H
 
 #include "operator_pw.h"
-#include "source_base/module_external/blas_connector.h"
 #include "source_base/kernels/math_kernel_op.h"
 #include "source_base/macros.h"
 #include "source_base/matrix.h"

--- a/source/source_pw/module_stodft/sto_che.cpp
+++ b/source/source_pw/module_stodft/sto_che.cpp
@@ -1,5 +1,4 @@
 #include "sto_che.h"
-#include "source_base/module_external/blas_connector.h"
 #include "source_base/module_device/device.h"
 #include "source_base/kernels/math_kernel_op.h"
 #include "source_base/module_container/ATen/kernels/blas.h"


### PR DESCRIPTION
Remove unreferenced `source_base/module_external/blas_connector.h` header, including:
- source_hsolver
- source_lcao/module_gint
- source_lcao/module_ri
- source_lcao/module_operator_lcao
- source_lcao/module_lr
- source_pw/module_stodft
- source_pw/pwdft

Also notice that Header in `source_base` are moved to the cpp file that actually use it instead of an `.h`.

I recommend that header files are only included where they are actually used. This will:
1. Reduce Compilation Dependencies
2. Avoid Namespace Pollution. Public headers should only expose necessary declarations. BLAS symbols (e.g., function names, macros) would otherwise **leak into the global namespace, risking conflicts with other libraries**.
3. Maintain Clean Public Interfaces


---
`source_lcao/module_deepks` is left unchanged.