### PR TITLE
Fix: remove gamma_only_local as para of write_rhog

### DIFF
--- a/source/source_esolver/esolver_fp.cpp
+++ b/source/source_esolver/esolver_fp.cpp
@@ -161,7 +161,7 @@ void ESolver_FP::iter_finish(UnitCell& ucell, const int istep, int& iter, bool& 
                 this->pw_rhod->real2recip(this->chr.rho_save[is], this->chr.rhog_save[is]);
             }
             ModuleIO::write_rhog(PARAM.globalv.global_out_dir + PARAM.inp.suffix + "-CHARGE-DENSITY.restart",
-                                 PARAM.globalv.gamma_only_pw || PARAM.globalv.gamma_only_local,
+                                 PARAM.globalv.gamma_only_pw,
                                  this->pw_rhod,
                                  PARAM.inp.nspin,
                                  ucell.GT,
@@ -180,7 +180,7 @@ void ESolver_FP::iter_finish(UnitCell& ucell, const int istep, int& iter, bool& 
                     this->pw_rhod->real2recip(this->chr.kin_r_save[is], kin_g[is]);
                 }
                 ModuleIO::write_rhog(PARAM.globalv.global_out_dir + PARAM.inp.suffix + "-TAU-DENSITY.restart",
-                                     PARAM.globalv.gamma_only_pw || PARAM.globalv.gamma_only_local,
+                                     PARAM.globalv.gamma_only_pw,
                                      this->pw_rhod,
                                      PARAM.inp.nspin,
                                      ucell.GT,


### PR DESCRIPTION
### What's changed?
- The `gamma only` in reading binary chg file is actually the gamma only algorithm instead of gamma only in LCAO, so the `gamma_only_local ` should be removed.