### PR TITLE
Memory Optimization for Hcontainer Class in Parallel Execution

### DIFF
--- a/source/source_lcao/module_gint/gint.h
+++ b/source/source_lcao/module_gint/gint.h
@@ -265,7 +265,7 @@ class Gint {
     std::vector<hamilt::HContainer<double>*> DMRGint; 
 
     //! tmp tools used in transfer_DM2DtoGrid 
-    hamilt::HContainer<double>* DMRGint_full = nullptr;
+    hamilt::HContainer<double>* DM2D_tmp = nullptr;
 
     std::vector<hamilt::HContainer<double>> pvdpRx_reduced;
     std::vector<hamilt::HContainer<double>> pvdpRy_reduced;

--- a/source/source_lcao/module_gint/gint_old.cpp
+++ b/source/source_lcao/module_gint/gint_old.cpp
@@ -33,7 +33,7 @@ Gint::~Gint() {
         delete this->hRGint_tmp[is];
     }
 #ifdef __MPI
-    delete this->DMRGint_full;
+    delete this->DM2D_tmp;
 #endif
 }
 
@@ -171,10 +171,9 @@ void Gint::initialize_pvpR(const UnitCell& ucell_in, const Grid_Driver* gd, cons
             this->hRGint_tmp[is] = new hamilt::HContainer<double>(ucell_in.nat);
         }
 #ifdef __MPI
-        if (this->DMRGint_full != nullptr) {
-            delete this->DMRGint_full;
+        if (this->DM2D_tmp != nullptr) {
+            delete this->DM2D_tmp;
         }
-        this->DMRGint_full = new hamilt::HContainer<double>(ucell_in.nat);
 #endif
     }
 
@@ -210,12 +209,6 @@ void Gint::initialize_pvpR(const UnitCell& ucell_in, const Grid_Driver* gd, cons
         ModuleBase::Memory::record("Gint::DMRGint",
                                        this->DMRGint[0]->get_memory_size()
                                            * this->DMRGint.size()*nspin);
-#ifdef __MPI
-        this->DMRGint_full->insert_ijrs(this->gridt->get_ijr_info(), ucell_in, npol);
-        this->DMRGint_full->allocate(nullptr, true);
-        ModuleBase::Memory::record("Gint::DMRGint_full",
-                                   this->DMRGint_full->get_memory_size());
-#endif
     }
 }
 
@@ -231,9 +224,7 @@ void Gint::reset_DMRGint(const int& nspin)
         {
             for (auto& d : this->DMRGint) { d->allocate(nullptr, false); }
 #ifdef __MPI
-            delete this->DMRGint_full;
-            this->DMRGint_full = new hamilt::HContainer<double>(*this->hRGint);
-            this->DMRGint_full->allocate(nullptr, false);
+            delete this->DM2D_tmp;
 #endif
         }
     }
@@ -262,37 +253,66 @@ void Gint::transfer_DM2DtoGrid(std::vector<hamilt::HContainer<double>*> DM2D) {
     } else // NSPIN=4 case
     {
 #ifdef __MPI
-        hamilt::transferParallels2Serials(*DM2D[0], this->DMRGint_full);
-#else
-        this->DMRGint_full = DM2D[0];
-#endif
-        std::vector<double*> tmp_pointer(4, nullptr);
-        for (int iap = 0; iap < this->DMRGint_full->size_atom_pairs(); ++iap) {
-            auto& ap = this->DMRGint_full->get_atom_pair(iap);
-            int iat1 = ap.get_atom_i();
-            int iat2 = ap.get_atom_j();
-            for (int ir = 0; ir < ap.get_R_size(); ++ir) {
-                const ModuleBase::Vector3<int> r_index = ap.get_R_index(ir);
-                for (int is = 0; is < 4; is++) {
-                    tmp_pointer[is] = this->DMRGint[is]
-                                          ->find_matrix(iat1, iat2, r_index)
-                                          ->get_pointer();
-                }
-                double* data_full = ap.get_pointer(ir);
-                for (int irow = 0; irow < ap.get_row_size(); irow += 2) {
-                    for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
-                        *(tmp_pointer[0])++ = data_full[icol];
-                        *(tmp_pointer[1])++ = data_full[icol + 1];
+        int mg = DM2D[0]->get_paraV()->get_global_row_size()/2;
+        int ng = DM2D[0]->get_paraV()->get_global_col_size()/2;
+        int nb = DM2D[0]->get_paraV()->get_block_size()/2;
+        int blacs_ctxt = DM2D[0]->get_paraV()->blacs_ctxt;
+        int *iat2iwt = new int[ucell->nat];
+        for (int iat = 0; iat < ucell->nat; iat++) {
+            iat2iwt[iat] = ucell->get_iat2iwt()[iat]/2;
+        }
+        Parallel_Orbitals *pv = new Parallel_Orbitals();
+        pv->set(mg, ng, nb, blacs_ctxt);
+        pv->set_atomic_trace(iat2iwt, ucell->nat, mg);
+        auto ijr_info = DM2D[0]->get_ijr_info();
+        this-> DM2D_tmp = new hamilt::HContainer<double>(pv, nullptr, &ijr_info);
+        ModuleBase::Memory::record("Gint::DM2D_tmp", this->DM2D_tmp->get_memory_size());
+        for (int is = 0; is < 4; is++){
+            for (int iap = 0; iap < DM2D[0]->size_atom_pairs(); ++iap) {
+                auto& ap = DM2D[0]->get_atom_pair(iap);
+                int iat1 = ap.get_atom_i();
+                int iat2 = ap.get_atom_j();
+                for (int ir = 0; ir < ap.get_R_size(); ++ir) {
+                    const ModuleBase::Vector3<int> r_index = ap.get_R_index(ir);
+                    double* tmp_pointer = this -> DM2D_tmp -> find_matrix(iat1, iat2, r_index)->get_pointer();
+                    double* data_full = ap.get_pointer(ir);
+                    for (int irow = 0; irow < ap.get_row_size(); irow += 2) {
+                        switch (is) {//todo: It can be written more compactly
+                            case 0:
+                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
+                                    *(tmp_pointer)++ = data_full[icol];
+                                }
+                                data_full += ap.get_col_size() * 2;
+                                break;
+                            case 1:
+                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
+                                    *(tmp_pointer)++ = data_full[icol + 1];
+                                }
+                                data_full += ap.get_col_size() * 2;
+                                break;
+                            case 2:
+                                data_full += ap.get_col_size();
+                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
+                                    *(tmp_pointer)++ = data_full[icol];
+                                }
+                                data_full += ap.get_col_size();
+                                break;
+                            case 3:
+                                data_full += ap.get_col_size();
+                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
+                                    *(tmp_pointer)++ = data_full[icol + 1];
+                                }
+                                data_full += ap.get_col_size();
+                                break;           
+                        }
                     }
-                    data_full += ap.get_col_size();
-                    for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
-                        *(tmp_pointer[2])++ = data_full[icol];
-                        *(tmp_pointer[3])++ = data_full[icol + 1];
-                    }
-                    data_full += ap.get_col_size();
                 }
             }
+            hamilt::transferParallels2Serials( *(this->DM2D_tmp), this->DMRGint[is]);
         }
+#else
+        //this->DMRGint_full = DM2D[0];
+#endif
     }
     ModuleBase::timer::tick("Gint", "transfer_DMR");
 }

--- a/source/source_lcao/module_gint/temp_gint/gint_common.cpp
+++ b/source/source_lcao/module_gint/temp_gint/gint_common.cpp
@@ -70,17 +70,18 @@ void transfer_hr_gint_to_hR(const HContainer<T>& hr_gint, HContainer<T>& hR)
 }
 
 //hRgint_tmp to hR
-void transfer_hr_gint_to_hR_nspin4(std::vector<HContainer<double>>& hRGint_tmp, 
+void merge_hR_n4(std::vector<HContainer<double>>& hRGint_tmp, 
                             HContainer<std::complex<double>>& hR,
                             const GintInfo& gint_info)
 {
-    ModuleBase::TITLE("Gint", "transfer_hr_gint_to_hR_nspin4");
-    ModuleBase::timer::tick("Gint", "transfer_hr_gint_to_hR_nspin4");
+    ModuleBase::TITLE("Gint", "merge_hR_n4");
+    ModuleBase::timer::tick("Gint", "merge_hR_n4");
 #ifdef __MPI
     int mg = hR.get_paraV()->get_global_row_size()/2;
     int ng = hR.get_paraV()->get_global_col_size()/2;
     int nb = hR.get_paraV()->get_block_size()/2;
     int blacs_ctxt = hR.get_paraV()->blacs_ctxt;
+    
     const UnitCell* ucell = gint_info.get_ucell();
     int *iat2iwt = new int[ucell->nat];
     for (int iat = 0; iat < ucell->nat; iat++) {
@@ -91,91 +92,49 @@ void transfer_hr_gint_to_hR_nspin4(std::vector<HContainer<double>>& hRGint_tmp,
     pv->set_atomic_trace(iat2iwt, ucell->nat, mg);
     auto ijr_info = hR.get_ijr_info();
 
-    hamilt::HContainer<double>* hR_tmp = new hamilt::HContainer<double>(pv, nullptr, &ijr_info);
+    auto* hR_tmp = new hamilt::HContainer<std::complex<double>>(pv, nullptr, &ijr_info);
+
+    std::vector<int> first = {0, 1, 1, 0};
+    std::vector<int> second= {3, 2, 2, 3};
+    std::vector<int> row_set = {0, 0, 1, 1};
+    std::vector<int> col_set = {0, 1, 0, 1};
+    std::vector<int> clx_i = {1, 0, 0, -1};
+    std::vector<int> clx_j = {0, 1, -1, 0};
     for (int is = 0; is < 4; is++){
-        hR_tmp->set_zero();
-        //std::cout<<"is: "<<is<<std::endl;
-        hamilt::transferSerials2Parallels( hRGint_tmp[is], hR_tmp);
-        for (int iap = 0; iap < hR.size_atom_pairs(); iap++)
+        hamilt::HContainer<std::complex<double>>* hRGint_tmpCd = new hamilt::HContainer<std::complex<double>>(ucell->nat);
+        ijr_info = hRGint_tmp[0].get_ijr_info();
+        hRGint_tmpCd->insert_ijrs(&ijr_info, *(ucell));
+        hRGint_tmpCd->allocate(nullptr, true);
+        hRGint_tmpCd->set_zero();
+        for (int iap = 0; iap < hRGint_tmpCd->size_atom_pairs(); iap++)
         {
             //std::cout<<"iap: "<<iap<<std::endl;
-            auto* ap = &hR.get_atom_pair(iap);
+            auto* ap = &hRGint_tmpCd->get_atom_pair(iap);
             const int iat1 = ap->get_atom_i();
             const int iat2 = ap->get_atom_j();
-            const hamilt::AtomPair<double>* ap_nspin = nullptr;
             if (iat1 <= iat2)
             {
                 hamilt::AtomPair<std::complex<double>>* upper_ap = ap;
-                hamilt::AtomPair<std::complex<double>>* lower_ap = hR.find_pair(iat2, iat1);
-                switch (is)
-                {
-                case 0:
-                    ap_nspin = hR_tmp->find_pair(iat1, iat2);
-                    break;
-                case 3:
-                    ap_nspin = hR_tmp->find_pair(iat1, iat2);
-                    break;
-                }
-                if(ap_nspin == nullptr) break;
+                hamilt::AtomPair<std::complex<double>>* lower_ap = hRGint_tmpCd->find_pair(iat2, iat1);
+                const hamilt::AtomPair<double>* ap_nspin1 = hRGint_tmp[first[is]].find_pair(iat1, iat2);
+                const hamilt::AtomPair<double>* ap_nspin2 = hRGint_tmp[second[is]].find_pair(iat1, iat2);
                 for (int ir = 0; ir < upper_ap->get_R_size(); ir++)
                 {   
                     const auto R_index = upper_ap->get_R_index(ir);
                     auto upper_mat = upper_ap->find_matrix(R_index);
-                    auto mat_nspin = ap_nspin->find_matrix(R_index);
-
+                    auto mat_nspin1 = ap_nspin1->find_matrix(R_index);
+                    auto mat_nspin2 = ap_nspin2->find_matrix(R_index);
                     // The row size and the col size of upper_matrix is double that of matrix_nspin_0
-                    for (int irow = 0; irow < mat_nspin->get_row_size(); ++irow)
+                    for (int irow = 0; irow < mat_nspin1->get_row_size(); ++irow)
                     {
-                        for (int icol = 0; icol < mat_nspin->get_col_size(); ++icol)
+                        for (int icol = 0; icol < mat_nspin1->get_col_size(); ++icol)
                         {
-                            switch (is)
-                            {
-                            case 0:
-                                upper_mat->get_value(2*irow, 2*icol) = mat_nspin->get_value(irow, icol);
-                                upper_mat->get_value(2*irow+1, 2*icol+1) = mat_nspin->get_value(irow, icol);
-                                break;
-                            case 3:
-                                upper_mat->get_value(2*irow, 2*icol) += mat_nspin->get_value(irow, icol);
-                                upper_mat->get_value(2*irow+1, 2*icol+1) -= mat_nspin->get_value(irow, icol);
-                                break;
-                            }
+                            upper_mat->get_value(irow, icol) = mat_nspin1->get_value(irow, icol) 
+                            + std::complex<double>(clx_i[is], clx_j[is]) * mat_nspin2->get_value(irow, icol);
                         }
                     }
-
-                    if (PARAM.globalv.domag)
-                    {
-                        const hamilt::AtomPair<double>* ap_nspin = nullptr;
-                        switch (is)
-                        {
-                        case 1:
-                            ap_nspin = hR_tmp->find_pair(iat1, iat2);
-                            break;
-                        case 2:
-                            ap_nspin = hR_tmp->find_pair(iat1, iat2);
-                            break;
-                        }
-                        const auto mat_nspin = ap_nspin->find_matrix(R_index);
-                        for (int irow = 0; irow < mat_nspin->get_row_size(); ++irow)
-                        {
-                            for (int icol = 0; icol < mat_nspin->get_col_size(); ++icol)
-                            {
-                                switch(is)
-                                {
-                                    case 1:
-                                        upper_mat->get_value(2*irow, 2*icol+1) = mat_nspin->get_value(irow, icol);
-                                        upper_mat->get_value(2*irow+1, 2*icol) = mat_nspin->get_value(irow, icol);
-                                        break;
-                                    case 2:
-                                        upper_mat->get_value(2*irow, 2*icol+1) += std::complex<double>(0.0, 1.0) * mat_nspin->get_value(irow, icol);
-                                        upper_mat->get_value(2*irow+1, 2*icol) -= std::complex<double>(0.0, 1.0) * mat_nspin->get_value(irow, icol);
-                                        break;
-                                }
-                             }
-                        }
-                    }
-                    
-                    // fill the lower triangle matrix
-                    if(is == 3){
+                    //fill the lower triangle matrix
+                    if (PARAM.globalv.domag){
                         if (iat1 < iat2)
                         {
                             auto lower_mat = lower_ap->find_matrix(-R_index);
@@ -191,15 +150,41 @@ void transfer_hr_gint_to_hR_nspin4(std::vector<HContainer<double>>& hRGint_tmp,
                 }
             }
         }
-        
+
+        hR_tmp->set_zero();
+        hamilt::transferSerials2Parallels( *hRGint_tmpCd, hR_tmp);
+        for (int iap = 0; iap < hR.size_atom_pairs(); iap++)
+        {
+            auto* ap = &hR.get_atom_pair(iap);
+            const int iat1 = ap->get_atom_i();
+            const int iat2 = ap->get_atom_j();
+            auto* ap_nspin = hR_tmp ->find_pair(iat1, iat2);
+            for (int ir = 0; ir < ap->get_R_size(); ir++)
+            {   
+                const auto R_index = ap->get_R_index(ir);
+                auto upper_mat = ap->find_matrix(R_index);
+                auto mat_nspin = ap_nspin->find_matrix(R_index);
+
+                // The row size and the col size of upper_matrix is double that of matrix_nspin_0
+                for (int irow = 0; irow < mat_nspin->get_row_size(); ++irow)
+                {
+                    for (int icol = 0; icol < mat_nspin->get_col_size(); ++icol)
+                    {
+                        upper_mat->get_value(2*irow+row_set[is], 2*icol+col_set[is]) = 
+                        mat_nspin->get_value(irow, icol);
+                    }
+                }
+            }
+        }
+        delete hRGint_tmpCd;
     }
     delete[] iat2iwt;
-    delete pv;
-    delete hR_tmp;
 #else
 
 #endif
-    ModuleBase::timer::tick("Gint", "transfer_hr_gint_to_hR_nspin4");
+
+    
+    ModuleBase::timer::tick("Gint", "merge_hR_n4");
     return;
 }
 
@@ -231,6 +216,9 @@ void transfer_dm_2d_to_gint(
     } else  // NSPIN=4 case
     {
 #ifdef __MPI
+        // is=0:↑↑, 1:↑↓, 2:↓↑, 3:↓↓
+        const int row_set[4] = {0, 0, 1, 1};
+        const int col_set[4] = {0, 1, 0, 1};
         int mg = dm[0]->get_paraV()->get_global_row_size()/2;
         int ng = dm[0]->get_paraV()->get_global_col_size()/2;
         int nb = dm[0]->get_paraV()->get_block_size()/2;
@@ -246,43 +234,20 @@ void transfer_dm_2d_to_gint(
         auto ijr_info = dm[0]->get_ijr_info();
         HContainer<T>* DM2D_tmp = new hamilt::HContainer<T>(pv, nullptr, &ijr_info);
         //ModuleBase::Memory::record("Gint::DM2D_tmp", this->DM2D_tmp->get_memory_size());
-         for (int is = 0; is < 4; is++){
+        for (int is = 0; is < 4; is++){
             for (int iap = 0; iap < dm[0]->size_atom_pairs(); ++iap) {
                 auto& ap = dm[0]->get_atom_pair(iap);
                 int iat1 = ap.get_atom_i();
                 int iat2 = ap.get_atom_j();
                 for (int ir = 0; ir < ap.get_R_size(); ++ir) {
                     const ModuleBase::Vector3<int> r_index = ap.get_R_index(ir);
-                    T* tmp_pointer = DM2D_tmp -> find_matrix(iat1, iat2, r_index)->get_pointer();
-                    T* data_full = ap.get_pointer(ir);
-                    for (int irow = 0; irow < ap.get_row_size(); irow += 2) {
-                        switch (is) {//todo: It can be written more compactly
-                            case 0:
-                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
-                                    *(tmp_pointer)++ = data_full[icol];
-                                }
-                                data_full += ap.get_col_size() * 2;
-                                break;
-                            case 1:
-                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
-                                    *(tmp_pointer)++ = data_full[icol + 1];
-                                }
-                                data_full += ap.get_col_size() * 2;
-                                break;
-                            case 2:
-                                data_full += ap.get_col_size();
-                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
-                                    *(tmp_pointer)++ = data_full[icol];
-                                }
-                                data_full += ap.get_col_size();
-                                break;
-                            case 3:
-                                data_full += ap.get_col_size();
-                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
-                                    *(tmp_pointer)++ = data_full[icol + 1];
-                                }
-                                data_full += ap.get_col_size();
-                                break;           
+                    T* matrix_out = DM2D_tmp -> find_matrix(iat1, iat2, r_index)->get_pointer();
+                    T* matrix_in = ap.get_pointer(ir);
+                    for (int irow = 0; irow < ap.get_row_size()/2; irow ++) {
+                        for (int icol = 0; icol < ap.get_col_size()/2; icol ++) {
+                            int index_i = irow* ap.get_col_size()/2 + icol;
+                            int index_j = (irow*2+row_set[is]) * ap.get_col_size() + icol*2+col_set[is];
+                            matrix_out[index_i] = matrix_in[index_j];
                         }
                     }
                 }

--- a/source/source_lcao/module_gint/temp_gint/gint_common.cpp
+++ b/source/source_lcao/module_gint/temp_gint/gint_common.cpp
@@ -47,73 +47,6 @@ void compose_hr_gint(HContainer<double>& hr_gint)
     ModuleBase::timer::tick("Gint", "compose_hr_gint");
 }
 
-void compose_hr_gint(const std::vector<HContainer<double>>& hr_gint_part,
-                     HContainer<std::complex<double>>& hr_gint_full)
-{
-    ModuleBase::TITLE("Gint", "compose_hr_gint");
-    ModuleBase::timer::tick("Gint", "compose_hr_gint");
-    for (int iap = 0; iap < hr_gint_full.size_atom_pairs(); iap++)
-    {
-        auto* ap = &(hr_gint_full.get_atom_pair(iap));
-        const int iat1 = ap->get_atom_i();
-        const int iat2 = ap->get_atom_j();
-        if (iat1 <= iat2)
-        {
-            hamilt::AtomPair<std::complex<double>>* upper_ap = ap;
-            hamilt::AtomPair<std::complex<double>>* lower_ap = hr_gint_full.find_pair(iat2, iat1);
-            const hamilt::AtomPair<double>* ap_nspin_0 = hr_gint_part[0].find_pair(iat1, iat2);
-            const hamilt::AtomPair<double>* ap_nspin_3 = hr_gint_part[3].find_pair(iat1, iat2);
-            for (int ir = 0; ir < upper_ap->get_R_size(); ir++)
-            {
-                const auto R_index = upper_ap->get_R_index(ir);
-                auto upper_mat = upper_ap->find_matrix(R_index);
-                auto mat_nspin_0 = ap_nspin_0->find_matrix(R_index);
-                auto mat_nspin_3 = ap_nspin_3->find_matrix(R_index);
-
-                // The row size and the col size of upper_matrix is double that of matrix_nspin_0
-                for (int irow = 0; irow < mat_nspin_0->get_row_size(); ++irow)
-                {
-                    for (int icol = 0; icol < mat_nspin_0->get_col_size(); ++icol)
-                    {
-                        upper_mat->get_value(2*irow, 2*icol) = mat_nspin_0->get_value(irow, icol) + mat_nspin_3->get_value(irow, icol);
-                        upper_mat->get_value(2*irow+1, 2*icol+1) = mat_nspin_0->get_value(irow, icol) - mat_nspin_3->get_value(irow, icol);
-                    }
-                }
-
-                if (PARAM.globalv.domag)
-                {
-                    const hamilt::AtomPair<double>* ap_nspin_1 = hr_gint_part[1].find_pair(iat1, iat2);
-                    const hamilt::AtomPair<double>* ap_nspin_2 = hr_gint_part[2].find_pair(iat1, iat2);
-                    const auto mat_nspin_1 = ap_nspin_1->find_matrix(R_index);
-                    const auto mat_nspin_2 = ap_nspin_2->find_matrix(R_index);
-                    for (int irow = 0; irow < mat_nspin_1->get_row_size(); ++irow)
-                    {
-                        for (int icol = 0; icol < mat_nspin_1->get_col_size(); ++icol)
-                        {
-                            upper_mat->get_value(2*irow, 2*icol+1) = mat_nspin_1->get_value(irow, icol) +  std::complex<double>(0.0, 1.0) * mat_nspin_2->get_value(irow, icol);
-                            upper_mat->get_value(2*irow+1, 2*icol) = mat_nspin_1->get_value(irow, icol) -  std::complex<double>(0.0, 1.0) * mat_nspin_2->get_value(irow, icol);
-                        }
-                    }
-                }
-
-                // fill the lower triangle matrix
-                if (iat1 < iat2)
-                {
-                    auto lower_mat = lower_ap->find_matrix(-R_index);
-                    for (int irow = 0; irow < upper_mat->get_row_size(); ++irow)
-                    {
-                        for (int icol = 0; icol < upper_mat->get_col_size(); ++icol)
-                        {
-                            lower_mat->get_value(icol, irow) = conj(upper_mat->get_value(irow, icol));
-                        }
-                    }
-                }
-            }
-        }
-    }
-    ModuleBase::timer::tick("Gint", "compose_hr_gint");
-}
-
 template <typename T>
 void transfer_hr_gint_to_hR(const HContainer<T>& hr_gint, HContainer<T>& hR)
 {
@@ -135,6 +68,141 @@ void transfer_hr_gint_to_hR(const HContainer<T>& hr_gint, HContainer<T>& hR)
 #endif
     ModuleBase::timer::tick("Gint", "transfer_hr_gint_to_hR");
 }
+
+//hRgint_tmp to hR
+void transfer_hr_gint_to_hR_nspin4(std::vector<HContainer<double>>& hRGint_tmp, 
+                            HContainer<std::complex<double>>& hR,
+                            const GintInfo& gint_info)
+{
+    ModuleBase::TITLE("Gint", "transfer_hr_gint_to_hR_nspin4");
+    ModuleBase::timer::tick("Gint", "transfer_hr_gint_to_hR_nspin4");
+#ifdef __MPI
+    int mg = hR.get_paraV()->get_global_row_size()/2;
+    int ng = hR.get_paraV()->get_global_col_size()/2;
+    int nb = hR.get_paraV()->get_block_size()/2;
+    int blacs_ctxt = hR.get_paraV()->blacs_ctxt;
+    const UnitCell* ucell = gint_info.get_ucell();
+    int *iat2iwt = new int[ucell->nat];
+    for (int iat = 0; iat < ucell->nat; iat++) {
+        iat2iwt[iat] = ucell->get_iat2iwt()[iat]/2;
+    }
+    Parallel_Orbitals *pv = new Parallel_Orbitals();
+    pv->set(mg, ng, nb, blacs_ctxt);
+    pv->set_atomic_trace(iat2iwt, ucell->nat, mg);
+    auto ijr_info = hR.get_ijr_info();
+
+    hamilt::HContainer<double>* hR_tmp = new hamilt::HContainer<double>(pv, nullptr, &ijr_info);
+    for (int is = 0; is < 4; is++){
+        hR_tmp->set_zero();
+        //std::cout<<"is: "<<is<<std::endl;
+        hamilt::transferSerials2Parallels( hRGint_tmp[is], hR_tmp);
+        for (int iap = 0; iap < hR.size_atom_pairs(); iap++)
+        {
+            //std::cout<<"iap: "<<iap<<std::endl;
+            auto* ap = &hR.get_atom_pair(iap);
+            const int iat1 = ap->get_atom_i();
+            const int iat2 = ap->get_atom_j();
+            const hamilt::AtomPair<double>* ap_nspin = nullptr;
+            if (iat1 <= iat2)
+            {
+                hamilt::AtomPair<std::complex<double>>* upper_ap = ap;
+                hamilt::AtomPair<std::complex<double>>* lower_ap = hR.find_pair(iat2, iat1);
+                switch (is)
+                {
+                case 0:
+                    ap_nspin = hR_tmp->find_pair(iat1, iat2);
+                    break;
+                case 3:
+                    ap_nspin = hR_tmp->find_pair(iat1, iat2);
+                    break;
+                }
+                if(ap_nspin == nullptr) break;
+                for (int ir = 0; ir < upper_ap->get_R_size(); ir++)
+                {   
+                    const auto R_index = upper_ap->get_R_index(ir);
+                    auto upper_mat = upper_ap->find_matrix(R_index);
+                    auto mat_nspin = ap_nspin->find_matrix(R_index);
+
+                    // The row size and the col size of upper_matrix is double that of matrix_nspin_0
+                    for (int irow = 0; irow < mat_nspin->get_row_size(); ++irow)
+                    {
+                        for (int icol = 0; icol < mat_nspin->get_col_size(); ++icol)
+                        {
+                            switch (is)
+                            {
+                            case 0:
+                                upper_mat->get_value(2*irow, 2*icol) = mat_nspin->get_value(irow, icol);
+                                upper_mat->get_value(2*irow+1, 2*icol+1) = mat_nspin->get_value(irow, icol);
+                                break;
+                            case 3:
+                                upper_mat->get_value(2*irow, 2*icol) += mat_nspin->get_value(irow, icol);
+                                upper_mat->get_value(2*irow+1, 2*icol+1) -= mat_nspin->get_value(irow, icol);
+                                break;
+                            }
+                        }
+                    }
+
+                    if (PARAM.globalv.domag)
+                    {
+                        const hamilt::AtomPair<double>* ap_nspin = nullptr;
+                        switch (is)
+                        {
+                        case 1:
+                            ap_nspin = hR_tmp->find_pair(iat1, iat2);
+                            break;
+                        case 2:
+                            ap_nspin = hR_tmp->find_pair(iat1, iat2);
+                            break;
+                        }
+                        const auto mat_nspin = ap_nspin->find_matrix(R_index);
+                        for (int irow = 0; irow < mat_nspin->get_row_size(); ++irow)
+                        {
+                            for (int icol = 0; icol < mat_nspin->get_col_size(); ++icol)
+                            {
+                                switch(is)
+                                {
+                                    case 1:
+                                        upper_mat->get_value(2*irow, 2*icol+1) = mat_nspin->get_value(irow, icol);
+                                        upper_mat->get_value(2*irow+1, 2*icol) = mat_nspin->get_value(irow, icol);
+                                        break;
+                                    case 2:
+                                        upper_mat->get_value(2*irow, 2*icol+1) += std::complex<double>(0.0, 1.0) * mat_nspin->get_value(irow, icol);
+                                        upper_mat->get_value(2*irow+1, 2*icol) -= std::complex<double>(0.0, 1.0) * mat_nspin->get_value(irow, icol);
+                                        break;
+                                }
+                             }
+                        }
+                    }
+                    
+                    // fill the lower triangle matrix
+                    if(is == 3){
+                        if (iat1 < iat2)
+                        {
+                            auto lower_mat = lower_ap->find_matrix(-R_index);
+                            for (int irow = 0; irow < upper_mat->get_row_size(); ++irow)
+                            {
+                                for (int icol = 0; icol < upper_mat->get_col_size(); ++icol)
+                                {
+                                    lower_mat->get_value(icol, irow) = conj(upper_mat->get_value(irow, icol));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
+    }
+    delete[] iat2iwt;
+    delete pv;
+    delete hR_tmp;
+#else
+
+#endif
+    ModuleBase::timer::tick("Gint", "transfer_hr_gint_to_hR_nspin4");
+    return;
+}
+
 
 // gint_info should not have been a parameter, but it was added to initialize dm_gint_full
 // In the future, we might try to remove the gint_info parameter

--- a/source/source_lcao/module_gint/temp_gint/gint_common.cpp
+++ b/source/source_lcao/module_gint/temp_gint/gint_common.cpp
@@ -163,44 +163,67 @@ void transfer_dm_2d_to_gint(
     } else  // NSPIN=4 case
     {
 #ifdef __MPI
-        const int npol = 2;
-        HContainer<T> dm_full = gint_info.get_hr<T>(npol);
-        hamilt::transferParallels2Serials(*dm[0], &dm_full);
-#else
-        HContainer<T>& dm_full = *(dm[0]);
-#endif
-        std::vector<T*> tmp_pointer(4, nullptr);
-        for (int iap = 0; iap < dm_full.size_atom_pairs(); iap++)
-        {
-            auto& ap = dm_full.get_atom_pair(iap);
-            const int iat1 = ap.get_atom_i();
-            const int iat2 = ap.get_atom_j();
-            for (int ir = 0; ir < ap.get_R_size(); ir++)
-            {
-                const ModuleBase::Vector3<int> r_index = ap.get_R_index(ir);
-                for (int is = 0; is < 4; is++)
-                {
-                    tmp_pointer[is] =
-                        dm_gint[is].find_matrix(iat1, iat2, r_index)->get_pointer();
-                }
-                T* data_full = ap.get_pointer(ir);
-                for (int irow = 0; irow < ap.get_row_size(); irow += 2)
-                {
-                    for (int icol = 0; icol < ap.get_col_size(); icol += 2)
-                    {
-                        *(tmp_pointer[0])++ = data_full[icol];
-                        *(tmp_pointer[1])++ = data_full[icol + 1];
+        int mg = dm[0]->get_paraV()->get_global_row_size()/2;
+        int ng = dm[0]->get_paraV()->get_global_col_size()/2;
+        int nb = dm[0]->get_paraV()->get_block_size()/2;
+        int blacs_ctxt = dm[0]->get_paraV()->blacs_ctxt;
+        const UnitCell* ucell = gint_info.get_ucell();
+        int *iat2iwt = new int[ucell->nat];
+        for (int iat = 0; iat < ucell->nat; iat++) {
+            iat2iwt[iat] = ucell->get_iat2iwt()[iat]/2;
+        }
+        Parallel_Orbitals *pv = new Parallel_Orbitals();
+        pv->set(mg, ng, nb, blacs_ctxt);
+        pv->set_atomic_trace(iat2iwt, ucell->nat, mg);
+        auto ijr_info = dm[0]->get_ijr_info();
+        HContainer<T>* DM2D_tmp = new hamilt::HContainer<T>(pv, nullptr, &ijr_info);
+        //ModuleBase::Memory::record("Gint::DM2D_tmp", this->DM2D_tmp->get_memory_size());
+         for (int is = 0; is < 4; is++){
+            for (int iap = 0; iap < dm[0]->size_atom_pairs(); ++iap) {
+                auto& ap = dm[0]->get_atom_pair(iap);
+                int iat1 = ap.get_atom_i();
+                int iat2 = ap.get_atom_j();
+                for (int ir = 0; ir < ap.get_R_size(); ++ir) {
+                    const ModuleBase::Vector3<int> r_index = ap.get_R_index(ir);
+                    T* tmp_pointer = DM2D_tmp -> find_matrix(iat1, iat2, r_index)->get_pointer();
+                    T* data_full = ap.get_pointer(ir);
+                    for (int irow = 0; irow < ap.get_row_size(); irow += 2) {
+                        switch (is) {//todo: It can be written more compactly
+                            case 0:
+                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
+                                    *(tmp_pointer)++ = data_full[icol];
+                                }
+                                data_full += ap.get_col_size() * 2;
+                                break;
+                            case 1:
+                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
+                                    *(tmp_pointer)++ = data_full[icol + 1];
+                                }
+                                data_full += ap.get_col_size() * 2;
+                                break;
+                            case 2:
+                                data_full += ap.get_col_size();
+                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
+                                    *(tmp_pointer)++ = data_full[icol];
+                                }
+                                data_full += ap.get_col_size();
+                                break;
+                            case 3:
+                                data_full += ap.get_col_size();
+                                for (int icol = 0; icol < ap.get_col_size(); icol += 2) {
+                                    *(tmp_pointer)++ = data_full[icol + 1];
+                                }
+                                data_full += ap.get_col_size();
+                                break;           
+                        }
                     }
-                    data_full += ap.get_col_size();
-                    for (int icol = 0; icol < ap.get_col_size(); icol += 2)
-                    {
-                        *(tmp_pointer[2])++ = data_full[icol];
-                        *(tmp_pointer[3])++ = data_full[icol + 1];
-                    }
-                    data_full += ap.get_col_size();
                 }
             }
+            hamilt::transferParallels2Serials( *DM2D_tmp, &dm_gint[is]);
         }
+#else
+        //HContainer<T>& dm_full = *(dm[0]);
+#endif
     }
     ModuleBase::timer::tick("Gint", "transfer_dm_2d_to_gint");
 }

--- a/source/source_lcao/module_gint/temp_gint/gint_common.h
+++ b/source/source_lcao/module_gint/temp_gint/gint_common.h
@@ -11,7 +11,7 @@ namespace ModuleGint
     template <typename T>
     void transfer_hr_gint_to_hR(const HContainer<T>& hr_gint, HContainer<T>& hR);
     // for nspin=4 case
-    void transfer_hr_gint_to_hR_nspin4(std::vector<HContainer<double>>& hRGint_tmp, 
+    void merge_hR_n4(std::vector<HContainer<double>>& hRGint_tmp, 
                             HContainer<std::complex<double>>& hR,
                             const GintInfo& gint_info);
 

--- a/source/source_lcao/module_gint/temp_gint/gint_common.h
+++ b/source/source_lcao/module_gint/temp_gint/gint_common.h
@@ -6,12 +6,14 @@ namespace ModuleGint
 {
     // fill the lower triangle matrix with the upper triangle matrix
     void compose_hr_gint(HContainer<double>& hr_gint);
-    // for nspin=4 case
-    void compose_hr_gint(const std::vector<HContainer<double>>& hr_gint_part,
-                         HContainer<std::complex<double>>& hr_gint_full);
+    
 
     template <typename T>
     void transfer_hr_gint_to_hR(const HContainer<T>& hr_gint, HContainer<T>& hR);
+    // for nspin=4 case
+    void transfer_hr_gint_to_hR_nspin4(std::vector<HContainer<double>>& hRGint_tmp, 
+                            HContainer<std::complex<double>>& hR,
+                            const GintInfo& gint_info);
 
     template<typename T>
     void transfer_dm_2d_to_gint(

--- a/source/source_lcao/module_gint/temp_gint/gint_info.h
+++ b/source/source_lcao/module_gint/temp_gint/gint_info.h
@@ -38,6 +38,7 @@ class GintInfo
     const std::vector<int>& get_trace_lo() const{ return trace_lo_; }
     int get_lgd() const { return lgd_; }
     int get_nat() const { return ucell_->nat; }        // return the number of atoms in the unitcell
+    const UnitCell* get_ucell() const { return ucell_; }
     int get_local_mgrid_num() const { return localcell_info_->get_mgrids_num(); }
     double get_mgrid_volume() const { return meshgrid_info_->get_volume(); }
 

--- a/source/source_lcao/module_gint/temp_gint/gint_vl_metagga_nspin4.cpp
+++ b/source/source_lcao/module_gint/temp_gint/gint_vl_metagga_nspin4.cpp
@@ -14,8 +14,7 @@ void Gint_vl_metagga_nspin4::cal_gint()
     ModuleBase::timer::tick("Gint", "cal_gint_vl");
     init_hr_gint_();
     cal_hr_gint_();
-    compose_hr_gint(hr_gint_part_, hr_gint_full_);
-    transfer_hr_gint_to_hR(hr_gint_full_, *hR_);
+    transfer_hr_gint_to_hR_nspin4(hr_gint_part_, *hR_, *gint_info_);
     ModuleBase::timer::tick("Gint", "cal_gint_vl");
 }
 
@@ -26,8 +25,6 @@ void Gint_vl_metagga_nspin4::init_hr_gint_()
     {
         hr_gint_part_[i] = gint_info_->get_hr<double>();
     }
-    const int npol = 2;
-    hr_gint_full_ = gint_info_->get_hr<std::complex<double>>(npol);
 }
 
 void Gint_vl_metagga_nspin4::cal_hr_gint_()

--- a/source/source_lcao/module_gint/temp_gint/gint_vl_metagga_nspin4.cpp
+++ b/source/source_lcao/module_gint/temp_gint/gint_vl_metagga_nspin4.cpp
@@ -14,7 +14,7 @@ void Gint_vl_metagga_nspin4::cal_gint()
     ModuleBase::timer::tick("Gint", "cal_gint_vl");
     init_hr_gint_();
     cal_hr_gint_();
-    transfer_hr_gint_to_hR_nspin4(hr_gint_part_, *hR_, *gint_info_);
+    merge_hR_n4(hr_gint_part_, *hR_, *gint_info_);
     ModuleBase::timer::tick("Gint", "cal_gint_vl");
 }
 

--- a/source/source_lcao/module_gint/temp_gint/gint_vl_metagga_nspin4.h
+++ b/source/source_lcao/module_gint/temp_gint/gint_vl_metagga_nspin4.h
@@ -37,7 +37,6 @@ class Gint_vl_metagga_nspin4 : public Gint
     const int nspin_ = 4;
 
     std::vector<HContainer<double>> hr_gint_part_;
-    HContainer<std::complex<double>> hr_gint_full_;
 };
 
 }

--- a/source/source_lcao/module_gint/temp_gint/gint_vl_metagga_nspin4_gpu.cpp
+++ b/source/source_lcao/module_gint/temp_gint/gint_vl_metagga_nspin4_gpu.cpp
@@ -13,7 +13,7 @@ void Gint_vl_metagga_nspin4_gpu::cal_gint()
     ModuleBase::timer::tick("Gint", "cal_gint_vl");
     init_hr_gint_();
     cal_hr_gint_();
-    transfer_hr_gint_to_hR_nspin4(hr_gint_part_, *hR_, *gint_info_);
+    merge_hR_n4(hr_gint_part_, *hR_, *gint_info_);
     ModuleBase::timer::tick("Gint", "cal_gint_vl");
 }
 

--- a/source/source_lcao/module_gint/temp_gint/gint_vl_metagga_nspin4_gpu.cpp
+++ b/source/source_lcao/module_gint/temp_gint/gint_vl_metagga_nspin4_gpu.cpp
@@ -13,8 +13,7 @@ void Gint_vl_metagga_nspin4_gpu::cal_gint()
     ModuleBase::timer::tick("Gint", "cal_gint_vl");
     init_hr_gint_();
     cal_hr_gint_();
-    compose_hr_gint(hr_gint_part_, hr_gint_full_);
-    transfer_hr_gint_to_hR(hr_gint_full_, *hR_);
+    transfer_hr_gint_to_hR_nspin4(hr_gint_part_, *hR_, *gint_info_);
     ModuleBase::timer::tick("Gint", "cal_gint_vl");
 }
 
@@ -25,8 +24,6 @@ void Gint_vl_metagga_nspin4_gpu::init_hr_gint_()
     {
         hr_gint_part_[i] = gint_info_->get_hr<double>();
     }
-    const int npol = 2;
-    hr_gint_full_ = gint_info_->get_hr<std::complex<double>>(npol);
 }
 
 void Gint_vl_metagga_nspin4_gpu::transfer_cpu_to_gpu_()

--- a/source/source_lcao/module_gint/temp_gint/gint_vl_metagga_nspin4_gpu.h
+++ b/source/source_lcao/module_gint/temp_gint/gint_vl_metagga_nspin4_gpu.h
@@ -42,7 +42,7 @@ class Gint_vl_metagga_nspin4_gpu : public Gint
     const int nspin_ = 4;
 
     std::vector<HContainer<double>> hr_gint_part_;
-    HContainer<std::complex<double>> hr_gint_full_;
+    //HContainer<std::complex<double>> hr_gint_full_;
     
     std::vector<CudaMemWrapper<double>> vr_eff_d_;
     std::vector<CudaMemWrapper<double>> vofk_d_;

--- a/source/source_lcao/module_gint/temp_gint/gint_vl_nspin4.cpp
+++ b/source/source_lcao/module_gint/temp_gint/gint_vl_nspin4.cpp
@@ -13,7 +13,7 @@ void Gint_vl_nspin4::cal_gint()
     ModuleBase::timer::tick("Gint", "cal_gint_vl");
     init_hr_gint_();
     cal_hr_gint_();
-    transfer_hr_gint_to_hR_nspin4(hr_gint_part_, *hR_, *gint_info_);
+    merge_hR_n4(hr_gint_part_, *hR_, *gint_info_);
     ModuleBase::timer::tick("Gint", "cal_gint_vl");
 }
 

--- a/source/source_lcao/module_gint/temp_gint/gint_vl_nspin4.cpp
+++ b/source/source_lcao/module_gint/temp_gint/gint_vl_nspin4.cpp
@@ -13,8 +13,7 @@ void Gint_vl_nspin4::cal_gint()
     ModuleBase::timer::tick("Gint", "cal_gint_vl");
     init_hr_gint_();
     cal_hr_gint_();
-    compose_hr_gint(hr_gint_part_, hr_gint_full_);
-    transfer_hr_gint_to_hR(hr_gint_full_, *hR_);
+    transfer_hr_gint_to_hR_nspin4(hr_gint_part_, *hR_, *gint_info_);
     ModuleBase::timer::tick("Gint", "cal_gint_vl");
 }
 
@@ -25,8 +24,6 @@ void Gint_vl_nspin4::init_hr_gint_()
     {
         hr_gint_part_[i] = gint_info_->get_hr<double>();
     }
-    const int npol = 2;
-    hr_gint_full_ = gint_info_->get_hr<std::complex<double>>(npol);
 }
 
 void Gint_vl_nspin4::cal_hr_gint_()

--- a/source/source_lcao/module_gint/temp_gint/gint_vl_nspin4.h
+++ b/source/source_lcao/module_gint/temp_gint/gint_vl_nspin4.h
@@ -39,7 +39,6 @@ class Gint_vl_nspin4 : public Gint
     const int nspin_ = 4;
 
     std::vector<HContainer<double>> hr_gint_part_;
-    HContainer<std::complex<double>> hr_gint_full_;
 };
 
 } // namespace ModuleGint

--- a/source/source_lcao/module_gint/temp_gint/gint_vl_nspin4_gpu.cpp
+++ b/source/source_lcao/module_gint/temp_gint/gint_vl_nspin4_gpu.cpp
@@ -13,7 +13,7 @@ void Gint_vl_nspin4_gpu::cal_gint()
     ModuleBase::timer::tick("Gint", "cal_gint_vl");
     init_hr_gint_();
     cal_hr_gint_();
-    transfer_hr_gint_to_hR_nspin4(hr_gint_part_, *hR_, *gint_info_);
+    merge_hR_n4(hr_gint_part_, *hR_, *gint_info_);
     ModuleBase::timer::tick("Gint", "cal_gint_vl");
 }
 

--- a/source/source_lcao/module_gint/temp_gint/gint_vl_nspin4_gpu.cpp
+++ b/source/source_lcao/module_gint/temp_gint/gint_vl_nspin4_gpu.cpp
@@ -13,8 +13,7 @@ void Gint_vl_nspin4_gpu::cal_gint()
     ModuleBase::timer::tick("Gint", "cal_gint_vl");
     init_hr_gint_();
     cal_hr_gint_();
-    compose_hr_gint(hr_gint_part_, hr_gint_full_);
-    transfer_hr_gint_to_hR(hr_gint_full_, *hR_);
+    transfer_hr_gint_to_hR_nspin4(hr_gint_part_, *hR_, *gint_info_);
     ModuleBase::timer::tick("Gint", "cal_gint_vl");
 }
 
@@ -25,8 +24,6 @@ void Gint_vl_nspin4_gpu::init_hr_gint_()
     {
         hr_gint_part_[i] = gint_info_->get_hr<double>();
     }
-    const int npol = 2;
-    hr_gint_full_ = gint_info_->get_hr<std::complex<double>>(npol);
 }
 
 void Gint_vl_nspin4_gpu::transfer_cpu_to_gpu_()

--- a/source/source_lcao/module_gint/temp_gint/gint_vl_nspin4_gpu.h
+++ b/source/source_lcao/module_gint/temp_gint/gint_vl_nspin4_gpu.h
@@ -44,7 +44,6 @@ class Gint_vl_nspin4_gpu : public Gint
     const int nspin_ = 4;
 
     std::vector<HContainer<double>> hr_gint_part_;
-    HContainer<std::complex<double>> hr_gint_full_;
     
     std::vector<CudaMemWrapper<double>> vr_eff_d_;
     std::vector<CudaMemWrapper<double>> hr_gint_part_d_;

--- a/source/source_lcao/module_lr/utils/gint_move.hpp
+++ b/source/source_lcao/module_lr/utils/gint_move.hpp
@@ -60,8 +60,8 @@ Gint& Gint::operator=(Gint&& rhs)
     this->pvdpRz_reduced = std::move(rhs.pvdpRz_reduced);
     this->DMRGint = std::move(rhs.DMRGint);
     this->hRGint_tmp = std::move(rhs.hRGint_tmp);
-    this->DMRGint_full = rhs.DMRGint_full;
-    rhs.DMRGint_full = nullptr;
+    this->DM2D_tmp = rhs.DM2D_tmp;
+    rhs.DM2D_tmp = nullptr;
 
     return *this;
 }


### PR DESCRIPTION
This pull request addresses issue #6377

### 7d4fe5aa9f48b57af742e06c74132593719457ec
Modify the transfer function `transfer_dm_2d_to_gint`. Removed the temporary variable **dm_full** when transitioning from serial to 2D block parallelism in Hcontainer. At the same time, update the `gint_old.cpp` file accordingly.
A temporary variable **DM2D_tmp** was created to split the 2D block parallel **dm** into smaller blocks, which are then handled by **DM2D_tmp**. The function transferParallels2Serials is directly called to convert **DM2D_tmp** into **dm_gint**. This approach avoids the large memory consumption that would occur if a large matrix **dm_full** was first used to hold **DM2D** and then split into smaller matrices **dm_gint**. 
_some detail need to modify_

### b5a0f8f8b6ecadc9addc73e7dea183701f007394
Delete the function that fills the lower triangle matrix when nspin=4, and integrate it into function `transfer_hr_gint_to_hR`.
Following a similar approach as described above, the temporary variable `hr_gint_full`, which was used in the conversion of HContainer from serial to 2D block distributed parallel layout, has been removed. Instead, a smaller auxiliary matrix `hR_tmp` is now used to partition `hR` into blocks, facilitating the type conversion. The data transfer path has been changed from the original `hr_gint_part → hr_gint_full → hR` to `hr_gint_part → hR_tmp → hR`.


### todo:
- [x]  delete dm_full
- [x]  delete hr_gint_full
- [ ]  Further optimize other variables

