### PR TITLE
fix bug in Pseudopot_upf::set_empty_element()

### DIFF
--- a/source/source_cell/read_pp.cpp
+++ b/source/source_cell/read_pp.cpp
@@ -399,22 +399,15 @@ int Pseudopot_upf::average_p(const double& lambda, Atom_pseudo& pp)
 void Pseudopot_upf::set_empty_element(Atom_pseudo& pp)
 {
 	pp.zv = 0;
-	for(int ir=0; ir<pp.mesh; ++ir)
-	{
-		pp.vloc_at[ir] = 0;
-	}
-	for(int i=0; i<pp.nbeta; ++i)
-	{
-		for(int j=0; j<pp.nbeta; ++j)
-		{
-			pp.dion(i,j) = 0;
-		}
-	}
-	for(int ir=0; ir<pp.mesh; ++ir)
-	{
-		pp.rho_at[ir] = 0;
-	}
-	return;
+	for(double &value : pp.vloc_at)
+		{ value = 0; }
+	for(double &value : pp.rho_atc)
+		{ value = 0; }
+	for(double &value : pp.rho_at)
+		{ value = 0; }
+	pp.chi.zero_out();
+	pp.dion.zero_out();
+	pp.betar.zero_out();
 }
 
 /**


### PR DESCRIPTION
fix a bug for bsse when pseudo potential is complicated