### PR TITLE
Add iostream include to cusolver.h

### DIFF
--- a/source/source_base/module_container/base/third_party/cusolver.h
+++ b/source/source_base/module_container/base/third_party/cusolver.h
@@ -3,6 +3,7 @@
 
 #include <cublas_v2.h>
 #include <cuda_runtime.h>
+#include <iostream>
 
 // #include <base/third_party/cusolver_utils.h> // traits, needed if generic API is used.
 // header provided by cusolver, including some data types and macros.


### PR DESCRIPTION
Added #include <iostream> to fix compilation errors related to std::cout.
![img_v3_02rt_edb7d457-c0ae-4433-9b65-3b35413580bg](https://github.com/user-attachments/assets/7a4858fd-20ed-4a7c-b262-897ebed1ac94)

### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)
