### PR TITLE
Fix:  Update NEP interface to match NEP_CPU's update

### DIFF
--- a/source/source_esolver/esolver_nep.h
+++ b/source/source_esolver/esolver_nep.h
@@ -90,7 +90,7 @@ class ESolver_NEP : public ESolver
      * @note These variables are only defined if the __NEP preprocessor macro is defined.
      */
 #ifdef __NEP
-    NEP3 nep; ///< NEP3 object for NEP calculations
+    NEP nep; ///< NEP object for NEP calculations
 #endif
 
     std::string nep_file;                ///< directory of NEP model file

--- a/toolchain/scripts/stage4/install_nep.sh
+++ b/toolchain/scripts/stage4/install_nep.sh
@@ -63,7 +63,7 @@ CXXFLAGS = -O2 -fPIC -std=c++11
 INCLUDES = -I./src
 
 # Source files
-SRCS = ./src/nep.cpp
+SRCS = ./src/nep.cpp ./src/ewald.cpp ./src/neighbor.cpp
 
 # Object files
 OBJS = \$(SRCS:.cpp=.o)
@@ -91,7 +91,7 @@ install:
 	mkdir -p \$(PREFIX)/lib
 	mkdir -p \$(PREFIX)/include
 	cp \$(TARGET) \$(PREFIX)/lib/
-	cp src/nep.h \$(PREFIX)/include/
+	cp src/*.h \$(PREFIX)/include/
 EOF
 
         make > make.log 2>&1 || tail -n ${LOG_LINES} make.log


### PR DESCRIPTION
Recently, the NEP_CPU has released a breaking change related to the `qNEP`, the original API has been changed:
1. Rename the `NEP3` to `NEP`.
2. Add the `ewald.cpp` and `neighbor.cpp`.

### Linked Issue
Fix #6800 

### What's changed?
- The `NEP3` in `esolver_nep.h` has been renamed to `NEP` to match the update.
- Update the related toolchain script.
