### PR TITLE
Fix: Fix toolchain installation of Cereal

### DIFF
--- a/toolchain/scripts/stage4/install_cereal.sh
+++ b/toolchain/scripts/stage4/install_cereal.sh
@@ -51,9 +51,9 @@ case "$with_cereal" in
         # - Branch names (master, main, develop) without v prefix
         # - Version tags (e.g., 1.0.0) with v prefix
         if [[ "${cereal_ver}" =~ ^(master|main|develop)$ ]]; then
-            url="https://codeload.github.com/USCiLab/cereal/tar.gz/${cereal_ver}"
+            url="https://codeload.github.com/MCresearch/cereal/tar.gz/${cereal_ver}"
         else
-            url="https://codeload.github.com/USCiLab/cereal/tar.gz/v${cereal_ver}"
+            url="https://codeload.github.com/MCresearch/cereal/tar.gz/v${cereal_ver}"
         fi
         if verify_checksums "${install_lock_file}"; then
             echo "$dirname is already installed, skipping it."


### PR DESCRIPTION
Currently when installing Cereal using ABACUS toolchain, we apply a patch to Cereal's code in order to solve a compilation problem. The file where this patch apply has changed so the patch doesn't work any longer. 
`cmake/FindCereal.cmake` uses a forked version of Cereal (`MCresearch/cereal`), making the cereal version in ABACUS compilation stable. This PR applies the practice above to the toolchain.  