### PR TITLE
Changed the positions of the template class declarations in `rdmft_tools.cpp`

### DIFF
--- a/source/source_lcao/module_rdmft/rdmft_tools.cpp
+++ b/source/source_lcao/module_rdmft/rdmft_tools.cpp
@@ -186,13 +186,6 @@ double occNum_func(const double eta, const int symbol, const std::string XC_func
     
 }
 
-
-template class Veff_rdmft<double, double>;
-
-template class Veff_rdmft<std::complex<double>, double>;
-
-template class Veff_rdmft<std::complex<double>, std::complex<double>>;
-
 // this part of the code is copying from class Veff
 // initialize_HR()
 template <typename TK, typename TR>
@@ -399,6 +392,10 @@ void Veff_rdmft<double, double>::contributeHR()
 }
 
 }
+template class rdmft::Veff_rdmft<double, double>;
 
+template class rdmft::Veff_rdmft<std::complex<double>, double>;
+
+template class rdmft::Veff_rdmft<std::complex<double>, std::complex<double>>;
 
 


### PR DESCRIPTION
Thanks for @Shen-Zhen-Xiong 's findings. We have moved the template class declarations of `Veff_rdmft` to the end of the `rdmft_tools.cpp`.


### Linked Issue
Fix #6700 
