### PR TITLE
Fix: Fix `cal_bandgap` for parallelism of k-points and band.

### DIFF
--- a/source/source_estate/elecstate_energy.cpp
+++ b/source/source_estate/elecstate_energy.cpp
@@ -5,6 +5,7 @@
 #include "source_io/module_parameter/parameter.h"
 
 #include <cmath>
+#include <limits>
 
 namespace elecstate
 {
@@ -16,25 +17,31 @@ void ElecState::cal_bandgap()
         this->bandgap = 0.0;
         return;
     }
-    // int nbands = PARAM.inp.nbands;
+
     int nbands = this->ekb.nc;
     int nks = this->klist->get_nks();
-    double homo = this->ekb(0, 0);
-    double lumo = this->ekb(0, nbands - 1);
+    double homo = -std::numeric_limits<double>::infinity();
+    double lumo = std::numeric_limits<double>::infinity();
     for (int ib = 0; ib < nbands; ib++)
     {
         for (int ik = 0; ik < nks; ik++)
         {
-            if (!(this->ekb(ik, ib) - this->eferm.ef > 1e-5) && homo < this->ekb(ik, ib))
+            if (this->ekb(ik, ib) <= this->eferm.ef && this->ekb(ik, ib) > homo)
             {
                 homo = this->ekb(ik, ib);
             }
-            if (this->ekb(ik, ib) - this->eferm.ef > 1e-5 && lumo > this->ekb(ik, ib))
+            if (this->ekb(ik, ib) >= this->eferm.ef && this->ekb(ik, ib) < lumo)
             {
                 lumo = this->ekb(ik, ib);
             }
         }
     }
+
+#ifdef __MPI
+    Parallel_Reduce::gather_max_double_all(GlobalV::NPROC, homo);
+    Parallel_Reduce::gather_min_double_all(GlobalV::NPROC, lumo);
+#endif
+
     this->bandgap = lumo - homo;
 }
 
@@ -51,38 +58,46 @@ void ElecState::cal_bandgap_updw()
     // int nbands = PARAM.inp.nbands;
     int nbands = this->ekb.nc;
     int nks = this->klist->get_nks();
-    double homo_up = this->ekb(0, 0);
-    double lumo_up = this->ekb(0, nbands - 1);
-    double homo_dw = this->ekb(0, 0);
-    double lumo_dw = this->ekb(0, nbands - 1);
+    double homo_up = -std::numeric_limits<double>::infinity();
+    double lumo_up = std::numeric_limits<double>::infinity();
+    double homo_dw = -std::numeric_limits<double>::infinity();
+    double lumo_dw = std::numeric_limits<double>::infinity();
     for (int ib = 0; ib < nbands; ib++)
     {
         for (int ik = 0; ik < nks; ik++)
         {
             if (this->klist->isk[ik] == 0)
             {
-                if (!(this->ekb(ik, ib) - this->eferm.ef_up > 1e-5) && homo_up < this->ekb(ik, ib))
+                if (this->ekb(ik, ib) <= this->eferm.ef_up && this->ekb(ik, ib) > homo_up)
                 {
                     homo_up = this->ekb(ik, ib);
                 }
-                if (this->ekb(ik, ib) - this->eferm.ef_up > 1e-5 && lumo_up > this->ekb(ik, ib))
+                if (this->ekb(ik, ib) >= this->eferm.ef_up && this->ekb(ik, ib) < lumo_up)
                 {
                     lumo_up = this->ekb(ik, ib);
                 }
             }
             if (this->klist->isk[ik] == 1)
             {
-                if (!(this->ekb(ik, ib) - this->eferm.ef_dw > 1e-5) && homo_dw < this->ekb(ik, ib))
+                if (this->ekb(ik, ib) <= this->eferm.ef_dw && this->ekb(ik, ib) > homo_dw)
                 {
                     homo_dw = this->ekb(ik, ib);
                 }
-                if (this->ekb(ik, ib) - this->eferm.ef_dw > 1e-5 && lumo_dw > this->ekb(ik, ib))
+                if (this->ekb(ik, ib) >= this->eferm.ef_dw && this->ekb(ik, ib) < lumo_dw)
                 {
                     lumo_dw = this->ekb(ik, ib);
                 }
             }
         }
     }
+
+#ifdef __MPI
+    Parallel_Reduce::gather_max_double_all(GlobalV::NPROC, homo_up);
+    Parallel_Reduce::gather_min_double_all(GlobalV::NPROC, lumo_up);
+    Parallel_Reduce::gather_max_double_all(GlobalV::NPROC, homo_dw);
+    Parallel_Reduce::gather_min_double_all(GlobalV::NPROC, lumo_dw);
+#endif
+
     this->bandgap_up = lumo_up - homo_up;
     this->bandgap_dw = lumo_dw - homo_dw;
 }

--- a/source/source_estate/elecstate_energy.cpp
+++ b/source/source_estate/elecstate_energy.cpp
@@ -13,36 +13,36 @@ namespace elecstate
 void ElecState::cal_bandgap()
 {
     if (this->ekb.nr == 0 || this->ekb.nc == 0)
-    { // which means no homo and no lumo
+    { // which means no vbm and no cbm
         this->bandgap = 0.0;
         return;
     }
 
     int nbands = this->ekb.nc;
     int nks = this->klist->get_nks();
-    double homo = -std::numeric_limits<double>::infinity();
-    double lumo = std::numeric_limits<double>::infinity();
+    double vbm = -std::numeric_limits<double>::infinity(); // Valence Band Maximum
+    double cbm = std::numeric_limits<double>::infinity(); // Conduction Band Minimum
     for (int ib = 0; ib < nbands; ib++)
     {
         for (int ik = 0; ik < nks; ik++)
         {
-            if (this->ekb(ik, ib) <= this->eferm.ef && this->ekb(ik, ib) > homo)
+            if (this->ekb(ik, ib) <= this->eferm.ef && this->ekb(ik, ib) > vbm)
             {
-                homo = this->ekb(ik, ib);
+                vbm = this->ekb(ik, ib);
             }
-            if (this->ekb(ik, ib) >= this->eferm.ef && this->ekb(ik, ib) < lumo)
+            if (this->ekb(ik, ib) >= this->eferm.ef && this->ekb(ik, ib) < cbm)
             {
-                lumo = this->ekb(ik, ib);
+                cbm = this->ekb(ik, ib);
             }
         }
     }
 
 #ifdef __MPI
-    Parallel_Reduce::gather_max_double_all(GlobalV::NPROC, homo);
-    Parallel_Reduce::gather_min_double_all(GlobalV::NPROC, lumo);
+    Parallel_Reduce::gather_max_double_all(GlobalV::NPROC, vbm);
+    Parallel_Reduce::gather_min_double_all(GlobalV::NPROC, cbm);
 #endif
 
-    this->bandgap = lumo - homo;
+    this->bandgap = cbm - vbm;
 }
 
 /// @brief calculate spin up & down band gap
@@ -50,7 +50,7 @@ void ElecState::cal_bandgap()
 void ElecState::cal_bandgap_updw()
 {
     if (this->ekb.nr == 0 || this->ekb.nc == 0)
-    { // which means no homo and no lumo
+    { // which means no vbm and no cbm
         this->bandgap_up = 0.0;
         this->bandgap_dw = 0.0;
         return;
@@ -58,48 +58,48 @@ void ElecState::cal_bandgap_updw()
     // int nbands = PARAM.inp.nbands;
     int nbands = this->ekb.nc;
     int nks = this->klist->get_nks();
-    double homo_up = -std::numeric_limits<double>::infinity();
-    double lumo_up = std::numeric_limits<double>::infinity();
-    double homo_dw = -std::numeric_limits<double>::infinity();
-    double lumo_dw = std::numeric_limits<double>::infinity();
+    double vbm_up = -std::numeric_limits<double>::infinity();
+    double cbm_up = std::numeric_limits<double>::infinity();
+    double vbm_dw = -std::numeric_limits<double>::infinity();
+    double cbm_dw = std::numeric_limits<double>::infinity();
     for (int ib = 0; ib < nbands; ib++)
     {
         for (int ik = 0; ik < nks; ik++)
         {
             if (this->klist->isk[ik] == 0)
             {
-                if (this->ekb(ik, ib) <= this->eferm.ef_up && this->ekb(ik, ib) > homo_up)
+                if (this->ekb(ik, ib) <= this->eferm.ef_up && this->ekb(ik, ib) > vbm_up)
                 {
-                    homo_up = this->ekb(ik, ib);
+                    vbm_up = this->ekb(ik, ib);
                 }
-                if (this->ekb(ik, ib) >= this->eferm.ef_up && this->ekb(ik, ib) < lumo_up)
+                if (this->ekb(ik, ib) >= this->eferm.ef_up && this->ekb(ik, ib) < cbm_up)
                 {
-                    lumo_up = this->ekb(ik, ib);
+                    cbm_up = this->ekb(ik, ib);
                 }
             }
             if (this->klist->isk[ik] == 1)
             {
-                if (this->ekb(ik, ib) <= this->eferm.ef_dw && this->ekb(ik, ib) > homo_dw)
+                if (this->ekb(ik, ib) <= this->eferm.ef_dw && this->ekb(ik, ib) > vbm_dw)
                 {
-                    homo_dw = this->ekb(ik, ib);
+                    vbm_dw = this->ekb(ik, ib);
                 }
-                if (this->ekb(ik, ib) >= this->eferm.ef_dw && this->ekb(ik, ib) < lumo_dw)
+                if (this->ekb(ik, ib) >= this->eferm.ef_dw && this->ekb(ik, ib) < cbm_dw)
                 {
-                    lumo_dw = this->ekb(ik, ib);
+                    cbm_dw = this->ekb(ik, ib);
                 }
             }
         }
     }
 
 #ifdef __MPI
-    Parallel_Reduce::gather_max_double_all(GlobalV::NPROC, homo_up);
-    Parallel_Reduce::gather_min_double_all(GlobalV::NPROC, lumo_up);
-    Parallel_Reduce::gather_max_double_all(GlobalV::NPROC, homo_dw);
-    Parallel_Reduce::gather_min_double_all(GlobalV::NPROC, lumo_dw);
+    Parallel_Reduce::gather_max_double_all(GlobalV::NPROC, vbm_up);
+    Parallel_Reduce::gather_min_double_all(GlobalV::NPROC, cbm_up);
+    Parallel_Reduce::gather_max_double_all(GlobalV::NPROC, vbm_dw);
+    Parallel_Reduce::gather_min_double_all(GlobalV::NPROC, cbm_dw);
 #endif
 
-    this->bandgap_up = lumo_up - homo_up;
-    this->bandgap_dw = lumo_dw - homo_dw;
+    this->bandgap_up = cbm_up - vbm_up;
+    this->bandgap_dw = cbm_dw - vbm_dw;
 }
 
 /// @brief calculate deband


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #6601 

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
This PR fixes inconsistencies in parallel computation results. Below are two examples demonstrating the improvements:

1. K-points Parallelism (01_PW/004_PW_UPF201_Si, Si)

Before fix:

| kpar | E_bandgap (Ry) |
|------|----------------|
| 1    | 0.0298852541   |
| 2    | 0.1033124558   |
| 3    | 0.1762318244   |

After fix:

| kpar | E_bandgap (Ry) |
|------|----------------|
| 1    | 0.0298852541   |
| 2    | 0.0298852541   |
| 3    | 0.0298852541   |

3. Band Parallelism (11_PW_GPU/001_PW_BPCG_GPU, GaAs, run with CPU)

Before fix:

| nCPU | E_bandgap (Ry) |
|------|----------------|
| 1    | 0.0416524880   |
| 4    | inf   |

After fix:

| nCPU | E_bandgap (Ry) |
|------|----------------|
| 1    | 0.0416524880   |
| 4    | 0.0416513276   |

Results are now consistent across different parallel configurations

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
