### PR TITLE
Feature: add MPI communicator injection for general-purpose parallel workflows

### DIFF
--- a/python/pyabacus/src/ModuleESolver/py_esolver_lcao.cpp
+++ b/python/pyabacus/src/ModuleESolver/py_esolver_lcao.cpp
@@ -448,15 +448,20 @@ PyESolverLCAO<TK, TR>::~PyESolverLCAO()
 }
 
 template <typename TK, typename TR>
-void PyESolverLCAO<TK, TR>::initialize(const std::string& input_dir)
+void PyESolverLCAO<TK, TR>::initialize(const std::string& input_dir, int mpi_comm_handle)
 {
     // Placeholder: will be implemented in Phase 3
     // This will:
-    // 1. Read INPUT file from input_dir
-    // 2. Initialize UnitCell
-    // 3. Create ESolver_KS_LCAO instance
+    // 1. Convert mpi_comm_handle to MPI_Comm via MPI_Comm_f2c()
+    //    (if mpi_comm_handle >= 0, otherwise use MPI_COMM_WORLD)
+    // 2. Use the resulting communicator for MPI_Comm_size/rank
+    // 3. Pass base_comm to Parallel_Global::init_pools(), split_diag_world(), split_grid_world()
+    // 4. Read INPUT file from input_dir
+    // 5. Initialize UnitCell
+    // 6. Create ESolver_KS_LCAO instance
     initialized_ = true;
-    std::cout << "[PyESolverLCAO] Initialized with input directory: " << input_dir << std::endl;
+    std::cout << "[PyESolverLCAO] Initialized with input directory: " << input_dir
+              << ", mpi_comm_handle: " << mpi_comm_handle << std::endl;
 }
 
 template <typename TK, typename TR>
@@ -861,7 +866,10 @@ void bind_esolver_lcao(py::module& m, const std::string& suffix)
             ----------
             input_dir : str
                 Directory containing INPUT, STRU, and other input files
-            )pbdoc", "input_dir"_a)
+            mpi_comm_handle : int, optional
+                Fortran MPI communicator handle from mpi4py comm.py2f().
+                Use -1 (default) to use MPI_COMM_WORLD.
+            )pbdoc", "input_dir"_a, "mpi_comm_handle"_a = -1)
         .def("before_all_runners", &ESolver::before_all_runners,
             "Initialize calculation environment")
 

--- a/python/pyabacus/src/ModuleESolver/py_esolver_lcao.hpp
+++ b/python/pyabacus/src/ModuleESolver/py_esolver_lcao.hpp
@@ -284,7 +284,10 @@ public:
     // ==================== Initialization ====================
 
     /// Initialize from INPUT file directory
-    void initialize(const std::string& input_dir);
+    /// @param input_dir Directory containing INPUT, STRU, and other input files
+    /// @param mpi_comm_handle Fortran MPI communicator handle from mpi4py comm.py2f().
+    ///        Use -1 (default) to use MPI_COMM_WORLD.
+    void initialize(const std::string& input_dir, int mpi_comm_handle = -1);
 
     /// Call before_all_runners
     void before_all_runners();

--- a/python/pyabacus/src/pyabacus/esolver/workflow.py
+++ b/python/pyabacus/src/pyabacus/esolver/workflow.py
@@ -54,7 +54,7 @@ class LCAOWorkflow:
         'after_scf',         # Called after after_scf()
     ]
 
-    def __init__(self, input_dir: str, gamma_only: bool = True):
+    def __init__(self, input_dir: str, gamma_only: bool = True, mpi_comm=None):
         """
         Initialize LCAOWorkflow.
 
@@ -64,9 +64,13 @@ class LCAOWorkflow:
             Directory containing input files
         gamma_only : bool
             Use gamma-only calculation if True, multi-k if False
+        mpi_comm : mpi4py.MPI.Comm, optional
+            MPI communicator to use. If None, uses MPI_COMM_WORLD.
+            Pass a sub-communicator to run this ESolver on a subset of MPI ranks.
         """
         self._input_dir = input_dir
         self._gamma_only = gamma_only
+        self._mpi_comm = mpi_comm
         self._esolver = None
         self._initialized = False
         self._scf_running = False
@@ -96,9 +100,16 @@ class LCAOWorkflow:
                 "Make sure pyabacus is properly installed with ESolver support."
             ) from e
 
-        self._esolver.initialize(self._input_dir)
+        self._esolver.initialize(self._input_dir, mpi_comm_handle=self._mpi_comm_handle)
         self._esolver.before_all_runners()
         self._initialized = True
+
+    @property
+    def _mpi_comm_handle(self) -> int:
+        """Convert mpi4py communicator to Fortran handle, or -1 for default."""
+        if self._mpi_comm is None:
+            return -1
+        return self._mpi_comm.py2f()
 
     def register_callback(self, event: str, callback: Callable[['LCAOWorkflow'], None]) -> None:
         """

--- a/source/source_base/parallel_common.cpp
+++ b/source/source_base/parallel_common.cpp
@@ -7,75 +7,75 @@
 #include <cstring>
 
 #ifdef __MPI
-void Parallel_Common::bcast_string(std::string& object) // Peize Lin fix bug 2019-03-18
+void Parallel_Common::bcast_string(std::string& object, MPI_Comm comm) // Peize Lin fix bug 2019-03-18
 {
     int size = object.size();
-    MPI_Bcast(&size, 1, MPI_INT, 0, MPI_COMM_WORLD);
-    
+    MPI_Bcast(&size, 1, MPI_INT, 0, comm);
+
     int my_rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
-    
+    MPI_Comm_rank(comm, &my_rank);
+
     if (0 != my_rank)
     {
         object.resize(size);
     }
 
-    MPI_Bcast(&object[0], size, MPI_CHAR, 0, MPI_COMM_WORLD);
+    MPI_Bcast(&object[0], size, MPI_CHAR, 0, comm);
     return;
 }
 
-void Parallel_Common::bcast_string(std::string* object, const int n) // Peize Lin fix bug 2019-03-18
+void Parallel_Common::bcast_string(std::string* object, const int n, MPI_Comm comm) // Peize Lin fix bug 2019-03-18
 {
     for (int i = 0; i < n; i++)
-        bcast_string(object[i]);
+        bcast_string(object[i], comm);
     return;
 }
 
-void Parallel_Common::bcast_complex_double(std::complex<double>& object)
+void Parallel_Common::bcast_complex_double(std::complex<double>& object, MPI_Comm comm)
 {
-    MPI_Bcast(&object, 1, MPI_DOUBLE_COMPLEX, 0, MPI_COMM_WORLD);
+    MPI_Bcast(&object, 1, MPI_DOUBLE_COMPLEX, 0, comm);
 }
 
-void Parallel_Common::bcast_complex_double(std::complex<double>* object, const int n)
+void Parallel_Common::bcast_complex_double(std::complex<double>* object, const int n, MPI_Comm comm)
 {
-    MPI_Bcast(object, n, MPI_DOUBLE_COMPLEX, 0, MPI_COMM_WORLD);
+    MPI_Bcast(object, n, MPI_DOUBLE_COMPLEX, 0, comm);
 }
 
-void Parallel_Common::bcast_double(double& object)
+void Parallel_Common::bcast_double(double& object, MPI_Comm comm)
 {
-    MPI_Bcast(&object, 1, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+    MPI_Bcast(&object, 1, MPI_DOUBLE, 0, comm);
 }
 
-void Parallel_Common::bcast_double(double* object, const int n)
+void Parallel_Common::bcast_double(double* object, const int n, MPI_Comm comm)
 {
-    MPI_Bcast(object, n, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+    MPI_Bcast(object, n, MPI_DOUBLE, 0, comm);
 }
 
-void Parallel_Common::bcast_int(int& object)
+void Parallel_Common::bcast_int(int& object, MPI_Comm comm)
 {
-    MPI_Bcast(&object, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    MPI_Bcast(&object, 1, MPI_INT, 0, comm);
 }
 
-void Parallel_Common::bcast_int(int* object, const int n)
+void Parallel_Common::bcast_int(int* object, const int n, MPI_Comm comm)
 {
-    MPI_Bcast(object, n, MPI_INT, 0, MPI_COMM_WORLD);
+    MPI_Bcast(object, n, MPI_INT, 0, comm);
 }
 
-void Parallel_Common::bcast_bool(bool& object)
+void Parallel_Common::bcast_bool(bool& object, MPI_Comm comm)
 {
     int swap = object;
     int my_rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
+    MPI_Comm_rank(comm, &my_rank);
     if (my_rank == 0)
         swap = object;
-    MPI_Bcast(&swap, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    MPI_Bcast(&swap, 1, MPI_INT, 0, comm);
     if (my_rank != 0)
         object = static_cast<bool>(swap);
 }
 
-void Parallel_Common::bcast_char(char* object, const int n)
+void Parallel_Common::bcast_char(char* object, const int n, MPI_Comm comm)
 {
-    MPI_Bcast(object, n, MPI_CHAR, 0, MPI_COMM_WORLD);
+    MPI_Bcast(object, n, MPI_CHAR, 0, comm);
 }
 
 #endif

--- a/source/source_base/parallel_common.h
+++ b/source/source_base/parallel_common.h
@@ -10,18 +10,58 @@
 namespace Parallel_Common
 {
 //(1) bcast array
-void bcast_complex_double(std::complex<double>* object, const int n);
-void bcast_string(std::string* object, const int n);
-void bcast_double(double* object, const int n);
-void bcast_int(int* object, const int n);
-void bcast_char(char* object, const int n);
+void bcast_complex_double(std::complex<double>* object, const int n
+#ifdef __MPI
+    , MPI_Comm comm = MPI_COMM_WORLD
+#endif
+    );
+void bcast_string(std::string* object, const int n
+#ifdef __MPI
+    , MPI_Comm comm = MPI_COMM_WORLD
+#endif
+    );
+void bcast_double(double* object, const int n
+#ifdef __MPI
+    , MPI_Comm comm = MPI_COMM_WORLD
+#endif
+    );
+void bcast_int(int* object, const int n
+#ifdef __MPI
+    , MPI_Comm comm = MPI_COMM_WORLD
+#endif
+    );
+void bcast_char(char* object, const int n
+#ifdef __MPI
+    , MPI_Comm comm = MPI_COMM_WORLD
+#endif
+    );
 
 //(2) bcast single
-void bcast_complex_double(std::complex<double>& object);
-void bcast_string(std::string& object);
-void bcast_double(double& object);
-void bcast_int(int& object);
-void bcast_bool(bool& object);
+void bcast_complex_double(std::complex<double>& object
+#ifdef __MPI
+    , MPI_Comm comm = MPI_COMM_WORLD
+#endif
+    );
+void bcast_string(std::string& object
+#ifdef __MPI
+    , MPI_Comm comm = MPI_COMM_WORLD
+#endif
+    );
+void bcast_double(double& object
+#ifdef __MPI
+    , MPI_Comm comm = MPI_COMM_WORLD
+#endif
+    );
+void bcast_int(int& object
+#ifdef __MPI
+    , MPI_Comm comm = MPI_COMM_WORLD
+#endif
+    );
+void bcast_bool(bool& object
+#ifdef __MPI
+    , MPI_Comm comm = MPI_COMM_WORLD
+#endif
+    );
 
 } // namespace Parallel_Common
 

--- a/source/source_base/parallel_global.cpp
+++ b/source/source_base/parallel_global.cpp
@@ -49,7 +49,11 @@ void Parallel_Global::split_diag_world(const int& diag_np,
                                        const int& my_rank,
                                        int& drank,
                                        int& dsize,
-                                       int& dcolor)
+                                       int& dcolor
+#ifdef __MPI
+                                       , MPI_Comm base_comm
+#endif
+                                       )
 {
 #ifdef __MPI
     assert(diag_np > 0);
@@ -57,7 +61,7 @@ void Parallel_Global::split_diag_world(const int& diag_np,
     int color = -1;
     int key = -1;
     divide_mpi_groups(nproc, diag_np, my_rank, group_grid_np, key, color);
-    MPI_Comm_split(MPI_COMM_WORLD, color, key, &DIAG_WORLD);
+    MPI_Comm_split(base_comm, color, key, &DIAG_WORLD);
     MPI_Comm_rank(DIAG_WORLD, &drank);
     MPI_Comm_size(DIAG_WORLD, &dsize);
     dcolor = color;
@@ -69,7 +73,11 @@ void Parallel_Global::split_diag_world(const int& diag_np,
     return;
 }
 
-void Parallel_Global::split_grid_world(const int diag_np, const int& nproc, const int& my_rank, int& grank, int& gsize)
+void Parallel_Global::split_grid_world(const int diag_np, const int& nproc, const int& my_rank, int& grank, int& gsize
+#ifdef __MPI
+    , MPI_Comm base_comm
+#endif
+    )
 {
 #ifdef __MPI
     assert(diag_np > 0);
@@ -77,7 +85,7 @@ void Parallel_Global::split_grid_world(const int diag_np, const int& nproc, cons
     int color = -1;
     int key = -1;
     divide_mpi_groups(nproc, diag_np, my_rank, group_grid_np, color, key);
-    MPI_Comm_split(MPI_COMM_WORLD, color, key, &GRID_WORLD);
+    MPI_Comm_split(base_comm, color, key, &GRID_WORLD);
     MPI_Comm_rank(GRID_WORLD, &grank);
     MPI_Comm_size(GRID_WORLD, &gsize);
 #else
@@ -258,7 +266,11 @@ void Parallel_Global::init_pools(const int& NPROC,
                                  int& MY_BNDGROUP,
                                  int& NPROC_IN_POOL,
                                  int& RANK_IN_POOL,
-                                 int& MY_POOL)
+                                 int& MY_POOL
+#ifdef __MPI
+                                 , MPI_Comm base_comm
+#endif
+                                 )
 {
 #ifdef __MPI
     //----------------------------------------------------------
@@ -273,7 +285,8 @@ void Parallel_Global::init_pools(const int& NPROC,
                                   MY_BNDGROUP,
                                   NPROC_IN_POOL,
                                   RANK_IN_POOL,
-                                  MY_POOL);
+                                  MY_POOL,
+                                  base_comm);
 
     // for test
     // turn on when you want to check the index of pools.
@@ -321,7 +334,8 @@ void Parallel_Global::divide_pools(const int& NPROC,
                                    int& MY_BNDGROUP,
                                    int& NPROC_IN_POOL,
                                    int& RANK_IN_POOL,
-                                   int& MY_POOL)
+                                   int& MY_POOL,
+                                   MPI_Comm base_comm)
 {
     // note: the order of k-point parallelization and band parallelization is important
     //       The order will not change the behavior of KP_WORLD or BP_WORLD, and MY_POOL
@@ -334,7 +348,7 @@ void Parallel_Global::divide_pools(const int& NPROC,
             "When BNDPAR > 1, number of processes NPROC must be divisible by the number of groups BNDPAR * KPAR.");
     }
     // k-point parallelization
-    MPICommGroup kpar_group(MPI_COMM_WORLD);
+    MPICommGroup kpar_group(base_comm);
     kpar_group.divide_group_comm(KPAR, false);
 
     // band parallelization
@@ -362,7 +376,7 @@ void Parallel_Global::divide_pools(const int& NPROC,
         NPROC_IN_BNDGROUP = kpar_group.ngroups * bndpar_group.nprocs_in_group;
         RANK_IN_BPGROUP = kpar_group.my_group * bndpar_group.nprocs_in_group + bndpar_group.rank_in_group;
         MY_BNDGROUP = bndpar_group.my_group;
-        MPI_Comm_split(MPI_COMM_WORLD, MY_BNDGROUP, RANK_IN_BPGROUP, &INT_BGROUP);
+        MPI_Comm_split(base_comm, MY_BNDGROUP, RANK_IN_BPGROUP, &INT_BGROUP);
         MPI_Comm_dup(bndpar_group.inter_comm, &BP_WORLD);
     }
     else
@@ -370,8 +384,8 @@ void Parallel_Global::divide_pools(const int& NPROC,
         NPROC_IN_BNDGROUP = NPROC;
         RANK_IN_BPGROUP = MY_RANK;
         MY_BNDGROUP = 0;
-        MPI_Comm_dup(MPI_COMM_WORLD, &INT_BGROUP);
-        MPI_Comm_split(MPI_COMM_WORLD, MY_RANK, 0, &BP_WORLD);
+        MPI_Comm_dup(base_comm, &INT_BGROUP);
+        MPI_Comm_split(base_comm, MY_RANK, 0, &BP_WORLD);
     }
     return;
 }

--- a/source/source_base/parallel_global.h
+++ b/source/source_base/parallel_global.h
@@ -37,8 +37,16 @@ void myProd(std::complex<double>* in, std::complex<double>* inout, int* len, MPI
  * leads to the 'diag world', diag
  * is only carried out using those 4 proc.
  */
-void split_diag_world(const int& diag_np, const int& nproc, const int& my_rank, int& drank, int& dsize, int& dcolor);
-void split_grid_world(const int diag_np, const int& nproc, const int& my_rank, int& grank, int& gsize);
+void split_diag_world(const int& diag_np, const int& nproc, const int& my_rank, int& drank, int& dsize, int& dcolor
+#ifdef __MPI
+    , MPI_Comm base_comm = MPI_COMM_WORLD
+#endif
+    );
+void split_grid_world(const int diag_np, const int& nproc, const int& my_rank, int& grank, int& gsize
+#ifdef __MPI
+    , MPI_Comm base_comm = MPI_COMM_WORLD
+#endif
+    );
 
 /**
  * @brief An interface function to call "Parallel_Global::divide_pools()"
@@ -53,7 +61,11 @@ void init_pools(const int& NPROC,
                 int& MY_BNDGROUP,
                 int& NPROC_IN_POOL,
                 int& RANK_IN_POOL,
-                int& MY_POOL);
+                int& MY_POOL
+#ifdef __MPI
+                , MPI_Comm base_comm = MPI_COMM_WORLD
+#endif
+                );
 
 void divide_pools(const int& NPROC,
                   const int& MY_RANK,
@@ -64,7 +76,11 @@ void divide_pools(const int& NPROC,
                   int& MY_BNDGROUP,
                   int& NPROC_IN_POOL,
                   int& RANK_IN_POOL,
-                  int& MY_POOL);
+                  int& MY_POOL
+#ifdef __MPI
+                  , MPI_Comm base_comm = MPI_COMM_WORLD
+#endif
+                  );
 
 /**
  * @brief Divide MPI processes into groups

--- a/source/source_base/parallel_reduce.cpp
+++ b/source/source_base/parallel_reduce.cpp
@@ -5,19 +5,27 @@
 #include <vector>
 
 template <>
-void Parallel_Reduce::reduce_all<int>(int& object)
+void Parallel_Reduce::reduce_all<int>(int& object
+#ifdef __MPI
+    , MPI_Comm comm
+#endif
+    )
 {
 #ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_INT, MPI_SUM, comm);
 #endif
     return;
 }
 
 template <>
-void Parallel_Reduce::reduce_all<long long>(long long& object)
+void Parallel_Reduce::reduce_all<long long>(long long& object
+#ifdef __MPI
+    , MPI_Comm comm
+#endif
+    )
 {
 #ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_LONG_LONG, MPI_SUM, comm);
 #endif
     return;
 }
@@ -31,37 +39,53 @@ void Parallel_Reduce::reduce_int_diag(int& object)
 }
 
 template <>
-void Parallel_Reduce::reduce_all<double>(double& object)
+void Parallel_Reduce::reduce_all<double>(double& object
+#ifdef __MPI
+    , MPI_Comm comm
+#endif
+    )
 {
 #ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_SUM, comm);
 #endif
     return;
 }
 
 template <>
-void Parallel_Reduce::reduce_all<float>(float& object)
+void Parallel_Reduce::reduce_all<float>(float& object
+#ifdef __MPI
+    , MPI_Comm comm
+#endif
+    )
 {
 #ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_FLOAT, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_FLOAT, MPI_SUM, comm);
 #endif
     return;
 }
 
 template <>
-void Parallel_Reduce::reduce_all<int>(int* object, const int n)
+void Parallel_Reduce::reduce_all<int>(int* object, const int n
+#ifdef __MPI
+    , MPI_Comm comm
+#endif
+    )
 {
 #ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_SUM, comm);
 #endif
     return;
 }
 
 template <>
-void Parallel_Reduce::reduce_all<long long>(long long* object, const int n)
+void Parallel_Reduce::reduce_all<long long>(long long* object, const int n
+#ifdef __MPI
+    , MPI_Comm comm
+#endif
+    )
 {
 #ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_LONG_LONG, MPI_SUM, comm);
 #endif
     return;
 }
@@ -75,10 +99,14 @@ void Parallel_Reduce::reduce_int_grid(int* object, const int n)
 }
 
 template <>
-void Parallel_Reduce::reduce_all<double>(double* object, const int n)
+void Parallel_Reduce::reduce_all<double>(double* object, const int n
+#ifdef __MPI
+    , MPI_Comm comm
+#endif
+    )
 {
 #ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE, MPI_SUM, comm);
 #endif
     return;
 }
@@ -136,23 +164,31 @@ void Parallel_Reduce::reduce_pool<double>(double* object, const int n)
 
 // (1) the value is same in each pool.
 // (2) we need to reduce the value from different pool.
-void Parallel_Reduce::reduce_double_allpool(const int& npool, const int& nproc_in_pool, double& object)
+void Parallel_Reduce::reduce_double_allpool(const int& npool, const int& nproc_in_pool, double& object
+#ifdef __MPI
+    , MPI_Comm comm
+#endif
+    )
 {
-    if (npool == 1) 
+    if (npool == 1)
     {
         return;
     }
 #ifdef __MPI
     double swap = object / nproc_in_pool;
-    MPI_Allreduce(&swap, &object, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(&swap, &object, 1, MPI_DOUBLE, MPI_SUM, comm);
 #endif
 }
 
 // (1) the value is same in each pool.
 // (2) we need to reduce the value from different pool.
-void Parallel_Reduce::reduce_double_allpool(const int& npool, const int& nproc_in_pool, double* object, const int n)
+void Parallel_Reduce::reduce_double_allpool(const int& npool, const int& nproc_in_pool, double* object, const int n
+#ifdef __MPI
+    , MPI_Comm comm
+#endif
+    )
 {
-    if (npool == 1) 
+    if (npool == 1)
     {
         return;
     }
@@ -162,45 +198,61 @@ void Parallel_Reduce::reduce_double_allpool(const int& npool, const int& nproc_i
     {
         swap[i] = object[i] / nproc_in_pool;
     }
-    MPI_Allreduce(swap.data(), object, n, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(swap.data(), object, n, MPI_DOUBLE, MPI_SUM, comm);
 #endif
 }
 
 template <>
-void Parallel_Reduce::reduce_all<std::complex<double>>(std::complex<double>& object)
-{
+void Parallel_Reduce::reduce_all<std::complex<double>>(std::complex<double>& object
 #ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_COMM_WORLD);
+    , MPI_Comm comm
 #endif
-    return;
-}
-
-// LiuXh add 2019-07-16
-template <>
-void Parallel_Reduce::reduce_all<std::complex<double>>(std::complex<double>* object, const int n)
+    )
 {
 #ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_COMM_WORLD);
-#endif
-    return;
-}
-
-
-template <>
-void Parallel_Reduce::reduce_all<std::complex<float>>(std::complex<float>& object)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_C_FLOAT_COMPLEX, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE_COMPLEX, MPI_SUM, comm);
 #endif
     return;
 }
 
 // LiuXh add 2019-07-16
 template <>
-void Parallel_Reduce::reduce_all<std::complex<float>>(std::complex<float>* object, const int n)
+void Parallel_Reduce::reduce_all<std::complex<double>>(std::complex<double>* object, const int n
+#ifdef __MPI
+    , MPI_Comm comm
+#endif
+    )
 {
 #ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_C_FLOAT_COMPLEX, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE_COMPLEX, MPI_SUM, comm);
+#endif
+    return;
+}
+
+
+template <>
+void Parallel_Reduce::reduce_all<std::complex<float>>(std::complex<float>& object
+#ifdef __MPI
+    , MPI_Comm comm
+#endif
+    )
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_C_FLOAT_COMPLEX, MPI_SUM, comm);
+#endif
+    return;
+}
+
+// LiuXh add 2019-07-16
+template <>
+void Parallel_Reduce::reduce_all<std::complex<float>>(std::complex<float>* object, const int n
+#ifdef __MPI
+    , MPI_Comm comm
+#endif
+    )
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_C_FLOAT_COMPLEX, MPI_SUM, comm);
 #endif
     return;
 }
@@ -232,52 +284,76 @@ void Parallel_Reduce::reduce_pool<std::complex<double>>(std::complex<double>* ob
     return;
 }
 
-void Parallel_Reduce::gather_int_all(int& v, int* all)
+void Parallel_Reduce::gather_int_all(int& v, int* all
+#ifdef __MPI
+    , MPI_Comm comm
+#endif
+    )
 {
 #ifdef __MPI
     assert(all != nullptr);
-    MPI_Allgather(&v, 1, MPI_INT, all, 1, MPI_INT, MPI_COMM_WORLD);
+    MPI_Allgather(&v, 1, MPI_INT, all, 1, MPI_INT, comm);
 #endif
     return;
 }
 
 template <>
-void Parallel_Reduce::reduce_min<int>(int& v)
+void Parallel_Reduce::reduce_min<int>(int& v
+#ifdef __MPI
+    , MPI_Comm comm
+#endif
+    )
 {
 #ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_INT, MPI_MIN, comm);
 #endif
 }
 
 template <>
-void Parallel_Reduce::reduce_min<float>(float& v)
+void Parallel_Reduce::reduce_min<float>(float& v
+#ifdef __MPI
+    , MPI_Comm comm
+#endif
+    )
 {
 #ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_FLOAT, MPI_MIN, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_FLOAT, MPI_MIN, comm);
 #endif
 }
 
 template <>
-void Parallel_Reduce::reduce_min<double>(double& v)
+void Parallel_Reduce::reduce_min<double>(double& v
+#ifdef __MPI
+    , MPI_Comm comm
+#endif
+    )
 {
 #ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_DOUBLE, MPI_MIN, comm);
 #endif
 }
 
 template <>
-void Parallel_Reduce::reduce_max<float>(float& v)
+void Parallel_Reduce::reduce_max<float>(float& v
+#ifdef __MPI
+    , MPI_Comm comm
+#endif
+    )
 {
 #ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_FLOAT, MPI_MAX, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_FLOAT, MPI_MAX, comm);
 #endif
 }
 
 template <>
-void Parallel_Reduce::reduce_max<double>(double& v)
+void Parallel_Reduce::reduce_max<double>(double& v
+#ifdef __MPI
+    , MPI_Comm comm
+#endif
+    )
 {
 #ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_DOUBLE, MPI_MAX, comm);
 #endif
 }
 
@@ -285,7 +361,7 @@ template <>
 void Parallel_Reduce::reduce_max_pool<double>(const int& nproc_in_pool, double& v)
 {
 #ifdef __MPI
-    if (nproc_in_pool == 1) 
+    if (nproc_in_pool == 1)
     {
         return;
     }
@@ -296,7 +372,7 @@ template <>
 void Parallel_Reduce::reduce_min_pool<double>(const int& nproc_in_pool, double& v)
 {
 #ifdef __MPI
-    if (nproc_in_pool == 1) 
+    if (nproc_in_pool == 1)
     {
         return;
     }

--- a/source/source_base/parallel_reduce.h
+++ b/source/source_base/parallel_reduce.h
@@ -12,19 +12,35 @@
 
 namespace Parallel_Reduce
 {
-/// reduce in all process
+/// reduce in all process, optionally specifying a communicator
 template <typename T>
-void reduce_all(T& object);
+void reduce_all(T& object
+#ifdef __MPI
+    , MPI_Comm comm = MPI_COMM_WORLD
+#endif
+    );
 template <typename T>
-void reduce_all(T* object, const int n);
+void reduce_all(T* object, const int n
+#ifdef __MPI
+    , MPI_Comm comm = MPI_COMM_WORLD
+#endif
+    );
 template <typename T>
 void reduce_pool(T& object);
 template <typename T>
 void reduce_pool(T* object, const int n);
 template <typename T>
-void reduce_min(T& v);
+void reduce_min(T& v
+#ifdef __MPI
+    , MPI_Comm comm = MPI_COMM_WORLD
+#endif
+    );
 template <typename T>
-void reduce_max(T& v);
+void reduce_max(T& v
+#ifdef __MPI
+    , MPI_Comm comm = MPI_COMM_WORLD
+#endif
+    );
 template <typename T>
 void reduce_min_pool(const int& nproc_in_pool, T& v);
 template <typename T>
@@ -39,10 +55,22 @@ void reduce_int_grid(int* object, const int n); // mohan add 2012-01-12
 void reduce_double_grid(double* object, const int n);
 void reduce_double_diag(double* object, const int n);
 
-void reduce_double_allpool(const int& npool, const int& nproc_in_pool, double& object);
-void reduce_double_allpool(const int& npool, const int& nproc_in_pool, double* object, const int n);
+void reduce_double_allpool(const int& npool, const int& nproc_in_pool, double& object
+#ifdef __MPI
+    , MPI_Comm comm = MPI_COMM_WORLD
+#endif
+    );
+void reduce_double_allpool(const int& npool, const int& nproc_in_pool, double* object, const int n
+#ifdef __MPI
+    , MPI_Comm comm = MPI_COMM_WORLD
+#endif
+    );
 
-void gather_int_all(int& v, int* all);
+void gather_int_all(int& v, int* all
+#ifdef __MPI
+    , MPI_Comm comm = MPI_COMM_WORLD
+#endif
+    );
 
 bool check_if_equal(double& v); // mohan add 2009-11-11
 


### PR DESCRIPTION

Replace hardcoded MPI_COMM_WORLD with configurable base_comm parameter in the MPI initialization path, enabling workflows like parallel NEB, phonon calculations, or replica exchange MD to split MPI ranks into independent groups, each running its own ESolver instance in a separate subprocess.

Changes:
- parallel_global: add base_comm parameter to divide_pools(), split_diag_world(), split_grid_world(), init_pools()
- parallel_reduce: add comm parameter to all reduce_all, reduce_min, reduce_max, reduce_double_allpool, gather_int_all functions
- parallel_common: add comm parameter to all bcast_* functions
- PyESolverLCAO: add mpi_comm_handle parameter to initialize()
- LCAOWorkflow: add mpi_comm parameter forwarded to ESolver

All parameters default to MPI_COMM_WORLD for full backward compatibility. Existing code compiles and behaves identically without modification.

### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
