### PR TITLE
Feature: support run Nudged Elastic Band (NEB) calculation in CLI mode

### DIFF
--- a/interfaces/ASE_interface/abacuslite/cli/__init__.py
+++ b/interfaces/ASE_interface/abacuslite/cli/__init__.py
@@ -42,7 +42,7 @@ def main():
         # 'gcmc': gcmc_cli,
     }
     # run the task
-    task[args.task](args)
+    task[args.task](*list(vars(args).values())[1:])
 
 if __name__ == '__main__':
     main()

--- a/interfaces/ASE_interface/abacuslite/cli/__init__.py
+++ b/interfaces/ASE_interface/abacuslite/cli/__init__.py
@@ -1,0 +1,48 @@
+'''abacuslite supports some complicated tasks run in cli mode
+'''
+import argparse
+from abacuslite.cli.neb import (
+    DESCRIPTION as neb_description,
+    add_argument as add_neb_argument,
+    run as neb_cli
+)
+# from abacuslite.cli.gcmc import (
+#     DESCRIPTION as gcmc_description,
+#     add_argument as add_gcmc_argument,
+#     run as gcmc_cli
+# )
+DESCRIPTION = '''AbacusLite CLI - user-friendly interface for complicated tasks
+Currently the cli supports following tasks:
+- NEB calculation
+'''
+
+def main():
+    '''
+    build parser and re-direct to the corresponding implementation
+    '''
+    root = argparse.ArgumentParser(description=DESCRIPTION)
+    subparsers = root.add_subparsers(dest='task', help='task help')
+
+    # NEB
+    neb = subparsers.add_parser('neb', help=neb_description)
+    # add the argument for neb calculation
+    add_neb_argument(neb)
+
+    # # GCMC
+    # gcmc = subparsers.add_parser('gcmc', help=gcmc_description)
+    # # add the argument for gcmc calculation
+    # add_gcmc_argument(gcmc)
+
+    # =======================================================
+    # parse
+    args = root.parse_args()
+    print(f'Abacuslite-CLI: task={args.task}')
+    task = {
+        'neb': neb_cli,
+        # 'gcmc': gcmc_cli,
+    }
+    # run the task
+    task[args.task](args)
+
+if __name__ == '__main__':
+    main()

--- a/interfaces/ASE_interface/abacuslite/cli/neb.py
+++ b/interfaces/ASE_interface/abacuslite/cli/neb.py
@@ -31,10 +31,9 @@ neb:
   parallel-images: true
 ```
 '''
-from pathlib import Path
-import unittest
 import argparse
 from typing import Dict
+from pathlib import Path
 
 try:
     from yaml import safe_load
@@ -78,7 +77,8 @@ def add_argument(parser: argparse.ArgumentParser):
                         help='k-points file, in ABACUS KPT format. If you set either '
                              'the `gamma_only` or `kspacing` in INPUT file, you can '
                              'ignore this flag',
-                        required=False)
+                        required=False,
+                        default=None)
     parser.add_argument('--configure', type=str, 
                         help='controls the details of the neb calculation, including '
                              'the number of images (replica, the initial and the final'
@@ -96,7 +96,7 @@ def check(conf):
     for section in NECESSARY_SECTIONS:
         assert section in conf, f'{section} section is required'
     
-def run(finp, fini, ffin, fneb, fkpt):
+def run(finp, fini, ffin, fkpt, fneb):
     conf = safe_load(open(fneb))
     _ = check(conf)
 
@@ -136,36 +136,3 @@ def run(finp, fini, ffin, fneb, fkpt):
     runner.run(fmax=nebparam['optimize']['fmax'],
                steps=nebparam['optimize'].get('nmax', 200))
     return ftraj
-
-class TestNEBCli(unittest.TestCase):
-
-    here = Path(__file__).parent
-    testfiles = here / 'testfiles'
-
-    def test_yaml_read(self):
-        param = {
-            'aprof': {
-                'command': 'mpirun -np 8 abacus',
-                'pseudo_dir': './',
-                'orbital_dir': './',
-                'omp_num_threads': 1,
-            },
-            'neb': {
-                'nreplica': 7,
-                'kspring': 0.02,
-                'fmax': 0.05,
-                'type': 'neb',
-                'atst': {
-                    'autoneb': {
-                        'placeholder1': 'TBD',
-                        'placeholder2': 'TBD',
-                    },
-                },
-                'parallel-images': True,
-            },
-        }
-        with open(self.testfiles / 'neb.yaml') as f:
-            self.assertEqual(param, safe_load(f))
-
-if __name__ == '__main__':
-    unittest.main()

--- a/interfaces/ASE_interface/abacuslite/cli/neb.py
+++ b/interfaces/ASE_interface/abacuslite/cli/neb.py
@@ -59,10 +59,33 @@ DESCRIPTION = '''Nudged Elastic Band (NEB) calculation
 
 def add_argument(parser: argparse.ArgumentParser):
     '''add argument for neb calculation'''
-    parser.add_argument('--ini', type=str, help='initial structure file')
-    parser.add_argument('--fin', type=str, help='final structure file')
-    parser.add_argument('--kpts', type=str, help='k-points file')
-    parser.add_argument('--configure', type=str, help='configure file')
+    parser.add_argument('-i', '--input', type=str, 
+                        help='standard ABACUS INPUT file, to define the calculation '
+                             'settings including `basis_type`, and so on. NOTE: '
+                             'if you define the `kspacing` here, you are not '
+                             'required to provide the KPT file via `kpts` flag. This '
+                             'file MUST be provided',
+                        required=True)
+    parser.add_argument('--ini', type=str, 
+                        help='initial structure file in STRU format. '
+                             'This file MUST be provided',
+                        required=True)
+    parser.add_argument('--fin', type=str, 
+                        help='final structure file in STRU format. '
+                             'This file MUST be provided',
+                        required=True)
+    parser.add_argument('--kpts', type=str, 
+                        help='k-points file, in ABACUS KPT format. If you set either '
+                             'the `gamma_only` or `kspacing` in INPUT file, you can '
+                             'ignore this flag',
+                        required=False)
+    parser.add_argument('--configure', type=str, 
+                        help='controls the details of the neb calculation, including '
+                             'the number of images (replica, the initial and the final'
+                             ' structures included), band type (e.g., cineb, neb, '
+                             'atst-autoneb, atst-autoneb-sella, etc.), etc. '
+                             'This file MUST be provided',
+                        required=True)
 
 def check(conf):
     '''

--- a/interfaces/ASE_interface/abacuslite/cli/neb.py
+++ b/interfaces/ASE_interface/abacuslite/cli/neb.py
@@ -1,0 +1,148 @@
+'''
+CLI calling example:
+```bash
+abacuslite neb -i INPUT 
+               --kpts KPT
+               --prefix neb
+               --ini STRU1
+               --fin STRU2
+               --configure neb.yaml
+```
+
+YAML configuration file example:
+```yaml
+aprof:
+  command: 'mpirun -np 8 abacus'
+  pseudo_dir: './'
+  orbital_dir: './'
+  omp_num_threads: 1
+
+neb:
+  nreplica: 7
+  kspring: 0.02
+  fmax: 0.05
+
+  type: 'neb' # neb, cineb, atst-autoneb, atst-autoneb-sella
+  atst:
+    autoneb:
+      placeholder1: 'TBD'
+      placeholder2: 'TBD'
+  
+  parallel-images: true
+```
+'''
+from pathlib import Path
+import unittest
+import argparse
+from typing import Dict
+
+try:
+    from yaml import safe_load
+except ModuleNotFoundError:
+    print('Please install yaml module by `pip install pyyaml`')
+    raise
+
+from ase.atoms import Atoms
+from ase.optimize import FIRE, BFGS
+from ase.optimize.optimize import Optimizer
+from ase.mep import NEB
+
+from abacuslite.io.generalio import read_stru
+from abacuslite.cli.utils import (
+    build_atoms_from_stru,
+    build_aprof,
+    build_calc
+)
+
+DESCRIPTION = '''Nudged Elastic Band (NEB) calculation
+'''
+
+def add_argument(parser: argparse.ArgumentParser):
+    '''add argument for neb calculation'''
+    parser.add_argument('--ini', type=str, help='initial structure file')
+    parser.add_argument('--fin', type=str, help='final structure file')
+    parser.add_argument('--kpts', type=str, help='k-points file')
+    parser.add_argument('--configure', type=str, help='configure file')
+
+def check(conf):
+    '''
+    check the correctness of the neb calculation configuration
+    '''
+    assert isinstance(conf, Dict)
+    NECESSARY_SECTIONS = ['io', 'aprof', 'neb']
+    for section in NECESSARY_SECTIONS:
+        assert section in conf, f'{section} section is required'
+    
+def run(finp, fini, ffin, fneb, fkpt):
+    conf = safe_load(open(fneb))
+    _ = check(conf)
+
+    # special check for this function
+    assert conf['neb']['type'] in ['neb', 'cineb']
+
+    ini, psp, orb = build_atoms_from_stru(read_stru(fini))
+    fin, _, _ = build_atoms_from_stru(read_stru(ffin))
+
+    assert isinstance(ini, Atoms)
+    assert isinstance(fin, Atoms)
+
+    outdir = Path(conf['io']['outdir'])
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    nrep = conf['neb']['nreplica']
+    replica = []
+    for irep in range(nrep):
+        image = ini.copy() if irep <= (nrep // 2) else fin.copy()
+        image.calc = build_calc(build_aprof(**conf['aprof']),
+            pseudopotentials=psp, basissets=orb,
+            finp=finp, fkpt=fkpt,
+            directory=outdir / f'{conf["io"].get("prefix", "abacuslite-neb")}-{irep}')
+        replica.append(image)
+
+    nebparam: Dict = conf['neb']
+    band = NEB(replica, 
+               k=nebparam['kspring'], 
+               climb=bool(nebparam['type'] == 'cineb'),
+               parallel=nebparam.get('parallel-images', False))
+
+    band.interpolate(method='linear' if not nebparam.get('idpp') else 'idpp')
+    
+    ftraj = outdir / f'{conf["io"].get("prefix", "abacuslite-neb")}.traj'
+    runner: Optimizer = {'fire': FIRE, 'bfgs': BFGS}[nebparam['optimize']['method'].lower()](
+        band, trajectory=ftraj)
+    runner.run(fmax=nebparam['optimize']['fmax'],
+               steps=nebparam['optimize'].get('nmax', 200))
+    return ftraj
+
+class TestNEBCli(unittest.TestCase):
+
+    here = Path(__file__).parent
+    testfiles = here / 'testfiles'
+
+    def test_yaml_read(self):
+        param = {
+            'aprof': {
+                'command': 'mpirun -np 8 abacus',
+                'pseudo_dir': './',
+                'orbital_dir': './',
+                'omp_num_threads': 1,
+            },
+            'neb': {
+                'nreplica': 7,
+                'kspring': 0.02,
+                'fmax': 0.05,
+                'type': 'neb',
+                'atst': {
+                    'autoneb': {
+                        'placeholder1': 'TBD',
+                        'placeholder2': 'TBD',
+                    },
+                },
+                'parallel-images': True,
+            },
+        }
+        with open(self.testfiles / 'neb.yaml') as f:
+            self.assertEqual(param, safe_load(f))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/interfaces/ASE_interface/abacuslite/cli/testfiles/neb.yaml
+++ b/interfaces/ASE_interface/abacuslite/cli/testfiles/neb.yaml
@@ -1,0 +1,27 @@
+io: 
+  prefix: 'neb'
+  outdir: './'
+
+aprof:
+  command: 'mpirun -np 8 abacus'
+  pseudo_dir: './'
+  orbital_dir: './'
+  omp_num_threads: 1
+
+neb:
+  nreplica: 7
+  kspring: 0.02
+  
+  optimize:
+    method: 'fire'
+    fmax: 0.05,
+    nmax: 200
+
+  type: 'neb' # neb, cineb, atst-autoneb, atst-autoneb-sella
+  atst:
+    autoneb:
+      placeholder1: 'TBD'
+      placeholder2: 'TBD'
+  
+  parallel-images: true
+  idpp: true

--- a/interfaces/ASE_interface/abacuslite/cli/utils.py
+++ b/interfaces/ASE_interface/abacuslite/cli/utils.py
@@ -1,0 +1,124 @@
+'''the utilities that only used in cli mode'''
+import uuid
+import tempfile
+from pathlib import Path
+from typing import Dict, Tuple, List, Optional
+from ase.atoms import Atoms
+from ase.build import bulk
+from ase.constraints import FixCartesian
+import unittest
+import numpy as np
+
+from abacuslite import Abacus, AbacusProfile
+from abacuslite.io.generalio import write_stru, read_stru, read_input, read_kpt
+
+def build_atoms_from_stru(stru) -> Tuple[Atoms, Dict[str, str], Dict[str, str]]:
+    '''
+    cast the read_stru returned dictionary to the ase.atoms.Atoms object,
+    optionally along with the mapping (correspondence) between the 
+    element and the pseudopotential files and the orbital files
+
+    Parameters
+    ----------
+    the stru : Dict
+        the read_stru returned dictionary
+    with_psp : bool, optional
+        whether to return the mapping of pseudopotential files
+    with_orb : bool, optional
+        whether to return the mapping of the orbital files
+    '''
+    from ase.units import (
+        Bohr as __BOHR__, 
+        Angstrom as __ANGSTROM__
+    )
+    cell = np.array(stru['lat']['vec']).reshape(3, 3)
+    cell *= stru['lat']['const'] # in bohr
+    cell /= __ANGSTROM__ / __BOHR__ # in Angstrom
+    
+    elem, pos, mob, psp, orb = [], [], [], {}, {}
+    for s in stru['species']:
+        elem.extend([s['symbol']]*s['natom'])
+        pos.extend([atom['coord'] for atom in s['atom']])
+        mob.extend([atom['m'] for atom in s['atom']])
+        psp[s['symbol']] = s['pp_file']
+        orb[s['symbol']] = s.get('orb_file')
+    # reshape
+    pos = np.array(pos).reshape(-1, 3)
+    constraints = [True if not m else False for m in np.array(mob, dtype=bool).flatten()]
+    constraints = [FixCartesian(i, c) for i, c in enumerate(np.array(constraints).reshape(-1, 3))]
+
+    # position transformation
+    if stru['coord_type'].lower() == 'direct':
+        pos = pos @ cell.T
+    if stru['coord_type'].lower() in ['cartesian', 'cartesian_au']:
+        pos *= stru['lat']['const'] # in bohr
+        pos /= __ANGSTROM__ / __BOHR__ # in angstrom
+    if stru['coord_type'].lower().startswith('cartesian_angstrom'):
+        pass # do nothing
+
+    return Atoms(symbols=elem, positions=pos, cell=cell, pbc=True,
+                 constraint=constraints), psp, orb
+
+def build_aprof(command,
+                pseudo_dir,
+                orbital_dir,
+                omp_num_threads,
+                **kwargs) -> AbacusProfile:
+    return AbacusProfile(command, 
+                         pseudo_dir, 
+                         orbital_dir, 
+                         omp_num_threads,
+                         **kwargs)
+
+def build_calc(aprof: AbacusProfile,
+               pseudopotentials: Dict[str, str],
+               basissets: Optional[Dict[str, str]],
+               finp: Path | str,
+               fkpt: Optional[Path | str],
+               **kwargs) -> Abacus:
+    inp = read_input(finp)
+    inp = dict(profile=aprof,
+               directory=kwargs.get('directory', str(uuid.uuid4().hex)),
+               pseudopotentials=pseudopotentials,
+               basissets=basissets,
+               inp=inp
+               )
+    if 'directory' in kwargs:
+        del kwargs['directory']
+    if fkpt:
+        inp['kpts'] = read_kpt(fkpt)
+    return Abacus(**inp, **kwargs)
+
+class TestCliUtils(unittest.TestCase):
+    here = Path(__file__).parent
+    testfiles = here / 'testfiles'
+    def test_build_atoms_from_stru(self):
+        nacl = bulk('NaCl', 'rocksalt', a=5.64)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fstru =write_stru(
+                nacl, 
+                outdir=tmpdir, 
+                pp_file={
+                    'Na': 'Na.pz-bhs.UPF',
+                    'Cl': 'Cl.pz-bhs.UPF'
+                },
+                orb_file={
+                    'Na': 'Na_gga_6au_100Ry_2s2p1d.orb',
+                    'Cl': 'Cl_gga_6au_100Ry_2s2p1d.orb',
+                },
+            )
+            stru = read_stru(fstru)
+        # print(nacl.positions) # [[0.   0.   0.  ], [2.82 0.   0.  ]]
+        # print(nacl.get_chemical_symbols()) # ['Na', 'Cl']
+        nacl_, psp, orb = build_atoms_from_stru(stru)
+        self.assertTrue(np.allclose(nacl.cell, nacl_.cell))
+        self.assertTrue(np.allclose(nacl_.positions, 
+                                    [[2.82, 0., 0.],
+                                     [  0., 0., 0.]]))
+        self.assertListEqual(nacl_.get_chemical_symbols(), ['Cl', 'Na'])
+        self.assertDictEqual(psp, {'Na': 'Na.pz-bhs.UPF', 'Cl': 'Cl.pz-bhs.UPF'})
+        self.assertDictEqual(orb, {'Na': 'Na_gga_6au_100Ry_2s2p1d.orb', 
+                                   'Cl': 'Cl_gga_6au_100Ry_2s2p1d.orb'})
+
+if __name__ == '__main__':
+    unittest.main()

--- a/interfaces/ASE_interface/examples/neb-cli/init.py
+++ b/interfaces/ASE_interface/examples/neb-cli/init.py
@@ -1,0 +1,68 @@
+'''
+generate the necessary files for running the NEB calculation in cli mode
+'''
+from pathlib import Path
+here = Path(__file__).parent
+
+import numpy as np
+from ase.atoms import Atoms
+
+from abacuslite.io.generalio import write_stru, write_input
+
+# find the PP_ORB directory
+pporb = here.parent.parent.parent.parent / 'tests' / 'PP_ORB'
+pporb = pporb.resolve()
+
+# build the Atoms objects
+elem = ['Ti', 'Pb', 'O', 'O', 'O']
+pseudopotentials = {
+    'Ti': 'Ti_ONCV_PBE-1.0.upf',
+    'Pb': 'Pb_ONCV_PBE-1.0.upf',
+    'O' : 'O_ONCV_PBE-1.0.upf',
+}
+basissets = {
+    'Ti': 'Ti_gga_8au_100Ry_4s2p2d1f.orb',
+    'Pb': 'Pb_gga_7au_100Ry_2s2p2d1f.orb',
+    'O' : 'O_gga_7au_100Ry_2s2p1d.orb',
+}
+
+taud = np.array([
+    [0.5, 0.5, 0.5948316037314115],
+    [0.0, 0.0, 0.1235879499999999],
+    [0.0, 0.5, 0.5094847864489368],
+    [0.5, 0.0, 0.5094847864489368],
+    [0.5, 0.5, 0.0088672395150394],
+])
+cell = np.array([
+   [3.8795519, 0.0000000, 0.00000000],
+   [0.0000000, 3.8795519, 0.00000000],
+   [0.0000000, 0.0000000, 4.28588762],
+])
+
+# we have relaxed with the parameters above :)
+write_stru(Atoms(elem, cell=cell, scaled_positions=taud), 
+           outdir=here, pp_file=pseudopotentials, orb_file=basissets, fname='STRU1')
+
+# get the polarisation inversed by inversing the Ti atoms
+taud = np.array([
+    [0.5, 0.5, 0.6508136593687969],
+    [0.0, 0.0, 0.1235879499999999],
+    [0.0, 0.5, 0.7348401327639794],
+    [0.5, 0.0, 0.7348401327639794],
+    [0.5, 0.5, 0.2364165087650052],
+])
+write_stru(Atoms(elem, cell=cell, scaled_positions=taud), 
+           outdir=here, pp_file=pseudopotentials, orb_file=basissets, fname='STRU2')
+
+write_input(
+    data={
+        'basis_type': 'lcao',
+        'symmetry': 1,
+        'kspacing': 0.25, # Oops!
+        'init_chg': 'auto',
+        'cal_force': 1,
+        'pseudo_dir': pporb,
+        'orbital_dir': pporb,
+    },
+    fn=here / 'INPUT'
+)

--- a/interfaces/ASE_interface/examples/neb-cli/neb.yaml
+++ b/interfaces/ASE_interface/examples/neb-cli/neb.yaml
@@ -3,9 +3,9 @@ io:
   outdir: './'
 
 aprof:
-  command: 'mpirun -np 8 abacus'
-  pseudo_dir: './'
-  orbital_dir: './'
+  command: 'mpirun -np 8 abacus_2p'
+  pseudo_dir: '/root/deepmodeling/abacus-develop/tests/PP_ORB'
+  orbital_dir: '/root/deepmodeling/abacus-develop/tests/PP_ORB'
   omp_num_threads: 1
 
 neb:

--- a/interfaces/ASE_interface/pyproject.toml
+++ b/interfaces/ASE_interface/pyproject.toml
@@ -22,3 +22,6 @@ dependencies = [
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["abacuslite*"]
+
+[project.scripts]
+abacuslite = "abacuslite.cli:main"


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### Unit Tests and/or Case Tests for my changes
- Not needed

### What's changed?
- Although the abacuslite provides flexible enough API, there are still users find it is not easy enough to perform the NEB calculation because not familiar with Python. Here a cli mode is provided:
```bash
abacuslite neb -i INPUT --ini STRU1 --fin STRU2 --configure neb.yaml
```
, such that all users can benefit from abacuslite

### Any changes of core modules? (ignore if not applicable)
- No
