### PR TITLE
2026PKUcourseHW5：optimize elecstate_pw_op kernels by pre-calculated constants and value passing

### DIFF
--- a/source/source_estate/kernels/cuda/elecstate_op.cu
+++ b/source/source_estate/kernels/cuda/elecstate_op.cu
@@ -59,8 +59,8 @@ __global__ void elecstate_pw(
 
 template <typename FPTYPE>
 void elecstate_pw_op<FPTYPE, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* ctx,
-                                                                  const int& spin,
-                                                                  const int& nrxx,
+                                                                  int spin,
+                                                                  int nrxx,
                                                                   const FPTYPE& w1,
                                                                   FPTYPE** rho,
                                                                   const std::complex<FPTYPE>* wfcr)
@@ -76,9 +76,9 @@ void elecstate_pw_op<FPTYPE, base_device::DEVICE_GPU>::operator()(const base_dev
 
 template <typename FPTYPE>
 void elecstate_pw_op<FPTYPE, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* ctx,
-                                                                  const bool& DOMAG,
-                                                                  const bool& DOMAG_Z,
-                                                                  const int& nrxx,
+                                                                  bool DOMAG,
+                                                                  bool DOMAG_Z,
+                                                                  int nrxx,
                                                                   const FPTYPE& w1,
                                                                   FPTYPE** rho,
                                                                   const std::complex<FPTYPE>* wfcr,

--- a/source/source_estate/kernels/elecstate_op.cpp
+++ b/source/source_estate/kernels/elecstate_op.cpp
@@ -26,9 +26,9 @@ struct elecstate_pw_op<FPTYPE, base_device::DEVICE_CPU>
     }
 
     void operator()(const base_device::DEVICE_CPU* ctx,
-                    const bool& DOMAG,
-                    const bool& DOMAG_Z,
-                    const int& nrxx,
+                    const bool DOMAG,
+                    const bool DOMAG_Z,
+                    const int nrxx,
                     const FPTYPE& w1,
                     FPTYPE** rho,
                     const std::complex<FPTYPE>* wfcr,
@@ -42,16 +42,15 @@ struct elecstate_pw_op<FPTYPE, base_device::DEVICE_CPU>
       }
       // In this case, calculate the three components of the magnetization
       if (DOMAG)
-      {
+      {  
+         const FPTYPE w2 = w1 * static_cast<FPTYPE>(2.0);
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
           for (int ir = 0; ir < nrxx; ir++) {
-              rho[1][ir] += w1 * 2.0
-                                          * (wfcr[ir].real() * wfcr_another_spin[ir].real()
+              rho[1][ir] += w2 * (wfcr[ir].real() * wfcr_another_spin[ir].real()
                                              + wfcr[ir].imag() * wfcr_another_spin[ir].imag());
-              rho[2][ir] += w1 * 2.0
-                                          * (wfcr[ir].real() * wfcr_another_spin[ir].imag()
+              rho[2][ir] += w2 * (wfcr[ir].real() * wfcr_another_spin[ir].imag()
                                              - wfcr_another_spin[ir].real() * wfcr[ir].imag());
               rho[3][ir] += w1 * (norm(wfcr[ir]) - norm(wfcr_another_spin[ir]));
           }

--- a/source/source_estate/kernels/elecstate_op.cpp
+++ b/source/source_estate/kernels/elecstate_op.cpp
@@ -6,8 +6,8 @@ template <typename FPTYPE>
 struct elecstate_pw_op<FPTYPE, base_device::DEVICE_CPU>
 {
     void operator()(const base_device::DEVICE_CPU* /*ctx*/,
-                    const int& spin,
-                    const int& nrxx,
+                    const int spin,
+                    const int nrxx,
                     const FPTYPE& w1,
                     FPTYPE** rho,
                     const std::complex<FPTYPE>* wfcr)

--- a/source/source_estate/kernels/elecstate_op.h
+++ b/source/source_estate/kernels/elecstate_op.h
@@ -23,8 +23,8 @@ struct elecstate_pw_op {
   /// @param rho - electronic densities
   void operator() (
       const Device* ctx,
-      const int& spin,
-      const int& nrxx,
+      const int spin,
+      const int nrxx,
       const FPTYPE& weight,
       FPTYPE** rho,
       const std::complex<FPTYPE>* wfcr);
@@ -44,9 +44,9 @@ struct elecstate_pw_op {
   /// @param rho - electronic densities
   void operator() (
       const Device* ctx,
-      const bool& DOMAG,
-      const bool& DOMAG_Z,
-      const int& nrxx,
+      const bool DOMAG,
+      const bool DOMAG_Z,
+      const int nrxx,
       const FPTYPE& weight,
       FPTYPE** rho,
       const std::complex<FPTYPE>* wfcr,
@@ -58,16 +58,16 @@ template <typename FPTYPE>
 struct elecstate_pw_op<FPTYPE, base_device::DEVICE_GPU>
 {
     void operator()(const base_device::DEVICE_GPU* ctx,
-                    const int& spin,
-                    const int& nrxx,
+                    int spin,
+                    int nrxx,
                     const FPTYPE& w1,
                     FPTYPE** rho,
                     const std::complex<FPTYPE>* wfcr);
 
     void operator()(const base_device::DEVICE_GPU* ctx,
-                    const bool& DOMAG,
-                    const bool& DOMAG_Z,
-                    const int& nrxx,
+                    bool DOMAG,
+                    bool DOMAG_Z,
+                    int nrxx,
                     const FPTYPE& w1,
                     FPTYPE** rho,
                     const std::complex<FPTYPE>* wfcr,

--- a/source/source_estate/kernels/rocm/elecstate_op.hip.cu
+++ b/source/source_estate/kernels/rocm/elecstate_op.hip.cu
@@ -59,8 +59,8 @@ __global__ void elecstate_pw(
 
 template <typename FPTYPE>
 void elecstate_pw_op<FPTYPE, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* ctx,
-                                                                  const int& spin,
-                                                                  const int& nrxx,
+                                                                  int spin,
+                                                                  int nrxx,
                                                                   const FPTYPE& w1,
                                                                   FPTYPE** rho,
                                                                   const std::complex<FPTYPE>* wfcr)
@@ -76,9 +76,9 @@ void elecstate_pw_op<FPTYPE, base_device::DEVICE_GPU>::operator()(const base_dev
 
 template <typename FPTYPE>
 void elecstate_pw_op<FPTYPE, base_device::DEVICE_GPU>::operator()(const base_device::DEVICE_GPU* ctx,
-                                                                  const bool& DOMAG,
-                                                                  const bool& DOMAG_Z,
-                                                                  const int& nrxx,
+                                                                  bool DOMAG,
+                                                                  bool DOMAG_Z,
+                                                                  int nrxx,
                                                                   const FPTYPE& w1,
                                                                   FPTYPE** rho,
                                                                   const std::complex<FPTYPE>* wfcr,


### PR DESCRIPTION
Based on C++ best practices

What's changed?
[ ] Parameter Passing. Changed primitive types (int, bool) from const & to value passing, following C++ Core Guideline F.16. 
This avoids unnecessary memory indirection and improves register usage.(from 8 byte back to 1-4 byte without safety questions).
[ ] Pre-calculation. w1 * 2.0 (as w2) outside the nrxx loop in the magnetization calculation. This reduces the number of multiplications inside the hot loop 2×nrxx times (with zero permanent memory)