### PR TITLE
Fix: resolve compile error with USE_ELPA=OFF + BUILD_TESTING=ON and switch to nvtx3 headers when CUDA_VERSION >= 12090

### DIFF
--- a/source/source_base/timer.cpp
+++ b/source/source_base/timer.cpp
@@ -15,7 +15,11 @@
 #include "source_base/formatter.h"
 
 #if defined(__CUDA) && defined(__USE_NVTX)
-#include <nvToolsExt.h>
+#if CUDA_VERSION < 12090
+#include "nvToolsExt.h"
+#else
+#include "nvtx3/nvToolsExt.h"
+#endif
 #include "source_io/module_parameter/parameter.h"
 #endif
 

--- a/source/source_hsolver/test/CMakeLists.txt
+++ b/source/source_hsolver/test/CMakeLists.txt
@@ -153,12 +153,19 @@ install(FILES diago_pexsi_parallel_test.sh DESTINATION ${CMAKE_CURRENT_BINARY_DI
 install(FILES parallel_k2d_test.sh DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 
-
-AddTest(
-  TARGET MODULE_HSOLVER_diago_hs_parallel
-  LIBS parameter  ${math_libs} ELPA::ELPA base device MPI::MPI_CXX genelpa psi
-  SOURCES test_diago_hs_para.cpp ../diag_hs_para.cpp ../diago_pxxxgvx.cpp ../diago_elpa.cpp ../diago_scalapack.cpp 
-)
+if (USE_ELPA)
+  AddTest(
+    TARGET MODULE_HSOLVER_diago_hs_parallel
+    LIBS parameter  ${math_libs} ELPA::ELPA base device MPI::MPI_CXX genelpa psi
+    SOURCES test_diago_hs_para.cpp ../diag_hs_para.cpp ../diago_pxxxgvx.cpp ../diago_elpa.cpp ../diago_scalapack.cpp 
+  )
+else()
+  AddTest(
+      TARGET MODULE_HSOLVER_diago_hs_parallel
+      LIBS parameter  ${math_libs} base device MPI::MPI_CXX psi
+      SOURCES test_diago_hs_para.cpp ../diag_hs_para.cpp ../diago_pxxxgvx.cpp ../diago_scalapack.cpp 
+    )
+endif()
 
 AddTest(
   TARGET MODULE_HSOLVER_linear_trans


### PR DESCRIPTION
### What's changed?
-  resolve compile error with USE_ELPA=OFF + BUILD_TESTING=ON

When building with:
```bash
cmake -B build -DUSE_CUDA=ON -DUSE_ELPA=OFF -DBUILD_TESTING=ON
```
The target MODULE_HSOLVER_diago_hs_parallel fails to compile.
Root cause: ELPA-related code is still compiled or referenced even when USE_ELPA=OFF, causing undeclared variables. 
<img width="455" height="90" alt="1757397888914_3C4835FD-8ED3-4a1c-AB13-FA90FA5D8B09" src="https://github.com/user-attachments/assets/7811a3d0-63fe-4383-b754-1b482e3b6f12" />

Fix: Wrap all ELPA-specific code — including timer variables, and function calls — inside `#ifdef __ELPA`.

-  switch to nvtx3 headers for CUDA >= 12.9 to improve compatibility with changes introduced in #6495

