### PR TITLE
Feature: Support RT-TDDFT EDM (energy-density matrix) calculation on GPU

### DIFF
--- a/source/source_esolver/esolver_ks_lcao_tddft.cpp
+++ b/source/source_esolver/esolver_ks_lcao_tddft.cpp
@@ -264,8 +264,13 @@ void ESolver_KS_LCAO_TDDFT<TR, Device>::hamilt2rho_single(UnitCell& ucell,
         {
             bool skip_charge = PARAM.inp.calculation == "nscf" ? true : false;
             hsolver::HSolverLCAO<std::complex<double>> hsolver_lcao_obj(&this->pv, PARAM.inp.ks_solver);
-			hsolver_lcao_obj.solve(this->p_hamilt, this->psi[0], this->pelec, *this->dmat.dm, 
-					this->chr, PARAM.inp.nspin, skip_charge);
+            hsolver_lcao_obj.solve(this->p_hamilt,
+                                   this->psi[0],
+                                   this->pelec,
+                                   *this->dmat.dm,
+                                   this->chr,
+                                   PARAM.inp.nspin,
+                                   skip_charge);
         }
     }
 
@@ -318,7 +323,14 @@ void ESolver_KS_LCAO_TDDFT<TR, Device>::iter_finish(UnitCell& ucell,
     if (conv_esolver && estep == estep_max - 1 && istep >= (PARAM.inp.init_wfc == "file" ? 0 : 1)
         && PARAM.inp.td_edm == 0)
     {
-        elecstate::cal_edm_tddft_tensor(this->pv, this->dmat, this->kv, this->p_hamilt);
+        if (use_tensor && use_lapack)
+        {
+            elecstate::cal_edm_tddft_tensor_lapack<Device>(this->pv, this->dmat, this->kv, this->p_hamilt);
+        }
+        else
+        {
+            elecstate::cal_edm_tddft(this->pv, this->dmat, this->kv, this->p_hamilt);
+        }
     }
 }
 
@@ -434,7 +446,7 @@ void ESolver_KS_LCAO_TDDFT<TR, Device>::store_h_s_psi(UnitCell& ucell,
                                     1);
             } // end use_tensor
         } // end ik
-    }// conv_esolver
+    } // conv_esolver
 }
 
 template <typename TR, typename Device>
@@ -483,7 +495,7 @@ void ESolver_KS_LCAO_TDDFT<TR, Device>::weight_dm_rho(const UnitCell& ucell)
     elecstate::calEBand(this->pelec->ekb, this->pelec->wg, this->pelec->f_en);
 
     elecstate::cal_dm_psi(this->dmat.dm->get_paraV_pointer(), this->pelec->wg, this->psi[0], *this->dmat.dm);
-    if(PARAM.inp.td_stype == 2)
+    if (PARAM.inp.td_stype == 2)
     {
         this->dmat.dm->cal_DMR_td(ucell, TD_info::cart_At);
     }

--- a/source/source_estate/module_dm/cal_edm_tddft.cpp
+++ b/source/source_estate/module_dm/cal_edm_tddft.cpp
@@ -8,6 +8,8 @@
 #include "source_base/module_external/lapack_connector.h"
 #include "source_base/module_external/scalapack_connector.h"
 #include "source_io/module_parameter/parameter.h" // use PARAM.globalv
+#include "source_lcao/module_rt/gather_mat.h"     // gatherMatrix and distributeMatrix
+#include "source_lcao/module_rt/propagator.h"     // Include header for create_identity_matrix
 
 namespace elecstate
 {
@@ -149,6 +151,7 @@ void cal_edm_tddft(Parallel_Orbitals& pv,
         const std::complex<double> zero_complex = {0.0, 0.0};
         const std::complex<double> half_complex = {0.5, 0.0};
 
+        // tmp1 = Htmp * Sinv
         ScalapackConnector::gemm(N_char,
                                  N_char,
                                  nlocal,
@@ -169,6 +172,7 @@ void cal_edm_tddft(Parallel_Orbitals& pv,
                                  one_int,
                                  pv.desc);
 
+        // tmp2 = tmp1^T * tmp_dmk
         ScalapackConnector::gemm(T_char,
                                  N_char,
                                  nlocal,
@@ -189,6 +193,7 @@ void cal_edm_tddft(Parallel_Orbitals& pv,
                                  one_int,
                                  pv.desc);
 
+        // tmp3 = Sinv * Htmp
         ScalapackConnector::gemm(N_char,
                                  N_char,
                                  nlocal,
@@ -209,6 +214,7 @@ void cal_edm_tddft(Parallel_Orbitals& pv,
                                  one_int,
                                  pv.desc);
 
+        // tmp4 = tmp_dmk * tmp3^T
         ScalapackConnector::gemm(N_char,
                                  T_char,
                                  nlocal,
@@ -229,6 +235,7 @@ void cal_edm_tddft(Parallel_Orbitals& pv,
                                  one_int,
                                  pv.desc);
 
+        // tmp4 = 0.5 * (tmp2 + tmp4)
         ScalapackConnector::geadd(N_char,
                                   nlocal,
                                   nlocal,
@@ -360,12 +367,16 @@ void cal_edm_tddft_tensor(Parallel_Orbitals& pv,
         BlasConnector::copy(nloc, h_mat.p, inc, Htmp_ptr, inc);
         BlasConnector::copy(nloc, s_mat.p, inc, Sinv_ptr, inc);
 
+        int myid = 0;
+        const int root_proc = 0;
+        MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+
         // --- ScaLAPACK Inversion of S ---
-        ct::Tensor ipiv_tensor(ct::DataType::DT_INT,
-                               ct::DeviceType::CpuDevice,
-                               ct::TensorShape({pv.nrow + pv.nb})); // Size for ScaLAPACK pivot array
-        ipiv_tensor.zero();
-        int* ipiv_ptr = ipiv_tensor.data<int>();
+        ct::Tensor ipiv(ct::DataType::DT_INT,
+                        ct::DeviceType::CpuDevice,
+                        ct::TensorShape({pv.nrow + pv.nb})); // Size for ScaLAPACK pivot array
+        ipiv.zero();
+        int* ipiv_ptr = ipiv.data<int>();
 
         int info = 0;
         const int one_int = 1;
@@ -373,8 +384,8 @@ void cal_edm_tddft_tensor(Parallel_Orbitals& pv,
 
         int lwork = -1;
         int liwork = -1;
-        ct::Tensor work_query_tensor(ct::DataType::DT_COMPLEX_DOUBLE, ct::DeviceType::CpuDevice, ct::TensorShape({1}));
-        ct::Tensor iwork_query_tensor(ct::DataType::DT_INT, ct::DeviceType::CpuDevice, ct::TensorShape({1}));
+        ct::Tensor work_query(ct::DataType::DT_COMPLEX_DOUBLE, ct::DeviceType::CpuDevice, ct::TensorShape({1}));
+        ct::Tensor iwork_query(ct::DataType::DT_INT, ct::DeviceType::CpuDevice, ct::TensorShape({1}));
 
         ScalapackConnector::getri(nlocal,
                                   Sinv_ptr,
@@ -382,17 +393,17 @@ void cal_edm_tddft_tensor(Parallel_Orbitals& pv,
                                   one_int,
                                   pv.desc,
                                   ipiv_ptr,
-                                  work_query_tensor.data<std::complex<double>>(),
+                                  work_query.data<std::complex<double>>(),
                                   &lwork,
-                                  iwork_query_tensor.data<int>(),
+                                  iwork_query.data<int>(),
                                   &liwork,
                                   &info);
 
         // Resize work arrays based on query results
-        lwork = work_query_tensor.data<std::complex<double>>()[0].real();
-        work_query_tensor.resize(ct::TensorShape({lwork}));
-        liwork = iwork_query_tensor.data<int>()[0];
-        iwork_query_tensor.resize(ct::TensorShape({liwork}));
+        lwork = work_query.data<std::complex<double>>()[0].real();
+        work_query.resize(ct::TensorShape({lwork}));
+        liwork = iwork_query.data<int>()[0];
+        iwork_query.resize(ct::TensorShape({liwork}));
 
         ScalapackConnector::getri(nlocal,
                                   Sinv_ptr,
@@ -400,9 +411,9 @@ void cal_edm_tddft_tensor(Parallel_Orbitals& pv,
                                   one_int,
                                   pv.desc,
                                   ipiv_ptr,
-                                  work_query_tensor.data<std::complex<double>>(),
+                                  work_query.data<std::complex<double>>(),
                                   &lwork,
-                                  iwork_query_tensor.data<int>(),
+                                  iwork_query.data<int>(),
                                   &liwork,
                                   &info);
 
@@ -413,18 +424,18 @@ void cal_edm_tddft_tensor(Parallel_Orbitals& pv,
         const std::complex<double> zero_complex = {0.0, 0.0};
         const std::complex<double> half_complex = {0.5, 0.0};
 
-        // tmp1 = Sinv * Htmp (result stored in tmp1)
+        // tmp1 = Htmp * Sinv
         ScalapackConnector::gemm(N_char,
                                  N_char,
                                  nlocal,
                                  nlocal,
                                  nlocal,
                                  one_complex,
-                                 Sinv_ptr,
+                                 Htmp_ptr,
                                  one_int,
                                  one_int,
                                  pv.desc,
-                                 Htmp_ptr,
+                                 Sinv_ptr,
                                  one_int,
                                  one_int,
                                  pv.desc,
@@ -434,8 +445,8 @@ void cal_edm_tddft_tensor(Parallel_Orbitals& pv,
                                  one_int,
                                  pv.desc);
 
-        // tmp2 = tmp1 * tmp_dmk (result stored in tmp2)
-        ScalapackConnector::gemm(N_char,
+        // tmp2 = tmp1^T * tmp_dmk
+        ScalapackConnector::gemm(T_char,
                                  N_char,
                                  nlocal,
                                  nlocal,
@@ -455,18 +466,18 @@ void cal_edm_tddft_tensor(Parallel_Orbitals& pv,
                                  one_int,
                                  pv.desc);
 
-        // tmp3 = Htmp * Sinv (result stored in tmp3)
+        // tmp3 = Sinv * Htmp
         ScalapackConnector::gemm(N_char,
                                  N_char,
                                  nlocal,
                                  nlocal,
                                  nlocal,
                                  one_complex,
-                                 Htmp_ptr,
+                                 Sinv_ptr,
                                  one_int,
                                  one_int,
                                  pv.desc,
-                                 Sinv_ptr,
+                                 Htmp_ptr,
                                  one_int,
                                  one_int,
                                  pv.desc,
@@ -476,9 +487,9 @@ void cal_edm_tddft_tensor(Parallel_Orbitals& pv,
                                  one_int,
                                  pv.desc);
 
-        // tmp4 = tmp_dmk * tmp3 (result stored in tmp4)
+        // tmp4 = tmp_dmk * tmp3^T
         ScalapackConnector::gemm(N_char,
-                                 N_char,
+                                 T_char,
                                  nlocal,
                                  nlocal,
                                  nlocal,
@@ -497,7 +508,7 @@ void cal_edm_tddft_tensor(Parallel_Orbitals& pv,
                                  one_int,
                                  pv.desc);
 
-        // tmp4 = 0.5 * tmp2 + 0.5 * tmp4 (final EDM contribution)
+        // tmp4 = 0.5 * (tmp2 + tmp4)
         ScalapackConnector::geadd(N_char,
                                   nlocal,
                                   nlocal,
@@ -516,42 +527,280 @@ void cal_edm_tddft_tensor(Parallel_Orbitals& pv,
         BlasConnector::copy(nloc, tmp4_ptr, inc, tmp_edmk.c, inc);
 
 #else
-        // Serial version remains unchanged, using ModuleBase::ComplexMatrix directly
-        tmp_edmk.create(pv.ncol, pv.nrow);
-        ModuleBase::ComplexMatrix Sinv(nlocal, nlocal);
-        ModuleBase::ComplexMatrix Htmp(nlocal, nlocal);
-        hamilt::MatrixBlock<std::complex<double>> h_mat;
-        hamilt::MatrixBlock<std::complex<double>> s_mat;
-        p_hamilt->matrix(h_mat, s_mat);
-        for (int i = 0; i < nlocal; i++)
-        {
-            for (int j = 0; j < nlocal; j++)
-            {
-                Htmp(i, j) = h_mat.p[i * nlocal + j];
-                Sinv(i, j) = s_mat.p[i * nlocal + j];
-            }
-        }
-        int INFO = 0;
-        int lwork = 3 * nlocal - 1; // tmp
-        std::complex<double>* work = new std::complex<double>[lwork];
-        ModuleBase::GlobalFunc::ZEROS(work, lwork);
-        int IPIV[nlocal];
-        LapackConnector::zgetrf(nlocal, nlocal, Sinv, nlocal, IPIV, &INFO);
-        LapackConnector::zgetri(nlocal, Sinv, nlocal, IPIV, work, lwork, &INFO);
-        ModuleBase::ComplexMatrix tmp_dmk_base(nlocal, nlocal);
-        for (int i = 0; i < nlocal; i++)
-        {
-            for (int j = 0; j < nlocal; j++)
-            {
-                tmp_dmk_base(i, j) = tmp_dmk[i * nlocal + j];
-            }
-        }
-        tmp_edmk = 0.5 * (Sinv * Htmp * tmp_dmk_base + tmp_dmk_base * Htmp * Sinv);
-        delete[] work;
+        ModuleBase::WARNING_QUIT("elecstate::cal_edm_tddft_tensor", "MPI is required for this function!");
 #endif
     } // end ik
     ModuleBase::timer::tick("elecstate", "cal_edm_tddft_tensor");
     return;
 } // cal_edm_tddft_tensor
+
+// Template function for EDM calculation supporting CPU and GPU
+template <typename Device>
+void cal_edm_tddft_tensor_lapack(Parallel_Orbitals& pv,
+                                 LCAO_domain::Setup_DM<std::complex<double>>& dmat,
+                                 K_Vectors& kv,
+                                 hamilt::Hamilt<std::complex<double>>* p_hamilt)
+{
+    ModuleBase::timer::tick("elecstate", "cal_edm_tddft_tensor_lapack");
+
+    const int nlocal = PARAM.globalv.nlocal;
+    assert(nlocal >= 0);
+    dmat.dm->EDMK.resize(kv.get_nks());
+
+    // ct_device_type = ct::DeviceType::CpuDevice or ct::DeviceType::GpuDevice
+    ct::DeviceType ct_device_type = ct::DeviceTypeToEnum<Device>::value;
+    // ct_Device = ct::DEVICE_CPU or ct::DEVICE_GPU
+    using ct_Device = typename ct::PsiToContainer<Device>::type;
+
+#if ((defined __CUDA) /* || (defined __ROCM) */)
+    if (ct_device_type == ct::DeviceType::GpuDevice)
+    {
+        // Initialize cuBLAS & cuSOLVER handle
+        ct::kernels::createGpuSolverHandle();
+        ct::kernels::createGpuBlasHandle();
+    }
+#endif // __CUDA
+
+    for (int ik = 0; ik < kv.get_nks(); ++ik)
+    {
+        p_hamilt->updateHk(ik);
+        std::complex<double>* tmp_dmk_local = dmat.dm->get_DMK_pointer(ik);
+        ModuleBase::ComplexMatrix& tmp_edmk = dmat.dm->EDMK[ik];
+
+#ifdef __MPI
+        int myid = 0;
+        const int root_proc = 0;
+        MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+
+        // Gather local H, S, and DMK matrices to global matrices on root process
+        hamilt::MatrixBlock<std::complex<double>> h_mat_local, s_mat_local;
+        p_hamilt->matrix(h_mat_local, s_mat_local);
+
+        module_rt::Matrix_g<std::complex<double>> h_mat_global, s_mat_global, dmk_global;
+        module_rt::gatherMatrix(myid, root_proc, h_mat_local, h_mat_global);
+        module_rt::gatherMatrix(myid, root_proc, s_mat_local, s_mat_global);
+
+        // Create a temporary MatrixBlock for local DMK
+        hamilt::MatrixBlock<std::complex<double>> dmk_local_block;
+        dmk_local_block.p = tmp_dmk_local;
+        dmk_local_block.desc = pv.desc;
+        module_rt::gatherMatrix(myid, root_proc, dmk_local_block, dmk_global);
+
+        // Declare and allocate global EDM matrix on ALL processes, prepare for distribution in the end
+        module_rt::Matrix_g<std::complex<double>> edm_global;
+        edm_global.p.reset(new std::complex<double>[nlocal * nlocal]);
+        edm_global.row = nlocal;
+        edm_global.col = nlocal;
+        // Set the descriptor of the global EDM matrix
+        edm_global.desc.reset(new int[9]{1, pv.desc[1], nlocal, nlocal, nlocal, nlocal, 0, 0, nlocal});
+
+        // Only root process performs the global calculation
+        if (myid == root_proc)
+        {
+            ct::Tensor Htmp_global(ct::DataType::DT_COMPLEX_DOUBLE,
+                                   ct::DeviceType::CpuDevice,
+                                   ct::TensorShape({nlocal, nlocal}));
+            ct::Tensor S_global(ct::DataType::DT_COMPLEX_DOUBLE,
+                                ct::DeviceType::CpuDevice,
+                                ct::TensorShape({nlocal, nlocal}));
+            ct::Tensor DMK_global(ct::DataType::DT_COMPLEX_DOUBLE,
+                                  ct::DeviceType::CpuDevice,
+                                  ct::TensorShape({nlocal, nlocal}));
+
+            // Copy gathered data into tensors
+            BlasConnector::copy(nlocal * nlocal,
+                                h_mat_global.p.get(),
+                                1,
+                                Htmp_global.template data<std::complex<double>>(),
+                                1);
+            BlasConnector::copy(nlocal * nlocal,
+                                s_mat_global.p.get(),
+                                1,
+                                S_global.template data<std::complex<double>>(),
+                                1);
+            BlasConnector::copy(nlocal * nlocal,
+                                dmk_global.p.get(),
+                                1,
+                                DMK_global.template data<std::complex<double>>(),
+                                1);
+
+            // Move tensors to the target device (CPU or GPU)
+            ct::Tensor Htmp_global_dev = Htmp_global.to_device<ct_Device>();
+            ct::Tensor S_global_dev = S_global.to_device<ct_Device>();
+            ct::Tensor DMK_global_dev = DMK_global.to_device<ct_Device>();
+
+            // --- Calculate S^-1 using getrf + getrs ---
+            ct::Tensor ipiv(ct::DataType::DT_INT, ct_device_type, ct::TensorShape({nlocal}));
+            ipiv.zero();
+
+            // 1. LU decomposition S = P * L * U
+            ct::kernels::lapack_getrf<std::complex<double>, ct_Device>()(
+                nlocal,
+                nlocal,
+                S_global_dev.template data<std::complex<double>>(),
+                nlocal,
+                ipiv.template data<int>());
+
+            // 2. Solve S * Sinv = I for Sinv using the LU decomposition
+            // Create identity matrix as RHS
+            auto Sinv_global = module_rt::create_identity_matrix<std::complex<double>>(nlocal, ct_device_type);
+
+            ct::kernels::lapack_getrs<std::complex<double>, ct_Device>()(
+                'N',
+                nlocal,
+                nlocal,
+                S_global_dev.template data<std::complex<double>>(),
+                nlocal,
+                ipiv.template data<int>(),
+                Sinv_global.template data<std::complex<double>>(),
+                nlocal);
+
+            // --- EDM Calculation using BLAS on global tensors ---
+            // tmp1 = Htmp * Sinv
+            ct::Tensor tmp1_global_tensor(ct::DataType::DT_COMPLEX_DOUBLE,
+                                          ct_device_type,
+                                          ct::TensorShape({nlocal, nlocal}));
+            tmp1_global_tensor.zero();
+            std::complex<double> one_complex = {1.0, 0.0};
+            std::complex<double> zero_complex = {0.0, 0.0};
+            ct::kernels::blas_gemm<std::complex<double>, ct_Device>()(
+                'N',
+                'N',
+                nlocal,
+                nlocal,
+                nlocal,
+                &one_complex,
+                Htmp_global_dev.template data<std::complex<double>>(),
+                nlocal,
+                Sinv_global.template data<std::complex<double>>(),
+                nlocal,
+                &zero_complex,
+                tmp1_global_tensor.template data<std::complex<double>>(),
+                nlocal);
+
+            // tmp2 = tmp1^T * tmp_dmk
+            ct::Tensor tmp2_global_tensor(ct::DataType::DT_COMPLEX_DOUBLE,
+                                          ct_device_type,
+                                          ct::TensorShape({nlocal, nlocal}));
+            tmp2_global_tensor.zero();
+            ct::kernels::blas_gemm<std::complex<double>, ct_Device>()(
+                'T',
+                'N',
+                nlocal,
+                nlocal,
+                nlocal,
+                &one_complex,
+                tmp1_global_tensor.template data<std::complex<double>>(),
+                nlocal,
+                DMK_global_dev.template data<std::complex<double>>(),
+                nlocal,
+                &zero_complex,
+                tmp2_global_tensor.template data<std::complex<double>>(),
+                nlocal);
+
+            // tmp3 = Sinv * Htmp
+            ct::Tensor tmp3_global_tensor(ct::DataType::DT_COMPLEX_DOUBLE,
+                                          ct_device_type,
+                                          ct::TensorShape({nlocal, nlocal}));
+            tmp3_global_tensor.zero();
+            ct::kernels::blas_gemm<std::complex<double>, ct_Device>()(
+                'N',
+                'N',
+                nlocal,
+                nlocal,
+                nlocal,
+                &one_complex,
+                Sinv_global.template data<std::complex<double>>(),
+                nlocal,
+                Htmp_global_dev.template data<std::complex<double>>(),
+                nlocal,
+                &zero_complex,
+                tmp3_global_tensor.template data<std::complex<double>>(),
+                nlocal);
+
+            // tmp4 = tmp_dmk * tmp3^T
+            ct::Tensor tmp4_global_tensor(ct::DataType::DT_COMPLEX_DOUBLE,
+                                          ct_device_type,
+                                          ct::TensorShape({nlocal, nlocal}));
+            tmp4_global_tensor.zero();
+            ct::kernels::blas_gemm<std::complex<double>, ct_Device>()(
+                'N',
+                'T',
+                nlocal,
+                nlocal,
+                nlocal,
+                &one_complex,
+                DMK_global_dev.template data<std::complex<double>>(),
+                nlocal,
+                tmp3_global_tensor.template data<std::complex<double>>(),
+                nlocal,
+                &zero_complex,
+                tmp4_global_tensor.template data<std::complex<double>>(),
+                nlocal);
+
+            // tmp4 = tmp2 + tmp4
+            ct::kernels::blas_axpy<std::complex<double>, ct_Device>()(
+                nlocal * nlocal,
+                &one_complex,
+                tmp2_global_tensor.template data<std::complex<double>>(),
+                1,
+                tmp4_global_tensor.template data<std::complex<double>>(),
+                1);
+
+            // tmp4 = 0.5 * tmp4
+            std::complex<double> half_complex = {0.5, 0.0};
+            ct::kernels::blas_scal<std::complex<double>, ct_Device>()(
+                nlocal * nlocal,
+                &half_complex,
+                tmp4_global_tensor.template data<std::complex<double>>(),
+                1);
+
+            // Copy result from device tensor back to CPU buffer for distribution
+            ct::Tensor tmp4_global_tensor_cpu = tmp4_global_tensor.to_device<ct::DEVICE_CPU>();
+            BlasConnector::copy(nlocal * nlocal,
+                                tmp4_global_tensor_cpu.template data<std::complex<double>>(),
+                                1,
+                                edm_global.p.get(),
+                                1);
+        }
+
+        // --- Distribute the globally computed EDM matrix back to distributed form ---
+        tmp_edmk.create(pv.ncol, pv.nrow);
+
+        hamilt::MatrixBlock<std::complex<double>> edm_local_block;
+        edm_local_block.p = tmp_edmk.c;
+        edm_local_block.desc = pv.desc;
+
+        // Distribute edm_global to all processes' local blocks
+        module_rt::distributeMatrix(edm_local_block, edm_global);
+#else
+        ModuleBase::WARNING_QUIT("elecstate::cal_edm_tddft_tensor_lapack", "MPI is required for this function!");
+#endif // __MPI
+    } // end ik
+
+#if ((defined __CUDA) /* || (defined __ROCM) */)
+    if (ct_device_type == ct::DeviceType::GpuDevice)
+    {
+        // Destroy cuBLAS & cuSOLVER handle
+        ct::kernels::destroyGpuSolverHandle();
+        ct::kernels::destroyGpuBlasHandle();
+    }
+#endif // __CUDA
+
+    ModuleBase::timer::tick("elecstate", "cal_edm_tddft_tensor_lapack");
+    return;
+} // cal_edm_tddft_tensor_lapack
+
+// Explicit instantiation of template functions
+template void cal_edm_tddft_tensor_lapack<base_device::DEVICE_CPU>(Parallel_Orbitals& pv,
+                                                                   LCAO_domain::Setup_DM<std::complex<double>>& dmat,
+                                                                   K_Vectors& kv,
+                                                                   hamilt::Hamilt<std::complex<double>>* p_hamilt);
+#if ((defined __CUDA) /* || (defined __ROCM) */)
+template void cal_edm_tddft_tensor_lapack<base_device::DEVICE_GPU>(Parallel_Orbitals& pv,
+                                                                   LCAO_domain::Setup_DM<std::complex<double>>& dmat,
+                                                                   K_Vectors& kv,
+                                                                   hamilt::Hamilt<std::complex<double>>* p_hamilt);
+#endif // __CUDA
 
 } // namespace elecstate

--- a/source/source_estate/module_dm/cal_edm_tddft.h
+++ b/source/source_estate/module_dm/cal_edm_tddft.h
@@ -17,5 +17,11 @@ void cal_edm_tddft_tensor(Parallel_Orbitals& pv,
                           LCAO_domain::Setup_DM<std::complex<double>>& dmat,
                           K_Vectors& kv,
                           hamilt::Hamilt<std::complex<double>>* p_hamilt);
+
+template <typename Device>
+void cal_edm_tddft_tensor_lapack(Parallel_Orbitals& pv,
+                                 LCAO_domain::Setup_DM<std::complex<double>>& dmat,
+                                 K_Vectors& kv,
+                                 hamilt::Hamilt<std::complex<double>>* p_hamilt);
 } // namespace elecstate
 #endif // CAL_EDM_TDDFT_H

--- a/source/source_lcao/module_rt/evolve_psi.cpp
+++ b/source/source_lcao/module_rt/evolve_psi.cpp
@@ -146,9 +146,12 @@ void evolve_psi_tensor(const int nband,
         = base_device::memory::synchronize_memory_op<std::complex<double>, Device, base_device::DEVICE_CPU>;
 
 #if ((defined __CUDA) /* || (defined __ROCM) */)
-    // Initialize cuBLAS & cuSOLVER handle
-    ct::kernels::createGpuSolverHandle();
-    ct::kernels::createGpuBlasHandle();
+    if (ct_device_type == ct::DeviceType::GpuDevice)
+    {
+        // Initialize cuBLAS & cuSOLVER handle
+        ct::kernels::createGpuSolverHandle();
+        ct::kernels::createGpuBlasHandle();
+    }
 #endif // __CUDA
 
     // ofs_running << " evolve_psi_tensor::start " << std::endl;
@@ -304,9 +307,12 @@ void evolve_psi_tensor(const int nband,
     // ofs_running << " evolve_psi_tensor::end " << std::endl;
 
 #if ((defined __CUDA) /* || (defined __ROCM) */)
-    // Destroy cuBLAS & cuSOLVER handle
-    ct::kernels::destroyGpuSolverHandle();
-    ct::kernels::destroyGpuBlasHandle();
+    if (ct_device_type == ct::DeviceType::GpuDevice)
+    {
+        // Destroy cuBLAS & cuSOLVER handle
+        ct::kernels::destroyGpuSolverHandle();
+        ct::kernels::destroyGpuBlasHandle();
+    }
 #endif // __CUDA
 
     return;

--- a/source/source_lcao/module_rt/gather_mat.h
+++ b/source/source_lcao/module_rt/gather_mat.h
@@ -46,6 +46,24 @@ void gatherMatrix(const int myid, const int root_proc, const hamilt::MatrixBlock
 }
 
 template <typename T>
+void distributeMatrix(hamilt::MatrixBlock<T>& mat_l, const module_rt::Matrix_g<T>& mat_g)
+{
+    const int* desc_local = mat_l.desc; // Obtain the descriptor from Parallel_Orbitals
+    int ctxt = desc_local[1];           // BLACS context
+    int nrows = desc_local[2];          // Global matrix row number
+    int ncols = desc_local[3];          // Global matrix column number
+
+    // Check matrix size consistency
+    if (mat_g.row != static_cast<size_t>(nrows) || mat_g.col != static_cast<size_t>(ncols))
+    {
+        throw std::invalid_argument("module_rt::distributeMatrix: Global matrix size mismatch.");
+    }
+
+    // Call the Cpxgemr2d function in ScaLAPACK to distribute the matrix data
+    Cpxgemr2d(nrows, ncols, mat_g.p.get(), 1, 1, mat_g.desc.get(), mat_l.p, 1, 1, const_cast<int*>(desc_local), ctxt);
+}
+
+template <typename T>
 void gatherPsi(const int myid,
                const int root_proc,
                T* psi_l,


### PR DESCRIPTION
### What's changed?
- Support RT-TDDFT EDM (energy-density matrix) calculation on GPU.
- ..., and fix a bug that causes a segmentation fault when running CPU-`Tensor` version of RT-TDDFT on a machine without a GPU.