### PR TITLE
Fix: Resolve memory leak when using solvation model in relaxing geometry

### DIFF
--- a/source/source_estate/module_pot/efield.cpp
+++ b/source/source_estate/module_pot/efield.cpp
@@ -227,7 +227,7 @@ double Efield::cal_induced_dipole(const UnitCell& cell,
 
     Parallel_Reduce::reduce_pool(induced_dipole);
     induced_dipole *= cell.lat0 / bmod * ModuleBase::FOUR_PI / rho_basis->nxyz;
-
+    delete[] induced_rho;
     return induced_dipole;
 }
 


### PR DESCRIPTION
Apologies for the previous PR https://github.com/deepmodeling/abacus-develop/pull/6832#issue-3780985438, which mixed bug fixes and refactoring. The refactoring was performed during the investigation of a memory leak issue https://github.com/deepmodeling/abacus-develop/issues/6794#issue-3737331936. Now the PR https://github.com/deepmodeling/abacus-develop/pull/6832#issue-3780985438 was divided into fix and refactor.

The previous memory leak was caused by induced_rho not being deleted in source/source_estate/module_pot/efield.cpp.

### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
