### PR TITLE
Fix the search radius for calculating angular momentum matrices

### DIFF
--- a/source/source_io/ctrl_scf_lcao.cpp
+++ b/source/source_io/ctrl_scf_lcao.cpp
@@ -278,7 +278,7 @@ void ModuleIO::ctrl_scf_lcao(UnitCell& ucell,
         ModuleIO::AngularMomentumCalculator mylcalculator(
             inp.orbital_dir,
             ucell,
-            inp.search_radius,
+            orb.get_rcutmax_Phi(),
             inp.test_deconstructor,
             inp.test_grid,
             inp.test_atom_input,


### PR DESCRIPTION
fix #6701 