### PR TITLE
Test: Add test for `out_alllog` to ensure the output log filenames are correct

### DIFF
--- a/tests/10_others/05_Alllog_filename/INPUT
+++ b/tests/10_others/05_Alllog_filename/INPUT
@@ -1,0 +1,21 @@
+INPUT_PARAMETERS 
+#Parameters (1.General)
+suffix               autotest
+calculation          md
+esolver_type         ksdft
+md_type              nve
+md_nstep             3
+symmetry             -1
+                 
+#Parameters (2.Iteration)
+ecutwfc              50
+scf_thr              1e-5
+scf_nmax             100
+#Parameters (3.Basis)
+basis_type           lcao
+                 
+#Parameters (4.Smearing)
+smearing_method      gauss
+smearing_sigma       0.002
+
+out_alllog           1

--- a/tests/10_others/05_Alllog_filename/KPT
+++ b/tests/10_others/05_Alllog_filename/KPT
@@ -1,0 +1,4 @@
+K_POINTS
+0
+Gamma
+3 2 2 0 0 0

--- a/tests/10_others/05_Alllog_filename/README
+++ b/tests/10_others/05_Alllog_filename/README
@@ -1,0 +1,1 @@
+Test if the log filenames are set correctly when out_alllog=1

--- a/tests/10_others/05_Alllog_filename/STRU
+++ b/tests/10_others/05_Alllog_filename/STRU
@@ -1,0 +1,21 @@
+ATOMIC_SPECIES
+Si 14.000 ../../PP_ORB/Si_ONCV_PBE_FR-1.1.upf
+
+NUMERICAL_ORBITAL
+../../PP_ORB/Si_gga_6au_100Ry_2s2p1d.orb
+
+LATTICE_CONSTANT
+10.2
+
+LATTICE_VECTORS
+0.0 0.5 0.5 		#Lattice vector 1
+0.5 0.0 0.5 		#Lattice vector 2
+0.5 0.5 0.0 		#Lattice vector 3
+
+ATOMIC_POSITIONS
+Cartesian 		#Cartesian(Unit is LATTICE_CONSTANT)
+Si 			#Name of element	
+0.0			#Magnetic for this element.
+2			#Number of atoms
+0.00 0.00 0.00 0 0 0	#x,y,z, move_x, move_y, move_z
+0.25 0.25 0.25 1 1 1

--- a/tests/10_others/05_Alllog_filename/result.ref
+++ b/tests/10_others/05_Alllog_filename/result.ref
@@ -1,0 +1,4 @@
+etotref -211.1186500606459
+etotperatomref -105.5593250303
+log_filename_validation 1
+totaltimeref 1.55

--- a/tests/10_others/CASES_CPU.txt
+++ b/tests/10_others/CASES_CPU.txt
@@ -1,3 +1,4 @@
 01_NP_KP_sp
 02_NP_KP_spd
 04_RDMFT_Si2
+05_Alllog_filename


### PR DESCRIPTION
### Linked Issue
Fix #6436. I checked the PR and I think no other changes are reverted. Following PR #6437, a test is added to ensure such bugs could be found immediately at the testing stage.