### PR TITLE
2026PKUCourseHW5: Case 2 Fix unsafe conversion

### DIFF
--- a/source/source_cell/read_pp_upf201.cpp
+++ b/source/source_cell/read_pp_upf201.cpp
@@ -307,31 +307,87 @@ void Pseudopot_upf::read_pseudo_upf201_header(std::ifstream& ifs, Atom_pseudo& p
         }
         else if (name[ip] == "total_psenergy")
         {
-            pp.etotps = atof(val[ip].c_str());
+	    try {
+   		 pp.etotps = std::stod(val[ip]);
+	    } catch (const std::invalid_argument& e) {
+   		 std::cerr << "Error: Cannot convert string '" << val[ip] << "' to double in read_pp_upf201.cpp at line " << __LINE__ << std::endl;
+   		 exit(1);
+	    } catch (const std::out_of_range& e) {
+   		 std::cerr << "Error: Double value out of range for string '" << val[ip] << "' in read_pp_upf201.cpp at line " << __LINE__ << std::endl;
+   		 exit(1);
+	    }
         }
         else if (name[ip] == "wfc_cutoff")
         {
-            pp.ecutwfc = atof(val[ip].c_str());
+	    try {
+                 pp.ecutwfc = std::stod(val[ip]);
+            } catch (const std::invalid_argument& e) {
+                 std::cerr << "Error: Cannot convert string '" << val[ip] << "' to double in read_pp_upf201.cpp at line " << __LINE__ << std::endl;
+                 exit(1);
+            } catch (const std::out_of_range& e) {
+                 std::cerr << "Error: Double value out of range for string '" << val[ip] << "' in read_pp_upf201.cpp at line " << __LINE__ << std::endl;
+                 exit(1);
+	    }	 
         }
         else if (name[ip] == "rho_cutoff")
         {
-            pp.ecutrho = atof(val[ip].c_str());
+	    try {
+                 pp.ecutrho = std::stod(val[ip]);
+            } catch (const std::invalid_argument& e) {
+                 std::cerr << "Error: Cannot convert string '" << val[ip] << "' to double in read_pp_upf201.cpp at line " << __LINE__ << std::endl;
+                 exit(1);
+            } catch (const std::out_of_range& e) {
+                 std::cerr << "Error: Double value out of range for string '" << val[ip] << "' in read_pp_upf201.cpp at line " << __LINE__ << std::endl;
+                 exit(1);
+	    }
         }
         else if (name[ip] == "l_max")
         {
-            pp.lmax = atoi(val[ip].c_str());
+	    try {
+   		 pp.lmax = std::stoi(val[ip]);
+	    } catch (const std::invalid_argument& e) {
+   		 std::cerr << "Error: Cannot convert string '" << val[ip] << "' to int in read_pp_upf201.cpp at line " << __LINE__ << std::endl;
+   		 exit(1);
+	    } catch (const std::out_of_range& e) {
+   		 std::cerr << "Error: Integer value out of range for string '" << val[ip] << "' in read_pp_upf201.cpp at line " << __LINE__ << std::endl;
+   		 exit(1);
+	    }
         }
         else if (name[ip] == "l_max_rho")
         {
-            this->lmax_rho = atoi(val[ip].c_str());
+	    try {
+                 this->lmax_rho = std::stoi(val[ip]);
+            } catch (const std::invalid_argument& e) {
+                 std::cerr << "Error: Cannot convert string '" << val[ip] << "' to int in read_pp_upf201.cpp at line " << __LINE__ << std::endl;
+                 exit(1);
+            } catch (const std::out_of_range& e) {
+                 std::cerr << "Error: Integer value out of range for string '" << val[ip] << "' in read_pp_upf201.cpp at line " << __LINE__ << std::endl;
+                 exit(1);
+            }
         }
         else if (name[ip] == "l_local")
         {
-            this->lloc = atoi(val[ip].c_str());
+	   try {
+                 this->lloc = std::stoi(val[ip]);
+            } catch (const std::invalid_argument& e) {
+                 std::cerr << "Error: Cannot convert string '" << val[ip] << "' to int in read_pp_upf201.cpp at line " << __LINE__ << std::endl;
+                 exit(1);
+            } catch (const std::out_of_range& e) {
+                 std::cerr << "Error: Integer value out of range for string '" << val[ip] << "' in read_pp_upf201.cpp at line " << __LINE__ << std::endl;
+                 exit(1);
+            }
         }
         else if (name[ip] == "mesh_size")
         {
-            pp.mesh = atoi(val[ip].c_str());
+	   try {
+                 pp.mesh = std::stoi(val[ip]);
+            } catch (const std::invalid_argument& e) {
+                 std::cerr << "Error: Cannot convert string '" << val[ip] << "' to int in read_pp_upf201.cpp at line " << __LINE__ << std::endl;
+                 exit(1);
+            } catch (const std::out_of_range& e) {
+                 std::cerr << "Error: Integer value out of range for string '" << val[ip] << "' in read_pp_upf201.cpp at line " << __LINE__ << std::endl;
+                 exit(1);
+            }
             this->mesh_changed = false;
             if (pp.mesh % 2 == 0)
             {
@@ -341,11 +397,27 @@ void Pseudopot_upf::read_pseudo_upf201_header(std::ifstream& ifs, Atom_pseudo& p
         }
         else if (name[ip] == "number_of_wfc")
         {
-            pp.nchi = atoi(val[ip].c_str());
+	   try {
+                 pp.nchi = std::stoi(val[ip]);
+            } catch (const std::invalid_argument& e) {
+                 std::cerr << "Error: Cannot convert string '" << val[ip] << "' to int in read_pp_upf201.cpp at line " << __LINE__ << std::endl;
+                 exit(1);
+            } catch (const std::out_of_range& e) {
+                 std::cerr << "Error: Integer value out of range for string '" << val[ip] << "' in read_pp_upf201.cpp at line " << __LINE__ << std::endl;
+                 exit(1);
+            }
         }
         else if (name[ip] == "number_of_proj")
         {
-            pp.nbeta = atoi(val[ip].c_str());
+	   try {
+                 pp.nbeta = std::stoi(val[ip]);
+            } catch (const std::invalid_argument& e) {
+                 std::cerr << "Error: Cannot convert string '" << val[ip] << "' to int in read_pp_upf201.cpp at line " << __LINE__ << std::endl;
+                 exit(1);
+            } catch (const std::out_of_range& e) {
+                 std::cerr << "Error: Integer value out of range for string '" << val[ip] << "' in read_pp_upf201.cpp at line " << __LINE__ << std::endl;
+                 exit(1);
+            }
         }
         else
         {


### PR DESCRIPTION
 Replaced atof/atoi with std::stod/std::stoi in read_pp_upf201.cpp.
Added try-catch blocks for invalid_argument and out_of_range exceptions.
Provides clear error messages and exits on failure.
