### PR TITLE
Fix the unmatched timer tick of DiagoIterAssist::diag_subspace

### DIFF
--- a/source/source_hsolver/diago_iter_assist.cpp
+++ b/source/source_hsolver/diago_iter_assist.cpp
@@ -166,7 +166,7 @@ void DiagoIterAssist<T, Device>::diag_subspace(const hamilt::Hamilt<T, Device>* 
     }
     delmem_complex_op()(vcc);
 
-    ModuleBase::timer::tick("DiagoAssist", "diag_subspace");
+    ModuleBase::timer::tick("DiagoIterAssist", "diag_subspace");
 }
 
 template <typename T, typename Device>


### PR DESCRIPTION
### Linked Issue
Fix #6597
