### PR TITLE
2026PKUCourseHW5：Add file open checks for multiple output files

### DIFF
--- a/source/source_io/module_energy/nscf_fermi_surf.cpp
+++ b/source/source_io/module_energy/nscf_fermi_surf.cpp
@@ -3,6 +3,9 @@
 #include "source_io/module_parameter/parameter.h"
 #include "source_base/global_variable.h"
 #include "source_base/timer.h"
+#include <fstream>
+#include <stdexcept>
+#include <string>
 
 #ifdef __MPI
 #include <mpi.h>
@@ -26,6 +29,10 @@ void ModuleIO::nscf_fermi_surface(const std::string &out_band_dir,
 	if(GlobalV::MY_RANK==0)
 	{
 		ofs.open(out_band_dir.c_str());
+		if (!ofs.is_open())
+		{
+    		    throw std::runtime_error("Failed to open file for writing: " + out_band_dir);
+		}
 		ofs << std::setprecision(6);
 		ofs.close();	
 	}

--- a/source/source_io/module_energy/nscf_fermi_surf.cpp
+++ b/source/source_io/module_energy/nscf_fermi_surf.cpp
@@ -4,7 +4,6 @@
 #include "source_base/global_variable.h"
 #include "source_base/timer.h"
 #include <fstream>
-#include <stdexcept>
 #include <string>
 
 #ifdef __MPI
@@ -31,7 +30,10 @@ void ModuleIO::nscf_fermi_surface(const std::string &out_band_dir,
 		ofs.open(out_band_dir.c_str());
 		if (!ofs.is_open())
 		{
-    		    throw std::runtime_error("Failed to open file for writing: " + out_band_dir);
+    		        ModuleBase::WARNING_QUIT(
+			    "ModuleIO::nscf_fermi_surface",
+			    "Failed to open file for writing: " + out_band_dir
+			);
 		}
 		ofs << std::setprecision(6);
 		ofs.close();	

--- a/source/source_lcao/module_operator_lcao/overlap.cpp
+++ b/source/source_lcao/module_operator_lcao/overlap.cpp
@@ -10,7 +10,6 @@
 #include "source_lcao/module_rt/td_folding.h"
 #include "source_lcao/module_rt/td_info.h"
 #include <fstream>
-#include <stdexcept>
 #include <string>
 
 #include <functional>
@@ -443,7 +442,10 @@ void hamilt::Overlap<hamilt::OperatorLCAO<TK, TR>>::output_SR_async_csr(const in
             ofs.open(filename);
             if (!ofs.is_open())
 	    {
-    		throw std::runtime_error("Failed to open file for writing: " + filename);
+		    ModuleBase::WARNING_QUIT(
+			"hamilt::Overlap::output_SR_async_csr",
+		        "Failed to open file for writing: " + filename
+		    );
 	    }
 	}
         else
@@ -451,7 +453,10 @@ void hamilt::Overlap<hamilt::OperatorLCAO<TK, TR>>::output_SR_async_csr(const in
             ofs.open(filename, std::ios::app);
             if (!ofs.is_open())
 	    {
-   		throw std::runtime_error("Failed to open file for writing: " + filename);
+		    ModuleBase::WARNING_QUIT(
+			"hamilt::Overlap::output_SR_async_csr",
+   			"Failed to open file for writing: " + filename
+		    );
 	    }
 	}
 

--- a/source/source_lcao/module_operator_lcao/overlap.cpp
+++ b/source/source_lcao/module_operator_lcao/overlap.cpp
@@ -9,6 +9,9 @@
 #include "source_lcao/module_operator_lcao/operator_lcao.h"
 #include "source_lcao/module_rt/td_folding.h"
 #include "source_lcao/module_rt/td_info.h"
+#include <fstream>
+#include <stdexcept>
+#include <string>
 
 #include <functional>
 #include <vector>
@@ -438,11 +441,19 @@ void hamilt::Overlap<hamilt::OperatorLCAO<TK, TR>>::output_SR_async_csr(const in
         if (istep <= 0)
         {
             ofs.open(filename);
-        }
+            if (!ofs.is_open())
+	    {
+    		throw std::runtime_error("Failed to open file for writing: " + filename);
+	    }
+	}
         else
         {
             ofs.open(filename, std::ios::app);
-        }
+            if (!ofs.is_open())
+	    {
+   		throw std::runtime_error("Failed to open file for writing: " + filename);
+	    }
+	}
 
         // Write header information
         ofs << "IONIC_STEP: " << istep + 1 << std::endl;

--- a/source/source_lcao/module_ri/module_exx_symmetry/irreducible_sector.cpp
+++ b/source/source_lcao/module_ri/module_exx_symmetry/irreducible_sector.cpp
@@ -1,7 +1,6 @@
 #include "source_lcao/module_ri/module_exx_symmetry/irreducible_sector.h"
 #include "source_io/module_parameter/parameter.h"
 #include <fstream>
-#include <stdexcept>
 #include <string>
 namespace ModuleSymmetry
 {
@@ -154,7 +153,10 @@ namespace ModuleSymmetry
     	    ofs.open(PARAM.globalv.global_out_dir + "irreducible_sector.txt");
     	    if (!ofs.is_open())
 	    {
-	    	throw std::runtime_error("Failed to open file for writing: " + PARAM.globalv.global_out_dir + "irreducible_sector.txt");
+	    	ModuleBase::WARNING_QUIT(
+		    "Irreducible_Sector::write_irreducible_sector",
+		    "Failed to open file for writing: " + PARAM.globalv.global_out_dir + "irreducible_sector.txt"
+		);
 	    }
     	    for (auto& irap_irR : this->irreducible_sector_)
             {

--- a/source/source_lcao/module_ri/module_exx_symmetry/irreducible_sector.cpp
+++ b/source/source_lcao/module_ri/module_exx_symmetry/irreducible_sector.cpp
@@ -1,5 +1,8 @@
 #include "source_lcao/module_ri/module_exx_symmetry/irreducible_sector.h"
 #include "source_io/module_parameter/parameter.h"
+#include <fstream>
+#include <stdexcept>
+#include <string>
 namespace ModuleSymmetry
 {
     TC Irreducible_Sector::rotate_R(const Symmetry& symm,
@@ -148,8 +151,12 @@ namespace ModuleSymmetry
         if(GlobalV::MY_RANK == 0)
         {
             std::ofstream ofs;
-            ofs.open(PARAM.globalv.global_out_dir + "irreducible_sector.txt");
-            for (auto& irap_irR : this->irreducible_sector_)
+    	    ofs.open(PARAM.globalv.global_out_dir + "irreducible_sector.txt");
+    	    if (!ofs.is_open())
+	    {
+	    	throw std::runtime_error("Failed to open file for writing: " + PARAM.globalv.global_out_dir + "irreducible_sector.txt");
+	    }
+    	    for (auto& irap_irR : this->irreducible_sector_)
             {
                 for (auto& irR : irap_irR.second){ofs << "atompair (" << irap_irR.first.first << ", " << irap_irR.first.second << "), R = (" << irR[0] << ", " << irR[1] << ", " << irR[2] << ") \n";}
             }

--- a/source/source_lcao/module_rt/td_info.cpp
+++ b/source/source_lcao/module_rt/td_info.cpp
@@ -2,6 +2,9 @@
 
 #include "source_estate/module_pot/H_TDDFT_pw.h"
 #include "source_io/module_parameter/parameter.h"
+#include <fstream>
+#include <stdexcept>
+#include <string>
 
 bool TD_info::out_mat_R = false;
 bool TD_info::out_vecpot = false;
@@ -72,13 +75,22 @@ void TD_info::output_cart_At(const std::string& out_dir)
         if (istep == estep_shift)
         {
             ofs.open(out_file.c_str(), std::ofstream::out);
-            ofs << std::left << std::setw(8) << "#istep" << std::setw(15) << "A_x" << std::setw(15) << "A_y"
+            if (!ofs.is_open())
+	    {
+                throw std::runtime_error("Failed to open file for writing: " + out_file);
+	    }
+	    ofs << std::left << std::setw(8) << "#istep" << std::setw(15) << "A_x" << std::setw(15) << "A_y"
                 << std::setw(15) << "A_z" << std::endl;
         }
         else
         {
             ofs.open(out_file.c_str(), std::ofstream::app);
-        }
+            if (!ofs.is_open())
+	    {
+    		throw std::runtime_error("Failed to open file for writing: " + out_file);
+	    }
+
+	}
         // output the vector potential
         ofs << std::left << std::setw(8) << istep;
         // divide by 2.0 to get the atomic unit

--- a/source/source_lcao/module_rt/td_info.cpp
+++ b/source/source_lcao/module_rt/td_info.cpp
@@ -3,7 +3,6 @@
 #include "source_estate/module_pot/H_TDDFT_pw.h"
 #include "source_io/module_parameter/parameter.h"
 #include <fstream>
-#include <stdexcept>
 #include <string>
 
 bool TD_info::out_mat_R = false;
@@ -77,7 +76,10 @@ void TD_info::output_cart_At(const std::string& out_dir)
             ofs.open(out_file.c_str(), std::ofstream::out);
             if (!ofs.is_open())
 	    {
-                throw std::runtime_error("Failed to open file for writing: " + out_file);
+                ModuleBase::WARNING_QUIT(
+		    "TD_info::output_cart_At",
+	    	    "Failed to open file for writing: " + out_file
+		);
 	    }
 	    ofs << std::left << std::setw(8) << "#istep" << std::setw(15) << "A_x" << std::setw(15) << "A_y"
                 << std::setw(15) << "A_z" << std::endl;
@@ -87,7 +89,10 @@ void TD_info::output_cart_At(const std::string& out_dir)
             ofs.open(out_file.c_str(), std::ofstream::app);
             if (!ofs.is_open())
 	    {
-    		throw std::runtime_error("Failed to open file for writing: " + out_file);
+    		ModuleBase::WARNING_QUIT(
+		    "TD_info::output_cart_At",
+		    "Failed to open file for writing: " + out_file
+		);
 	    }
 
 	}


### PR DESCRIPTION
### Unit Tests and/or Case Tests for my changes
- No new unit test was added.
- This PR improves robustness by adding file-open checks before writing output files.

### What's changed?
- Add file-open checks for several output files.
- Throw `std::runtime_error` with the output file path when opening a file fails.
- This makes output-related failures easier to detect and debug.