### PR TITLE
[Fix][LTS]Change `torch::linalg::eigh` to `torch::linalg_eigh` for libtorch >= 2.6.0

### DIFF
--- a/source/module_hamilt_lcao/module_deepks/LCAO_deepks_torch.cpp
+++ b/source/module_hamilt_lcao/module_deepks/LCAO_deepks_torch.cpp
@@ -115,7 +115,7 @@ void LCAO_Deepks::cal_gevdm(const int nat, std::vector<torch::Tensor>& gevdm)
             // repeat each block for nm times in an additional dimension
             torch::Tensor tmp_x = this->pdm[inl].reshape({nm, nm}).unsqueeze(0).repeat({nm, 1, 1});
             // torch::Tensor tmp_y = std::get<0>(torch::symeig(tmp_x, true));
-            torch::Tensor tmp_y = std::get<0>(torch::linalg::eigh(tmp_x, "U"));
+            torch::Tensor tmp_y = std::get<0>(torch::linalg_eigh(tmp_x, "U"));
             torch::Tensor tmp_yshell = torch::eye(nm, torch::TensorOptions().dtype(torch::kFloat64));
             std::vector<torch::Tensor> tmp_rpt; // repeated-pdm-tensor (x)
             std::vector<torch::Tensor> tmp_rdt; // repeated-d-tensor (y)

--- a/source/module_hamilt_lcao/module_deepks/cal_descriptor.cpp
+++ b/source/module_hamilt_lcao/module_deepks/cal_descriptor.cpp
@@ -67,7 +67,7 @@ void LCAO_Deepks::cal_descriptor(const int nat)
         std::tuple<torch::Tensor, torch::Tensor> d_v(this->d_tensor[inl], vd);
         // d_v = torch::symeig(pdm[inl], /*eigenvalues=*/true,
         // /*upper=*/true);
-        d_v = torch::linalg::eigh(pdm[inl], /*uplo*/ "U");
+        d_v = torch::linalg_eigh(pdm[inl], /*uplo*/ "U");
         d_tensor[inl] = std::get<0>(d_v);
     }
     ModuleBase::timer::tick("LCAO_Deepks", "cal_descriptor");


### PR DESCRIPTION
### Linked Issue
Fix #5921 


### Unit Tests and/or Case Tests for my changes
- No unit test is added.

### What's changed?
- Just change `torch::linalg::eigh` to `torch::linalg_eigh` (refer to #6461).

### Any changes of core modules? 
- No.