### PR TITLE
Fix: use direct import of full_3x3_to_voigt_6_index

### DIFF
--- a/interfaces/ASE_interface/abacuslite/io/latestio.py
+++ b/interfaces/ASE_interface/abacuslite/io/latestio.py
@@ -12,7 +12,7 @@ from ase.calculators.singlepoint import (
     SinglePointDFTCalculator
 )
 from ase.units import GPa
-from ase.constraints import full_3x3_to_voigt_6_stress
+from ase.stress import full_3x3_to_voigt_6_stress
 
 # some output formats are not updated,
 # for these cases, we import from the legacyio module

--- a/interfaces/ASE_interface/abacuslite/io/legacyio.py
+++ b/interfaces/ASE_interface/abacuslite/io/legacyio.py
@@ -12,7 +12,7 @@ from ase.calculators.singlepoint import (
     SinglePointDFTCalculator
 )
 from ase.units import Ry, eV, GPa, bar
-from ase.constraints import full_3x3_to_voigt_6_stress
+from ase.stress import full_3x3_to_voigt_6_stress
 # from ase.utils import reader
 
 __all__ = ['read_kpoints_from_running_log', 


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #7041 

### Unit Tests and/or Case Tests for my changes
- not needed

### What's changed?
In previous versions, the function to convert the stress tensor `full_3x3_to_voigt_6_index` is imported from the `ase.constraints` module, however, it is not the place where the function is implemented, instead, it is an indirect import. In this PR, I change to import it from the `ase.stress` module

### Any changes of core modules? (ignore if not applicable)
- no
