### PR TITLE
Fix: Fix calculation type inconsistency across MPI ranks, so that the log file names are correct when `out_alllog = 1`

### DIFF
--- a/source/source_io/read_set_globalv.cpp
+++ b/source/source_io/read_set_globalv.cpp
@@ -1,8 +1,8 @@
+#include "read_input.h"
+#include "read_input_tool.h"
 #include "source_base/global_variable.h"
 #include "source_base/tool_quit.h"
 #include "source_io/module_parameter/parameter.h"
-#include "read_input.h"
-#include "read_input_tool.h"
 namespace ModuleIO
 {
 /// @note Here para.inp has been synchronized of all ranks.
@@ -101,7 +101,7 @@ void ReadInput::set_global_dir(const Input_para& inp, System_para& sys)
     sys.global_mlkedf_descriptor_dir = sys.global_out_dir + "MLKEDF_Descriptors/";
     sys.global_mlkedf_descriptor_dir = to_dir(sys.global_mlkedf_descriptor_dir);
 
-    /// get the global directory for DeePKS labels during electronic steps 
+    /// get the global directory for DeePKS labels during electronic steps
     sys.global_deepks_label_elec_dir = sys.global_out_dir + "DeePKS_Labels_Elec/";
     sys.global_deepks_label_elec_dir = to_dir(sys.global_deepks_label_elec_dir);
 
@@ -130,17 +130,22 @@ void ReadInput::set_global_dir(const Input_para& inp, System_para& sys)
 
     // set the global log file
     bool out_alllog = inp.out_alllog;
+    // set the global calculation type
+    std::string cal_type = inp.calculation;
 #ifdef __MPI
     // because log_file is different for each rank, so we need to bcast the out_alllog
     Parallel_Common::bcast_bool(out_alllog);
+    // In `ReadInput::read_parameters`, `bcastfunc(param)` is after `set_global_dir`,
+    // so `cal_type` must be synchronized here manually
+    Parallel_Common::bcast_string(cal_type);
 #endif
     if (out_alllog)
     {
-        PARAM.sys.log_file = "running_" + PARAM.inp.calculation + "_" + std::to_string(PARAM.sys.myrank + 1) + ".log";
+        PARAM.sys.log_file = "running_" + cal_type + "_" + std::to_string(PARAM.sys.myrank + 1) + ".log";
     }
     else
     {
-        PARAM.sys.log_file = "running_" + PARAM.inp.calculation + ".log";
+        PARAM.sys.log_file = "running_" + cal_type + ".log";
     }
 #ifdef __MPI
     Parallel_Common::bcast_string(sys.global_in_card);


### PR DESCRIPTION
### Linked Issue
Fix #6352. And also see #6436. I will add related unit tests in the recent future.