### PR TITLE
2026PKUCourseHW5: Case 5 Fix unsafe reinterpret_cast in sto_wf.cpp

### DIFF
--- a/source/source_pw/module_stodft/sto_wf.cpp
+++ b/source/source_pw/module_stodft/sto_wf.cpp
@@ -125,7 +125,7 @@ void Stochastic_WF<T, Device>::allocate_chi0()
     }
     else
     {
-        this->chi0 = reinterpret_cast<psi::Psi<T, Device>*>(this->chi0_cpu);
+        this->chi0 = this->chi0_cpu;
     }
 }
 

--- a/source/source_pw/module_stodft/sto_wf.h
+++ b/source/source_pw/module_stodft/sto_wf.h
@@ -19,7 +19,7 @@ class Stochastic_WF
     void init(K_Vectors* p_kv, const int npwx_in);
 
     // origin stochastic wavefunctions in CPU
-    psi::Psi<T, base_device::DEVICE_CPU>* chi0_cpu = nullptr;
+    psi::Psi<T, Device>* chi0_cpu = nullptr;
     // origin stochastic wavefunctions in GPU or CPU
     psi::Psi<T, Device>* chi0 = nullptr;
     // stochastic wavefunctions after in reciprocal space orthogonalized with KS wavefunctions

--- a/source/source_relax/bfgs.cpp
+++ b/source/source_relax/bfgs.cpp
@@ -3,7 +3,10 @@
 #include "source_io/module_parameter/parameter.h"
 #include "ions_move_basic.h"
 #include "source_cell/update_cell.h"
-#include "source_cell/print_cell.h" // lanshuyue add 2025-06-19  
+#include "source_cell/print_cell.h" // lanshuyue add 2025-06-19
+#include <limits>
+#include <iostream>
+#include <cstdlib>
 
 //! initialize H0、H、pos0、force0、force
 void BFGS::allocate(const int _size) 
@@ -128,7 +131,13 @@ void BFGS::PrepareStep(std::vector<ModuleBase::Vector3<double>>& force,
     //! call dysev
     std::vector<double> omega(3*size);
     std::vector<double> work(3*size*3*size);
-    int lwork=3*size*3*size;
+    //use size_t to safely compute lwork and avoid integer overflow
+    size_t safe_lwork = static_cast<size_t>(3) * size * 3 * size;
+    if (safe_lwork > static_cast<size_t>(std::numeric_limits<int>::max())) {
+    	std::cerr << "Error: lwork exceeds INT_MAX in BFGS::PrepareStep" << std::endl;
+    	exit(1);
+    }
+    int lwork = static_cast<int>(safe_lwork);
     int info=0;
     std::vector<double> H_flat;
     


### PR DESCRIPTION
Modified the type of ‘chi0_cpu’ in ‘sto_wf.h’ from ‘psi::Psi<T, base_device::DEVICE_CPU>*’ to ‘psi::Psi<T, Device>*’, making it identical to ‘chi0’. This eliminates the need for the dangerous ‘reinterpret_cast’ in ‘sto_wf.cpp’ line 128, where the assignment is now simply ‘this->chi0 = this->chi0_cpu;’. The change ensures type safety and follows the "redesign interface" improvement direction.