### PR TITLE
Add check for init_wfc to use proper atomic/random starting wavefunction

### DIFF
--- a/source/source_psi/psi_init.cpp
+++ b/source/source_psi/psi_init.cpp
@@ -51,11 +51,26 @@ void PSIInit<T, Device>::prepare_init(const int& random_seed)
     }
     else if ((this->init_wfc.substr(0, 6) == "atomic") && (this->ucell.natomwfc == 0))
     {
+        ModuleBase::WARNING_QUIT("PSIInit::prepare_init",
+            "init_wfc = atomic requires pseudo wavefunctions, but number of atom wfc = 0. \n"
+            "Please use init_wfc = random or try a pseudopotential with pseudo wavefunctions.");
         this->psi_initer = std::unique_ptr<psi_initializer<T>>(new psi_initializer_random<T>());
     }
     else if (this->init_wfc == "atomic"
              || (this->init_wfc == "atomic+random" && this->ucell.natomwfc < PARAM.inp.nbands))
     {
+        if (this->ucell.natomwfc < PARAM.inp.nbands)
+        {
+            int nrandom = PARAM.inp.nbands - this->ucell.natomwfc;
+            GlobalV::ofs_running << "\n Using ATOMIC starting wave functions with " << this->ucell.natomwfc << " atomic orbitals"
+            << " + " << nrandom << " random orbitals"
+            << " (total " << PARAM.inp.nbands << " bands)";
+        }
+        else
+        {
+            GlobalV::ofs_running << "\n Using ATOMIC starting wave functions for all " << this->ucell.natomwfc << " atomic orbitals"
+                << " (covers " << PARAM.inp.nbands << " bands)";
+        }
         this->psi_initer = std::unique_ptr<psi_initializer<T>>(new psi_initializer_atomic<T>());
     }
     else if (this->init_wfc == "atomic+random")

--- a/source/source_psi/psi_init.cpp
+++ b/source/source_psi/psi_init.cpp
@@ -53,7 +53,7 @@ void PSIInit<T, Device>::prepare_init(const int& random_seed)
     {
         ModuleBase::WARNING_QUIT("PSIInit::prepare_init",
             "init_wfc = atomic requires pseudo wavefunctions, but number of atom wfc = 0. \n"
-            "Please use init_wfc = random or try a pseudopotential with pseudo wavefunctions.");
+            " Please use init_wfc = random or try a pseudopotential with pseudo wavefunctions.");
         this->psi_initer = std::unique_ptr<psi_initializer<T>>(new psi_initializer_random<T>());
     }
     else if (this->init_wfc == "atomic"
@@ -163,7 +163,7 @@ void PSIInit<T, Device>::initialize_psi(Psi<std::complex<double>>* psi,
             {
                 syncmem_h2d_op()(psi_device->get_pointer(), psi_cpu->get_pointer(), nbands_start * nbasis);
             }
-                
+
 
             if (this->ks_solver == "cg")
             {
@@ -221,7 +221,7 @@ void PSIInit<T, Device>::initialize_psi(Psi<std::complex<double>>* psi,
             {
                 MPI_Status status;
                 Parallel_Common::recv_dev<T, Device>(kspw_psi->get_pointer(), nbands_l * nbasis, 0, 0, BP_WORLD, &status);
-            }            
+            }
         }
 #endif
     } // end k-point loop

--- a/tests/01_PW/011_PW_0ATOM/INPUT
+++ b/tests/01_PW/011_PW_0ATOM/INPUT
@@ -1,7 +1,8 @@
 INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
-calculation     	scf
+calculation     scf
+init_wfc        random
 
 nbands			6
 symmetry		0

--- a/tests/01_PW/013_PW_ONCV_LDA/INPUT
+++ b/tests/01_PW/013_PW_ONCV_LDA/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			6
 symmetry		1

--- a/tests/01_PW/016_PW_BLPS/INPUT
+++ b/tests/01_PW/016_PW_BLPS/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			6
 symmetry		1

--- a/tests/01_PW/017_PW_LPS6/INPUT
+++ b/tests/01_PW/017_PW_LPS6/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			13
 symmetry		1

--- a/tests/01_PW/018_PW_LPS8/INPUT
+++ b/tests/01_PW/018_PW_LPS8/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			3
 symmetry		1

--- a/tests/01_PW/020_PW_kspace/INPUT
+++ b/tests/01_PW/020_PW_kspace/INPUT
@@ -1,6 +1,7 @@
 INPUT_PARAMETERS
 suffix                  autotest
 calculation             scf
+init_wfc        random
 
 symmetry            1
 ecutwfc                 20

--- a/tests/01_PW/021_PW_kspace3/INPUT
+++ b/tests/01_PW/021_PW_kspace3/INPUT
@@ -1,6 +1,7 @@
 INPUT_PARAMETERS
 suffix                  autotest
 calculation             scf
+init_wfc                random
 
 symmetry                1
 ecutwfc                 5

--- a/tests/01_PW/029_PW_15_CF_CS_S1_smallg/INPUT
+++ b/tests/01_PW/029_PW_15_CF_CS_S1_smallg/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			6
 symmetry		1

--- a/tests/01_PW/030_PW_15_CF_CS_S2_smallg/INPUT
+++ b/tests/01_PW/030_PW_15_CF_CS_S2_smallg/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			6
 symmetry		1

--- a/tests/01_PW/035_PW_15_SO/INPUT
+++ b/tests/01_PW/035_PW_15_SO/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters	(General)
 suffix	         autotest
 pseudo_dir	     ../../PP_ORB
+init_wfc         random
 
 #nbands          40
 gamma_only       0

--- a/tests/01_PW/036_PW_AF/INPUT
+++ b/tests/01_PW/036_PW_AF/INPUT
@@ -1,6 +1,7 @@
 INPUT_PARAMETERS
 suffix    autotest
 
+init_wfc        random
 #nbands   40
 
 calculation   scf
@@ -18,7 +19,7 @@ out_chg    0
 smearing_method    gaussian
 smearing_sigma       0.07
 
-mixing_type    broyden 
+mixing_type    broyden
 mixing_beta    0.2
 
 ks_solver     cg

--- a/tests/01_PW/037_PW_FM/INPUT
+++ b/tests/01_PW/037_PW_FM/INPUT
@@ -1,6 +1,7 @@
 INPUT_PARAMETERS
 suffix    autotest
 
+init_wfc        random
 #nbands   40
 
 calculation   scf
@@ -18,7 +19,7 @@ out_chg    0
 smearing_method    gaussian
 smearing_sigma       0.07
 
-mixing_type    broyden 
+mixing_type    broyden
 mixing_beta    0.2
 
 ks_solver     cg

--- a/tests/01_PW/038_PW_NC/INPUT
+++ b/tests/01_PW/038_PW_NC/INPUT
@@ -1,5 +1,6 @@
 INPUT_PARAMETERS
 
+init_wfc        random
 # pw scf non-collinear calculations
 basis_type    pw
 calculation   scf
@@ -20,7 +21,7 @@ smearing_method    gaussian
 smearing_sigma       0.02
 
 # charge mixing method
-mixing_type    broyden 
+mixing_type    broyden
 mixing_beta    0.2
 mixing_ndim 10
 

--- a/tests/01_PW/039_PW_FD_smear/INPUT
+++ b/tests/01_PW/039_PW_FD_smear/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			35
 symmetry		1

--- a/tests/01_PW/041_PW_GA_smear/INPUT
+++ b/tests/01_PW/041_PW_GA_smear/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			30
 symmetry		1
@@ -17,7 +18,7 @@ scf_nmax			100
 basis_type		pw
 
 #Parameters (4.Smearing)
-smearing_method	    gauss	
+smearing_method	    gauss
 smearing_sigma			0.002
 
 #Parameters (5.Mixing)

--- a/tests/01_PW/042_PW_M2_smear/INPUT
+++ b/tests/01_PW/042_PW_M2_smear/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			8
 symmetry		1

--- a/tests/01_PW/043_PW_MP_smear/INPUT
+++ b/tests/01_PW/043_PW_MP_smear/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			12
 symmetry		1

--- a/tests/01_PW/044_PW_MV_smear/INPUT
+++ b/tests/01_PW/044_PW_MV_smear/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			6
 symmetry		1

--- a/tests/01_PW/045_PW_BD_chgmix/INPUT
+++ b/tests/01_PW/045_PW_BD_chgmix/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			12
 symmetry		1
@@ -21,6 +22,6 @@ smearing_method		gauss
 smearing_sigma			0.002
 
 #Parameters (5.Mixing)
-mixing_type	    broyden 
+mixing_type	    broyden
 mixing_beta		0.7
 

--- a/tests/01_PW/046_PW_KK_chgmix/INPUT
+++ b/tests/01_PW/046_PW_KK_chgmix/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			12
 symmetry		1

--- a/tests/01_PW/047_PW_PK_chgmix/INPUT
+++ b/tests/01_PW/047_PW_PK_chgmix/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			12
 symmetry		1

--- a/tests/01_PW/048_PW_PL_chgmix/INPUT
+++ b/tests/01_PW/048_PW_PL_chgmix/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			12
 symmetry		1
@@ -21,6 +22,6 @@ smearing_method		gauss
 smearing_sigma			0.002
 
 #Parameters (5.Mixing)
-mixing_type	    plain	
+mixing_type	    plain
 mixing_beta		0.7
 

--- a/tests/01_PW/049_PW_PU_chgmix/INPUT
+++ b/tests/01_PW/049_PW_PU_chgmix/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			12
 symmetry		1

--- a/tests/01_PW/050_PW_CHG_mismatch/INPUT
+++ b/tests/01_PW/050_PW_CHG_mismatch/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nspin           2
 nbands			6

--- a/tests/01_PW/055_PW_OW/INPUT
+++ b/tests/01_PW/055_PW_OW/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 basis_type    pw
 nspin         2
 calculation   scf
+init_wfc      random
 out_wfc_pw    1
 
 nbands        6

--- a/tests/01_PW/058_PW_RE_MB/INPUT
+++ b/tests/01_PW/058_PW_RE_MB/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 # Directories
 suffix           autotest
 pseudo_dir       ../../PP_ORB
+init_wfc         random
 
 # Relaxation Method
 calculation      relax

--- a/tests/01_PW/059_PW_RE_MB_traj/INPUT
+++ b/tests/01_PW/059_PW_RE_MB_traj/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix      autotest
 calculation relax
+init_wfc    random
 
 nbands     8
 symmetry   1

--- a/tests/01_PW/060_PW_RE_MG/INPUT
+++ b/tests/01_PW/060_PW_RE_MG/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     relax
+init_wfc        random
 
 nbands			8
 symmetry		1

--- a/tests/01_PW/063_PW_CR/INPUT
+++ b/tests/01_PW/063_PW_CR/INPUT
@@ -1,6 +1,7 @@
 INPUT_PARAMETERS
 #Parameters (General)
 suffix       autotest
+init_wfc     random
 pseudo_dir   ../../PP_ORB
 calculation  cell-relax
 basis_type   pw
@@ -19,7 +20,7 @@ relax_new    0
 cal_stress   1
 stress_thr   0.1
 cal_force    1
-force_thr_ev 0.001 
+force_thr_ev 0.001
 
 mixing_type  broyden
 mixing_beta  0.7

--- a/tests/01_PW/064_PW_CR_fix_a/INPUT
+++ b/tests/01_PW/064_PW_CR_fix_a/INPUT
@@ -2,8 +2,9 @@ INPUT_PARAMETERS
 #Parameters (General)
 suffix         autotest
 pseudo_dir     ../../PP_ORB
+init_wfc       random
 pw_seed        1
- 
+
 nbands         8
 calculation    cell-relax
 symmetry       0

--- a/tests/01_PW/065_PW_CR_fix_ab/INPUT
+++ b/tests/01_PW/065_PW_CR_fix_ab/INPUT
@@ -3,7 +3,8 @@ INPUT_PARAMETERS
 suffix              autotest
 pseudo_dir	../../PP_ORB
 pw_seed             1
-	
+init_wfc            random
+
 nbands			    8
 calculation         cell-relax
 symmetry        0

--- a/tests/01_PW/066_PW_CR_fix_abc/INPUT
+++ b/tests/01_PW/066_PW_CR_fix_abc/INPUT
@@ -3,7 +3,8 @@ INPUT_PARAMETERS
 suffix              autotest
 pseudo_dir	../../PP_ORB
 pw_seed             1
-	
+init_wfc            random
+
 nbands			    8
 calculation         cell-relax
 

--- a/tests/01_PW/067_PW_CR_fix_ac/INPUT
+++ b/tests/01_PW/067_PW_CR_fix_ac/INPUT
@@ -3,7 +3,8 @@ INPUT_PARAMETERS
 suffix              autotest
 pseudo_dir	../../PP_ORB
 pw_seed             1
-	
+init_wfc            random
+
 nbands			    8
 calculation         cell-relax
 symmetry        0

--- a/tests/01_PW/068_PW_CR_fix_b/INPUT
+++ b/tests/01_PW/068_PW_CR_fix_b/INPUT
@@ -3,7 +3,8 @@ INPUT_PARAMETERS
 suffix              autotest
 pseudo_dir	../../PP_ORB
 pw_seed             1
-	
+init_wfc            random
+
 nbands			    8
 calculation         cell-relax
 symmetry        0

--- a/tests/01_PW/069_PW_CR_fix_bc/INPUT
+++ b/tests/01_PW/069_PW_CR_fix_bc/INPUT
@@ -3,7 +3,8 @@ INPUT_PARAMETERS
 suffix              autotest
 pseudo_dir	../../PP_ORB
 pw_seed             1
-	
+init_wfc            random
+
 nbands			    8
 calculation         cell-relax
 symmetry        0

--- a/tests/01_PW/070_PW_CR_fix_c/INPUT
+++ b/tests/01_PW/070_PW_CR_fix_c/INPUT
@@ -3,7 +3,8 @@ INPUT_PARAMETERS
 suffix              autotest
 pseudo_dir	../../PP_ORB
 pw_seed             1
-	
+init_wfc            random
+
 nbands			    8
 calculation         cell-relax
 symmetry        0

--- a/tests/01_PW/071_PW_CR_move/INPUT
+++ b/tests/01_PW/071_PW_CR_move/INPUT
@@ -2,7 +2,8 @@ INPUT_PARAMETERS
 #Parameters	(General)
 suffix              autotest
 pseudo_dir	../../PP_ORB
-	
+init_wfc            random
+
 nbands			8
 calculation             cell-relax
 #Parameters (Accuracy)

--- a/tests/01_PW/072_PW_ELF/INPUT
+++ b/tests/01_PW/072_PW_ELF/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			6
 symmetry		1

--- a/tests/01_PW/075_PW_CHG_BINARY/INPUT
+++ b/tests/01_PW/075_PW_CHG_BINARY/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix                  autotest
 calculation             scf
+init_wfc                random
 nbands                  8
 symmetry                0
 latname                 fcc

--- a/tests/01_PW/076_PW_elec_add/INPUT
+++ b/tests/01_PW/076_PW_elec_add/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			8
 symmetry		1

--- a/tests/01_PW/077_PW_elec_minus/INPUT
+++ b/tests/01_PW/077_PW_elec_minus/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			8
 symmetry		1

--- a/tests/01_PW/078_PW_S2_elec_add/INPUT
+++ b/tests/01_PW/078_PW_S2_elec_add/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			8
 symmetry		1

--- a/tests/01_PW/079_PW_S2_elec_minus/INPUT
+++ b/tests/01_PW/079_PW_S2_elec_minus/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			8
 symmetry		1

--- a/tests/01_PW/080_PW_dipole/INPUT
+++ b/tests/01_PW/080_PW_dipole/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			    autotest
 calculation         scf
+init_wfc            random
 
 nbands			    6
 symmetry		    0

--- a/tests/01_PW/081_PW_efield/INPUT
+++ b/tests/01_PW/081_PW_efield/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			    autotest
 calculation         scf
+init_wfc            random
 
 nbands			    6
 symmetry		    0

--- a/tests/01_PW/082_PW_gatefield/INPUT
+++ b/tests/01_PW/082_PW_gatefield/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			    autotest
 calculation         scf
+init_wfc            random
 
 nbands			    6
 symmetry		    0

--- a/tests/01_PW/083_PW_sol_H2/INPUT
+++ b/tests/01_PW/083_PW_sol_H2/INPUT
@@ -2,8 +2,9 @@ INPUT_PARAMETERS
 #Parameters	(General)
 suffix      	autotest
 pseudo_dir	../../PP_ORB
+init_wfc        random
 pw_seed         1
-	
+
 nbands			2
 calculation 	scf
 basis_type		pw

--- a/tests/01_PW/084_PW_sol_H2O/INPUT
+++ b/tests/01_PW/084_PW_sol_H2O/INPUT
@@ -1,7 +1,8 @@
 INPUT_PARAMETERS
-	
+
 calculation 	scf
 basis_type		pw
+init_wfc        random
 pw_seed         1
 cal_force       1
 nbands			20

--- a/tests/01_PW/085_PW_get_pchg/INPUT
+++ b/tests/01_PW/085_PW_get_pchg/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix             autotest
 calculation        scf
+init_wfc           random
 
 nbands             6
 symmetry           1

--- a/tests/01_PW/086_PW_get_wf/INPUT
+++ b/tests/01_PW/086_PW_get_wf/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix             autotest
 calculation        scf
+init_wfc           random
 
 nbands             6
 symmetry           1

--- a/tests/01_PW/087_PW_get_pchg_kpar/INPUT
+++ b/tests/01_PW/087_PW_get_pchg_kpar/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix             autotest
 calculation        scf
+init_wfc           random
 
 nbands             6
 symmetry           1

--- a/tests/01_PW/088_PW_get_pchg_sepk/INPUT
+++ b/tests/01_PW/088_PW_get_pchg_sepk/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix             autotest
 calculation        scf
+init_wfc           random
 
 nbands             6
 symmetry           1

--- a/tests/01_PW/089_PW_get_wf_kpar/INPUT
+++ b/tests/01_PW/089_PW_get_wf_kpar/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix             autotest
 calculation        scf
+init_wfc           random
 
 nbands             6
 symmetry           1

--- a/tests/01_PW/091_PW_CR_VDW3/INPUT
+++ b/tests/01_PW/091_PW_CR_VDW3/INPUT
@@ -1,5 +1,6 @@
 INPUT_PARAMETERS
 
+init_wfc                      random
 ecutwfc                       20
 scf_thr                           1e-08
 scf_nmax                         400

--- a/tests/01_PW/092_PW_MSST/INPUT
+++ b/tests/01_PW/092_PW_MSST/INPUT
@@ -2,7 +2,8 @@ INPUT_PARAMETERS
 #Parameters	(General)
 suffix          autotest
 pseudo_dir	    ../../PP_ORB
-	
+init_wfc        random
+
 nbands			8
 calculation     md
 read_file_dir   ./

--- a/tests/01_PW/093_PW_MSST2/INPUT
+++ b/tests/01_PW/093_PW_MSST2/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters	(General)
 suffix          autotest
 calculation     md
+init_wfc        random
 nbands          8
 pseudo_dir      ../../PP_ORB
 

--- a/tests/01_PW/094_PW_NPT/INPUT
+++ b/tests/01_PW/094_PW_NPT/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters	(General)
 suffix          autotest
 calculation     md
+init_wfc        random
 pseudo_dir      ../../PP_ORB
 pw_seed         1
 nbands          8

--- a/tests/01_PW/095_PW_NVT/INPUT
+++ b/tests/01_PW/095_PW_NVT/INPUT
@@ -2,7 +2,8 @@ INPUT_PARAMETERS
 #Parameters	(General)
 suffix          autotest
 pseudo_dir	    ../../PP_ORB
-	
+init_wfc        random
+
 nbands			8
 calculation     md
 read_file_dir   ./

--- a/tests/01_PW/096_PW_PBE0/INPUT
+++ b/tests/01_PW/096_PW_PBE0/INPUT
@@ -1,6 +1,7 @@
 INPUT_PARAMETERS
 #Parameters	(System)
 suffix                  autotest
+init_wfc        random
 
 nbands			2
 stru_file		STRU
@@ -11,7 +12,7 @@ calculation             scf
 #Parameters (PW)
 ecutwfc			10.0              # Rydberg
 #Parameters (electronic)
-basis_type		pw 	
+basis_type		pw
 scf_thr			1e-3
 smearing_method fixed
 

--- a/tests/01_PW/097_PW_LDOS/INPUT
+++ b/tests/01_PW/097_PW_LDOS/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			6
 symmetry		1

--- a/tests/01_PW/098_PW_15_SO_avg/INPUT
+++ b/tests/01_PW/098_PW_15_SO_avg/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters	(General)
 suffix	         autotest
 pseudo_dir	     ../../PP_ORB
+init_wfc         random
 #nbands          40
 gamma_only       0
 

--- a/tests/01_PW/100_PW_W90/INPUT
+++ b/tests/01_PW/100_PW_W90/INPUT
@@ -1,5 +1,6 @@
 INPUT_PARAMETERS
 suffix			autotest
+init_wfc        random
 pseudo_dir              ../../PP_ORB
 orbital_dir             ../../PP_ORB
 ecutwfc                 50

--- a/tests/01_PW/101_PW_MD_1O/INPUT
+++ b/tests/01_PW/101_PW_MD_1O/INPUT
@@ -1,7 +1,8 @@
 INPUT_PARAMETERS
 #Parameters	(General)
 suffix      	autotest
-	
+init_wfc        random
+
 nbands			8
 calculation 	md
 

--- a/tests/01_PW/102_PW_MD_2O/INPUT
+++ b/tests/01_PW/102_PW_MD_2O/INPUT
@@ -1,7 +1,8 @@
 INPUT_PARAMETERS
 #Parameters	(General)
 suffix      	autotest
-	
+init_wfc        random
+
 nbands			8
 calculation 	md
 

--- a/tests/01_PW/202_PW_ONCV_Libxc/INPUT
+++ b/tests/01_PW/202_PW_ONCV_Libxc/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			6
 symmetry		1

--- a/tests/01_PW/204_PW_SY/INPUT
+++ b/tests/01_PW/204_PW_SY/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 symmetry		1
 pseudo_dir	../../PP_ORB

--- a/tests/01_PW/205_PW_SCAN/INPUT
+++ b/tests/01_PW/205_PW_SCAN/INPUT
@@ -3,6 +3,7 @@ INPUT_PARAMETERS
 suffix			autotest
 calculation     scf
 kpar            2
+init_wfc        random
 
 pseudo_dir	../../PP_ORB
 

--- a/tests/01_PW/206_PW_SCAN_S2/INPUT
+++ b/tests/01_PW/206_PW_SCAN_S2/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 pseudo_dir	../../PP_ORB
 pw_seed         1

--- a/tests/01_PW/207_PW_skip/INPUT
+++ b/tests/01_PW/207_PW_skip/INPUT
@@ -2,6 +2,7 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix			autotest
 calculation     scf
+init_wfc        random
 
 nbands			10
 symmetry		1

--- a/tests/01_PW/209_PW_DFTHALF/INPUT
+++ b/tests/01_PW/209_PW_DFTHALF/INPUT
@@ -4,6 +4,7 @@ suffix          autotest
 calculation     scf
 ks_solver       dav
 dfthalf_type    1
+init_wfc        random
 
 symmetry                1
 pseudo_dir      ../../PP_ORB

--- a/tests/06_SDFT/01_PW_SDFT_10S_M/INPUT
+++ b/tests/06_SDFT/01_PW_SDFT_10S_M/INPUT
@@ -4,6 +4,7 @@ suffix			autotest
 calculation     scf
 esolver_type    sdft
 method_sto      1
+init_wfc        random
 
 symmetry		0
 pseudo_dir	../../PP_ORB

--- a/tests/11_PW_GPU/006_PW_get_wf_GPU/INPUT
+++ b/tests/11_PW_GPU/006_PW_get_wf_GPU/INPUT
@@ -8,6 +8,7 @@ symmetry            0
 pseudo_dir          ../../PP_ORB
 
 device              gpu
+init_wfc            random
 
 #Parameters (2.Iteration)
 ecutwfc             100

--- a/tests/11_PW_GPU/007_PW_OW_GPU/INPUT
+++ b/tests/11_PW_GPU/007_PW_OW_GPU/INPUT
@@ -8,6 +8,7 @@ symmetry		1
 pseudo_dir	    ../../PP_ORB
 
 device          gpu
+init_wfc        random
 
 #Parameters (2.Iteration)
 ecutwfc			20


### PR DESCRIPTION
### What's changed?
- When `init_wfc` = `atomic`, atomic wave functions should be read from pseodopotential input. If zero atomic wfc is found, pop a warning and quit, suggesting using `random` or different pseudopotentials instead.
- Report the composition of the starting guess.
