### PR TITLE
2026PKUCourseHW5：Fix issues in partial files in the source directory

### DIFF
--- a/source/source_base/mcd.c
+++ b/source/source_base/mcd.c
@@ -585,6 +585,7 @@ int MCD_asprintf(char **ptr,const char *fmt,char *fun, char*file, int line,...)
 		fprintf(RTL,"asprintf failure %s:%s, line %i [id ",
 			file,fun,line);
 		#endif
+		va_end(argptr); //cleanup va_list  
 		return retval;
 	}
 	va_end(argptr);

--- a/source/source_base/vector3.h
+++ b/source/source_base/vector3.h
@@ -152,8 +152,7 @@ template <class T> class Vector3
     T operator[](int index) const
     {
         //return (&x)[index]; // this is undefind behavior and breaks with icpx
-        T const* ptr[3] = {&x, &y, &z};
-        return *ptr[index];
+        return *(&x + index);
     }
 
     /**
@@ -165,8 +164,7 @@ template <class T> class Vector3
     T &operator[](int index)
     {
         //return (&x)[index]; // this is undefind behavior and breaks with icpx
-        T* ptr[3] = {&x, &y, &z};
-        return *ptr[index];
+        return *(&x + index);
     }
 
     /**

--- a/source/source_cell/unitcell.cpp
+++ b/source/source_cell/unitcell.cpp
@@ -498,8 +498,9 @@ void UnitCell::compare_atom_labels(const std::string &label1, const std::string 
 					break;
 				}
 			}
-			stru_label[0] = toupper(stru_label[0]);
-
+			if(!stru_label.empty()){
+				stru_label[0] = toupper(stru_label[0]);
+			}
 			for (int ip = 0; ip < label2.length(); ip++)
 			{
 				if (!(isdigit(label2[ip]) || label2[ip] == '_'))

--- a/source/source_hsolver/module_genelpa/utils.cpp
+++ b/source/source_hsolver/module_genelpa/utils.cpp
@@ -91,8 +91,14 @@ void loadMatrix(const char FileName[], int nFull, double* a, int* desca, int bla
 
     const int ROOT_PROC = 0;
     std::ifstream matrixFile;
-    if (myid == ROOT_PROC)
-        matrixFile.open(FileName);
+    if (myid == ROOT_PROC){
+	matrixFile.open(FileName);
+
+	if (!matrixFile.is_open()){
+		std::cerr << "Error: cannot open file " << FileName << std::endl;
+		return;
+	}
+    }
 
     double* b; // buffer
     const int MAX_BUFFER_SIZE = 1e9; // max buffer size is 1GB

--- a/source/source_io/module_output/cif_io.cpp
+++ b/source/source_io/module_output/cif_io.cpp
@@ -195,8 +195,8 @@ std::map<std::string, std::vector<std::string>> _build_block_data(const std::vec
     std::vector<std::string> values;
     // first drop all elements that does not startswith "_" before the first element that startswith "_"
     std::vector<std::string> block_ = block;
-    auto it = std::find_if(block.begin(), block.end(), [](const std::string& s) { return FmtCore::startswith(s, "_"); });
-    if (it != block.begin())
+    auto it = std::find_if(block_.begin(), block_.end(), [](const std::string& s) { return FmtCore::startswith(s, "_"); });
+    if (it != block_.begin())
     {
         block_.erase(block_.begin(), it);
     }

--- a/source/source_pw/module_pwdft/op_pw_exx_pot.cpp
+++ b/source/source_pw/module_pwdft/op_pw_exx_pot.cpp
@@ -41,6 +41,7 @@ void get_exx_potential(const K_Vectors* kv,
 
     if (ik > nks)
     {
+	delete[] pot_cpu;    //release memory
         return;
     }
 

--- a/source/source_pw/module_stodft/sto_wf.cpp
+++ b/source/source_pw/module_stodft/sto_wf.cpp
@@ -64,13 +64,14 @@ void Stochastic_WF<T, Device>::clean_chiallorder()
 template <typename T, typename Device>
 void Stochastic_WF<T, Device>::init_sto_orbitals(const int seed_in)
 {
+    static constexpr int SEED_PROCESS_OFFSET = 10000;
     if (seed_in == 0 || seed_in == -1)
     {
-        srand((unsigned)time(nullptr) + GlobalV::MY_RANK * 10000); // GlobalV global variables are reserved
+        srand(static_cast<unsigned int>(time(nullptr)) + static_cast<unsigned int>(GlobalV::MY_RANK) * SEED_PROCESS_OFFSET); // GlobalV global variables are reserved
     }
     else
     {
-        srand((unsigned)std::abs(seed_in) + (GlobalV::MY_BNDGROUP * GlobalV::NPROC_IN_BNDGROUP + GlobalV::RANK_IN_BPGROUP) * 10000);
+        srand(static_cast<unsigned int>(std::abs(seed_in)) + static_cast<unsigned int>(GlobalV::MY_BNDGROUP * GlobalV::NPROC_IN_BNDGROUP + GlobalV::RANK_IN_BPGROUP) * SEED_PROCESS_OFFSET);
     }
 
     this->allocate_chi0();

--- a/source/source_relax/bfgs.cpp
+++ b/source/source_relax/bfgs.cpp
@@ -128,7 +128,7 @@ void BFGS::PrepareStep(std::vector<ModuleBase::Vector3<double>>& force,
     //! call dysev
     std::vector<double> omega(3*size);
     std::vector<double> work(3*size*3*size);
-    int lwork=3*size*3*size;
+    size_t lwork=3*size*3*size;
     int info=0;
     std::vector<double> H_flat;
     


### PR DESCRIPTION
1.修复source_base/vector3.h中169行可能出现悬空指针的问题
2.修复source_base/mcd.c中588行可能出现内存泄露的问题
3.修复source_pw/module_pwdft/op_pw_exx_pot.cpp中44行可能出现内存泄露的问题 
4.修复案例1 source_pw/module_stodft/sto_wf.cpp中魔数问题
5.修复案例3 source_relax/bfgs.cpp中可能溢出的问题
6.修复案例4 source_hsolver/module_genelpa/utils.cpp中未检查文件能否打开的漏洞 7.修复source_io/module_output/cif_io.cpp中201行不同迭代器混用的问题 8.修复 source_cell/unitcell.cpp中501行可能访问空字符串导致越界的问题

### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
