### PR TITLE
2026PKUCourseHW5: Fix(io): check nx*ny*nz before glo_order allocation in read_wfc_pw

### DIFF
--- a/source/source_io/module_wf/read_wfc_pw.cpp
+++ b/source/source_io/module_wf/read_wfc_pw.cpp
@@ -9,6 +9,8 @@
 #include "source_base/timer.h"
 #include "source_base/vector3.h"
 
+#include <limits>
+
 void ModuleIO::read_wfc_pw(const std::string& filename,
 		const ModulePW::PW_Basis_K* pw_wfc,
 		const int rank_in_pool,
@@ -195,9 +197,18 @@ void ModuleIO::read_wfc_pw(const std::string& filename,
             rfs >> size;
         }
 
+        const size_t nxyz_sz = static_cast<size_t>(nx) * static_cast<size_t>(ny) * static_cast<size_t>(nz);
+        if (nx <= 0 || ny <= 0 || nz <= 0
+            || nxyz_sz > static_cast<size_t>(std::numeric_limits<int>::max()))
+        {
+            ModuleBase::WARNING_QUIT("ModuleIO::read_wfc_pw",
+                                     "Invalid FFT grid or nx*ny*nz overflow for glo_order allocation.");
+        }
+        const int nxyz = static_cast<int>(nxyz_sz);
+
         // map global index to read ordering for plane waves
-        glo_order = new int[nx * ny * nz];
-        for (int i = 0; i < nx * ny * nz; i++)
+        glo_order = new int[nxyz];
+        for (int i = 0; i < nxyz; i++)
         {
             glo_order[i] = -1;
         }


### PR DESCRIPTION


### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Use size_t product and reject non-positive or INT_MAX overflow before new int[]

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
