### PR TITLE
2026PKUCourseHW5: replace atoi/atof with std::stoi/stod in pseudo-pot…

### DIFF
--- a/source/source_basis/module_ao/test/ORB_nonlocal_lm_test.cpp
+++ b/source/source_basis/module_ao/test/ORB_nonlocal_lm_test.cpp
@@ -1,3 +1,4 @@
+#include <string>
 #include "gtest/gtest.h"
 #include "source_base/global_function.h"
 #define private public
@@ -157,9 +158,9 @@ void NumericalNonlocalLmTest::SetUp() {
         if (label == "element") {
             elem_label_ = val;
         } else if (label == "number_of_proj") {
-            nproj_ = std::atoi(val.c_str());
+            nproj_ = std::stoi(val);
         } else if (label == "mesh_size") {
-            nmesh_upf = std::atoi(val.c_str());
+            nmesh_upf = std::stoi(val);
         }
 
         if (linebuf.find("/>") != std::string::npos) {
@@ -207,7 +208,7 @@ void NumericalNonlocalLmTest::SetUp() {
             }
 
             if (linebuf.find("angular_momentum") != std::string::npos) {
-                l_[iproj] = std::atoi(trim(linebuf).c_str());
+                l_[iproj] = std::stoi(trim(linebuf));
             }
         }
 

--- a/source/source_cell/read_pp_upf201.cpp
+++ b/source/source_cell/read_pp_upf201.cpp
@@ -1,3 +1,4 @@
+#include <string>
 #include "read_pp.h"
 
 // qianrui rewrite it 2021-5-10
@@ -307,31 +308,31 @@ void Pseudopot_upf::read_pseudo_upf201_header(std::ifstream& ifs, Atom_pseudo& p
         }
         else if (name[ip] == "total_psenergy")
         {
-            pp.etotps = atof(val[ip].c_str());
+            pp.etotps = std::stod(val[ip]);
         }
         else if (name[ip] == "wfc_cutoff")
         {
-            pp.ecutwfc = atof(val[ip].c_str());
+            pp.ecutwfc = std::stod(val[ip]);
         }
         else if (name[ip] == "rho_cutoff")
         {
-            pp.ecutrho = atof(val[ip].c_str());
+            pp.ecutrho = std::stod(val[ip]);
         }
         else if (name[ip] == "l_max")
         {
-            pp.lmax = atoi(val[ip].c_str());
+            pp.lmax = std::stoi(val[ip]);
         }
         else if (name[ip] == "l_max_rho")
         {
-            this->lmax_rho = atoi(val[ip].c_str());
+            this->lmax_rho = std::stoi(val[ip]);
         }
         else if (name[ip] == "l_local")
         {
-            this->lloc = atoi(val[ip].c_str());
+            this->lloc = std::stoi(val[ip]);
         }
         else if (name[ip] == "mesh_size")
         {
-            pp.mesh = atoi(val[ip].c_str());
+            pp.mesh = std::stoi(val[ip]);
             this->mesh_changed = false;
             if (pp.mesh % 2 == 0)
             {
@@ -341,11 +342,11 @@ void Pseudopot_upf::read_pseudo_upf201_header(std::ifstream& ifs, Atom_pseudo& p
         }
         else if (name[ip] == "number_of_wfc")
         {
-            pp.nchi = atoi(val[ip].c_str());
+            pp.nchi = std::stoi(val[ip]);
         }
         else if (name[ip] == "number_of_proj")
         {
-            pp.nbeta = atoi(val[ip].c_str());
+            pp.nbeta = std::stoi(val[ip]);
         }
         else
         {
@@ -377,11 +378,11 @@ void Pseudopot_upf::read_pseudo_upf201_mesh(std::ifstream& ifs, Atom_pseudo& pp)
         {
             if (name[ip] == "dx")
             {
-                dx = atof(val[ip].c_str());
+                dx = std::stod(val[ip]);
             }
             else if (name[ip] == "mesh")
             {
-                pp.mesh = atoi(val[ip].c_str());
+                pp.mesh = std::stoi(val[ip]);
 
                 this->mesh_changed = false;
                 if (pp.mesh % 2 == 0)
@@ -392,15 +393,15 @@ void Pseudopot_upf::read_pseudo_upf201_mesh(std::ifstream& ifs, Atom_pseudo& pp)
             }
             else if (name[ip] == "xmin")
             {
-                xmin = atof(val[ip].c_str());
+                xmin = std::stod(val[ip]);
             }
             else if (name[ip] == "rmax")
             {
-                rmax = atof(val[ip].c_str());
+                rmax = std::stod(val[ip]);
             }
             else if (name[ip] == "zmesh")
             {
-                zmesh = atof(val[ip].c_str());
+                zmesh = std::stod(val[ip]);
             }
             else
             {
@@ -501,19 +502,19 @@ void Pseudopot_upf::read_pseudo_upf201_nonlocal(std::ifstream& ifs, Atom_pseudo&
             }
             else if (name[ip] == "angular_momentum")
             {
-                pp.lll[ib] = atoi(val[ip].c_str());
+                pp.lll[ib] = std::stoi(val[ip]);
             }
             else if (name[ip] == "cutoff_radius_index")
             {
-                this->kbeta[ib] = atoi(val[ip].c_str());
+                this->kbeta[ib] = std::stoi(val[ip]);
             }
             else if (name[ip] == "cutoff_radius")
             {
-                rcut[ib] = atof(val[ip].c_str());
+                rcut[ib] = std::stod(val[ip]);
             }
             else if (name[ip] == "ultrasoft_cutoff_radius")
             {
-                rcutus[ib] = atof(val[ip].c_str());
+                rcutus[ib] = std::stod(val[ip]);
             }
             else
             {
@@ -572,11 +573,11 @@ void Pseudopot_upf::read_pseudo_upf201_nonlocal(std::ifstream& ifs, Atom_pseudo&
             }
             else if (name[ip] == "nqf")
             {
-                nqf = atoi(val[ip].c_str());
+                nqf = std::stoi(val[ip]);
             }
             else if (name[ip] == "nqlc")
             {
-                pp.nqlc = atoi(val[ip].c_str());
+                pp.nqlc = std::stoi(val[ip]);
             }
             else
             {
@@ -752,7 +753,7 @@ void Pseudopot_upf::read_pseudo_upf201_pswfc(std::ifstream& ifs, Atom_pseudo& pp
             }
             else if (name[ip] == "l")
             {
-                pp.lchi[iw] = atoi(val[ip].c_str());
+                pp.lchi[iw] = std::stoi(val[ip]);
                 if (nchi[iw] == -1)
                 {
                     nchi[iw] = pp.lchi[iw] - 1;
@@ -760,23 +761,23 @@ void Pseudopot_upf::read_pseudo_upf201_pswfc(std::ifstream& ifs, Atom_pseudo& pp
             }
             else if (name[ip] == "occupation")
             {
-                pp.oc[iw] = atof(val[ip].c_str());
+                pp.oc[iw] = std::stod(val[ip]);
             }
             else if (name[ip] == "n")
             {
-                nchi[iw] = atoi(val[ip].c_str());
+                nchi[iw] = std::stoi(val[ip]);
             }
             else if (name[ip] == "pseudo_energy")
             {
-                epseu[iw] = atof(val[ip].c_str());
+                epseu[iw] = std::stod(val[ip]);
             }
             else if (name[ip] == "cutoff_radius")
             {
-                rcut_chi[iw] = atof(val[ip].c_str());
+                rcut_chi[iw] = std::stod(val[ip]);
             }
             else if (name[ip] == "ultrasoft_cutoff_radius")
             {
-                rcutus_chi[iw] = atof(val[ip].c_str());
+                rcutus_chi[iw] = std::stod(val[ip]);
             }
             else
             {
@@ -870,19 +871,19 @@ void Pseudopot_upf::read_pseudo_upf201_so(std::ifstream& ifs, Atom_pseudo& pp)
             }
             else if (name[ip] == "nn")
             {
-                pp.nn[nw] = atoi(val[ip].c_str());
+                pp.nn[nw] = std::stoi(val[ip]);
             }
             else if (name[ip] == "lchi")
             {
-                pp.lchi[nw] = atoi(val[ip].c_str());
+                pp.lchi[nw] = std::stoi(val[ip]);
             }
             else if (name[ip] == "jchi")
             {
-                pp.jchi[nw] = atof(val[ip].c_str());
+                pp.jchi[nw] = std::stod(val[ip]);
             }
             else if (name[ip] == "oc")
             {
-                pp.oc[nw] = atof(val[ip].c_str());
+                pp.oc[nw] = std::stod(val[ip]);
             }
             else
             {
@@ -907,11 +908,11 @@ void Pseudopot_upf::read_pseudo_upf201_so(std::ifstream& ifs, Atom_pseudo& pp)
             }
             else if (name[ip] == "lll")
             {
-                pp.lll[nb] = atoi(val[ip].c_str());
+                pp.lll[nb] = std::stoi(val[ip]);
             }
             else if (name[ip] == "jjj")
             {
-                pp.jjj[nb] = atof(val[ip].c_str());
+                pp.jjj[nb] = std::stod(val[ip]);
             }
             else
             {

--- a/source/source_cell/read_pp_vwr.cpp
+++ b/source/source_cell/read_pp_vwr.cpp
@@ -1,3 +1,4 @@
+#include <string>
 #include "read_pp.h"
 
 //----------------------------------------------------------
@@ -30,7 +31,7 @@ int Pseudopot_upf::read_pseudo_vwr(std::ifstream &ifs, Atom_pseudo& pp)
 	std::string value;
 	size_t length=0;
 	ifs >> value; length = value.find(","); value.erase(length,1);
-	pp.mesh = std::atoi( value.c_str() );
+	pp.mesh = std::stoi(value);
 	//the mesh should be odd, which is forced in Simpson integration
 	this->mesh_changed = false;
 	if(pp.mesh%2==0) 
@@ -42,7 +43,7 @@ int Pseudopot_upf::read_pseudo_vwr(std::ifstream &ifs, Atom_pseudo& pp)
 	GlobalV::ofs_running << std::setw(15) << "MESH" << std::setw(15) << pp.mesh << std::endl;
 	// (2) read in nlcc: nonlinear core correction
 	ifs >> value; length = value.find(","); value.erase(length,1);
-	pp.nlcc = std::atoi( value.c_str() );
+	pp.nlcc = std::stoi(value);
 	GlobalV::ofs_running << std::setw(15) << "NLCC" << std::setw(15) << pp.nlcc << std::endl;
 	// (3) iatom : index for atom 
 	ifs >> value; length = value.find(","); value.erase(length,1);
@@ -54,16 +55,16 @@ int Pseudopot_upf::read_pseudo_vwr(std::ifstream &ifs, Atom_pseudo& pp)
 	GlobalV::ofs_running << std::setw(15) << "Z(VALENCE)" << std::setw(15) << pp.zv << std::endl;
 	// (5) spd_loc, which local pseudopotential should I choose
 	ifs >> value; length = value.find(","); value.erase(length,1);
-	spd_loc = std::atoi( value.c_str() );
+	spd_loc = std::stoi(value);
 	GlobalV::ofs_running << std::setw(15) << "LOC(spd)" << std::setw(15) << spd_loc << std::endl;
 	// (6) read in the occupations
 	std::vector<double> tmp_oc(3, 0.0);
 	ifs >> value; length = value.find(","); value.erase(length,1);
-	tmp_oc[0]= std::atoi( value.c_str() );
+	tmp_oc[0]= std::stoi(value);
 	ifs >> value; length = value.find(","); value.erase(length,1);
-	tmp_oc[1]= std::atoi( value.c_str() );
+	tmp_oc[1]= std::stoi(value);
 	ifs >> value; length = value.find(","); value.erase(length,1);
-	tmp_oc[2]= std::atoi( value.c_str() );
+	tmp_oc[2]= std::stoi(value);
 	GlobalV::ofs_running << std::setw(15) << "OCCUPATION" << std::setw(15) << tmp_oc[0] 
 	<< std::setw(15) << tmp_oc[1] << std::setw(15) << tmp_oc[2] << std::endl;
 	// (7) spin orbital


### PR DESCRIPTION
## Description
According to Case 2 in the homework, I have replaced the insecure C-style string-to-number conversion functions (`atoi`, `atof`) with modern C++ standard functions (`std::stoi`, `std::stod`).

## Changes
- Replaced `std::atoi(val.c_str())` with `std::stoi(val)` in `read_pp_upf201.cpp` and `read_pp_vwr.cpp`.
- Replaced `atof` with `std::stod` in pseudo-potential reading logic.
- Added `#include <string>` in files where it was missing to ensure compilation.
- Cleaned up redundant `.c_str()` calls to make the code more concise.
- Applied similar fixes to `ORB_nonlocal_lm_test.cpp` to maintain consistency.

## Motivation
- `std::stoi/stod` are safer as they throw exceptions on conversion failure.
- Modern C++ style improves code readability and maintainability.