### PR TITLE
2026PKUCourseHW5：Fix potential integer overflow in BFGS module

### DIFF
--- a/source/source_relax/bfgs.cpp
+++ b/source/source_relax/bfgs.cpp
@@ -126,18 +126,20 @@ void BFGS::PrepareStep(std::vector<ModuleBase::Vector3<double>>& force,
     std::vector<double> changedpos = ReshapeMToV(pos);
     this->Update(changedpos, changedforce,H,ucell);
     
-    //! call dysev
-    std::vector<double> omega(3*size);
-    std::vector<double> work(3*size*3*size);
-    // overflow checking for lwork added
-    if (size > 0 && 9 > INT_MAX / size) {
-        throw std::runtime_error("Integer overflow detected: 9 * size exceeds INT_MAX");
+    // overflow checking for size/lwork added by spokening125 2026-03-22 
+    if (size > 0 && 3 > INT_MAX / size) {
+        throw std::runtime_error("Integer overflow detected: 3 * size exceeds INT_MAX");
     }
-    int intermediate = 9 * size;
-    if (size > 0 && intermediate > INT_MAX / size) {
+    int intermediate = 3*size;
+    if (size > 0 && intermediate > INT_MAX / intermediate) {
         throw std::runtime_error("Integer overflow detected: lwork exceeds INT_MAX");
     }
-    int lwork = intermediate * size;
+    int lwork = intermediate*intermediate;
+
+    //! call dysev
+    std::vector<double> omega(intermediate);
+    std::vector<double> work(lwork);
+
     int info=0;
     std::vector<double> H_flat;
     

--- a/source/source_relax/bfgs.cpp
+++ b/source/source_relax/bfgs.cpp
@@ -128,8 +128,15 @@ void BFGS::PrepareStep(std::vector<ModuleBase::Vector3<double>>& force,
     //! call dysev
     std::vector<double> omega(3*size);
     std::vector<double> work(3*size*3*size);
-    // type of lwork changed to size_t to prevent overflow
-    size_t lwork=3*size*3*size;
+    // overflow checking for lwork added
+    if (size > 0 && 9 > INT_MAX / size) {
+        throw std::runtime_error("Integer overflow detected: 9 * size exceeds INT_MAX");
+    }
+    int intermediate = 9 * size;
+    if (size > 0 && intermediate > INT_MAX / size) {
+        throw std::runtime_error("Integer overflow detected: lwork exceeds INT_MAX");
+    }
+    int lwork = intermediate * size;
     int info=0;
     std::vector<double> H_flat;
     

--- a/source/source_relax/bfgs.cpp
+++ b/source/source_relax/bfgs.cpp
@@ -4,6 +4,7 @@
 #include "ions_move_basic.h"
 #include "source_cell/update_cell.h"
 #include "source_cell/print_cell.h" // lanshuyue add 2025-06-19  
+#include <climits> // spokening125 add 2026-03-22
 
 //! initialize H0、H、pos0、force0、force
 void BFGS::allocate(const int _size) 

--- a/source/source_relax/bfgs.cpp
+++ b/source/source_relax/bfgs.cpp
@@ -128,7 +128,8 @@ void BFGS::PrepareStep(std::vector<ModuleBase::Vector3<double>>& force,
     //! call dysev
     std::vector<double> omega(3*size);
     std::vector<double> work(3*size*3*size);
-    int lwork=3*size*3*size;
+    // type of lwork changed to size_t to prevent overflow
+    size_t lwork=3*size*3*size;
     int info=0;
     std::vector<double> H_flat;
     


### PR DESCRIPTION
Added a warning for integer overflow of the variable `lwork`, in `source/source_relax/bfgs.cpp`, line 133.