### PR TITLE
2026PKUCourseHW5: replace magic number and C-style cast in sto_wf

### DIFF
--- a/source/source_pw/module_stodft/sto_wf.cpp
+++ b/source/source_pw/module_stodft/sto_wf.cpp
@@ -63,10 +63,12 @@ void Stochastic_WF<T, Device>::clean_chiallorder()
 template <typename T, typename Device>
 void Stochastic_WF<T, Device>::init_sto_orbitals(const int seed_in)
 {
-    const unsigned int rank_seed_offset = 10000;
+    constexpr unsigned int RANK_SEED_OFFSET = 10000U;
     if (seed_in == 0 || seed_in == -1)
     {
-        srand(static_cast<unsigned int>(time(nullptr)) + GlobalV::MY_RANK * rank_seed_offset); // GlobalV global variables are reserved
+        
+        srand(static_cast<unsigned int>(time(nullptr))
+                + static_cast<unsigned int>(GlobalV::MY_RANK) * RANK_SEED_OFFSET);
     }
     else
     {


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [x] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
No linked issue.

### Unit Tests and/or Case Tests for my changes
No additional unit test is added because this PR is a small refactoring change and does not modify program behavior.

### What's changed?
- replaced the magic number `10000` with a named constant
- replaced the C-style cast with `static_cast<unsigned int>`
- improved readability and code style in `source/source_pw/module_stodft/sto_wf.cpp`

### Any changes of core modules? (ignore if not applicable)
Not applicable.