### PR TITLE
Fix: fix a bug caused by intel compiler

### DIFF
--- a/source/source_base/ylm.cpp
+++ b/source/source_base/ylm.cpp
@@ -808,9 +808,9 @@ void Ylm::rl_sph_harm
 void Ylm::grad_rl_sph_harm
 (
  	const int& Lmax, //max momentum of L
- 	const double& x,
-	const double& y,
-	const double& z,
+ 	const double x,
+	const double y,
+	const double z,
 	double* rly,
 	double** grly
 )

--- a/source/source_base/ylm.cpp
+++ b/source/source_base/ylm.cpp
@@ -324,10 +324,10 @@ void Ylm::get_ylm_real( const int &Lmax, const ModuleBase::Vector3<double> &vec,
  * *************************/
 void Ylm::rlylm
 (
- 	const int& Lmax, //max momentum of l + 1
- 	const double& x,
-	const double& y,
-	const double& z,
+ 	const int Lmax, //max momentum of l + 1
+ 	const double x,
+	const double y,
+	const double z,
 	double rly[]
 )
 {
@@ -529,10 +529,10 @@ void Ylm::rlylm
 //return ylm, not rlylm
 void Ylm::sph_harm
 (
- 	const int& Lmax, //max momentum of l
- 	const double& xdr,
-	const double& ydr,
-	const double& zdr,
+ 	const int Lmax, //max momentum of l
+ 	const double xdr,
+	const double ydr,
+	const double zdr,
 	std::vector<double> &rly
 )
 {
@@ -668,10 +668,10 @@ void Ylm::sph_harm
 // Peize Lin change rly 2016-08-26
 void Ylm::rl_sph_harm
 (
- 	const int& Lmax, //max momentum of L
- 	const double& x,
-	const double& y,
-	const double& z,
+ 	const int Lmax, //max momentum of L
+ 	const double x,
+	const double y,
+	const double z,
 	std::vector<double>& rly
 )
 {
@@ -807,7 +807,7 @@ void Ylm::rl_sph_harm
 
 void Ylm::grad_rl_sph_harm
 (
- 	const int& Lmax, //max momentum of L
+ 	const int Lmax, //max momentum of L
  	const double x,
 	const double y,
 	const double z,
@@ -1097,10 +1097,10 @@ void Ylm::grad_rl_sph_harm
 
 void Ylm::hes_rl_sph_harm
 (
- 	const int& Lmax, //max momentum of L
- 	const double& x,
-	const double& y,
-	const double& z,
+ 	const int Lmax, //max momentum of L
+ 	const double x,
+	const double y,
+	const double z,
 	std::vector<std::vector<double>>& hrly
 )
 {
@@ -1394,10 +1394,10 @@ void Ylm::test2 (void)
 
 void Ylm::rlylm
 (
- 	const int& Lmax, //max momentum of l + 1
- 	const double& x,
-	const double& y,
-	const double& z,
+ 	const int Lmax, //max momentum of l + 1
+ 	const double x,
+	const double y,
+	const double z,
 	double rly[],
 	double grly[][3]
 )

--- a/source/source_base/ylm.h
+++ b/source/source_base/ylm.h
@@ -124,9 +124,9 @@ class Ylm
 	 */
 	static void grad_rl_sph_harm(
 			const int& Lmax,
-			const double& x,
-			const double& y,
-			const double& z,
+			const double x,
+			const double y,
+			const double z,
 			double* rly,
 			double** grly);
 

--- a/source/source_base/ylm.h
+++ b/source/source_base/ylm.h
@@ -53,10 +53,10 @@ class Ylm
 	 * @param rly [in] calculated Ylm, Y00, Y10, Y11, Y1-1, Y20, Y21, Y2-1, Y22, Y2-2...
 	 */
 	static void rlylm(
-			const int& Lmax, 
-			const double& x,
-			const double& y,
-			const double& z,
+			const int Lmax, 
+			const double x,
+			const double y,
+			const double z,
 			double rly[]);
 
 	/**
@@ -70,10 +70,10 @@ class Ylm
 	 * @param grly [out] gradient of Ylm, [dY00/dx, dY00/dy, dY00/dz], [dY10/dx, dY10/dy, dY10/dz], [dY11/dx, dY11/dy, dY11/dz],...
 	 */
 	static void rlylm(
-			const int& Lmax, 
-			const double& x,
-			const double& y,
-			const double& z,
+			const int Lmax, 
+			const double x,
+			const double y,
+			const double z,
 			double rly[],
 			double grly[][3]);
 
@@ -87,10 +87,10 @@ class Ylm
 	 * @param rly [in] calculated Ylm, Y00, Y10, Y11, Y1-1, Y20, Y21, Y2-1, Y22, Y2-2...
 	 */
 	static void sph_harm(
-			const int& Lmax,
-			const double& xdr,
-			const double& ydr,
-			const double& zdr,
+			const int Lmax,
+			const double xdr,
+			const double ydr,
+			const double zdr,
 			std::vector<double> &rly);
 	
 	/**
@@ -105,10 +105,10 @@ class Ylm
 	 * @date 2016-08-26
 	 */
 	static void rl_sph_harm(
-			const int& Lmax,
-			const double& x,
-			const double& y,
-			const double& z,
+			const int Lmax,
+			const double x,
+			const double y,
+			const double z,
 			std::vector<double>& rly);
 	
 	/**
@@ -123,7 +123,7 @@ class Ylm
 	 *             grly should be a memory-contiguous two-dimensional array for better performance.
 	 */
 	static void grad_rl_sph_harm(
-			const int& Lmax,
+			const int Lmax,
 			const double x,
 			const double y,
 			const double z,
@@ -140,10 +140,10 @@ class Ylm
 	 * @param hrly [out] hessian of Ylm, [dY00/dx2, dY00/dxy, dY00/dxz, dY00/dyy, dY00/dyz, dY00/dzz] , ...
 	 */
 	static void hes_rl_sph_harm(
-			const int& Lmax,
-			const double& x,
-			const double& y,
-			const double& z,
+			const int Lmax,
+			const double x,
+			const double y,
+			const double z,
 			std::vector<std::vector<double>>& hrly);
 
 	//calculate the coefficient of Ylm, ylmcoef.		


### PR DESCRIPTION
### Linked Issue
Fix #6698 

### What's changed?
- When using the Intel compiler, the force calculation results for the test case `02_NAO_Gamma/020_NO_GO_SCAN_Si2` are incorrect. Testing revealed that this is due to an error in the computation of `grad_rl_sph_harm`. Moreover, the way to fix it is quite unusual, leading me to suspect that this issue stems from a bug within the Intel compiler itself. Anyway, this PR resolves the problem.

