### PR TITLE
Tests: Lower the threshold for CI/CD test 096_PW_PBE0_FM

### DIFF
--- a/tests/01_PW/096_PW_PBE0_FM/threshold
+++ b/tests/01_PW/096_PW_PBE0_FM/threshold
@@ -1,0 +1,1 @@
+threshold 0.001


### PR DESCRIPTION
For some reasons, this test for PBE0 behaves unstable when using different math libs, causing error. In order to suppress this error, We lower the threshold for the test 096_PW_PBE0_FM. 

**AMD AOCL:**
<img width="1616" height="211" alt="image" src="https://github.com/user-attachments/assets/089f3339-51bb-4fe9-b17f-3d382af63d73" />
**Intel OneAPI:**
<img width="2393" height="256" alt="image" src="https://github.com/user-attachments/assets/afdebcc0-bded-4ab2-a3b8-180b1f2a14e0" />
**OpenBLAS+FFTW**
(should be identical to the reference results)
