### PR TITLE
26PKUCourseHW5: Fix potential int overflow(3)

### DIFF
--- a/source/source_cell/read_pp_upf201.cpp
+++ b/source/source_cell/read_pp_upf201.cpp
@@ -195,6 +195,40 @@ void Pseudopot_upf::getnameval(std::ifstream& ifs, int& n, std::string* name, st
     return;
 }
 
+namespace // internal helper functions, only local unit
+{
+    double parse_double(const std::string& s, const std::string& name)
+    {
+        try 
+        {
+            double value = std::stod(s);
+            return value;
+        }
+        catch (const std::exception& e)
+        {
+            std::string e_info = "invalid number for " + name + " : " + s;
+            ModuleBase::WARNING_QUIT("Pseudopot_upf::read_pseudo_upf201_header", e_info);
+            return 0.0; // unreachable, for compiler
+        }
+    }
+
+    int parse_int(const std::string& s, const std::string& name)
+    {
+        try 
+        {
+            double value = std::stoi(s);
+            return value;
+        }
+        catch (const std::exception& e)
+        {
+            std::string e_info = "invalid number for " + name + " : " + s;
+            ModuleBase::WARNING_QUIT("Pseudopot_upf::read_pseudo_upf201_header", e_info);
+            return 0; // unreachable, for compiler
+        }
+    }
+}
+
+
 void Pseudopot_upf::read_pseudo_upf201_header(std::ifstream& ifs, Atom_pseudo& pp)
 {
 	if (!ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_HEADER"))
@@ -303,35 +337,35 @@ void Pseudopot_upf::read_pseudo_upf201_header(std::ifstream& ifs, Atom_pseudo& p
         }
         else if (name[ip] == "z_valence")
         {
-            pp.zv = std::stod(val[ip]);
+            pp.zv = parse_double(val[ip], name[ip]);
         }
         else if (name[ip] == "total_psenergy")
         {
-            pp.etotps = atof(val[ip].c_str());
+            pp.etotps = parse_double(val[ip], name[ip]);
         }
         else if (name[ip] == "wfc_cutoff")
         {
-            pp.ecutwfc = atof(val[ip].c_str());
+            pp.ecutwfc = parse_double(val[ip], name[ip]);
         }
         else if (name[ip] == "rho_cutoff")
         {
-            pp.ecutrho = atof(val[ip].c_str());
+            pp.ecutrho = parse_double(val[ip], name[ip]);
         }
         else if (name[ip] == "l_max")
         {
-            pp.lmax = atoi(val[ip].c_str());
+            pp.lmax = parse_int(val[ip], name[ip]);
         }
         else if (name[ip] == "l_max_rho")
         {
-            this->lmax_rho = atoi(val[ip].c_str());
+            this->lmax_rho = parse_int(val[ip], name[ip]);
         }
         else if (name[ip] == "l_local")
         {
-            this->lloc = atoi(val[ip].c_str());
+            this->lloc = parse_int(val[ip], name[ip]);
         }
         else if (name[ip] == "mesh_size")
         {
-            pp.mesh = atoi(val[ip].c_str());
+            pp.mesh = parse_int(val[ip], name[ip]);
             this->mesh_changed = false;
             if (pp.mesh % 2 == 0)
             {
@@ -341,11 +375,11 @@ void Pseudopot_upf::read_pseudo_upf201_header(std::ifstream& ifs, Atom_pseudo& p
         }
         else if (name[ip] == "number_of_wfc")
         {
-            pp.nchi = atoi(val[ip].c_str());
+            pp.nchi = parse_int(val[ip], name[ip]);
         }
         else if (name[ip] == "number_of_proj")
         {
-            pp.nbeta = atoi(val[ip].c_str());
+            pp.nbeta = parse_int(val[ip], name[ip]);
         }
         else
         {

--- a/source/source_cell/read_pp_upf201.cpp
+++ b/source/source_cell/read_pp_upf201.cpp
@@ -195,40 +195,6 @@ void Pseudopot_upf::getnameval(std::ifstream& ifs, int& n, std::string* name, st
     return;
 }
 
-namespace // internal helper functions, only local unit
-{
-    double parse_double(const std::string& s, const std::string& name)
-    {
-        try 
-        {
-            double value = std::stod(s);
-            return value;
-        }
-        catch (const std::exception& e)
-        {
-            std::string e_info = "invalid number for " + name + " : " + s;
-            ModuleBase::WARNING_QUIT("Pseudopot_upf::read_pseudo_upf201_header", e_info);
-            return 0.0; // unreachable, for compiler
-        }
-    }
-
-    int parse_int(const std::string& s, const std::string& name)
-    {
-        try 
-        {
-            double value = std::stoi(s);
-            return value;
-        }
-        catch (const std::exception& e)
-        {
-            std::string e_info = "invalid number for " + name + " : " + s;
-            ModuleBase::WARNING_QUIT("Pseudopot_upf::read_pseudo_upf201_header", e_info);
-            return 0; // unreachable, for compiler
-        }
-    }
-}
-
-
 void Pseudopot_upf::read_pseudo_upf201_header(std::ifstream& ifs, Atom_pseudo& pp)
 {
 	if (!ModuleBase::GlobalFunc::SCAN_BEGIN(ifs, "<PP_HEADER"))
@@ -337,35 +303,35 @@ void Pseudopot_upf::read_pseudo_upf201_header(std::ifstream& ifs, Atom_pseudo& p
         }
         else if (name[ip] == "z_valence")
         {
-            pp.zv = parse_double(val[ip], name[ip]);
+            pp.zv = std::stod(val[ip]);
         }
         else if (name[ip] == "total_psenergy")
         {
-            pp.etotps = parse_double(val[ip], name[ip]);
+            pp.etotps = atof(val[ip].c_str());
         }
         else if (name[ip] == "wfc_cutoff")
         {
-            pp.ecutwfc = parse_double(val[ip], name[ip]);
+            pp.ecutwfc = atof(val[ip].c_str());
         }
         else if (name[ip] == "rho_cutoff")
         {
-            pp.ecutrho = parse_double(val[ip], name[ip]);
+            pp.ecutrho = atof(val[ip].c_str());
         }
         else if (name[ip] == "l_max")
         {
-            pp.lmax = parse_int(val[ip], name[ip]);
+            pp.lmax = atoi(val[ip].c_str());
         }
         else if (name[ip] == "l_max_rho")
         {
-            this->lmax_rho = parse_int(val[ip], name[ip]);
+            this->lmax_rho = atoi(val[ip].c_str());
         }
         else if (name[ip] == "l_local")
         {
-            this->lloc = parse_int(val[ip], name[ip]);
+            this->lloc = atoi(val[ip].c_str());
         }
         else if (name[ip] == "mesh_size")
         {
-            pp.mesh = parse_int(val[ip], name[ip]);
+            pp.mesh = atoi(val[ip].c_str());
             this->mesh_changed = false;
             if (pp.mesh % 2 == 0)
             {
@@ -375,11 +341,11 @@ void Pseudopot_upf::read_pseudo_upf201_header(std::ifstream& ifs, Atom_pseudo& p
         }
         else if (name[ip] == "number_of_wfc")
         {
-            pp.nchi = parse_int(val[ip], name[ip]);
+            pp.nchi = atoi(val[ip].c_str());
         }
         else if (name[ip] == "number_of_proj")
         {
-            pp.nbeta = parse_int(val[ip], name[ip]);
+            pp.nbeta = atoi(val[ip].c_str());
         }
         else
         {

--- a/source/source_relax/bfgs.cpp
+++ b/source/source_relax/bfgs.cpp
@@ -128,7 +128,16 @@ void BFGS::PrepareStep(std::vector<ModuleBase::Vector3<double>>& force,
     //! call dysev
     std::vector<double> omega(3*size);
     std::vector<double> work(3*size*3*size);
+
+    if (size != 0 && 
+        size > std::sqrt(std::numeric_limits<int>::max() / 9.0)) // lwork overflow
+    {
+        ModuleBase::WARNING_QUIT("BFGS::PrepareStep", "lwork overflow");
+    }
+    
     int lwork=3*size*3*size;
+
+
     int info=0;
     std::vector<double> H_flat;
     


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### What's changed?
- Fixed potential overflow while calculating lwork in  source/source_relax/bfgs.cpp.