### PR TITLE
Fix CUDA warning by including internal header file device_functions.h that is not allowed

### DIFF
--- a/source/source_lcao/module_gint/test/test_sph.cu
+++ b/source/source_lcao/module_gint/test/test_sph.cu
@@ -3,7 +3,6 @@
 
 #include "float.h"
 #include "cuda_runtime.h"
-#include "device_functions.h"
 #include "device_launch_parameters.h"
 #include "gtest/gtest.h"
 #include "source_lcao/module_hcontainer/hcontainer.h"


### PR DESCRIPTION
CUDA internal header file `device_functions.h` is not allowed  to be included directly and will be removed in future CUDA release.
This PR fixes this, removes header, eliminating compile warning by nvcc.

