### PR TITLE
Fix kpar check for DSP

### DIFF
--- a/source/source_main/driver_run.cpp
+++ b/source/source_main/driver_run.cpp
@@ -128,7 +128,7 @@ void Driver::init_hardware()
 #endif
 
 #ifdef __DSP
-    if (GlobalV::NPROC > PARAM.inp.KPAR)
+    if (GlobalV::NPROC > PARAM.inp.kpar)
     {
         ModuleBase::WARNING_QUIT(
             "Driver::init_hardware",


### PR DESCRIPTION
### Linked Issue
Fix #6771 and use the correct `PARAM.inp.kpar` instead of `KPAR` for DSP check.
