### PR TITLE
Fix: Value error of vdrpre in DeePKS.

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -2258,7 +2258,7 @@ Warning: this function is not robust enough for the current version. Please try 
 
 - **Type**: int
 - **Availability**: Numerical atomic orbital basis
-- **Description**: Include V_delta/V_delta_R (Hamiltonian in k/real space) label for DeePKS training. When `deepks_out_labels` is true and `deepks_v_delta` > 0 (k space), ABACUS will output `deepks_hbase.npy`, `deepks_vdelta.npy` and `deepks_htot.npy`(htot=hbase+vdelta). When `deepks_out_labels` is true and `deepks_v_delta` < 0 (real space), ABACUS will output `deepks_hrtot.csr`, `deepks_hrdelta.csr`. Some more files output for different settings.
+- **Description**: Include V_delta/V_delta_R (Hamiltonian in k/real space) label for DeePKS training. When `deepks_out_labels` is true and `deepks_v_delta` > 0 (k space), ABACUS will output `deepks_hbase.npy`, `deepks_vdelta.npy` and `deepks_htot.npy`(htot=hbase+vdelta). When `deepks_out_labels` is true and `deepks_v_delta` < 0 (real space), ABACUS will output `deepks_hrtot.csr`, `deepks_hrdelta.csr`. Some more files output for different settings. *NOTICE: To match the unit Normally used in DeePKS, the unit of Hamiltonian in k space is Hartree. However, currently in R space the unit is still Ry.*
   - `deepks_v_delta` = 1: `deepks_vdpre.npy`, which is used to calculate V_delta during DeePKS training.
   - `deepks_v_delta` = 2: `deepks_phialpha.npy` and `deepks_gevdm.npy`, which can be used to calculate `deepks_vdpre.npy`. A recommanded method for memory saving.
   - `deepks_v_delta` = -1: `deepks_vdrpre.npy`, which is used to calculate V_delta_R during DeePKS training.

--- a/source/source_lcao/module_deepks/deepks_vdrpre.cpp
+++ b/source/source_lcao/module_deepks/deepks_vdrpre.cpp
@@ -153,7 +153,7 @@ void DeePKS_domain::cal_vdr_precalc(const int nlocal,
             hamilt::BaseMatrix<double>* overlap_1 = phialpha[0]->find_matrix(iat, ibt1, dR1);
             hamilt::BaseMatrix<double>* overlap_2 = phialpha[0]->find_matrix(iat, ibt2, dR2);
             assert(overlap_1->get_col_size() == overlap_2->get_col_size());
-            ModuleBase::Vector3<int> dR = dR1 - dR2;
+            ModuleBase::Vector3<int> dR = dR2 - dR1;
             int iRx = DeePKS_domain::mapping_R(dR.x);
             int iRy = DeePKS_domain::mapping_R(dR.y);
             int iRz = DeePKS_domain::mapping_R(dR.z);


### PR DESCRIPTION
### Linked Issue
Fix #6474 

### What's changed?
- Value error of vdrpre in DeePKS caused by a minus sign.
