### PR TITLE
[Fix] Remove useless code in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -616,10 +616,6 @@ if(ENABLE_LIBCOMM)
 endif()
 
 
-
-list(APPEND math_libs m)
-target_link_libraries(${ABACUS_BIN_NAME} ${math_libs})
-
 if(DEFINED Libxc_DIR)
   set(ENABLE_LIBXC ON)
 endif()


### PR DESCRIPTION
I found that I forgot to remove some code in CMakeLists when trying to fix the compiling problem. This will not affect the actual compiling process but leaving them there is not elegant. This pr removes them.
