### PR TITLE
2026PKUCourseHW5：案例二、添加字符串类型转换以及错误判断

### DIFF
--- a/source/source_cell/read_pp_upf201.cpp
+++ b/source/source_cell/read_pp_upf201.cpp
@@ -307,31 +307,115 @@ void Pseudopot_upf::read_pseudo_upf201_header(std::ifstream& ifs, Atom_pseudo& p
         }
         else if (name[ip] == "total_psenergy")
         {
-            pp.etotps = atof(val[ip].c_str());
+            //pp.etotps = atof(val[ip].c_str());
+	    try {
+		    pp.etotps=std::stod(val[ip]);
+	    }catch(const std::invalid_argument& e){
+		    std::cerr<<"错误：类型转换失败（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }catch(const std::out_of_range& e){
+		    std::cerr<<"错误：数值大小超出范围（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }catch(const std::exception& e){
+		    std::cerr<<"错误：未知问题（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }
         }
         else if (name[ip] == "wfc_cutoff")
         {
-            pp.ecutwfc = atof(val[ip].c_str());
+            //pp.ecutwfc = atof(val[ip].c_str());
+	    try {
+		    pp.ecutwfc=std::stod(val[ip]);
+	    }catch(const std::invalid_argument& e){
+		    std::cerr<<"错误：类型转换失败（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }catch(const std::out_of_range& e){
+		    std::cerr<<"错误：数值大小超出范围（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }catch(const std::exception& e){
+		    std::cerr<<"错误：未知问题（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }
         }
         else if (name[ip] == "rho_cutoff")
         {
-            pp.ecutrho = atof(val[ip].c_str());
+            //pp.ecutrho = atof(val[ip].c_str());
+	    try {
+		    pp.ecutrho=std::stod(val[ip]);
+	    }catch(const std::invalid_argument& e){
+		    std::cerr<<"错误：类型转换失败（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }catch(const std::out_of_range& e){
+		    std::cerr<<"错误：数值大小超出范围（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }catch(const std::exception& e){
+		    std::cerr<<"错误：未知问题（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }
         }
         else if (name[ip] == "l_max")
         {
-            pp.lmax = atoi(val[ip].c_str());
+            //pp.lmax = atoi(val[ip].c_str());
+	    try {
+		    pp.lmax=std::stoi(val[ip]);
+	    }catch(const std::invalid_argument& e){
+		    std::cerr<<"错误：类型转换失败（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }catch(const std::out_of_range& e){
+		    std::cerr<<"错误：数值大小超出范围（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }catch(const std::exception& e){
+		    std::cerr<<"错误：未知问题（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }
         }
         else if (name[ip] == "l_max_rho")
         {
-            this->lmax_rho = atoi(val[ip].c_str());
+            //this->lmax_rho = atoi(val[ip].c_str());
+	    try {
+		    this->lmax_rho=std::stoi(val[ip]);
+	    }catch(const std::invalid_argument& e){
+		    std::cerr<<"错误：类型转换失败（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }catch(const std::out_of_range& e){
+		    std::cerr<<"错误：数值大小超出范围（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }catch(const std::exception& e){
+		    std::cerr<<"错误：未知问题（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }
         }
         else if (name[ip] == "l_local")
         {
-            this->lloc = atoi(val[ip].c_str());
+            //this->lloc = atoi(val[ip].c_str());
+	    try {
+		    this->lloc=std::stoi(val[ip]);
+	    }catch(const std::invalid_argument& e){
+		    std::cerr<<"错误：类型转换失败（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }catch(const std::out_of_range& e){
+		    std::cerr<<"错误：数值大小超出范围（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }catch(const std::exception& e){
+		    std::cerr<<"错误：未知问题（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }
         }
         else if (name[ip] == "mesh_size")
         {
-            pp.mesh = atoi(val[ip].c_str());
+            //pp.mesh = atoi(val[ip].c_str());
+	    try {
+		    pp.mesh=std::stoi(val[ip]);
+	    }catch(const std::invalid_argument& e){
+		    std::cerr<<"错误：类型转换失败（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }catch(const std::out_of_range& e){
+		    std::cerr<<"错误：数值大小超出范围（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }catch(const std::exception& e){
+		    std::cerr<<"错误：未知问题（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }
             this->mesh_changed = false;
             if (pp.mesh % 2 == 0)
             {
@@ -341,11 +425,35 @@ void Pseudopot_upf::read_pseudo_upf201_header(std::ifstream& ifs, Atom_pseudo& p
         }
         else if (name[ip] == "number_of_wfc")
         {
-            pp.nchi = atoi(val[ip].c_str());
+            //pp.nchi = atoi(val[ip].c_str());
+	    try {
+		    pp.nchi=std::stoi(val[ip]);
+	    }catch(const std::invalid_argument& e){
+		    std::cerr<<"错误：类型转换失败（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }catch(const std::out_of_range& e){
+		    std::cerr<<"错误：数值大小超出范围（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }catch(const std::exception& e){
+		    std::cerr<<"错误：未知问题（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }
         }
         else if (name[ip] == "number_of_proj")
         {
-            pp.nbeta = atoi(val[ip].c_str());
+            //pp.nbeta = atoi(val[ip].c_str());
+	    try {
+		    pp.nbeta=std::stoi(val[ip]);
+	    }catch(const std::invalid_argument& e){
+		    std::cerr<<"错误：类型转换失败（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }catch(const std::out_of_range& e){
+		    std::cerr<<"错误：数值大小超出范围（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }catch(const std::exception& e){
+		    std::cerr<<"错误：未知问题（"<<e.what()<<"）"<<std::endl;
+		    return ;
+	    }
         }
         else
         {

--- a/source/source_relax/bfgs.cpp
+++ b/source/source_relax/bfgs.cpp
@@ -129,8 +129,11 @@ void BFGS::PrepareStep(std::vector<ModuleBase::Vector3<double>>& force,
     std::vector<double> omega(3*size);
     std::vector<double> work(3*size*3*size);
     //add the check to avoid overflow
-    size_t size_overflow=static_cast<size_t>(size);
-    size_t lwork=3*size_overflow*3*size_overflow;
+    if(size>46340){
+	std::cerr<<"size out of range!"<<std::endl;
+	return ;
+    }
+    int lwork=3*size*3*size;
     int info=0;
     std::vector<double> H_flat;
     

--- a/source/source_relax/bfgs.cpp
+++ b/source/source_relax/bfgs.cpp
@@ -128,7 +128,9 @@ void BFGS::PrepareStep(std::vector<ModuleBase::Vector3<double>>& force,
     //! call dysev
     std::vector<double> omega(3*size);
     std::vector<double> work(3*size*3*size);
-    int lwork=3*size*3*size;
+    //add the check to avoid overflow
+    size_t size_overlow=static_cast<size_t>(size);
+    size_t lwork=3*size_overflow*3*size_overflow;
     int info=0;
     std::vector<double> H_flat;
     

--- a/source/source_relax/bfgs.cpp
+++ b/source/source_relax/bfgs.cpp
@@ -129,7 +129,7 @@ void BFGS::PrepareStep(std::vector<ModuleBase::Vector3<double>>& force,
     std::vector<double> omega(3*size);
     std::vector<double> work(3*size*3*size);
     //add the check to avoid overflow
-    size_t size_overlow=static_cast<size_t>(size);
+    size_t size_overflow=static_cast<size_t>(size);
     size_t lwork=3*size_overflow*3*size_overflow;
     int info=0;
     std::vector<double> H_flat;


### PR DESCRIPTION
### Linked Issue
该修改旨在修正案例二和案例三的错误，在原先的字符串转换上添加了异常和错误的诊断，同时使用size_t类型处理超出范围的数据。

### Unit Tests and/or Case Tests for my changes
尚未经过本地测试。

### What's changed?
对于每一个atoi和atof转换命令，分别修正为std::stoi和std::stof命令，对于出现的错误，进行错误流输出。
类型转换错误：std::invalid_argument。
数据超出范围错误：std::out_of_range。
其他错误：std::exception。
数据范围判断：对于超出范围的数据size，结束任务并报错。

### Any changes of core modules? (ignore if not applicable)
由于不了解H文件和CPP文件的依赖关系，没有添加新的函数，而是直接修改，可能降低代码可读性，需要进一步更正。
建议：建立新的函数switch_function，单独进行输入val的诊断。
