### PR TITLE
Fix local pseudopotential energy calculation with k-point parallelization

### DIFF
--- a/source/source_esolver/esolver_of.cpp
+++ b/source/source_esolver/esolver_of.cpp
@@ -539,7 +539,7 @@ double ESolver_OF::cal_energy()
                                                 this->pw_rho->nrxx,
                                                 this->dV_);
     }
-    Parallel_Reduce::reduce_all(pseudopot_energy);
+    Parallel_Reduce::reduce_pool(pseudopot_energy);
     this->pelec->f_en.ekinetic = kinetic_energy;
     this->pelec->f_en.e_local_pp = pseudopot_energy;
     this->pelec->f_en.etot += kinetic_energy + pseudopot_energy;

--- a/source/source_estate/elecstate_energy_terms.cpp
+++ b/source/source_estate/elecstate_energy_terms.cpp
@@ -45,10 +45,13 @@ double ElecState::get_local_pp_energy()
     for (int is = 0; is < PARAM.inp.nspin; ++is)
     {
         local_pseudopot_energy
-            += BlasConnector::dot(this->charge->rhopw->nrxx, this->pot->get_fixed_v(), 1, this->charge->rho[is], 1)
-               * this->charge->rhopw->omega / this->charge->rhopw->nxyz;
+            += BlasConnector::dot(this->charge->rhopw->nrxx, 
+                                  this->pot->get_fixed_v(), 
+                                  1, 
+                                  this->charge->rho[is], 1)
+                                  * this->charge->rhopw->omega / this->charge->rhopw->nxyz;
     }
-    Parallel_Reduce::reduce_all(local_pseudopot_energy);
+    Parallel_Reduce::reduce_pool(local_pseudopot_energy);
     return local_pseudopot_energy;
 }
 


### PR DESCRIPTION
## Description 

Fixes an overcounting bug in the local pseudopotential energy (`E_local_pp`) when using k-point parallelization (`kpar > 1`).

## Problem

When `kpar > 1`, the real-space charge density and local pseudopotential are:
- **Distributed within** each k-point pool (i.e., across processes in the same pool),
- But **duplicated across** different k-point pools.

The previous implementation used `Parallel_Reduce::reduce_all` to sum `E_local_pp`, which aggregates values from **all MPI processes across all pools**. This caused the local pseudopotential energy to be **overcounted by a factor of `kpar`**, leading to incorrect total energies in both KS-DFT and OF-DFT calculations.

## Solution

Replaced `Parallel_Reduce::reduce_all` with `Parallel_Reduce::reduce_pool` in:
- `source/elecstate/elecstate_energy_terms.cpp` (KS-DFT)
- `source/esolver/esolver_of.cpp` (OF-DFT)

`reduce_pool` performs reduction only within the current k-point pool communicator—where the real-space grid data is uniquely partitioned—ensuring the energy is summed exactly once.

