### PR TITLE
Fix : add overlap output for deepks_out_freq_elec

### DIFF
--- a/tests/09_DeePKS/103_NO_GO_deepks_out_freq_elec/result.ref
+++ b/tests/09_DeePKS/103_NO_GO_deepks_out_freq_elec/result.ref
@@ -22,4 +22,6 @@ deepks_f_label_elec .06676003678176294
 deepks_fdelta_elec .017979102769780632
 deepks_s_label_elec .06851710382835817
 deepks_sdelta_elec .013725178909672755
+deepks_overlap 61.931587180384426
+deepks_overlap_elec 309.657935901922130
 totaltimeref 3.76

--- a/tests/09_DeePKS/103_NO_KP_deepks_out_freq_elec/result.ref
+++ b/tests/09_DeePKS/103_NO_KP_deepks_out_freq_elec/result.ref
@@ -22,4 +22,6 @@ deepks_f_label_elec .0667600367817765
 deepks_fdelta_elec .017979102769778977
 deepks_s_label_elec .06851710382837811
 deepks_sdelta_elec .013725178909649378
+deepks_overlap 61.931587180384426
+deepks_overlap_elec 309.657935901922130
 totaltimeref 3.52

--- a/tests/integrate/tools/catch_deepks_properties.sh
+++ b/tests/integrate/tools/catch_deepks_properties.sh
@@ -203,6 +203,11 @@ if ! test -z "$deepks_out_labels" && [ $deepks_out_labels == 1 ]; then
     # Process deepks_out_freq_elec > 0
     if [ ! -z "$deepks_out_freq_elec" ] && [ $deepks_out_freq_elec -gt 0 ]; then
         process_many_npys "multi" "_elec" "$1"
+        if ! test -z "$deepks_v_delta" && [[ $deepks_v_delta -gt 0 ]]; then
+            process_npy "single" "abs" "overlap" "" "deepks_overlap" "$1"
+            process_npy "multi" "abs" "overlap" "" "deepks_overlap_elec" "$1"
+            
+        fi
     fi
 fi
 


### PR DESCRIPTION
When using deepks_out_freq_elec and deepks_v_delta > 0, overlap.npy files are output in OUT.ABACUS and OUT.ABACUS/DeePKS_Labels_Elec.
