### PR TITLE
Fix C++17 inline constexpr to support C++11

### DIFF
--- a/source/source_base/ylmcoef.h
+++ b/source/source_base/ylmcoef.h
@@ -12,7 +12,8 @@ constexpr int YLMCOEF_SIZE = 36;
 // GPU version: must use numeric constants (CUDA doesn't support runtime init for __device__)
 __device__ static const double ylmcoef[YLMCOEF_SIZE] = {
 #else
-inline constexpr double ylmcoef[YLMCOEF_SIZE] = {
+// Use static constexpr for C++11 compatibility (inline variables require C++17)
+static constexpr double ylmcoef[YLMCOEF_SIZE] = {
 #endif
 0.28209479177387813964,     // 1.0 / sqrt(ModuleBase::FOUR_PI)
 0.48860251190291992263,		// sqrt (3.0 / ModuleBase::FOUR_PI)


### PR DESCRIPTION
## Summary
- Replace `inline constexpr` with `static constexpr` in `ylmcoef.h` to eliminate C++17 dependency
- The project only supports up to C++11, and `inline` variables are a C++17 feature

Closes #6956

🤖 Generated with [Claude Code](https://claude.com/claude-code)