### PR TITLE
[Test] Use WARNING_QUIT instead of exit, Add and refactor unittests for ParaGlobal

### DIFF
--- a/source/source_base/parallel_global.cpp
+++ b/source/source_base/parallel_global.cpp
@@ -385,8 +385,6 @@ void Parallel_Global::divide_mpi_groups(const int& procs,
 {
     if (num_groups == 0)
     {
-        std::cerr << "Error: Number of groups must be greater than 0." << std::endl;
-        // note that WARNING_QUIT writes to stdout
         ModuleBase::WARNING_QUIT(
             "Parallel_Global::divide_mpi_groups",
             "Number of groups must be greater than 0."
@@ -394,8 +392,6 @@ void Parallel_Global::divide_mpi_groups(const int& procs,
     }
     if (procs < num_groups)
     {
-        std::cerr << "Error: Number of processes (" << procs << ") must be greater than the number of groups ("
-                  << num_groups << ")." << std::endl;
         ModuleBase::WARNING_QUIT(
             "Parallel_Global::divide_mpi_groups",
             "Number of processes must be greater than the number of groups."

--- a/source/source_base/parallel_global.cpp
+++ b/source/source_base/parallel_global.cpp
@@ -328,9 +328,10 @@ void Parallel_Global::divide_pools(const int& NPROC,
     //       and MY_BNDGROUP will be the same as well.
     if(BNDPAR > 1 && NPROC %(BNDPAR * KPAR) != 0)
     {
-        std::cerr << "Error: When BNDPAR = " << BNDPAR << " > 1, number of processes (" << NPROC << ") must be divisible by the number of groups ("
+        std::cout<< "Error: When BNDPAR = " << BNDPAR << " > 1, number of processes (" << NPROC << ") must be divisible by the number of groups ("
                   << BNDPAR * KPAR << ")." << std::endl;
-        exit(1);
+        ModuleBase::WARNING_QUIT("ParallelGlobal::divide_pools",
+            "When BNDPAR > 1, number of processes NPROC must be divisible by the number of groups BNDPAR * KPAR.");
     }
     // k-point parallelization
     MPICommGroup kpar_group(MPI_COMM_WORLD);
@@ -392,7 +393,7 @@ void Parallel_Global::divide_mpi_groups(const int& procs,
     }
     if (procs < num_groups)
     {
-        std::cerr << "Error: Number of processes (" << procs << ") must be greater than the number of groups ("
+        std::cout << "Error: Number of processes (" << procs << ") must be greater than the number of groups ("
                   << num_groups << ")." << std::endl;
         ModuleBase::WARNING_QUIT(
             "Parallel_Global::divide_mpi_groups",

--- a/source/source_base/parallel_global.cpp
+++ b/source/source_base/parallel_global.cpp
@@ -328,8 +328,8 @@ void Parallel_Global::divide_pools(const int& NPROC,
     //       and MY_BNDGROUP will be the same as well.
     if(BNDPAR > 1 && NPROC %(BNDPAR * KPAR) != 0)
     {
-        std::cout<< "Error: When BNDPAR = " << BNDPAR << " > 1, number of processes (" << NPROC << ") must be divisible by the number of groups ("
-                  << BNDPAR * KPAR << ")." << std::endl;
+        std::cout << "Error: When BNDPAR = " << BNDPAR << " > 1, number of processes (" << NPROC
+            << ") must be divisible by the number of groups (" << BNDPAR * KPAR << ")." << std::endl;
         ModuleBase::WARNING_QUIT("ParallelGlobal::divide_pools",
             "When BNDPAR > 1, number of processes NPROC must be divisible by the number of groups BNDPAR * KPAR.");
     }

--- a/source/source_base/parallel_global.cpp
+++ b/source/source_base/parallel_global.cpp
@@ -392,6 +392,8 @@ void Parallel_Global::divide_mpi_groups(const int& procs,
     }
     if (procs < num_groups)
     {
+        std::cerr << "Error: Number of processes (" << procs << ") must be greater than the number of groups ("
+                  << num_groups << ")." << std::endl;
         ModuleBase::WARNING_QUIT(
             "Parallel_Global::divide_mpi_groups",
             "Number of processes must be greater than the number of groups."

--- a/source/source_base/parallel_global.cpp
+++ b/source/source_base/parallel_global.cpp
@@ -328,7 +328,7 @@ void Parallel_Global::divide_pools(const int& NPROC,
     //       and MY_BNDGROUP will be the same as well.
     if(BNDPAR > 1 && NPROC %(BNDPAR * KPAR) != 0)
     {
-        std::cout << "Error: When BNDPAR = " << BNDPAR << " > 1, number of processes (" << NPROC << ") must be divisible by the number of groups ("
+        std::cerr << "Error: When BNDPAR = " << BNDPAR << " > 1, number of processes (" << NPROC << ") must be divisible by the number of groups ("
                   << BNDPAR * KPAR << ")." << std::endl;
         exit(1);
     }
@@ -385,6 +385,8 @@ void Parallel_Global::divide_mpi_groups(const int& procs,
 {
     if (num_groups == 0)
     {
+        std::cerr << "Error: Number of groups must be greater than 0." << std::endl;
+        // note that WARNING_QUIT writes to stdout
         ModuleBase::WARNING_QUIT(
             "Parallel_Global::divide_mpi_groups",
             "Number of groups must be greater than 0."
@@ -392,7 +394,7 @@ void Parallel_Global::divide_mpi_groups(const int& procs,
     }
     if (procs < num_groups)
     {
-        std::cout << "Error: Number of processes (" << procs << ") must be greater than the number of groups ("
+        std::cerr << "Error: Number of processes (" << procs << ") must be greater than the number of groups ("
                   << num_groups << ")." << std::endl;
         ModuleBase::WARNING_QUIT(
             "Parallel_Global::divide_mpi_groups",

--- a/source/source_base/test_parallel/parallel_global_test.cpp
+++ b/source/source_base/test_parallel/parallel_global_test.cpp
@@ -9,7 +9,7 @@
 #include <cstring>
 #include <string>
 
-#include "source_base/tool_quit.h"
+#include "source_base/global_variable.h"
 
 /************************************************
  *  unit test of functions in parallel_global.cpp
@@ -66,6 +66,7 @@ class MPIContext
     int _size;
 };
 
+// --- Normal Test ---
 class ParaGlobal : public ::testing::Test
 {
   protected:
@@ -162,26 +163,6 @@ TEST_F(ParaGlobal, MyProd)
     EXPECT_EQ(inout[1], std::complex<double>(-3.0, -3.0));
 }
 
-TEST_F(ParaGlobal, InitPools)
-{
-    nproc = 12;
-    mpi.kpar = 3;
-    mpi.nstogroup = 3;
-    my_rank = 5;
-    testing::internal::CaptureStdout();
-    EXPECT_EXIT(Parallel_Global::init_pools(nproc,
-                                my_rank,
-                                mpi.nstogroup,
-                                mpi.kpar,
-                                mpi.nproc_in_stogroup,
-                                mpi.rank_in_stogroup,
-                                mpi.MY_BNDGROUP,
-                                mpi.nproc_in_pool,
-                                mpi.rank_in_pool,
-                                mpi.my_pool), ::testing::ExitedWithCode(1), "");
-    std::string output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("Error:"));
-}
 
 
 TEST_F(ParaGlobal, DivideMPIPools)
@@ -198,6 +179,117 @@ TEST_F(ParaGlobal, DivideMPIPools)
     EXPECT_EQ(mpi.nproc_in_pool, 4);
     EXPECT_EQ(mpi.my_pool, 1);
     EXPECT_EQ(mpi.rank_in_pool, 1);
+}
+
+
+// --- DeathTest: Single thread ---
+class ParaGlobalDeathTest : public ::testing::Test
+{
+  protected:
+    MPIContext mpi;
+    int nproc;
+    int my_rank;
+
+    // DeathTest SetUp:
+    // Init variable, single thread
+    void SetUp() override
+    {
+        // Only master process runs death test (avoid multi-process conflict)
+        if (mpi.GetRank() != 0) {return;}
+
+        // init log file
+        GlobalV::ofs_warning.open("warning.log");
+        // needed by WARNING_QUIT
+    }
+
+    // clean log file
+    void TearDown() override
+    {
+        if (mpi.GetRank() != 0) {return;}
+
+        GlobalV::ofs_warning.close();
+        remove("warning.log");
+    }
+};
+
+TEST_F(ParaGlobalDeathTest, InitPools)
+{
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+    nproc = 12;
+    mpi.kpar = 3;
+    mpi.nstogroup = 3;
+    my_rank = 5;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(Parallel_Global::init_pools(nproc,
+                                my_rank,
+                                mpi.nstogroup,
+                                mpi.kpar,
+                                mpi.nproc_in_stogroup,
+                                mpi.rank_in_stogroup,
+                                mpi.MY_BNDGROUP,
+                                mpi.nproc_in_pool,
+                                mpi.rank_in_pool,
+                                mpi.my_pool), ::testing::ExitedWithCode(1), "Error:");
+}
+
+TEST_F(ParaGlobalDeathTest, DivideMPIPoolsNgEqZero)
+{
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+    // test for num_groups == 0,
+    // Num_group Equals 0
+    // WARNING_QUIT
+    this->nproc = 12;
+    mpi.kpar = 0;
+    this->my_rank = 5;
+    EXPECT_EXIT(
+        Parallel_Global::divide_mpi_groups(this->nproc,
+                                       mpi.kpar,
+                                       this->my_rank,
+                                       mpi.nproc_in_pool,
+                                       mpi.my_pool,
+                                       mpi.rank_in_pool),
+        ::testing::ExitedWithCode(1),
+        "Number of groups must be greater than 0."
+    );
+    // should WARNING_QUIT inside!
+    std::string output;
+    std::ifstream ifs;
+    ifs.open("warning.log");
+    getline(ifs,output);
+	// test output in warning.log file
+	EXPECT_THAT(output,testing::HasSubstr("warning"));
+	EXPECT_THAT(output,testing::HasSubstr("Number of groups must be greater than 0."));
+    ifs.close();
+}
+
+TEST_F(ParaGlobalDeathTest, DivideMPIPoolsNgGtProc)
+{
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+    // test for procs < num_groups
+    // Num_group GreaterThan Processors
+    // WARNING_QUIT
+    this->nproc = 12;
+    mpi.kpar = 24;
+    this->my_rank = 5;
+    EXPECT_EXIT(
+        Parallel_Global::divide_mpi_groups(this->nproc,
+                                        mpi.kpar,
+                                        this->my_rank,
+                                        mpi.nproc_in_pool,
+                                        mpi.my_pool,
+                                        mpi.rank_in_pool)
+        ,testing::ExitedWithCode(1),
+        "Error: Number of processes.*must be greater than the number of groups"
+    );
+    // should WARNING_QUIT inside!
+    std::string output;
+    std::ifstream ifs;
+    ifs.open("warning.log");
+    getline(ifs,output);
+	// test output in warning.log file
+	EXPECT_THAT(output,testing::HasSubstr("warning"));
+	EXPECT_THAT(output,testing::HasSubstr("Number of processes must be greater than the number of groups."));
+    ifs.close();
 }
 
 int main(int argc, char** argv)

--- a/source/source_base/test_parallel/parallel_global_test.cpp
+++ b/source/source_base/test_parallel/parallel_global_test.cpp
@@ -80,23 +80,6 @@ class ParaGlobal : public ::testing::Test
     }
 };
 
-TEST_F(ParaGlobal, InitPools)
-{
-    nproc = 12;
-    mpi.kpar = 3;
-    mpi.nstogroup = 3;
-    my_rank = 5;
-    EXPECT_EXIT(Parallel_Global::init_pools(nproc,
-                                my_rank,
-                                mpi.nstogroup,
-                                mpi.kpar,
-                                mpi.nproc_in_stogroup,
-                                mpi.rank_in_stogroup,
-                                mpi.MY_BNDGROUP,
-                                mpi.nproc_in_pool,
-                                mpi.rank_in_pool,
-                                mpi.my_pool), ::testing::ExitedWithCode(1), "Error");
-}
 
 TEST_F(ParaGlobal, SplitGrid)
 {
@@ -280,6 +263,24 @@ class ParaGlobalDeathTest : public ::testing::Test
         remove("warning.log");
     }
 };
+
+TEST_F(ParaGlobalDeathTest, InitPools)
+{
+    nproc = 12;
+    mpi.kpar = 3;
+    mpi.nstogroup = 3;
+    my_rank = 5;
+    EXPECT_EXIT(Parallel_Global::init_pools(nproc,
+                                my_rank,
+                                mpi.nstogroup,
+                                mpi.kpar,
+                                mpi.nproc_in_stogroup,
+                                mpi.rank_in_stogroup,
+                                mpi.MY_BNDGROUP,
+                                mpi.nproc_in_pool,
+                                mpi.rank_in_pool,
+                                mpi.my_pool), ::testing::ExitedWithCode(1), "Error");
+}
 
 TEST_F(ParaGlobalDeathTest, DivideMPIPoolsNgEqZero)
 {

--- a/source/source_base/test_parallel/parallel_global_test.cpp
+++ b/source/source_base/test_parallel/parallel_global_test.cpp
@@ -8,6 +8,7 @@
 #include <complex>
 #include <cstring>
 #include <string>
+#include <unistd.h>
 
 #include "source_base/global_variable.h"
 
@@ -249,9 +250,10 @@ class ParaGlobalDeathTest : public ::testing::Test
         nproc = mpi.GetSize();
         my_rank = mpi.GetRank();
 
-        // init log file
+        // init log file needed by WARNING_QUIT
         GlobalV::ofs_warning.open("warning.log");
-        // needed by WARNING_QUIT
+
+
     }
 
     // clean log file
@@ -266,11 +268,16 @@ class ParaGlobalDeathTest : public ::testing::Test
 
 TEST_F(ParaGlobalDeathTest, InitPools)
 {
+    if (real_rank != 0) return;
     nproc = 12;
     mpi.kpar = 3;
     mpi.nstogroup = 3;
     my_rank = 5;
-    EXPECT_EXIT(Parallel_Global::init_pools(nproc,
+    EXPECT_EXIT(
+        {
+            // redirect stdout to stderr to capture WARNING_QUIT output
+            dup2(STDERR_FILENO, STDOUT_FILENO);
+            Parallel_Global::init_pools(nproc,
                                 my_rank,
                                 mpi.nstogroup,
                                 mpi.kpar,
@@ -279,7 +286,10 @@ TEST_F(ParaGlobalDeathTest, InitPools)
                                 mpi.MY_BNDGROUP,
                                 mpi.nproc_in_pool,
                                 mpi.rank_in_pool,
-                                mpi.my_pool), ::testing::ExitedWithCode(1), "Error");
+                                mpi.my_pool);
+        },
+        ::testing::ExitedWithCode(1),
+        "Error");
 }
 
 TEST_F(ParaGlobalDeathTest, DivideMPIPoolsNgEqZero)
@@ -288,26 +298,22 @@ TEST_F(ParaGlobalDeathTest, DivideMPIPoolsNgEqZero)
     // test for num_groups == 0,
     // Num_group Equals 0
     // WARNING_QUIT
+    this->nproc = 12;
     mpi.kpar = 0;
     EXPECT_EXIT(
-        Parallel_Global::divide_mpi_groups(this->nproc,
+        {
+            // redirect stdout to stderr to capture WARNING_QUIT output
+            dup2(STDERR_FILENO, STDOUT_FILENO);
+            Parallel_Global::divide_mpi_groups(this->nproc,
                                        mpi.kpar,
                                        this->my_rank,
                                        mpi.nproc_in_pool,
                                        mpi.my_pool,
-                                       mpi.rank_in_pool),
+                                       mpi.rank_in_pool);
+        },
         ::testing::ExitedWithCode(1),
         "Number of groups must be greater than 0."
     );
-    // should WARNING_QUIT inside!
-    std::string output;
-    std::ifstream ifs;
-    ifs.open("warning.log");
-    getline(ifs,output);
-	// test output in warning.log file
-	EXPECT_THAT(output,testing::HasSubstr("warning"));
-	EXPECT_THAT(output,testing::HasSubstr("Number of groups must be greater than 0."));
-    ifs.close();
 }
 
 TEST_F(ParaGlobalDeathTest, DivideMPIPoolsNgGtProc)
@@ -320,24 +326,18 @@ TEST_F(ParaGlobalDeathTest, DivideMPIPoolsNgGtProc)
     mpi.kpar = 24;
     this->my_rank = 5;
     EXPECT_EXIT(
-        Parallel_Global::divide_mpi_groups(this->nproc,
+        {
+            dup2(STDERR_FILENO, STDOUT_FILENO);
+            Parallel_Global::divide_mpi_groups(this->nproc,
                                         mpi.kpar,
                                         this->my_rank,
                                         mpi.nproc_in_pool,
                                         mpi.my_pool,
-                                        mpi.rank_in_pool),
+                                        mpi.rank_in_pool);
+        },
         testing::ExitedWithCode(1),
         "Error: Number of processes.*must be greater than the number of groups"
     );
-    // should WARNING_QUIT inside!
-    std::string output;
-    std::ifstream ifs;
-    ifs.open("warning.log");
-    getline(ifs,output);
-	// test output in warning.log file
-	EXPECT_THAT(output,testing::HasSubstr("warning"));
-	EXPECT_THAT(output,testing::HasSubstr("Number of processes must be greater than the number of groups."));
-    ifs.close();
 }
 
 int main(int argc, char** argv)
@@ -350,11 +350,13 @@ int main(int argc, char** argv)
         }
     }
 
-    if (!is_death_test_child) {
+    if (!is_death_test_child)
+    {
         MPI_Init(&argc, &argv);
     }
 
     testing::InitGoogleTest(&argc, argv);
+    testing::FLAGS_gtest_death_test_style = "threadsafe";
     int result = RUN_ALL_TESTS();
 
     if (!is_death_test_child) {

--- a/source/source_base/test_parallel/parallel_global_test.cpp
+++ b/source/source_base/test_parallel/parallel_global_test.cpp
@@ -80,6 +80,24 @@ class ParaGlobal : public ::testing::Test
     }
 };
 
+TEST_F(ParaGlobal, InitPools)
+{
+    nproc = 12;
+    mpi.kpar = 3;
+    mpi.nstogroup = 3;
+    my_rank = 5;
+    EXPECT_EXIT(Parallel_Global::init_pools(nproc,
+                                my_rank,
+                                mpi.nstogroup,
+                                mpi.kpar,
+                                mpi.nproc_in_stogroup,
+                                mpi.rank_in_stogroup,
+                                mpi.MY_BNDGROUP,
+                                mpi.nproc_in_pool,
+                                mpi.rank_in_pool,
+                                mpi.my_pool), ::testing::ExitedWithCode(1), "Error:");
+}
+
 TEST_F(ParaGlobal, SplitGrid)
 {
     // NPROC is set to 4 in parallel_global_test.sh
@@ -213,24 +231,6 @@ class ParaGlobalDeathTest : public ::testing::Test
         remove("warning.log");
     }
 };
-
-TEST_F(ParaGlobalDeathTest, InitPools)
-{
-    nproc = 12;
-    mpi.kpar = 3;
-    mpi.nstogroup = 3;
-    my_rank = 5;
-    EXPECT_EXIT(Parallel_Global::init_pools(nproc,
-                                my_rank,
-                                mpi.nstogroup,
-                                mpi.kpar,
-                                mpi.nproc_in_stogroup,
-                                mpi.rank_in_stogroup,
-                                mpi.MY_BNDGROUP,
-                                mpi.nproc_in_pool,
-                                mpi.rank_in_pool,
-                                mpi.my_pool), ::testing::ExitedWithCode(1), "Error:");
-}
 
 TEST_F(ParaGlobalDeathTest, DivideMPIPoolsNgEqZero)
 {

--- a/source/source_base/test_parallel/parallel_global_test.cpp
+++ b/source/source_base/test_parallel/parallel_global_test.cpp
@@ -80,25 +80,6 @@ class ParaGlobal : public ::testing::Test
     }
 };
 
-TEST_F(ParaGlobal, InitPools)
-{
-    nproc = 12;
-    mpi.kpar = 3;
-    mpi.nstogroup = 3;
-    my_rank = 5;
-    testing::internal::CaptureStdout();
-    EXPECT_EXIT(Parallel_Global::init_pools(nproc,
-                                my_rank,
-                                mpi.nstogroup,
-                                mpi.kpar,
-                                mpi.nproc_in_stogroup,
-                                mpi.rank_in_stogroup,
-                                mpi.MY_BNDGROUP,
-                                mpi.nproc_in_pool,
-                                mpi.rank_in_pool,
-                                mpi.my_pool), ::testing::ExitedWithCode(1), "Error:");
-}
-
 TEST_F(ParaGlobal, SplitGrid)
 {
     // NPROC is set to 4 in parallel_global_test.sh
@@ -233,6 +214,23 @@ class ParaGlobalDeathTest : public ::testing::Test
     }
 };
 
+TEST_F(ParaGlobalDeathTest, InitPools)
+{
+    nproc = 12;
+    mpi.kpar = 3;
+    mpi.nstogroup = 3;
+    my_rank = 5;
+    EXPECT_EXIT(Parallel_Global::init_pools(nproc,
+                                my_rank,
+                                mpi.nstogroup,
+                                mpi.kpar,
+                                mpi.nproc_in_stogroup,
+                                mpi.rank_in_stogroup,
+                                mpi.MY_BNDGROUP,
+                                mpi.nproc_in_pool,
+                                mpi.rank_in_pool,
+                                mpi.my_pool), ::testing::ExitedWithCode(1), "Error:");
+}
 
 TEST_F(ParaGlobalDeathTest, DivideMPIPoolsNgEqZero)
 {

--- a/source/source_base/test_parallel/parallel_global_test.cpp
+++ b/source/source_base/test_parallel/parallel_global_test.cpp
@@ -95,7 +95,7 @@ TEST_F(ParaGlobal, InitPools)
                                 mpi.MY_BNDGROUP,
                                 mpi.nproc_in_pool,
                                 mpi.rank_in_pool,
-                                mpi.my_pool), ::testing::ExitedWithCode(1), "Error:");
+                                mpi.my_pool), ::testing::ExitedWithCode(1), "Error");
 }
 
 TEST_F(ParaGlobal, SplitGrid)
@@ -200,22 +200,71 @@ TEST_F(ParaGlobal, DivideMPIPools)
 }
 
 
+class FakeMPIContext
+{
+  public:
+    FakeMPIContext()
+    {
+        _rank = 0;
+        _size = 1;
+    }
+
+    int GetRank() const
+    {
+        return _rank;
+    }
+    int GetSize() const
+    {
+        return _size;
+    }
+
+    int drank;
+    int dsize;
+    int dcolor;
+
+    int grank;
+    int gsize;
+
+    int kpar;
+    int nproc_in_pool;
+    int my_pool;
+    int rank_in_pool;
+
+    int nstogroup;
+    int MY_BNDGROUP;
+    int rank_in_stogroup;
+    int nproc_in_stogroup;
+
+  private:
+    int _rank;
+    int _size;
+};
+
 // --- DeathTest: Single thread ---
 class ParaGlobalDeathTest : public ::testing::Test
 {
   protected:
-    MPIContext mpi;
+    FakeMPIContext mpi;
     int nproc;
     int my_rank;
+    int real_rank;
 
     // DeathTest SetUp:
     // Init variable, single thread
     void SetUp() override
     {
+        int is_init = 0;
+        MPI_Initialized(&is_init);
+        if (is_init) {
+             MPI_Comm_rank(MPI_COMM_WORLD, &real_rank);
+        } else {
+             real_rank = 0;
+        }
+
+        if (real_rank != 0) return;
+
         nproc = mpi.GetSize();
         my_rank = mpi.GetRank();
-        // Only master process runs death test (avoid multi-process conflict)
-        if (mpi.GetRank() != 0) {return;}
 
         // init log file
         GlobalV::ofs_warning.open("warning.log");
@@ -225,7 +274,7 @@ class ParaGlobalDeathTest : public ::testing::Test
     // clean log file
     void TearDown() override
     {
-        if (mpi.GetRank() != 0) {return;}
+        if (real_rank != 0) return;
 
         GlobalV::ofs_warning.close();
         remove("warning.log");
@@ -234,12 +283,11 @@ class ParaGlobalDeathTest : public ::testing::Test
 
 TEST_F(ParaGlobalDeathTest, DivideMPIPoolsNgEqZero)
 {
+    if (real_rank != 0) return;
     // test for num_groups == 0,
     // Num_group Equals 0
     // WARNING_QUIT
-    this->nproc = 12;
     mpi.kpar = 0;
-    this->my_rank = 5;
     EXPECT_EXIT(
         Parallel_Global::divide_mpi_groups(this->nproc,
                                        mpi.kpar,
@@ -263,6 +311,7 @@ TEST_F(ParaGlobalDeathTest, DivideMPIPoolsNgEqZero)
 
 TEST_F(ParaGlobalDeathTest, DivideMPIPoolsNgGtProc)
 {
+    if (real_rank != 0) return;
     // test for procs < num_groups
     // Num_group GreaterThan Processors
     // WARNING_QUIT
@@ -292,12 +341,24 @@ TEST_F(ParaGlobalDeathTest, DivideMPIPoolsNgGtProc)
 
 int main(int argc, char** argv)
 {
+    bool is_death_test_child = false;
+    for (int i = 0; i < argc; ++i) {
+        if (std::string(argv[i]).find("gtest_internal_run_death_test") != std::string::npos) {
+            is_death_test_child = true;
+            break;
+        }
+    }
 
-    MPI_Init(&argc, &argv);
-    testing::FLAGS_gtest_death_test_style = "threadsafe";
+    if (!is_death_test_child) {
+        MPI_Init(&argc, &argv);
+    }
+
     testing::InitGoogleTest(&argc, argv);
     int result = RUN_ALL_TESTS();
-    MPI_Finalize();
+
+    if (!is_death_test_child) {
+        MPI_Finalize();
+    }
     return result;
 }
 #endif // __MPI

--- a/source/source_base/test_parallel/parallel_global_test.cpp
+++ b/source/source_base/test_parallel/parallel_global_test.cpp
@@ -225,6 +225,10 @@ class FakeMPIContext
 };
 
 // --- DeathTest: Single thread ---
+// Since these precondition checks cause the processes to die, we call such tests death tests.
+// convention of naming the test suite: *DeathTest
+// Death tests should be run in a single-threaded context.
+// Such DeathTest will be run before all other tests.
 class ParaGlobalDeathTest : public ::testing::Test
 {
   protected:
@@ -274,6 +278,9 @@ TEST_F(ParaGlobalDeathTest, InitPools)
     mpi.nstogroup = 3;
     my_rank = 5;
     EXPECT_EXIT(
+    // This gtest Macro expect that a given `statement` causes the program to exit, with an
+    // integer exit status that satisfies `predicate`(Here ::testing::ExitedWithCode(1)),
+    // and emitting error output that matches `matcher`(Here "Error").
         {
             // redirect stdout to stderr to capture WARNING_QUIT output
             dup2(STDERR_FILENO, STDOUT_FILENO);
@@ -327,6 +334,7 @@ TEST_F(ParaGlobalDeathTest, DivideMPIPoolsNgGtProc)
     this->my_rank = 5;
     EXPECT_EXIT(
         {
+            // redirect stdout to stderr to capture WARNING_QUIT output
             dup2(STDERR_FILENO, STDOUT_FILENO);
             Parallel_Global::divide_mpi_groups(this->nproc,
                                         mpi.kpar,

--- a/source/source_base/test_parallel/parallel_global_test.cpp
+++ b/source/source_base/test_parallel/parallel_global_test.cpp
@@ -194,6 +194,8 @@ class ParaGlobalDeathTest : public ::testing::Test
     // Init variable, single thread
     void SetUp() override
     {
+        nproc = mpi.GetSize();
+        my_rank = mpi.GetRank();
         // Only master process runs death test (avoid multi-process conflict)
         if (mpi.GetRank() != 0) {return;}
 

--- a/source/source_base/test_parallel/parallel_global_test.cpp
+++ b/source/source_base/test_parallel/parallel_global_test.cpp
@@ -214,7 +214,6 @@ class ParaGlobalDeathTest : public ::testing::Test
 
 TEST_F(ParaGlobalDeathTest, InitPools)
 {
-    GTEST_FLAG_SET(death_test_style, "threadsafe");
     nproc = 12;
     mpi.kpar = 3;
     mpi.nstogroup = 3;
@@ -234,7 +233,6 @@ TEST_F(ParaGlobalDeathTest, InitPools)
 
 TEST_F(ParaGlobalDeathTest, DivideMPIPoolsNgEqZero)
 {
-    GTEST_FLAG_SET(death_test_style, "threadsafe");
     // test for num_groups == 0,
     // Num_group Equals 0
     // WARNING_QUIT
@@ -264,7 +262,6 @@ TEST_F(ParaGlobalDeathTest, DivideMPIPoolsNgEqZero)
 
 TEST_F(ParaGlobalDeathTest, DivideMPIPoolsNgGtProc)
 {
-    GTEST_FLAG_SET(death_test_style, "threadsafe");
     // test for procs < num_groups
     // Num_group GreaterThan Processors
     // WARNING_QUIT
@@ -296,6 +293,7 @@ int main(int argc, char** argv)
 {
 
     MPI_Init(&argc, &argv);
+    testing::FLAGS_gtest_death_test_style = "threadsafe";
     testing::InitGoogleTest(&argc, argv);
     int result = RUN_ALL_TESTS();
     MPI_Finalize();

--- a/source/source_base/test_parallel/parallel_global_test.cpp
+++ b/source/source_base/test_parallel/parallel_global_test.cpp
@@ -277,8 +277,8 @@ TEST_F(ParaGlobalDeathTest, DivideMPIPoolsNgGtProc)
                                         this->my_rank,
                                         mpi.nproc_in_pool,
                                         mpi.my_pool,
-                                        mpi.rank_in_pool)
-        ,testing::ExitedWithCode(1),
+                                        mpi.rank_in_pool),
+        testing::ExitedWithCode(1),
         "Error: Number of processes.*must be greater than the number of groups"
     );
     // should WARNING_QUIT inside!

--- a/source/source_base/test_parallel/parallel_global_test.cpp
+++ b/source/source_base/test_parallel/parallel_global_test.cpp
@@ -80,6 +80,25 @@ class ParaGlobal : public ::testing::Test
     }
 };
 
+TEST_F(ParaGlobal, InitPools)
+{
+    nproc = 12;
+    mpi.kpar = 3;
+    mpi.nstogroup = 3;
+    my_rank = 5;
+    testing::internal::CaptureStdout();
+    EXPECT_EXIT(Parallel_Global::init_pools(nproc,
+                                my_rank,
+                                mpi.nstogroup,
+                                mpi.kpar,
+                                mpi.nproc_in_stogroup,
+                                mpi.rank_in_stogroup,
+                                mpi.MY_BNDGROUP,
+                                mpi.nproc_in_pool,
+                                mpi.rank_in_pool,
+                                mpi.my_pool), ::testing::ExitedWithCode(1), "Error:");
+}
+
 TEST_F(ParaGlobal, SplitGrid)
 {
     // NPROC is set to 4 in parallel_global_test.sh
@@ -214,24 +233,6 @@ class ParaGlobalDeathTest : public ::testing::Test
     }
 };
 
-TEST_F(ParaGlobalDeathTest, InitPools)
-{
-    nproc = 12;
-    mpi.kpar = 3;
-    mpi.nstogroup = 3;
-    my_rank = 5;
-    testing::internal::CaptureStdout();
-    EXPECT_EXIT(Parallel_Global::init_pools(nproc,
-                                my_rank,
-                                mpi.nstogroup,
-                                mpi.kpar,
-                                mpi.nproc_in_stogroup,
-                                mpi.rank_in_stogroup,
-                                mpi.MY_BNDGROUP,
-                                mpi.nproc_in_pool,
-                                mpi.rank_in_pool,
-                                mpi.my_pool), ::testing::ExitedWithCode(1), "Error:");
-}
 
 TEST_F(ParaGlobalDeathTest, DivideMPIPoolsNgEqZero)
 {


### PR DESCRIPTION
### Linked PR
#6771

### Unit Tests and/or Case Tests for my changes
- Add `ParaGlobalDeathTest` for `Parallel_Global`, specifically for `error-exit` cases.
- Add tests for `kpar` check in `Parallel_Global` with `WARNING_QUIT`.
- Use a single process for DeathTest.

### What's changed?
- TEST: Use GoogleTest DeathTest convension.
- Write Error/Warning message to `stdout` and check by redirecting `stdout` to `stderr` in test context to be captured by gtest `EXPECT_EXIT`.


### Any changes of core modules? (ignore if not applicable)
- Switch to `WARNING_QUIT` instead of `exit` if the input parallel group does not meet expectations.

### Note
Note that `WARNING_QUIT` writes warning/error log to `stdout`.

