### PR TITLE
Fix: replace fflush with flush

### DIFF
--- a/source/source_estate/elecstate_print.cpp
+++ b/source/source_estate/elecstate_print.cpp
@@ -146,7 +146,7 @@ void print_scf_iterinfo(const std::string& ks_solver,
     {
         buf += FmtCore::format(td_fmt[i].c_str(), values[i]);
     }
-    std::cout << buf << std::fflush;
+    std::cout << buf << std::flush;
 }
 
 


### PR DESCRIPTION
### What's changed?
- Correct a misuse of "fflush" by replacing it with "flush".