### PR TITLE
Tests: Do not run time-consuming PERF_MODULE_HSOLVER_KERNELS in CI/CD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
           GTEST_COLOR: 'yes'
           OMP_NUM_THREADS: '2'
         run: |
-          ctest --test-dir build -V --timeout 1700 -R MODULE_HSOLVER
+          ctest --test-dir build -V --timeout 1700 -R MODULE_HSOLVER -E PERF_MODULE_HSOLVER_KERNELS
           
       - name: Module_Cell Unittests
         env:


### PR DESCRIPTION
### Linked Issue
Fix #6976

### Unit Tests and/or Case Tests for my changes
- Exclude `PERF_MODULE_HSOLVER_KERNELS` from `source_hsolver/kernels/test` when running CI test workflow.
- The code itself is reserved for potential needs.
