### PR TITLE
Fix: skip MPI test for lapack UT

### DIFF
--- a/source/source_hsolver/test/diago_lcao_test.cpp
+++ b/source/source_hsolver/test/diago_lcao_test.cpp
@@ -302,6 +302,15 @@ TEST_P(DiagoGammaOnlyTest, LCAO)
     std::stringstream out_info;
     DiagoPrepare<double> dp = GetParam();
     ASSERT_TRUE(dp.produce_HS());
+
+    // Skip lapack tests in multi-process environment
+    // LAPACK is a serial solver and cannot work with distributed matrices
+    if (dp.ks_solver == "lapack" && dp.dsize > 1)
+    {
+        GTEST_SKIP() << "Skipping lapack test with " << dp.dsize
+                     << " MPI processes (lapack only supports single process)";
+    }
+
     dp.diago();
 
     if (dp.myrank == 0)
@@ -336,6 +345,15 @@ TEST_P(DiagoKPointsTest, LCAO)
     std::stringstream out_info;
     DiagoPrepare<std::complex<double>> dp = GetParam();
     ASSERT_TRUE(dp.produce_HS());
+
+    // Skip lapack tests in multi-process environment
+    // LAPACK is a serial solver and cannot work with distributed matrices
+    if (dp.ks_solver == "lapack" && dp.dsize > 1)
+    {
+        GTEST_SKIP() << "Skipping lapack test with " << dp.dsize
+                     << " MPI processes (lapack only supports single process)";
+    }
+
     dp.diago();
 
     if (dp.myrank == 0)
@@ -378,9 +396,6 @@ int main(int argc, char** argv)
         std::cout << "ERROR:some tests are not passed" << std::endl;
         return result;
     }
-    else
-    {
-        MPI_Finalize();
-        return 0;
-    }
+    MPI_Finalize();
+    return 0;
 }


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
In #6858 , one UT failed with:
<img width="2837" height="795" alt="image" src="https://github.com/user-attachments/assets/e835b457-3a68-4065-b3ac-92b250a27ec6" />

but that PR is not related with HSolver, this PR aim to fix the UT error for conflict of lapack interface with multi-processes UT tests.

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
