### PR TITLE
Feature: Add a new parameter `out_freq_td` to control output frequency in RT-TDDFT

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -135,6 +135,7 @@
     - [cell\_factor](#cell_factor)
   - [Output Variables](#variables-related-to-output-information)
     - [out\_freq\_ion](#out_freq_ion)
+    - [out\_freq\_td](#out_freq_td)
     - [out\_freq\_elec](#out_freq_elec)
     - [out\_chg](#out_chg)
     - [out\_pot](#out_pot)
@@ -535,7 +536,7 @@ These variables are used to control general system parameters.
   - ofdft: orbital-free density functional theory
   - tdofdft: time-dependent orbital-free density functional theory
   - sdft: [stochastic density functional theory](#electronic-structure-sdft)
-  - tddft: real-time time-dependent density functional theory (TDDFT)
+  - tddft: real-time time-dependent density functional theory (RT-TDDFT)
   - lj: Leonard Jones potential
   - dp: DeeP potential, see details in [md.md](../md.md#dpmd)
   - nep: Neuroevolution Potential, see details in [md.md](../md.md#nep)
@@ -1688,15 +1689,22 @@ These variables are used to control the output of properties.
 ### out_freq_ion
 
 - **Type**: Integer
-- **Description**: Control the interval to print information every few ion steps. These properties cover charge density, local potential, electrostatic potential, Hamiltonian matrix, overlap matrix, density matrix, Mulliken population analysis and so on.
+- **Description**: Controls the output interval in **ionic steps**. When set to a positive integer $N$, information such as charge density, local potential, electrostatic potential, Hamiltonian matrix, overlap matrix, density matrix, and Mulliken population analysis is printed every $N$ ionic steps.
 - **Default**: 0
-- **Note**: The integer indicates to print information every 'out_freq_ion' ion steps. 
+- **Note**: In RT-TDDFT calculations, this parameter is inactive; output frequency is instead controlled by [`out_freq_td`](#out_freq_td)—see its description for details.
+
+### out_freq_td
+
+- **Type**: Integer
+- **Description**: Controls the output interval in **completed electronic evolution steps** during RT-TDDFT calculations. When set to a positive integer $N$, detailed information (see [`out_freq_ion`](#out_freq_ion)) is printed every $N$ electron time-evolution steps (i.e., every $N$ `STEP OF ELECTRON EVOLVE`). For example, if you wish to output information once per ionic step, you should set `out_freq_td` equal to [`estep_per_md`](#estep_per_md), since one ionic step corresponds to [`estep_per_md`](#estep_per_md) electronic evolution steps.
+- **Default**: 0
+- **Note**: This parameter is **only active in RT-TDDFT mode** (`esolver_type = tddft`). It has no effect in ground-state calculations.
 
 ### out_freq_elec
 
 - **Type**: Integer
-- **Description**: Output the charge density (only binary format, controlled by [out_chg](#out_chg)), wavefunction (controlled by [out_wfc_pw](#out_wfc_pw)) per `out_freq_elec` electronic iterations. Note that they are always output when converged or reach the maximum iterations [scf_nmax](#scf_nmax).
-- **Default**: [scf_nmax](#scf_nmax)
+- **Description**: Output the charge density (only binary format, controlled by [`out_chg`](#out_chg)), wavefunction (controlled by [`out_wfc_pw`](#out_wfc_pw)) per `out_freq_elec` electronic iterations. Note that they are always output when converged or reach the maximum iterations [`scf_nmax`](#scf_nmax).
+- **Default**: [`scf_nmax`](#scf_nmax)
 
 ### out_chg
 

--- a/source/source_esolver/esolver_ks_lcao_tddft.cpp
+++ b/source/source_esolver/esolver_ks_lcao_tddft.cpp
@@ -107,7 +107,9 @@ void ESolver_KS_LCAO_TDDFT<TR, Device>::runner(UnitCell& ucell, const int istep)
     {
         estep_max = PARAM.inp.estep_per_md + 1;
     }
-    // reset laststep matrix and wfc, if any atom cross the boundary
+
+    // Reset laststep matrix and wfc, if any atom cross the boundary
+    // Apply a phase correction to H, S, and psi to keep consistency when atoms cross periodic boundaries
     const size_t len_hs_ik = use_tensor && use_lapack ? PARAM.globalv.nlocal * PARAM.globalv.nlocal : this->pv.nloc;
     module_rt::reset_matrix_boundary(ucell,
                                      this->kv,
@@ -116,6 +118,7 @@ void ESolver_KS_LCAO_TDDFT<TR, Device>::runner(UnitCell& ucell, const int istep)
                                      this->Sk_laststep,
                                      this->psi_laststep,
                                      len_hs_ik);
+
     for (int estep = 0; estep < estep_max; estep++)
     {
         // calculate total time step

--- a/source/source_io/ctrl_output_fp.cpp
+++ b/source/source_io/ctrl_output_fp.cpp
@@ -1,9 +1,10 @@
-#include "source_io/ctrl_output_fp.h" // use ctrl_output_fp() 
+#include "source_io/ctrl_output_fp.h" // use ctrl_output_fp()
+
+#include "cube_io.h"                                  // use write_vdata_palgrid
 #include "source_estate/module_charge/symmetry_rho.h" // use Symmetry_rho
-#include "source_io/write_elecstat_pot.h" // use write_elecstat_pot 
+#include "source_hamilt/module_xc/xc_functional.h"    // use XC_Functional
+#include "source_io/write_elecstat_pot.h"             // use write_elecstat_pot
 #include "source_io/write_elf.h"
-#include "cube_io.h"  // use write_vdata_palgrid
-#include "source_hamilt/module_xc/xc_functional.h" // use XC_Functional
 
 #ifdef USE_LIBXC
 #include "source_io/write_libxc_r.h"
@@ -12,14 +13,14 @@
 namespace ModuleIO
 {
 
-void ctrl_output_fp(UnitCell& ucell, 
-		elecstate::ElecState* pelec,	
-        ModulePW::PW_Basis_Big* pw_big,
-        ModulePW::PW_Basis* pw_rhod,
-        Charge &chr,
-        surchem &solvent,
-        Parallel_Grid &para_grid,
-		const int istep)
+void ctrl_output_fp(UnitCell& ucell,
+                    elecstate::ElecState* pelec,
+                    ModulePW::PW_Basis_Big* pw_big,
+                    ModulePW::PW_Basis* pw_rhod,
+                    Charge& chr,
+                    surchem& solvent,
+                    Parallel_Grid& para_grid,
+                    const int istep)
 {
     ModuleBase::TITLE("ModuleIO", "ctrl_output_fp");
     ModuleBase::timer::tick("ModuleIO", "ctrl_output_fp");
@@ -29,27 +30,32 @@ void ctrl_output_fp(UnitCell& ucell,
     const int nspin = PARAM.inp.nspin;
     const std::string global_out_dir = PARAM.globalv.global_out_dir;
 
-
-    // print out the 'g' index when istep_in!=-1
+    // print out the 'g' index when istep_in != -1
     int istep_in = -1;
-    if (PARAM.inp.out_freq_ion>0) // default value of out_freq_ion is 0
+    if (PARAM.inp.esolver_type != "tddft" && PARAM.inp.out_freq_ion > 0) // default value of out_freq_ion is 0
     {
         if (istep % PARAM.inp.out_freq_ion == 0)
         {
             istep_in = istep;
         }
     }
+    else if (PARAM.inp.esolver_type == "tddft" && PARAM.inp.out_freq_td > 0) // default value of out_freq_td is 0
+    {
+        if (istep % PARAM.inp.out_freq_td == 0)
+        {
+            istep_in = istep;
+        }
+    }
 
     std::string geom_block;
-    if(istep_in==-1)
+    if (istep_in == -1)
     {
         // do nothing
     }
-    else if(istep_in>=0)
+    else if (istep_in >= 0)
     {
         geom_block = "g" + std::to_string(istep + 1);
     }
-
 
     // 4) write charge density
     if (PARAM.inp.out_chg[0] > 0)
@@ -58,14 +64,14 @@ void ctrl_output_fp(UnitCell& ucell,
         {
             pw_rhod->real2recip(chr.rho_save[is], chr.rhog_save[is]);
 
-            std::string fn =PARAM.globalv.global_out_dir + "chg";
+            std::string fn = PARAM.globalv.global_out_dir + "chg";
 
             std::string spin_block;
-            if(nspin == 2 || nspin == 4)
+            if (nspin == 2 || nspin == 4)
             {
-                spin_block= "s" + std::to_string(is + 1);
+                spin_block = "s" + std::to_string(is + 1);
             }
-            else if(nspin == 1)
+            else if (nspin == 1)
             {
                 // do nothing
             }
@@ -73,15 +79,15 @@ void ctrl_output_fp(UnitCell& ucell,
             fn += spin_block + geom_block + ".cube";
 
             ModuleIO::write_vdata_palgrid(para_grid,
-                    chr.rho_save[is],
-                    is,
-                    nspin,
-                    istep_in,
-                    fn,
-                    pelec->eferm.get_efval(is),
-                    &(ucell),
-                    PARAM.inp.out_chg[1],
-                    1);
+                                          chr.rho_save[is],
+                                          is,
+                                          nspin,
+                                          istep_in,
+                                          fn,
+                                          pelec->eferm.get_efval(is),
+                                          &(ucell),
+                                          PARAM.inp.out_chg[1],
+                                          1);
 
             if (XC_Functional::get_ked_flag())
             {
@@ -90,13 +96,13 @@ void ctrl_output_fp(UnitCell& ucell,
                 fn += spin_block + geom_block + ".cube";
 
                 ModuleIO::write_vdata_palgrid(para_grid,
-                        chr.kin_r_save[is],
-                        is,
-                        nspin,
-                        istep,
-                        fn,
-                        pelec->eferm.get_efval(is),
-                        &(ucell));
+                                              chr.kin_r_save[is],
+                                              is,
+                                              nspin,
+                                              istep,
+                                              fn,
+                                              pelec->eferm.get_efval(is),
+                                              &(ucell));
             }
         }
     }
@@ -106,14 +112,14 @@ void ctrl_output_fp(UnitCell& ucell,
     {
         for (int is = 0; is < nspin; is++)
         {
-            std::string fn =PARAM.globalv.global_out_dir + "pot";
+            std::string fn = PARAM.globalv.global_out_dir + "pot";
 
             std::string spin_block;
-            if(nspin == 2 || nspin == 4)
+            if (nspin == 2 || nspin == 4)
             {
-                spin_block= "s" + std::to_string(is + 1);
+                spin_block = "s" + std::to_string(is + 1);
             }
-            else if(nspin == 1)
+            else if (nspin == 1)
             {
                 // do nothing
             }
@@ -121,34 +127,34 @@ void ctrl_output_fp(UnitCell& ucell,
             fn += spin_block + geom_block + ".cube";
 
             ModuleIO::write_vdata_palgrid(para_grid,
-                    pelec->pot->get_eff_v(is),
-                    is,
-                    nspin,
-                    istep_in,
-                    fn,
-                    0.0, // efermi
-                    &(ucell),
-                    3,  // precision
-                    0); // out_fermi
+                                          pelec->pot->get_eff_v(is),
+                                          is,
+                                          nspin,
+                                          istep_in,
+                                          fn,
+                                          0.0, // efermi
+                                          &(ucell),
+                                          3,  // precision
+                                          0); // out_fermi
         }
     }
     else if (PARAM.inp.out_pot == 2)
     {
-        std::string fn =PARAM.globalv.global_out_dir + "potes";
+        std::string fn = PARAM.globalv.global_out_dir + "potes";
         fn += geom_block + ".cube";
 
         ModuleIO::write_elecstat_pot(
 #ifdef __MPI
-                pw_big->bz,
-                pw_big->nbz,
+            pw_big->bz,
+            pw_big->nbz,
 #endif
-                fn,
-                istep,
-                pw_rhod,
-                &chr,
-                &(ucell),
-                pelec->pot->get_fixed_v(),
-                solvent);
+            fn,
+            istep,
+            pw_rhod,
+            &chr,
+            &(ucell),
+            pelec->pot->get_fixed_v(),
+            solvent);
     }
 
     // 6) write ELF
@@ -161,40 +167,39 @@ void ctrl_output_fp(UnitCell& ucell,
             srho.begin(is, chr, pw_rhod, ucell.symm);
         }
 
-        std::string out_dir =PARAM.globalv.global_out_dir;
+        std::string out_dir = PARAM.globalv.global_out_dir;
         ModuleIO::write_elf(
 #ifdef __MPI
-                pw_big->bz,
-                pw_big->nbz,
+            pw_big->bz,
+            pw_big->nbz,
 #endif
-                out_dir,
-                istep,
-                nspin,
-                chr.rho,
-                chr.kin_r,
-                pw_rhod,
-                para_grid,
-                &(ucell),
-                PARAM.inp.out_elf[1]);
+            out_dir,
+            istep,
+            nspin,
+            chr.rho,
+            chr.kin_r,
+            pw_rhod,
+            para_grid,
+            &(ucell),
+            PARAM.inp.out_elf[1]);
     }
 
 #ifdef USE_LIBXC
     // 7) write xc(r)
-    if(PARAM.inp.out_xc_r[0]>=0)
+    if (PARAM.inp.out_xc_r[0] >= 0)
     {
-        ModuleIO::write_libxc_r(
-                PARAM.inp.out_xc_r[0],
-                XC_Functional::get_func_id(),
-                pw_rhod->nrxx, // number of real-space grid
-                ucell.omega, // volume of cell
-                ucell.tpiba,
-                chr,
-                *pw_big,
-                *pw_rhod);
+        ModuleIO::write_libxc_r(PARAM.inp.out_xc_r[0],
+                                XC_Functional::get_func_id(),
+                                pw_rhod->nrxx, // number of real-space grid
+                                ucell.omega,   // volume of cell
+                                ucell.tpiba,
+                                chr,
+                                *pw_big,
+                                *pw_rhod);
     }
 #endif
 
     ModuleBase::timer::tick("ModuleIO", "ctrl_output_fp");
 }
 
-} // End ModuleIO
+} // namespace ModuleIO

--- a/source/source_io/ctrl_output_fp.h
+++ b/source/source_io/ctrl_output_fp.h
@@ -1,19 +1,19 @@
-#ifndef CTRL_OUTPUT_FP_H 
-#define CTRL_OUTPUT_FP_H 
+#ifndef CTRL_OUTPUT_FP_H
+#define CTRL_OUTPUT_FP_H
 
 #include "source_estate/elecstate_lcao.h"
 
 namespace ModuleIO
 {
 
-	void ctrl_output_fp(UnitCell& ucell, 
-			elecstate::ElecState* pelec,	
-			ModulePW::PW_Basis_Big* pw_big,
-			ModulePW::PW_Basis* pw_rhod,
-			Charge &chr,
-			surchem &solvent,
-			Parallel_Grid &para_grid,
-			const int istep);
+void ctrl_output_fp(UnitCell& ucell,
+                    elecstate::ElecState* pelec,
+                    ModulePW::PW_Basis_Big* pw_big,
+                    ModulePW::PW_Basis* pw_rhod,
+                    Charge& chr,
+                    surchem& solvent,
+                    Parallel_Grid& para_grid,
+                    const int istep);
 
 }
 #endif

--- a/source/source_io/ctrl_output_td.cpp
+++ b/source/source_io/ctrl_output_td.cpp
@@ -59,9 +59,9 @@ void ctrl_output_td(const UnitCell& ucell,
     }
 
     // (3) Output file for restart
-    if (PARAM.inp.out_freq_ion > 0) // default value of out_freq_ion is 0
+    if (PARAM.inp.out_freq_td > 0) // default value of out_freq_td is 0
     {
-        if (istep % PARAM.inp.out_freq_ion == 0)
+        if (istep % PARAM.inp.out_freq_td == 0)
         {
             if (td_p != nullptr)
             {

--- a/source/source_io/ctrl_scf_lcao.cpp
+++ b/source/source_io/ctrl_scf_lcao.cpp
@@ -1,60 +1,60 @@
-#include <complex>
+#include "source_io/ctrl_scf_lcao.h" // use ctrl_scf_lcao()
 
 #include "source_estate/elecstate_lcao.h" // use elecstate::ElecState
-#include "source_io/ctrl_scf_lcao.h" // use ctrl_scf_lcao() 
-#include "source_lcao/hamilt_lcao.h" // use hamilt::HamiltLCAO<TK, TR>
-#include "source_hamilt/hamilt.h" // use Hamilt<T>  
+#include "source_hamilt/hamilt.h"         // use Hamilt<T>
+#include "source_lcao/hamilt_lcao.h"      // use hamilt::HamiltLCAO<TK, TR>
+
+#include <complex>
 
 // functions
-#include "source_io/write_dos_lcao.h" // use ModuleIO::write_dos_lcao() 
-#include "source_io/write_dmr.h" // use ModuleIO::write_dmr() 
-#include "source_io/write_dmk.h" // use ModuleIO::write_dmk()
-#include "source_io/write_HS.h" // use ModuleIO::write_hsk()
-#include "source_io/write_wfc_nao.h" // use ModuleIO::write_wfc_nao() 
-#include "source_io/output_mat_sparse.h" // use ModuleIO::output_mat_sparse() 
-#include "source_io/output_mulliken.h" // use cal_mag()
+#include "source_io/berryphase.h"                          // use berryphase
+#include "source_io/cal_pLpR.h"                            // use AngularMomentumCalculator()
+#include "source_io/output_mat_sparse.h"                   // use ModuleIO::output_mat_sparse()
+#include "source_io/output_mulliken.h"                     // use cal_mag()
+#include "source_io/to_wannier90_lcao.h"                   // use toWannier90_LCAO
+#include "source_io/to_wannier90_lcao_in_pw.h"             // use toWannier90_LCAO_IN_PW
+#include "source_io/write_HS.h"                            // use ModuleIO::write_hsk()
+#include "source_io/write_dmk.h"                           // use ModuleIO::write_dmk()
+#include "source_io/write_dmr.h"                           // use ModuleIO::write_dmr()
+#include "source_io/write_dos_lcao.h"                      // use ModuleIO::write_dos_lcao()
+#include "source_io/write_wfc_nao.h"                       // use ModuleIO::write_wfc_nao()
+#include "source_lcao/module_deltaspin/spin_constrain.h"   // use spinconstrain::SpinConstrain<TK>
 #include "source_lcao/module_operator_lcao/ekinetic_new.h" // use hamilt::EkineticNew
-#include "source_io/cal_pLpR.h" // use AngularMomentumCalculator()
-#include "source_lcao/module_deltaspin/spin_constrain.h" // use spinconstrain::SpinConstrain<TK>
-#include "source_io/berryphase.h" // use berryphase
-#include "source_io/to_wannier90_lcao.h" // use toWannier90_LCAO
-#include "source_io/to_wannier90_lcao_in_pw.h" // use toWannier90_LCAO_IN_PW
 #ifdef __MLALGO
 #include "source_lcao/module_deepks/LCAO_deepks.h"
 #include "source_lcao/module_deepks/LCAO_deepks_interface.h"
 #endif
 #ifdef __EXX
 #include "source_lcao/module_ri/Exx_LRI_interface.h" // use EXX codes
-#include "source_lcao/module_ri/RPA_LRI.h" // use RPA code
+#include "source_lcao/module_ri/RPA_LRI.h"           // use RPA code
 #endif
+#include "source_io/to_qo.h"                // use toQO
 #include "source_lcao/module_rdmft/rdmft.h" // use RDMFT codes
-#include "source_io/to_qo.h" // use toQO
-#include "source_lcao/rho_tau_lcao.h" // mohan add 2025-10-24
-
+#include "source_lcao/rho_tau_lcao.h"       // mohan add 2025-10-24
 
 template <typename TK, typename TR>
 void ModuleIO::ctrl_scf_lcao(UnitCell& ucell,
-        const Input_para& inp,
-		K_Vectors& kv,
-		elecstate::ElecState* pelec, 
-		elecstate::DensityMatrix<TK,double>* dm, // mohan add 2025-11-04
-		Parallel_Orbitals& pv,
-		Grid_Driver& gd,
-		psi::Psi<TK>* psi,
-		hamilt::HamiltLCAO<TK, TR>* p_hamilt,
-        Plus_U &dftu, // mohan add 2025-11-07
-		TwoCenterBundle &two_center_bundle,
-		LCAO_Orbitals &orb,
-		const ModulePW::PW_Basis_K* pw_wfc, // for berryphase
-		const ModulePW::PW_Basis* pw_rho, // for berryphase
-		const ModulePW::PW_Basis_Big* pw_big, // for Wannier90
-		const Structure_Factor& sf, // for Wannier90
-		rdmft::RDMFT<TK, TR> &rdmft_solver, // for RDMFT
-		Setup_DeePKS<TK> &deepks,
-		Exx_NAO<TK> &exx_nao,
-        const bool conv_esolver,
-        const bool scf_nmax_flag,
-		const int istep)
+                             const Input_para& inp,
+                             K_Vectors& kv,
+                             elecstate::ElecState* pelec,
+                             elecstate::DensityMatrix<TK, double>* dm, // mohan add 2025-11-04
+                             Parallel_Orbitals& pv,
+                             Grid_Driver& gd,
+                             psi::Psi<TK>* psi,
+                             hamilt::HamiltLCAO<TK, TR>* p_hamilt,
+                             Plus_U& dftu, // mohan add 2025-11-07
+                             TwoCenterBundle& two_center_bundle,
+                             LCAO_Orbitals& orb,
+                             const ModulePW::PW_Basis_K* pw_wfc,   // for berryphase
+                             const ModulePW::PW_Basis* pw_rho,     // for berryphase
+                             const ModulePW::PW_Basis_Big* pw_big, // for Wannier90
+                             const Structure_Factor& sf,           // for Wannier90
+                             rdmft::RDMFT<TK, TR>& rdmft_solver,   // for RDMFT
+                             Setup_DeePKS<TK>& deepks,
+                             Exx_NAO<TK>& exx_nao,
+                             const bool conv_esolver,
+                             const bool scf_nmax_flag,
+                             const int istep)
 {
     ModuleBase::TITLE("ModuleIO", "ctrl_scf_lcao");
     ModuleBase::timer::tick("ModuleIO", "ctrl_scf_lcao");
@@ -65,7 +65,7 @@ void ModuleIO::ctrl_scf_lcao(UnitCell& ucell,
     int istep_in = -1;
     int iter_in = -1;
     bool out_flag = false;
-    if (inp.out_freq_ion>0) // default value of out_freq_ion is 0
+    if (PARAM.inp.esolver_type != "tddft" && inp.out_freq_ion > 0) // default value of out_freq_ion is 0
     {
         if (istep % inp.out_freq_ion == 0)
         {
@@ -73,15 +73,23 @@ void ModuleIO::ctrl_scf_lcao(UnitCell& ucell,
             out_flag = true;
         }
     }
-    else if(conv_esolver || scf_nmax_flag) // mohan add scf_nmax_flag on 20250921
+    else if (PARAM.inp.esolver_type == "tddft" && inp.out_freq_td > 0) // default value of out_freq_td is 0
+    {
+        if (istep % inp.out_freq_td == 0)
+        {
+            istep_in = istep;
+            out_flag = true;
+        }
+    }
+    else if (conv_esolver || scf_nmax_flag) // mohan add scf_nmax_flag on 20250921
     {
         out_flag = true;
     }
 
-	if(!out_flag)
-	{
-		return;
-	}
+    if (!out_flag)
+    {
+        return;
+    }
 
     //*****
 
@@ -90,141 +98,139 @@ void ModuleIO::ctrl_scf_lcao(UnitCell& ucell,
     const int nspin = inp.nspin;
     const std::string global_out_dir = PARAM.globalv.global_out_dir;
 
-	//------------------------------------------------------------------
+    //------------------------------------------------------------------
     //! 1) print out density of states (DOS)
-	//------------------------------------------------------------------
+    //------------------------------------------------------------------
     if (inp.out_dos)
     {
         ModuleIO::write_dos_lcao(psi,
-                p_hamilt,
-                pv,
-                ucell,
-                kv,
-                inp.nbands,
-                pelec->eferm,
-                pelec->ekb,
-                pelec->wg,
-                inp.dos_edelta_ev,
-                inp.dos_scale,
-                inp.dos_sigma,
-                out_app_flag,
-                istep,
-                GlobalV::ofs_running);
+                                 p_hamilt,
+                                 pv,
+                                 ucell,
+                                 kv,
+                                 inp.nbands,
+                                 pelec->eferm,
+                                 pelec->ekb,
+                                 pelec->wg,
+                                 inp.dos_edelta_ev,
+                                 inp.dos_scale,
+                                 inp.dos_sigma,
+                                 out_app_flag,
+                                 istep,
+                                 GlobalV::ofs_running);
     }
 
-	//------------------------------------------------------------------
-	//! 2) Output density matrix DM(R)
-	//------------------------------------------------------------------
-    if(inp.out_dmr[0])
-	{
+    //------------------------------------------------------------------
+    //! 2) Output density matrix DM(R)
+    //------------------------------------------------------------------
+    if (inp.out_dmr[0])
+    {
         const int precision = inp.out_dmr[1];
 
-		ModuleIO::write_dmr(dm->get_DMR_vector(), precision, pv, out_app_flag,
-				ucell.get_iat2iwt(), ucell.nat, istep);
-	}
+        ModuleIO::write_dmr(dm->get_DMR_vector(), precision, pv, out_app_flag, ucell.get_iat2iwt(), ucell.nat, istep);
+    }
 
-	//------------------------------------------------------------------
-	//! 3) Output density matrix DM(k)
-	//------------------------------------------------------------------
-	if (inp.out_dmk[0])
-	{
-		std::vector<double> efermis(nspin == 2 ? 2 : 1);
-		for (int ispin = 0; ispin < efermis.size(); ispin++)
-		{
-			efermis[ispin] = pelec->eferm.get_efval(ispin);
-		}
-		const int precision = inp.out_dmk[1];
+    //------------------------------------------------------------------
+    //! 3) Output density matrix DM(k)
+    //------------------------------------------------------------------
+    if (inp.out_dmk[0])
+    {
+        std::vector<double> efermis(nspin == 2 ? 2 : 1);
+        for (int ispin = 0; ispin < efermis.size(); ispin++)
+        {
+            efermis[ispin] = pelec->eferm.get_efval(ispin);
+        }
+        const int precision = inp.out_dmk[1];
 
-		ModuleIO::write_dmk(dm->get_DMK_vector(),
-				precision, efermis, &(ucell), pv, istep);
-	}
+        ModuleIO::write_dmk(dm->get_DMK_vector(), precision, efermis, &(ucell), pv, istep);
+    }
 
     //------------------------------------------------------------------
     // 4) Output H(k) and S(k) matrices for each k-point
     //------------------------------------------------------------------
-	if (inp.out_mat_hs[0])
-	{
-		ModuleIO::write_hsk(global_out_dir,
-				nspin,
-				kv.get_nks(), 
-				kv.get_nkstot(), 
-				kv.ik2iktot, 
-				kv.isk,
-				p_hamilt, 
-				pv, 
-				gamma_only,
-				out_app_flag,
-				istep,
-				GlobalV::ofs_running);
-	}
+    if (inp.out_mat_hs[0])
+    {
+        ModuleIO::write_hsk(global_out_dir,
+                            nspin,
+                            kv.get_nks(),
+                            kv.get_nkstot(),
+                            kv.ik2iktot,
+                            kv.isk,
+                            p_hamilt,
+                            pv,
+                            gamma_only,
+                            out_app_flag,
+                            istep,
+                            GlobalV::ofs_running);
+    }
 
     //------------------------------------------------------------------
     //! 5) Output electronic wavefunctions Psi(k)
     //------------------------------------------------------------------
     if (elecstate::ElecStateLCAO<TK>::out_wfc_lcao)
     {
-		ModuleIO::write_wfc_nao(elecstate::ElecStateLCAO<TK>::out_wfc_lcao,
-				out_app_flag,
-				psi[0],
-				pelec->ekb,
-				pelec->wg,
-				kv.kvec_c,
-				kv.ik2iktot,
-				kv.get_nkstot(),
-				pv,
-				nspin,
-				istep);
-	}
+        ModuleIO::write_wfc_nao(elecstate::ElecStateLCAO<TK>::out_wfc_lcao,
+                                out_app_flag,
+                                psi[0],
+                                pelec->ekb,
+                                pelec->wg,
+                                kv.kvec_c,
+                                kv.ik2iktot,
+                                kv.get_nkstot(),
+                                pv,
+                                nspin,
+                                istep);
+    }
 
     //------------------------------------------------------------------
     //! 6) Output DeePKS information
     //------------------------------------------------------------------
 #ifdef __MLALGO
     // need control parameter
-	hamilt::HamiltLCAO<TK, TR>* p_ham_deepks = p_hamilt;
-	std::shared_ptr<LCAO_Deepks<TK>> ld_shared_ptr(&deepks.ld, [](LCAO_Deepks<TK>*) {});
-	LCAO_Deepks_Interface<TK, TR> deepks_interface(ld_shared_ptr);
+    hamilt::HamiltLCAO<TK, TR>* p_ham_deepks = p_hamilt;
+    std::shared_ptr<LCAO_Deepks<TK>> ld_shared_ptr(&deepks.ld, [](LCAO_Deepks<TK>*) {});
+    LCAO_Deepks_Interface<TK, TR> deepks_interface(ld_shared_ptr);
 
-	deepks_interface.out_deepks_labels(pelec->f_en.etot,
-			kv.get_nks(),
-			ucell.nat,
-			PARAM.globalv.nlocal,
-			pelec->ekb,
-			kv.kvec_d,
-			ucell,
-			orb,
-			gd,
-			&pv,
-			*psi,
-			dm,
-			p_ham_deepks,
-            -1, // -1 when called in after scf
-            true, // no used when after scf
-			GlobalV::MY_RANK,
-            GlobalV::ofs_running);
+    deepks_interface.out_deepks_labels(pelec->f_en.etot,
+                                       kv.get_nks(),
+                                       ucell.nat,
+                                       PARAM.globalv.nlocal,
+                                       pelec->ekb,
+                                       kv.kvec_d,
+                                       ucell,
+                                       orb,
+                                       gd,
+                                       &pv,
+                                       *psi,
+                                       dm,
+                                       p_ham_deepks,
+                                       -1,   // -1 when called in after scf
+                                       true, // no used when after scf
+                                       GlobalV::MY_RANK,
+                                       GlobalV::ofs_running);
 #endif
 
     //------------------------------------------------------------------
     //! 7) Output <phi_i|O|phi_j> matrices, where O can be chosen as
-    //!    H, S, dH, dS, T, r. The format is CSR format. 
+    //!    H, S, dH, dS, T, r. The format is CSR format.
     //------------------------------------------------------------------
     hamilt::Hamilt<TK>* p_ham_tk = static_cast<hamilt::Hamilt<TK>*>(p_hamilt);
 
-	ModuleIO::output_mat_sparse(inp.out_mat_hs2,
-			inp.out_mat_dh,
-			inp.out_mat_ds,
-			inp.out_mat_t,
-			inp.out_mat_r,
-			istep,
-			pelec->pot->get_eff_v(),
-			pv,
-			two_center_bundle,
-			orb,
-			ucell,
-			gd,
-			kv,
-			p_ham_tk, 
-			&dftu);
+    ModuleIO::output_mat_sparse(inp.out_mat_hs2,
+                                inp.out_mat_dh,
+                                inp.out_mat_ds,
+                                inp.out_mat_t,
+                                inp.out_mat_r,
+                                istep,
+                                pelec->pot->get_eff_v(),
+                                pv,
+                                two_center_bundle,
+                                orb,
+                                ucell,
+                                gd,
+                                kv,
+                                p_ham_tk,
+                                &dftu);
 
     //------------------------------------------------------------------
     //! 8) Output kinetic matrix
@@ -234,13 +240,13 @@ void ModuleIO::ctrl_scf_lcao(UnitCell& ucell,
         hamilt::HS_Matrix_K<TK> hsk(&pv, true);
         hamilt::HContainer<TR> hR(&pv);
         hamilt::Operator<TK>* ekinetic
-			= new hamilt::EkineticNew<hamilt::OperatorLCAO<TK, TR>>(&hsk,
-					kv.kvec_d,
-					&hR,
-					&ucell,
-					orb.cutoffs(),
-					&gd,
-					two_center_bundle.kinetic_orb.get());
+            = new hamilt::EkineticNew<hamilt::OperatorLCAO<TK, TR>>(&hsk,
+                                                                    kv.kvec_d,
+                                                                    &hR,
+                                                                    &ucell,
+                                                                    orb.cutoffs(),
+                                                                    &gd,
+                                                                    two_center_bundle.kinetic_orb.get());
 
         const int nspin_k = (nspin == 2 ? 2 : 1);
         for (int ik = 0; ik < kv.get_nks() / nspin_k; ++ik)
@@ -249,11 +255,17 @@ void ModuleIO::ctrl_scf_lcao(UnitCell& ucell,
 
             const int out_label = 1; // 1: .txt, 2: .dat
 
-			std::string t_fn = ModuleIO::filename_output(global_out_dir,
-					"tk","nao",ik,kv.ik2iktot,
-					inp.nspin,kv.get_nkstot(),
-					out_label,out_app_flag,
-                    gamma_only,istep);
+            std::string t_fn = ModuleIO::filename_output(global_out_dir,
+                                                         "tk",
+                                                         "nao",
+                                                         ik,
+                                                         kv.ik2iktot,
+                                                         inp.nspin,
+                                                         kv.get_nkstot(),
+                                                         out_label,
+                                                         out_app_flag,
+                                                         gamma_only,
+                                                         istep);
 
             ModuleIO::save_mat(istep,
                                hsk.get_hk(),
@@ -262,7 +274,7 @@ void ModuleIO::ctrl_scf_lcao(UnitCell& ucell,
                                inp.out_mat_tk[1],
                                1, // true for upper triangle matrix
                                inp.out_app_flag,
-                               t_fn, 
+                               t_fn,
                                pv,
                                GlobalV::DRANK);
         }
@@ -275,22 +287,16 @@ void ModuleIO::ctrl_scf_lcao(UnitCell& ucell,
     //------------------------------------------------------------------
     if (inp.out_mat_l[0])
     {
-        ModuleIO::AngularMomentumCalculator mylcalculator(
-            inp.orbital_dir,
-            ucell,
-            orb.get_rcutmax_Phi(),
-            inp.test_deconstructor,
-            inp.test_grid,
-            inp.test_atom_input,
-            PARAM.globalv.search_pbc,
-            &GlobalV::ofs_running,
-            GlobalV::MY_RANK
-        );
-        mylcalculator.calculate(inp.suffix,
-                                global_out_dir,
-                                ucell,
-                                inp.out_mat_l[1],
-                                GlobalV::MY_RANK);
+        ModuleIO::AngularMomentumCalculator mylcalculator(inp.orbital_dir,
+                                                          ucell,
+                                                          orb.get_rcutmax_Phi(),
+                                                          inp.test_deconstructor,
+                                                          inp.test_grid,
+                                                          inp.test_atom_input,
+                                                          PARAM.globalv.search_pbc,
+                                                          &GlobalV::ofs_running,
+                                                          GlobalV::MY_RANK);
+        mylcalculator.calculate(inp.suffix, global_out_dir, ucell, inp.out_mat_l[1], GlobalV::MY_RANK);
     }
 
     //------------------------------------------------------------------
@@ -299,15 +305,15 @@ void ModuleIO::ctrl_scf_lcao(UnitCell& ucell,
     if (inp.out_mul)
     {
         ModuleIO::cal_mag(&pv,
-                p_hamilt,
-                kv,
-                dm, // mohan add 2025-11-04
-                two_center_bundle,
-                orb,
-                ucell,
-                gd,
-                istep,
-                true);
+                          p_hamilt,
+                          kv,
+                          dm, // mohan add 2025-11-04
+                          two_center_bundle,
+                          orb,
+                          ucell,
+                          gd,
+                          istep,
+                          true);
     }
 
     //------------------------------------------------------------------
@@ -341,41 +347,40 @@ void ModuleIO::ctrl_scf_lcao(UnitCell& ucell,
     if (inp.calculation == "nscf" && inp.towannier90)
     {
         std::cout << FmtCore::format("\n * * * * * *\n << Start %s.\n", "Wave function to Wannier90");
-		if (inp.wannier_method == 1)
-		{
-			toWannier90_LCAO_IN_PW wan(inp.out_wannier_mmn,
-					inp.out_wannier_amn,
-					inp.out_wannier_unk,
-					inp.out_wannier_eig,
-					inp.out_wannier_wvfn_formatted,
-					inp.nnkpfile,
-					inp.wannier_spin);
-			wan.set_tpiba_omega(ucell.tpiba, ucell.omega);
-			wan.calculate(ucell,pelec->ekb,pw_wfc,pw_big,
-					sf,kv,psi,&pv);
-		}
-		else if (inp.wannier_method == 2)
-		{
-			toWannier90_LCAO wan(inp.out_wannier_mmn,
-					inp.out_wannier_amn,
-					inp.out_wannier_unk,
-					inp.out_wannier_eig,
-					inp.out_wannier_wvfn_formatted,
-					inp.nnkpfile,
-					inp.wannier_spin,
-					orb);
+        if (inp.wannier_method == 1)
+        {
+            toWannier90_LCAO_IN_PW wan(inp.out_wannier_mmn,
+                                       inp.out_wannier_amn,
+                                       inp.out_wannier_unk,
+                                       inp.out_wannier_eig,
+                                       inp.out_wannier_wvfn_formatted,
+                                       inp.nnkpfile,
+                                       inp.wannier_spin);
+            wan.set_tpiba_omega(ucell.tpiba, ucell.omega);
+            wan.calculate(ucell, pelec->ekb, pw_wfc, pw_big, sf, kv, psi, &pv);
+        }
+        else if (inp.wannier_method == 2)
+        {
+            toWannier90_LCAO wan(inp.out_wannier_mmn,
+                                 inp.out_wannier_amn,
+                                 inp.out_wannier_unk,
+                                 inp.out_wannier_eig,
+                                 inp.out_wannier_wvfn_formatted,
+                                 inp.nnkpfile,
+                                 inp.wannier_spin,
+                                 orb);
 
-			wan.calculate(ucell, gd, pelec->ekb, kv, *psi, &pv);
-		}
-		std::cout << FmtCore::format(" >> Finish %s.\n * * * * * *\n", "Wave function to Wannier90");
-	}
+            wan.calculate(ucell, gd, pelec->ekb, kv, *psi, &pv);
+        }
+        std::cout << FmtCore::format(" >> Finish %s.\n * * * * * *\n", "Wave function to Wannier90");
+    }
 
     // 14) calculate the kinetic energy density tau
     // mohan add 2025-10-24
-//    if (inp.out_elf[0] > 0)
-//	{
-//		LCAO_domain::dm2tau(pelec->DM->get_DMR_vector(), inp.nspin, pelec->charge);
-//	}
+    //    if (inp.out_elf[0] > 0)
+    //	{
+    //		LCAO_domain::dm2tau(pelec->DM->get_DMR_vector(), inp.nspin, pelec->charge);
+    //	}
 
 #ifdef __EXX
     //------------------------------------------------------------------
@@ -386,8 +391,7 @@ void ModuleIO::ctrl_scf_lcao(UnitCell& ucell,
     {
         if (GlobalC::exx_info.info_global.cal_exx && inp.calculation != "nscf") // Peize Lin add if 2022.11.14
         {
-            const std::string file_name_exx = global_out_dir
-                + "HexxR" + std::to_string(GlobalV::MY_RANK);
+            const std::string file_name_exx = global_out_dir + "HexxR" + std::to_string(GlobalV::MY_RANK);
             if (GlobalC::exx_info.info_ri.real_number)
             {
                 ModuleIO::write_Hexxs_csr(file_name_exx, ucell, exx_nao.exd->get_Hexxs());
@@ -405,11 +409,7 @@ void ModuleIO::ctrl_scf_lcao(UnitCell& ucell,
     if (inp.rpa)
     {
         RPA_LRI<TK, double> rpa_lri_double(GlobalC::exx_info.info_ri);
-        rpa_lri_double.cal_postSCF_exx(*dm,
-                                       MPI_COMM_WORLD,
-                                       ucell,
-                                       kv,
-                                       orb);
+        rpa_lri_double.cal_postSCF_exx(*dm, MPI_COMM_WORLD, ucell, kv, orb);
         rpa_lri_double.init(MPI_COMM_WORLD, kv, orb.cutoffs());
         rpa_lri_double.out_for_RPA(ucell, pv, *psi, pelec);
     }
@@ -459,82 +459,79 @@ void ModuleIO::ctrl_scf_lcao(UnitCell& ucell,
         tqo.calculate();
     }
 
-
     ModuleBase::timer::tick("ModuleIO", "ctrl_scf_lcao");
 }
 
-
-
 // For gamma only
 template void ModuleIO::ctrl_scf_lcao<double, double>(
-        UnitCell& ucell, 
-        const Input_para& inp,
-		K_Vectors& kv,
-		elecstate::ElecState* pelec, 
-        elecstate::DensityMatrix<double,double>* dm, // mohan add 2025-11-04
-		Parallel_Orbitals& pv,
-		Grid_Driver& gd,
-		psi::Psi<double>* psi,
-		hamilt::HamiltLCAO<double, double>* p_hamilt,
-        Plus_U &dftu, // mohan add 2025-11-07
-		TwoCenterBundle &two_center_bundle,
-		LCAO_Orbitals &orb,
-		const ModulePW::PW_Basis_K* pw_wfc, // for berryphase
-		const ModulePW::PW_Basis* pw_rho, // for berryphase
-		const ModulePW::PW_Basis_Big* pw_big, // for Wannier90
-		const Structure_Factor& sf, // for Wannier90
-		rdmft::RDMFT<double, double> &rdmft_solver, // for RDMFT
-		Setup_DeePKS<double> &deepks,
-		Exx_NAO<double> &exx_nao,
-        const bool conv_esolver,
-        const bool scf_nmax_flag,
-		const int istep);
+    UnitCell& ucell,
+    const Input_para& inp,
+    K_Vectors& kv,
+    elecstate::ElecState* pelec,
+    elecstate::DensityMatrix<double, double>* dm, // mohan add 2025-11-04
+    Parallel_Orbitals& pv,
+    Grid_Driver& gd,
+    psi::Psi<double>* psi,
+    hamilt::HamiltLCAO<double, double>* p_hamilt,
+    Plus_U& dftu, // mohan add 2025-11-07
+    TwoCenterBundle& two_center_bundle,
+    LCAO_Orbitals& orb,
+    const ModulePW::PW_Basis_K* pw_wfc,         // for berryphase
+    const ModulePW::PW_Basis* pw_rho,           // for berryphase
+    const ModulePW::PW_Basis_Big* pw_big,       // for Wannier90
+    const Structure_Factor& sf,                 // for Wannier90
+    rdmft::RDMFT<double, double>& rdmft_solver, // for RDMFT
+    Setup_DeePKS<double>& deepks,
+    Exx_NAO<double>& exx_nao,
+    const bool conv_esolver,
+    const bool scf_nmax_flag,
+    const int istep);
 
 // For multiple k-points
 template void ModuleIO::ctrl_scf_lcao<std::complex<double>, double>(
-        UnitCell& ucell, 
-        const Input_para& inp,
-		K_Vectors& kv,
-		elecstate::ElecState* pelec, 
-        elecstate::DensityMatrix<std::complex<double>,double>* dm, // mohan add 2025-11-04
-		Parallel_Orbitals& pv,
-		Grid_Driver& gd,
-		psi::Psi<std::complex<double>>* psi,
-		hamilt::HamiltLCAO<std::complex<double>, double>* p_hamilt,
-        Plus_U &dftu, // mohan add 2025-11-07
-		TwoCenterBundle &two_center_bundle,
-		LCAO_Orbitals &orb,
-		const ModulePW::PW_Basis_K* pw_wfc, // for berryphase
-		const ModulePW::PW_Basis* pw_rho, // for berryphase
-		const ModulePW::PW_Basis_Big* pw_big, // for Wannier90
-		const Structure_Factor& sf, // for Wannier90
-		rdmft::RDMFT<std::complex<double>, double> &rdmft_solver, // for RDMFT
-		Setup_DeePKS<std::complex<double>> &deepks,
-		Exx_NAO<std::complex<double>> &exx_nao,
-        const bool conv_esolver,
-        const bool scf_nmax_flag,
-		const int istep);
+    UnitCell& ucell,
+    const Input_para& inp,
+    K_Vectors& kv,
+    elecstate::ElecState* pelec,
+    elecstate::DensityMatrix<std::complex<double>, double>* dm, // mohan add 2025-11-04
+    Parallel_Orbitals& pv,
+    Grid_Driver& gd,
+    psi::Psi<std::complex<double>>* psi,
+    hamilt::HamiltLCAO<std::complex<double>, double>* p_hamilt,
+    Plus_U& dftu, // mohan add 2025-11-07
+    TwoCenterBundle& two_center_bundle,
+    LCAO_Orbitals& orb,
+    const ModulePW::PW_Basis_K* pw_wfc,                       // for berryphase
+    const ModulePW::PW_Basis* pw_rho,                         // for berryphase
+    const ModulePW::PW_Basis_Big* pw_big,                     // for Wannier90
+    const Structure_Factor& sf,                               // for Wannier90
+    rdmft::RDMFT<std::complex<double>, double>& rdmft_solver, // for RDMFT
+    Setup_DeePKS<std::complex<double>>& deepks,
+    Exx_NAO<std::complex<double>>& exx_nao,
+    const bool conv_esolver,
+    const bool scf_nmax_flag,
+    const int istep);
 
 template void ModuleIO::ctrl_scf_lcao<std::complex<double>, std::complex<double>>(
-        UnitCell& ucell, 
-        const Input_para& inp,
-		K_Vectors& kv,
-		elecstate::ElecState* pelec, 
-        elecstate::DensityMatrix<std::complex<double>,double>* dm, // mohan add 2025-11-04
-		Parallel_Orbitals& pv,
-		Grid_Driver& gd,
-		psi::Psi<std::complex<double>>* psi,
-		hamilt::HamiltLCAO<std::complex<double>, std::complex<double>>* p_hamilt,
-        Plus_U &dftu, // mohan add 2025-11-07
-		TwoCenterBundle &two_center_bundle,
-		LCAO_Orbitals &orb,
-		const ModulePW::PW_Basis_K* pw_wfc, // for berryphase
-		const ModulePW::PW_Basis* pw_rho, // for berryphase
-		const ModulePW::PW_Basis_Big* pw_big, // for Wannier90
-		const Structure_Factor& sf, // for Wannier90
-		rdmft::RDMFT<std::complex<double>, std::complex<double>> &rdmft_solver, // for RDMFT
-		Setup_DeePKS<std::complex<double>> &deepks,
-		Exx_NAO<std::complex<double>> &exx_nao,
-        const bool conv_esolver,
-        const bool scf_nmax_flag,
-		const int istep);
+    UnitCell& ucell,
+    const Input_para& inp,
+    K_Vectors& kv,
+    elecstate::ElecState* pelec,
+    elecstate::DensityMatrix<std::complex<double>, double>* dm, // mohan add 2025-11-04
+    Parallel_Orbitals& pv,
+    Grid_Driver& gd,
+    psi::Psi<std::complex<double>>* psi,
+    hamilt::HamiltLCAO<std::complex<double>, std::complex<double>>* p_hamilt,
+    Plus_U& dftu, // mohan add 2025-11-07
+    TwoCenterBundle& two_center_bundle,
+    LCAO_Orbitals& orb,
+    const ModulePW::PW_Basis_K* pw_wfc,                                     // for berryphase
+    const ModulePW::PW_Basis* pw_rho,                                       // for berryphase
+    const ModulePW::PW_Basis_Big* pw_big,                                   // for Wannier90
+    const Structure_Factor& sf,                                             // for Wannier90
+    rdmft::RDMFT<std::complex<double>, std::complex<double>>& rdmft_solver, // for RDMFT
+    Setup_DeePKS<std::complex<double>>& deepks,
+    Exx_NAO<std::complex<double>>& exx_nao,
+    const bool conv_esolver,
+    const bool scf_nmax_flag,
+    const int istep);

--- a/source/source_io/ctrl_scf_lcao.h
+++ b/source/source_io/ctrl_scf_lcao.h
@@ -1,48 +1,47 @@
-#ifndef CTRL_SCF_LCAO_H 
-#define CTRL_SCF_LCAO_H 
+#ifndef CTRL_SCF_LCAO_H
+#define CTRL_SCF_LCAO_H
+
+#include "source_basis/module_nao/two_center_bundle.h" // use TwoCenterBundle
+#include "source_basis/module_pw/pw_basis_k.h"         // use ModulePW::PW_Basis_K and ModulePW::PW_Basis
+#include "source_cell/klist.h"                         // use K_Vectors
+#include "source_cell/unitcell.h"                      // use UnitCell
+#include "source_estate/elecstate.h"                   // use elecstate::ElecStateLCAO<TK>
+#include "source_estate/module_dm/density_matrix.h"    // mohan add 2025-11-04
+#include "source_lcao/hamilt_lcao.h"                   // use hamilt::HamiltLCAO<TK, TR>
+#include "source_lcao/module_dftu/dftu.h"              // mohan add 20251107
+#include "source_lcao/module_rdmft/rdmft.h"            // use RDMFT codes
+#include "source_lcao/setup_deepks.h"                  // for deepks, mohan add 20251008
+#include "source_lcao/setup_exx.h"                     // for exx, mohan add 20251008
+#include "source_psi/psi.h"                            // use Psi<TK>
+#include "source_pw/module_pwdft/structure_factor.h"   // use Structure_Factor
 
 #include <complex>
 
-#include "source_cell/unitcell.h" // use UnitCell
-#include "source_cell/klist.h" // use K_Vectors
-#include "source_estate/elecstate.h" // use elecstate::ElecStateLCAO<TK> 
-#include "source_psi/psi.h" // use Psi<TK>
-#include "source_lcao/hamilt_lcao.h" // use hamilt::HamiltLCAO<TK, TR>
-#include "source_basis/module_nao/two_center_bundle.h" // use TwoCenterBundle
-#include "source_basis/module_pw/pw_basis_k.h" // use ModulePW::PW_Basis_K and ModulePW::PW_Basis
-#include "source_pw/module_pwdft/structure_factor.h" // use Structure_Factor 
-#include "source_lcao/module_rdmft/rdmft.h" // use RDMFT codes
-
-#include "source_lcao/setup_deepks.h" // for deepks, mohan add 20251008
-#include "source_lcao/setup_exx.h" // for exx, mohan add 20251008
-#include "source_estate/module_dm/density_matrix.h" // mohan add 2025-11-04
-#include "source_lcao/module_dftu/dftu.h" // mohan add 20251107
-
 namespace ModuleIO
 {
-    // in principle, we need to add const for all of the variables, mohan note 2025-06-05
-	template <typename TK, typename TR>
-		void ctrl_scf_lcao(UnitCell& ucell, 
-				const Input_para& inp,
-				K_Vectors& kv,
-				elecstate::ElecState* pelec, 
-                elecstate::DensityMatrix<TK,double> *dm, // mohan add 2025-11-04
-				Parallel_Orbitals& pv,
-				Grid_Driver& gd,
-				psi::Psi<TK>* psi,
-				hamilt::HamiltLCAO<TK, TR>* p_hamilt,
-				Plus_U &dftu, // mohan add 2025-11-07
-				TwoCenterBundle &two_center_bundle,
-				LCAO_Orbitals &orb,
-				const ModulePW::PW_Basis_K* pw_wfc, // for berryphase
-				const ModulePW::PW_Basis* pw_rho, // for berryphase
-				const ModulePW::PW_Basis_Big* pw_big, // for Wannier90
-				const Structure_Factor& sf, // for Wannier90
-				rdmft::RDMFT<TK, TR> &rdmft_solver, // for RDMFT
-                Setup_DeePKS<TK> &deepks,
-                Exx_NAO<TK> &exx_nao,
-				const bool conv_esolver,
-				const bool scf_nmax_flag,
-				const int istep);
-}
+// in principle, we need to add const for all of the variables, mohan note 2025-06-05
+template <typename TK, typename TR>
+void ctrl_scf_lcao(UnitCell& ucell,
+                   const Input_para& inp,
+                   K_Vectors& kv,
+                   elecstate::ElecState* pelec,
+                   elecstate::DensityMatrix<TK, double>* dm, // mohan add 2025-11-04
+                   Parallel_Orbitals& pv,
+                   Grid_Driver& gd,
+                   psi::Psi<TK>* psi,
+                   hamilt::HamiltLCAO<TK, TR>* p_hamilt,
+                   Plus_U& dftu, // mohan add 2025-11-07
+                   TwoCenterBundle& two_center_bundle,
+                   LCAO_Orbitals& orb,
+                   const ModulePW::PW_Basis_K* pw_wfc,   // for berryphase
+                   const ModulePW::PW_Basis* pw_rho,     // for berryphase
+                   const ModulePW::PW_Basis_Big* pw_big, // for Wannier90
+                   const Structure_Factor& sf,           // for Wannier90
+                   rdmft::RDMFT<TK, TR>& rdmft_solver,   // for RDMFT
+                   Setup_DeePKS<TK>& deepks,
+                   Exx_NAO<TK>& exx_nao,
+                   const bool conv_esolver,
+                   const bool scf_nmax_flag,
+                   const int istep);
+} // namespace ModuleIO
 #endif

--- a/source/source_io/module_parameter/input_parameter.h
+++ b/source/source_io/module_parameter/input_parameter.h
@@ -367,6 +367,7 @@ struct Input_para
     bool out_stru = false;                ///< outut stru file each ion step
     int out_freq_elec = 0;                ///< print information every few electronic steps 
     int out_freq_ion = 0;                 ///< print information every few ionic steps 
+    int out_freq_td = 0;                  ///< print information every few completed electronic iterations in RT-TDDFT
     std::vector<int> out_chg = {0, 3};    ///< output charge density. 0: no; 1: yes
     std::vector<int> out_xc_r = {-1, 3};  ///< output xc(r). -1: no; >=0: output the order of xc(r)
     int out_pot = 0;                      ///< yes or no

--- a/source/source_io/read_input_item_output.cpp
+++ b/source/source_io/read_input_item_output.cpp
@@ -345,12 +345,24 @@ void ReadInput::item_output()
         Input_Item item("out_freq_ion");
         item.annotation = "print information every few ionic steps";
         item.reset_value = [](const Input_Item& item, Parameter& para) {
-			if (para.input.out_freq_ion <= 0)
-			{
-				para.input.out_freq_ion = 0; // 0 means no output of info
-			}
-		};
-		read_sync_int(input.out_freq_ion);
+            if (para.input.out_freq_ion <= 0)
+            {
+                para.input.out_freq_ion = 0; // 0 means no output of info
+            }
+        };
+        read_sync_int(input.out_freq_ion);
+        this->add_item(item);
+    }
+    {
+        Input_Item item("out_freq_td");
+        item.annotation = "print information every few completed electronic iterations in RT-TDDFT";
+        item.reset_value = [](const Input_Item& item, Parameter& para) {
+            if (para.input.out_freq_td <= 0)
+            {
+                para.input.out_freq_td = 0; // 0 means no output of info
+            }
+        };
+        read_sync_int(input.out_freq_td);
         this->add_item(item);
     }
     {

--- a/source/source_io/test/read_input_ptest.cpp
+++ b/source/source_io/test/read_input_ptest.cpp
@@ -182,6 +182,7 @@ TEST_F(InputParaTest, ParaRead)
     EXPECT_EQ(param.inp.chg_extrap, "atomic");
     EXPECT_EQ(param.inp.out_freq_elec, 50);
     EXPECT_EQ(param.inp.out_freq_ion, 0);
+    EXPECT_EQ(param.inp.out_freq_td, 0);
     EXPECT_EQ(param.inp.out_chg[0], 0);
     EXPECT_EQ(param.inp.out_chg[1], 3);
     EXPECT_EQ(param.inp.out_elf[0], 0);
@@ -207,7 +208,6 @@ TEST_F(InputParaTest, ParaRead)
     EXPECT_FALSE(param.inp.out_mat_xc);
     EXPECT_FALSE(param.inp.out_mat_xc2);
     EXPECT_FALSE(param.inp.out_eband_terms);
-    EXPECT_EQ(param.inp.out_freq_ion, 0);
     EXPECT_EQ(param.inp.out_app_flag, 0);
     EXPECT_EQ(param.inp.out_mat_r, 0);
     EXPECT_FALSE(param.inp.out_wfc_lcao);


### PR DESCRIPTION
### Changes
- In RT-TDDFT, outputs from `ctrl_output_fp`, `ctrl_scf_lcao`, and `ctrl_output_td` are now controlled by `out_freq_td`, triggering every N completed electronic evolution steps.
