### PR TITLE
Memory Optimization for Hcontainer Class in Parallel Execution

### DIFF
--- a/source/module_hamilt_lcao/module_gint/gint.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint.cpp
@@ -252,6 +252,10 @@ void Gint::transfer_DM2DtoGrid(std::vector<hamilt::HContainer<double>*> DM2D) {
     } else // NSPIN=4 case
     {
 #ifdef __MPI
+        // is=0:↑↑, 1:↑↓, 2:↓↑, 3:↓↓
+        const int row_set[4] = {0, 0, 1, 1};
+        const int col_set[4] = {0, 1, 0, 1};
+
         int mg = DM2D[0]->get_paraV()->get_global_row_size()/2;
         int ng = DM2D[0]->get_paraV()->get_global_col_size()/2;
         int nb = DM2D[0]->get_paraV()->get_block_size()/2;
@@ -267,42 +271,20 @@ void Gint::transfer_DM2DtoGrid(std::vector<hamilt::HContainer<double>*> DM2D) {
         this-> DM2D_tmp = new hamilt::HContainer<double>(pv, nullptr, &ijr_info);
         ModuleBase::Memory::record("Gint::DM2D_tmp", this->DM2D_tmp->get_memory_size());
         for (int is = 0; is < 4; is++){
+            this->DM2D_tmp->set_zero();
             for (int iap = 0; iap < DM2D[0]->size_atom_pairs(); ++iap) {
                 auto& ap = DM2D[0]->get_atom_pair(iap);
                 int iat1 = ap.get_atom_i();
                 int iat2 = ap.get_atom_j();
                 for (int ir = 0; ir < ap.get_R_size(); ++ir) {
                     const ModuleBase::Vector3<int> r_index = ap.get_R_index(ir);
-                    double* tmp_pointer = this -> DM2D_tmp -> find_matrix(iat1, iat2, r_index)->get_pointer();
-                    double* data_full = ap.get_pointer(ir);
-                    for (int irow = 0; irow < ap.get_row_size(); irow += 2) {
-                        switch (is) {//todo: It can be written more compactly
-                            case 0:
-                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
-                                    *(tmp_pointer)++ = data_full[icol];
-                                }
-                                data_full += ap.get_col_size() * 2;
-                                break;
-                            case 1:
-                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
-                                    *(tmp_pointer)++ = data_full[icol + 1];
-                                }
-                                data_full += ap.get_col_size() * 2;
-                                break;
-                            case 2:
-                                data_full += ap.get_col_size();
-                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
-                                    *(tmp_pointer)++ = data_full[icol];
-                                }
-                                data_full += ap.get_col_size();
-                                break;
-                            case 3:
-                                data_full += ap.get_col_size();
-                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
-                                    *(tmp_pointer)++ = data_full[icol + 1];
-                                }
-                                data_full += ap.get_col_size();
-                                break;           
+                    double* matrix_out = this -> DM2D_tmp -> find_matrix(iat1, iat2, r_index)->get_pointer();
+                    double* matrix_in = ap.get_pointer(ir);
+                    for (int irow = 0; irow < ap.get_row_size()/2; irow ++) {
+                        for (int icol = 0; icol < ap.get_col_size()/2; icol++){
+                            int index_i = irow* ap.get_col_size()/2 + icol;
+                            int index_j = (irow*2+row_set[is]) * ap.get_col_size() + icol*2+col_set[is];
+                            matrix_out[index_i] = matrix_in[index_j];
                         }
                     }
                 }

--- a/source/module_hamilt_lcao/module_gint/gint.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint.cpp
@@ -199,6 +199,8 @@ void Gint::initialize_pvpR(const UnitCell& ucell_in, const Grid_Driver* gd, cons
     } else {
         this->hRGintCd->insert_ijrs(this->gridt->get_ijr_info(), ucell_in, npol);
         this->hRGintCd->allocate(nullptr, true);
+        ModuleBase::Memory::record("Gint::hRGintCd",
+                                   this->hRGintCd->get_memory_size());
         for(int is = 0; is < nspin; is++) {
             this->hRGint_tmp[is]->insert_ijrs(this->gridt->get_ijr_info(), ucell_in);
             this->DMRGint[is]->insert_ijrs(this->gridt->get_ijr_info(), ucell_in);
@@ -208,8 +210,7 @@ void Gint::initialize_pvpR(const UnitCell& ucell_in, const Grid_Driver* gd, cons
         ModuleBase::Memory::record("Gint::hRGint_tmp",
                                        this->hRGint_tmp[0]->get_memory_size()*nspin);
         ModuleBase::Memory::record("Gint::DMRGint",
-                                       this->DMRGint[0]->get_memory_size()
-                                           * this->DMRGint.size()*nspin);
+                                       this->DMRGint[0]->get_memory_size()*nspin);
 #ifdef __MPI
         this->DMRGint_full->insert_ijrs(this->gridt->get_ijr_info(), ucell_in, npol);
         this->DMRGint_full->allocate(nullptr, true);

--- a/source/module_hamilt_lcao/module_gint/gint.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint.cpp
@@ -23,7 +23,7 @@
 Gint::~Gint() {
 
     delete this->hRGint;
-    delete this->hRGintCd;
+    //delete this->hRGintCd;
     // in gamma_only case, DMRGint.size()=0, 
     // in multi-k case, DMRGint.size()=nspin
     for (int is = 0; is < this->DMRGint.size(); is++) {
@@ -155,11 +155,11 @@ void Gint::initialize_pvpR(const UnitCell& ucell_in, const Grid_Driver* gd, cons
         this->hRGint = new hamilt::HContainer<double>(ucell_in.nat);
     } else {
         npol = 2;
-        if (this->hRGintCd != nullptr) {
-            delete this->hRGintCd;
-        }
-        this->hRGintCd
-            = new hamilt::HContainer<std::complex<double>>(ucell_in.nat);
+        // if (this->hRGintCd != nullptr) {
+        //     delete this->hRGintCd;
+        // }
+        // this->hRGintCd
+         //   = new hamilt::HContainer<std::complex<double>>(ucell_in.nat);
         for (int is = 0; is < nspin; is++) {
             if (this->DMRGint[is] != nullptr) {
                 delete this->DMRGint[is];
@@ -196,10 +196,10 @@ void Gint::initialize_pvpR(const UnitCell& ucell_in, const Grid_Driver* gd, cons
                                    this->DMRGint[0]->get_memory_size()
                                        * this->DMRGint.size());
     } else {
-        this->hRGintCd->insert_ijrs(this->gridt->get_ijr_info(), ucell_in, npol);
-        this->hRGintCd->allocate(nullptr, true);
-        ModuleBase::Memory::record("Gint::hRGintCd",
-                                   this->hRGintCd->get_memory_size());
+        // this->hRGintCd->insert_ijrs(this->gridt->get_ijr_info(), ucell_in, npol);
+        // this->hRGintCd->allocate(nullptr, true);
+        // ModuleBase::Memory::record("Gint::hRGintCd",
+        //                            this->hRGintCd->get_memory_size());
         for(int is = 0; is < nspin; is++) {
             this->hRGint_tmp[is]->insert_ijrs(this->gridt->get_ijr_info(), ucell_in);
             this->DMRGint[is]->insert_ijrs(this->gridt->get_ijr_info(), ucell_in);

--- a/source/module_hamilt_lcao/module_gint/gint.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint.cpp
@@ -33,7 +33,7 @@ Gint::~Gint() {
         delete this->hRGint_tmp[is];
     }
 #ifdef __MPI
-    delete this->DMRGint_full;
+    delete this->DM2D_tmp;
 #endif
 }
 
@@ -171,10 +171,9 @@ void Gint::initialize_pvpR(const UnitCell& ucell_in, const Grid_Driver* gd, cons
             this->hRGint_tmp[is] = new hamilt::HContainer<double>(ucell_in.nat);
         }
 #ifdef __MPI
-        if (this->DMRGint_full != nullptr) {
-            delete this->DMRGint_full;
+        if (this->DM2D_tmp != nullptr) {
+            delete this->DM2D_tmp;
         }
-        this->DMRGint_full = new hamilt::HContainer<double>(ucell_in.nat);
 #endif
     }
 
@@ -211,12 +210,6 @@ void Gint::initialize_pvpR(const UnitCell& ucell_in, const Grid_Driver* gd, cons
                                        this->hRGint_tmp[0]->get_memory_size()*nspin);
         ModuleBase::Memory::record("Gint::DMRGint",
                                        this->DMRGint[0]->get_memory_size()*nspin);
-#ifdef __MPI
-        this->DMRGint_full->insert_ijrs(this->gridt->get_ijr_info(), ucell_in, npol);
-        this->DMRGint_full->allocate(nullptr, true);
-        ModuleBase::Memory::record("Gint::DMRGint_full",
-                                   this->DMRGint_full->get_memory_size());
-#endif
     }
 }
 
@@ -232,10 +225,8 @@ void Gint::reset_DMRGint(const int& nspin)
         {
             for (auto& d : this->DMRGint) { d->allocate(nullptr, false); }
 #ifdef __MPI
-            delete this->DMRGint_full;
-            this->DMRGint_full = new hamilt::HContainer<double>(*this->hRGint);
-            this->DMRGint_full->allocate(nullptr, false);
-#endif
+            delete this->DM2D_tmp;
+#endif       
         }
     }
 }
@@ -263,37 +254,69 @@ void Gint::transfer_DM2DtoGrid(std::vector<hamilt::HContainer<double>*> DM2D) {
     } else // NSPIN=4 case
     {
 #ifdef __MPI
-        hamilt::transferParallels2Serials(*DM2D[0], this->DMRGint_full);
-#else
-        this->DMRGint_full = DM2D[0];
-#endif
-        std::vector<double*> tmp_pointer(4, nullptr);
-        for (int iap = 0; iap < this->DMRGint_full->size_atom_pairs(); ++iap) {
-            auto& ap = this->DMRGint_full->get_atom_pair(iap);
-            int iat1 = ap.get_atom_i();
-            int iat2 = ap.get_atom_j();
-            for (int ir = 0; ir < ap.get_R_size(); ++ir) {
-                const ModuleBase::Vector3<int> r_index = ap.get_R_index(ir);
-                for (int is = 0; is < 4; is++) {
-                    tmp_pointer[is] = this->DMRGint[is]
-                                          ->find_matrix(iat1, iat2, r_index)
-                                          ->get_pointer();
-                }
-                double* data_full = ap.get_pointer(ir);
-                for (int irow = 0; irow < ap.get_row_size(); irow += 2) {
-                    for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
-                        *(tmp_pointer[0])++ = data_full[icol];
-                        *(tmp_pointer[1])++ = data_full[icol + 1];
+        int mg = DM2D[0]->get_paraV()->get_global_row_size()/2;
+        int ng = DM2D[0]->get_paraV()->get_global_col_size()/2;
+        int nb = DM2D[0]->get_paraV()->get_block_size()/2;
+        int blacs_ctxt = DM2D[0]->get_paraV()->blacs_ctxt;
+        int *iat2iwt = new int[ucell->nat];
+        for (int iat = 0; iat < ucell->nat; iat++) {
+            iat2iwt[iat] = ucell->get_iat2iwt()[iat]/2;
+        }
+        Parallel_Orbitals *pv = new Parallel_Orbitals();
+        pv->set(mg, ng, nb, blacs_ctxt);
+        pv->set_atomic_trace(iat2iwt, ucell->nat, mg);
+        auto ijr_info = DM2D[0]->get_ijr_info();
+        this-> DM2D_tmp = new hamilt::HContainer<double>(pv, nullptr, &ijr_info);
+        ModuleBase::Memory::record("Gint::DM2D_tmp", this->DM2D_tmp->get_memory_size());
+        for (int is = 0; is < 4; is++){
+            for (int iap = 0; iap < DM2D[0]->size_atom_pairs(); ++iap) {
+                auto& ap = DM2D[0]->get_atom_pair(iap);
+                int iat1 = ap.get_atom_i();
+                int iat2 = ap.get_atom_j();
+                for (int ir = 0; ir < ap.get_R_size(); ++ir) {
+                    const ModuleBase::Vector3<int> r_index = ap.get_R_index(ir);
+                    double* tmp_pointer = this -> DM2D_tmp -> find_matrix(iat1, iat2, r_index)->get_pointer();
+                    double* data_full = ap.get_pointer(ir);
+                    for (int irow = 0; irow < ap.get_row_size(); irow += 2) {
+                        switch (is) {//todo: It can be written more compactly
+                            case 0:
+                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
+                                    *(tmp_pointer)++ = data_full[icol];
+                                }
+                                data_full += ap.get_col_size() * 2;
+                                break;
+                            case 1:
+                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
+                                    *(tmp_pointer)++ = data_full[icol + 1];
+                                }
+                                data_full += ap.get_col_size() * 2;
+                                break;
+                            case 2:
+                                data_full += ap.get_col_size();
+                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
+                                    *(tmp_pointer)++ = data_full[icol];
+                                }
+                                data_full += ap.get_col_size();
+                                break;
+                            case 3:
+                                data_full += ap.get_col_size();
+                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
+                                    *(tmp_pointer)++ = data_full[icol + 1];
+                                }
+                                data_full += ap.get_col_size();
+                                break;           
+                        }
                     }
-                    data_full += ap.get_col_size();
-                    for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
-                        *(tmp_pointer[2])++ = data_full[icol];
-                        *(tmp_pointer[3])++ = data_full[icol + 1];
-                    }
-                    data_full += ap.get_col_size();
                 }
             }
+            hamilt::transferParallels2Serials( *(this->DM2D_tmp), this->DMRGint[is]);
         }
+        // delete iat2iwt;
+        // delete pv;
+        // delete this-> DM2D_tmp;
+#else
+        //this->DMRGint_full = DM2D[0];
+#endif
     }
     ModuleBase::timer::tick("Gint", "transfer_DMR");
 }

--- a/source/module_hamilt_lcao/module_gint/gint.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint.cpp
@@ -23,7 +23,7 @@
 Gint::~Gint() {
 
     delete this->hRGint;
-    //delete this->hRGintCd;
+    delete this->hR_tmp;
     // in gamma_only case, DMRGint.size()=0, 
     // in multi-k case, DMRGint.size()=nspin
     for (int is = 0; is < this->DMRGint.size(); is++) {
@@ -155,11 +155,9 @@ void Gint::initialize_pvpR(const UnitCell& ucell_in, const Grid_Driver* gd, cons
         this->hRGint = new hamilt::HContainer<double>(ucell_in.nat);
     } else {
         npol = 2;
-        // if (this->hRGintCd != nullptr) {
-        //     delete this->hRGintCd;
-        // }
-        // this->hRGintCd
-         //   = new hamilt::HContainer<std::complex<double>>(ucell_in.nat);
+        if (this->hR_tmp != nullptr) {
+            delete this->hR_tmp;
+        }
         for (int is = 0; is < nspin; is++) {
             if (this->DMRGint[is] != nullptr) {
                 delete this->DMRGint[is];

--- a/source/module_hamilt_lcao/module_gint/gint.h
+++ b/source/module_hamilt_lcao/module_gint/gint.h
@@ -258,7 +258,7 @@ class Gint {
     std::vector<hamilt::HContainer<double>*> hRGint_tmp; 
 
     //! stores Hamiltonian in sparse format
-    //hamilt::HContainer<std::complex<double>>* hRGintCd = nullptr; 
+    hamilt::HContainer<std::complex<double>>* hR_tmp = nullptr; 
 
     //! stores DMR in sparse format
     std::vector<hamilt::HContainer<double>*> DMRGint; 

--- a/source/module_hamilt_lcao/module_gint/gint.h
+++ b/source/module_hamilt_lcao/module_gint/gint.h
@@ -264,7 +264,7 @@ class Gint {
     std::vector<hamilt::HContainer<double>*> DMRGint; 
 
     //! tmp tools used in transfer_DM2DtoGrid 
-    hamilt::HContainer<double>* DMRGint_full = nullptr;
+    hamilt::HContainer<double>* DM2D_tmp = nullptr;
 
     std::vector<hamilt::HContainer<double>> pvdpRx_reduced;
     std::vector<hamilt::HContainer<double>> pvdpRy_reduced;

--- a/source/module_hamilt_lcao/module_gint/gint.h
+++ b/source/module_hamilt_lcao/module_gint/gint.h
@@ -258,7 +258,7 @@ class Gint {
     std::vector<hamilt::HContainer<double>*> hRGint_tmp; 
 
     //! stores Hamiltonian in sparse format
-    hamilt::HContainer<std::complex<double>>* hRGintCd = nullptr; 
+    //hamilt::HContainer<std::complex<double>>* hRGintCd = nullptr; 
 
     //! stores DMR in sparse format
     std::vector<hamilt::HContainer<double>*> DMRGint; 

--- a/source/module_hamilt_lcao/module_gint/gint_k_pvpr.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_k_pvpr.cpp
@@ -81,6 +81,7 @@ void Gint_k::transfer_pvpR(hamilt::HContainer<std::complex<double>>* hR,
     int mg = hR->get_paraV()->get_global_row_size()/2;
     int ng = hR->get_paraV()->get_global_col_size()/2;
     int nb = hR->get_paraV()->get_block_size()/2;
+    hR->set_zero();
 #ifdef __MPI
     int blacs_ctxt = hR->get_paraV()->blacs_ctxt;
     int *iat2iwt = new int[ucell_in->nat];
@@ -98,8 +99,11 @@ void Gint_k::transfer_pvpR(hamilt::HContainer<std::complex<double>>* hR,
     //0,3;1,2;1,2;0,3
     std::vector<int> first = {0, 1, 1, 0};
     std::vector<int> second= {3, 2, 2, 3};
+    std::vector<int> row_set = {0, 0, 1, 1};
+    std::vector<int> col_set = {0, 1, 0, 1};
+    std::vector<int> clx_i = {1, 0, 0, -1};
+    std::vector<int> clx_j = {0, 1, -1, 0};
     for (int is = 0; is < 4; is++){
-        this->hR_tmp->set_zero();
         hamilt::HContainer<std::complex<double>>* hRGint_tmpCd = new hamilt::HContainer<std::complex<double>>(this->ucell->nat);
         hRGint_tmpCd->insert_ijrs(this->gridt->get_ijr_info(), *(this->ucell));
         hRGint_tmpCd->allocate(nullptr, true);
@@ -128,23 +132,8 @@ void Gint_k::transfer_pvpR(hamilt::HContainer<std::complex<double>>* hR,
                     {
                         for (int icol = 0; icol < mat_nspin1->get_col_size(); ++icol)
                         {
-                            switch (is)
-                            {
-                            case 0:
-                                upper_mat->get_value(irow, icol) = mat_nspin1->get_value(irow, icol) + mat_nspin2->get_value(irow, icol);
-                                break;
-                            case 1:
-                                upper_mat->get_value(irow, icol) = mat_nspin1->get_value(irow, icol) + 
-                                                                        std::complex<double>(0.0, 1.0) * mat_nspin2->get_value(irow, icol);
-                                break;
-                            case 2:
-                                upper_mat->get_value(irow, icol) = mat_nspin1->get_value(irow, icol) - 
-                                                                        std::complex<double>(0.0, 1.0) * mat_nspin2->get_value(irow, icol);
-                                break;
-                            case 3:
-                                upper_mat->get_value(irow, icol) = mat_nspin1->get_value(irow, icol) - mat_nspin2->get_value(irow, icol);
-                                break;
-                            }
+                            upper_mat->get_value(irow, icol) = mat_nspin1->get_value(irow, icol) 
+                            + std::complex<double>(clx_i[is], clx_j[is]) * mat_nspin2->get_value(irow, icol);
                         }
                     }
                     //fill the lower triangle matrix
@@ -166,7 +155,7 @@ void Gint_k::transfer_pvpR(hamilt::HContainer<std::complex<double>>* hR,
         }
 
         //std::cout<<"success"<<std::endl;
-
+        this->hR_tmp->set_zero();
         hamilt::transferSerials2Parallels( *hRGint_tmpCd, this->hR_tmp);
         for (int iap = 0; iap < hR->size_atom_pairs(); iap++)
         {
@@ -186,48 +175,19 @@ void Gint_k::transfer_pvpR(hamilt::HContainer<std::complex<double>>* hR,
                 {
                     for (int icol = 0; icol < mat_nspin->get_col_size(); ++icol)
                     {
-                        switch (is)
-                        {
-                        case 0:
-                            upper_mat->get_value(2*irow, 2*icol) += mat_nspin->get_value(irow, icol);
-                            break;
-                        case 1:
-                            upper_mat->get_value(2*irow, 2*icol+1) += mat_nspin->get_value(irow, icol);
-                            break;
-                        case 2:
-                            upper_mat->get_value(2*irow+1, 2*icol) += mat_nspin->get_value(irow, icol);
-                            break;
-                        case 3:
-                            upper_mat->get_value(2*irow+1, 2*icol+1) += mat_nspin->get_value(irow, icol);
-                            break;
-                        }
+                        upper_mat->get_value(2*irow+row_set[is], 2*icol+col_set[is]) = 
+                        mat_nspin->get_value(irow, icol);
                     }
                 }
             }
         }
+        delete hRGint_tmpCd;
     }
     delete[] iat2iwt;
 #else
 
 #endif
 
-    // ===================================
-    // transfer HR from Gint to Veff<OperatorLCAO<std::complex<double>, std::complex<double>>>
-    // ===================================
-// #ifdef __MPI
-//     int size;
-//     MPI_Comm_size(MPI_COMM_WORLD, &size);
-//     if (size == 1)
-//     {
-//         hR->add(*this->hRGintCd);
-//     }
-//     else
-//     {
-//         hamilt::transferSerials2Parallels<std::complex<double>>(*this->hRGintCd, hR);
-//     }
-// #else
-    //  hR->add(*this->hRGintCd);
-// #endif
     ModuleBase::timer::tick("Gint_k", "transfer_pvpR");
     return;
 }

--- a/source/module_hamilt_lcao/module_gint/gint_k_pvpr.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_k_pvpr.cpp
@@ -78,86 +78,176 @@ void Gint_k::transfer_pvpR(hamilt::HContainer<std::complex<double>>* hR,
     ModuleBase::TITLE("Gint_k", "transfer_pvpR");
     ModuleBase::timer::tick("Gint_k", "transfer_pvpR");
 
-    this->hRGintCd->set_zero();
+    //this->hRGintCd->set_zero();
     
-    for (int iap = 0; iap < this->hRGintCd->size_atom_pairs(); iap++)
-    {
-        auto* ap = &this->hRGintCd->get_atom_pair(iap);
-        const int iat1 = ap->get_atom_i();
-        const int iat2 = ap->get_atom_j();
-        if (iat1 <= iat2)
+#ifdef __MPI
+    int mg = hR->get_paraV()->get_global_row_size()/2;
+    int ng = hR->get_paraV()->get_global_col_size()/2;
+    int nb = hR->get_paraV()->get_block_size()/2;
+    int blacs_ctxt = hR->get_paraV()->blacs_ctxt;
+    int *iat2iwt = new int[ucell_in->nat];
+    for (int iat = 0; iat < ucell_in->nat; iat++) {
+        iat2iwt[iat] = ucell_in->get_iat2iwt()[iat]/2;
+    }
+    Parallel_Orbitals *pv = new Parallel_Orbitals();
+    pv->set(mg, ng, nb, blacs_ctxt);
+    pv->set_atomic_trace(iat2iwt, ucell_in->nat, mg);
+    auto ijr_info = hR->get_ijr_info();
+    
+
+    hamilt::HContainer<double>* hR_tmp = new hamilt::HContainer<double>(pv, nullptr, &ijr_info);
+    ModuleBase::Memory::record("Gint::hRGintCd", hR_tmp->get_memory_size());
+    // std::cout<<"test1"<<std::endl;
+
+    // std::cout<<hRGint_tmp[0]->size_atom_pairs()<<std::endl;
+    // std::cout<<hR_tmp->size_atom_pairs()<<std::endl;
+    // for(int i =0; i < hRGint_tmp[0]->size_atom_pairs(); i++){
+    //     std::cout<<"hRGint_tmp"<<hRGint_tmp[0]->get_atom_pair(i).get_row_size()<<' '<<hRGint_tmp[0]->get_atom_pair(i).get_row_size()<<std::endl;
+    //     std::cout<<"hR_tmp"<<hR_tmp->get_atom_pair(i).get_row_size()<<' '<<hR_tmp->get_atom_pair(i).get_row_size()<<std::endl;
+    //     std::cout<<"pv1:" << pv->get_indexes_col(0).size()<< ' '<<pv->get_indexes_row(0).size()<<std::endl;
+    //     std::cout<<"pv2:" << pv->get_indexes_col().size()<< ' '<<pv->get_indexes_row().size()<<std::endl;
+    // }
+
+
+
+    for (int is = 0; is < 4; is++){
+        hR_tmp->set_zero();
+        //std::cout<<"is: "<<is<<std::endl;
+        hamilt::transferSerials2Parallels( *(this->hRGint_tmp[is]), hR_tmp);
+        for (int iap = 0; iap < hR->size_atom_pairs(); iap++)
         {
-            hamilt::AtomPair<std::complex<double>>* upper_ap = ap;
-            hamilt::AtomPair<std::complex<double>>* lower_ap = this->hRGintCd->find_pair(iat2, iat1);
-            const hamilt::AtomPair<double>* ap_nspin_0 = this->hRGint_tmp[0]->find_pair(iat1, iat2);
-            const hamilt::AtomPair<double>* ap_nspin_3 = this->hRGint_tmp[3]->find_pair(iat1, iat2);
-            for (int ir = 0; ir < upper_ap->get_R_size(); ir++)
-            {   
-                const auto R_index = upper_ap->get_R_index(ir);
-                auto upper_mat = upper_ap->find_matrix(R_index);
-                auto mat_nspin_0 = ap_nspin_0->find_matrix(R_index);
-                auto mat_nspin_3 = ap_nspin_3->find_matrix(R_index);
-
-                // The row size and the col size of upper_matrix is double that of matrix_nspin_0
-                for (int irow = 0; irow < mat_nspin_0->get_row_size(); ++irow)
+            //std::cout<<"iap: "<<iap<<std::endl;
+            auto* ap = &hR->get_atom_pair(iap);
+            const int iat1 = ap->get_atom_i();
+            const int iat2 = ap->get_atom_j();
+            const hamilt::AtomPair<double>* ap_nspin = nullptr;
+            if (iat1 <= iat2)
+            {
+                hamilt::AtomPair<std::complex<double>>* upper_ap = ap;
+                hamilt::AtomPair<std::complex<double>>* lower_ap = hR->find_pair(iat2, iat1);
+                switch (is)
                 {
-                    for (int icol = 0; icol < mat_nspin_0->get_col_size(); ++icol)
-                    {
-                        upper_mat->get_value(2*irow, 2*icol) = mat_nspin_0->get_value(irow, icol) + mat_nspin_3->get_value(irow, icol);
-                        upper_mat->get_value(2*irow+1, 2*icol+1) = mat_nspin_0->get_value(irow, icol) - mat_nspin_3->get_value(irow, icol);
-                    }
+                case 0:
+                    ap_nspin = hR_tmp->find_pair(iat1, iat2);
+                    break;
+                case 3:
+                    ap_nspin = hR_tmp->find_pair(iat1, iat2);
+                    break;
                 }
+                if(ap_nspin == nullptr) break;
+                //const hamilt::AtomPair<double>* ap_nspin_0 = this->hR_tmp[0]->find_pair(iat1, iat2);
+                //const hamilt::AtomPair<double>* ap_nspin_3 = this->hRGint_tmp[3]->find_pair(iat1, iat2);
+                for (int ir = 0; ir < upper_ap->get_R_size(); ir++)
+                {   
+                    const auto R_index = upper_ap->get_R_index(ir);
+                    auto upper_mat = upper_ap->find_matrix(R_index);
+                    //auto mat_nspin_0 = ap_nspin_0->find_matrix(R_index);
+                    //auto mat_nspin_3 = ap_nspin_3->find_matrix(R_index);
+                    auto mat_nspin = ap_nspin->find_matrix(R_index);
 
-                if (PARAM.globalv.domag)
-                {
-                    const hamilt::AtomPair<double>* ap_nspin_1 = this->hRGint_tmp[1]->find_pair(iat1, iat2);
-                    const hamilt::AtomPair<double>* ap_nspin_2 = this->hRGint_tmp[2]->find_pair(iat1, iat2);
-                    const auto mat_nspin_1 = ap_nspin_1->find_matrix(R_index);
-                    const auto mat_nspin_2 = ap_nspin_2->find_matrix(R_index);
-                    for (int irow = 0; irow < mat_nspin_1->get_row_size(); ++irow)
+                    // The row size and the col size of upper_matrix is double that of matrix_nspin_0
+                    for (int irow = 0; irow < mat_nspin->get_row_size(); ++irow)
                     {
-                        for (int icol = 0; icol < mat_nspin_1->get_col_size(); ++icol)
+                        for (int icol = 0; icol < mat_nspin->get_col_size(); ++icol)
                         {
-                            upper_mat->get_value(2*irow, 2*icol+1) = mat_nspin_1->get_value(irow, icol) +  std::complex<double>(0.0, 1.0) * mat_nspin_2->get_value(irow, icol);
-                            upper_mat->get_value(2*irow+1, 2*icol) = mat_nspin_1->get_value(irow, icol) -  std::complex<double>(0.0, 1.0) * mat_nspin_2->get_value(irow, icol);
+                            //upper_mat->get_value(2*irow, 2*icol) = mat_nspin_0->get_value(irow, icol) + mat_nspin_3->get_value(irow, icol);
+                            //upper_mat->get_value(2*irow+1, 2*icol+1) = mat_nspin_0->get_value(irow, icol) - mat_nspin_3->get_value(irow, icol);
+                            switch (is)
+                            {
+                            case 0:
+                                upper_mat->get_value(2*irow, 2*icol) = mat_nspin->get_value(irow, icol);
+                                upper_mat->get_value(2*irow+1, 2*icol+1) = mat_nspin->get_value(irow, icol);
+                                break;
+                            case 3:
+                                upper_mat->get_value(2*irow, 2*icol) += mat_nspin->get_value(irow, icol);
+                                upper_mat->get_value(2*irow+1, 2*icol+1) -= mat_nspin->get_value(irow, icol);
+                                break;
+                            }
                         }
                     }
-                }
 
-                // fill the lower triangle matrix
-                if (iat1 < iat2)
-                {
-                    auto lower_mat = lower_ap->find_matrix(-R_index);
-                    for (int irow = 0; irow < upper_mat->get_row_size(); ++irow)
+                    if (PARAM.globalv.domag)
                     {
-                        for (int icol = 0; icol < upper_mat->get_col_size(); ++icol)
+                        const hamilt::AtomPair<double>* ap_nspin = nullptr;
+                        switch (is)
                         {
-                            lower_mat->get_value(icol, irow) = conj(upper_mat->get_value(irow, icol));
+                        case 1:
+                            ap_nspin = hR_tmp->find_pair(iat1, iat2);
+                            break;
+                        case 2:
+                            ap_nspin = hR_tmp->find_pair(iat1, iat2);
+                            break;
+                        }
+                        //const hamilt::AtomPair<double>* ap_nspin_1 = this->hRGint_tmp[1]->find_pair(iat1, iat2);
+                        //const hamilt::AtomPair<double>* ap_nspin_2 = this->hRGint_tmp[2]->find_pair(iat1, iat2);
+                        //const auto mat_nspin_1 = ap_nspin_1->find_matrix(R_index);
+                        //const auto mat_nspin_2 = ap_nspin_2->find_matrix(R_index);
+                        const auto mat_nspin = ap_nspin->find_matrix(R_index);
+                        for (int irow = 0; irow < mat_nspin->get_row_size(); ++irow)
+                        {
+                            for (int icol = 0; icol < mat_nspin->get_col_size(); ++icol)
+                            {
+                                switch(is)
+                                {
+                                    case 1:
+                                        upper_mat->get_value(2*irow, 2*icol+1) = mat_nspin->get_value(irow, icol);
+                                        upper_mat->get_value(2*irow+1, 2*icol) = mat_nspin->get_value(irow, icol);
+                                        break;
+                                    case 2:
+                                        upper_mat->get_value(2*irow, 2*icol+1) += std::complex<double>(0.0, 1.0) * mat_nspin->get_value(irow, icol);
+                                        upper_mat->get_value(2*irow+1, 2*icol) -= std::complex<double>(0.0, 1.0) * mat_nspin->get_value(irow, icol);
+                                        break;
+                                }
+                                //upper_mat->get_value(2*irow, 2*icol+1) = mat_nspin->get_value(irow, icol) +  std::complex<double>(0.0, 1.0) * mat_nspin_2->get_value(irow, icol);
+                                //upper_mat->get_value(2*irow+1, 2*icol) = mat_nspin->get_value(irow, icol) -  std::complex<double>(0.0, 1.0) * mat_nspin_2->get_value(irow, icol);
+                            }
                         }
                     }
+                    
+                    // fill the lower triangle matrix
+                    if(is == 3){
+                        if (iat1 < iat2)
+                        {
+                            auto lower_mat = lower_ap->find_matrix(-R_index);
+                            for (int irow = 0; irow < upper_mat->get_row_size(); ++irow)
+                            {
+                                for (int icol = 0; icol < upper_mat->get_col_size(); ++icol)
+                                {
+                                    lower_mat->get_value(icol, irow) = conj(upper_mat->get_value(irow, icol));
+                                }
+                            }
+                        }
+                    }
+                        // std::cout<<"end"<<std::endl;
                 }
             }
         }
+        
     }
+    delete[] iat2iwt;
+    delete pv;
+    delete hR_tmp;
+#else
+
+#endif
 
     // ===================================
     // transfer HR from Gint to Veff<OperatorLCAO<std::complex<double>, std::complex<double>>>
     // ===================================
-#ifdef __MPI
-    int size;
-    MPI_Comm_size(MPI_COMM_WORLD, &size);
-    if (size == 1)
-    {
-        hR->add(*this->hRGintCd);
-    }
-    else
-    {
-        hamilt::transferSerials2Parallels<std::complex<double>>(*this->hRGintCd, hR);
-    }
-#else
-    hR->add(*this->hRGintCd);
-#endif
-
+// #ifdef __MPI
+//     int size;
+//     MPI_Comm_size(MPI_COMM_WORLD, &size);
+//     if (size == 1)
+//     {
+//         hR->add(*this->hRGintCd);
+//     }
+//     else
+//     {
+//         hamilt::transferSerials2Parallels<std::complex<double>>(*this->hRGintCd, hR);
+//     }
+// #else
+//     hR->add(*this->hRGintCd);
+// #endif
     ModuleBase::timer::tick("Gint_k", "transfer_pvpR");
     return;
 }

--- a/source/module_hamilt_lcao/module_gint/gint_k_pvpr.cpp
+++ b/source/module_hamilt_lcao/module_gint/gint_k_pvpr.cpp
@@ -78,12 +78,10 @@ void Gint_k::transfer_pvpR(hamilt::HContainer<std::complex<double>>* hR,
     ModuleBase::TITLE("Gint_k", "transfer_pvpR");
     ModuleBase::timer::tick("Gint_k", "transfer_pvpR");
 
-    //this->hRGintCd->set_zero();
-    
-#ifdef __MPI
     int mg = hR->get_paraV()->get_global_row_size()/2;
     int ng = hR->get_paraV()->get_global_col_size()/2;
     int nb = hR->get_paraV()->get_block_size()/2;
+#ifdef __MPI
     int blacs_ctxt = hR->get_paraV()->blacs_ctxt;
     int *iat2iwt = new int[ucell_in->nat];
     for (int iat = 0; iat < ucell_in->nat; iat++) {
@@ -93,119 +91,64 @@ void Gint_k::transfer_pvpR(hamilt::HContainer<std::complex<double>>* hR,
     pv->set(mg, ng, nb, blacs_ctxt);
     pv->set_atomic_trace(iat2iwt, ucell_in->nat, mg);
     auto ijr_info = hR->get_ijr_info();
-    
 
-    hamilt::HContainer<double>* hR_tmp = new hamilt::HContainer<double>(pv, nullptr, &ijr_info);
-    ModuleBase::Memory::record("Gint::hRGintCd", hR_tmp->get_memory_size());
-    // std::cout<<"test1"<<std::endl;
+    this->hR_tmp = new hamilt::HContainer<std::complex<double>>(pv, nullptr, &ijr_info);
+    ModuleBase::Memory::record("Gint::hRGintCd", this->hR_tmp->get_memory_size());
 
-    // std::cout<<hRGint_tmp[0]->size_atom_pairs()<<std::endl;
-    // std::cout<<hR_tmp->size_atom_pairs()<<std::endl;
-    // for(int i =0; i < hRGint_tmp[0]->size_atom_pairs(); i++){
-    //     std::cout<<"hRGint_tmp"<<hRGint_tmp[0]->get_atom_pair(i).get_row_size()<<' '<<hRGint_tmp[0]->get_atom_pair(i).get_row_size()<<std::endl;
-    //     std::cout<<"hR_tmp"<<hR_tmp->get_atom_pair(i).get_row_size()<<' '<<hR_tmp->get_atom_pair(i).get_row_size()<<std::endl;
-    //     std::cout<<"pv1:" << pv->get_indexes_col(0).size()<< ' '<<pv->get_indexes_row(0).size()<<std::endl;
-    //     std::cout<<"pv2:" << pv->get_indexes_col().size()<< ' '<<pv->get_indexes_row().size()<<std::endl;
-    // }
-
-
-
+    //0,3;1,2;1,2;0,3
+    std::vector<int> first = {0, 1, 1, 0};
+    std::vector<int> second= {3, 2, 2, 3};
     for (int is = 0; is < 4; is++){
-        hR_tmp->set_zero();
-        //std::cout<<"is: "<<is<<std::endl;
-        hamilt::transferSerials2Parallels( *(this->hRGint_tmp[is]), hR_tmp);
-        for (int iap = 0; iap < hR->size_atom_pairs(); iap++)
+        this->hR_tmp->set_zero();
+        hamilt::HContainer<std::complex<double>>* hRGint_tmpCd = new hamilt::HContainer<std::complex<double>>(this->ucell->nat);
+        hRGint_tmpCd->insert_ijrs(this->gridt->get_ijr_info(), *(this->ucell));
+        hRGint_tmpCd->allocate(nullptr, true);
+        hRGint_tmpCd->set_zero();
+        for (int iap = 0; iap < hRGint_tmpCd->size_atom_pairs(); iap++)
         {
             //std::cout<<"iap: "<<iap<<std::endl;
-            auto* ap = &hR->get_atom_pair(iap);
+            auto* ap = &hRGint_tmpCd->get_atom_pair(iap);
             const int iat1 = ap->get_atom_i();
             const int iat2 = ap->get_atom_j();
-            const hamilt::AtomPair<double>* ap_nspin = nullptr;
             if (iat1 <= iat2)
             {
                 hamilt::AtomPair<std::complex<double>>* upper_ap = ap;
-                hamilt::AtomPair<std::complex<double>>* lower_ap = hR->find_pair(iat2, iat1);
-                switch (is)
-                {
-                case 0:
-                    ap_nspin = hR_tmp->find_pair(iat1, iat2);
-                    break;
-                case 3:
-                    ap_nspin = hR_tmp->find_pair(iat1, iat2);
-                    break;
-                }
-                if(ap_nspin == nullptr) break;
-                //const hamilt::AtomPair<double>* ap_nspin_0 = this->hR_tmp[0]->find_pair(iat1, iat2);
-                //const hamilt::AtomPair<double>* ap_nspin_3 = this->hRGint_tmp[3]->find_pair(iat1, iat2);
+                hamilt::AtomPair<std::complex<double>>* lower_ap = hRGint_tmpCd->find_pair(iat2, iat1);
+                const hamilt::AtomPair<double>* ap_nspin1 = this->hRGint_tmp[first[is]] ->find_pair(iat1, iat2);
+                const hamilt::AtomPair<double>* ap_nspin2 = this->hRGint_tmp[second[is]] ->find_pair(iat1, iat2);
                 for (int ir = 0; ir < upper_ap->get_R_size(); ir++)
                 {   
+                    //std::cout<<"ir"<<ir<<std::endl;
                     const auto R_index = upper_ap->get_R_index(ir);
                     auto upper_mat = upper_ap->find_matrix(R_index);
-                    //auto mat_nspin_0 = ap_nspin_0->find_matrix(R_index);
-                    //auto mat_nspin_3 = ap_nspin_3->find_matrix(R_index);
-                    auto mat_nspin = ap_nspin->find_matrix(R_index);
-
+                    auto mat_nspin1 = ap_nspin1->find_matrix(R_index);
+                    auto mat_nspin2 = ap_nspin2->find_matrix(R_index);
                     // The row size and the col size of upper_matrix is double that of matrix_nspin_0
-                    for (int irow = 0; irow < mat_nspin->get_row_size(); ++irow)
+                    for (int irow = 0; irow < mat_nspin1->get_row_size(); ++irow)
                     {
-                        for (int icol = 0; icol < mat_nspin->get_col_size(); ++icol)
+                        for (int icol = 0; icol < mat_nspin1->get_col_size(); ++icol)
                         {
-                            //upper_mat->get_value(2*irow, 2*icol) = mat_nspin_0->get_value(irow, icol) + mat_nspin_3->get_value(irow, icol);
-                            //upper_mat->get_value(2*irow+1, 2*icol+1) = mat_nspin_0->get_value(irow, icol) - mat_nspin_3->get_value(irow, icol);
                             switch (is)
                             {
                             case 0:
-                                upper_mat->get_value(2*irow, 2*icol) = mat_nspin->get_value(irow, icol);
-                                upper_mat->get_value(2*irow+1, 2*icol+1) = mat_nspin->get_value(irow, icol);
+                                upper_mat->get_value(irow, icol) = mat_nspin1->get_value(irow, icol) + mat_nspin2->get_value(irow, icol);
+                                break;
+                            case 1:
+                                upper_mat->get_value(irow, icol) = mat_nspin1->get_value(irow, icol) + 
+                                                                        std::complex<double>(0.0, 1.0) * mat_nspin2->get_value(irow, icol);
+                                break;
+                            case 2:
+                                upper_mat->get_value(irow, icol) = mat_nspin1->get_value(irow, icol) - 
+                                                                        std::complex<double>(0.0, 1.0) * mat_nspin2->get_value(irow, icol);
                                 break;
                             case 3:
-                                upper_mat->get_value(2*irow, 2*icol) += mat_nspin->get_value(irow, icol);
-                                upper_mat->get_value(2*irow+1, 2*icol+1) -= mat_nspin->get_value(irow, icol);
+                                upper_mat->get_value(irow, icol) = mat_nspin1->get_value(irow, icol) - mat_nspin2->get_value(irow, icol);
                                 break;
                             }
                         }
                     }
-
-                    if (PARAM.globalv.domag)
-                    {
-                        const hamilt::AtomPair<double>* ap_nspin = nullptr;
-                        switch (is)
-                        {
-                        case 1:
-                            ap_nspin = hR_tmp->find_pair(iat1, iat2);
-                            break;
-                        case 2:
-                            ap_nspin = hR_tmp->find_pair(iat1, iat2);
-                            break;
-                        }
-                        //const hamilt::AtomPair<double>* ap_nspin_1 = this->hRGint_tmp[1]->find_pair(iat1, iat2);
-                        //const hamilt::AtomPair<double>* ap_nspin_2 = this->hRGint_tmp[2]->find_pair(iat1, iat2);
-                        //const auto mat_nspin_1 = ap_nspin_1->find_matrix(R_index);
-                        //const auto mat_nspin_2 = ap_nspin_2->find_matrix(R_index);
-                        const auto mat_nspin = ap_nspin->find_matrix(R_index);
-                        for (int irow = 0; irow < mat_nspin->get_row_size(); ++irow)
-                        {
-                            for (int icol = 0; icol < mat_nspin->get_col_size(); ++icol)
-                            {
-                                switch(is)
-                                {
-                                    case 1:
-                                        upper_mat->get_value(2*irow, 2*icol+1) = mat_nspin->get_value(irow, icol);
-                                        upper_mat->get_value(2*irow+1, 2*icol) = mat_nspin->get_value(irow, icol);
-                                        break;
-                                    case 2:
-                                        upper_mat->get_value(2*irow, 2*icol+1) += std::complex<double>(0.0, 1.0) * mat_nspin->get_value(irow, icol);
-                                        upper_mat->get_value(2*irow+1, 2*icol) -= std::complex<double>(0.0, 1.0) * mat_nspin->get_value(irow, icol);
-                                        break;
-                                }
-                                //upper_mat->get_value(2*irow, 2*icol+1) = mat_nspin->get_value(irow, icol) +  std::complex<double>(0.0, 1.0) * mat_nspin_2->get_value(irow, icol);
-                                //upper_mat->get_value(2*irow+1, 2*icol) = mat_nspin->get_value(irow, icol) -  std::complex<double>(0.0, 1.0) * mat_nspin_2->get_value(irow, icol);
-                            }
-                        }
-                    }
-                    
-                    // fill the lower triangle matrix
-                    if(is == 3){
+                    //fill the lower triangle matrix
+                    if (PARAM.globalv.domag){
                         if (iat1 < iat2)
                         {
                             auto lower_mat = lower_ap->find_matrix(-R_index);
@@ -218,15 +161,52 @@ void Gint_k::transfer_pvpR(hamilt::HContainer<std::complex<double>>* hR,
                             }
                         }
                     }
-                        // std::cout<<"end"<<std::endl;
                 }
             }
         }
-        
+
+        //std::cout<<"success"<<std::endl;
+
+        hamilt::transferSerials2Parallels( *hRGint_tmpCd, this->hR_tmp);
+        for (int iap = 0; iap < hR->size_atom_pairs(); iap++)
+        {
+            //std::cout<<"iap: "<<iap<<std::endl;
+            auto* ap = &hR->get_atom_pair(iap);
+            const int iat1 = ap->get_atom_i();
+            const int iat2 = ap->get_atom_j();
+            auto* ap_nspin = this->hR_tmp ->find_pair(iat1, iat2);
+            for (int ir = 0; ir < ap->get_R_size(); ir++)
+            {   
+                const auto R_index = ap->get_R_index(ir);
+                auto upper_mat = ap->find_matrix(R_index);
+                auto mat_nspin = ap_nspin->find_matrix(R_index);
+
+                // The row size and the col size of upper_matrix is double that of matrix_nspin_0
+                for (int irow = 0; irow < mat_nspin->get_row_size(); ++irow)
+                {
+                    for (int icol = 0; icol < mat_nspin->get_col_size(); ++icol)
+                    {
+                        switch (is)
+                        {
+                        case 0:
+                            upper_mat->get_value(2*irow, 2*icol) += mat_nspin->get_value(irow, icol);
+                            break;
+                        case 1:
+                            upper_mat->get_value(2*irow, 2*icol+1) += mat_nspin->get_value(irow, icol);
+                            break;
+                        case 2:
+                            upper_mat->get_value(2*irow+1, 2*icol) += mat_nspin->get_value(irow, icol);
+                            break;
+                        case 3:
+                            upper_mat->get_value(2*irow+1, 2*icol+1) += mat_nspin->get_value(irow, icol);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
     }
     delete[] iat2iwt;
-    delete pv;
-    delete hR_tmp;
 #else
 
 #endif
@@ -246,7 +226,7 @@ void Gint_k::transfer_pvpR(hamilt::HContainer<std::complex<double>>* hR,
 //         hamilt::transferSerials2Parallels<std::complex<double>>(*this->hRGintCd, hR);
 //     }
 // #else
-//     hR->add(*this->hRGintCd);
+    //  hR->add(*this->hRGintCd);
 // #endif
     ModuleBase::timer::tick("Gint_k", "transfer_pvpR");
     return;

--- a/source/module_lr/utils/gint_move.hpp
+++ b/source/module_lr/utils/gint_move.hpp
@@ -60,8 +60,8 @@ Gint& Gint::operator=(Gint&& rhs)
     this->pvdpRz_reduced = std::move(rhs.pvdpRz_reduced);
     this->DMRGint = std::move(rhs.DMRGint);
     this->hRGint_tmp = std::move(rhs.hRGint_tmp);
-    this->DMRGint_full = rhs.DMRGint_full;
-    rhs.DMRGint_full = nullptr;
+    this->DM2D_tmp = rhs.DM2D_tmp;
+    rhs.DM2D_tmp = nullptr;
 
     return *this;
 }

--- a/source/module_lr/utils/gint_move.hpp
+++ b/source/module_lr/utils/gint_move.hpp
@@ -45,8 +45,8 @@ Gint& Gint::operator=(Gint&& rhs)
     // move hR after refactor
     this->hRGint = rhs.hRGint;
     rhs.hRGint = nullptr;
-    this->hRGintCd = rhs.hRGintCd;
-    rhs.hRGintCd = nullptr;
+    // this->hRGintCd = rhs.hRGintCd;
+    // rhs.hRGintCd = nullptr;
     for (int i = 0; i < this->DMRGint.size(); i++)
     {
         delete this->DMRGint[i];

--- a/source/module_lr/utils/gint_move.hpp
+++ b/source/module_lr/utils/gint_move.hpp
@@ -45,8 +45,8 @@ Gint& Gint::operator=(Gint&& rhs)
     // move hR after refactor
     this->hRGint = rhs.hRGint;
     rhs.hRGint = nullptr;
-    // this->hRGintCd = rhs.hRGintCd;
-    // rhs.hRGintCd = nullptr;
+    this->hR_tmp = rhs.hR_tmp;
+    rhs.hR_tmp = nullptr;
     for (int i = 0; i < this->DMRGint.size(); i++)
     {
         delete this->DMRGint[i];


### PR DESCRIPTION
This pull request addresses issue #6377
<img width="939" height="299" alt="image" src="https://github.com/user-attachments/assets/4aacfa7a-74e6-4132-8f2f-94315f509019" />

### 44b21367652663ba1496a76a180b9af66a2f49ba
Fix memory statistics error
      -  The memory for the record variable `hRGintCd` was not accounted for.
      - When calculating the memory for the record variable `DMRGint`, it was multiplied by 4 twice.

### 07a9a23530437959c6a2e78a3d85492905cd3f8d
Removed the temporary variable `DMRGint_full` when transitioning from 2D block parallelism to serial in Hcontainer.
      A temporary variable `DM2D_tmp` was created to split the 2D block parallel `DM2D` into smaller blocks. The function `transferParallels2Serials` is directly called to convert `DM2D_tmp` into `DMRGint[]`. This approach avoids the large memory consumption that would occur if a large matrix `DMRGint_full` was first used to hold `DM2D` and then split into smaller matrices `DMRGint`.
      _some detail need to modify_

### 0a799ba06acc8be690aebaf99cf98cadef8270e9
Following a similar approach as described above, the temporary variable `hRGintCd`, which was used in the conversion of HContainer from serial to 2D block distributed parallel layout, has been removed. Instead, a smaller auxiliary matrix `hR_tmp` is now used to partition `hR` into blocks, facilitating the type conversion. The data transfer path has been changed from the original `hRGint_tmp → hRGintCd → hR` to `hRGint_tmp → hR_tmp → hR`.

**todo:**
- [x]  delete DMRGint_full
- [x]  delete hRGintCd
- [ ]  Further optimize other variables