### PR TITLE
Fix: fix output bug

### DIFF
--- a/source/source_estate/elecstate_print.cpp
+++ b/source/source_estate/elecstate_print.cpp
@@ -146,7 +146,7 @@ void print_scf_iterinfo(const std::string& ks_solver,
     {
         buf += FmtCore::format(td_fmt[i].c_str(), values[i]);
     }
-    std::cout << buf;
+    std::cout << buf << std::fflush;
 }
 
 


### PR DESCRIPTION
In some cases, SCF iteration steps are not output at each step, but rather all output at the end; this PR attempts to fix this issue