### PR TITLE
Remove blas/lapack_connector.h that are not referenced in test

### DIFF
--- a/source/source_base/kernels/test/math_kernel_test.cpp
+++ b/source/source_base/kernels/test/math_kernel_test.cpp
@@ -1,7 +1,7 @@
-#include "source_base/module_external/blas_connector.h"
 #include "source_base/constants.h"
 #include "source_base/module_device/memory_op.h"
 #include "source_base/kernels/math_kernel_op.h"
+#include "source_base/module_external/blas_connector.h"
 
 #include <complex>
 #include <gtest/gtest.h>

--- a/source/source_hsolver/kernels/test/math_dngvd_test.cpp
+++ b/source/source_hsolver/kernels/test/math_dngvd_test.cpp
@@ -1,5 +1,4 @@
 #include "source_base/complexmatrix.h"
-#include "source_base/module_external/lapack_connector.h"
 #include "source_base/module_device/memory_op.h"
 #include "source_hsolver/kernels/dngvd_op.h"
 #include "source_base/kernels/math_kernel_op.h"

--- a/source/source_hsolver/kernels/test/perf_math_kernel.cpp
+++ b/source/source_hsolver/kernels/test/perf_math_kernel.cpp
@@ -1,4 +1,3 @@
-#include "source_base/module_external/blas_connector.h"
 #include "source_base/constants.h"
 #include "source_base/module_device/memory_op.h"
 #include "source_base/kernels/math_kernel_op.h"

--- a/source/source_hsolver/test/diago_lapack_test.cpp
+++ b/source/source_hsolver/test/diago_lapack_test.cpp
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "source_hsolver/diago_lapack.h"
-#include "source_base/module_external/lapack_connector.h"
 
 #define PASSTHRESHOLD 1e-5
 #define DETAILINFO false

--- a/source/source_hsolver/test/diago_mock.h
+++ b/source/source_hsolver/test/diago_mock.h
@@ -1,6 +1,4 @@
 #include<random>
-#include "../../source_base/module_external/lapack_connector.h"
-#include "../../source_base/module_external/blas_connector.h"
 #include "mpi.h"
 #include "source_base/parallel_reduce.h"
 #include "source_pw/module_pwdft/hamilt_pw.h"


### PR DESCRIPTION
After #6398/#6400, remove unused `blas_connector.h` & `lapack_connector.h` in test source files.
