### PR TITLE
2026PKUCourseHW5: Fix other unsafe type conversions by grep

### DIFF
--- a/source/source_base/parallel_global.cpp
+++ b/source/source_base/parallel_global.cpp
@@ -109,7 +109,7 @@ void Parallel_Global::read_pal_param(int argc,
     MPI_Init(&argc, &argv); // Peize Lin change 2018-07-12
 #endif //_OPENMP
 
-    //  KPAR = atoi(argv[1]); // mohan abandon 2010-06-09
+    //  KPAR = std::stoi(argv[1]); // mohan abandon 2010-06-09
 
     // get world size --> NPROC
     // get global rank --> MY_RANK

--- a/source/source_basis/module_ao/test/ORB_nonlocal_lm_test.cpp
+++ b/source/source_basis/module_ao/test/ORB_nonlocal_lm_test.cpp
@@ -157,9 +157,9 @@ void NumericalNonlocalLmTest::SetUp() {
         if (label == "element") {
             elem_label_ = val;
         } else if (label == "number_of_proj") {
-            nproj_ = std::atoi(val.c_str());
+            nproj_ = std::stoi(val);
         } else if (label == "mesh_size") {
-            nmesh_upf = std::atoi(val.c_str());
+            nmesh_upf = std::stoi(val);
         }
 
         if (linebuf.find("/>") != std::string::npos) {

--- a/source/source_cell/read_pp_vwr.cpp
+++ b/source/source_cell/read_pp_vwr.cpp
@@ -30,7 +30,7 @@ int Pseudopot_upf::read_pseudo_vwr(std::ifstream &ifs, Atom_pseudo& pp)
 	std::string value;
 	size_t length=0;
 	ifs >> value; length = value.find(","); value.erase(length,1);
-	pp.mesh = std::atoi( value.c_str() );
+	pp.mesh = std::stoi(value);
 	//the mesh should be odd, which is forced in Simpson integration
 	this->mesh_changed = false;
 	if(pp.mesh%2==0) 
@@ -42,7 +42,7 @@ int Pseudopot_upf::read_pseudo_vwr(std::ifstream &ifs, Atom_pseudo& pp)
 	GlobalV::ofs_running << std::setw(15) << "MESH" << std::setw(15) << pp.mesh << std::endl;
 	// (2) read in nlcc: nonlinear core correction
 	ifs >> value; length = value.find(","); value.erase(length,1);
-	pp.nlcc = std::atoi( value.c_str() );
+	pp.nlcc = std::stoi(value);
 	GlobalV::ofs_running << std::setw(15) << "NLCC" << std::setw(15) << pp.nlcc << std::endl;
 	// (3) iatom : index for atom 
 	ifs >> value; length = value.find(","); value.erase(length,1);
@@ -54,16 +54,16 @@ int Pseudopot_upf::read_pseudo_vwr(std::ifstream &ifs, Atom_pseudo& pp)
 	GlobalV::ofs_running << std::setw(15) << "Z(VALENCE)" << std::setw(15) << pp.zv << std::endl;
 	// (5) spd_loc, which local pseudopotential should I choose
 	ifs >> value; length = value.find(","); value.erase(length,1);
-	spd_loc = std::atoi( value.c_str() );
+	spd_loc = std::stoi(value);
 	GlobalV::ofs_running << std::setw(15) << "LOC(spd)" << std::setw(15) << spd_loc << std::endl;
 	// (6) read in the occupations
 	std::vector<double> tmp_oc(3, 0.0);
 	ifs >> value; length = value.find(","); value.erase(length,1);
-	tmp_oc[0]= std::atoi( value.c_str() );
+	tmp_oc[0]= std::stoi(value);
 	ifs >> value; length = value.find(","); value.erase(length,1);
-	tmp_oc[1]= std::atoi( value.c_str() );
+	tmp_oc[1]= std::stoi(value);
 	ifs >> value; length = value.find(","); value.erase(length,1);
-	tmp_oc[2]= std::atoi( value.c_str() );
+	tmp_oc[2]= std::stoi(value);
 	GlobalV::ofs_running << std::setw(15) << "OCCUPATION" << std::setw(15) << tmp_oc[0] 
 	<< std::setw(15) << tmp_oc[1] << std::setw(15) << tmp_oc[2] << std::endl;
 	// (7) spin orbital


### PR DESCRIPTION
This PR further fixes unsafe integer conversions by replacing additional atoi usages found with "grep", improving code safety and consistency.