### PR TITLE
Refactor: Modify the call to `Parallel_Orbital` in RT-TDDFT and remove unnecessary code in `ctrl_output_td`

### DIFF
--- a/source/source_esolver/esolver_ks_lcao_tddft.cpp
+++ b/source/source_esolver/esolver_ks_lcao_tddft.cpp
@@ -447,20 +447,20 @@ void ESolver_KS_LCAO_TDDFT<TR, Device>::after_scf(UnitCell& ucell, const int ist
     // Output energy for sub-loop (electronic step)
     std::cout << " Potential (Ry): " << std::setprecision(15) << this->pelec->f_en.etot << std::endl;
 
-    ModuleIO::ctrl_output_td<TR>(
-        ucell,
-        this->chr.rho_save,
-        this->chr.rhopw,
-        istep,
-        this->psi,
-        this->pelec,
-        this->kv,
-        this->two_center_bundle_.overlap_orb.get(),
-        dynamic_cast<const elecstate::ElecStateLCAO<std::complex<double>>*>(this->pelec)->get_DM()->get_paraV_pointer(),
-        this->orb_,
-        this->velocity_mat,
-        this->RA,
-        this->td_p);
+    // Output dipole, current, etc.
+    ModuleIO::ctrl_output_td<TR>(ucell,
+                                 this->chr.rho_save,
+                                 this->chr.rhopw,
+                                 istep,
+                                 this->psi,
+                                 this->pelec,
+                                 this->kv,
+                                 this->two_center_bundle_.overlap_orb.get(),
+                                 &this->pv,
+                                 this->orb_,
+                                 this->velocity_mat,
+                                 this->RA,
+                                 this->td_p);
 
     ModuleBase::timer::tick(this->classname, "after_scf");
 }

--- a/source/source_io/ctrl_output_td.cpp
+++ b/source/source_io/ctrl_output_td.cpp
@@ -25,61 +25,6 @@ void ctrl_output_td(const UnitCell& ucell,
 {
     ModuleBase::TITLE("ModuleIO", "ctrl_output_td");
 
-    // Original code commented out, might need reference later
-
-    // // (1) Write dipole information
-    // for (int is = 0; is < PARAM.inp.nspin; is++)
-    // {
-    //     if (PARAM.inp.out_dipole == 1)
-    //     {
-    //         std::stringstream ss_dipole;
-    //         ss_dipole << PARAM.globalv.global_out_dir << "dipole_s" << is + 1 << ".txt";
-    //         ModuleIO::write_dipole(ucell, this->chr.rho_save[is], this->chr.rhopw, is, istep, ss_dipole.str());
-    //     }
-    // }
-
-    // // (2) Write current information
-    // elecstate::DensityMatrix<std::complex<double>, double>* tmp_DM
-    //     = dynamic_cast<elecstate::ElecStateLCAO<std::complex<double>>*>(this->pelec)->get_DM();
-    // if (TD_info::out_current)
-    // {
-    //     if (TD_info::out_current_k)
-    //     {
-    //         ModuleIO::write_current_eachk(ucell,
-    //                                       istep,
-    //                                       this->psi,
-    //                                       this->pelec,
-    //                                       this->kv,
-    //                                       this->two_center_bundle_.overlap_orb.get(),
-    //                                       tmp_DM->get_paraV_pointer(),
-    //                                       this->orb_,
-    //                                       this->velocity_mat,
-    //                                       this->RA);
-    //     }
-    //     else
-    //     {
-    //         ModuleIO::write_current(ucell,
-    //                                 istep,
-    //                                 this->psi,
-    //                                 this->pelec,
-    //                                 this->kv,
-    //                                 this->two_center_bundle_.overlap_orb.get(),
-    //                                 tmp_DM->get_paraV_pointer(),
-    //                                 this->orb_,
-    //                                 this->velocity_mat,
-    //                                 this->RA);
-    //     }
-    // }
-
-    // // (3) Output file for restart
-    // if (PARAM.inp.out_freq_ion > 0) // default value of out_freq_ion is 0
-    // {
-    //     if (istep % PARAM.inp.out_freq_ion == 0)
-    //     {
-    //         td_p->out_restart_info(istep, elecstate::H_TDDFT_pw::At, elecstate::H_TDDFT_pw::At_laststep);
-    //     }
-    // }
-
 #ifdef __LCAO
     // (1) Write dipole information
     for (int is = 0; is < PARAM.inp.nspin; ++is)


### PR DESCRIPTION
### What's changed?
- Updated the call to `ModuleIO::ctrl_output_td` in `esolver_ks_lcao_tddft.cpp` to directly pass `&this->pv` instead of extracting a pointer from a dynamic cast.