### PR TITLE
Fix: Add template disambiguator for certain `Tensor` access in `ESolver_KS_LCAO_TDDFT`

### DIFF
--- a/source/source_esolver/esolver_ks_lcao_tddft.cpp
+++ b/source/source_esolver/esolver_ks_lcao_tddft.cpp
@@ -407,7 +407,7 @@ void ESolver_KS_LCAO_TDDFT<TR, Device>::store_h_s_psi(UnitCell& ucell,
                 BlasConnector::copy(len_HS_ik,
                                     h_mat_g.p.get(),
                                     1,
-                                    this->Hk_laststep.data<std::complex<double>>() + ik * len_HS_ik,
+                                    this->Hk_laststep.template data<std::complex<double>>() + ik * len_HS_ik,
                                     1);
 
                 // Collect S matrix
@@ -415,7 +415,7 @@ void ESolver_KS_LCAO_TDDFT<TR, Device>::store_h_s_psi(UnitCell& ucell,
                 BlasConnector::copy(len_HS_ik,
                                     s_mat_g.p.get(),
                                     1,
-                                    this->Sk_laststep.data<std::complex<double>>() + ik * len_HS_ik,
+                                    this->Sk_laststep.template data<std::complex<double>>() + ik * len_HS_ik,
                                     1);
 #endif
             }
@@ -424,12 +424,12 @@ void ESolver_KS_LCAO_TDDFT<TR, Device>::store_h_s_psi(UnitCell& ucell,
                 BlasConnector::copy(len_HS_ik,
                                     h_mat.p,
                                     1,
-                                    this->Hk_laststep.data<std::complex<double>>() + ik * len_HS_ik,
+                                    this->Hk_laststep.template data<std::complex<double>>() + ik * len_HS_ik,
                                     1);
                 BlasConnector::copy(len_HS_ik,
                                     s_mat.p,
                                     1,
-                                    this->Sk_laststep.data<std::complex<double>>() + ik * len_HS_ik,
+                                    this->Sk_laststep.template data<std::complex<double>>() + ik * len_HS_ik,
                                     1);
             }
         }


### PR DESCRIPTION
### What's changed?
 - Adds the `template` keyword when calling the `data<std::complex<double>>()` method on `Hk_laststep` and `Sk_laststep`, resolving potential compilation issues with dependent types in templated code.