### PR TITLE
Refactor: Replace explicit MPI reduction calls with Parallel_Reduce wrappers

### DIFF
--- a/source/source_base/parallel_device.cpp
+++ b/source/source_base/parallel_device.cpp
@@ -2,100 +2,135 @@
 #ifdef __MPI
 namespace Parallel_Common
 {
+
+// optimize: use a global static variable to avoid the overhead of function-static thread-safety checks
+static bool is_mpi_active = false;
+inline static bool is_mpi_initialized() {
+    if (is_mpi_active) return true;
+    int flag = 0;
+    MPI_Initialized(&flag);
+    if (flag) is_mpi_active = true;
+    return flag != 0;
+}
+
 void isend_data(const double* buf, int count, int dest, int tag, MPI_Comm& comm, MPI_Request* request)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Isend(buf, count, MPI_DOUBLE, dest, tag, comm, request);
 }
 void isend_data(const std::complex<double>* buf, int count, int dest, int tag, MPI_Comm& comm, MPI_Request* request)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Isend(buf, count, MPI_DOUBLE_COMPLEX, dest, tag, comm, request);
 }
 void isend_data(const float* buf, int count, int dest, int tag, MPI_Comm& comm, MPI_Request* request)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Isend(buf, count, MPI_FLOAT, dest, tag, comm, request);
 }
 void isend_data(const std::complex<float>* buf, int count, int dest, int tag, MPI_Comm& comm, MPI_Request* request)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Isend(buf, count, MPI_COMPLEX, dest, tag, comm, request);
 }
 void send_data(const double* buf, int count, int dest, int tag, MPI_Comm& comm)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Send(buf, count, MPI_DOUBLE, dest, tag, comm);
 }
 void send_data(const std::complex<double>* buf, int count, int dest, int tag, MPI_Comm& comm)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Send(buf, count, MPI_DOUBLE_COMPLEX, dest, tag, comm);
 }
 void send_data(const float* buf, int count, int dest, int tag, MPI_Comm& comm)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Send(buf, count, MPI_FLOAT, dest, tag, comm);
 }
 void send_data(const std::complex<float>* buf, int count, int dest, int tag, MPI_Comm& comm)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Send(buf, count, MPI_COMPLEX, dest, tag, comm);
 }
 void recv_data(double* buf, int count, int source, int tag, MPI_Comm& comm, MPI_Status* status)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Recv(buf, count, MPI_DOUBLE, source, tag, comm, status);
 }
 void recv_data(std::complex<double>* buf, int count, int source, int tag, MPI_Comm& comm, MPI_Status* status)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Recv(buf, count, MPI_DOUBLE_COMPLEX, source, tag, comm, status);
 }
 void recv_data(float* buf, int count, int source, int tag, MPI_Comm& comm, MPI_Status* status)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Recv(buf, count, MPI_FLOAT, source, tag, comm, status);
 }
 void recv_data(std::complex<float>* buf, int count, int source, int tag, MPI_Comm& comm, MPI_Status* status)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Recv(buf, count, MPI_COMPLEX, source, tag, comm, status);
 }
 void bcast_data(std::complex<double>* object, const int& n, const MPI_Comm& comm)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Bcast(object, n * 2, MPI_DOUBLE, 0, comm);
 }
 void bcast_data(std::complex<float>* object, const int& n, const MPI_Comm& comm)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Bcast(object, n * 2, MPI_FLOAT, 0, comm);
 }
 void bcast_data(double* object, const int& n, const MPI_Comm& comm)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Bcast(object, n, MPI_DOUBLE, 0, comm);
 }
 void bcast_data(float* object, const int& n, const MPI_Comm& comm)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Bcast(object, n, MPI_FLOAT, 0, comm);
 }
 void reduce_data(std::complex<double>* object, const int& n, const MPI_Comm& comm)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n * 2, MPI_DOUBLE, MPI_SUM, comm);
 }
 void reduce_data(std::complex<float>* object, const int& n, const MPI_Comm& comm)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n * 2, MPI_FLOAT, MPI_SUM, comm);
 }
 void reduce_data(double* object, const int& n, const MPI_Comm& comm)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE, MPI_SUM, comm);
 }
 void reduce_data(float* object, const int& n, const MPI_Comm& comm)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_FLOAT, MPI_SUM, comm);
 }
 void gatherv_data(const double* sendbuf, int sendcount, double* recvbuf, const int* recvcounts, const int* displs, MPI_Comm& comm)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Allgatherv(sendbuf, sendcount, MPI_DOUBLE, recvbuf, recvcounts, displs, MPI_DOUBLE, comm);
 }
 void gatherv_data(const std::complex<double>* sendbuf, int sendcount, std::complex<double>* recvbuf, const int* recvcounts, const int* displs, MPI_Comm& comm)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Allgatherv(sendbuf, sendcount, MPI_DOUBLE_COMPLEX, recvbuf, recvcounts, displs, MPI_DOUBLE_COMPLEX, comm);
 }
 void gatherv_data(const float* sendbuf, int sendcount, float* recvbuf, const int* recvcounts, const int* displs, MPI_Comm& comm)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Allgatherv(sendbuf, sendcount, MPI_FLOAT, recvbuf, recvcounts, displs, MPI_FLOAT, comm);
 }
 void gatherv_data(const std::complex<float>* sendbuf, int sendcount, std::complex<float>* recvbuf, const int* recvcounts, const int* displs, MPI_Comm& comm)
 {
+    if (!is_mpi_initialized()) return;
     MPI_Allgatherv(sendbuf, sendcount, MPI_COMPLEX, recvbuf, recvcounts, displs, MPI_COMPLEX, comm);
 }
 

--- a/source/source_base/parallel_reduce.cpp
+++ b/source/source_base/parallel_reduce.cpp
@@ -314,21 +314,24 @@ void Parallel_Reduce::reduce_min_pool<double>(double& object)
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_MIN, POOL_WORLD);
 #endif
 }
-void Parallel_Reduce::reduce_or_bool_all(bool& v)
+template<>
+void Parallel_Reduce::reduce_or_all<bool>(bool& v)
 {
 #ifdef __MPI
     MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_C_BOOL, MPI_LOR, MPI_COMM_WORLD);
 #endif
 }
 
-void Parallel_Reduce::reduce_or_bool_bp(bool& v)
+template<>
+void Parallel_Reduce::reduce_or_bp<bool>(bool& v)
 {
 #ifdef __MPI
     MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_C_BOOL, MPI_LOR, BP_WORLD);
 #endif
 }
 
-void Parallel_Reduce::reduce_kp(double* object, const int n)
+template<>
+void Parallel_Reduce::reduce_kp<double>(double* object, const int n)
 {
 #ifdef __MPI
     if (KP_WORLD != MPI_COMM_NULL)
@@ -336,21 +339,24 @@ void Parallel_Reduce::reduce_kp(double* object, const int n)
 #endif
 }
 
-void Parallel_Reduce::reduce_bp(double* object, const int n)
+template<>
+void Parallel_Reduce::reduce_bp<double>(double* object, const int n)
 {
 #ifdef __MPI
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE, MPI_SUM, BP_WORLD);
 #endif
 }
 
-void Parallel_Reduce::reduce_bgroup(double* object, const int n)
+template<>
+void Parallel_Reduce::reduce_bgroup<double>(double* object, const int n)
 {
 #ifdef __MPI
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE, MPI_SUM, INT_BGROUP);
 #endif
 }
 
-void Parallel_Reduce::reduce_kp(int* object, const int n)
+template<>
+void Parallel_Reduce::reduce_kp<int>(int* object, const int n)
 {
 #ifdef __MPI
     if (KP_WORLD != MPI_COMM_NULL)
@@ -358,14 +364,16 @@ void Parallel_Reduce::reduce_kp(int* object, const int n)
 #endif
 }
 
-void Parallel_Reduce::reduce_bp(int* object, const int n)
+template<>
+void Parallel_Reduce::reduce_bp<int>(int* object, const int n)
 {
 #ifdef __MPI
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_SUM, BP_WORLD);
 #endif
 }
 
-void Parallel_Reduce::reduce_bgroup(int* object, const int n)
+template<>
+void Parallel_Reduce::reduce_bgroup<int>(int* object, const int n)
 {
 #ifdef __MPI
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_SUM, INT_BGROUP);

--- a/source/source_base/parallel_reduce.cpp
+++ b/source/source_base/parallel_reduce.cpp
@@ -299,6 +299,13 @@ void Parallel_Reduce::reduce_max_int_pool(int& object)
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_INT, MPI_MAX, POOL_WORLD);
 #endif
 }
+
+void Parallel_Reduce::reduce_max_int_pool(int* object, const int n)
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_MAX, POOL_WORLD);
+#endif
+}
 void Parallel_Reduce::reduce_or_bool_all(bool& v)
 {
 #ifdef __MPI

--- a/source/source_base/parallel_reduce.cpp
+++ b/source/source_base/parallel_reduce.cpp
@@ -251,59 +251,67 @@ void Parallel_Reduce::gather_int_all(int& v, int* all)
     return;
 }
 
-void Parallel_Reduce::reduce_min_int_all(int& object)
+template<>
+void Parallel_Reduce::reduce_min_all<int>(int& object)
 {
 #ifdef __MPI
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
 #endif
 }
 
-void Parallel_Reduce::reduce_max_double_all(double& object)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
-#endif
-}
-
-void Parallel_Reduce::reduce_max_double_pool(double& object)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_MAX, POOL_WORLD);
-#endif
-}
-
-void Parallel_Reduce::reduce_min_double_pool(double& object)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_MIN, POOL_WORLD);
-#endif
-}
-
-void Parallel_Reduce::reduce_min_double_all(double& object)
+template<>
+void Parallel_Reduce::reduce_min_all<double>(double& object)
 {
 #ifdef __MPI
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
 #endif
 }
 
-void Parallel_Reduce::reduce_max_int_all(int& object)
+template<>
+void Parallel_Reduce::reduce_max_all<int>(int& object)
 {
 #ifdef __MPI
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
 #endif
 }
 
-void Parallel_Reduce::reduce_max_int_pool(int& object)
+template<>
+void Parallel_Reduce::reduce_max_all<double>(double& object)
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+#endif
+}
+
+template<>
+void Parallel_Reduce::reduce_max_pool<double>(double& object)
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_MAX, POOL_WORLD);
+#endif
+}
+
+template<>
+void Parallel_Reduce::reduce_max_pool<int>(int& object)
 {
 #ifdef __MPI
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_INT, MPI_MAX, POOL_WORLD);
 #endif
 }
 
-void Parallel_Reduce::reduce_max_int_pool(int* object, const int n)
+template<>
+void Parallel_Reduce::reduce_max_pool<int>(int* object, const int n)
 {
 #ifdef __MPI
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_MAX, POOL_WORLD);
+#endif
+}
+
+template<>
+void Parallel_Reduce::reduce_min_pool<double>(double& object)
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_MIN, POOL_WORLD);
 #endif
 }
 void Parallel_Reduce::reduce_or_bool_all(bool& v)

--- a/source/source_base/parallel_reduce.cpp
+++ b/source/source_base/parallel_reduce.cpp
@@ -251,130 +251,62 @@ void Parallel_Reduce::gather_int_all(int& v, int* all)
     return;
 }
 
-void Parallel_Reduce::gather_min_int_all(const int& nproc, int& v)
+void Parallel_Reduce::reduce_min_int_all(int& object)
 {
 #ifdef __MPI
-    std::vector<int> all(nproc, 0);
-    MPI_Allgather(&v, 1, MPI_INT, all.data(), 1, MPI_INT, MPI_COMM_WORLD);
-    for (int i = 0; i < nproc; i++)
-    {
-        if (v > all[i])
-        {
-            v = all[i];
-        }
-    }
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
 #endif
 }
 
-void Parallel_Reduce::gather_max_double_all(const int& nproc, double& v)
+void Parallel_Reduce::reduce_max_double_all(double& object)
 {
 #ifdef __MPI
-    std::vector<double> value(nproc, 0.0);
-    MPI_Allgather(&v, 1, MPI_DOUBLE, value.data(), 1, MPI_DOUBLE, MPI_COMM_WORLD);
-    for (int i = 0; i < nproc; i++)
-    {
-        if (v < value[i])
-        {
-            v = value[i];
-        }
-    }
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
 #endif
 }
 
-void Parallel_Reduce::gather_max_double_pool(const int& nproc_in_pool, double& v)
+void Parallel_Reduce::reduce_max_double_pool(double& object)
 {
 #ifdef __MPI
-    if (nproc_in_pool == 1) 
-    {
-        return;
-    }
-    std::vector<double> value(nproc_in_pool, 0.0);
-    MPI_Allgather(&v, 1, MPI_DOUBLE, value.data(), 1, MPI_DOUBLE, POOL_WORLD);
-    for (int i = 0; i < nproc_in_pool; i++)
-    {
-        if (v < value[i])
-        {
-            v = value[i];
-        }
-    }
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_MAX, POOL_WORLD);
 #endif
 }
 
-void Parallel_Reduce::gather_min_double_pool(const int& nproc_in_pool, double& v)
+void Parallel_Reduce::reduce_min_double_pool(double& object)
 {
 #ifdef __MPI
-    if (nproc_in_pool == 1) 
-    {
-        return;
-    }
-    std::vector<double> value(nproc_in_pool, 0.0);
-    MPI_Allgather(&v, 1, MPI_DOUBLE, value.data(), 1, MPI_DOUBLE, POOL_WORLD);
-    for (int i = 0; i < nproc_in_pool; i++)
-    {
-        if (v > value[i])
-        {
-            v = value[i];
-        }
-    }
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_MIN, POOL_WORLD);
 #endif
 }
 
-void Parallel_Reduce::gather_min_double_all(const int& nproc, double& v)
+void Parallel_Reduce::reduce_min_double_all(double& object)
 {
 #ifdef __MPI
-    std::vector<double> value(nproc, 0.0);
-    MPI_Allgather(&v, 1, MPI_DOUBLE, value.data(), 1, MPI_DOUBLE, MPI_COMM_WORLD);
-    for (int i = 0; i < nproc; i++)
-    {
-        if (v > value[i])
-        {
-            v = value[i];
-        }
-    }
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
 #endif
 }
 
-void Parallel_Reduce::gather_max_int_all(const int& nproc, int& v)
+void Parallel_Reduce::reduce_max_int_all(int& object)
 {
 #ifdef __MPI
-    std::vector<int> value(nproc, 0);
-    MPI_Allgather(&v, 1, MPI_INT, value.data(), 1, MPI_INT, MPI_COMM_WORLD);
-    for (int i = 0; i < nproc; i++)
-    {
-        if (v < value[i])
-        {
-            v = value[i];
-        }
-    }
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
 #endif
 }
 
-void Parallel_Reduce::gather_max_int_pool(const int& nproc_in_pool, int& v)
+void Parallel_Reduce::reduce_max_int_pool(int& object)
 {
 #ifdef __MPI
-    if (nproc_in_pool == 1) 
-    {
-        return;
-    }
-    std::vector<int> value(nproc_in_pool, 0);
-    MPI_Allgather(&v, 1, MPI_INT, value.data(), 1, MPI_INT, POOL_WORLD);
-    for (int i = 0; i < nproc_in_pool; i++)
-    {
-        if (v < value[i])
-        {
-            v = value[i];
-        }
-    }
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_INT, MPI_MAX, POOL_WORLD);
 #endif
 }
-void Parallel_Reduce::gather_or_bool_all(bool& v)
+void Parallel_Reduce::reduce_or_bool_all(bool& v)
 {
 #ifdef __MPI
     MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_C_BOOL, MPI_LOR, MPI_COMM_WORLD);
 #endif
 }
 
-void Parallel_Reduce::gather_or_bool_bp(bool& v)
+void Parallel_Reduce::reduce_or_bool_bp(bool& v)
 {
 #ifdef __MPI
     MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_C_BOOL, MPI_LOR, BP_WORLD);

--- a/source/source_base/parallel_reduce.cpp
+++ b/source/source_base/parallel_reduce.cpp
@@ -1,9 +1,6 @@
 #include "parallel_reduce.h"
-
 #include "parallel_comm.h"
-
 #include <vector>
-#include <iostream>
 #include <cassert>
 
 // Helper to safely check MPI status for WORLD comm
@@ -364,5 +361,65 @@ void Parallel_Reduce::reduce_bgroup<int>(int* object, const int n)
 #ifdef __MPI
     if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_SUM, INT_BGROUP);
+#endif
+}
+
+template <>
+void Parallel_Reduce::reduce_min_all<int>(int& object)
+{
+#ifdef __MPI
+    if (!is_mpi_initialized()) return;
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+#endif
+}
+
+template <>
+void Parallel_Reduce::reduce_min_all<double>(double& object)
+{
+#ifdef __MPI
+    if (!is_mpi_initialized()) return;
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
+#endif
+}
+
+void Parallel_Reduce::gather_int_all(int& v, int* all)
+{
+#ifdef __MPI
+    if (!is_mpi_initialized()) return;
+    MPI_Allgather(&v, 1, MPI_INT, all, 1, MPI_INT, MPI_COMM_WORLD);
+#else
+    all[0] = v;
+#endif
+}
+
+template<>
+void Parallel_Reduce::reduce_kp<double>(double* object, const int n)
+{
+#ifdef __MPI
+    if (!is_mpi_initialized()) return;
+    if (KP_WORLD != MPI_COMM_NULL)
+    {
+        MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE, MPI_SUM, KP_WORLD);
+    }
+#endif
+}
+
+template<>
+void Parallel_Reduce::reduce_bp<double>(double* object, const int n)
+{
+#ifdef __MPI
+    if (!is_mpi_initialized()) return;
+    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE, MPI_SUM, BP_WORLD);
+#endif
+}
+
+template<>
+void Parallel_Reduce::reduce_or_bp<bool>(bool& object)
+{
+#ifdef __MPI
+    if (!is_mpi_initialized()) return;
+    int v_int = object ? 1 : 0;
+    MPI_Allreduce(MPI_IN_PLACE, &v_int, 1, MPI_INT, MPI_LOR, BP_WORLD);
+    object = (v_int != 0);
 #endif
 }

--- a/source/source_base/parallel_reduce.cpp
+++ b/source/source_base/parallel_reduce.cpp
@@ -3,11 +3,29 @@
 #include "parallel_comm.h"
 
 #include <vector>
+#include <iostream>
+#include <cassert>
+
+// Helper to safely check MPI status for WORLD comm
+// optimize: use a global static variable to avoid the overhead of function-static thread-safety checks
+static bool is_mpi_active = false;
+inline static bool is_mpi_initialized() {
+#ifdef __MPI
+    if (is_mpi_active) return true;
+    int flag = 0;
+    MPI_Initialized(&flag);
+    if (flag) is_mpi_active = true;
+    return flag != 0;
+#else
+    return false;
+#endif
+}
 
 template <>
 void Parallel_Reduce::reduce_all<int>(int& object)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
 #endif
     return;
@@ -17,6 +35,7 @@ template <>
 void Parallel_Reduce::reduce_all<long long>(long long& object)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
 #endif
     return;
@@ -25,6 +44,7 @@ void Parallel_Reduce::reduce_all<long long>(long long& object)
 void Parallel_Reduce::reduce_int_diag(int& object)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_INT, MPI_SUM, DIAG_WORLD);
 #endif
     return;
@@ -34,6 +54,7 @@ template <>
 void Parallel_Reduce::reduce_all<double>(double& object)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
 #endif
     return;
@@ -43,6 +64,7 @@ template <>
 void Parallel_Reduce::reduce_all<float>(float& object)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_FLOAT, MPI_SUM, MPI_COMM_WORLD);
 #endif
     return;
@@ -52,6 +74,7 @@ template <>
 void Parallel_Reduce::reduce_all<int>(int* object, const int n)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
 #endif
     return;
@@ -61,6 +84,7 @@ template <>
 void Parallel_Reduce::reduce_all<long long>(long long* object, const int n)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
 #endif
     return;
@@ -69,6 +93,7 @@ void Parallel_Reduce::reduce_all<long long>(long long* object, const int n)
 void Parallel_Reduce::reduce_int_grid(int* object, const int n)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_SUM, GRID_WORLD);
 #endif
     return;
@@ -78,6 +103,7 @@ template <>
 void Parallel_Reduce::reduce_all<double>(double* object, const int n)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
 #endif
     return;
@@ -86,6 +112,7 @@ void Parallel_Reduce::reduce_all<double>(double* object, const int n)
 void Parallel_Reduce::reduce_double_grid(double* object, const int n)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE, MPI_SUM, GRID_WORLD);
 #endif
     return;
@@ -94,6 +121,7 @@ void Parallel_Reduce::reduce_double_grid(double* object, const int n)
 void Parallel_Reduce::reduce_double_diag(double* object, const int n)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE, MPI_SUM, DIAG_WORLD);
 #endif
     return;
@@ -103,6 +131,7 @@ template <>
 void Parallel_Reduce::reduce_pool<float>(float& object)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_FLOAT, MPI_SUM, POOL_WORLD);
 #endif
     return;
@@ -112,6 +141,7 @@ template <>
 void Parallel_Reduce::reduce_pool<double>(double& object)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_SUM, POOL_WORLD);
 #endif
     return;
@@ -121,6 +151,7 @@ template <>
 void Parallel_Reduce::reduce_pool<double>(double* object, const int n)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE, MPI_SUM, POOL_WORLD);
 #endif
     return;
@@ -130,6 +161,7 @@ template <>
 void Parallel_Reduce::reduce_pool<int>(int& object)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_INT, MPI_SUM, POOL_WORLD);
 #endif
     return;
@@ -139,6 +171,7 @@ template <>
 void Parallel_Reduce::reduce_pool<int>(int* object, const int n)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_SUM, POOL_WORLD);
 #endif
     return;
@@ -153,6 +186,7 @@ void Parallel_Reduce::reduce_double_allpool(const int& npool, const int& nproc_i
         return;
     }
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     double swap = object / nproc_in_pool;
     MPI_Allreduce(&swap, &object, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
 #endif
@@ -167,6 +201,7 @@ void Parallel_Reduce::reduce_double_allpool(const int& npool, const int& nproc_i
         return;
     }
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     std::vector<double> swap(n, 0.0);
     for (int i = 0; i < n; i++)
     {
@@ -180,6 +215,7 @@ template <>
 void Parallel_Reduce::reduce_all<std::complex<double>>(std::complex<double>& object)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_COMM_WORLD);
 #endif
     return;
@@ -190,6 +226,7 @@ template <>
 void Parallel_Reduce::reduce_all<std::complex<double>>(std::complex<double>* object, const int n)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_COMM_WORLD);
 #endif
     return;
@@ -200,17 +237,8 @@ template <>
 void Parallel_Reduce::reduce_all<std::complex<float>>(std::complex<float>& object)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_C_FLOAT_COMPLEX, MPI_SUM, MPI_COMM_WORLD);
-#endif
-    return;
-}
-
-// LiuXh add 2019-07-16
-template <>
-void Parallel_Reduce::reduce_all<std::complex<float>>(std::complex<float>* object, const int n)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_C_FLOAT_COMPLEX, MPI_SUM, MPI_COMM_WORLD);
 #endif
     return;
 }
@@ -219,6 +247,7 @@ template <>
 void Parallel_Reduce::reduce_pool<std::complex<double>>(std::complex<double>& object)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE_COMPLEX, MPI_SUM, POOL_WORLD);
 #endif
     return;
@@ -228,6 +257,7 @@ template <>
 void Parallel_Reduce::reduce_pool<std::complex<float>>(std::complex<float>* object, const int n)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_C_FLOAT_COMPLEX, MPI_SUM, POOL_WORLD);
 #endif
     return;
@@ -237,48 +267,27 @@ template <>
 void Parallel_Reduce::reduce_pool<std::complex<double>>(std::complex<double>* object, const int n)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE_COMPLEX, MPI_SUM, POOL_WORLD);
 #endif
     return;
 }
 
-void Parallel_Reduce::gather_int_all(int& v, int* all)
+template <>
+void Parallel_Reduce::reduce_all<std::complex<float>>(std::complex<float>* object, int n)
 {
 #ifdef __MPI
-    assert(all != nullptr);
-    MPI_Allgather(&v, 1, MPI_INT, all, 1, MPI_INT, MPI_COMM_WORLD);
+    if (!is_mpi_initialized()) return;
+    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_C_FLOAT_COMPLEX, MPI_SUM, MPI_COMM_WORLD);
 #endif
     return;
 }
 
-template<>
-void Parallel_Reduce::reduce_min_all<int>(int& object)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
-#endif
-}
-
-template<>
-void Parallel_Reduce::reduce_min_all<double>(double& object)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
-#endif
-}
-
-template<>
-void Parallel_Reduce::reduce_max_all<int>(int& object)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
-#endif
-}
-
-template<>
+template <>
 void Parallel_Reduce::reduce_max_all<double>(double& object)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
 #endif
 }
@@ -287,6 +296,7 @@ template<>
 void Parallel_Reduce::reduce_max_pool<double>(double& object)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_MAX, POOL_WORLD);
 #endif
 }
@@ -295,6 +305,7 @@ template<>
 void Parallel_Reduce::reduce_max_pool<int>(int& object)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_INT, MPI_MAX, POOL_WORLD);
 #endif
 }
@@ -303,6 +314,7 @@ template<>
 void Parallel_Reduce::reduce_max_pool<int>(int* object, const int n)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_MAX, POOL_WORLD);
 #endif
 }
@@ -311,39 +323,8 @@ template<>
 void Parallel_Reduce::reduce_min_pool<double>(double& object)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_MIN, POOL_WORLD);
-#endif
-}
-template<>
-void Parallel_Reduce::reduce_or_all<bool>(bool& v)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_C_BOOL, MPI_LOR, MPI_COMM_WORLD);
-#endif
-}
-
-template<>
-void Parallel_Reduce::reduce_or_bp<bool>(bool& v)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_C_BOOL, MPI_LOR, BP_WORLD);
-#endif
-}
-
-template<>
-void Parallel_Reduce::reduce_kp<double>(double* object, const int n)
-{
-#ifdef __MPI
-    if (KP_WORLD != MPI_COMM_NULL)
-        MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE, MPI_SUM, KP_WORLD);
-#endif
-}
-
-template<>
-void Parallel_Reduce::reduce_bp<double>(double* object, const int n)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE, MPI_SUM, BP_WORLD);
 #endif
 }
 
@@ -351,6 +332,7 @@ template<>
 void Parallel_Reduce::reduce_bgroup<double>(double* object, const int n)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE, MPI_SUM, INT_BGROUP);
 #endif
 }
@@ -359,8 +341,11 @@ template<>
 void Parallel_Reduce::reduce_kp<int>(int* object, const int n)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     if (KP_WORLD != MPI_COMM_NULL)
+    {
         MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_SUM, KP_WORLD);
+    }
 #endif
 }
 
@@ -368,6 +353,7 @@ template<>
 void Parallel_Reduce::reduce_bp<int>(int* object, const int n)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_SUM, BP_WORLD);
 #endif
 }
@@ -376,6 +362,7 @@ template<>
 void Parallel_Reduce::reduce_bgroup<int>(int* object, const int n)
 {
 #ifdef __MPI
+    if (!is_mpi_initialized()) return;
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_SUM, INT_BGROUP);
 #endif
 }

--- a/source/source_base/parallel_reduce.cpp
+++ b/source/source_base/parallel_reduce.cpp
@@ -126,6 +126,24 @@ void Parallel_Reduce::reduce_pool<double>(double* object, const int n)
     return;
 }
 
+template <>
+void Parallel_Reduce::reduce_pool<int>(int& object)
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_INT, MPI_SUM, POOL_WORLD);
+#endif
+    return;
+}
+
+template <>
+void Parallel_Reduce::reduce_pool<int>(int* object, const int n)
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_SUM, POOL_WORLD);
+#endif
+    return;
+}
+
 // (1) the value is same in each pool.
 // (2) we need to reduce the value from different pool.
 void Parallel_Reduce::reduce_double_allpool(const int& npool, const int& nproc_in_pool, double& object)
@@ -313,5 +331,96 @@ void Parallel_Reduce::gather_min_double_all(const int& nproc, double& v)
             v = value[i];
         }
     }
+#endif
+}
+
+void Parallel_Reduce::gather_max_int_all(const int& nproc, int& v)
+{
+#ifdef __MPI
+    std::vector<int> value(nproc, 0);
+    MPI_Allgather(&v, 1, MPI_INT, value.data(), 1, MPI_INT, MPI_COMM_WORLD);
+    for (int i = 0; i < nproc; i++)
+    {
+        if (v < value[i])
+        {
+            v = value[i];
+        }
+    }
+#endif
+}
+
+void Parallel_Reduce::gather_max_int_pool(const int& nproc_in_pool, int& v)
+{
+#ifdef __MPI
+    if (nproc_in_pool == 1) 
+    {
+        return;
+    }
+    std::vector<int> value(nproc_in_pool, 0);
+    MPI_Allgather(&v, 1, MPI_INT, value.data(), 1, MPI_INT, POOL_WORLD);
+    for (int i = 0; i < nproc_in_pool; i++)
+    {
+        if (v < value[i])
+        {
+            v = value[i];
+        }
+    }
+#endif
+}
+void Parallel_Reduce::gather_or_bool_all(bool& v)
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_C_BOOL, MPI_LOR, MPI_COMM_WORLD);
+#endif
+}
+
+void Parallel_Reduce::gather_or_bool_bp(bool& v)
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_C_BOOL, MPI_LOR, BP_WORLD);
+#endif
+}
+
+void Parallel_Reduce::reduce_kp(double* object, const int n)
+{
+#ifdef __MPI
+    if (KP_WORLD != MPI_COMM_NULL)
+        MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE, MPI_SUM, KP_WORLD);
+#endif
+}
+
+void Parallel_Reduce::reduce_bp(double* object, const int n)
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE, MPI_SUM, BP_WORLD);
+#endif
+}
+
+void Parallel_Reduce::reduce_bgroup(double* object, const int n)
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE, MPI_SUM, INT_BGROUP);
+#endif
+}
+
+void Parallel_Reduce::reduce_kp(int* object, const int n)
+{
+#ifdef __MPI
+    if (KP_WORLD != MPI_COMM_NULL)
+        MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_SUM, KP_WORLD);
+#endif
+}
+
+void Parallel_Reduce::reduce_bp(int* object, const int n)
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_SUM, BP_WORLD);
+#endif
+}
+
+void Parallel_Reduce::reduce_bgroup(int* object, const int n)
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_SUM, INT_BGROUP);
 #endif
 }

--- a/source/source_base/parallel_reduce.h
+++ b/source/source_base/parallel_reduce.h
@@ -42,6 +42,7 @@ void reduce_min_double_pool(double& object);
 
 void reduce_max_int_all(int& object);
 void reduce_max_int_pool(int& object);
+void reduce_max_int_pool(int* object, const int n);
 
 void reduce_or_bool_all(bool& v);
 void reduce_or_bool_bp(bool& v);

--- a/source/source_base/parallel_reduce.h
+++ b/source/source_base/parallel_reduce.h
@@ -45,16 +45,17 @@ void reduce_max_pool(T* object, const int n);
 template <typename T>
 void reduce_min_pool(T& object);
 
-void reduce_or_bool_all(bool& v);
-void reduce_or_bool_bp(bool& v);
+template <typename T>
+void reduce_or_all(T& v);
+template <typename T>
+void reduce_or_bp(T& v);
 
-void reduce_kp(double* object, const int n);
-void reduce_bp(double* object, const int n);
-void reduce_bgroup(double* object, const int n);
-
-void reduce_kp(int* object, const int n);
-void reduce_bp(int* object, const int n);
-void reduce_bgroup(int* object, const int n);
+template <typename T>
+void reduce_kp(T* object, const int n);
+template <typename T>
+void reduce_bp(T* object, const int n);
+template <typename T>
+void reduce_bgroup(T* object, const int n);
 
 // mohan add 2011-04-21
 void gather_int_all(int& v, int* all);

--- a/source/source_base/parallel_reduce.h
+++ b/source/source_base/parallel_reduce.h
@@ -34,17 +34,17 @@ void reduce_double_diag(double* object, const int n);
 void reduce_double_allpool(const int& npool, const int& nproc_in_pool, double& object);
 void reduce_double_allpool(const int& npool, const int& nproc_in_pool, double* object, const int n);
 
-void gather_min_int_all(const int& nproc, int& v);
-void gather_max_double_all(const int& nproc, double& v);
-void gather_min_double_all(const int& nproc, double& v);
-void gather_max_double_pool(const int& nproc_in_pool, double& v);
-void gather_min_double_pool(const int& nproc_in_pool, double& v);
+void reduce_min_int_all(int& object);
+void reduce_max_double_all(double& object);
+void reduce_min_double_all(double& object);
+void reduce_max_double_pool(double& object);
+void reduce_min_double_pool(double& object);
 
-void gather_max_int_all(const int& nproc, int& v);
-void gather_max_int_pool(const int& nproc_in_pool, int& v);
+void reduce_max_int_all(int& object);
+void reduce_max_int_pool(int& object);
 
-void gather_or_bool_all(bool& v);
-void gather_or_bool_bp(bool& v);
+void reduce_or_bool_all(bool& v);
+void reduce_or_bool_bp(bool& v);
 
 void reduce_kp(double* object, const int n);
 void reduce_bp(double* object, const int n);

--- a/source/source_base/parallel_reduce.h
+++ b/source/source_base/parallel_reduce.h
@@ -34,15 +34,16 @@ void reduce_double_diag(double* object, const int n);
 void reduce_double_allpool(const int& npool, const int& nproc_in_pool, double& object);
 void reduce_double_allpool(const int& npool, const int& nproc_in_pool, double* object, const int n);
 
-void reduce_min_int_all(int& object);
-void reduce_max_double_all(double& object);
-void reduce_min_double_all(double& object);
-void reduce_max_double_pool(double& object);
-void reduce_min_double_pool(double& object);
-
-void reduce_max_int_all(int& object);
-void reduce_max_int_pool(int& object);
-void reduce_max_int_pool(int* object, const int n);
+template <typename T>
+void reduce_max_all(T& object);
+template <typename T>
+void reduce_min_all(T& object);
+template <typename T>
+void reduce_max_pool(T& object);
+template <typename T>
+void reduce_max_pool(T* object, const int n);
+template <typename T>
+void reduce_min_pool(T& object);
 
 void reduce_or_bool_all(bool& v);
 void reduce_or_bool_bp(bool& v);

--- a/source/source_base/parallel_reduce.h
+++ b/source/source_base/parallel_reduce.h
@@ -40,6 +40,20 @@ void gather_min_double_all(const int& nproc, double& v);
 void gather_max_double_pool(const int& nproc_in_pool, double& v);
 void gather_min_double_pool(const int& nproc_in_pool, double& v);
 
+void gather_max_int_all(const int& nproc, int& v);
+void gather_max_int_pool(const int& nproc_in_pool, int& v);
+
+void gather_or_bool_all(bool& v);
+void gather_or_bool_bp(bool& v);
+
+void reduce_kp(double* object, const int n);
+void reduce_bp(double* object, const int n);
+void reduce_bgroup(double* object, const int n);
+
+void reduce_kp(int* object, const int n);
+void reduce_bp(int* object, const int n);
+void reduce_bgroup(int* object, const int n);
+
 // mohan add 2011-04-21
 void gather_int_all(int& v, int* all);
 

--- a/source/source_base/test_parallel/parallel_reduce_test.cpp
+++ b/source/source_base/test_parallel/parallel_reduce_test.cpp
@@ -233,7 +233,7 @@ TEST_F(ParaReduce, GatherIntAll)
     EXPECT_EQ(local_number, array[my_rank]);
     // get minimum integer among all processes
     int min_number = local_number;
-    Parallel_Reduce::reduce_min_int_all(min_number);
+    Parallel_Reduce::reduce_min_all(min_number);
     for (int i = 0; i < nproc; i++)
     {
         EXPECT_LE(min_number, array[i]);
@@ -256,10 +256,10 @@ TEST_F(ParaReduce, GatherDoubleAll)
     EXPECT_EQ(local_number, array[my_rank]);
     // get minimum integer among all processes
     double min_number = local_number;
-    Parallel_Reduce::reduce_min_double_all(min_number);
+    Parallel_Reduce::reduce_min_all(min_number);
     // get maximum integer among all processes
     double max_number = local_number;
-    Parallel_Reduce::reduce_max_double_all(max_number);
+    Parallel_Reduce::reduce_max_all(max_number);
     for (int i = 0; i < nproc; i++)
     {
         EXPECT_LE(min_number, array[i]);
@@ -587,10 +587,10 @@ TEST_F(ParaReduce, GatherDoublePool)
         EXPECT_EQ(local_number, array[mpiContext.rank_in_pool]);
         // get minimum integer among all processes
         double min_number = local_number;
-        Parallel_Reduce::reduce_min_double_pool(min_number);
+        Parallel_Reduce::reduce_min_pool(min_number);
         // get maximum integer among all processes
         double max_number = local_number;
-        Parallel_Reduce::reduce_max_double_pool(max_number);
+        Parallel_Reduce::reduce_max_pool(max_number);
         for (int i = 0; i < mpiContext.nproc_in_pool; i++)
         {
             EXPECT_LE(min_number, array[i]);

--- a/source/source_base/test_parallel/parallel_reduce_test.cpp
+++ b/source/source_base/test_parallel/parallel_reduce_test.cpp
@@ -233,7 +233,7 @@ TEST_F(ParaReduce, GatherIntAll)
     EXPECT_EQ(local_number, array[my_rank]);
     // get minimum integer among all processes
     int min_number = local_number;
-    Parallel_Reduce::gather_min_int_all(nproc, min_number);
+    Parallel_Reduce::reduce_min_int_all(min_number);
     for (int i = 0; i < nproc; i++)
     {
         EXPECT_LE(min_number, array[i]);
@@ -256,10 +256,10 @@ TEST_F(ParaReduce, GatherDoubleAll)
     EXPECT_EQ(local_number, array[my_rank]);
     // get minimum integer among all processes
     double min_number = local_number;
-    Parallel_Reduce::gather_min_double_all(nproc, min_number);
+    Parallel_Reduce::reduce_min_double_all(min_number);
     // get maximum integer among all processes
     double max_number = local_number;
-    Parallel_Reduce::gather_max_double_all(nproc, max_number);
+    Parallel_Reduce::reduce_max_double_all(max_number);
     for (int i = 0; i < nproc; i++)
     {
         EXPECT_LE(min_number, array[i]);
@@ -587,10 +587,10 @@ TEST_F(ParaReduce, GatherDoublePool)
         EXPECT_EQ(local_number, array[mpiContext.rank_in_pool]);
         // get minimum integer among all processes
         double min_number = local_number;
-        Parallel_Reduce::gather_min_double_pool(mpiContext.nproc_in_pool, min_number);
+        Parallel_Reduce::reduce_min_double_pool(min_number);
         // get maximum integer among all processes
         double max_number = local_number;
-        Parallel_Reduce::gather_max_double_pool(mpiContext.nproc_in_pool, max_number);
+        Parallel_Reduce::reduce_max_double_pool(max_number);
         for (int i = 0; i < mpiContext.nproc_in_pool; i++)
         {
             EXPECT_LE(min_number, array[i]);

--- a/source/source_basis/module_pw/pw_basis_big.h
+++ b/source/source_basis/module_pw/pw_basis_big.h
@@ -168,7 +168,7 @@ public:
     ibox[0] = 2*n1+1;
     ibox[1] = 2*n2+1;
     ibox[2] = 2*n3+1;
-    Parallel_Reduce::reduce_max_int_pool(ibox, 3);
+    Parallel_Reduce::reduce_max_pool(ibox, 3);
 
     // Find the minimal FFT box size the factors into the primes (2,3,5,7).
     for (int i = 0; i < 3; i++)
@@ -349,7 +349,7 @@ public:
                 }
             }
         }
-        Parallel_Reduce::reduce_min_double_pool(this->gridecut_lat);
+        Parallel_Reduce::reduce_min_pool(this->gridecut_lat);
         this->gridecut_lat -= 1e-6;
 
         delete[] ibox;

--- a/source/source_basis/module_pw/pw_basis_big.h
+++ b/source/source_basis/module_pw/pw_basis_big.h
@@ -2,6 +2,8 @@
 #define PW_BASIS_BIG_H
 #include "source_base/constants.h"
 #include "source_base/global_function.h"
+#include "source_base/parallel_reduce.h" 
+#include "source_base/parallel_global.h" 
 #ifdef __MPI
 #include "mpi.h"
 #endif
@@ -166,9 +168,9 @@ public:
     ibox[0] = 2*n1+1;
     ibox[1] = 2*n2+1;
     ibox[2] = 2*n3+1;
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, ibox, 3, MPI_INT, MPI_MAX , this->pool_world);
-#endif
+    Parallel_Reduce::gather_max_int_pool(GlobalV::NPROC_IN_POOL, ibox[0]);
+    Parallel_Reduce::gather_max_int_pool(GlobalV::NPROC_IN_POOL, ibox[1]);
+    Parallel_Reduce::gather_max_int_pool(GlobalV::NPROC_IN_POOL, ibox[2]);
 
     // Find the minimal FFT box size the factors into the primes (2,3,5,7).
     for (int i = 0; i < 3; i++)
@@ -349,9 +351,7 @@ public:
                 }
             }
         }
-#ifdef __MPI
-        MPI_Allreduce(MPI_IN_PLACE, &this->gridecut_lat, 1, MPI_DOUBLE, MPI_MIN , this->pool_world);
-#endif
+        Parallel_Reduce::gather_min_double_pool(GlobalV::NPROC_IN_POOL, this->gridecut_lat);
         this->gridecut_lat -= 1e-6;
 
         delete[] ibox;

--- a/source/source_basis/module_pw/pw_basis_big.h
+++ b/source/source_basis/module_pw/pw_basis_big.h
@@ -168,9 +168,9 @@ public:
     ibox[0] = 2*n1+1;
     ibox[1] = 2*n2+1;
     ibox[2] = 2*n3+1;
-    Parallel_Reduce::gather_max_int_pool(GlobalV::NPROC_IN_POOL, ibox[0]);
-    Parallel_Reduce::gather_max_int_pool(GlobalV::NPROC_IN_POOL, ibox[1]);
-    Parallel_Reduce::gather_max_int_pool(GlobalV::NPROC_IN_POOL, ibox[2]);
+    Parallel_Reduce::reduce_max_int_pool(ibox[0]);
+    Parallel_Reduce::reduce_max_int_pool(ibox[1]);
+    Parallel_Reduce::reduce_max_int_pool(ibox[2]);
 
     // Find the minimal FFT box size the factors into the primes (2,3,5,7).
     for (int i = 0; i < 3; i++)
@@ -351,7 +351,7 @@ public:
                 }
             }
         }
-        Parallel_Reduce::gather_min_double_pool(GlobalV::NPROC_IN_POOL, this->gridecut_lat);
+        Parallel_Reduce::reduce_min_double_pool(this->gridecut_lat);
         this->gridecut_lat -= 1e-6;
 
         delete[] ibox;

--- a/source/source_basis/module_pw/pw_basis_big.h
+++ b/source/source_basis/module_pw/pw_basis_big.h
@@ -168,9 +168,7 @@ public:
     ibox[0] = 2*n1+1;
     ibox[1] = 2*n2+1;
     ibox[2] = 2*n3+1;
-    Parallel_Reduce::reduce_max_int_pool(ibox[0]);
-    Parallel_Reduce::reduce_max_int_pool(ibox[1]);
-    Parallel_Reduce::reduce_max_int_pool(ibox[2]);
+    Parallel_Reduce::reduce_max_int_pool(ibox, 3);
 
     // Find the minimal FFT box size the factors into the primes (2,3,5,7).
     for (int i = 0; i < 3; i++)

--- a/source/source_basis/module_pw/pw_init.cpp
+++ b/source/source_basis/module_pw/pw_init.cpp
@@ -86,9 +86,7 @@ void PW_Basis:: initgrids(
     ibox[0] = 2*n1+1;
     ibox[1] = 2*n2+1;
     ibox[2] = 2*n3+1;
-    Parallel_Reduce::reduce_max_int_pool(ibox[0]);
-    Parallel_Reduce::reduce_max_int_pool(ibox[1]);
-    Parallel_Reduce::reduce_max_int_pool(ibox[2]);
+    Parallel_Reduce::reduce_max_int_pool(ibox, 3);
 
     // Find the minimal FFT box size the factors into the primes (2,3,5,7).
     for (int i = 0; i < 3; i++)

--- a/source/source_basis/module_pw/pw_init.cpp
+++ b/source/source_basis/module_pw/pw_init.cpp
@@ -86,7 +86,7 @@ void PW_Basis:: initgrids(
     ibox[0] = 2*n1+1;
     ibox[1] = 2*n2+1;
     ibox[2] = 2*n3+1;
-    Parallel_Reduce::reduce_max_int_pool(ibox, 3);
+    Parallel_Reduce::reduce_max_pool(ibox, 3);
 
     // Find the minimal FFT box size the factors into the primes (2,3,5,7).
     for (int i = 0; i < 3; i++)
@@ -198,7 +198,7 @@ void PW_Basis:: initgrids(
             }
         }
     }
-            Parallel_Reduce::reduce_min_double_pool(this->gridecut_lat);    this->gridecut_lat -= 1e-6;
+            Parallel_Reduce::reduce_min_pool(this->gridecut_lat);    this->gridecut_lat -= 1e-6;
 
     delete[] ibox;
     return;

--- a/source/source_basis/module_pw/pw_init.cpp
+++ b/source/source_basis/module_pw/pw_init.cpp
@@ -86,9 +86,9 @@ void PW_Basis:: initgrids(
     ibox[0] = 2*n1+1;
     ibox[1] = 2*n2+1;
     ibox[2] = 2*n3+1;
-    Parallel_Reduce::gather_max_int_pool(GlobalV::NPROC_IN_POOL, ibox[0]);
-    Parallel_Reduce::gather_max_int_pool(GlobalV::NPROC_IN_POOL, ibox[1]);
-    Parallel_Reduce::gather_max_int_pool(GlobalV::NPROC_IN_POOL, ibox[2]);
+    Parallel_Reduce::reduce_max_int_pool(ibox[0]);
+    Parallel_Reduce::reduce_max_int_pool(ibox[1]);
+    Parallel_Reduce::reduce_max_int_pool(ibox[2]);
 
     // Find the minimal FFT box size the factors into the primes (2,3,5,7).
     for (int i = 0; i < 3; i++)
@@ -200,8 +200,7 @@ void PW_Basis:: initgrids(
             }
         }
     }
-    Parallel_Reduce::gather_min_double_pool(GlobalV::NPROC_IN_POOL, this->gridecut_lat);
-    this->gridecut_lat -= 1e-6;
+            Parallel_Reduce::reduce_min_double_pool(this->gridecut_lat);    this->gridecut_lat -= 1e-6;
 
     delete[] ibox;
     return;

--- a/source/source_basis/module_pw/pw_init.cpp
+++ b/source/source_basis/module_pw/pw_init.cpp
@@ -1,5 +1,6 @@
 #include "pw_basis.h"
-#include "source_base/constants.h"
+#include "source_base/parallel_global.h" // GlobalV
+#include "source_base/parallel_reduce.h"
 
 namespace ModulePW
 {
@@ -85,9 +86,9 @@ void PW_Basis:: initgrids(
     ibox[0] = 2*n1+1;
     ibox[1] = 2*n2+1;
     ibox[2] = 2*n3+1;
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, ibox, 3, MPI_INT, MPI_MAX , this->pool_world);
-#endif
+    Parallel_Reduce::gather_max_int_pool(GlobalV::NPROC_IN_POOL, ibox[0]);
+    Parallel_Reduce::gather_max_int_pool(GlobalV::NPROC_IN_POOL, ibox[1]);
+    Parallel_Reduce::gather_max_int_pool(GlobalV::NPROC_IN_POOL, ibox[2]);
 
     // Find the minimal FFT box size the factors into the primes (2,3,5,7).
     for (int i = 0; i < 3; i++)
@@ -199,9 +200,7 @@ void PW_Basis:: initgrids(
             }
         }
     }
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &this->gridecut_lat, 1, MPI_DOUBLE, MPI_MIN , this->pool_world);
-#endif
+    Parallel_Reduce::gather_min_double_pool(GlobalV::NPROC_IN_POOL, this->gridecut_lat);
     this->gridecut_lat -= 1e-6;
 
     delete[] ibox;

--- a/source/source_basis/module_pw/test/depend_mock.cpp
+++ b/source/source_basis/module_pw/test/depend_mock.cpp
@@ -6,6 +6,7 @@
 namespace GlobalV
 { 
     std::ofstream ofs_running;
+    int NPROC_IN_POOL = 1;
 }
 #ifdef __MPI
 MPI_Comm POOL_WORLD;
@@ -20,5 +21,8 @@ namespace Parallel_Reduce
     void reduce_pool<double>(double& object) { return; };
     template<>
     void reduce_pool<float>(float& object) { return; };
-}
+
+    void reduce_min_double_pool(double& val) { return; }
+
+    void reduce_max_int_pool(int& val) { return; }}
 #endif

--- a/source/source_basis/module_pw/test/depend_mock.cpp
+++ b/source/source_basis/module_pw/test/depend_mock.cpp
@@ -23,6 +23,11 @@ namespace Parallel_Reduce
 
     template <typename T> void reduce_min_pool(T& object) { return; }
     template <typename T> void reduce_max_pool(T* object, const int n) { return; }
+    template <typename T> void reduce_or_all(T& v) { return; }
+    template <typename T> void reduce_or_bp(T& v) { return; }
+    template <typename T> void reduce_kp(T* object, const int n) { return; }
+    template <typename T> void reduce_bp(T* object, const int n) { return; }
+    template <typename T> void reduce_bgroup(T* object, const int n) { return; }
 
     template<> void reduce_min_pool<double>(double& val) { return; }
     template<> void reduce_max_pool<int>(int* object, const int n) { return; }

--- a/source/source_basis/module_pw/test/depend_mock.cpp
+++ b/source/source_basis/module_pw/test/depend_mock.cpp
@@ -19,12 +19,12 @@ namespace Parallel_Reduce
     void reduce_all<double>(double& object) { return; };
     template<>
     void reduce_pool<double>(double& object) { return; };
-    template<>
-    void reduce_pool<float>(float& object) { return; };
+    template<> void reduce_pool<float>(float& object) { return; };
 
-    void reduce_min_double_pool(double& val) { return; }
+    template <typename T> void reduce_min_pool(T& object) { return; }
+    template <typename T> void reduce_max_pool(T* object, const int n) { return; }
 
-    void reduce_max_int_pool(int& val) { return; }
-    void reduce_max_int_pool(int* object, const int n) { return; }
+    template<> void reduce_min_pool<double>(double& val) { return; }
+    template<> void reduce_max_pool<int>(int* object, const int n) { return; }
 }
 #endif

--- a/source/source_basis/module_pw/test/depend_mock.cpp
+++ b/source/source_basis/module_pw/test/depend_mock.cpp
@@ -24,5 +24,7 @@ namespace Parallel_Reduce
 
     void reduce_min_double_pool(double& val) { return; }
 
-    void reduce_max_int_pool(int& val) { return; }}
+    void reduce_max_int_pool(int& val) { return; }
+    void reduce_max_int_pool(int* object, const int n) { return; }
+}
 #endif

--- a/source/source_basis/module_pw/test_serial/pw_basis_k_test.cpp
+++ b/source/source_basis/module_pw/test_serial/pw_basis_k_test.cpp
@@ -192,14 +192,7 @@ TEST_F(PWBasisKTEST, CollectLocalPW)
 
 int main(int argc, char **argv)
 {
-    int NPROC, MY_RANK, NTHREAD_PER_PROC;
-    Parallel_Global::read_pal_param(argc, argv, NPROC, NTHREAD_PER_PROC, MY_RANK);
-    int NPROC_IN_BNDGROUP, RANK_IN_BPGROUP, MY_BNDGROUP;
-    int NPROC_IN_POOL, RANK_IN_POOL, MY_POOL;
-    int BNDPAR = 1, KPAR = 1;
-    Parallel_Global::init_pools(NPROC, MY_RANK, BNDPAR, KPAR, NPROC_IN_BNDGROUP, RANK_IN_BPGROUP, MY_BNDGROUP, NPROC_IN_POOL, RANK_IN_POOL, MY_POOL);
     testing::InitGoogleTest(&argc, argv);
-    int result = RUN_ALL_TESTS();
-    MPI_Finalize();
-    return result;
+    return RUN_ALL_TESTS();
 }
+

--- a/source/source_basis/module_pw/test_serial/pw_basis_k_test.cpp
+++ b/source/source_basis/module_pw/test_serial/pw_basis_k_test.cpp
@@ -1,4 +1,6 @@
 #include "gtest/gtest.h"
+#include <mpi.h>
+#include "source_base/parallel_global.h"
 #include "source_base/global_function.h"
 #include "source_base/constants.h"
 #include "source_base/matrix3.h"
@@ -188,4 +190,16 @@ TEST_F(PWBasisKTEST, CollectLocalPW)
 	EXPECT_EQ(basis_k.npwk_max,2721);
 }
 
-
+int main(int argc, char **argv)
+{
+    int NPROC, MY_RANK, NTHREAD_PER_PROC;
+    Parallel_Global::read_pal_param(argc, argv, NPROC, NTHREAD_PER_PROC, MY_RANK);
+    int NPROC_IN_BNDGROUP, RANK_IN_BPGROUP, MY_BNDGROUP;
+    int NPROC_IN_POOL, RANK_IN_POOL, MY_POOL;
+    int BNDPAR = 1, KPAR = 1;
+    Parallel_Global::init_pools(NPROC, MY_RANK, BNDPAR, KPAR, NPROC_IN_BNDGROUP, RANK_IN_BPGROUP, MY_BNDGROUP, NPROC_IN_POOL, RANK_IN_POOL, MY_POOL);
+    testing::InitGoogleTest(&argc, argv);
+    int result = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return result;
+}

--- a/source/source_basis/module_pw/test_serial/pw_basis_test.cpp
+++ b/source/source_basis/module_pw/test_serial/pw_basis_test.cpp
@@ -364,16 +364,3 @@ TEST_F(PWBasisTEST,CollectUniqgg)
 	pwb.collect_uniqgg();
 	EXPECT_EQ(pwb.ngg,78);
 }
-int main(int argc, char **argv)
-{
-    int NPROC, MY_RANK, NTHREAD_PER_PROC;
-    Parallel_Global::read_pal_param(argc, argv, NPROC, NTHREAD_PER_PROC, MY_RANK);
-    int NPROC_IN_BNDGROUP, RANK_IN_BPGROUP, MY_BNDGROUP;
-    int NPROC_IN_POOL, RANK_IN_POOL, MY_POOL;
-    int BNDPAR = 1, KPAR = 1;
-    Parallel_Global::init_pools(NPROC, MY_RANK, BNDPAR, KPAR, NPROC_IN_BNDGROUP, RANK_IN_BPGROUP, MY_BNDGROUP, NPROC_IN_POOL, RANK_IN_POOL, MY_POOL);
-    testing::InitGoogleTest(&argc, argv);
-    int result = RUN_ALL_TESTS();
-    MPI_Finalize();
-    return result;
-}

--- a/source/source_basis/module_pw/test_serial/pw_basis_test.cpp
+++ b/source/source_basis/module_pw/test_serial/pw_basis_test.cpp
@@ -1,4 +1,6 @@
 #include "gtest/gtest.h"
+#include <mpi.h>
+#include "source_base/parallel_global.h"
 #include "source_base/global_function.h"
 #include "source_base/constants.h"
 #include "source_base/matrix3.h"
@@ -361,4 +363,17 @@ TEST_F(PWBasisTEST,CollectUniqgg)
 	EXPECT_EQ(pwb.ig_gge0,9);
 	pwb.collect_uniqgg();
 	EXPECT_EQ(pwb.ngg,78);
+}
+int main(int argc, char **argv)
+{
+    int NPROC, MY_RANK, NTHREAD_PER_PROC;
+    Parallel_Global::read_pal_param(argc, argv, NPROC, NTHREAD_PER_PROC, MY_RANK);
+    int NPROC_IN_BNDGROUP, RANK_IN_BPGROUP, MY_BNDGROUP;
+    int NPROC_IN_POOL, RANK_IN_POOL, MY_POOL;
+    int BNDPAR = 1, KPAR = 1;
+    Parallel_Global::init_pools(NPROC, MY_RANK, BNDPAR, KPAR, NPROC_IN_BNDGROUP, RANK_IN_BPGROUP, MY_BNDGROUP, NPROC_IN_POOL, RANK_IN_POOL, MY_POOL);
+    testing::InitGoogleTest(&argc, argv);
+    int result = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return result;
 }

--- a/source/source_cell/k_vector_utils.cpp
+++ b/source/source_cell/k_vector_utils.cpp
@@ -245,7 +245,7 @@ void kvec_mpi_k(K_Vectors& kv)
     ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "Number of k-points in this process", kv.nks);
     int nks_minimum = kv.nks;
 
-    Parallel_Reduce::gather_min_int_all(GlobalV::NPROC, nks_minimum);
+    Parallel_Reduce::reduce_min_int_all(nks_minimum);
 
     if (nks_minimum == 0)
     {

--- a/source/source_cell/k_vector_utils.cpp
+++ b/source/source_cell/k_vector_utils.cpp
@@ -245,7 +245,7 @@ void kvec_mpi_k(K_Vectors& kv)
     ModuleBase::GlobalFunc::OUT(GlobalV::ofs_running, "Number of k-points in this process", kv.nks);
     int nks_minimum = kv.nks;
 
-    Parallel_Reduce::reduce_min_int_all(nks_minimum);
+    Parallel_Reduce::reduce_min_all(nks_minimum);
 
     if (nks_minimum == 0)
     {

--- a/source/source_cell/parallel_kpoints.cpp
+++ b/source/source_cell/parallel_kpoints.cpp
@@ -123,8 +123,7 @@ void Parallel_Kpoints::gatherkvec(const std::vector<ModuleBase::Vector3<double>>
             vec_global[i + startk_pool[this->my_pool]] = vec_local[i];
         }
     }
-
-    Parallel_Reduce::reduce_all(&vec_global[0], 3 * this->nkstot_np);
+    Parallel_Reduce::reduce_all(reinterpret_cast<double*>(vec_global.data()), 3 * this->nkstot_np);
     return;
 }
 #endif

--- a/source/source_cell/parallel_kpoints.cpp
+++ b/source/source_cell/parallel_kpoints.cpp
@@ -1,5 +1,5 @@
 #include "parallel_kpoints.h"
-
+#include "source_base/parallel_reduce.h"
 #include "source_base/parallel_common.h"
 #include "source_base/parallel_global.h"
 
@@ -124,7 +124,7 @@ void Parallel_Kpoints::gatherkvec(const std::vector<ModuleBase::Vector3<double>>
         }
     }
 
-    MPI_Allreduce(MPI_IN_PLACE, &vec_global[0], 3 * this->nkstot_np, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+    Parallel_Reduce::reduce_all(&vec_global[0], 3 * this->nkstot_np);
     return;
 }
 #endif

--- a/source/source_estate/elecstate_energy.cpp
+++ b/source/source_estate/elecstate_energy.cpp
@@ -171,11 +171,8 @@ double ElecState::cal_delta_eband(const UnitCell& ucell) const
         }
     }
 
-#ifdef __MPI
-    MPI_Allreduce(&deband_aux, &deband0, 1, MPI_DOUBLE, MPI_SUM, POOL_WORLD);
-#else
     deband0 = deband_aux;
-#endif
+    Parallel_Reduce::reduce_pool(deband0);
 
     deband0 *= ucell.omega / this->charge->rhopw->nxyz;
 

--- a/source/source_estate/elecstate_energy.cpp
+++ b/source/source_estate/elecstate_energy.cpp
@@ -39,8 +39,8 @@ void ElecState::cal_bandgap()
     }
 
 #ifdef __MPI
-    Parallel_Reduce::reduce_max_double_all(vbm);
-    Parallel_Reduce::reduce_min_double_all(cbm);
+    Parallel_Reduce::reduce_max_all(vbm);
+    Parallel_Reduce::reduce_min_all(cbm);
 #endif
 
     this->bandgap = cbm - vbm;
@@ -94,10 +94,10 @@ void ElecState::cal_bandgap_updw()
     }
 
 #ifdef __MPI
-    Parallel_Reduce::reduce_max_double_all(vbm_up);
-    Parallel_Reduce::reduce_min_double_all(cbm_up);
-    Parallel_Reduce::reduce_max_double_all(vbm_dw);
-    Parallel_Reduce::reduce_min_double_all(cbm_dw);
+    Parallel_Reduce::reduce_max_all(vbm_up);
+    Parallel_Reduce::reduce_min_all(cbm_up);
+    Parallel_Reduce::reduce_max_all(vbm_dw);
+    Parallel_Reduce::reduce_min_all(cbm_dw);
 #endif
 
     this->bandgap_up = cbm_up - vbm_up;

--- a/source/source_estate/elecstate_energy.cpp
+++ b/source/source_estate/elecstate_energy.cpp
@@ -39,8 +39,8 @@ void ElecState::cal_bandgap()
     }
 
 #ifdef __MPI
-    Parallel_Reduce::gather_max_double_all(GlobalV::NPROC, vbm);
-    Parallel_Reduce::gather_min_double_all(GlobalV::NPROC, cbm);
+    Parallel_Reduce::reduce_max_double_all(vbm);
+    Parallel_Reduce::reduce_min_double_all(cbm);
 #endif
 
     this->bandgap = cbm - vbm;
@@ -94,10 +94,10 @@ void ElecState::cal_bandgap_updw()
     }
 
 #ifdef __MPI
-    Parallel_Reduce::gather_max_double_all(GlobalV::NPROC, vbm_up);
-    Parallel_Reduce::gather_min_double_all(GlobalV::NPROC, cbm_up);
-    Parallel_Reduce::gather_max_double_all(GlobalV::NPROC, vbm_dw);
-    Parallel_Reduce::gather_min_double_all(GlobalV::NPROC, cbm_dw);
+    Parallel_Reduce::reduce_max_double_all(vbm_up);
+    Parallel_Reduce::reduce_min_double_all(cbm_up);
+    Parallel_Reduce::reduce_max_double_all(vbm_dw);
+    Parallel_Reduce::reduce_min_double_all(cbm_dw);
 #endif
 
     this->bandgap_up = cbm_up - vbm_up;

--- a/source/source_estate/module_charge/charge_mpi.cpp
+++ b/source/source_estate/module_charge/charge_mpi.cpp
@@ -30,7 +30,7 @@ void Charge::reduce_diff_pools(double* array_rho) const
     ModuleBase::timer::tick("Charge", "reduce_diff_pools");
     if (KP_WORLD != MPI_COMM_NULL)
     {
-        MPI_Allreduce(MPI_IN_PLACE, array_rho, this->nrxx, MPI_DOUBLE, MPI_SUM, KP_WORLD);
+        Parallel_Reduce::reduce_kp(array_rho, this->nrxx);
     }
     else
     {
@@ -92,7 +92,11 @@ void Charge::reduce_diff_pools(double* array_rho) const
         //==================================
         // Reduce all the rho in each cpu
         //==================================
-        MPI_Allreduce(array_tot_aux, array_tot, this->rhopw->nxyz, MPI_DOUBLE, MPI_SUM, INT_BGROUP);
+        for (int i = 0; i < this->rhopw->nxyz; i++)
+        {
+            array_tot[i] = array_tot_aux[i];
+        }
+        Parallel_Reduce::reduce_bgroup(array_tot, this->rhopw->nxyz);
 
         //=====================================
         // Change the order of rho in each cpu
@@ -111,7 +115,7 @@ void Charge::reduce_diff_pools(double* array_rho) const
     }
     if(PARAM.globalv.all_ks_run && PARAM.inp.bndpar > 1)
     {
-        MPI_Allreduce(MPI_IN_PLACE, array_rho, this->nrxx, MPI_DOUBLE, MPI_SUM, BP_WORLD);
+        Parallel_Reduce::reduce_bp(array_rho, this->nrxx);
     }
     ModuleBase::timer::tick("Charge", "reduce_diff_pools");
 }

--- a/source/source_estate/module_charge/symmetry_rhog.cpp
+++ b/source/source_estate/module_charge/symmetry_rhog.cpp
@@ -1,6 +1,7 @@
 #include "symmetry_rho.h"
 #include "source_pw/module_pwdft/global.h"
 #include "source_base/parallel_global.h"
+#include "source_base/parallel_reduce.h"
 #include "source_hamilt/module_xc/xc_functional.h"
 
 
@@ -9,8 +10,8 @@ void Symmetry_rho::psymmg(std::complex<double>* rhog_part, const ModulePW::PW_Ba
 	//(1) get fftixy2is and do Allreduce
 	int * fftixy2is = new int [rho_basis->fftnxy];
 	rho_basis->getfftixy2is(fftixy2is);		//current proc
+    Parallel_Reduce::reduce_pool(fftixy2is, rho_basis->fftnxy);
 #ifdef __MPI
-	MPI_Allreduce(MPI_IN_PLACE, fftixy2is, rho_basis->fftnxy, MPI_INT, MPI_SUM, POOL_WORLD);
 	if(rho_basis->poolnproc>1)
 		for (int i=0;i<rho_basis->fftnxy;++i)
 			fftixy2is[i]+=rho_basis->poolnproc-1;

--- a/source/source_estate/occupy.cpp
+++ b/source/source_estate/occupy.cpp
@@ -180,7 +180,7 @@ void Occupy::iweights(
         }
     }
 #ifdef __MPI
-    Parallel_Reduce::gather_max_double_all(GlobalV::NPROC, ef);
+    Parallel_Reduce::reduce_max_double_all(ef);
 #endif
 
     return;
@@ -309,8 +309,9 @@ void Occupy::efermig(const ModuleBase::matrix& ekb,
 
 #ifdef __MPI
     // find min and max across pools
-    Parallel_Reduce::gather_max_double_all(GlobalV::NPROC, eup);
-    Parallel_Reduce::gather_min_double_all(GlobalV::NPROC, elw);
+    Parallel_Reduce::reduce_max_double_all(ef);
+    Parallel_Reduce::reduce_max_double_all(eup);
+    Parallel_Reduce::reduce_min_double_all(elw);
 
 #endif
     //=================

--- a/source/source_estate/occupy.cpp
+++ b/source/source_estate/occupy.cpp
@@ -180,7 +180,7 @@ void Occupy::iweights(
         }
     }
 #ifdef __MPI
-    Parallel_Reduce::reduce_max_double_all(ef);
+    Parallel_Reduce::reduce_max_all(ef);
 #endif
 
     return;
@@ -309,9 +309,9 @@ void Occupy::efermig(const ModuleBase::matrix& ekb,
 
 #ifdef __MPI
     // find min and max across pools
-    Parallel_Reduce::reduce_max_double_all(ef);
-    Parallel_Reduce::reduce_max_double_all(eup);
-    Parallel_Reduce::reduce_min_double_all(elw);
+    Parallel_Reduce::reduce_max_all(ef);
+    Parallel_Reduce::reduce_max_all(eup);
+    Parallel_Reduce::reduce_min_all(elw);
 
 #endif
     //=================

--- a/source/source_estate/test/charge_mixing_test.cpp
+++ b/source/source_estate/test/charge_mixing_test.cpp
@@ -1144,16 +1144,4 @@ TEST_F(ChargeMixingTest, SCFOscillationTest)
     } 
 }
 
-int main(int argc, char **argv)
-{
-    int NPROC, MY_RANK, NTHREAD_PER_PROC;
-    Parallel_Global::read_pal_param(argc, argv, NPROC, NTHREAD_PER_PROC, MY_RANK);
-    int NPROC_IN_BNDGROUP, RANK_IN_BPGROUP, MY_BNDGROUP;
-    int NPROC_IN_POOL, RANK_IN_POOL, MY_POOL;
-    int BNDPAR = 1, KPAR = 1;
-    Parallel_Global::init_pools(NPROC, MY_RANK, BNDPAR, KPAR, NPROC_IN_BNDGROUP, RANK_IN_BPGROUP, MY_BNDGROUP, NPROC_IN_POOL, RANK_IN_POOL, MY_POOL);
-    testing::InitGoogleTest(&argc, argv);
-    int result = RUN_ALL_TESTS();
-    MPI_Finalize();
-    return result;
-}
+

--- a/source/source_estate/test/charge_mixing_test.cpp
+++ b/source/source_estate/test/charge_mixing_test.cpp
@@ -1,5 +1,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include <mpi.h>
+#include "source_base/parallel_global.h"
+
 #define private public
 #include "../module_charge/charge_mixing.h"
 #include "source_base/module_mixing/broyden_mixing.h"
@@ -1139,4 +1142,18 @@ TEST_F(ChargeMixingTest, SCFOscillationTest)
         scf_oscillate = CMtest.if_scf_oscillate(i,drho[i-1],scf_os_ndim,scf_os_thr);
         EXPECT_EQ(scf_oscillate, scf_oscillate_ref[i-1]);
     } 
+}
+
+int main(int argc, char **argv)
+{
+    int NPROC, MY_RANK, NTHREAD_PER_PROC;
+    Parallel_Global::read_pal_param(argc, argv, NPROC, NTHREAD_PER_PROC, MY_RANK);
+    int NPROC_IN_BNDGROUP, RANK_IN_BPGROUP, MY_BNDGROUP;
+    int NPROC_IN_POOL, RANK_IN_POOL, MY_POOL;
+    int BNDPAR = 1, KPAR = 1;
+    Parallel_Global::init_pools(NPROC, MY_RANK, BNDPAR, KPAR, NPROC_IN_BNDGROUP, RANK_IN_BPGROUP, MY_BNDGROUP, NPROC_IN_POOL, RANK_IN_POOL, MY_POOL);
+    testing::InitGoogleTest(&argc, argv);
+    int result = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return result;
 }

--- a/source/source_estate/test/charge_test.cpp
+++ b/source/source_estate/test/charge_test.cpp
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
+#include <mpi.h>
 
 #define private public
 #define protected public
@@ -219,5 +220,29 @@ TEST_F(ChargeTest, InitFinalScf)
     PARAM.input.test_charge = 2;
     charge->init_final_scf();
     EXPECT_TRUE(charge->allocate_rho_final_scf);
+}
+
+int main(int argc, char **argv)
+{
+    int NPROC, MY_RANK, NTHREAD_PER_PROC;
+    Parallel_Global::read_pal_param(argc, argv, NPROC, NTHREAD_PER_PROC, MY_RANK);
+
+    int NPROC_IN_BNDGROUP;
+    int RANK_IN_BPGROUP;
+    int MY_BNDGROUP;
+    int NPROC_IN_POOL;
+    int RANK_IN_POOL;
+    int MY_POOL;
+    int BNDPAR = 1;
+    int KPAR = 1;
+
+    Parallel_Global::init_pools(NPROC, MY_RANK, BNDPAR, KPAR, 
+                                NPROC_IN_BNDGROUP, RANK_IN_BPGROUP, MY_BNDGROUP, 
+                                NPROC_IN_POOL, RANK_IN_POOL, MY_POOL);
+
+    testing::InitGoogleTest(&argc, argv);
+    int result = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return result;
 }
 

--- a/source/source_estate/test/charge_test.cpp
+++ b/source/source_estate/test/charge_test.cpp
@@ -221,28 +221,3 @@ TEST_F(ChargeTest, InitFinalScf)
     charge->init_final_scf();
     EXPECT_TRUE(charge->allocate_rho_final_scf);
 }
-
-int main(int argc, char **argv)
-{
-    int NPROC, MY_RANK, NTHREAD_PER_PROC;
-    Parallel_Global::read_pal_param(argc, argv, NPROC, NTHREAD_PER_PROC, MY_RANK);
-
-    int NPROC_IN_BNDGROUP;
-    int RANK_IN_BPGROUP;
-    int MY_BNDGROUP;
-    int NPROC_IN_POOL;
-    int RANK_IN_POOL;
-    int MY_POOL;
-    int BNDPAR = 1;
-    int KPAR = 1;
-
-    Parallel_Global::init_pools(NPROC, MY_RANK, BNDPAR, KPAR, 
-                                NPROC_IN_BNDGROUP, RANK_IN_BPGROUP, MY_BNDGROUP, 
-                                NPROC_IN_POOL, RANK_IN_POOL, MY_POOL);
-
-    testing::InitGoogleTest(&argc, argv);
-    int result = RUN_ALL_TESTS();
-    MPI_Finalize();
-    return result;
-}
-

--- a/source/source_estate/test/potential_new_test.cpp
+++ b/source/source_estate/test/potential_new_test.cpp
@@ -1,10 +1,12 @@
 #include "gtest/gtest.h"
+#include <mpi.h>
 #include <vector>
 
 #define private public
 #include "source_estate/module_pot/potential_new.h"
 #include "source_hamilt/module_xc/xc_functional.h"
 #include "source_io/module_parameter/parameter.h"
+#include "source_base/parallel_global.h"
 // mock functions
 Structure_Factor::Structure_Factor()
 {
@@ -675,4 +677,18 @@ TEST_F(PotentialNewTest, InterpolateVrsSingleGrids)
         }
     }
 
+}
+
+int main(int argc, char **argv)
+{
+    int NPROC, MY_RANK, NTHREAD_PER_PROC;
+    Parallel_Global::read_pal_param(argc, argv, NPROC, NTHREAD_PER_PROC, MY_RANK);
+    int NPROC_IN_BNDGROUP, RANK_IN_BPGROUP, MY_BNDGROUP;
+    int NPROC_IN_POOL, RANK_IN_POOL, MY_POOL;
+    int BNDPAR = 1, KPAR = 1;
+    Parallel_Global::init_pools(NPROC, MY_RANK, BNDPAR, KPAR, NPROC_IN_BNDGROUP, RANK_IN_BPGROUP, MY_BNDGROUP, NPROC_IN_POOL, RANK_IN_POOL, MY_POOL);
+    testing::InitGoogleTest(&argc, argv);
+    int result = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return result;
 }

--- a/source/source_estate/test/potential_new_test.cpp
+++ b/source/source_estate/test/potential_new_test.cpp
@@ -679,16 +679,3 @@ TEST_F(PotentialNewTest, InterpolateVrsSingleGrids)
 
 }
 
-int main(int argc, char **argv)
-{
-    int NPROC, MY_RANK, NTHREAD_PER_PROC;
-    Parallel_Global::read_pal_param(argc, argv, NPROC, NTHREAD_PER_PROC, MY_RANK);
-    int NPROC_IN_BNDGROUP, RANK_IN_BPGROUP, MY_BNDGROUP;
-    int NPROC_IN_POOL, RANK_IN_POOL, MY_POOL;
-    int BNDPAR = 1, KPAR = 1;
-    Parallel_Global::init_pools(NPROC, MY_RANK, BNDPAR, KPAR, NPROC_IN_BNDGROUP, RANK_IN_BPGROUP, MY_BNDGROUP, NPROC_IN_POOL, RANK_IN_POOL, MY_POOL);
-    testing::InitGoogleTest(&argc, argv);
-    int result = RUN_ALL_TESTS();
-    MPI_Finalize();
-    return result;
-}

--- a/source/source_hsolver/diago_bpcg.cpp
+++ b/source/source_hsolver/diago_bpcg.cpp
@@ -86,7 +86,7 @@ bool DiagoBPCG<T, Device>::test_error(const ct::Tensor& err_in, const std::vecto
             not_conv = true;
         }
     }
-    Parallel_Reduce::reduce_or_bool_bp(not_conv);
+    Parallel_Reduce::reduce_or_bp(not_conv);
     return not_conv;
 }
 

--- a/source/source_hsolver/diago_bpcg.cpp
+++ b/source/source_hsolver/diago_bpcg.cpp
@@ -86,7 +86,7 @@ bool DiagoBPCG<T, Device>::test_error(const ct::Tensor& err_in, const std::vecto
             not_conv = true;
         }
     }
-    Parallel_Reduce::gather_or_bool_bp(not_conv);
+    Parallel_Reduce::reduce_or_bool_bp(not_conv);
     return not_conv;
 }
 

--- a/source/source_hsolver/diago_bpcg.cpp
+++ b/source/source_hsolver/diago_bpcg.cpp
@@ -4,6 +4,7 @@
 #include "source_base/global_function.h"
 #include "source_base/kernels/math_kernel_op.h"
 #include "source_base/parallel_comm.h" // different MPI worlds
+#include "source_base/parallel_reduce.h"
 #include "source_hsolver/kernels/bpcg_kernel_op.h"
 #include "para_linear_transform.h"
 
@@ -85,9 +86,7 @@ bool DiagoBPCG<T, Device>::test_error(const ct::Tensor& err_in, const std::vecto
             not_conv = true;
         }
     }
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &not_conv, 1, MPI_C_BOOL, MPI_LOR, BP_WORLD);
-#endif
+    Parallel_Reduce::gather_or_bool_bp(not_conv);
     return not_conv;
 }
 

--- a/source/source_io/cal_dos.cpp
+++ b/source/source_io/cal_dos.cpp
@@ -56,8 +56,8 @@ void ModuleIO::prepare_dos(std::ofstream& ofs_running,
     }
 
 #ifdef __MPI
-    Parallel_Reduce::reduce_max_double_all(emax);
-    Parallel_Reduce::reduce_min_double_all(emin);
+    Parallel_Reduce::reduce_max_all(emax);
+    Parallel_Reduce::reduce_min_all(emin);
 #endif
 
     emax *= ModuleBase::Ry_to_eV;

--- a/source/source_io/cal_dos.cpp
+++ b/source/source_io/cal_dos.cpp
@@ -56,8 +56,8 @@ void ModuleIO::prepare_dos(std::ofstream& ofs_running,
     }
 
 #ifdef __MPI
-    Parallel_Reduce::gather_max_double_all(GlobalV::NPROC, emax);
-    Parallel_Reduce::gather_min_double_all(GlobalV::NPROC, emin);
+    Parallel_Reduce::reduce_max_double_all(emax);
+    Parallel_Reduce::reduce_min_double_all(emin);
 #endif
 
     emax *= ModuleBase::Ry_to_eV;

--- a/source/source_io/output_log.cpp
+++ b/source/source_io/output_log.cpp
@@ -6,6 +6,7 @@
 #include "source_base/global_variable.h"
 
 #include "source_base/parallel_comm.h"
+#include "source_base/parallel_reduce.h"
 
 #ifdef __MPI
 #include <mpi.h>
@@ -154,7 +155,7 @@ void output_vacuum_level(const UnitCell* ucell,
         }
 
 #ifdef __MPI
-        MPI_Allreduce(MPI_IN_PLACE, ave, length, MPI_DOUBLE, MPI_SUM, POOL_WORLD);
+        Parallel_Reduce::reduce_pool(ave, length);
 #endif
 
         int surface = nxyz / length;


### PR DESCRIPTION
This PR refactors the codebase to replace direct MPI_Allreduce calls with unified wrapper functions from the Parallel_Reduce namespace. The goal is to improve maintainability, reduce code duplication, and encapsulate MPI reduction logic behind a consistent interface.

Key Changes:
- elecstate_energy.cpp: Replaced MPI_Allreduce (POOL_WORLD) with Parallel_Reduce::reduce_pool.
- charge_mpi.cpp:
  - Replaced MPI_Allreduce (KP_WORLD) with Parallel_Reduce::reduce_kp.
  - Replaced MPI_Allreduce (INT_BGROUP) with Parallel_Reduce::reduce_bgroup.
  - Replaced MPI_Allreduce (BP_WORLD) with Parallel_Reduce::reduce_bp.
- symmetry_rhog.cpp: Replaced MPI_Allreduce (POOL_WORLD) with Parallel_Reduce::reduce_pool for fftixy2is.
- diago_bpcg.cpp: Replaced MPI_Allreduce (MPI_LOR, BP_WORLD) with Parallel_Reduce::gather_or_bool_bp for convergence check.
- source/source_io/output_log.cpp: Replaced MPI_Allreduce (POOL_WORLD) with Parallel_Reduce::reduce_pool for vacuum level calculation.

Impact:
- No functional changes — only internal refactoring.
- All reductions retain their original communicator semantics.
- Easier to audit, extend, or switch underlying MPI implementations in the future.