### PR TITLE
Fix: Change int to long long in save_sparse to avoid overflow.

### DIFF
--- a/source/source_base/parallel_reduce.cpp
+++ b/source/source_base/parallel_reduce.cpp
@@ -13,6 +13,15 @@ void Parallel_Reduce::reduce_all<int>(int& object)
     return;
 }
 
+template <>
+void Parallel_Reduce::reduce_all<long long>(long long& object)
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+#endif
+    return;
+}
+
 void Parallel_Reduce::reduce_int_diag(int& object)
 {
 #ifdef __MPI
@@ -44,6 +53,15 @@ void Parallel_Reduce::reduce_all<int>(int* object, const int n)
 {
 #ifdef __MPI
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+#endif
+    return;
+}
+
+template <>
+void Parallel_Reduce::reduce_all<long long>(long long* object, const int n)
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
 #endif
     return;
 }

--- a/source/source_io/single_R_io.cpp
+++ b/source/source_io/single_R_io.cpp
@@ -23,7 +23,7 @@ void ModuleIO::output_single_R(std::ofstream& ofs,
     const bool& reduce)
 {
     T* line = nullptr;
-    std::vector<int> indptr;
+    std::vector<long long> indptr;
     indptr.reserve(PARAM.globalv.nlocal + 1);
     indptr.push_back(0);
 

--- a/source/source_io/write_HS_sparse.cpp
+++ b/source/source_io/write_HS_sparse.cpp
@@ -716,7 +716,7 @@ void ModuleIO::save_sparse(
     ModuleBase::timer::tick("ModuleIO", "save_sparse");
 
     int total_R_num = all_R_coor.size();
-    std::vector<int> nonzero_num(total_R_num, 0);
+    std::vector<long long> nonzero_num(total_R_num, 0);
     int count = 0;
     for (auto& R_coor: all_R_coor) {
         auto iter = smat.find(R_coor);


### PR DESCRIPTION
### Linked Issue
Fix #6730

### What's changed?
- Change int to long long in save_sparse to avoid overflow.
