### PR TITLE
Fix: eliminate compile warning of iteration index(int) undefined behavior

### DIFF
--- a/source/source_hamilt/module_vdw/vdwd2.h
+++ b/source/source_hamilt/module_vdw/vdwd2.h
@@ -36,9 +36,9 @@ class Vdwd2 : public Vdw
         int yidx = para_.period().y / 2;
         int zidx = para_.period().z / 2;
 
-        for (int it1 = 0; it1 != ucell_.ntype; ++it1)
+        for (int it1 = 0; it1 < ucell_.ntype; ++it1)
         {
-            for (int it2 = 0; it2 != ucell_.ntype; ++it2)
+            for (int it2 = 0; it2 < ucell_.ntype; ++it2)
             {
                 const double C6_product
                     = sqrt(para_.C6().at(ucell_.atoms[it1].ncpp.psd) * para_.C6().at(ucell_.atoms[it2].ncpp.psd))


### PR DESCRIPTION
### Description
Compile warning:
```
In file included from /abacus-develop/source/source_hamilt/module_vdw/vdwd2.cpp:7:
In member function ‘void vdw::Vdwd2::index_loops(F&&) [with F = vdw::Vdwd2::cal_force()::<lambda(double, double, double, double, int, int, const ModuleBase::Vector3<double>&, const ModuleBase::Vector3<double>&)>&]’,
    inlined from ‘virtual void vdw::Vdwd2::cal_force()’ at /abacus-develop/source/source_hamilt/module_vdw/vdwd2.cpp:58:16:
/abacus-develop/source/source_hamilt/module_vdw/vdwd2.h:39:9: warning: iteration 2147483646 invokes undefined behavior [-Waggressive-loop-optimizations]
   39 |         for (int it1 = 0; it1 != ucell_.ntype; ++it1)
      |         ^~~
/abacus-develop/source/source_hamilt/module_vdw/vdwd2.h:39:31: note: within this loop
   39 |         for (int it1 = 0; it1 != ucell_.ntype; ++it1)
      |                           ~~~~^~~~~~~~~~~~~~~
```


### What's changed?
- Change the `for` loop boundary check from `!=` to `<`, now no warning popped.

