### PR TITLE
Fix: change uplo to U for lapack_hegvd to be consistent with former routine

### DIFF
--- a/source/source_base/module_container/ATen/kernels/cuda/lapack.cu
+++ b/source/source_base/module_container/ATen/kernels/cuda/lapack.cu
@@ -289,7 +289,7 @@ struct lapack_hegvd<T, DEVICE_GPU> {
     {
         const int itype = 1;
         const char jobz = 'V';
-        const char uplo = 'L';
+        const char uplo = 'U';
         cudaErrcheck(cudaMemcpy(eigen_vec, Mat_A, sizeof(T) * dim * lda, cudaMemcpyDeviceToDevice));
 
         // prevent B from being overwritten by Cholesky


### PR DESCRIPTION
### Linked Issue
Fix #6867 

### What's changed?
- change uplo to U for lapack_hegvd to be consistent with former routine. Now GPU result is the same as CPU for `ks_solver dav_subspace`.

