### PR TITLE
Fix cudaErrIllegalAddress by using correct device pointer

### DIFF
--- a/source/source_hsolver/diago_dav_subspace.cpp
+++ b/source/source_hsolver/diago_dav_subspace.cpp
@@ -323,7 +323,7 @@ void Diago_DavSubspace<T, Device>::cal_grad(const HPsiFunc& hpsi_func,
     }
 
     // vcc = - vcc * eigenvalue
-    ModuleBase::matrix_mul_vector_op<T, Device>()(nbase, notconv, vcc, this->nbase_x, eigenvalue_iter->data(), -1.0, vcc, this->nbase_x);
+    ModuleBase::matrix_mul_vector_op<T, Device>()(nbase, notconv, vcc, this->nbase_x, e_temp_hd, -1.0, vcc, this->nbase_x);
 
 #ifdef __DSP
     ModuleBase::gemm_op_mt<T, Device>()


### PR DESCRIPTION
### Linked Issue
Fix #6850 #6563

### What's changed?
- The error was caused by passing a host pointer to a device function `matrix_mul_vector_op`.
- CPU vector `eigenvalue_iter->data()` on the host is replaced with the device copy `e_temp_hd` in the call.


