### PR TITLE
2026PKUCourseHW5: Add if(!file.is_open()) check in write_restart

### DIFF
--- a/source/source_md/md_base.cpp
+++ b/source/source_md/md_base.cpp
@@ -235,6 +235,13 @@ void MD_base::write_restart(const std::string& global_out_dir)
         std::stringstream ssc;
         ssc << global_out_dir << "Restart_md.txt";
         std::ofstream file(ssc.str().c_str());
+        
+        if (!file.is_open()) 
+        {
+            std::cerr << "Fatal Error in MD_base::write_restart: " << std::endl;
+            std::cerr << "Cannot open file " << ssc.str() << " for writing." << std::endl;
+            std::cerr << "Please check if the directory exists and has write permissions." << std::endl;
+        }
 
         file << step_ + step_rst_ << std::endl;
         file << md_tfirst << std::endl;


### PR DESCRIPTION
fix(io): prevent silent failure when writing restart file

Previously, if `global_out_dir` did not exist or lacked write permissions, `std::ofstream` would silently fail. The MD simulation would continue running without saving restart points, leading to potential loss of computational progress.
This commit adds an `is_open()` check in `MD_base::write_restart`. It now prints a clear error message to `std::cerr`.