### PR TITLE
Enable compatibility of GNU compilers + MKL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,7 +322,7 @@ if(DEBUG_INFO)
 endif()
 
 if(ENABLE_MPI)
-  find_package(MPI REQUIRED)
+  find_package(MPI COMPONENTS CXX REQUIRED)
   include_directories(${MPI_CXX_INCLUDE_PATH})
   target_link_libraries(${ABACUS_BIN_NAME} MPI::MPI_CXX)
   add_compile_definitions(__MPI)

--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -22,9 +22,18 @@ else()
   find_library(MKL_THREAD NAMES mkl_gnu_thread HINTS ${MKLROOT}/lib ${MKLROOT}/lib/intel64)
   # With GCC we use system-installed GNU OpenMP
 endif()
+
 if(ENABLE_MPI)
+  execute_process(COMMAND ${MPI_CXX_COMPILER} --showme:version
+                  OUTPUT_VARIABLE MPI_VER_OUT
+                  ERROR_VARIABLE MPI_VER_ERR)
+  if(MPI_VER_OUT MATCHES "Open MPI" OR MPI_VER_ERR MATCHES "Open MPI")
+    set(MKL_BLACS_LIB_NAME "mkl_blacs_openmpi_lp64")
+  else()
+    set(MKL_BLACS_LIB_NAME "mkl_blacs_intelmpi_lp64")
+  endif()
   find_library(MKL_SCALAPACK NAMES mkl_scalapack_lp64 HINTS ${MKLROOT}/lib ${MKLROOT}/lib/intel64)
-  find_library(MKL_BLACS_INTELMPI NAMES mkl_blacs_intelmpi_lp64 HINTS ${MKLROOT}/lib ${MKLROOT}/lib/intel64)
+  find_library(MKL_BLACS NAMES ${MKL_BLACS_LIB_NAME} HINTS ${MKLROOT}/lib ${MKLROOT}/lib/intel64)
 endif()
 
 include(FindPackageHandleStandardArgs)
@@ -32,7 +41,7 @@ include(FindPackageHandleStandardArgs)
 # if all listed variables are TRUE
 
 if(ENABLE_MPI)
-  find_package_handle_standard_args(MKL DEFAULT_MSG MKL_INTERFACE_LIB MKL_THREAD MKL_CORE MKL_SCALAPACK MKL_BLACS_INTELMPI MKL_INCLUDE)
+  find_package_handle_standard_args(MKL DEFAULT_MSG MKL_INTERFACE_LIB MKL_THREAD MKL_CORE MKL_SCALAPACK MKL_BLACS MKL_INCLUDE)
 else()
   find_package_handle_standard_args(MKL MKL_INTERFACE_LIB MKL_THREAD MKL_CORE MKL_INCLUDE)
 endif()
@@ -62,10 +71,10 @@ if(MKL_FOUND)
       IMPORTED_LOCATION "${MKL_SCALAPACK}"
       INTERFACE_INCLUDE_DIRECTORIES "${MKL_INCLUDE}")
   endif()
-  if(NOT TARGET MKL::BLACS_INTELMPI)
-    add_library(MKL::BLACS_INTELMPI UNKNOWN IMPORTED)
-    set_target_properties(MKL::BLACS_INTELMPI PROPERTIES
-      IMPORTED_LOCATION "${MKL_BLACS_INTELMPI}"
+  if(ENABLE_MPI AND NOT TARGET MKL::BLACS)
+    add_library(MKL::BLACS UNKNOWN IMPORTED)
+    set_target_properties(MKL::BLACS PROPERTIES
+      IMPORTED_LOCATION "${MKL_BLACS}"
       INTERFACE_INCLUDE_DIRECTORIES "${MKL_INCLUDE}")
   endif()
   if(MKL_IOMP5 AND NOT TARGET MKL::IOMP5)
@@ -78,7 +87,7 @@ if(MKL_FOUND)
     set_property(TARGET MKL::MKL PROPERTY
     INTERFACE_LINK_LIBRARIES
     "-Wl,--start-group"
-    MKL::INTERFACE_LIB MKL::THREAD MKL::CORE MKL::MKL_SCALAPACK MKL::BLACS_INTELMPI
+    MKL::INTERFACE_LIB MKL::THREAD MKL::CORE MKL::MKL_SCALAPACK MKL::BLACS
     "-Wl,--end-group"
     )
   else()
@@ -96,7 +105,7 @@ if(MKL_FOUND)
 endif()
 
 if(ENABLE_MPI)
-  mark_as_advanced(MKL_INCLUDE MKL_INTERFACE_LIB MKL_THREAD MKL_CORE MKL_SCALAPACK MKL_BLACS_INTELMPI)
+  mark_as_advanced(MKL_INCLUDE MKL_INTERFACE_LIB MKL_THREAD MKL_CORE MKL_SCALAPACK MKL_BLACS)
 else()
   mark_as_advanced(MKL_INCLUDE MKL_INTERFACE_LIB MKL_THREAD MKL_CORE)
 endif()

--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -9,13 +9,19 @@ if(NOT TARGET MKL::MKL)
 
 find_path(MKL_INCLUDE mkl_service.h HINTS ${MKLROOT}/include)
 
-find_library(MKL_INTEL NAMES mkl_intel_lp64 HINTS ${MKLROOT}/lib ${MKLROOT}/lib/intel64)
-find_library(MKL_INTEL_THREAD NAMES mkl_intel_thread HINTS ${MKLROOT}/lib ${MKLROOT}/lib/intel64)
 find_library(MKL_CORE NAMES mkl_core HINTS ${MKLROOT}/lib ${MKLROOT}/lib/intel64)
-find_library(MKL_IOMP5 NAMES iomp5
-  HINTS ENV CMPLR_ROOT
-  PATH_SUFFIXES lib lib/intel64 linux/compiler/lib/intel64_lin
-)
+if(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
+  find_library(MKL_INTERFACE_LIB NAMES mkl_intel_lp64 HINTS ${MKLROOT}/lib ${MKLROOT}/lib/intel64)
+  find_library(MKL_THREAD NAMES mkl_intel_thread HINTS ${MKLROOT}/lib ${MKLROOT}/lib/intel64)
+  find_library(MKL_IOMP5 NAMES iomp5
+    HINTS ENV CMPLR_ROOT
+    PATH_SUFFIXES lib lib/intel64 linux/compiler/lib/intel64_lin
+  )
+else()
+  find_library(MKL_INTERFACE_LIB NAMES mkl_gf_lp64 HINTS ${MKLROOT}/lib ${MKLROOT}/lib/intel64)
+  find_library(MKL_THREAD NAMES mkl_gnu_thread HINTS ${MKLROOT}/lib ${MKLROOT}/lib/intel64)
+  # With GCC we use system-installed GNU OpenMP
+endif()
 if(ENABLE_MPI)
   find_library(MKL_SCALAPACK NAMES mkl_scalapack_lp64 HINTS ${MKLROOT}/lib ${MKLROOT}/lib/intel64)
   find_library(MKL_BLACS_INTELMPI NAMES mkl_blacs_intelmpi_lp64 HINTS ${MKLROOT}/lib ${MKLROOT}/lib/intel64)
@@ -26,22 +32,22 @@ include(FindPackageHandleStandardArgs)
 # if all listed variables are TRUE
 
 if(ENABLE_MPI)
-  find_package_handle_standard_args(MKL DEFAULT_MSG MKL_INTEL MKL_INTEL_THREAD MKL_CORE MKL_SCALAPACK MKL_BLACS_INTELMPI MKL_INCLUDE)
+  find_package_handle_standard_args(MKL DEFAULT_MSG MKL_INTERFACE_LIB MKL_THREAD MKL_CORE MKL_SCALAPACK MKL_BLACS_INTELMPI MKL_INCLUDE)
 else()
-  find_package_handle_standard_args(MKL MKL_INTEL MKL_INTEL_THREAD MKL_CORE MKL_INCLUDE)
+  find_package_handle_standard_args(MKL MKL_INTERFACE_LIB MKL_THREAD MKL_CORE MKL_INCLUDE)
 endif()
 
 if(MKL_FOUND)
-  if(NOT TARGET MKL::INTEL)
-    add_library(MKL::INTEL UNKNOWN IMPORTED)
-    set_target_properties(MKL::INTEL PROPERTIES
-      IMPORTED_LOCATION "${MKL_INTEL}"
+  if(NOT TARGET MKL::INTERFACE_LIB)
+    add_library(MKL::INTERFACE_LIB UNKNOWN IMPORTED)
+    set_target_properties(MKL::INTERFACE_LIB PROPERTIES
+      IMPORTED_LOCATION "${MKL_INTERFACE_LIB}"
       INTERFACE_INCLUDE_DIRECTORIES "${MKL_INCLUDE}")
   endif()
-  if(NOT TARGET MKL::INTEL_THREAD)
-    add_library(MKL::INTEL_THREAD UNKNOWN IMPORTED)
-    set_target_properties(MKL::INTEL_THREAD PROPERTIES
-      IMPORTED_LOCATION "${MKL_INTEL_THREAD}"
+  if(NOT TARGET MKL::THREAD)
+    add_library(MKL::THREAD UNKNOWN IMPORTED)
+    set_target_properties(MKL::THREAD PROPERTIES
+      IMPORTED_LOCATION "${MKL_THREAD}"
       INTERFACE_INCLUDE_DIRECTORIES "${MKL_INCLUDE}")
   endif()
   if(NOT TARGET MKL::CORE)
@@ -72,14 +78,14 @@ if(MKL_FOUND)
     set_property(TARGET MKL::MKL PROPERTY
     INTERFACE_LINK_LIBRARIES
     "-Wl,--start-group"
-    MKL::INTEL MKL::INTEL_THREAD MKL::CORE MKL::MKL_SCALAPACK MKL::BLACS_INTELMPI
+    MKL::INTERFACE_LIB MKL::THREAD MKL::CORE MKL::MKL_SCALAPACK MKL::BLACS_INTELMPI
     "-Wl,--end-group"
     )
   else()
     set_property(TARGET MKL::MKL PROPERTY
     INTERFACE_LINK_LIBRARIES
     "-Wl,--start-group"
-    MKL::INTEL MKL::INTEL_THREAD MKL::CORE
+    MKL::INTERFACE_LIB MKL::THREAD MKL::CORE
     "-Wl,--end-group"
     )
   endif()
@@ -90,9 +96,9 @@ if(MKL_FOUND)
 endif()
 
 if(ENABLE_MPI)
-  mark_as_advanced(MKL_INCLUDE MKL_INTEL MKL_INTEL_THREAD MKL_CORE MKL_SCALAPACK MKL_BLACS_INTELMPI)
+  mark_as_advanced(MKL_INCLUDE MKL_INTERFACE_LIB MKL_THREAD MKL_CORE MKL_SCALAPACK MKL_BLACS_INTELMPI)
 else()
-  mark_as_advanced(MKL_INCLUDE MKL_INTEL MKL_INTEL_THREAD MKL_CORE)
+  mark_as_advanced(MKL_INCLUDE MKL_INTERFACE_LIB MKL_THREAD MKL_CORE)
 endif()
 
 endif() # MKL::MKL

--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -57,8 +57,9 @@ For new users, start with one of these pre-configured toolchains:
 # GNU toolchain (GCC + OpenMPI + OpenBLAS)
 ./toolchain_gnu.sh
 
-# Intel toolchain (Intel compilers + Intel MPI + MKL)
-./toolchain_intel.sh
+# Intel toolchain
+./toolchain_gcc-mkl.sh # GCC + OpenMPI + MKL
+./toolchain_intel.sh # Intel compilers + Intel MPI + MKL
 
 # AMD toolchain options
 ./toolchain_gcc-aocl.sh    # GCC + AMD AOCL
@@ -341,10 +342,6 @@ Related discussion here [#4976](https://github.com/deepmodeling/abacus-develop/i
 ```
 
 Notice: `icc` and `icpc` from Intel Classic Compiler of Intel-oneAPI are not supported for 2024.0 and newer version. And Intel-OneAPI 2023.2.0 can be found in QE website. You need to download Base-toolkit for MKL and HPC-toolkit for MPi and compiler for Intel-OneAPI 2023.2.0, while in Intel-OneAPI 2024.x, only the HPC-toolkit is needed.
-
-#### Gcc-MKL Issues
-
-You cannot use gcc as compiler while using MKL as math library for compile ABACUS, there will be lots of error in the lask linking step. See [#3198](https://github.com/deepmodeling/abacus-develop/issues/3198)
 
 #### AMD AOCC-AOCL problem
 

--- a/toolchain/build_abacus_gcc-mkl.sh
+++ b/toolchain/build_abacus_gcc-mkl.sh
@@ -1,0 +1,79 @@
+#!/bin/bash -e
+#SBATCH -J build_abacus_aocl
+#SBATCH -N 1
+#SBATCH -n 16
+#SBATCH -o install.log
+#SBATCH -e install.err
+
+# Build ABACUS by gcc-mkl toolchain
+
+# load system env modules at first
+# module load mkl compiler mpi
+# source path/to/setvars.sh
+
+ABACUS_DIR=..
+TOOL=$(pwd)
+INSTALL_DIR=$TOOL/install
+source $INSTALL_DIR/setup
+cd $ABACUS_DIR
+ABACUS_DIR=$(pwd)
+
+BUILD_DIR=build_abacus_gcc_mkl
+rm -rf $BUILD_DIR
+
+PREFIX=$ABACUS_DIR
+ELPA=$INSTALL_DIR/elpa-2025.06.001/cpu
+# ELPA=$INSTALL_DIR/elpa-2025.06.001/nvidia # for elpa-gpu
+CEREAL=$INSTALL_DIR/cereal-master/include/cereal
+LIBXC=$INSTALL_DIR/libxc-7.0.0
+RAPIDJSON=$INSTALL_DIR/rapidjson-master
+LIBRI=$INSTALL_DIR/LibRI-master
+LIBCOMM=$INSTALL_DIR/LibComm-master
+USE_CUDA=OFF  # set ON to enable gpu-abacus
+# NEP_DIR=$INSTALL_DIR/NEP_CPU-main
+# LIBTORCH=$INSTALL_DIR/libtorch-2.1.2/share/cmake/Torch
+# LIBNPY=$INSTALL_DIR/libnpy-1.0.1/include
+# DEEPMD=$HOME/apps/anaconda3/envs/deepmd
+
+cmake -B $BUILD_DIR -DCMAKE_INSTALL_PREFIX=$PREFIX \
+        -DCMAKE_CXX_COMPILER=g++ \
+        -DMPI_CXX_COMPILER=mpicxx \
+        -DMKLROOT=$MKLROOT \
+        -DELPA_DIR=$ELPA \
+        -DCEREAL_INCLUDE_DIR=$CEREAL \
+        -DLibxc_DIR=$LIBXC \
+        -DENABLE_LCAO=ON \
+        -DENABLE_LIBXC=ON \
+        -DUSE_OPENMP=ON \
+        -DUSE_ELPA=ON \
+        -DENABLE_RAPIDJSON=ON \
+        -DRapidJSON_DIR=$RAPIDJSON \
+        -DENABLE_LIBRI=ON \
+        -DLIBRI_DIR=$LIBRI \
+        -DLIBCOMM_DIR=$LIBCOMM \
+        -DUSE_CUDA=$USE_CUDA \
+#         -DCMAKE_CUDA_COMPILER=/path/to/cuda/bin/nvcc \
+#         -DNEP_DIR=$NEP_DIR \
+#         -DENABLE_MLALGO=1 \
+#         -DTorch_DIR=$LIBTORCH \
+#         -Dlibnpy_INCLUDE_DIR=$LIBNPY \
+# 	      -DDeePMD_DIR=$DEEPMD \
+#         -DENABLE_CUSOLVERMP=ON \
+
+cmake --build $BUILD_DIR -j `nproc`
+cmake --install $BUILD_DIR 2>/dev/null
+
+# generate abacus_env.sh
+cat << EOF > "${TOOL}/abacus_env.sh"
+#!/bin/bash
+source $INSTALL_DIR/setup
+export PATH="${PREFIX}/bin":\${PATH}
+EOF
+
+# generate information
+cat << EOF
+========================== usage =========================
+Done!
+To use the installed ABACUS version
+You need to source ${TOOL}/abacus_env.sh first !
+EOF

--- a/toolchain/install_abacus_toolchain_new.sh
+++ b/toolchain/install_abacus_toolchain_new.sh
@@ -201,6 +201,7 @@ EOF
     ui_print_color "${UI_GREEN}${UI_BOLD}" "🚀 Build ABACUS with your preferred toolchain:"
     ui_print_color "${UI_WHITE}" "   ./build_abacus_gnu.sh        # GNU toolchain (GCC + OpenBLAS)"
     ui_print_color "${UI_WHITE}" "   ./build_abacus_intel.sh      # Intel toolchain (ICC + MKL)"
+    ui_print_color "${UI_WHITE}" "   ./build_abacus_gcc-mkl.sh    # GCC + MKL"
     ui_print_color "${UI_WHITE}" "   ./build_abacus_gcc-aocl.sh   # AMD GCC + AOCL"
     ui_print_color "${UI_WHITE}" "   ./build_abacus_aocc-aocl.sh  # AMD AOCC + AOCL"
     echo ""

--- a/toolchain/toolchain_gcc-mkl.sh
+++ b/toolchain/toolchain_gcc-mkl.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+#SBATCH -J install
+#SBATCH -N 1
+#SBATCH -n 16
+#SBATCH -o compile.log
+#SBATCH -e compile.err
+
+# Users can easily modify these parameters to customize the build
+# Before running this script, ensure you have loaded your system packages
+
+# Compiler Configuration
+TOOLCHAIN_COMPILER="gcc-mkl"
+WITH_GCC="system"
+WITH_AMD="no"
+WITH_INTEL="no"
+
+# Math Libraries (Intel MKL recommended)
+MATH_MODE="mkl"
+WITH_MKL="system"
+
+# MPI Implementation (OpenMPI recommended)
+MPI_MODE="openmpi"
+WITH_OPENMPI="install"
+WITH_4TH_OPENMPI="no"  # Set to "yes" for OpenMPI v4, deprecated
+WITH_MPICH="no"
+
+# Core Dependencies
+WITH_CMAKE="install"
+WITH_SCALAPACK="system"  # MKL provides ScaLAPACK
+WITH_FFTW="system"       # MKL provides FFTW
+WITH_LIBXC="install"
+WITH_ELPA="install"
+
+# Utility Libraries
+WITH_CEREAL="install"
+WITH_RAPIDJSON="install"
+
+# Advanced Features (EXX calculations)
+WITH_LIBRI="install"
+WITH_LIBCOMM="install"
+
+# Optional Features (MLALGO support)
+WITH_LIBTORCH="no"
+WITH_LIBNPY="no"
+WITH_NEP="no"
+
+# ELPA-GPU Support (uncomment and modify as needed)
+# ENABLE_CUDA="yes"
+# GPU_VERSION="75"  # Check your GPU compute capability
+# export CUDA_PATH="/usr/local/cuda"
+
+# ============================================================================
+# Execution Mode Control
+# ============================================================================
+# Dry-run mode: Show what would be done without actually executing
+DRY_RUN_MODE="no"   # Set to "yes" to enable dry-run mode
+
+# Pack-run mode: Only check and install required packages
+PACK_RUN_MODE="no"  # Set to "yes" to enable pack-run mode
+
+# ============================================================================
+# Package Version Selection (main/alt versions)
+# ============================================================================
+# Choose between main (latest stable) and alt (alternative/legacy) versions
+# Refer to scripts/package_versions.sh for specific version numbers
+
+CMAKE_VERSION="main"        # main=3.31.7, alt=3.30.5
+OPENMPI_VERSION="main"      # main=5.0.8, alt=4.1.6
+ELPA_VERSION="main"         # main=2025.06.001, alt=2024.05.001
+LIBXC_VERSION="main"        # main=7.0.0, alt=6.2.2
+# Optional Libraries
+LIBTORCH_VERSION="main"     # main=2.1.2, alt=1.12.1 (use alt for older GLIBC)
+# Note: main(2.1.2) version of LibTorch need glibc > 2.27
+# Note: alt(1.12.1) version of LibTorch cannot support DeePMD-Torch for DPA
+
+# Note: GCC-MKL toolchain uses MKL for math libraries (FFTW, ScaLAPACK)
+# so OpenBLAS and ScaLAPACK version selections are not applicable
+
+# ============================================================================
+# Execute Installation (DO NOT MODIFY BELOW THIS LINE)
+# ============================================================================
+
+# Call the main installation script with configured parameters
+exec ./install_abacus_toolchain_new.sh \
+  --with-gcc="$WITH_GCC" \
+  --math-mode="$MATH_MODE" \
+  --mpi-mode="$MPI_MODE" \
+  --with-mkl="$WITH_MKL" \
+  --with-openmpi="$WITH_OPENMPI" \
+  --with-mpich="$WITH_MPICH" \
+  --with-cmake="$WITH_CMAKE" \
+  --with-scalapack="$WITH_SCALAPACK" \
+  --with-libxc="$WITH_LIBXC" \
+  --with-fftw="$WITH_FFTW" \
+  --with-elpa="$WITH_ELPA" \
+  --with-cereal="$WITH_CEREAL" \
+  --with-rapidjson="$WITH_RAPIDJSON" \
+  --with-libtorch="$WITH_LIBTORCH" \
+  --with-nep="$WITH_NEP" \
+  --with-libnpy="$WITH_LIBNPY" \
+  --with-libri="$WITH_LIBRI" \
+  --with-libcomm="$WITH_LIBCOMM" \
+  --with-4th-openmpi="$WITH_4TH_OPENMPI" \
+  --package-version cmake:"$CMAKE_VERSION" \
+  --package-version openmpi:"$OPENMPI_VERSION" \
+  --package-version elpa:"$ELPA_VERSION" \
+  --package-version libxc:"$LIBXC_VERSION" \
+  --package-version libtorch:"$LIBTORCH_VERSION" \
+  ${DRY_RUN_MODE:+$([ "$DRY_RUN_MODE" = "yes" ] && echo "--dry-run")} \
+  ${PACK_RUN_MODE:+$([ "$PACK_RUN_MODE" = "yes" ] && echo "--pack-run")} \
+  ${ENABLE_CUDA:+--enable-cuda} \
+  ${GPU_VERSION:+--gpu-ver="$GPU_VERSION"} \
+  "$@" \
+  | tee compile.log


### PR DESCRIPTION
Previously `FindMKL.cmake` only detect the interface with Intel compilers, which would cause linking error in case GCC and Intel MKL are used together. This PR updates `FindMKL.cmake` to detect the specific MKL libraries designed for GCC and OpenMPI, which are essential for linking MKL correctly when building ABACUS with GCC. With this PR the combination of GCC and Intel MKL should be available.

Further fixes #3198.