### PR TITLE
[Refactor] Update init_wfc message to be user-friendly

### DIFF
--- a/source/source_psi/psi_init.cpp
+++ b/source/source_psi/psi_init.cpp
@@ -44,17 +44,28 @@ void PSIInit<T, Device>::prepare_init(const int& random_seed)
     if (this->init_wfc == "random")
     {
         this->psi_initer = std::unique_ptr<psi_initializer<T>>(new psi_initializer_random<T>());
+        GlobalV::ofs_running << "\n Using RANDOM starting wave functions for all " << PARAM.inp.nbands << " bands\n";
     }
     else if (this->init_wfc == "file")
     {
         this->psi_initer = std::unique_ptr<psi_initializer<T>>(new psi_initializer_file<T>());
+        GlobalV::ofs_running << "\n Using FILE starting wave functions\n";
     }
     else if ((this->init_wfc.substr(0, 6) == "atomic") && (this->ucell.natomwfc == 0))
     {
-        ModuleBase::WARNING_QUIT("PSIInit::prepare_init",
-            "init_wfc = atomic requires pseudo wavefunctions, but number of atom wfc = 0. \n"
-            " Please use init_wfc = random or try a pseudopotential with pseudo wavefunctions.");
+        std::cout << " WARNING: init_wfc = " + this->init_wfc +
+            " requires atomic pseudo wavefunctions(PP_PSWFC),\n but none available."
+            " Automatically switch to random initialization." << std::endl;
+        GlobalV::ofs_running << "\n Using RANDOM starting wave functions for all " << PARAM.inp.nbands << " bands\n";
+        GlobalV::ofs_running << "\n WARNING:\n init_wfc = " + this->init_wfc + " requires atomic pseudo wavefunctions(PP_PSWFC), but none available. \n"
+            " Automatically switch to random initialization.\n"
+            " Note: Random starting wavefunctions may slow down convergence.\n"
+            "      For faster convergence, consider using:\n"
+            "      1) A pseudopotential file that includes atomic wavefunctions (with PP_PSWFC), or\n"
+            "      2) Numerical atomic orbitals with 'init_wfc = nao' or 'nao+random' if available.\n"
+            << std::endl;
         this->psi_initer = std::unique_ptr<psi_initializer<T>>(new psi_initializer_random<T>());
+
     }
     else if (this->init_wfc == "atomic"
              || (this->init_wfc == "atomic+random" && this->ucell.natomwfc < PARAM.inp.nbands))
@@ -64,26 +75,30 @@ void PSIInit<T, Device>::prepare_init(const int& random_seed)
             int nrandom = PARAM.inp.nbands - this->ucell.natomwfc;
             GlobalV::ofs_running << "\n Using ATOMIC starting wave functions with " << this->ucell.natomwfc << " atomic orbitals"
             << " + " << nrandom << " random orbitals"
-            << " (total " << PARAM.inp.nbands << " bands)";
+            << " (total " << PARAM.inp.nbands << " bands)\n";
         }
         else
         {
             GlobalV::ofs_running << "\n Using ATOMIC starting wave functions for all " << this->ucell.natomwfc << " atomic orbitals"
-                << " (covers " << PARAM.inp.nbands << " bands)";
+                << " (covers " << PARAM.inp.nbands << " bands)\n";
         }
         this->psi_initer = std::unique_ptr<psi_initializer<T>>(new psi_initializer_atomic<T>());
     }
     else if (this->init_wfc == "atomic+random")
     {
         this->psi_initer = std::unique_ptr<psi_initializer<T>>(new psi_initializer_atomic_random<T>());
+        GlobalV::ofs_running << "\n Using ATOMIC+RANDOM starting wave functions with "
+                             << this->ucell.natomwfc << " atomic orbitals\n";
     }
     else if (this->init_wfc == "nao")
     {
         this->psi_initer = std::unique_ptr<psi_initializer<T>>(new psi_initializer_nao<T>());
+        GlobalV::ofs_running << "\n Using NAO starting wave functions\n";
     }
     else if (this->init_wfc == "nao+random")
     {
         this->psi_initer = std::unique_ptr<psi_initializer<T>>(new psi_initializer_nao_random<T>());
+        GlobalV::ofs_running << "\n Using NAO+RANDOM starting wave functions\n";
     }
     else
     {


### PR DESCRIPTION
### Linked Issue
Fix #6875

### What's changed?
- Now do not quit if `init_wfc` is set to `atomic`(default) while no atomic wfcs are read from pseudopotentials, but leave a warning message and suggest using pseudopotential with `PP_PSWFC` or `init_wfc=nao` instead, and proceed with `random`.
- Output starting wavefunction composition in all cases.
