### PR TITLE
Fix: enhance several warning messages

### DIFF
--- a/source/source_estate/module_pot/pot_ml_exx.h
+++ b/source/source_estate/module_pot/pot_ml_exx.h
@@ -62,7 +62,7 @@ class PotML_EXX : public PotBase
     }
     ~PotML_EXX() {};
 
-    void cal_v_eff(const Charge*const chg, const UnitCell*const ucell, ModuleBase::matrix& v_eff)
+    void cal_v_eff(const Charge*const chg, const UnitCell*const ucell, ModuleBase::matrix& v_eff) override
     {
         if (PARAM.inp.of_ml_local_test) this->ml_exx.localTest(chg->rho, this->rho_basis_);
         this->ml_exx.ml_potential(chg->rho, this->rho_basis_, v_eff);

--- a/source/source_io/read_input_item_ofdft.cpp
+++ b/source/source_io/read_input_item_ofdft.cpp
@@ -14,7 +14,8 @@ void ReadInput::item_ofdft()
 #ifndef __MLALGO
             if (para.input.of_kinetic == "ml" || para.input.of_kinetic == "mpn" || para.input.of_kinetic == "cpn5")
             {
-                ModuleBase::WARNING_QUIT("ReadInput", "ML KEDF is not supported.");
+                ModuleBase::WARNING_QUIT("ReadInput", "Error: ML KEDF requires ENABLE_MLALGO option.\n "
+                                                      "Please enable ENABLE_MLALGO during compilation to use this feature.");
             }
 #endif
             if (para.input.of_kinetic != "tf" && para.input.of_kinetic != "vw" && para.input.of_kinetic != "wt"

--- a/source/source_io/read_input_item_output.cpp
+++ b/source/source_io/read_input_item_output.cpp
@@ -564,6 +564,10 @@ void ReadInput::item_output()
             {
                 ModuleBase::WARNING_QUIT("ReadInput", "ELF is only aviailable for ksdft and ofdft");
             }
+            if (para.input.out_elf[0] > 0 && para.input.nspin == 4)
+            {
+                ModuleBase::WARNING_QUIT("ReadInput", "ELF is not aviailable for nspin = 4");
+            }
         };
         sync_intvec(input.out_elf, 2, 0);
         this->add_item(item);


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Add `override` to `Pot_ML_EXX::cal_v_eff` to avoid compilation warning.
- Provide a clearer, friendlier error when ML KEDF is used without `ENABLE_MLALGO`.
- Add validation for `out_elf` and `spin=4` combo.

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
