### PR TITLE
Add subspace diagonalization for orthogonal input

### DIFF
--- a/python/pyabacus/CONTRIBUTING.md
+++ b/python/pyabacus/CONTRIBUTING.md
@@ -189,7 +189,7 @@ list(APPEND _diago
     ${HSOLVER_PATH}/diago_david.cpp
     ${HSOLVER_PATH}/diag_const_nums.cpp
     ${HSOLVER_PATH}/diago_iter_assist.cpp
-    ${HSOLVER_PATH}/kernels/dngvd_op.cpp
+    ${HSOLVER_PATH}/kernels/hegvd_op.cpp
     ${HSOLVER_PATH}/kernels/bpcg_kernel_op.cpp
     ${BASE_PATH}/kernels/math_kernel_op.cpp
     ${BASE_PATH}/kernels/math_kernel_op_vec.cpp

--- a/python/pyabacus/src/hsolver/py_diago_cg.hpp
+++ b/python/pyabacus/src/hsolver/py_diago_cg.hpp
@@ -145,7 +145,7 @@ public:
             std::copy(hpsi_ptr, hpsi_ptr + nvec * ld_psi, hpsi_out.data<std::complex<double>>());
         };
 
-        auto subspace_func = [ha](const ct::Tensor& psi_in, ct::Tensor& psi_out, const bool S_orth) { /*do nothing*/ };
+        auto subspace_func = [](const ct::Tensor& psi_in, ct::Tensor& psi_out, const bool S_orth) { /*do nothing*/ };
 
         auto spsi_func = [this] (const ct::Tensor& psi_in, ct::Tensor& spsi_out) {
             const auto ndim = psi_in.shape().ndim();

--- a/python/pyabacus/src/hsolver/py_diago_cg.hpp
+++ b/python/pyabacus/src/hsolver/py_diago_cg.hpp
@@ -145,7 +145,7 @@ public:
             std::copy(hpsi_ptr, hpsi_ptr + nvec * ld_psi, hpsi_out.data<std::complex<double>>());
         };
 
-        auto subspace_func = [] (const ct::Tensor& psi_in, ct::Tensor& psi_out) { /*do nothing*/ };
+        auto subspace_func = [ha](const ct::Tensor& psi_in, ct::Tensor& psi_out, const bool S_orth) { /*do nothing*/ };
 
         auto spsi_func = [this] (const ct::Tensor& psi_in, ct::Tensor& spsi_out) {
             const auto ndim = psi_in.shape().ndim();

--- a/python/pyabacus/src/hsolver/py_diago_dav_subspace.hpp
+++ b/python/pyabacus/src/hsolver/py_diago_dav_subspace.hpp
@@ -144,7 +144,6 @@ public:
             dav_ndim, 
             tol, 
             max_iter, 
-            need_subspace, 
             comm_info,
             diag_subspace,
             nb2d

--- a/source/source_hsolver/diago_cg.cpp
+++ b/source/source_hsolver/diago_cg.cpp
@@ -54,7 +54,7 @@ DiagoCG<T, Device>::~DiagoCG()
 }
 
 template <typename T, typename Device>
-void DiagoCG<T, Device>::diag_mock(const ct::Tensor& prec_in,
+void DiagoCG<T, Device>::diag_once(const ct::Tensor& prec_in,
                                    ct::Tensor& psi,
                                    ct::Tensor& eigen,
                                    const std::vector<double>& ethr_band)
@@ -592,16 +592,29 @@ void DiagoCG<T, Device>::diag(const Func& hpsi_func,
     ct::Tensor psi_temp = psi.slice({0, 0}, {int(psi.shape().dim_size(0)), int(prec.shape().dim_size(0))});
     do
     {
-        if (need_subspace_ || ntry > 0)
+        // subspace diagonalization to get a better starting guess
+        // for cg diagonalization, restart from current psi approximation
+        // Note: if not the first try, then psi is already S-orthogonalized by CG iterations!
+        // Otherwise, if the first try, then psi is not assumed to be S-orthogonalized
+        if (ntry > 0)
         {
             ct::TensorMap psi_map = ct::TensorMap(psi.data(), psi_temp);
-            this->subspace_func_(psi_temp, psi_map);
+            const bool assume_S_orthogonal = true;
+            this->subspace_func_(psi_temp, psi_map, assume_S_orthogonal);
+            psi_temp.sync(psi_map);
+        }
+        else if (need_subspace_)
+        {
+            ct::TensorMap psi_map = ct::TensorMap(psi.data(), psi_temp);
+            const bool assume_S_orthogonal = false;
+            this->subspace_func_(psi_temp, psi_map, assume_S_orthogonal);
             psi_temp.sync(psi_map);
         }
 
+
         ++ntry;
         avg_iter_ += 1.0;
-        this->diag_mock(prec, psi_temp, eigen, ethr_band);
+        this->diag_once(prec, psi_temp, eigen, ethr_band);
     } while (this->test_exit_cond(ntry, this->notconv_));
 
     if (this->notconv_ > std::max(5, this->n_band_ / 4))

--- a/source/source_hsolver/diago_cg.cpp
+++ b/source/source_hsolver/diago_cg.cpp
@@ -28,7 +28,7 @@ template <typename T, typename Device>
 DiagoCG<T, Device>::DiagoCG(const std::string& basis_type,
                             const std::string& calculation,
                             const bool& need_subspace,
-                            const Func& subspace_func,
+                            const SubspaceFunc& subspace_func,
                             const Real& pw_diag_thr,
                             const int& pw_diag_nmax,
                             const int& nproc_in_pool)
@@ -569,7 +569,7 @@ bool DiagoCG<T, Device>::test_exit_cond(const int& ntry, const int& notconv) con
     // In non-self consistent calculation, do until totally converged.
     const bool f2 = !scf && notconv > 0;
     // if self consistent calculation, if not converged > 5,
-    // using diagH_subspace and cg method again. ntry++
+    // using diag_subspace and cg method again. ntry++
     const bool f3 = scf && notconv > 5;
     return f1 && (f2 || f3);
 }

--- a/source/source_hsolver/diago_cg.h
+++ b/source/source_hsolver/diago_cg.h
@@ -22,6 +22,7 @@ class DiagoCG final
     using ct_Device = typename ct::PsiToContainer<Device>::type;
   public:
     using Func = std::function<void(const ct::Tensor&, ct::Tensor&)>;
+    using SubspaceFunc = std::function<void(const ct::Tensor&, ct::Tensor&, const bool)>;
     // Constructor need:
     // 1. temporary mock of Hamiltonian "Hamilt_PW"
     // 2. precondition pointer should point to place of precondition array.
@@ -30,7 +31,7 @@ class DiagoCG final
         const std::string& basis_type,
         const std::string& calculation,
         const bool& need_subspace,
-        const Func& subspace_func,
+        const SubspaceFunc& subspace_func,
         const Real& pw_diag_thr,
         const int& pw_diag_nmax,
         const int& nproc_in_pool);
@@ -72,11 +73,11 @@ class DiagoCG final
 
     bool need_subspace_ = false;
     /// A function object that performs the hPsi calculation.
-    std::function<void(const ct::Tensor&, ct::Tensor&)> hpsi_func_ = nullptr;
+    Func hpsi_func_ = nullptr;
     /// A function object that performs the sPsi calculation.
-    std::function<void(const ct::Tensor&, ct::Tensor&)> spsi_func_ = nullptr;
+    Func spsi_func_ = nullptr;
     /// A function object that performs the subspace calculation.
-    std::function<void(const ct::Tensor&, ct::Tensor&)> subspace_func_ = nullptr;
+    SubspaceFunc subspace_func_ = nullptr;
 
     void calc_grad(
         const ct::Tensor& prec,
@@ -119,7 +120,7 @@ class DiagoCG final
     void schmit_orth(const int& m, const ct::Tensor& psi, const ct::Tensor& sphi, ct::Tensor& phi_m);
 
     // used in diag() for template replace Hamilt with Hamilt_PW
-    void diag_mock(const ct::Tensor& prec,
+    void diag_once(const ct::Tensor& prec,
                    ct::Tensor& psi,
                    ct::Tensor& eigen,
                    const std::vector<double>& ethr_band);

--- a/source/source_hsolver/diago_dav_subspace.h
+++ b/source/source_hsolver/diago_dav_subspace.h
@@ -30,7 +30,6 @@ class Diago_DavSubspace
                       const int& david_ndim_in,
                       const double& diag_thr_in,
                       const int& diag_nmax_in,
-                      const bool& need_subspace_in,
                       const diag_comm_info& diag_comm_in,
                       const int diago_dav_method_in,
                       const int block_size_in);
@@ -57,9 +56,6 @@ class Diago_DavSubspace
 
     /// maximal iteration number
     const int iter_nmax;
-
-    /// is diagH_subspace needed?
-    const bool is_subspace;
 
     /// the first dimension of the matrix to be diagonalized
     const int n_band = 0;

--- a/source/source_hsolver/diago_iter_assist.h
+++ b/source/source_hsolver/diago_iter_assist.h
@@ -29,11 +29,28 @@ class DiagoIterAssist
     static int SCF_ITER;
 
     // for psi::Psi structure
-    static void diagH_subspace(const hamilt::Hamilt<T, Device>* const pHamilt,
-                               const psi::Psi<T, Device>& psi,
-                               psi::Psi<T, Device>& evc,
-                               Real* en,
-                               int n_band = 0);
+     /**
+     * @brief Diagonalizes the Hamiltonian in a subspace defined by the given wavefunction.
+     *
+     * This static function computes the eigenvalues and eigenvectors of the Hamiltonian
+     * within the subspace spanned by the provided wavefunction `psi`. The resulting eigenvectors
+     * are stored in `evc`, and the corresponding eigenvalues are written to `en`.
+     *
+     * @tparam T      Data type for computation (e.g., float, double).
+     * @tparam Device Device type for computation (e.g., CPU, GPU).
+     * @param pHamilt Pointer to the Hamiltonian object.
+     * @param psi     Input wavefunction defining the subspace.
+     * @param evc     Output container for computed eigenvectors.
+     * @param en      Output array for computed eigenvalues.
+     * @param n_band  Number of bands (eigenvalues/eigenvectors) to compute. Default is 0 (all).
+     * @param is_S_orthogonal If true, assumes the input wavefunction is already orthogonalized.
+     */
+    static void diag_subspace(const hamilt::Hamilt<T, Device>* const pHamilt,
+                              const psi::Psi<T, Device>& psi,
+                              psi::Psi<T, Device>& evc,
+                              Real *en,
+                              int n_band = 0,
+                              const bool is_S_orthogonal = false);
 
     /// @brief use LAPACK to diagonalize the Hamiltonian matrix
     /// @param pHamilt interface to hamiltonian
@@ -44,7 +61,7 @@ class DiagoIterAssist
     /// @param en eigenenergies
     /// @note exception handle: if there is no operator initialized in Hamilt, will directly copy value from psi to evc, 
     /// and return all - zero eigenenergies.
-    static void diagH_subspace_init(
+    static void diag_subspace_init(
             hamilt::Hamilt<T, Device>* pHamilt,
             const T* psi,
             int psi_nr,
@@ -54,13 +71,19 @@ class DiagoIterAssist
             const std::function<void(T*, const int)>& add_to_hcc = [](T* null, const int n) {},
             const std::function<void(const T* const, const int, const int)>& export_vcc = [](const T* null, const int n, const int m) {});
 
-    static void diagH_LAPACK(const int nstart,
-                             const int nbands,
-                             const T* hcc,
-                             const T* sc,
-                             const int ldh, // nstart
-                             Real* e,
-                             T* vcc);
+    static void diag_heevx(const int nstart,
+                            const int nbands,
+                            const T *hcc,
+                            const int ldh,
+                            Real *e,
+                            T *vcc);
+    static void diag_hegvd(const int nstart,
+                            const int nbands,
+                            const T *hcc,
+                            const T *sc,
+                            const int ldh, // nstart
+                            Real *e,
+                            T *vcc);
 
     /// @brief calculate Hamiltonian and overlap matrix in subspace spanned by nstart states psi
     /// @param pHamilt : hamiltonian operator carrier

--- a/source/source_hsolver/hsolver_lcaopw.cpp
+++ b/source/source_hsolver/hsolver_lcaopw.cpp
@@ -65,7 +65,7 @@ void HSolverLIP<T>::solve(hamilt::Hamilt<T>* pHamilt, // ESolver_KS_PW::p_hamilt
         };
 #endif
         /// solve eigenvector and eigenvalue for H(k)
-        hsolver::DiagoIterAssist<T>::diagH_subspace_init(
+        hsolver::DiagoIterAssist<T>::diag_subspace_init(
             pHamilt,                 // interface to hamilt
             transform.get_pointer(), // transform matrix between lcao and pw
             transform.get_nbands(),

--- a/source/source_hsolver/kernels/hegvd_op.h
+++ b/source/source_hsolver/kernels/hegvd_op.h
@@ -119,13 +119,14 @@ struct heevx_op
     ///
     /// Input Parameters
     ///     @param d : the type of device
-    ///     @param nstart : the number of cols of the matrix
-    ///     @param ldh : the number of rows of the matrix
-    ///     @param A : the hermitian matrix A in A x=lambda B x (row major)
+    ///     @param ndim : the size of square matrix
+    ///     @param lda : leading dimension of the matrix
+    ///     @param A : the hermitian matrix A in A x=lambda x
+    ///     @param neig : the number of eigenpairs to be calculated
     /// Output Parameter
-    ///     @param W : calculated eigenvalues
-    ///     @param V : calculated eigenvectors (row major)
-    void operator()(const Device* d, const int nstart, const int ldh, const T* A, const int m, Real* W, T* V);
+    ///     @param w: calculated eigenvalues
+    ///     @param z: calculated eigenvectors
+    void operator()(const Device *d, const int ndim, const int lda, const T *A, const int neig, Real *w, T *z);
 };
 
 #if __CUDA || __UT_USE_CUDA || __ROCM || __UT_USE_ROCM

--- a/source/source_hsolver/test/diago_cg_float_test.cpp
+++ b/source/source_hsolver/test/diago_cg_float_test.cpp
@@ -142,7 +142,7 @@ class DiagoCGPrepare
         //  New interface of cg method
         /**************************************************************/
         // warp the subspace_func into a lambda function
-        auto subspace_func = [ha](const ct::Tensor& psi_in, ct::Tensor& psi_out) { /*do nothing*/ };
+        auto subspace_func = [ha](const ct::Tensor& psi_in, ct::Tensor& psi_out, const bool S_orth) { /*do nothing*/ };
         hsolver::DiagoCG<std::complex<float>> cg(
             PARAM.input.basis_type,
             PARAM.input.calculation,

--- a/source/source_hsolver/test/diago_cg_real_test.cpp
+++ b/source/source_hsolver/test/diago_cg_real_test.cpp
@@ -147,7 +147,7 @@ public:
         //  New interface of cg method
         /**************************************************************/
         // warp the subspace_func into a lambda function
-        auto subspace_func = [ha](const ct::Tensor& psi_in, ct::Tensor& psi_out) { /*do nothing*/ };
+        auto subspace_func = [ha](const ct::Tensor& psi_in, ct::Tensor& psi_out, const bool S_orth) { /*do nothing*/ };
         hsolver::DiagoCG<double> cg(
             PARAM.input.basis_type,
             PARAM.input.calculation,

--- a/source/source_hsolver/test/diago_cg_test.cpp
+++ b/source/source_hsolver/test/diago_cg_test.cpp
@@ -136,7 +136,7 @@ class DiagoCGPrepare
         //  New interface of cg method
         /**************************************************************/
         // warp the subspace_func into a lambda function
-        auto subspace_func = [ha](const ct::Tensor& psi_in, ct::Tensor& psi_out) { /*do nothing*/ };
+        auto subspace_func = [ha](const ct::Tensor& psi_in, ct::Tensor& psi_out, const bool S_orth) { /*do nothing*/ };
         hsolver::DiagoCG<std::complex<double>> cg(
             PARAM.input.basis_type,
             PARAM.input.calculation,

--- a/source/source_hsolver/test/hsolver_pw_sup.h
+++ b/source/source_hsolver/test/hsolver_pw_sup.h
@@ -68,7 +68,7 @@ template <typename T, typename Device>
 DiagoCG<T, Device>::DiagoCG(const std::string& basis_type,
                             const std::string& calculation,
                             const bool& need_subspace,
-                            const Func& subspace_func,
+                            const SubspaceFunc& subspace_func,
                             const Real& pw_diag_thr,
                             const int& pw_diag_nmax,
                             const int& nproc_in_pool) {

--- a/source/source_hsolver/test/test_diago_assist.cpp
+++ b/source/source_hsolver/test/test_diago_assist.cpp
@@ -27,14 +27,14 @@ class TestDiagoIterAssist : public ::testing::Test
       std::ofstream temp_ofs;
 };
 
-TEST_F(TestDiagoIterAssist, diagH_subspace)
+TEST_F(TestDiagoIterAssist, diag_subspace)
 {
-    dia_f::diagH_subspace();
-    dia_d::diagH_subspace();
+    dia_f::diag_subspace();
+    dia_d::diag_subspace();
     EXPECT_EQ(true);
 }
 
-TEST_F(TestDiagoIterAssist, diagH_LAPACK)
+TEST_F(TestDiagoIterAssist, diag_hegvd)
 {
     EXPECT_EQ(true);
 }

--- a/source/source_lcao/module_lr/hsolver_lrtd.hpp
+++ b/source/source_lcao/module_lr/hsolver_lrtd.hpp
@@ -100,7 +100,6 @@ namespace LR
                         PARAM.inp.pw_diag_ndim,
                         diag_ethr,
                         maxiter,
-                        false, //always do the subspace diag (check the implementation)
                         comm_info,
                         PARAM.inp.diag_subspace,
                         PARAM.inp.nb2d);
@@ -135,7 +134,7 @@ namespace LR
                     ////// why diago_cg depends on basis_type?
                     // hsolver::DiagoCG<T> cg("lcao", "nscf", true, subspace_func, diag_ethr, maxiter, GlobalV::NPROC_IN_POOL);
 
-                    auto subspace_func = [](const ct::Tensor& psi_in, ct::Tensor& psi_out) {};
+                    auto subspace_func = [](const ct::Tensor& psi_in, ct::Tensor& psi_out, const bool S_orth) {};
                     hsolver::DiagoCG<T> cg("lcao", "nscf", false, subspace_func, diag_ethr, maxiter, GlobalV::NPROC_IN_POOL);
 
                     auto psi_tensor = ct::TensorMap(psi, ct::DataTypeToEnum<T>::value, ct::DeviceType::CpuDevice, ct::TensorShape({ nband, dim }));

--- a/source/source_psi/psi_init.cpp
+++ b/source/source_psi/psi_init.cpp
@@ -157,7 +157,7 @@ void PSIInit<T, Device>::initialize_psi(Psi<std::complex<double>>* psi,
                 {
                     // for diagH_subspace_init, psi_device->get_pointer() and kspw_psi->get_pointer() should be
                     // different
-                    hsolver::DiagoIterAssist<T, Device>::diagH_subspace_init(p_hamilt,
+                    hsolver::DiagoIterAssist<T, Device>::diag_subspace_init(p_hamilt,
                                                                              psi_device->get_pointer(),
                                                                              nbands_start,
                                                                              nbasis,
@@ -167,7 +167,7 @@ void PSIInit<T, Device>::initialize_psi(Psi<std::complex<double>>* psi,
                 else
                 {
                     // for diagH_subspace, psi_device->get_pointer() and kspw_psi->get_pointer() can be the same
-                    hsolver::DiagoIterAssist<T, Device>::diagH_subspace(p_hamilt,
+                    hsolver::DiagoIterAssist<T, Device>::diag_subspace(p_hamilt,
                                                                         *psi_device,
                                                                         *kspw_psi,
                                                                         etatom.data(),


### PR DESCRIPTION
### Linked Issue
Fix #5615

### Description

- `diagH_subspace` is used in `hsolver` to do a diagonalization in the subspace spanned by given psi vectors.
- When input vectors are orthogonal, there is no need to do the overlap and solve generalized eigenvalue problems.
- Add a parameter to support this procedure without assigning and calculating overlap block.
- Remove `need_subspace` parameter not needed in `dav_subspace` code.