### PR TITLE
Tests: Simplify MODULE_HSOLVER test to reduce time consumption

### DIFF
--- a/source/source_hsolver/test/diago_bpcg_test.cpp
+++ b/source/source_hsolver/test/diago_bpcg_test.cpp
@@ -202,9 +202,10 @@ INSTANTIATE_TEST_SUITE_P(VerifyCG,
                          ::testing::Values(
                              // nband, npw, sparsity, reorder, eps, maxiter, threshold
                              DiagoBPCGPrepare(10, 500, 0, true, 1e-5, 300, 5e-2),
-                             DiagoBPCGPrepare(20, 500, 6, true, 1e-5, 300, 5e-2),
-                             DiagoBPCGPrepare(20, 1000, 8, true, 1e-5, 300, 5e-2),
-                             DiagoBPCGPrepare(40, 1000, 8, true, 1e-6, 300, 5e-2))); 
+                             DiagoBPCGPrepare(20, 500, 6, true, 1e-5, 300, 5e-2)
+                            //  DiagoBPCGPrepare(20, 1000, 8, true, 1e-5, 300, 5e-2),
+                            //  DiagoBPCGPrepare(40, 1000, 8, true, 1e-6, 300, 5e-2)
+                            )); 
                             //DiagoBPCGPrepare(40, 2000, 8, true, 1e-5, 500, 1e-2))); 
 			    // the last one is passed but time-consumming.
 
@@ -251,7 +252,7 @@ TEST(DiagoBPCGTest, readH)
     // read Hamilt matrix from file data-H
     std::vector<std::complex<double>> hm;
     std::ifstream ifs;
-    std::string filename = "H-KPoints-Si64.dat";
+    std::string filename = "H-KPoints-Si2.dat";
     ifs.open(filename);
     // open file and check status
     if (!ifs.is_open())

--- a/source/source_hsolver/test/diago_bpcg_test.cpp
+++ b/source/source_hsolver/test/diago_bpcg_test.cpp
@@ -201,8 +201,8 @@ INSTANTIATE_TEST_SUITE_P(VerifyCG,
                          DiagoBPCGTest,
                          ::testing::Values(
                              // nband, npw, sparsity, reorder, eps, maxiter, threshold
-                             DiagoBPCGPrepare(10, 500, 0, true, 1e-5, 300, 5e-2),
-                             DiagoBPCGPrepare(20, 500, 6, true, 1e-5, 300, 5e-2)
+                             DiagoBPCGPrepare(10, 500, 0, true, 1e-5, 300, 5e-2)
+                            //  DiagoBPCGPrepare(20, 500, 6, true, 1e-5, 300, 5e-2)
                             //  DiagoBPCGPrepare(20, 1000, 8, true, 1e-5, 300, 5e-2),
                             //  DiagoBPCGPrepare(40, 1000, 8, true, 1e-6, 300, 5e-2)
                             )); 

--- a/source/source_hsolver/test/diago_cg_float_test.cpp
+++ b/source/source_hsolver/test/diago_cg_float_test.cpp
@@ -240,9 +240,10 @@ INSTANTIATE_TEST_SUITE_P(VerifyCG,
                          ::testing::Values(
                              // nband, npw, sparsity, reorder, eps, maxiter, threshold
                              DiagoCGPrepare(10, 200, 0, true, 1e-6, 300, 1e-0),
-                             DiagoCGPrepare(10, 200, 6, true, 1e-6, 300, 1e-0),
-                             DiagoCGPrepare(10, 400, 8, true, 1e-6, 300, 1e-0),
-                             DiagoCGPrepare(10, 600, 8, true, 1e-6, 300, 1e-0))); 
+                             DiagoCGPrepare(10, 200, 6, true, 1e-6, 300, 1e-0)
+                            //  DiagoCGPrepare(10, 400, 8, true, 1e-6, 300, 1e-0),
+                            //  DiagoCGPrepare(10, 600, 8, true, 1e-6, 300, 1e-0)
+                            )); 
                             //DiagoCGPrepare(40, 2000, 8, true, 1e-5, 500, 1e-2))); 
 			    // the last one is passed but time-consumming.
 
@@ -312,7 +313,7 @@ TEST(DiagoCGFloatTest, readH)
     // read Hamilt matrix from file data-H
     std::vector<std::complex<float>> hm;
     std::ifstream ifs;
-    std::string filename = "H-KPoints-Si64.dat";
+    std::string filename = "H-KPoints-Si2.dat";
     // open file and check status
     ifs.open(filename);
     if (!ifs.is_open())

--- a/source/source_hsolver/test/diago_cg_float_test.cpp
+++ b/source/source_hsolver/test/diago_cg_float_test.cpp
@@ -239,8 +239,8 @@ INSTANTIATE_TEST_SUITE_P(VerifyCG,
                          DiagoCGFloatTest,
                          ::testing::Values(
                              // nband, npw, sparsity, reorder, eps, maxiter, threshold
-                             DiagoCGPrepare(10, 200, 0, true, 1e-6, 300, 1e-0),
-                             DiagoCGPrepare(10, 200, 6, true, 1e-6, 300, 1e-0)
+                             DiagoCGPrepare(10, 200, 0, true, 1e-6, 300, 1e-0)
+                            //  DiagoCGPrepare(10, 200, 6, true, 1e-6, 300, 1e-0)
                             //  DiagoCGPrepare(10, 400, 8, true, 1e-6, 300, 1e-0),
                             //  DiagoCGPrepare(10, 600, 8, true, 1e-6, 300, 1e-0)
                             )); 

--- a/source/source_hsolver/test/diago_cg_real_test.cpp
+++ b/source/source_hsolver/test/diago_cg_real_test.cpp
@@ -240,8 +240,8 @@ INSTANTIATE_TEST_SUITE_P(VerifyCG,
     DiagoCGTest,
     ::testing::Values(
         // nband, npw, sparsity, reorder, eps, maxiter, threshold
-        DiagoCGPrepare(10, 500, 0, true, 1e-5, 300, 1e-3),
-        DiagoCGPrepare(20, 500, 6, true, 1e-5, 300, 1e-3)
+        DiagoCGPrepare(10, 500, 0, true, 1e-5, 300, 1e-3)
+        // DiagoCGPrepare(20, 500, 6, true, 1e-5, 300, 1e-3)
         // DiagoCGPrepare(20, 1000, 8, true, 1e-5, 300, 1e-3),
         // DiagoCGPrepare(40, 1000, 8, true, 1e-6, 300, 1e-3)
     ));

--- a/source/source_hsolver/test/diago_cg_real_test.cpp
+++ b/source/source_hsolver/test/diago_cg_real_test.cpp
@@ -241,9 +241,10 @@ INSTANTIATE_TEST_SUITE_P(VerifyCG,
     ::testing::Values(
         // nband, npw, sparsity, reorder, eps, maxiter, threshold
         DiagoCGPrepare(10, 500, 0, true, 1e-5, 300, 1e-3),
-        DiagoCGPrepare(20, 500, 6, true, 1e-5, 300, 1e-3),
-        DiagoCGPrepare(20, 1000, 8, true, 1e-5, 300, 1e-3),
-        DiagoCGPrepare(40, 1000, 8, true, 1e-6, 300, 1e-3)));
+        DiagoCGPrepare(20, 500, 6, true, 1e-5, 300, 1e-3)
+        // DiagoCGPrepare(20, 1000, 8, true, 1e-5, 300, 1e-3),
+        // DiagoCGPrepare(40, 1000, 8, true, 1e-6, 300, 1e-3)
+    ));
 //DiagoCGPrepare(40, 2000, 8, true, 1e-5, 500, 1e-2))); 
 // the last one is passed but time-consumming.
 
@@ -289,7 +290,7 @@ TEST(DiagoCGTest, readH)
     // read Hamilt matrix from file data-H
     std::vector<double> hm;
     std::ifstream ifs;
-    std::string filename = "H-GammaOnly-Si64.dat";
+    std::string filename = "H-GammaOnly-Si2.dat";
     ifs.open(filename);
     // open file and check status
     if (!ifs.is_open())

--- a/source/source_hsolver/test/diago_cg_test.cpp
+++ b/source/source_hsolver/test/diago_cg_test.cpp
@@ -235,9 +235,10 @@ INSTANTIATE_TEST_SUITE_P(VerifyCG,
                          ::testing::Values(
                              // nband, npw, sparsity, reorder, eps, maxiter, threshold
                              DiagoCGPrepare(10, 500, 0, true, 1e-5, 300, 1e-3),
-                             DiagoCGPrepare(20, 500, 6, true, 1e-5, 300, 1e-3),
-                             DiagoCGPrepare(20, 1000, 8, true, 1e-5, 300, 1e-3),
-                             DiagoCGPrepare(40, 1000, 8, true, 1e-6, 300, 1e-3))); 
+                             DiagoCGPrepare(20, 500, 6, true, 1e-5, 300, 1e-3)
+                            //  DiagoCGPrepare(20, 1000, 8, true, 1e-5, 300, 1e-3),
+                            //  DiagoCGPrepare(40, 1000, 8, true, 1e-6, 300, 1e-3)
+                            )); 
                             //DiagoCGPrepare(40, 2000, 8, true, 1e-5, 500, 1e-2))); 
 			    // the last one is passed but time-consumming.
 
@@ -307,7 +308,7 @@ TEST(DiagoCGTest, readH)
     // read Hamilt matrix from file data-H
     std::vector<std::complex<double>> hm;
     std::ifstream ifs;
-    std::string filename = "H-KPoints-Si64.dat";
+    std::string filename = "H-KPoints-Si2.dat";
     ifs.open(filename);
     // open file and check status
     if (!ifs.is_open())

--- a/source/source_hsolver/test/diago_cg_test.cpp
+++ b/source/source_hsolver/test/diago_cg_test.cpp
@@ -234,8 +234,8 @@ INSTANTIATE_TEST_SUITE_P(VerifyCG,
                          DiagoCGTest,
                          ::testing::Values(
                              // nband, npw, sparsity, reorder, eps, maxiter, threshold
-                             DiagoCGPrepare(10, 500, 0, true, 1e-5, 300, 1e-3),
-                             DiagoCGPrepare(20, 500, 6, true, 1e-5, 300, 1e-3)
+                             DiagoCGPrepare(10, 500, 0, true, 1e-5, 300, 1e-3)
+                            //  DiagoCGPrepare(20, 500, 6, true, 1e-5, 300, 1e-3)
                             //  DiagoCGPrepare(20, 1000, 8, true, 1e-5, 300, 1e-3),
                             //  DiagoCGPrepare(40, 1000, 8, true, 1e-6, 300, 1e-3)
                             )); 

--- a/source/source_hsolver/test/diago_david_float_test.cpp
+++ b/source/source_hsolver/test/diago_david_float_test.cpp
@@ -197,7 +197,7 @@ TEST(DiagoDavRealSystemTest,dataH)
 {
 	std::vector<std::complex<float>> hmatrix;
 	std::ifstream ifs;
-	std::string filename = "H-KPoints-Si64.dat";
+	std::string filename = "H-KPoints-Si2.dat";
 	ifs.open(filename);
     // open file and check status
     if (!ifs.is_open())

--- a/source/source_hsolver/test/diago_david_real_test.cpp
+++ b/source/source_hsolver/test/diago_david_real_test.cpp
@@ -195,7 +195,7 @@ TEST(DiagoDavRealSystemTest, dataH)
 {
     std::vector<double> hmatrix;
     std::ifstream ifs;
-    std::string filename = "H-GammaOnly-Si64.dat";
+    std::string filename = "H-GammaOnly-Si2.dat";
     ifs.open(filename);
     // open file and check status
     if (!ifs.is_open())

--- a/source/source_hsolver/test/diago_david_test.cpp
+++ b/source/source_hsolver/test/diago_david_test.cpp
@@ -201,7 +201,7 @@ TEST(DiagoDavRealSystemTest, dataH)
 {
 	std::vector<std::complex<double>> hmatrix;
 	std::ifstream ifs;
-	std::string filename = "H-KPoints-Si64.dat";
+	std::string filename = "H-KPoints-Si2.dat";
 	ifs.open(filename);
     // open file and check status
     if (!ifs.is_open())

--- a/source/source_hsolver/test/diago_lcao_test.cpp
+++ b/source/source_hsolver/test/diago_lcao_test.cpp
@@ -333,9 +333,10 @@ INSTANTIATE_TEST_SUITE_P(
         DiagoPrepare<double>(0, 0, 32, 0, "genelpa", "H-GammaOnly-Si64.dat", "S-GammaOnly-Si64.dat"),
 #endif
         DiagoPrepare<double>(0, 0, 1, 0, "scalapack_gvx", "H-GammaOnly-Si2.dat", "S-GammaOnly-Si2.dat"),
-        DiagoPrepare<double>(0, 0, 32, 0, "scalapack_gvx", "H-GammaOnly-Si64.dat", "S-GammaOnly-Si64.dat"),
+        // DiagoPrepare<double>(0, 0, 32, 0, "scalapack_gvx", "H-GammaOnly-Si64.dat", "S-GammaOnly-Si64.dat"),
         DiagoPrepare<double>(0, 0, 1, 0, "lapack", "H-GammaOnly-Si2.dat", "S-GammaOnly-Si2.dat"),
-        DiagoPrepare<double>(0, 0, 32, 0, "lapack", "H-GammaOnly-Si64.dat", "S-GammaOnly-Si64.dat")));
+        // DiagoPrepare<double>(0, 0, 32, 0, "lapack", "H-GammaOnly-Si64.dat", "S-GammaOnly-Si64.dat")
+    ));
 
 class DiagoKPointsTest : public ::testing::TestWithParam<DiagoPrepare<std::complex<double>>>
 {

--- a/source/source_hsolver/test/diago_lcao_test.cpp
+++ b/source/source_hsolver/test/diago_lcao_test.cpp
@@ -334,7 +334,7 @@ INSTANTIATE_TEST_SUITE_P(
 #endif
         DiagoPrepare<double>(0, 0, 1, 0, "scalapack_gvx", "H-GammaOnly-Si2.dat", "S-GammaOnly-Si2.dat"),
         // DiagoPrepare<double>(0, 0, 32, 0, "scalapack_gvx", "H-GammaOnly-Si64.dat", "S-GammaOnly-Si64.dat"),
-        DiagoPrepare<double>(0, 0, 1, 0, "lapack", "H-GammaOnly-Si2.dat", "S-GammaOnly-Si2.dat"),
+        DiagoPrepare<double>(0, 0, 1, 0, "lapack", "H-GammaOnly-Si2.dat", "S-GammaOnly-Si2.dat")
         // DiagoPrepare<double>(0, 0, 32, 0, "lapack", "H-GammaOnly-Si64.dat", "S-GammaOnly-Si64.dat")
     ));
 


### PR DESCRIPTION
Fix #6976.

### Unit Tests and/or Case Tests for my changes
- Do not do unit tests on big input to reduce time consumption.

### What's changed?
- Do not run big random tests(e.g. matrix size 1000).
- Use Si2 dat file instead of Si64 dat file.
