### PR TITLE
2026PKUCourseHW5：fix integer overflow risk

### DIFF
--- a/source/source_relax/bfgs.cpp
+++ b/source/source_relax/bfgs.cpp
@@ -128,7 +128,7 @@ void BFGS::PrepareStep(std::vector<ModuleBase::Vector3<double>>& force,
     //! call dysev
     std::vector<double> omega(3*size);
     std::vector<double> work(3*size*3*size);
-    int lwork=3*size*3*size;
+    size_t lwork = (size_t)9 * size * size;   //replace int with size_t 
     int info=0;
     std::vector<double> H_flat;
     


### PR DESCRIPTION
### Linked Issue
Fix source/source_relax/bfgs.cpp line131，the integer overflow risk

###What's changed?
The calculation of the variable "lwork" will not overflow if "size" is large

