### PR TITLE
2026PKUCourseHW5:add file open check in loadMatrix

### DIFF
--- a/source/source_hsolver/module_genelpa/utils.cpp
+++ b/source/source_hsolver/module_genelpa/utils.cpp
@@ -91,8 +91,13 @@ void loadMatrix(const char FileName[], int nFull, double* a, int* desca, int bla
 
     const int ROOT_PROC = 0;
     std::ifstream matrixFile;
-    if (myid == ROOT_PROC)
+    if (myid == ROOT_PROC){
         matrixFile.open(FileName);
+    	if (!matrixFile.is_open()) {
+		std::cerr << "Error: Failed to open this file" << FileName << std:::endl;
+		exit(1);
+	}
+    }
 
     double* b = nullptr; // buffer
     const int MAX_BUFFER_SIZE = 1e9; // max buffer size is 1GB

--- a/source/source_hsolver/module_genelpa/utils.cpp
+++ b/source/source_hsolver/module_genelpa/utils.cpp
@@ -94,7 +94,7 @@ void loadMatrix(const char FileName[], int nFull, double* a, int* desca, int bla
     if (myid == ROOT_PROC){
         matrixFile.open(FileName);
     	if (!matrixFile.is_open()) {
-		std::cerr << "Error: Failed to open this file" << FileName << std:::endl;
+		std::cerr << "Error: Failed to open this file" << FileName << std::endl;
 		exit(1);
 	}
     }


### PR DESCRIPTION
### Problem
The function `loadMatrix` attempts to open a file without checking if the operation was successful.

### Solution
Add `is_open` check after opening the file.