### PR TITLE
2026PKUCourseHW5: Refactor: replace sprintf with std::snprintf in genelpa utils for memory safety

### DIFF
--- a/source/source_hsolver/module_genelpa/utils.cpp
+++ b/source/source_hsolver/module_genelpa/utils.cpp
@@ -4,6 +4,7 @@
 #include "source_base/module_external/scalapack_connector.h"
 
 #include <complex>
+#include <cstdio>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -145,7 +146,7 @@ void saveLocalMatrix(const char filePrefix[], int narows, int nacols, double* a)
     myid = 0;
 #endif
 
-    sprintf(FileName, "%s_%3.3d.dat", filePrefix, myid);
+    std::snprintf(FileName, sizeof(FileName), "%s_%3.3d.dat", filePrefix, myid);
     matrixFile.open(FileName);
     matrixFile.flags(std::ios_base::scientific);
     matrixFile.precision(17);
@@ -283,7 +284,7 @@ void saveLocalMatrix(const char filePrefix[], int narows, int nacols, std::compl
     myid = 0;
 #endif
 
-    sprintf(FileName, "%s_%3.3d.dat", filePrefix, myid);
+    std::snprintf(FileName, sizeof(FileName), "%s_%3.3d.dat", filePrefix, myid);
     matrixFile.open(FileName);
     matrixFile.flags(std::ios_base::scientific);
     matrixFile.precision(17);


### PR DESCRIPTION
### Description
Replaced the `sprintf` function with `std::snprintf` in `source/source_hsolver/module_genelpa/utils.cpp`. 

### Motivation and Context
`sprintf` does not perform bounds checking, which can potentially lead to buffer overflow if the combined string of `filePrefix` and `myid` exceeds the allocated size of `FileName`. Using `std::snprintf` with `sizeof(FileName)` ensures memory safety by strictly limiting the number of characters written to the buffer. Also included `<cstdio>` as required.

### Type of change
- [x] Refactoring (non-breaking change which improves code quality/safety)