### PR TITLE
2026PKUCourseHW5: Fix unchecked file opening with MPI-safe error handling in loadMatrix

### DIFF
--- a/source/source_hsolver/module_genelpa/utils.cpp
+++ b/source/source_hsolver/module_genelpa/utils.cpp
@@ -92,7 +92,14 @@ void loadMatrix(const char FileName[], int nFull, double* a, int* desca, int bla
     const int ROOT_PROC = 0;
     std::ifstream matrixFile;
     if (myid == ROOT_PROC)
+    {
         matrixFile.open(FileName);
+        if (!matrixFile.is_open())
+        {
+            std::cerr << "[loadMatrix]Error: Cannot open file " << FileName << " for reading" << std::endl;
+            MPI_Abort(MPI_COMM_WORLD, 1);
+        }
+    }
 
     double* b = nullptr; // buffer
     const int MAX_BUFFER_SIZE = 1e9; // max buffer size is 1GB
@@ -229,8 +236,14 @@ void loadMatrix(const char FileName[], int nFull, std::complex<double>* a, int* 
     const int ROOT_PROC = 0;
     std::ifstream matrixFile;
     if (myid == ROOT_PROC)
+    {
         matrixFile.open(FileName);
-
+        if (!matrixFile.is_open())
+        {
+            std::cerr << "[loadMatrix]Error: Cannot open file " << FileName << " for reading" << std::endl;
+            MPI_Abort(MPI_COMM_WORLD, 1);
+        }
+    }
     std::complex<double>* b; // buffer
     const int MAX_BUFFER_SIZE = 1e9; // max buffer size is 1GB
 


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [x] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

## Description
This PR addresses the unchecked file opening issue in `source/source_hsolver/module_genelpa/utils.cpp` as part of the PKU Parallel Programming course assignment (2026PKUCourseHW5).

## Changes
- Wrapped the `matrixFile.open()` and its corresponding `is_open()` check strictly inside the `if (myid == ROOT_PROC)` block for both `loadMatrix` functions (real and complex versions, line ~96 and line ~211).
- Replaced potential silent failures with `MPI_Abort(MPI_COMM_WORLD, 1)` to ensure that if the root process fails to open the file, all MPI processes are terminated immediately to prevent deadlocks.

