### PR TITLE
Refactor: reduce FFT calls in Leps2

### DIFF
--- a/source/source_hamilt/module_surchem/minimize_cg.cpp
+++ b/source/source_hamilt/module_surchem/minimize_cg.cpp
@@ -26,16 +26,12 @@ void surchem::minimize_cg(const UnitCell& ucell,
 
     std::complex<double> *gradphi_G_work = new std::complex<double>[rho_basis->npw];
 
-    // Removed unused phi_work allocation
-    // std::complex<double> *phi_work = new std::complex<double>[rho_basis->npw];
-
     // ==========================================================
     // PRE-ALLOCATION FOR LEPS2 (Avoids allocation inside loop)
     // ==========================================================
     ModuleBase::Vector3<double> *aux_grad_phi = new ModuleBase::Vector3<double>[rho_basis->nrxx];
-    std::complex<double> *aux_grad_grad_phi_G = new std::complex<double>[rho_basis->npw];
-    double *aux_lp_real = new double[rho_basis->nrxx];
     double *aux_grad_grad_phi_real = new double[rho_basis->nrxx];
+    // remove aux_grad_grad_phi_G and aux_lp_real
 
     ModuleBase::GlobalFunc::ZEROS(resid, rho_basis->npw);
     ModuleBase::GlobalFunc::ZEROS(z, rho_basis->npw);
@@ -68,7 +64,7 @@ void surchem::minimize_cg(const UnitCell& ucell,
     // call leps to calculate div ( epsilon * grad ) phi
     // Updated Leps2 call with new buffers
     Leps2(ucell, rho_basis, phi, d_eps, gradphi_G_work, lp,
-          aux_grad_phi, aux_grad_grad_phi_G, aux_lp_real, aux_grad_grad_phi_real);
+          aux_grad_phi, aux_grad_grad_phi_real);
 
     // the residue
     // r = A*phi + (chtot + N)
@@ -106,7 +102,7 @@ void surchem::minimize_cg(const UnitCell& ucell,
 
         // Updated Leps2 call inside loop
         Leps2(ucell, rho_basis, d, d_eps, gradphi_G_work, lp,
-              aux_grad_phi, aux_grad_grad_phi_G, aux_lp_real, aux_grad_grad_phi_real);
+              aux_grad_phi, aux_grad_grad_phi_real);
 
         // calculate alpha
         alpha = -rinvLr / ModuleBase::GlobalFunc::ddot_real(rho_basis->npw, d, lp);
@@ -161,12 +157,13 @@ void surchem::minimize_cg(const UnitCell& ucell,
 
     // Clean up auxiliary buffers
     delete[] aux_grad_phi;
-    delete[] aux_grad_grad_phi_G;
-    delete[] aux_lp_real;
+    // delete[] aux_grad_grad_phi_G; // Removed
+    // delete[] aux_lp_real;         // Removed
     delete[] aux_grad_grad_phi_real;
 }
 
 // avoid creating large temporary matrices inside its iteration loop
+// reduce the intermediate FFT related calls
 void surchem::Leps2(const UnitCell& ucell,
                     const ModulePW::PW_Basis* rho_basis,
                     std::complex<double>* phi,
@@ -174,8 +171,6 @@ void surchem::Leps2(const UnitCell& ucell,
                     std::complex<double>* gradphi_G_work,
                     std::complex<double>* lp,
                     ModuleBase::Vector3<double>* grad_phi_R,   // size: nrxx
-                    std::complex<double>* aux_G,               // size: npw
-                    double* lp_real,                           // size: nrxx
                     double* aux_R)                             // size: nrxx
 {
 
@@ -190,45 +185,32 @@ void surchem::Leps2(const UnitCell& ucell,
     }
 
 
-    ModuleBase::GlobalFunc::ZEROS(lp_real, rho_basis->nrxx);
+    ModuleBase::GlobalFunc::ZEROS(lp, rho_basis->npw);
 
-    // 1. R -> G
+    // R -> G
     for (int ir = 0; ir < rho_basis->nrxx; ir++) aux_R[ir] = grad_phi_R[ir].x;
-    rho_basis->real2recip(aux_R, gradphi_G_work); // 
+    rho_basis->real2recip(aux_R, gradphi_G_work); 
     
- 
     for(int ig=0; ig<rho_basis->npw; ig++) {
-        aux_G[ig] = ModuleBase::IMAG_UNIT * gradphi_G_work[ig] * rho_basis->gcar[ig][0]; // 0 = x
-    }
-    rho_basis->recip2real(aux_G, aux_R);
-    for(int ir=0; ir<rho_basis->nrxx; ir++) {
-        lp_real[ir] += aux_R[ir] * ucell.tpiba; 
+        // Divergence in G space: div(F) -> i * G * F(G)
+        lp[ig] += ModuleBase::IMAG_UNIT * gradphi_G_work[ig] * rho_basis->gcar[ig][0]; // 0 = x
     }
 
- 
     for (int ir = 0; ir < rho_basis->nrxx; ir++) aux_R[ir] = grad_phi_R[ir].y;
     rho_basis->real2recip(aux_R, gradphi_G_work); 
     
     for(int ig=0; ig<rho_basis->npw; ig++) {
-        aux_G[ig] = ModuleBase::IMAG_UNIT * gradphi_G_work[ig] * rho_basis->gcar[ig][1]; // 1 = y
+        lp[ig] += ModuleBase::IMAG_UNIT * gradphi_G_work[ig] * rho_basis->gcar[ig][1]; // 1 = y
     }
-    rho_basis->recip2real(aux_G, aux_R);
-    for(int ir=0; ir<rho_basis->nrxx; ir++) {
-        lp_real[ir] += aux_R[ir] * ucell.tpiba; 
-    }
-
 
     for (int ir = 0; ir < rho_basis->nrxx; ir++) aux_R[ir] = grad_phi_R[ir].z;
     rho_basis->real2recip(aux_R, gradphi_G_work);
     
     for(int ig=0; ig<rho_basis->npw; ig++) {
-        aux_G[ig] = ModuleBase::IMAG_UNIT * gradphi_G_work[ig] * rho_basis->gcar[ig][2]; // 2 = z
-    }
-    rho_basis->recip2real(aux_G, aux_R);
-    for(int ir=0; ir<rho_basis->nrxx; ir++) {
-        lp_real[ir] += aux_R[ir] * ucell.tpiba; 
+        lp[ig] += ModuleBase::IMAG_UNIT * gradphi_G_work[ig] * rho_basis->gcar[ig][2]; // 2 = z
     }
 
-
-    rho_basis->real2recip(lp_real, lp);
+    for(int ig=0; ig<rho_basis->npw; ig++) {
+        lp[ig] *= ucell.tpiba; 
+    }
 }

--- a/source/source_hamilt/module_surchem/surchem.h
+++ b/source/source_hamilt/module_surchem/surchem.h
@@ -100,11 +100,8 @@ class surchem
                double* epsilon,            // epsilon from shapefunc, dim=nrxx
                std::complex<double>* gradphi_G_work,
                std::complex<double>* lp,
-               // New buffers
-               ModuleBase::Vector3<double>* grad_phi_R,
-               std::complex<double>* grad_grad_phi_G,
-               double* lp_real,
-               double* grad_grad_phi_real);
+               ModuleBase::Vector3<double>* grad_phi_R,   // size: nrxx
+               double* aux_R);
 
     void v_correction(const UnitCell& cell,
                       const Parallel_Grid& pgrid,


### PR DESCRIPTION
Previously, the code seemed to perform unnecessary IFFT (G to R) transformations for each component (x, y, z) and an extra FFT (R to G) for the final result. So I reduced the number of FFT/IFFT calls per iteration from 10 to 6.

Then, the efficiency of the solvation model can be further increased by about 25%. For example, during the scf calculation of Ag-COOH example in https://github.com/deepmodeling/abacus-develop/pull/6836#issue-3786964264, the time for cal_vel further decreased from 375.72 s to 272.63 s (total time decreased from 667 s to 566 s, GNU toolchain, 7950x, mpirun -n 16). 

I will appreciate it if you can check if they are correct and safe.

### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
