### PR TITLE
Update Cereal URL in FindCereal.cmake

### DIFF
--- a/cmake/FindCereal.cmake
+++ b/cmake/FindCereal.cmake
@@ -15,7 +15,7 @@ if(NOT CEREAL_INCLUDE_DIR)
     include(FetchContent)
     FetchContent_Declare(
         cereal
-        URL https://codeload.github.com/USCiLab/cereal/tar.gz/master
+        URL https://codeload.github.com/MCresearch/cereal/tar.gz/master
     )
     FetchContent_Populate(cereal)
     set(CEREAL_INCLUDE_DIR ${cereal_SOURCE_DIR}/include)


### PR DESCRIPTION
This PR is also related to https://github.com/USCiLab/cereal/issues/852 and Issue #6190 
### Linked Issue
Fix #6713 

### What's changed?
Try to use a patched version of Cereal.