### PR TITLE
2026PKUCourseHW5: Replace C-style cast with static_cast in read_pp_complete.cpp

### DIFF
--- a/source/source_cell/read_pp_complete.cpp
+++ b/source/source_cell/read_pp_complete.cpp
@@ -140,7 +140,7 @@ void Pseudopot_upf::complete_default_atom(Atom_pseudo& pp)
 	if (br)
 	{
 		// force msh to be odd for simpson integration
-		pp.msh = 2 * (int)((pp.msh + 1) / 2) - 1;	// 5
+		pp.msh = 2 * static_cast<int>((pp.msh + 1) / 2) - 1;	// Use static_cast instead of C-style cast for type safety
 	}
 	else
 	{


### PR DESCRIPTION
 replaced the C-style cast (int) with static_cast<int> in source/source_cell/read_pp_complete.cpp at line 143 for better type safety. This is for the PKU Parallel Programming course homework5.