### PR TITLE
[Bug] Fix dsp compilation error

### DIFF
--- a/source/source_main/driver_run.cpp
+++ b/source/source_main/driver_run.cpp
@@ -6,6 +6,7 @@
 #include "source_io/para_json.h"
 #include "source_io/print_info.h"
 #include "source_md/run_md.h"
+#include "source_base/global_variable.h"
 #include "source_base/module_device/device.h"
 #include "source_base/module_device/memory_op.h"
 #include "source_base/kernels/math_kernel_op.h"


### PR DESCRIPTION
Initializing DSP hardware needs to use GlobalV, but I forgot to add the header in the previous PR. This PR quickly fixed the problem.