### PR TITLE
Fix: adjust loop boundary in ESolver_LJ to include all adjacent atoms

### DIFF
--- a/source/source_esolver/esolver_lj.cpp
+++ b/source/source_esolver/esolver_lj.cpp
@@ -56,7 +56,7 @@ void ESolver_LJ::runner(UnitCell& ucell, const int istep)
         {
             tau1 = atom1->tau[ia];
             grid_neigh.Find_atom(ucell, tau1, it, ia);
-            for (int ad = 0; ad < grid_neigh.getAdjacentNum(); ++ad)
+            for (int ad = 0; ad < grid_neigh.getAdjacentNum() + 1; ++ad)
             {
                 tau2 = grid_neigh.getAdjacentTau(ad);
                 int it2 = grid_neigh.getType(ad);


### PR DESCRIPTION


### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #6654 

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
