### PR TITLE
Fix warnings in *_mixing.h by partially overridden

### DIFF
--- a/source/source_base/module_mixing/broyden_mixing.h
+++ b/source/source_base/module_mixing/broyden_mixing.h
@@ -54,6 +54,10 @@ class Broyden_Mixing : public Mixing
         this->address = nullptr;
     }
 
+    // explicitly introduce push_data version of the base class
+    // that is not overridden in this class
+    using Mixing::push_data;
+
     /**
      * @brief
      *

--- a/source/source_base/module_mixing/plain_mixing.h
+++ b/source/source_base/module_mixing/plain_mixing.h
@@ -30,6 +30,10 @@ class Plain_Mixing : public Mixing
         return;
     }
 
+    // explicitly introduce push_data version of the base class
+    // that is not overridden in this class
+    using Mixing::push_data;
+
     /**
      * @brief
      *


### PR DESCRIPTION
### Compiler warning
Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"

/abacus-develop/source/source_base/module_mixing/plain_mixing.h(11): warning #611-D: overloaded virtual function "Base_Mixing::Mixing::push_data" is only partially overridden in class "Base_Mixing::Plain_Mixing"
  class Plain_Mixing : public Mixing
        ^



## Solutions
explicitly introduce `push_data` version of the base class that is not overridden in 
- source/source_base/module_mixing/broyden_mixing.h
- source/source_base/module_mixing/plain_mixing.h


### Note
If each overloaded version is expected to have the behavior of the derived class, then all the overloaded versions of `push_data` defined in the base class should be actually overridden.
