### PR TITLE
2026PKUCourseHW5: Fix uninitialized variable in lattice_change_cg.cpp

### DIFF
--- a/source/source_relax/lattice_change_cg.cpp
+++ b/source/source_relax/lattice_change_cg.cpp
@@ -279,7 +279,7 @@ void Lattice_Change_CG::setup_cg_grad(double *grad,
 {
     ModuleBase::TITLE("Lattice_Change_CG", "setup_cg_grad");
     assert(Lattice_Change_Basic::stress_step > 0);
-    double gamma;
+    double gamma = 0.0;
     double cg0_cg, cg0_cg0, cg0_g;
 
     if (ncggrad % 10000 == 0 || flag == 2)


### PR DESCRIPTION
修复内容：修复了 source/source_relax/lattice_change_cg.cpp 文件中变量声明后未初始化的问题（作业案例9）。
修复方法：在声明时直接赋初值（如 = 0.0;），避免潜在的未定义行为。