### PR TITLE
2026PKUCourseHW5: Fix magic number and C-style cast in sto_wf.cppfix: replace magic number and C-style cast in sto_wf.cpp

### DIFF
--- a/source/source_pw/module_stodft/sto_wf.cpp
+++ b/source/source_pw/module_stodft/sto_wf.cpp
@@ -1,4 +1,5 @@
 #include "sto_wf.h"
+
 #include "source_base/parallel_comm.h" // use POOL_WORLD
 
 #include "source_base/memory.h"
@@ -8,7 +9,7 @@
 #include <ctime>
 
 #include "source_base/global_function.h"
-
+const unsigned int SEED_OFFSET_PER_RANK = 10000; // 每个Rank间的种子偏移量
 template <typename T, typename Device>
 Stochastic_WF<T, Device>::Stochastic_WF()
 {
@@ -64,7 +65,7 @@ void Stochastic_WF<T, Device>::clean_chiallorder()
 template <typename T, typename Device>
 void Stochastic_WF<T, Device>::init_sto_orbitals(const int seed_in)
 {
-    if (seed_in == 0 || seed_in == -1)
+    if (seed_in == 0 || seed_in == -1)srand(static_cast<unsigned int>(time(nullptr)) + GlobalV::MY_RANK * SEED_OFFSET_PER_RANK);
     {
         srand((unsigned)time(nullptr) + GlobalV::MY_RANK * 10000); // GlobalV global variables are reserved
     }


### PR DESCRIPTION
- Replace magic number 10000 with named constant SEED_OFFSET_PER_RANK
- Replace C-style cast (unsigned) with static_cast<unsigned int>()

### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
