### PR TITLE
Fix: Add a threshold to avoid E_gap(k)=0 for insulators

### DIFF
--- a/source/source_estate/elecstate_energy.cpp
+++ b/source/source_estate/elecstate_energy.cpp
@@ -22,15 +22,16 @@ void ElecState::cal_bandgap()
     int nks = this->klist->get_nks();
     double vbm = -std::numeric_limits<double>::infinity(); // Valence Band Maximum
     double cbm = std::numeric_limits<double>::infinity(); // Conduction Band Minimum
+    const double threshold = 1.0e-5; // threshold to avoid E_gap(k) = 0
     for (int ib = 0; ib < nbands; ib++)
     {
         for (int ik = 0; ik < nks; ik++)
         {
-            if (this->ekb(ik, ib) <= this->eferm.ef && this->ekb(ik, ib) > vbm)
+            if (this->ekb(ik, ib) <= this->eferm.ef + threshold && this->ekb(ik, ib) > vbm)
             {
                 vbm = this->ekb(ik, ib);
             }
-            if (this->ekb(ik, ib) >= this->eferm.ef && this->ekb(ik, ib) < cbm)
+            if (this->ekb(ik, ib) > this->eferm.ef + threshold && this->ekb(ik, ib) < cbm)
             {
                 cbm = this->ekb(ik, ib);
             }
@@ -62,28 +63,29 @@ void ElecState::cal_bandgap_updw()
     double cbm_up = std::numeric_limits<double>::infinity();
     double vbm_dw = -std::numeric_limits<double>::infinity();
     double cbm_dw = std::numeric_limits<double>::infinity();
+    const double threshold = 1.0e-5;
     for (int ib = 0; ib < nbands; ib++)
     {
         for (int ik = 0; ik < nks; ik++)
         {
             if (this->klist->isk[ik] == 0)
             {
-                if (this->ekb(ik, ib) <= this->eferm.ef_up && this->ekb(ik, ib) > vbm_up)
+                if (this->ekb(ik, ib) <= this->eferm.ef_up + threshold && this->ekb(ik, ib) > vbm_up)
                 {
                     vbm_up = this->ekb(ik, ib);
                 }
-                if (this->ekb(ik, ib) >= this->eferm.ef_up && this->ekb(ik, ib) < cbm_up)
+                if (this->ekb(ik, ib) > this->eferm.ef_up + threshold && this->ekb(ik, ib) < cbm_up)
                 {
                     cbm_up = this->ekb(ik, ib);
                 }
             }
             if (this->klist->isk[ik] == 1)
             {
-                if (this->ekb(ik, ib) <= this->eferm.ef_dw && this->ekb(ik, ib) > vbm_dw)
+                if (this->ekb(ik, ib) <= this->eferm.ef_dw + threshold && this->ekb(ik, ib) > vbm_dw)
                 {
                     vbm_dw = this->ekb(ik, ib);
                 }
-                if (this->ekb(ik, ib) >= this->eferm.ef_dw && this->ekb(ik, ib) < cbm_dw)
+                if (this->ekb(ik, ib) > this->eferm.ef_dw + threshold && this->ekb(ik, ib) < cbm_dw)
                 {
                     cbm_dw = this->ekb(ik, ib);
                 }


### PR DESCRIPTION
This PR is trying to fix an issue in cal_bandgap and cal_bandgap_updw where the bandgap of insulators (e.g., NaCl) was calculated as 0.0 eV. The threshold of 1e-5 is the value implemented in the old method in ABACUS-LTS.

### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [x] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
