### PR TITLE
2026PKUCourseHW5：Case4 is_open() check

### DIFF
--- a/source/source_hsolver/module_genelpa/utils.cpp
+++ b/source/source_hsolver/module_genelpa/utils.cpp
@@ -91,9 +91,13 @@ void loadMatrix(const char FileName[], int nFull, double* a, int* desca, int bla
 
     const int ROOT_PROC = 0;
     std::ifstream matrixFile;
-    if (myid == ROOT_PROC)
-        matrixFile.open(FileName);
-
+    if (myid == ROOT_PROC) {
+    matrixFile.open(FileName);
+    if (!matrixFile.is_open()) {
+        std::cerr << "Error: Failed to open file \"" << FileName << "\"." << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+}
     double* b = nullptr; // buffer
     const int MAX_BUFFER_SIZE = 1e9; // max buffer size is 1GB
 


### PR DESCRIPTION
The original code did not check whether a file was successfully opened before attempting to read from it. If the file failed to open, the program would continue silently. Added an is_open() check immediately after attempting to open the file. If the file is not open, the program now throws a clear, descriptive error and exits.