### PR TITLE
2026PKUCourseHW5：add file open check in utils.cpp

### DIFF
--- a/source/source_hsolver/module_genelpa/utils.cpp
+++ b/source/source_hsolver/module_genelpa/utils.cpp
@@ -3,6 +3,7 @@
 #include "source_base/module_external/blacs_connector.h"
 #include "source_base/module_external/scalapack_connector.h"
 
+#include <cerrno>
 #include <complex>
 #include <cstring>
 #include <fstream>
@@ -91,8 +92,14 @@ void loadMatrix(const char FileName[], int nFull, double* a, int* desca, int bla
 
     const int ROOT_PROC = 0;
     std::ifstream matrixFile;
-    if (myid == ROOT_PROC)
-        matrixFile.open(FileName);
+    if (myid == ROOT_PROC) {
+    matrixFile.open(FileName);
+    if (!matrixFile.is_open()) {
+        std::cerr << "Error: Failed to open file " << FileName 
+                  << " (errno: " << errno << ")" << std::endl;
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+}
 
     double* b = nullptr; // buffer
     const int MAX_BUFFER_SIZE = 1e9; // max buffer size is 1GB


### PR DESCRIPTION
### Reminder
- [ x] Have you linked an issue with this pull request?
- [ x] Have you added adequate unit tests and/or case tests for your pull request?
- [ x] Have you noticed possible changes of behavior below or in the linked issue?
- [ x] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
#None

### Unit Tests and/or Case Tests for my changes
- No unit test added - this is a simple error handling improvement.

### What's changed?
-Added file open check in `source/source_hsolver/module_genelpa/utils.cpp` (line 94-95). If file open fails, print error message and call MPI_Abort.


### Any changes of core modules? (ignore if not applicable)
- No
