### PR TITLE
2026PKUCourseHW5:Solve Magic Number

### DIFF
--- a/source/source_pw/module_stodft/sto_wf.cpp
+++ b/source/source_pw/module_stodft/sto_wf.cpp
@@ -64,13 +64,14 @@ void Stochastic_WF<T, Device>::clean_chiallorder()
 template <typename T, typename Device>
 void Stochastic_WF<T, Device>::init_sto_orbitals(const int seed_in)
 {
+	const unsigned int RANK_SEED_OFFSET = 10000;
     if (seed_in == 0 || seed_in == -1)
     {
-        srand((unsigned)time(nullptr) + GlobalV::MY_RANK * 10000); // GlobalV global variables are reserved
+        srand(static_cast<unsigned int>(time(nullptr)) + GlobalV::MY_RANK * RANK_SEED_OFFSET); // GlobalV global variables are reserved
     }
     else
     {
-        srand((unsigned)std::abs(seed_in) + (GlobalV::MY_BNDGROUP * GlobalV::NPROC_IN_BNDGROUP + GlobalV::RANK_IN_BPGROUP) * 10000);
+        srand(static_cast<unsigned int>(std::abs(seed_in)) + (GlobalV::MY_BNDGROUP * GlobalV::NPROC_IN_BNDGROUP + GlobalV::RANK_IN_BPGROUP) * RANK_SEED_OFFSET);
     }
 
     this->allocate_chi0();


### PR DESCRIPTION
### Refactor: Replace magic number with named constant for RNG seed offset

This PR removes the hard-coded magic number (`10000`) used in random seed generation and replaces it with a named constant `RANK_SEED_OFFSET`.

#### Changes

* Introduced a local constant `RANK_SEED_OFFSET` to represent the seed offset value
* Replaced all occurrences of the literal `10000` with the named constant
* Improved type safety by using `static_cast<unsigned int>` for seed initialization

#### Motivation

Using a named constant improves code readability and maintainability by:

* Making the purpose of the offset explicit
* Avoiding duplicated magic numbers
* Simplifying future modifications

#### Notes

* No functional changes intended
* Behavior remains identical to previous implementation
