### PR TITLE
Refactor: rename dngvd op

### DIFF
--- a/source/source_hsolver/diago_dav_subspace.cpp
+++ b/source/source_hsolver/diago_dav_subspace.cpp
@@ -542,7 +542,7 @@ void Diago_DavSubspace<T, Device>::diag_zhegvx(const int& nbase,
         if (this->diag_comm.rank == 0)
         {
             base_device::memory::synchronize_memory_op<T, Device, Device>()(this->d_scc, scc, nbase * this->nbase_x);
-            dngvd_op<T, Device>()(this->ctx, nbase, this->nbase_x, this->hcc, this->d_scc, this->d_eigenvalue, this->vcc);
+            hegvd_op<T, Device>()(this->ctx, nbase, this->nbase_x, this->hcc, this->d_scc, this->d_eigenvalue, this->vcc);
             syncmem_var_d2h_op()((*eigenvalue_iter).data(), this->d_eigenvalue, this->nbase_x);
         }
 #endif
@@ -564,7 +564,7 @@ void Diago_DavSubspace<T, Device>::diag_zhegvx(const int& nbase,
                         s_diag[i][j] = scc[i * this->nbase_x + j];
                     }
                 }
-                dngvx_op<T, Device>()(this->ctx,
+                hegvx_op<T, Device>()(this->ctx,
                                       nbase,
                                       this->nbase_x,
                                       this->hcc,

--- a/source/source_hsolver/diago_david.cpp
+++ b/source/source_hsolver/diago_david.cpp
@@ -622,7 +622,7 @@ void DiagoDavid<T, Device>::diag_zhegvx(const int& nbase,
             resmem_var_op()(eigenvalue_gpu, nbase_x);
             syncmem_var_h2d_op()(eigenvalue_gpu, this->eigenvalue, nbase_x);
 
-            dnevx_op<T, Device>()(this->ctx, nbase, nbase_x, hcc, nband, eigenvalue_gpu, vcc);
+            heevx_op<T, Device>()(this->ctx, nbase, nbase_x, hcc, nband, eigenvalue_gpu, vcc);
 
             syncmem_var_d2h_op()(this->eigenvalue, eigenvalue_gpu, nbase_x);
             delmem_var_op()(eigenvalue_gpu);
@@ -630,7 +630,7 @@ void DiagoDavid<T, Device>::diag_zhegvx(const int& nbase,
         }
         else
         {
-            dnevx_op<T, Device>()(this->ctx, nbase, nbase_x, hcc, nband, this->eigenvalue, vcc);
+            heevx_op<T, Device>()(this->ctx, nbase, nbase_x, hcc, nband, this->eigenvalue, vcc);
         }
     }
 

--- a/source/source_hsolver/diago_iter_assist.cpp
+++ b/source/source_hsolver/diago_iter_assist.cpp
@@ -372,7 +372,7 @@ void DiagoIterAssist<T, Device>::diagH_LAPACK(const int nstart,
     resmem_var_op()(eigenvalues, nstart);
     setmem_var_op()(eigenvalues, 0, nstart);
 
-    dngvd_op<T, Device>()(ctx, nstart, ldh, hcc, scc, eigenvalues, vcc);
+    hegvd_op<T, Device>()(ctx, nstart, ldh, hcc, scc, eigenvalues, vcc);
 
     if (base_device::get_device_type<Device>(ctx) == base_device::GpuDevice)
     {

--- a/source/source_hsolver/kernels/cuda/dngvd_op.cu
+++ b/source/source_hsolver/kernels/cuda/dngvd_op.cu
@@ -225,7 +225,7 @@ struct dngvd_op<T, base_device::DEVICE_GPU>
 };
 
 template <typename T>
-struct dnevx_op<T, base_device::DEVICE_GPU>
+struct heevx_op<T, base_device::DEVICE_GPU>
 {
     using Real = typename GetTypeReal<T>::type;
     void operator()(const base_device::DEVICE_GPU* d,
@@ -261,16 +261,16 @@ struct dngvx_op<T, base_device::DEVICE_GPU>
 };
 
 template struct dngvd_op<std::complex<float>, base_device::DEVICE_GPU>;
-template struct dnevx_op<std::complex<float>, base_device::DEVICE_GPU>;
+template struct heevx_op<std::complex<float>, base_device::DEVICE_GPU>;
 template struct dngvx_op<std::complex<float>, base_device::DEVICE_GPU>;
 
 template struct dngvd_op<std::complex<double>, base_device::DEVICE_GPU>;
-template struct dnevx_op<std::complex<double>, base_device::DEVICE_GPU>;
+template struct heevx_op<std::complex<double>, base_device::DEVICE_GPU>;
 template struct dngvx_op<std::complex<double>, base_device::DEVICE_GPU>;
 
 #ifdef __LCAO
 template struct dngvd_op<double, base_device::DEVICE_GPU>;
-template struct dnevx_op<double, base_device::DEVICE_GPU>;
+template struct heevx_op<double, base_device::DEVICE_GPU>;
 template struct dngvx_op<double, base_device::DEVICE_GPU>;
 #endif
 

--- a/source/source_hsolver/kernels/cuda/dngvd_op.cu
+++ b/source/source_hsolver/kernels/cuda/dngvd_op.cu
@@ -205,7 +205,7 @@ void xheevd_wrapper (
 }
 
 template <typename T>
-struct dngvd_op<T, base_device::DEVICE_GPU>
+struct hegvd_op<T, base_device::DEVICE_GPU>
 {
     using Real = typename GetTypeReal<T>::type;
     void operator()(const base_device::DEVICE_GPU* d,
@@ -260,16 +260,16 @@ struct dngvx_op<T, base_device::DEVICE_GPU>
     }
 };
 
-template struct dngvd_op<std::complex<float>, base_device::DEVICE_GPU>;
+template struct hegvd_op<std::complex<float>, base_device::DEVICE_GPU>;
 template struct heevx_op<std::complex<float>, base_device::DEVICE_GPU>;
 template struct dngvx_op<std::complex<float>, base_device::DEVICE_GPU>;
 
-template struct dngvd_op<std::complex<double>, base_device::DEVICE_GPU>;
+template struct hegvd_op<std::complex<double>, base_device::DEVICE_GPU>;
 template struct heevx_op<std::complex<double>, base_device::DEVICE_GPU>;
 template struct dngvx_op<std::complex<double>, base_device::DEVICE_GPU>;
 
 #ifdef __LCAO
-template struct dngvd_op<double, base_device::DEVICE_GPU>;
+template struct hegvd_op<double, base_device::DEVICE_GPU>;
 template struct heevx_op<double, base_device::DEVICE_GPU>;
 template struct dngvx_op<double, base_device::DEVICE_GPU>;
 #endif

--- a/source/source_hsolver/kernels/cuda/dngvd_op.cu
+++ b/source/source_hsolver/kernels/cuda/dngvd_op.cu
@@ -244,7 +244,7 @@ struct heevx_op<T, base_device::DEVICE_GPU>
 };
 
 template <typename T>
-struct dngvx_op<T, base_device::DEVICE_GPU>
+struct hegvx_op<T, base_device::DEVICE_GPU>
 {
     using Real = typename GetTypeReal<T>::type;
     void operator()(const base_device::DEVICE_GPU* d,
@@ -262,16 +262,16 @@ struct dngvx_op<T, base_device::DEVICE_GPU>
 
 template struct hegvd_op<std::complex<float>, base_device::DEVICE_GPU>;
 template struct heevx_op<std::complex<float>, base_device::DEVICE_GPU>;
-template struct dngvx_op<std::complex<float>, base_device::DEVICE_GPU>;
+template struct hegvx_op<std::complex<float>, base_device::DEVICE_GPU>;
 
 template struct hegvd_op<std::complex<double>, base_device::DEVICE_GPU>;
 template struct heevx_op<std::complex<double>, base_device::DEVICE_GPU>;
-template struct dngvx_op<std::complex<double>, base_device::DEVICE_GPU>;
+template struct hegvx_op<std::complex<double>, base_device::DEVICE_GPU>;
 
 #ifdef __LCAO
 template struct hegvd_op<double, base_device::DEVICE_GPU>;
 template struct heevx_op<double, base_device::DEVICE_GPU>;
-template struct dngvx_op<double, base_device::DEVICE_GPU>;
+template struct hegvx_op<double, base_device::DEVICE_GPU>;
 #endif
 
 } // namespace hsolver

--- a/source/source_hsolver/kernels/dngvd_op.cpp
+++ b/source/source_hsolver/kernels/dngvd_op.cpp
@@ -6,7 +6,7 @@
 
 namespace hsolver
 {
-
+// hegvd and sygvd; dn for dense?
 template <typename T>
 struct dngvd_op<T, base_device::DEVICE_CPU>
 {

--- a/source/source_hsolver/kernels/dngvd_op.cpp
+++ b/source/source_hsolver/kernels/dngvd_op.cpp
@@ -140,7 +140,7 @@ struct dngv_op<T, base_device::DEVICE_CPU>
 };
 
 template <typename T>
-struct dnevx_op<T, base_device::DEVICE_CPU>
+struct heevx_op<T, base_device::DEVICE_CPU>
 {
     using Real = typename GetTypeReal<T>::type;
     void operator()(const base_device::DEVICE_CPU* /*ctx*/,
@@ -324,8 +324,8 @@ struct dngvx_op<T, base_device::DEVICE_CPU>
 template struct dngvd_op<std::complex<float>, base_device::DEVICE_CPU>;
 template struct dngvd_op<std::complex<double>, base_device::DEVICE_CPU>;
 
-template struct dnevx_op<std::complex<float>, base_device::DEVICE_CPU>;
-template struct dnevx_op<std::complex<double>, base_device::DEVICE_CPU>;
+template struct heevx_op<std::complex<float>, base_device::DEVICE_CPU>;
+template struct heevx_op<std::complex<double>, base_device::DEVICE_CPU>;
 
 template struct dngvx_op<std::complex<float>, base_device::DEVICE_CPU>;
 template struct dngvx_op<std::complex<double>, base_device::DEVICE_CPU>;
@@ -334,7 +334,7 @@ template struct dngv_op<std::complex<float>, base_device::DEVICE_CPU>;
 template struct dngv_op<std::complex<double>, base_device::DEVICE_CPU>;
 #ifdef __LCAO
 template struct dngvd_op<double, base_device::DEVICE_CPU>;
-template struct dnevx_op<double, base_device::DEVICE_CPU>;
+template struct heevx_op<double, base_device::DEVICE_CPU>;
 template struct dngvx_op<double, base_device::DEVICE_CPU>;
 template struct dngv_op<double, base_device::DEVICE_CPU>;
 #endif

--- a/source/source_hsolver/kernels/dngvd_op.cpp
+++ b/source/source_hsolver/kernels/dngvd_op.cpp
@@ -83,7 +83,7 @@ struct hegvd_op<T, base_device::DEVICE_CPU>
 };
 
 template <typename T>
-struct dngv_op<T, base_device::DEVICE_CPU>
+struct hegv_op<T, base_device::DEVICE_CPU>
 {
     using Real = typename GetTypeReal<T>::type;
     void operator()(const base_device::DEVICE_CPU* d,
@@ -243,7 +243,7 @@ struct heevx_op<T, base_device::DEVICE_CPU>
 };
 
 template <typename T>
-struct dngvx_op<T, base_device::DEVICE_CPU>
+struct hegvx_op<T, base_device::DEVICE_CPU>
 {
     using Real = typename GetTypeReal<T>::type;
     void operator()(const base_device::DEVICE_CPU* d,
@@ -335,15 +335,15 @@ template struct hegvd_op<std::complex<double>, base_device::DEVICE_CPU>;
 template struct heevx_op<std::complex<float>, base_device::DEVICE_CPU>;
 template struct heevx_op<std::complex<double>, base_device::DEVICE_CPU>;
 
-template struct dngvx_op<std::complex<float>, base_device::DEVICE_CPU>;
-template struct dngvx_op<std::complex<double>, base_device::DEVICE_CPU>;
+template struct hegvx_op<std::complex<float>, base_device::DEVICE_CPU>;
+template struct hegvx_op<std::complex<double>, base_device::DEVICE_CPU>;
 
-template struct dngv_op<std::complex<float>, base_device::DEVICE_CPU>;
-template struct dngv_op<std::complex<double>, base_device::DEVICE_CPU>;
+template struct hegv_op<std::complex<float>, base_device::DEVICE_CPU>;
+template struct hegv_op<std::complex<double>, base_device::DEVICE_CPU>;
 #ifdef __LCAO
 template struct hegvd_op<double, base_device::DEVICE_CPU>;
 template struct heevx_op<double, base_device::DEVICE_CPU>;
-template struct dngvx_op<double, base_device::DEVICE_CPU>;
-template struct dngv_op<double, base_device::DEVICE_CPU>;
+template struct hegvx_op<double, base_device::DEVICE_CPU>;
+template struct hegv_op<double, base_device::DEVICE_CPU>;
 #endif
 } // namespace hsolver

--- a/source/source_hsolver/kernels/dngvd_op.cpp
+++ b/source/source_hsolver/kernels/dngvd_op.cpp
@@ -8,7 +8,7 @@ namespace hsolver
 {
 // hegvd and sygvd; dn for dense?
 template <typename T>
-struct dngvd_op<T, base_device::DEVICE_CPU>
+struct hegvd_op<T, base_device::DEVICE_CPU>
 {
     using Real = typename GetTypeReal<T>::type;
     void operator()(const base_device::DEVICE_CPU* d,
@@ -139,6 +139,14 @@ struct dngv_op<T, base_device::DEVICE_CPU>
     }
 };
 
+// heevx and syevx
+/**
+ * @brief heevx computes the first m eigenvalues and their corresponding eigenvectors of
+ * a complex generalized Hermitian-definite eigenproblem.
+ * 
+ * both heevx and syevx are implemented through the `evx` interface of LAPACK.
+ * wrapped in LapackWrapper::xheevx
+ */
 template <typename T>
 struct heevx_op<T, base_device::DEVICE_CPU>
 {
@@ -321,8 +329,8 @@ struct dngvx_op<T, base_device::DEVICE_CPU>
     }
 };
 
-template struct dngvd_op<std::complex<float>, base_device::DEVICE_CPU>;
-template struct dngvd_op<std::complex<double>, base_device::DEVICE_CPU>;
+template struct hegvd_op<std::complex<float>, base_device::DEVICE_CPU>;
+template struct hegvd_op<std::complex<double>, base_device::DEVICE_CPU>;
 
 template struct heevx_op<std::complex<float>, base_device::DEVICE_CPU>;
 template struct heevx_op<std::complex<double>, base_device::DEVICE_CPU>;
@@ -333,7 +341,7 @@ template struct dngvx_op<std::complex<double>, base_device::DEVICE_CPU>;
 template struct dngv_op<std::complex<float>, base_device::DEVICE_CPU>;
 template struct dngv_op<std::complex<double>, base_device::DEVICE_CPU>;
 #ifdef __LCAO
-template struct dngvd_op<double, base_device::DEVICE_CPU>;
+template struct hegvd_op<double, base_device::DEVICE_CPU>;
 template struct heevx_op<double, base_device::DEVICE_CPU>;
 template struct dngvx_op<double, base_device::DEVICE_CPU>;
 template struct dngv_op<double, base_device::DEVICE_CPU>;

--- a/source/source_hsolver/kernels/dngvd_op.h
+++ b/source/source_hsolver/kernels/dngvd_op.h
@@ -1,5 +1,16 @@
 // TODO: This is a temperary location for these functions.
 // And will be moved to a global module(module base) later.
+
+// DeNse Generalized eigenValue eXtended
+// he stands for Hermitian
+// sy stands for Symmetric
+// gv stands for Generalized eigenValue problem
+// ev stands for EigenValues
+// dn stands for dense, maybe, who knows?
+// x stands for compute a subset of the eigenvalues and, optionally,
+// their corresponding eigenvectors
+// d for all, x for selected
+
 #ifndef MODULE_HSOLVER_DNGVD_H
 #define MODULE_HSOLVER_DNGVD_H
 
@@ -47,10 +58,10 @@ struct hegvd_op
 };
 
 template <typename T, typename Device>
-struct dngv_op
+struct hegv_op
 {
     using Real = typename GetTypeReal<T>::type;
-    /// @brief DNGVX computes first m eigenvalues and eigenvectors of a complex generalized
+    /// @brief HEGV computes first m eigenvalues and eigenvectors of a complex generalized
     /// Input Parameters
     ///     @param d : the type of device
     ///     @param nbase : the number of dim of the matrix
@@ -64,10 +75,10 @@ struct dngv_op
 };
 
 template <typename T, typename Device>
-struct dngvx_op
+struct hegvx_op
 {
     using Real = typename GetTypeReal<T>::type;
-    /// @brief DNGVX computes first m eigenvalues and eigenvectors of a complex generalized
+    /// @brief HEGVX computes first m eigenvalues and eigenvectors of a complex generalized
     /// Input Parameters
     ///     @param d : the type of device
     ///     @param nbase : the number of dim of the matrix

--- a/source/source_hsolver/kernels/dngvd_op.h
+++ b/source/source_hsolver/kernels/dngvd_op.h
@@ -21,10 +21,10 @@ inline float get_real(const float &x) { return x; }
 
 
 template <typename T, typename Device>
-struct dngvd_op
+struct hegvd_op
 {
     using Real = typename GetTypeReal<T>::type;
-    /// @brief DNGVD computes all the eigenvalues and eigenvectors of a complex generalized
+    /// @brief HEGVD computes all the eigenvalues and eigenvectors of a complex generalized
     /// Hermitian-definite eigenproblem. If eigenvectors are desired, it uses a divide and conquer algorithm.
     ///
     /// In this op, the CPU version is implemented through the `gvd` interface, and the CUDA version

--- a/source/source_hsolver/kernels/dngvd_op.h
+++ b/source/source_hsolver/kernels/dngvd_op.h
@@ -82,7 +82,7 @@ struct dngvx_op
 };
 
 template <typename T, typename Device>
-struct dnevx_op
+struct heevx_op
 {
     using Real = typename GetTypeReal<T>::type;
     /// @brief DNEVX computes the first m eigenvalues and their corresponding eigenvectors of

--- a/source/source_hsolver/kernels/dngvd_op.h
+++ b/source/source_hsolver/kernels/dngvd_op.h
@@ -85,7 +85,7 @@ template <typename T, typename Device>
 struct heevx_op
 {
     using Real = typename GetTypeReal<T>::type;
-    /// @brief DNEVX computes the first m eigenvalues and their corresponding eigenvectors of
+    /// @brief heevx computes the first m eigenvalues and their corresponding eigenvectors of
     /// a complex generalized Hermitian-definite eigenproblem
     ///
     /// In this op, the CPU version is implemented through the `evx` interface, and the CUDA version

--- a/source/source_hsolver/kernels/rocm/dngvd_op.hip.cu
+++ b/source/source_hsolver/kernels/rocm/dngvd_op.hip.cu
@@ -328,7 +328,7 @@ void heevx_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const b
 }
 
 template <>
-void dngvx_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* d,
+void hegvx_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* d,
                                                                         const int nbase,
                                                                         const int ldh,
                                                                         std::complex<float>* hcc,
@@ -340,7 +340,7 @@ void dngvx_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const ba
 }
 
 template <>
-void dngvx_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* d,
+void hegvx_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* d,
                                                                          const int nbase,
                                                                          const int ldh,
                                                                          std::complex<double>* hcc,
@@ -353,7 +353,7 @@ void dngvx_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const b
 
 #ifdef __LCAO
 template <>
-void dngvx_op<double, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* d,
+void hegvx_op<double, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* d,
                                                            const int nbase,
                                                            const int ldh,
                                                            double* hcc,

--- a/source/source_hsolver/kernels/rocm/dngvd_op.hip.cu
+++ b/source/source_hsolver/kernels/rocm/dngvd_op.hip.cu
@@ -5,7 +5,7 @@
 
 namespace hsolver {
 
-// NOTE: mimicked from ../cuda/dngvd_op.cu for three dngvd_op
+// NOTE: mimicked from ../cuda/dngvd_op.cu for three hegvd_op
 
 static hipsolverHandle_t hipsolver_H = nullptr;
 // Test on DCU platform. When nstart is greater than 234, code on DCU performs better.
@@ -28,7 +28,7 @@ void destroyGpuSolverHandle() {
 
 #ifdef __LCAO
 template <>
-void dngvd_op<double, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* ctx,
+void hegvd_op<double, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* ctx,
                                                            const int nstart,
                                                            const int ldh,
                                                            const double* _hcc,
@@ -36,7 +36,7 @@ void dngvd_op<double, base_device::DEVICE_GPU>::operator()(const base_device::DE
                                                            double* _eigenvalue,
                                                            double* _vcc)
 {
-    // copied from ../cuda/dngvd_op.cu, "dngvd_op"
+    // copied from ../cuda/dngvd_op.cu, "hegvd_op"
     assert(nstart == ldh);
 
     if (nstart > N_DCU){
@@ -86,7 +86,7 @@ void dngvd_op<double, base_device::DEVICE_GPU>::operator()(const base_device::DE
         hipErrcheck(hipMemcpy(hcc.data(), _hcc, sizeof(double) * hcc.size(), hipMemcpyDeviceToHost));
         hipErrcheck(hipMemcpy(scc.data(), _scc, sizeof(double) * scc.size(), hipMemcpyDeviceToHost));
         base_device::DEVICE_CPU* cpu_ctx = {};
-        dngvd_op<double, base_device::DEVICE_CPU>()(cpu_ctx,
+        hegvd_op<double, base_device::DEVICE_CPU>()(cpu_ctx,
                                                    nstart,
                                                    ldh,
                                                    hcc.data(),
@@ -102,7 +102,7 @@ void dngvd_op<double, base_device::DEVICE_GPU>::operator()(const base_device::DE
 #endif // __LCAO
 
 template <>
-void dngvd_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* ctx,
+void hegvd_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* ctx,
                                                                         const int nstart,
                                                                         const int ldh,
                                                                         const std::complex<float>* _hcc,
@@ -110,7 +110,7 @@ void dngvd_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const ba
                                                                         float* _eigenvalue,
                                                                         std::complex<float>* _vcc)
 {
-    // copied from ../cuda/dngvd_op.cu, "dngvd_op"
+    // copied from ../cuda/dngvd_op.cu, "hegvd_op"
     assert(nstart == ldh);
 
     if (nstart > N_DCU){
@@ -159,7 +159,7 @@ void dngvd_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const ba
         hipErrcheck(hipMemcpy(hcc.data(), _hcc, sizeof(std::complex<float>) * hcc.size(), hipMemcpyDeviceToHost));
         hipErrcheck(hipMemcpy(scc.data(), _scc, sizeof(std::complex<float>) * scc.size(), hipMemcpyDeviceToHost));
         base_device::DEVICE_CPU* cpu_ctx = {};
-        dngvd_op<std::complex<float>, base_device::DEVICE_CPU>()(cpu_ctx,
+        hegvd_op<std::complex<float>, base_device::DEVICE_CPU>()(cpu_ctx,
                                                                 nstart,
                                                                 ldh,
                                                                 hcc.data(),
@@ -174,7 +174,7 @@ void dngvd_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const ba
 }
 
 template <>
-void dngvd_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* ctx,
+void hegvd_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* ctx,
                                                                          const int nstart,
                                                                          const int ldh,
                                                                          const std::complex<double>* _hcc,
@@ -183,7 +183,7 @@ void dngvd_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const b
                                                                          std::complex<double>* _vcc
                                                                         )
 {
-    // copied from ../cuda/dngvd_op.cu, "dngvd_op"
+    // copied from ../cuda/dngvd_op.cu, "hegvd_op"
     // assert(nstart == ldh);
 
     // save a copy of scc in case the diagonalization fails
@@ -237,7 +237,7 @@ void dngvd_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const b
         hipErrcheck(hipMemcpy(hcc.data(), _hcc, sizeof(std::complex<double>) * hcc.size(), hipMemcpyDeviceToHost));
         hipErrcheck(hipMemcpy(scc.data(), _scc, sizeof(std::complex<double>) * scc.size(), hipMemcpyDeviceToHost));
         base_device::DEVICE_CPU* cpu_ctx = {};
-        dngvd_op<std::complex<double>, base_device::DEVICE_CPU>()(cpu_ctx,
+        hegvd_op<std::complex<double>, base_device::DEVICE_CPU>()(cpu_ctx,
                                                                 nstart,
                                                                 ldh,
                                                                 hcc.data(),

--- a/source/source_hsolver/kernels/rocm/dngvd_op.hip.cu
+++ b/source/source_hsolver/kernels/rocm/dngvd_op.hip.cu
@@ -258,7 +258,7 @@ void dngvd_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const b
 
 #ifdef __LCAO
 template <>
-void dnevx_op<double, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* ctx,
+void heevx_op<double, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* ctx,
                                                            const int nstart,
                                                            const int ldh,
                                                            const double* _hcc,
@@ -271,14 +271,14 @@ void dnevx_op<double, base_device::DEVICE_GPU>::operator()(const base_device::DE
     std::vector<double> eigenvalue(ldh, 0);
     hipErrcheck(hipMemcpy(hcc.data(), _hcc, sizeof(double) * hcc.size(), hipMemcpyDeviceToHost));
     base_device::DEVICE_CPU* cpu_ctx = {};
-    dnevx_op<double, base_device::DEVICE_CPU>()(cpu_ctx, nstart, ldh, hcc.data(), m, eigenvalue.data(), vcc.data());
+    heevx_op<double, base_device::DEVICE_CPU>()(cpu_ctx, nstart, ldh, hcc.data(), m, eigenvalue.data(), vcc.data());
     hipErrcheck(hipMemcpy(_vcc, vcc.data(), sizeof(double) * vcc.size(), hipMemcpyHostToDevice));
     hipErrcheck(hipMemcpy(_eigenvalue, eigenvalue.data(), sizeof(double) * eigenvalue.size(), hipMemcpyHostToDevice));
 }
 #endif // __LCAO
 
 template <>
-void dnevx_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* ctx,
+void heevx_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* ctx,
                                                                         const int nstart,
                                                                         const int ldh,
                                                                         const std::complex<float>* _hcc,
@@ -291,7 +291,7 @@ void dnevx_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const ba
     std::vector<float> eigenvalue(ldh, 0);
     hipErrcheck(hipMemcpy(hcc.data(), _hcc, sizeof(std::complex<float>) * hcc.size(), hipMemcpyDeviceToHost));
     base_device::DEVICE_CPU* cpu_ctx = {};
-    dnevx_op<std::complex<float>, base_device::DEVICE_CPU>()(cpu_ctx,
+    heevx_op<std::complex<float>, base_device::DEVICE_CPU>()(cpu_ctx,
                                                              nstart,
                                                              ldh,
                                                              hcc.data(),
@@ -303,7 +303,7 @@ void dnevx_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const ba
 }
 
 template <>
-void dnevx_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* ctx,
+void heevx_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* ctx,
                                                                          const int nstart,
                                                                          const int ldh,
                                                                          const std::complex<double>* _hcc,
@@ -316,7 +316,7 @@ void dnevx_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(const b
     std::vector<double> eigenvalue(ldh, 0);
     hipErrcheck(hipMemcpy(hcc.data(), _hcc, sizeof(std::complex<double>) * hcc.size(), hipMemcpyDeviceToHost));
     base_device::DEVICE_CPU* cpu_ctx = {};
-    dnevx_op<std::complex<double>, base_device::DEVICE_CPU>()(cpu_ctx,
+    heevx_op<std::complex<double>, base_device::DEVICE_CPU>()(cpu_ctx,
                                                               nstart,
                                                               ldh,
                                                               hcc.data(),

--- a/source/source_hsolver/test/test_diago_hs_para.cpp
+++ b/source/source_hsolver/test/test_diago_hs_para.cpp
@@ -231,7 +231,7 @@ void test_performance(int lda, int nb, int nbands, MPI_Comm comm,int case_numb, 
             {
                 h_tmp = h_mat;
                 s_tmp = s_mat;
-                hsolver::dngvx_op<T,base_device::DEVICE_CPU>()(ctx,
+                hsolver::hegvx_op<T,base_device::DEVICE_CPU>()(ctx,
                                       lda,
                                       lda,
                                       h_tmp.data(),


### PR DESCRIPTION
If one searches the Web for `dngvd`, he will find ABACUS source code and nothing else. But what is it exactly?
However, it is just a wrapper of standard LAPACK library functions including `he/sy`-`ev/gv`-`d/x`, which have a full set of documentations in the web.

### What's changed?
- Rename `dn` ops in `hsolver/kernels` to `he` ops.
- Including: evx, gv, gvx, gvd
- Now consistent with LAPACK and wrapper.