### PR TITLE
2026PKUCourseHW5: Initialize potentially uninitialized variables

### DIFF
--- a/source/source_io/module_energy/nscf_fermi_surf.cpp
+++ b/source/source_io/module_energy/nscf_fermi_surf.cpp
@@ -3,6 +3,9 @@
 #include "source_io/module_parameter/parameter.h"
 #include "source_base/global_variable.h"
 #include "source_base/timer.h"
+#include <fstream>
+#include <stdexcept>
+#include <string>
 
 #ifdef __MPI
 #include <mpi.h>
@@ -26,6 +29,10 @@ void ModuleIO::nscf_fermi_surface(const std::string &out_band_dir,
 	if(GlobalV::MY_RANK==0)
 	{
 		ofs.open(out_band_dir.c_str());
+		if (!ofs.is_open())
+		{
+    		    throw std::runtime_error("Failed to open file for writing: " + out_band_dir);
+		}
 		ofs << std::setprecision(6);
 		ofs.close();	
 	}

--- a/source/source_lcao/module_operator_lcao/overlap.cpp
+++ b/source/source_lcao/module_operator_lcao/overlap.cpp
@@ -9,6 +9,9 @@
 #include "source_lcao/module_operator_lcao/operator_lcao.h"
 #include "source_lcao/module_rt/td_folding.h"
 #include "source_lcao/module_rt/td_info.h"
+#include <fstream>
+#include <stdexcept>
+#include <string>
 
 #include <functional>
 #include <vector>
@@ -438,11 +441,19 @@ void hamilt::Overlap<hamilt::OperatorLCAO<TK, TR>>::output_SR_async_csr(const in
         if (istep <= 0)
         {
             ofs.open(filename);
-        }
+            if (!ofs.is_open())
+	    {
+    		throw std::runtime_error("Failed to open file for writing: " + filename);
+	    }
+	}
         else
         {
             ofs.open(filename, std::ios::app);
-        }
+            if (!ofs.is_open())
+	    {
+   		throw std::runtime_error("Failed to open file for writing: " + filename);
+	    }
+	}
 
         // Write header information
         ofs << "IONIC_STEP: " << istep + 1 << std::endl;

--- a/source/source_lcao/module_ri/module_exx_symmetry/irreducible_sector.cpp
+++ b/source/source_lcao/module_ri/module_exx_symmetry/irreducible_sector.cpp
@@ -1,5 +1,8 @@
 #include "source_lcao/module_ri/module_exx_symmetry/irreducible_sector.h"
 #include "source_io/module_parameter/parameter.h"
+#include <fstream>
+#include <stdexcept>
+#include <string>
 namespace ModuleSymmetry
 {
     TC Irreducible_Sector::rotate_R(const Symmetry& symm,
@@ -148,8 +151,12 @@ namespace ModuleSymmetry
         if(GlobalV::MY_RANK == 0)
         {
             std::ofstream ofs;
-            ofs.open(PARAM.globalv.global_out_dir + "irreducible_sector.txt");
-            for (auto& irap_irR : this->irreducible_sector_)
+    	    ofs.open(PARAM.globalv.global_out_dir + "irreducible_sector.txt");
+    	    if (!ofs.is_open())
+	    {
+	    	throw std::runtime_error("Failed to open file for writing: " + PARAM.globalv.global_out_dir + "irreducible_sector.txt");
+	    }
+    	    for (auto& irap_irR : this->irreducible_sector_)
             {
                 for (auto& irR : irap_irR.second){ofs << "atompair (" << irap_irR.first.first << ", " << irap_irR.first.second << "), R = (" << irR[0] << ", " << irR[1] << ", " << irR[2] << ") \n";}
             }

--- a/source/source_lcao/module_ri/singular_value.cpp
+++ b/source/source_lcao/module_ri/singular_value.cpp
@@ -199,7 +199,7 @@ double cal_massidda(const UnitCell& ucell,
             = std::bind(&fq_massidda, ucell.tpiba, gaussian_abfs, qdiv, lambda, lmax);
         double prefactor
             = ModuleBase::TWO_PI * std::pow(lambda, -1.0 / qdiv) * ucell.omega / std::pow(ModuleBase::TWO_PI, 3);
-        double fq_int;
+        double fq_int; 
         if (qdiv == 2)
             fq_int = prefactor * std::sqrt(ModuleBase::PI);
         else if (qdiv == 1)
@@ -213,7 +213,7 @@ double cal_massidda(const UnitCell& ucell,
     double val_extra_old = 0.5 * std::numeric_limits<double>::max();
     double lammda_old = start_lambda;
     double val_old = cal_chi(lammda_old);
-    double val_extra;
+    double val_extra = 0.0;  //Initialize variables to avoid undefined behavior
     for (size_t iter = 0; iter != niter; ++iter)
     {
         double lammda_new = lammda_old * 0.5;

--- a/source/source_lcao/module_rt/td_info.cpp
+++ b/source/source_lcao/module_rt/td_info.cpp
@@ -2,6 +2,9 @@
 
 #include "source_estate/module_pot/H_TDDFT_pw.h"
 #include "source_io/module_parameter/parameter.h"
+#include <fstream>
+#include <stdexcept>
+#include <string>
 
 bool TD_info::out_mat_R = false;
 bool TD_info::out_vecpot = false;
@@ -72,13 +75,22 @@ void TD_info::output_cart_At(const std::string& out_dir)
         if (istep == estep_shift)
         {
             ofs.open(out_file.c_str(), std::ofstream::out);
-            ofs << std::left << std::setw(8) << "#istep" << std::setw(15) << "A_x" << std::setw(15) << "A_y"
+            if (!ofs.is_open())
+	    {
+                throw std::runtime_error("Failed to open file for writing: " + out_file);
+	    }
+	    ofs << std::left << std::setw(8) << "#istep" << std::setw(15) << "A_x" << std::setw(15) << "A_y"
                 << std::setw(15) << "A_z" << std::endl;
         }
         else
         {
             ofs.open(out_file.c_str(), std::ofstream::app);
-        }
+            if (!ofs.is_open())
+	    {
+    		throw std::runtime_error("Failed to open file for writing: " + out_file);
+	    }
+
+	}
         // output the vector potential
         ofs << std::left << std::setw(8) << istep;
         // divide by 2.0 to get the atomic unit

--- a/source/source_relax/ions_move_cg.cpp
+++ b/source/source_relax/ions_move_cg.cpp
@@ -264,7 +264,7 @@ void Ions_Move_CG::setup_cg_grad(double *grad,
 {
     ModuleBase::TITLE("Ions_Move_CG", "setup_cg_grad");
     assert(Ions_Move_Basic::istep > 0);
-    double gamma;
+    double gamma = 0.0;  //Initialize variables to avoid undefined behavior
     double cg0_cg, cg0_cg0, cg0_g;
 
     if (ncggrad % 10000 == 0 || flag == 2)
@@ -364,11 +364,11 @@ void Ions_Move_CG::Brent(double &fa,
                          double &best_x,
                          double &xpt)
 {
-    double dmove;
-    double tmp;
-    double k2, k1, k0;
-    double xnew1, xnew2;
-    double ecalnew1, ecalnew2;
+    double dmove = 0.0;
+    double tmp = 0.0;
+    double k2 = 0.0, k1 = 0.0, k0 = 0.0;
+    double xnew1 = 0.0, xnew2 = 0.0;
+    double ecalnew1 = 0.0, ecalnew2 = 0.0;  //Initialize variables to avoid undefined behavior
 
     if ((fa * fb) > 0)
     {


### PR DESCRIPTION
### Unit Tests and/or Case Tests for my changes
- No new unit test was added.
- The modified code was manually reviewed to ensure that the affected local variables are initialized before use.
- This change is small and localized, and it is intended to avoid potential undefined behavior caused by uninitialized values.

### What's changed?
- Initialize local variables that may otherwise be used without guaranteed assignment on all control-flow paths.
- Keep the change minimal by using explicit initialization at declaration.
- Improve robustness and make the control flow safer and easier to reason about.
