### PR TITLE
2026PKUCourseHW5: Initialize uninitialized variable gamma in lattice_change_cg.cpp

### DIFF
--- a/source/source_relax/lattice_change_cg.cpp
+++ b/source/source_relax/lattice_change_cg.cpp
@@ -279,7 +279,7 @@ void Lattice_Change_CG::setup_cg_grad(double *grad,
 {
     ModuleBase::TITLE("Lattice_Change_CG", "setup_cg_grad");
     assert(Lattice_Change_Basic::stress_step > 0);
-    double gamma = 0.0;
+    double gamma = 0.0;  //Initialize to avoid undefined behavior
     double cg0_cg, cg0_cg0, cg0_g;
 
     if (ncggrad % 10000 == 0 || flag == 2)


### PR DESCRIPTION
Fix uninitialized variable ‘gamma’ in ‘lattice_change_cg.cpp’ line 282 by initializing it to 0.0. This addresses Case 9 of Homework 5.