### PR TITLE
2026PKUCourseHW5：Improve matrix I/O robustness and CG safety checks

### DIFF
--- a/source/source_hsolver/module_genelpa/utils.cpp
+++ b/source/source_hsolver/module_genelpa/utils.cpp
@@ -2,6 +2,7 @@
 
 #include "source_base/module_external/blacs_connector.h"
 #include "source_base/module_external/scalapack_connector.h"
+#include "source_base/tool_quit.h"
 
 #include <complex>
 #include <cstring>
@@ -93,6 +94,8 @@ void loadMatrix(const char FileName[], int nFull, double* a, int* desca, int bla
     std::ifstream matrixFile;
     if (myid == ROOT_PROC)
         matrixFile.open(FileName);
+    if (myid == ROOT_PROC && !matrixFile.is_open())
+        ModuleBase::WARNING_QUIT("loadMatrix", std::string("failed to open matrix file: ") + FileName);
 
     double* b = nullptr; // buffer
     const int MAX_BUFFER_SIZE = 1e9; // max buffer size is 1GB
@@ -230,6 +233,8 @@ void loadMatrix(const char FileName[], int nFull, std::complex<double>* a, int* 
     std::ifstream matrixFile;
     if (myid == ROOT_PROC)
         matrixFile.open(FileName);
+    if (myid == ROOT_PROC && !matrixFile.is_open())
+        ModuleBase::WARNING_QUIT("loadMatrix", std::string("failed to open matrix file: ") + FileName);
 
     std::complex<double>* b; // buffer
     const int MAX_BUFFER_SIZE = 1e9; // max buffer size is 1GB

--- a/source/source_relax/lattice_change_cg.cpp
+++ b/source/source_relax/lattice_change_cg.cpp
@@ -305,7 +305,7 @@ void Lattice_Change_CG::setup_cg_grad(double *grad,
             cgp_g += cg_grad0[i] * grad[i];
         }
 
-        assert(g_gp != 0.0);
+        assert(gp_gp != 0.0);
         const double gamma1 = gg / gp_gp; // FR
         // const double gamma2 = -(gg - g_gp)/(cgp_g - cgp_gp);  //CW
         const double gamma2 = (gg - g_gp) / gp_gp; // PRP


### PR DESCRIPTION
    fix: improve matrix I/O robustness and CG safety checks
    
    - add file-open failure checks in both real/complex loadMatrix paths
    
    - use ModuleBase::WARNING_QUIT for explicit fatal diagnostics
    
    - correct setup_cg_grad assertion to guard the actual denominator (gp_gp)