### PR TITLE
2026PKUCourseHW5：Improve error message in Fcoef::create

### DIFF
--- a/source/source_pw/module_pwdft/soc.cpp
+++ b/source/source_pw/module_pwdft/soc.cpp
@@ -27,7 +27,9 @@ void Fcoef::create(const int i1, const int i2, const int i3)
     }
     else
     {
-        std::cout << "not allowed!" << std::endl;
+        std::cout << "Fcoef::create received invalid dimensions: "
+		  << "i1=" << i1 << ", i2=" << i2 << ", i3=" << i3
+		  << ". All dimensions must be positive." << std::endl;
     }
 
     return;


### PR DESCRIPTION
## Summary
Improve the error message in `Fcoef::create` in `source/source_pw/module_pwdft/soc.cpp`.

## Motivation
The original error message `not allowed!` was too vague and did not provide enough context for debugging invalid input dimensions.

## Changes
- Replaced the vague error message with a more descriptive one
- Included the values of `i1`, `i2`, and `i3`
- Clarified that all dimensions must be positive

## Notes
This PR is submitted for PKU Parallel Programming Course HW5.
