### PR TITLE
Fix: Minor fixes for EXX PW

### DIFF
--- a/source/source_pw/module_pwdft/module_exx_helper/exx_helper.cpp
+++ b/source/source_pw/module_pwdft/module_exx_helper/exx_helper.cpp
@@ -28,7 +28,7 @@ bool Exx_Helper<T, Device>::exx_after_converge(int &iter, bool ene_conv)
     {
         return true;
     }
-    else if (iter >= PARAM.inp.exx_hybrid_step)
+    else if (exx_iter >= PARAM.inp.exx_hybrid_step)
     {
         GlobalV::ofs_running << " !!EXX IS NOT CONVERGED!!" << std::endl;
         std::cout << " !!EXX IS NOT CONVERGED!!" << std::endl;

--- a/source/source_pw/module_pwdft/operator_pw/exx_pw_ace.cpp
+++ b/source/source_pw/module_pwdft/operator_pw/exx_pw_ace.cpp
@@ -328,13 +328,13 @@ double OperatorEXXPW<T, Device>::cal_exx_energy_ace(psi::Psi<T, Device>* ppsi_) 
             T* hpsi_i_n = h_psi_ace + nband * psi_.get_nbasis();
             double wg_i_n = (*wg)(i, nband);
             // Eexx += dot(psi_i_n, h_psi_i_n)
-            Eexx += dot_op()(psi_.get_nbasis(), psi_i_n, hpsi_i_n, false) * wg_i_n * 2;
+            Eexx += dot_op()(psi_.get_nbasis(), psi_i_n, hpsi_i_n, false) * wg_i_n;
         }
     }
 
     Parallel_Reduce::reduce_all(Eexx);
     *ik_ = ik_save;
-    Eexx = Eexx / hybrid_alpha / 4;
+    Eexx = Eexx / hybrid_alpha / 2; // This factor of 2 is from the definition of EXX energy.
     return Eexx;
 }
 template class OperatorEXXPW<std::complex<float>, base_device::DEVICE_CPU>;

--- a/source/source_pw/module_pwdft/operator_pw/exx_pw_ace.cpp
+++ b/source/source_pw/module_pwdft/operator_pw/exx_pw_ace.cpp
@@ -1,6 +1,7 @@
 #include "op_exx_pw.h"
 #include "source_base/parallel_comm.h"
 #include "source_io/module_parameter/parameter.h"
+#include "source_hamilt/module_xc/exx_info.h"
 
 namespace hamilt
 {
@@ -311,6 +312,7 @@ double OperatorEXXPW<T, Device>::cal_exx_energy_ace(psi::Psi<T, Device>* ppsi_) 
     psi::Psi<T, Device> psi_ = *ppsi_;
     int* ik_ = const_cast<int*>(&this->ik);
     int ik_save = this->ik;
+    Real hybrid_alpha = GlobalC::exx_info.info_global.hybrid_alpha;
     for (int i = 0; i < wfcpw->nks; i++)
     {
         setmem_complex_op()(h_psi_ace, 0, psi_.get_nbands() * psi_.get_nbasis());
@@ -332,6 +334,7 @@ double OperatorEXXPW<T, Device>::cal_exx_energy_ace(psi::Psi<T, Device>* ppsi_) 
 
     Parallel_Reduce::reduce_all(Eexx);
     *ik_ = ik_save;
+    Eexx = Eexx / hybrid_alpha / 4;
     return Eexx;
 }
 template class OperatorEXXPW<std::complex<float>, base_device::DEVICE_CPU>;


### PR DESCRIPTION
- Previously, `exx_hybrid_step` for setting the maximum number of the outer loop in EXX doesn't work for EXX PW due to a wrong variable. This PR fixes this. 
- ACE method for EXX PW gives wrong EXX energy when the propotion for EXX isn't 0.25 since the `exx_hybrid_alpha` is multiplied twice. This PR should fix this. 