### PR TITLE
Remove lapack_connector.h that are not referenced

### DIFF
--- a/source/source_esolver/esolver_ks_lcao_tddft.cpp
+++ b/source/source_esolver/esolver_ks_lcao_tddft.cpp
@@ -12,7 +12,6 @@
 //--------------temporary----------------------------
 #include "source_base/module_external/blas_connector.h"
 #include "source_base/global_function.h"
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/module_external/scalapack_connector.h"
 #include "source_estate/module_charge/symmetry_rho.h"
 #include "source_estate/module_dm/cal_dm_psi.h"

--- a/source/source_hsolver/diago_dav_subspace.cpp
+++ b/source/source_hsolver/diago_dav_subspace.cpp
@@ -6,7 +6,7 @@
 #include "source_base/timer.h"
 #include "source_hsolver/kernels/dngvd_op.h"
 #include "source_base/kernels/math_kernel_op.h"
-#include "source_hsolver/kernels/bpcg_kernel_op.h"
+#include "source_hsolver/kernels/bpcg_kernel_op.h" // normalize_op, precondition_op, apply_eigenvalues_op
 #include "source_base/kernels/dsp/dsp_connector.h"
 
 #include "source_hsolver/diag_hs_para.h"

--- a/source/source_hsolver/diago_elpa.cpp
+++ b/source/source_hsolver/diago_elpa.cpp
@@ -4,7 +4,6 @@
 #include "module_genelpa/elpa_solver.h"
 #include "source_base/module_external/blacs_connector.h"
 #include "source_base/global_variable.h"
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/module_external/scalapack_connector.h"
 #include "source_base/timer.h"
 #include "source_base/tool_quit.h"

--- a/source/source_hsolver/diago_elpa.cpp
+++ b/source/source_hsolver/diago_elpa.cpp
@@ -4,7 +4,6 @@
 #include "module_genelpa/elpa_solver.h"
 #include "source_base/module_external/blacs_connector.h"
 #include "source_base/global_variable.h"
-#include "source_base/module_external/scalapack_connector.h"
 #include "source_base/timer.h"
 #include "source_base/tool_quit.h"
 

--- a/source/source_hsolver/diago_elpa_native.cpp
+++ b/source/source_hsolver/diago_elpa_native.cpp
@@ -3,7 +3,6 @@
 #include "source_base/module_external/blacs_connector.h"
 #include "source_base/global_variable.h"
 #include "source_io/module_parameter/parameter.h"
-#include "source_base/module_external/scalapack_connector.h"
 #include "source_base/timer.h"
 #include "source_base/tool_quit.h"
 #include "source_hsolver/module_genelpa/elpa_new.h"

--- a/source/source_hsolver/diago_elpa_native.cpp
+++ b/source/source_hsolver/diago_elpa_native.cpp
@@ -3,7 +3,6 @@
 #include "source_base/module_external/blacs_connector.h"
 #include "source_base/global_variable.h"
 #include "source_io/module_parameter/parameter.h"
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/module_external/scalapack_connector.h"
 #include "source_base/timer.h"
 #include "source_base/tool_quit.h"

--- a/source/source_hsolver/diago_iter_assist.cpp
+++ b/source/source_hsolver/diago_iter_assist.cpp
@@ -4,7 +4,6 @@
 #include "source_base/complexmatrix.h"
 #include "source_base/constants.h"
 #include "source_base/global_variable.h"
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/module_device/device.h"
 #include "source_base/parallel_reduce.h"
 #include "source_base/timer.h"

--- a/source/source_io/berryphase.cpp
+++ b/source/source_io/berryphase.cpp
@@ -1,5 +1,7 @@
 ﻿#include "berryphase.h"
 
+#include "source_base/module_external/lapack_connector.h"
+
 #include "source_io/module_parameter/parameter.h"
 #include "source_cell/klist.h"
 #include "source_pw/module_pwdft/global.h"

--- a/source/source_io/numerical_descriptor.cpp
+++ b/source/source_io/numerical_descriptor.cpp
@@ -4,7 +4,6 @@
 #include "source_cell/module_symmetry/symmetry.h"
 #include "winput.h"
 #include "source_base/math_ylmreal.h"
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/parallel_reduce.h"
 #include "source_base/timer.h"
 

--- a/source/source_io/to_wannier90.h
+++ b/source/source_io/to_wannier90.h
@@ -11,7 +11,6 @@
 #include "source_base/complexmatrix.h"
 #include "source_base/global_function.h"
 #include "source_base/global_variable.h"
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/matrix.h"
 #include "source_base/matrix3.h"
 #include "source_cell/klist.h"

--- a/source/source_io/to_wannier90_lcao.h
+++ b/source/source_io/to_wannier90_lcao.h
@@ -5,7 +5,6 @@
 #include "source_base/complexmatrix.h"
 #include "source_base/global_function.h"
 #include "source_base/global_variable.h"
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/matrix.h"
 #include "source_base/matrix3.h"
 #include "source_base/parallel_reduce.h"

--- a/source/source_io/to_wannier90_lcao_in_pw.h
+++ b/source/source_io/to_wannier90_lcao_in_pw.h
@@ -5,7 +5,6 @@
 #include "source_base/complexmatrix.h"
 #include "source_base/global_function.h"
 #include "source_base/global_variable.h"
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/matrix.h"
 #include "source_base/matrix3.h"
 #include "source_base/parallel_reduce.h"

--- a/source/source_io/to_wannier90_pw.h
+++ b/source/source_io/to_wannier90_pw.h
@@ -12,7 +12,6 @@
 #include "source_base/complexmatrix.h"
 #include "source_base/global_function.h"
 #include "source_base/global_variable.h"
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/matrix.h"
 #include "source_base/matrix3.h"
 #include "source_cell/klist.h"

--- a/source/source_io/unk_overlap_pw.h
+++ b/source/source_io/unk_overlap_pw.h
@@ -8,7 +8,6 @@
 
 #include "source_base/complexmatrix.h"
 #include "source_base/global_variable.h"
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/parallel_reduce.h"
 #include "source_base/vector3.h"
 #include "source_basis/module_pw/pw_basis.h"

--- a/source/source_lcao/module_rt/band_energy.cpp
+++ b/source/source_lcao/module_rt/band_energy.cpp
@@ -1,7 +1,6 @@
 #include "band_energy.h"
 
 #include "evolve_elec.h"
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/module_container/ATen/kernels/blas.h"
 #include "source_base/module_external/scalapack_connector.h"
 

--- a/source/source_lcao/module_rt/evolve_psi.cpp
+++ b/source/source_lcao/module_rt/evolve_psi.cpp
@@ -5,7 +5,6 @@
 #include "norm_psi.h"
 #include "propagator.h"
 #include "solve_propagation.h"
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/module_container/ATen/kernels/blas.h"   // cuBLAS handle
 #include "source_base/module_container/ATen/kernels/lapack.h" // cuSOLVER handle
 #include "source_base/module_external/scalapack_connector.h"

--- a/source/source_lcao/module_rt/middle_hamilt.cpp
+++ b/source/source_lcao/module_rt/middle_hamilt.cpp
@@ -1,6 +1,5 @@
 #include "middle_hamilt.h"
 
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/module_container/ATen/kernels/blas.h"
 #include "source_base/module_device/memory_op.h" // memory operations
 #include "source_base/module_external/scalapack_connector.h"

--- a/source/source_lcao/module_rt/norm_psi.cpp
+++ b/source/source_lcao/module_rt/norm_psi.cpp
@@ -1,11 +1,14 @@
 #include "norm_psi.h"
 
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/module_container/ATen/kernels/blas.h"
+#include "source_base/module_external/blas_connector.h"
 #include "source_base/module_external/scalapack_connector.h"
+
+#include "source_base/global_function.h" // ModuleBase::GlobalFunc::ZEROS
 
 #include <complex>
 #include <iostream>
+#include <cassert>
 
 namespace module_rt
 {

--- a/source/source_lcao/module_rt/propagator.cpp
+++ b/source/source_lcao/module_rt/propagator.cpp
@@ -1,12 +1,12 @@
 #include "propagator.h"
 
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/module_container/ATen/kernels/blas.h"
 #include "source_base/module_container/ATen/kernels/lapack.h"
 #include "source_base/module_container/ATen/kernels/memory.h" // memory operations (Tensor)
 #include "source_base/module_device/memory_op.h"              // memory operations
 #include "source_base/module_external/scalapack_connector.h"
 #include "source_io/module_parameter/parameter.h"
+#include "source_base/global_function.h"
 
 #include <complex>
 #include <iostream>

--- a/source/source_lcao/module_rt/propagator_cn2.cpp
+++ b/source/source_lcao/module_rt/propagator_cn2.cpp
@@ -1,4 +1,4 @@
-#include "source_base/module_external/lapack_connector.h"
+#include "source_base/module_external/blas_connector.h"
 #include "source_base/module_container/ATen/kernels/blas.h"
 #include "source_base/module_container/ATen/kernels/lapack.h"
 #include "source_base/module_container/ATen/kernels/memory.h" // memory operations (Tensor)
@@ -6,9 +6,11 @@
 #include "source_base/module_external/scalapack_connector.h"
 #include "source_io/module_parameter/parameter.h"
 #include "propagator.h"
+#include "source_base/global_function.h"
 
 #include <complex>
 #include <iostream>
+#include <cassert>
 
 namespace module_rt
 {

--- a/source/source_lcao/module_rt/propagator_etrs.cpp
+++ b/source/source_lcao/module_rt/propagator_etrs.cpp
@@ -1,4 +1,3 @@
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/module_container/ATen/kernels/blas.h"
 #include "source_base/module_container/ATen/kernels/lapack.h"
 #include "source_base/module_container/ATen/kernels/memory.h" // memory operations (Tensor)

--- a/source/source_lcao/module_rt/propagator_taylor.cpp
+++ b/source/source_lcao/module_rt/propagator_taylor.cpp
@@ -1,4 +1,3 @@
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/module_container/ATen/kernels/blas.h"
 #include "source_base/module_container/ATen/kernels/lapack.h"
 #include "source_base/module_container/ATen/kernels/memory.h" // memory operations (Tensor)
@@ -6,6 +5,8 @@
 #include "source_base/module_external/scalapack_connector.h"
 #include "source_io/module_parameter/parameter.h"
 #include "propagator.h"
+
+#include "source_base/global_function.h"
 
 #include <complex>
 #include <iostream>

--- a/source/source_lcao/module_rt/solve_propagation.cpp
+++ b/source/source_lcao/module_rt/solve_propagation.cpp
@@ -2,7 +2,6 @@
 
 #include <iostream>
 
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/module_external/scalapack_connector.h"
 #include "source_pw/module_pwdft/global.h"
 

--- a/source/source_lcao/module_rt/upsi.cpp
+++ b/source/source_lcao/module_rt/upsi.cpp
@@ -1,6 +1,5 @@
 #include "upsi.h"
 
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/module_container/ATen/kernels/blas.h"
 #include "source_base/module_external/scalapack_connector.h"
 

--- a/source/source_pw/module_pwdft/operator_pw/op_exx_pw.cpp
+++ b/source/source_pw/module_pwdft/operator_pw/op_exx_pw.cpp
@@ -1,6 +1,7 @@
 #include "source_base/constants.h"
 #include "source_base/global_variable.h"
 #include "source_base/parallel_reduce.h"
+#include "source_base/module_external/lapack_connector.h"
 #include "source_base/timer.h"
 #include "source_cell/klist.h"
 #include "source_hamilt/operator.h"

--- a/source/source_relax/bfgs.cpp
+++ b/source/source_relax/bfgs.cpp
@@ -1,5 +1,6 @@
 #include "bfgs.h"
 #include "source_pw/module_pwdft/global.h"
+#include "source_base/module_external/lapack_connector.h"
 #include "source_base/matrix3.h"
 #include "source_io/module_parameter/parameter.h"
 #include "ions_move_basic.h"

--- a/source/source_relax/bfgs.h
+++ b/source/source_relax/bfgs.h
@@ -5,7 +5,6 @@
 #include <tuple> 
 #include<algorithm>
 #include<cmath>
-#include"source_base/module_external/lapack_connector.h"
 #include "source_base/matrix.h"
 #include "source_base/matrix3.h"
 #include "source_cell/unitcell.h"

--- a/source/source_relax/lbfgs.h
+++ b/source/source_relax/lbfgs.h
@@ -5,7 +5,6 @@
 #include <tuple> 
 #include <algorithm>
 #include <cmath>
-#include "source_base/module_external/lapack_connector.h"
 #include "matrix_methods.h"
 //#include "line_search.h"
 #include "source_base/matrix.h"


### PR DESCRIPTION
Remove lapack_connector.h that are not referenced and place them on files where lapack is actually used.

---

All TESTS and files related to PEXSI are left unchanged.