### PR TITLE
Fix: Fix DSP gemv_op_mt compile

### DIFF
--- a/source/source_base/kernels/math_kernel_op.cpp
+++ b/source/source_base/kernels/math_kernel_op.cpp
@@ -191,4 +191,4 @@ template struct gemv_op_mt<std::complex<double>, base_device::DEVICE_CPU>;
 template struct gemm_op_mt<std::complex<float>, base_device::DEVICE_CPU>;
 template struct gemm_op_mt<std::complex<double>, base_device::DEVICE_CPU>;
 #endif
-} // namespace hsolver
+} // namespace ModuleBase

--- a/source/source_base/kernels/math_kernel_op.cpp
+++ b/source/source_base/kernels/math_kernel_op.cpp
@@ -184,6 +184,8 @@ template struct matrixTranspose_op<double, base_device::DEVICE_CPU>;
 #ifdef __DSP
 template struct gemm_op_mt<float, base_device::DEVICE_CPU>;
 template struct gemm_op_mt<double, base_device::DEVICE_CPU>;
+template struct gemv_op_mt<float, base_device::DEVICE_CPU>;
+template struct gemv_op_mt<double, base_device::DEVICE_CPU>;
 template struct gemv_op_mt<std::complex<float>, base_device::DEVICE_CPU>;
 template struct gemv_op_mt<std::complex<double>, base_device::DEVICE_CPU>;
 template struct gemm_op_mt<std::complex<float>, base_device::DEVICE_CPU>;


### PR DESCRIPTION
### What's changed?
- Add `gemm_op_mt` for float and double so that it compiles on DSP.
