### PR TITLE
Optimize install_openmpi.sh script

### DIFF
--- a/toolchain/scripts/stage1/install_openmpi.sh
+++ b/toolchain/scripts/stage1/install_openmpi.sh
@@ -91,7 +91,12 @@ case "${with_openmpi}" in
             #   else
             #     EXTRA_CONFIGURE_FLAGS=""
             #   fi
-            ./configure CFLAGS="${CFLAGS}" \
+            ./configure \
+                CC=gcc \
+                CXX=g++ \
+                FC=gfortran \
+                F77=gfortran \
+                CFLAGS="${CFLAGS}" \
                 --prefix=${pkg_install_dir} \
                 --libdir="${pkg_install_dir}/lib" \
                 --with-libevent=internal \


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
When using the toolchain_gnu.sh script to download the required math libraries for ABACUS on the Huawei Kunpeng platform, I encountered the error: "Configure: error: Could not compile an MPI Fortran program." According to ChatGPT, the reason is that on the Kunpeng platform, OpenMPI automatically disables Fortran support without reporting an explicit error. I resolved this issue by modifying the install_openmpi.sh script. Therefore, I submit this PR to make the toolchain more adaptable to different environments.

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
