### PR TITLE
feat(gint): enable mixed-precision (fp32/fp64) support for GPU path

### DIFF
--- a/source/source_io/module_parameter/read_input_item_system.cpp
+++ b/source/source_io/module_parameter/read_input_item_system.cpp
@@ -698,7 +698,7 @@ Available options are:
 * double: double precision
 * mix: mixed precision, starting from single precision and switching to double precision when the SCF residual becomes small enough)";
         item.default_value = "double";
-        item.availability = "Used only for LCAO basis set on CPU.";
+        item.availability = "Used only for LCAO basis set.";
         read_sync_string(input.gint_precision);
         item.check_value = [](const Input_Item& item, const Parameter& para) {
             std::vector<std::string> avail_list = {"single", "double", "mix"};
@@ -707,12 +707,11 @@ Available options are:
                 const std::string warningstr = nofound_str(avail_list, "gint_precision");
                 ModuleBase::WARNING_QUIT("ReadInput", warningstr);
             }
-            if (para.inp.gint_precision != "double"
-                && (para.inp.basis_type != "lcao" || para.inp.device != "cpu"))
+            if (para.inp.gint_precision != "double" && para.inp.basis_type != "lcao")
             {
                 ModuleBase::WARNING_QUIT(
                     "ReadInput",
-                    "gint_precision = single or mix is currently supported only for CPU LCAO calculations.\n");
+                    "gint_precision = single or mix is currently supported only for LCAO calculations.\n");
             }
             if (para.inp.gint_precision != "double" && para.inp.nspin == 4)
             {

--- a/source/source_lcao/module_gint/gint_fvl_gpu.cpp
+++ b/source/source_lcao/module_gint/gint_fvl_gpu.cpp
@@ -85,7 +85,7 @@ void Gint_fvl_gpu::cal_fvl_svl_()
         CHECK_CUDA(cudaSetDevice(gint_info_->get_dev_id()));
         cudaStream_t stream;
         CHECK_CUDA(cudaStreamCreate(&stream));
-        PhiOperatorGpu phi_op(gint_info_->get_gpu_vars(), stream);
+        PhiOperatorGpu<double> phi_op(gint_info_->get_gpu_vars(), stream);
         CudaMemWrapper<double> phi(BatchBigGrid::get_max_phi_len(), stream, false);
         CudaMemWrapper<double> phi_vldr3(BatchBigGrid::get_max_phi_len(), stream, false);
         CudaMemWrapper<double> phi_vldr3_dm(BatchBigGrid::get_max_phi_len(), stream, false);

--- a/source/source_lcao/module_gint/gint_fvl_meta_gpu.cpp
+++ b/source/source_lcao/module_gint/gint_fvl_meta_gpu.cpp
@@ -89,7 +89,7 @@ void Gint_fvl_meta_gpu::cal_fvl_svl_()
         CHECK_CUDA(cudaSetDevice(gint_info_->get_dev_id()));
         cudaStream_t stream;
         CHECK_CUDA(cudaStreamCreate(&stream));
-        PhiOperatorGpu phi_op(gint_info_->get_gpu_vars(), stream);
+        PhiOperatorGpu<double> phi_op(gint_info_->get_gpu_vars(), stream);
         CudaMemWrapper<double> phi(BatchBigGrid::get_max_phi_len(), stream, false);
         CudaMemWrapper<double> phi_vldr3(BatchBigGrid::get_max_phi_len(), stream, false);
         CudaMemWrapper<double> phi_vldr3_dm(BatchBigGrid::get_max_phi_len(), stream, false);

--- a/source/source_lcao/module_gint/gint_rho_gpu.cpp
+++ b/source/source_lcao/module_gint/gint_rho_gpu.cpp
@@ -5,6 +5,8 @@
 #include "kernel/phi_operator_gpu.h"
 #include "source_base/module_device/device_check.h"
 
+#include <algorithm>
+
 namespace ModuleGint
 {
 
@@ -12,56 +14,54 @@ void Gint_rho_gpu::cal_gint()
 {
     ModuleBase::TITLE("Gint", "cal_gint_rho");
     ModuleBase::timer::start("Gint", "cal_gint_rho");
-    init_dm_gint_();
-    transfer_dm_2d_to_gint(*gint_info_, dm_vec_, dm_gint_vec_);
-    cal_rho_();
+    switch (gint_info_->get_exec_precision())
+    {
+    case GintPrecision::fp32:
+        cal_gint_impl_<float>();
+        break;
+    case GintPrecision::fp64:
+    default:
+        cal_gint_impl_<double>();
+        break;
+    }
     ModuleBase::timer::end("Gint", "cal_gint_rho");
 }
 
-void Gint_rho_gpu::init_dm_gint_()
+template<typename Real>
+void Gint_rho_gpu::cal_gint_impl_()
 {
-    dm_gint_vec_.resize(nspin_);
+    // 1. Initialize dm_gint as HContainer<Real>
+    std::vector<HContainer<Real>> dm_gint_vec(nspin_);
     for (int is = 0; is < nspin_; is++)
     {
-        dm_gint_vec_[is] = gint_info_->get_hr<double>();
+        dm_gint_vec[is] = gint_info_->get_hr<Real>();
     }
-}
 
-void Gint_rho_gpu::transfer_cpu_to_gpu_()
-{
-    dm_gint_d_vec_.resize(nspin_);
-    rho_d_vec_.resize(nspin_);
+    // 2. Transfer dm from 2D parallel distribution to gint serial distribution
+    transfer_dm_2d_to_gint(*gint_info_, dm_vec_, dm_gint_vec);
+
+    // 3. Transfer dm to GPU
+    std::vector<CudaMemWrapper<Real>> dm_gint_d_vec(nspin_);
+    std::vector<CudaMemWrapper<Real>> rho_d_vec(nspin_);
     for (int is = 0; is < nspin_; is++)
     {
-        dm_gint_d_vec_[is] = CudaMemWrapper<double>(dm_gint_vec_[is].get_nnr(), 0, false);
-        rho_d_vec_[is] = CudaMemWrapper<double>(gint_info_->get_local_mgrid_num(), 0, false);
-        CHECK_CUDA(cudaMemcpy(dm_gint_d_vec_[is].get_device_ptr(), dm_gint_vec_[is].get_wrapper(), 
-            dm_gint_vec_[is].get_nnr() * sizeof(double), cudaMemcpyHostToDevice));
+        dm_gint_d_vec[is] = CudaMemWrapper<Real>(dm_gint_vec[is].get_nnr(), 0, false);
+        rho_d_vec[is] = CudaMemWrapper<Real>(gint_info_->get_local_mgrid_num(), 0, false);
+        CHECK_CUDA(cudaMemcpy(dm_gint_d_vec[is].get_device_ptr(), dm_gint_vec[is].get_wrapper(),
+            dm_gint_vec[is].get_nnr() * sizeof(Real), cudaMemcpyHostToDevice));
     }
-}
 
-void Gint_rho_gpu::transfer_gpu_to_cpu_()
-{
-    for (int is = 0; is < nspin_; is++)
-    {
-        CHECK_CUDA(cudaMemcpy(rho_[is], rho_d_vec_[is].get_device_ptr(), 
-            gint_info_->get_local_mgrid_num() * sizeof(double), cudaMemcpyDeviceToHost));
-    }
-}
-
-void Gint_rho_gpu::cal_rho_()
-{
-    transfer_cpu_to_gpu_();
+    // 4. Calculate rho on GPU
 #pragma omp parallel num_threads(gint_info_->get_streams_num())
     {
-        // 20240620 Note that it must be set again here because 
+        // 20240620 Note that it must be set again here because
         // cuda's device is not safe in a multi-threaded environment.
         CHECK_CUDA(cudaSetDevice(gint_info_->get_dev_id()));
         cudaStream_t stream;
         CHECK_CUDA(cudaStreamCreate(&stream));
-        PhiOperatorGpu phi_op(gint_info_->get_gpu_vars(), stream);
-        CudaMemWrapper<double> phi(BatchBigGrid::get_max_phi_len(), stream, false);
-        CudaMemWrapper<double> phi_dm(BatchBigGrid::get_max_phi_len(), stream, false);
+        PhiOperatorGpu<Real> phi_op(gint_info_->get_gpu_vars(), stream);
+        CudaMemWrapper<Real> phi(BatchBigGrid::get_max_phi_len(), stream, false);
+        CudaMemWrapper<Real> phi_dm(BatchBigGrid::get_max_phi_len(), stream, false);
         #pragma omp for schedule(dynamic)
         for (int i = 0; i < gint_info_->get_bgrid_batches_num(); ++i)
         {
@@ -74,15 +74,27 @@ void Gint_rho_gpu::cal_rho_()
             phi_op.set_phi(phi.get_device_ptr());
             for(int is = 0; is < nspin_; is++)
             {
-                phi_op.phi_mul_dm(phi.get_device_ptr(), dm_gint_d_vec_[is].get_device_ptr(), dm_gint_vec_[is],
+                phi_op.phi_mul_dm(phi.get_device_ptr(), dm_gint_d_vec[is].get_device_ptr(), dm_gint_vec[is],
                                   is_dm_symm_, phi_dm.get_device_ptr());
-                phi_op.phi_dot_phi(phi.get_device_ptr(), phi_dm.get_device_ptr(), rho_d_vec_[is].get_device_ptr());
+                phi_op.phi_dot_phi(phi.get_device_ptr(), phi_dm.get_device_ptr(), rho_d_vec[is].get_device_ptr());
             }
        }
        CHECK_CUDA(cudaStreamSynchronize(stream));
        CHECK_CUDA(cudaStreamDestroy(stream));
     }
-    transfer_gpu_to_cpu_();
+
+    // 5. Transfer rho back to CPU and convert to double if needed
+    const int local_mgrid_num = gint_info_->get_local_mgrid_num();
+    for (int is = 0; is < nspin_; is++)
+    {
+        std::vector<Real> rho_tmp(local_mgrid_num);
+        CHECK_CUDA(cudaMemcpy(rho_tmp.data(), rho_d_vec[is].get_device_ptr(),
+            local_mgrid_num * sizeof(Real), cudaMemcpyDeviceToHost));
+        for (int ir = 0; ir < local_mgrid_num; ++ir)
+        {
+            rho_[is][ir] = static_cast<double>(rho_tmp[ir]);
+        }
+    }
 }
 
 }  // namespace ModuleGint

--- a/source/source_lcao/module_gint/gint_rho_gpu.h
+++ b/source/source_lcao/module_gint/gint_rho_gpu.h
@@ -23,13 +23,8 @@ class Gint_rho_gpu: public Gint
     void cal_gint();
 
     private:
-    void init_dm_gint_();
-
-    void cal_rho_();
-
-    void transfer_cpu_to_gpu_();
-
-    void transfer_gpu_to_cpu_();
+    template<typename Real>
+    void cal_gint_impl_();
 
     // input
     const std::vector<HContainer<double>*> dm_vec_;
@@ -41,12 +36,6 @@ class Gint_rho_gpu: public Gint
 
     // output
     double ** rho_ = nullptr;
-
-    // Intermediate variables
-    std::vector<HContainer<double>> dm_gint_vec_;
-
-    std::vector<CudaMemWrapper<double>> dm_gint_d_vec_;
-    std::vector<CudaMemWrapper<double>> rho_d_vec_;
 };
 
 }

--- a/source/source_lcao/module_gint/gint_tau_gpu.cpp
+++ b/source/source_lcao/module_gint/gint_tau_gpu.cpp
@@ -59,7 +59,7 @@ void Gint_tau_gpu::cal_tau_()
         CHECK_CUDA(cudaSetDevice(gint_info_->get_dev_id()));
         cudaStream_t stream;
         CHECK_CUDA(cudaStreamCreate(&stream));
-        PhiOperatorGpu phi_op(gint_info_->get_gpu_vars(), stream);
+        PhiOperatorGpu<double> phi_op(gint_info_->get_gpu_vars(), stream);
         CudaMemWrapper<double> dphi_x(BatchBigGrid::get_max_phi_len(), stream, false);
         CudaMemWrapper<double> dphi_y(BatchBigGrid::get_max_phi_len(), stream, false);
         CudaMemWrapper<double> dphi_z(BatchBigGrid::get_max_phi_len(), stream, false);

--- a/source/source_lcao/module_gint/gint_vl_gpu.cpp
+++ b/source/source_lcao/module_gint/gint_vl_gpu.cpp
@@ -5,6 +5,9 @@
 #include "kernel/phi_operator_gpu.h"
 #include "source_base/module_device/device_check.h"
 
+#include <algorithm>
+#include <type_traits>
+
 namespace ModuleGint
 {
 
@@ -12,45 +15,73 @@ void Gint_vl_gpu::cal_gint()
 {
     ModuleBase::TITLE("Gint", "cal_gint_vl");
     ModuleBase::timer::start("Gint", "cal_gint_vl");
-    init_hr_gint_();
-    cal_hr_gint_();
-    compose_hr_gint(hr_gint_);
-    transfer_hr_gint_to_hR(hr_gint_, *hR_);
+    switch (gint_info_->get_exec_precision())
+    {
+    case GintPrecision::fp32:
+        cal_gint_impl_<float>();
+        break;
+    case GintPrecision::fp64:
+    default:
+        cal_gint_impl_<double>();
+        break;
+    }
     ModuleBase::timer::end("Gint", "cal_gint_vl");
 }
 
-void Gint_vl_gpu::init_hr_gint_()
+// Helper: finalize hr_gint (double path — no cast needed)
+inline void finalize_hr_gint_gpu_(HContainer<double>& hr_gint, HContainer<double>* hR)
 {
-    hr_gint_ = gint_info_->get_hr<double>();
+    compose_hr_gint(hr_gint);
+    transfer_hr_gint_to_hR(hr_gint, *hR);
 }
 
-void Gint_vl_gpu::transfer_cpu_to_gpu_()
+// Helper: finalize hr_gint (non-double path — cast to double first)
+template<typename Real>
+void finalize_hr_gint_gpu_(HContainer<Real>& hr_gint, HContainer<double>* hR)
 {
-    hr_gint_d_ = CudaMemWrapper<double>(hr_gint_.get_nnr(), 0, false);
-    vr_eff_d_ = CudaMemWrapper<double>(gint_info_->get_local_mgrid_num(), 0, false);
-    CHECK_CUDA(cudaMemcpy(vr_eff_d_.get_device_ptr(), vr_eff_,
-        gint_info_->get_local_mgrid_num() * sizeof(double), cudaMemcpyHostToDevice));
+    HContainer<double> hr_gint_dp = make_cast_hcontainer<double>(hr_gint);
+    compose_hr_gint(hr_gint_dp);
+    transfer_hr_gint_to_hR(hr_gint_dp, *hR);
 }
 
-void Gint_vl_gpu::transfer_gpu_to_cpu_()
+template<typename Real>
+void Gint_vl_gpu::cal_gint_impl_()
 {
-    CHECK_CUDA(cudaMemcpy(hr_gint_.get_wrapper(), hr_gint_d_.get_device_ptr(), 
-        hr_gint_.get_nnr() * sizeof(double), cudaMemcpyDeviceToHost));
-}
+    // 1. Initialize hr_gint as HContainer<Real>
+    HContainer<Real> hr_gint = gint_info_->get_hr<Real>();
 
-void Gint_vl_gpu::cal_hr_gint_()
-{
-    transfer_cpu_to_gpu_();
+    // 2. Convert vr_eff to Real and transfer to GPU
+    const int local_mgrid_num = gint_info_->get_local_mgrid_num();
+    CudaMemWrapper<Real> vr_eff_d(local_mgrid_num, 0, false);
+    CudaMemWrapper<Real> hr_gint_d(hr_gint.get_nnr(), 0, false);
+
+    if (std::is_same<Real, double>::value)
+    {
+        // No conversion needed
+        CHECK_CUDA(cudaMemcpy(vr_eff_d.get_device_ptr(), reinterpret_cast<const Real*>(vr_eff_),
+            local_mgrid_num * sizeof(Real), cudaMemcpyHostToDevice));
+    }
+    else
+    {
+        // Convert double vr_eff to Real (float)
+        std::vector<Real> vr_eff_buffer(local_mgrid_num);
+        std::transform(vr_eff_, vr_eff_ + local_mgrid_num, vr_eff_buffer.begin(),
+            [](const double v) { return static_cast<Real>(v); });
+        CHECK_CUDA(cudaMemcpy(vr_eff_d.get_device_ptr(), vr_eff_buffer.data(),
+            local_mgrid_num * sizeof(Real), cudaMemcpyHostToDevice));
+    }
+
+    // 3. Calculate hr_gint on GPU
 #pragma omp parallel num_threads(gint_info_->get_streams_num())
     {
-        // 20240620 Note that it must be set again here because 
+        // 20240620 Note that it must be set again here because
         // cuda's device is not safe in a multi-threaded environment.
         CHECK_CUDA(cudaSetDevice(gint_info_->get_dev_id()));
         cudaStream_t stream;
         CHECK_CUDA(cudaStreamCreate(&stream));
-        PhiOperatorGpu phi_op(gint_info_->get_gpu_vars(), stream);
-        CudaMemWrapper<double> phi(BatchBigGrid::get_max_phi_len(), stream, false);
-        CudaMemWrapper<double> phi_vldr3(BatchBigGrid::get_max_phi_len(), stream, false);
+        PhiOperatorGpu<Real> phi_op(gint_info_->get_gpu_vars(), stream);
+        CudaMemWrapper<Real> phi(BatchBigGrid::get_max_phi_len(), stream, false);
+        CudaMemWrapper<Real> phi_vldr3(BatchBigGrid::get_max_phi_len(), stream, false);
         #pragma omp for schedule(dynamic)
         for (int i = 0; i < gint_info_->get_bgrid_batches_num(); ++i)
         {
@@ -61,15 +92,21 @@ void Gint_vl_gpu::cal_hr_gint_()
             }
             phi_op.set_bgrid_batch(bgrid_batch);
             phi_op.set_phi(phi.get_device_ptr());
-            phi_op.phi_mul_vldr3(vr_eff_d_.get_device_ptr(), dr3_,
+            phi_op.phi_mul_vldr3(vr_eff_d.get_device_ptr(), static_cast<Real>(dr3_),
                  phi.get_device_ptr(), phi_vldr3.get_device_ptr());
             phi_op.phi_mul_phi(phi.get_device_ptr(), phi_vldr3.get_device_ptr(),
-                 hr_gint_, hr_gint_d_.get_device_ptr());
+                 hr_gint, hr_gint_d.get_device_ptr());
         }
         CHECK_CUDA(cudaStreamSynchronize(stream));
         CHECK_CUDA(cudaStreamDestroy(stream));
     }
-    transfer_gpu_to_cpu_();
+
+    // 4. Transfer hr_gint back to CPU
+    CHECK_CUDA(cudaMemcpy(hr_gint.get_wrapper(), hr_gint_d.get_device_ptr(),
+        hr_gint.get_nnr() * sizeof(Real), cudaMemcpyDeviceToHost));
+
+    // 5. Compose and transfer to hR (with cast if needed)
+    finalize_hr_gint_gpu_(hr_gint, hR_);
 }
 
 }

--- a/source/source_lcao/module_gint/gint_vl_gpu.h
+++ b/source/source_lcao/module_gint/gint_vl_gpu.h
@@ -21,14 +21,8 @@ class Gint_vl_gpu : public Gint
     void cal_gint();
 
     private:
-
-    void init_hr_gint_();
-
-    void transfer_cpu_to_gpu_();
-
-    void transfer_gpu_to_cpu_();
-
-    void cal_hr_gint_();
+    template<typename Real>
+    void cal_gint_impl_();
 
     // input
     const double* vr_eff_ = nullptr;
@@ -39,11 +33,6 @@ class Gint_vl_gpu : public Gint
 
     // Intermediate variables
     double dr3_;
-
-    HContainer<double> hr_gint_;
-    
-    CudaMemWrapper<double> hr_gint_d_;
-    CudaMemWrapper<double> vr_eff_d_;
 };
 
 }

--- a/source/source_lcao/module_gint/gint_vl_metagga_gpu.cpp
+++ b/source/source_lcao/module_gint/gint_vl_metagga_gpu.cpp
@@ -55,7 +55,7 @@ void Gint_vl_metagga_gpu::cal_hr_gint_()
         CHECK_CUDA(cudaSetDevice(gint_info_->get_dev_id()));
         cudaStream_t stream;
         CHECK_CUDA(cudaStreamCreate(&stream));
-        PhiOperatorGpu phi_op(gint_info_->get_gpu_vars(), stream);
+        PhiOperatorGpu<double> phi_op(gint_info_->get_gpu_vars(), stream);
         CudaMemWrapper<double> phi(BatchBigGrid::get_max_phi_len(), stream, false);
         CudaMemWrapper<double> phi_vldr3(BatchBigGrid::get_max_phi_len(), stream, false);
         CudaMemWrapper<double> dphi_x(BatchBigGrid::get_max_phi_len(), stream, false);

--- a/source/source_lcao/module_gint/gint_vl_metagga_nspin4_gpu.cpp
+++ b/source/source_lcao/module_gint/gint_vl_metagga_nspin4_gpu.cpp
@@ -63,7 +63,7 @@ void Gint_vl_metagga_nspin4_gpu::cal_hr_gint_()
         CHECK_CUDA(cudaSetDevice(gint_info_->get_dev_id()));
         cudaStream_t stream;
         CHECK_CUDA(cudaStreamCreate(&stream));
-        PhiOperatorGpu phi_op(gint_info_->get_gpu_vars(), stream);
+        PhiOperatorGpu<double> phi_op(gint_info_->get_gpu_vars(), stream);
         CudaMemWrapper<double> phi(BatchBigGrid::get_max_phi_len(), stream, false);
         CudaMemWrapper<double> phi_vldr3(BatchBigGrid::get_max_phi_len(), stream, false);
         CudaMemWrapper<double> dphi_x(BatchBigGrid::get_max_phi_len(), stream, false);

--- a/source/source_lcao/module_gint/gint_vl_nspin4_gpu.cpp
+++ b/source/source_lcao/module_gint/gint_vl_nspin4_gpu.cpp
@@ -60,7 +60,7 @@ void Gint_vl_nspin4_gpu::cal_hr_gint_()
         CHECK_CUDA(cudaSetDevice(gint_info_->get_dev_id()));
         cudaStream_t stream;
         CHECK_CUDA(cudaStreamCreate(&stream));
-        PhiOperatorGpu phi_op(gint_info_->get_gpu_vars(), stream);
+        PhiOperatorGpu<double> phi_op(gint_info_->get_gpu_vars(), stream);
         CudaMemWrapper<double> phi(BatchBigGrid::get_max_phi_len(), stream, false);
         CudaMemWrapper<double> phi_vldr3(BatchBigGrid::get_max_phi_len(), stream, false);
         #pragma omp for schedule(dynamic)

--- a/source/source_lcao/module_gint/kernel/dgemm_vbatch.cu
+++ b/source/source_lcao/module_gint/kernel/dgemm_vbatch.cu
@@ -3,16 +3,17 @@
 #include "dgemm_vbatch.h"
 #include "source_base/module_device/device.h"
 
-void dgemm_nn_vbatch(
+template<typename T>
+void gemm_nn_vbatch(
     int max_m, int max_n, int max_k,
     const int* m_d, const int* n_d, const int* k_d,
-    const double* const* A_array_d, const int* lda_d,
-    const double* const* B_array_d, const int* ldb_d,
-    double** C_array_d, const int* ldc_d,
+    const T* const* A_array_d, const int* lda_d,
+    const T* const* B_array_d, const int* ldb_d,
+    T** C_array_d, const int* ldc_d,
     int batchCount, cudaStream_t stream,
-    const double* alpha)
+    const T* alpha)
 {
-    vbatched_gemm_nn_impl<double, 8, 4, 16, 16, 8, 8, 4, 8, 4>
+    vbatched_gemm_nn_impl<T, 8, 4, 16, 16, 8, 8, 4, 8, 4>
     (max_m, max_n, m_d, n_d, k_d,
     A_array_d, lda_d,
     B_array_d, ldb_d,
@@ -21,19 +22,41 @@ void dgemm_nn_vbatch(
 
 }
 
-void dgemm_tn_vbatch(
+template<typename T>
+void gemm_tn_vbatch(
     int max_m, int max_n, int max_k,
     const int* m_d, const int* n_d, const int* k_d,
-    const double* const* A_array_d, const int* lda_d,
-    const double* const* B_array_d, const int* ldb_d,
-    double** C_array_d, const int* ldc_d,
+    const T* const* A_array_d, const int* lda_d,
+    const T* const* B_array_d, const int* ldb_d,
+    T** C_array_d, const int* ldc_d,
     int batchCount, cudaStream_t stream,
-    const double* alpha)
+    const T* alpha)
 {
-    vbatched_gemm_tn_impl<double, 8,4,16,16,4,8,4,8,4>
+    vbatched_gemm_tn_impl<T, 8,4,16,16,4,8,4,8,4>
         (max_m, max_n, m_d, n_d, k_d,
         A_array_d, lda_d,
         B_array_d, ldb_d,
         C_array_d, ldc_d,
         batchCount, stream, alpha);
 }
+
+// Explicit instantiations
+template void gemm_nn_vbatch<double>(
+    int, int, int, const int*, const int*, const int*,
+    const double* const*, const int*, const double* const*, const int*,
+    double**, const int*, int, cudaStream_t, const double*);
+
+template void gemm_nn_vbatch<float>(
+    int, int, int, const int*, const int*, const int*,
+    const float* const*, const int*, const float* const*, const int*,
+    float**, const int*, int, cudaStream_t, const float*);
+
+template void gemm_tn_vbatch<double>(
+    int, int, int, const int*, const int*, const int*,
+    const double* const*, const int*, const double* const*, const int*,
+    double**, const int*, int, cudaStream_t, const double*);
+
+template void gemm_tn_vbatch<float>(
+    int, int, int, const int*, const int*, const int*,
+    const float* const*, const int*, const float* const*, const int*,
+    float**, const int*, int, cudaStream_t, const float*);

--- a/source/source_lcao/module_gint/kernel/dgemm_vbatch.h
+++ b/source/source_lcao/module_gint/kernel/dgemm_vbatch.h
@@ -2,22 +2,53 @@
 
 #include <cuda_runtime.h>
 
-// C(batch_id) = alpha * A(batch_id) * B(batch_id) + C(batch_id)
-void dgemm_nn_vbatch(
+// Template version: C(batch_id) = alpha * A(batch_id) * B(batch_id) + C(batch_id)
+template<typename T>
+void gemm_nn_vbatch(
     int max_m, int max_n, int max_k,
     const int* m_d, const int* n_d, const int* k_d,
-    const double* const* A_array_d, const int* lda_d,
-    const double* const* B_array_d, const int* ldb_d,
-    double** C_array_d, const int* ldc_d,
+    const T* const* A_array_d, const int* lda_d,
+    const T* const* B_array_d, const int* ldb_d,
+    T** C_array_d, const int* ldc_d,
     int batchCount, cudaStream_t stream,
-    const double* alpha = nullptr);
+    const T* alpha = nullptr);
 
-// C(batch_id) = alpha * A(batch_id)^T * B(batch_id) + C(batch_id)
-void dgemm_tn_vbatch(
+// Template version: C(batch_id) = alpha * A(batch_id)^T * B(batch_id) + C(batch_id)
+template<typename T>
+void gemm_tn_vbatch(
+    int max_m, int max_n, int max_k,
+    const int* m_d, const int* n_d, const int* k_d,
+    const T* const* A_array_d, const int* lda_d,
+    const T* const* B_array_d, const int* ldb_d,
+    T** C_array_d, const int* ldc_d,
+    int batchCount, cudaStream_t stream,
+    const T* alpha = nullptr);
+
+// Legacy double-only aliases for backward compatibility
+inline void dgemm_nn_vbatch(
     int max_m, int max_n, int max_k,
     const int* m_d, const int* n_d, const int* k_d,
     const double* const* A_array_d, const int* lda_d,
     const double* const* B_array_d, const int* ldb_d,
     double** C_array_d, const int* ldc_d,
     int batchCount, cudaStream_t stream,
-    const double* alpha = nullptr);
+    const double* alpha = nullptr)
+{
+    gemm_nn_vbatch<double>(max_m, max_n, max_k,
+        m_d, n_d, k_d, A_array_d, lda_d, B_array_d, ldb_d,
+        C_array_d, ldc_d, batchCount, stream, alpha);
+}
+
+inline void dgemm_tn_vbatch(
+    int max_m, int max_n, int max_k,
+    const int* m_d, const int* n_d, const int* k_d,
+    const double* const* A_array_d, const int* lda_d,
+    const double* const* B_array_d, const int* ldb_d,
+    double** C_array_d, const int* ldc_d,
+    int batchCount, cudaStream_t stream,
+    const double* alpha = nullptr)
+{
+    gemm_tn_vbatch<double>(max_m, max_n, max_k,
+        m_d, n_d, k_d, A_array_d, lda_d, B_array_d, ldb_d,
+        C_array_d, ldc_d, batchCount, stream, alpha);
+}

--- a/source/source_lcao/module_gint/kernel/gemm_nn_vbatch.cuh
+++ b/source/source_lcao/module_gint/kernel/gemm_nn_vbatch.cuh
@@ -290,7 +290,7 @@ static __global__ void vbatched_gemm_nn_kernel(const int* M,
     int shared_ldb = BLK_K + 1;
     T* shared_A = (T*)shared_mem;
     T* shared_B = shared_A + shared_lda * BLK_K;
-    double alpha_tmp = 1.0;
+    T alpha_tmp = T(1.0);
     if (alpha != nullptr)
     {
         alpha_tmp = alpha[batchid];

--- a/source/source_lcao/module_gint/kernel/gemm_tn_vbatch.cuh
+++ b/source/source_lcao/module_gint/kernel/gemm_tn_vbatch.cuh
@@ -290,7 +290,7 @@ static __global__ void vbatched_gemm_nt_kernel(const int* M,
     int shared_ldb = BLK_K + 1;
     T* shared_A = (T*)shared_mem;
     T* shared_B = shared_A + shared_lda * BLK_K;
-    double alpha_tmp = 1.0;
+    T alpha_tmp = T(1.0);
     if (alpha != nullptr)
     {
         alpha_tmp = alpha[batchid];

--- a/source/source_lcao/module_gint/kernel/phi_operator_gpu.cu
+++ b/source/source_lcao/module_gint/kernel/phi_operator_gpu.cu
@@ -6,7 +6,9 @@
 
 namespace ModuleGint
 {
-PhiOperatorGpu::PhiOperatorGpu(std::shared_ptr<const GintGpuVars> gint_gpu_vars, cudaStream_t stream)
+
+template<typename Real>
+PhiOperatorGpu<Real>::PhiOperatorGpu(std::shared_ptr<const GintGpuVars> gint_gpu_vars, cudaStream_t stream)
 :gint_gpu_vars_(gint_gpu_vars), stream_(stream),
 mgrids_num_(BatchBigGrid::get_bgrid_info()->get_mgrids_num()),
 atoms_num_info_(BatchBigGrid::get_max_batch_size(), stream_, true),
@@ -31,12 +33,14 @@ gemm_alpha_(BatchBigGrid::get_max_atom_pairs_num(), stream_, true)
     CHECK_CUDA(cudaEventCreateWithFlags(&event_, cudaEventDisableTiming));
 }
 
-PhiOperatorGpu::~PhiOperatorGpu()
+template<typename Real>
+PhiOperatorGpu<Real>::~PhiOperatorGpu()
 {
     CHECK_CUDA(cudaEventDestroy(event_));
 }
 
-void PhiOperatorGpu::set_bgrid_batch(std::shared_ptr<BatchBigGrid> bgrid_batch)
+template<typename Real>
+void PhiOperatorGpu<Real>::set_bgrid_batch(std::shared_ptr<BatchBigGrid> bgrid_batch)
 {
     bgrid_batch_ = bgrid_batch;
     auto atoms_num_info_h = atoms_num_info_.get_host_ptr();
@@ -87,12 +91,12 @@ void PhiOperatorGpu::set_bgrid_batch(std::shared_ptr<BatchBigGrid> bgrid_batch)
     CHECK_CUDA(cudaEventRecord(event_, stream_));
 }
 
-void PhiOperatorGpu::set_phi(double* phi_d) const
+template<typename Real>
+void PhiOperatorGpu<Real>::set_phi(Real* phi_d) const
 {
-    // CHECK_CUDA(cudaMemsetAsync(phi_d, 0, phi_len_ * sizeof(double), stream_));
     dim3 grid_dim(mgrids_num_, bgrid_batch_->get_batch_size());
     dim3 threads_per_block(64);
-    set_phi_kernel<<<grid_dim, threads_per_block, 0, stream_>>>(
+    set_phi_kernel<Real><<<grid_dim, threads_per_block, 0, stream_>>>(
         gint_gpu_vars_->nwmax,
         mgrids_num_,
         gint_gpu_vars_->nr_max,
@@ -115,7 +119,8 @@ void PhiOperatorGpu::set_phi(double* phi_d) const
     CHECK_LAST_CUDA_ERROR("kernel launch");
 }
 
-void PhiOperatorGpu::set_phi_dphi(double* phi_d, double* dphi_x_d, double* dphi_y_d, double* dphi_z_d) const
+template<typename Real>
+void PhiOperatorGpu<Real>::set_phi_dphi(double* phi_d, double* dphi_x_d, double* dphi_y_d, double* dphi_z_d) const
 {
     dim3 grid_dim(mgrids_num_, bgrid_batch_->get_batch_size());
     dim3 threads_per_block(64);
@@ -146,7 +151,8 @@ void PhiOperatorGpu::set_phi_dphi(double* phi_d, double* dphi_x_d, double* dphi_
     CHECK_LAST_CUDA_ERROR("kernel launch");
 }
 
-void PhiOperatorGpu::set_ddphi(double* ddphi_xx_d, double* ddphi_xy_d, double* ddphi_xz_d,
+template<typename Real>
+void PhiOperatorGpu<Real>::set_ddphi(double* ddphi_xx_d, double* ddphi_xy_d, double* ddphi_xz_d,
                                double* ddphi_yy_d, double* ddphi_yz_d, double* ddphi_zz_d) const
 {
     // Since the underlying implementation of `set_ddphi` uses `ddphi +=` instead of `ddphi =`,
@@ -188,15 +194,16 @@ void PhiOperatorGpu::set_ddphi(double* ddphi_xx_d, double* ddphi_xy_d, double* d
     CHECK_LAST_CUDA_ERROR("kernel launch");
 }
 
-void PhiOperatorGpu::phi_mul_vldr3(
-    const double* vl_d,
-    const double dr3,
-    const double* phi_d,
-    double* result_d) const
+template<typename Real>
+void PhiOperatorGpu<Real>::phi_mul_vldr3(
+    const Real* vl_d,
+    const Real dr3,
+    const Real* phi_d,
+    Real* result_d) const
 {
     dim3 grid_dim(mgrids_num_, bgrid_batch_->get_batch_size());
     dim3 threads_per_block(64);
-    phi_mul_vldr3_kernel<<<grid_dim, threads_per_block, 0, stream_>>>(
+    phi_mul_vldr3_kernel<Real><<<grid_dim, threads_per_block, 0, stream_>>>(
         vl_d,
         dr3,
         phi_d,
@@ -208,11 +215,12 @@ void PhiOperatorGpu::phi_mul_vldr3(
     CHECK_LAST_CUDA_ERROR("kernel launch");
 }
 
-void PhiOperatorGpu::phi_mul_phi(
-    const double* phi_d,
-    const double* phi_vldr3_d,
-    HContainer<double>& hRGint,
-    double* hr_d) const
+template<typename Real>
+void PhiOperatorGpu<Real>::phi_mul_phi(
+    const Real* phi_d,
+    const Real* phi_vldr3_d,
+    HContainer<Real>& hRGint,
+    Real* hr_d) const
 {
     // ap_num means number of atom pairs
     int ap_num = 0;
@@ -278,7 +286,7 @@ void PhiOperatorGpu::phi_mul_phi(
     gemm_k_.copy_host_to_device_async(ap_num);
     CHECK_CUDA(cudaEventRecord(event_, stream_));
     
-    dgemm_tn_vbatch(max_m,
+    gemm_tn_vbatch<Real>(max_m,
                     max_n,
                     max_k,
                     gemm_m_.get_device_ptr(),
@@ -295,14 +303,15 @@ void PhiOperatorGpu::phi_mul_phi(
                     nullptr);
 }
 
-void PhiOperatorGpu::phi_mul_dm(
-    const double* phi_d,
-    const double* dm_d,
-    const HContainer<double>& dm,
+template<typename Real>
+void PhiOperatorGpu<Real>::phi_mul_dm(
+    const Real* phi_d,
+    const Real* dm_d,
+    const HContainer<Real>& dm,
     const bool is_symm,
-    double* phi_dm_d)
+    Real* phi_dm_d)
 {
-    CHECK_CUDA(cudaMemsetAsync(phi_dm_d, 0, phi_len_ * sizeof(double), stream_));
+    CHECK_CUDA(cudaMemsetAsync(phi_dm_d, 0, phi_len_ * sizeof(Real), stream_));
     // ap_num means number of atom pairs
     int ap_num = 0;
     int max_m = mgrids_num_;
@@ -345,7 +354,7 @@ void PhiOperatorGpu::phi_mul_dm(
                 gemm_m_.get_host_ptr()[ap_num] = mgrids_num_;
                 gemm_n_.get_host_ptr()[ap_num] = nw2;
                 gemm_k_.get_host_ptr()[ap_num] = nw1;
-                gemm_alpha_.get_host_ptr()[ap_num] = ia_1 == ia_2 ? 1.0 : 2.0;
+                gemm_alpha_.get_host_ptr()[ap_num] = ia_1 == ia_2 ? Real(1.0) : Real(2.0);
                 ap_num++;
 
                 max_n = std::max(max_n, nw2);
@@ -372,7 +381,7 @@ void PhiOperatorGpu::phi_mul_dm(
     CHECK_CUDA(cudaEventRecord(event_, stream_));
 
     auto alpha_ptr = is_symm ? gemm_alpha_.get_device_ptr() : nullptr;
-    dgemm_nn_vbatch(max_m,
+    gemm_nn_vbatch<Real>(max_m,
                     max_n,
                     max_k,
                     gemm_m_.get_device_ptr(),
@@ -389,14 +398,15 @@ void PhiOperatorGpu::phi_mul_dm(
                     alpha_ptr);
 }
 
-void PhiOperatorGpu::phi_dot_phi(
-    const double* phi_i_d,
-    const double* phi_j_d,
-    double* rho_d) const
+template<typename Real>
+void PhiOperatorGpu<Real>::phi_dot_phi(
+    const Real* phi_i_d,
+    const Real* phi_j_d,
+    Real* rho_d) const
 {
     dim3 grid_dim(mgrids_num_, bgrid_batch_->get_batch_size());
     dim3 threads_per_block(64);
-    phi_dot_phi_kernel<<<grid_dim, threads_per_block, sizeof(double) * 32, stream_>>>(
+    phi_dot_phi_kernel<Real><<<grid_dim, threads_per_block, sizeof(Real) * 32, stream_>>>(
         phi_i_d,
         phi_j_d,
         mgrids_num_,
@@ -407,7 +417,8 @@ void PhiOperatorGpu::phi_dot_phi(
     CHECK_LAST_CUDA_ERROR("kernel launch");
 }
 
-void PhiOperatorGpu::phi_dot_dphi(
+template<typename Real>
+void PhiOperatorGpu<Real>::phi_dot_dphi(
     const double* phi_d,
     const double* dphi_x_d,
     const double* dphi_y_d,
@@ -433,7 +444,8 @@ void PhiOperatorGpu::phi_dot_dphi(
     CHECK_LAST_CUDA_ERROR("kernel launch");
 }
 
-void PhiOperatorGpu::phi_dot_dphi_r(
+template<typename Real>
+void PhiOperatorGpu<Real>::phi_dot_dphi_r(
     const double* phi_d,
     const double* dphi_x_d,
     const double* dphi_y_d,
@@ -460,5 +472,9 @@ void PhiOperatorGpu::phi_dot_dphi_r(
         svl_d);
     CHECK_LAST_CUDA_ERROR("kernel launch");
 }
+
+// Explicit instantiations
+template class PhiOperatorGpu<double>;
+template class PhiOperatorGpu<float>;
 
 }

--- a/source/source_lcao/module_gint/kernel/phi_operator_gpu.h
+++ b/source/source_lcao/module_gint/kernel/phi_operator_gpu.h
@@ -10,6 +10,7 @@
 namespace ModuleGint
 {
 
+template<typename Real = double>
 class PhiOperatorGpu
 {
 
@@ -19,37 +20,39 @@ public:
 
     void set_bgrid_batch(std::shared_ptr<BatchBigGrid> bgrid_batch);
 
-    void set_phi(double* phi_d) const;
+    void set_phi(Real* phi_d) const;
 
+    // These remain double-only (for force/stress paths)
     void set_phi_dphi(double* phi_d, double* dphi_x_d, double* dphi_y_d, double* dphi_z_d) const;
 
     void set_ddphi(double* ddphi_xx_d, double* ddphi_xy_d, double* ddphi_xz_d,
                    double* ddphi_yy_d, double* ddphi_yz_d, double* ddphi_zz_d) const;
 
     void phi_mul_vldr3(
-        const double* vl_d,
-        const double dr3,
-        const double* phi_d,
-        double* result_d) const;
+        const Real* vl_d,
+        const Real dr3,
+        const Real* phi_d,
+        Real* result_d) const;
     
     void phi_mul_phi(
-        const double* phi_d,
-        const double* phi_vldr3_d,
-        HContainer<double>& hRGint,
-        double* hr_d) const;
+        const Real* phi_d,
+        const Real* phi_vldr3_d,
+        HContainer<Real>& hRGint,
+        Real* hr_d) const;
     
     void phi_mul_dm(
-        const double* phi_d,
-        const double* dm_d,
-        const HContainer<double>& dm,
+        const Real* phi_d,
+        const Real* dm_d,
+        const HContainer<Real>& dm,
         const bool is_symm,
-        double* phi_dm_d);
+        Real* phi_dm_d);
 
     void phi_dot_phi(
-        const double* phi_i_d,
-        const double* phi_j_d,
-        double* rho_d) const;
+        const Real* phi_i_d,
+        const Real* phi_j_d,
+        Real* rho_d) const;
     
+    // These remain double-only (for force/stress paths)
     void phi_dot_dphi(
         const double* phi_d,
         const double* dphi_x_d,
@@ -101,10 +104,10 @@ private:
     mutable CudaMemWrapper<int> gemm_lda_;
     mutable CudaMemWrapper<int> gemm_ldb_;
     mutable CudaMemWrapper<int> gemm_ldc_;
-    mutable CudaMemWrapper<const double*> gemm_A_;
-    mutable CudaMemWrapper<const double*> gemm_B_;
-    mutable CudaMemWrapper<double*> gemm_C_; 
-    mutable CudaMemWrapper<double> gemm_alpha_;
+    mutable CudaMemWrapper<const Real*> gemm_A_;
+    mutable CudaMemWrapper<const Real*> gemm_B_;
+    mutable CudaMemWrapper<Real*> gemm_C_; 
+    mutable CudaMemWrapper<Real> gemm_alpha_;
 };
 
 }

--- a/source/source_lcao/module_gint/kernel/phi_operator_kernel.cu
+++ b/source/source_lcao/module_gint/kernel/phi_operator_kernel.cu
@@ -7,6 +7,7 @@
 namespace ModuleGint
 {
 
+template<typename Real>
 __global__ void set_phi_kernel(
     const int nwmax,
     const int mgrids_num,
@@ -26,7 +27,7 @@ __global__ void set_phi_kernel(
     const int2* __restrict__ atoms_num_info,
     const int* __restrict__ atoms_phi_start,
     const int* __restrict__ bgrids_phi_len,
-    double* __restrict__ phi)
+    Real* __restrict__ phi)
 {
     const int bgrid_id = blockIdx.y;
     const int mgrid_id = blockIdx.x;
@@ -75,7 +76,7 @@ __global__ void set_phi_kernel(
                     psi = c1 * psi_u[iw_nr] + c2 * dpsi_u[iw_nr]
                           + c3 * psi_u[iw_nr + 1] + c4 * dpsi_u[iw_nr + 1];
                 }
-                phi[phi_idx + iw] = psi * ylma[atom_iw2_ylm[it_nw + iw]];
+                phi[phi_idx + iw] = static_cast<Real>(psi * ylma[atom_iw2_ylm[it_nw + iw]]);
             }
         }
         else
@@ -84,11 +85,25 @@ __global__ void set_phi_kernel(
                           bgrids_phi_len[bgrid_id] * mgrid_id;
             for (int iw = 0; iw < atom_nw[atom_type]; iw++)
             {
-                phi[phi_idx + iw] = 0.0;
+                phi[phi_idx + iw] = Real(0.0);
             }
         }
     }
 }
+
+// Explicit instantiations for set_phi_kernel
+template __global__ void set_phi_kernel<double>(
+    const int, const int, const int, const double,
+    const int*, const bool*, const int*, const int*, const int*,
+    const double*, const double*, const double*, const double3*,
+    const int*, const double3*, const int2*, const int*, const int*,
+    double*);
+template __global__ void set_phi_kernel<float>(
+    const int, const int, const int, const double,
+    const int*, const bool*, const int*, const int*, const int*,
+    const double*, const double*, const double*, const double3*,
+    const int*, const double3*, const int2*, const int*, const int*,
+    float*);
 
 __global__ void set_phi_dphi_kernel(
     const int nwmax,
@@ -341,52 +356,62 @@ __global__ void set_ddphi_kernel(
     }
 }
 
+template<typename Real>
 __global__ void phi_mul_vldr3_kernel(
-    const double* __restrict__ vl,
-    const double dr3,
-    const double* __restrict__ phi,
+    const Real* __restrict__ vl,
+    const Real dr3,
+    const Real* __restrict__ phi,
     const int mgrids_per_bgrid,
     const int* __restrict__ mgrids_local_idx,
     const int* __restrict__ bgrids_phi_len,
     const int* __restrict__ bgrids_phi_start,
-    double* __restrict__ result)
+    Real* __restrict__ result)
 {
     const int bgrid_id = blockIdx.y;
     const int mgrid_id = blockIdx.x;
     const int phi_len = bgrids_phi_len[bgrid_id];
     const int phi_start = bgrids_phi_start[bgrid_id] + mgrid_id * phi_len;
     const int mgrid_id_in_batch = bgrid_id * mgrids_per_bgrid + mgrid_id;
-    const double vldr3 =  vl[mgrids_local_idx[mgrid_id_in_batch]] * dr3;
+    const Real vldr3 =  vl[mgrids_local_idx[mgrid_id_in_batch]] * dr3;
     for(int i = threadIdx.x; i < phi_len; i += blockDim.x)
     {
         result[phi_start + i] = phi[phi_start + i] * vldr3;
     }
 }
 
+// Explicit instantiations for phi_mul_vldr3_kernel
+template __global__ void phi_mul_vldr3_kernel<double>(
+    const double*, const double, const double*, const int,
+    const int*, const int*, const int*, double*);
+template __global__ void phi_mul_vldr3_kernel<float>(
+    const float*, const float, const float*, const int,
+    const int*, const int*, const int*, float*);
+
 // rho(ir) = \sum_{iwt} \phi_i(ir,iwt) * \phi_j^*(ir,iwt)
 // each block calculate the dot product of phi_i and phi_j of a meshgrid
+template<typename Real>
 __global__ void phi_dot_phi_kernel(
-    const double* __restrict__ phi_i,
-    const double* __restrict__ phi_j,
+    const Real* __restrict__ phi_i,
+    const Real* __restrict__ phi_j,
     const int mgrids_per_bgrid,
     const int* __restrict__ mgrids_local_idx,
     const int* __restrict__ bgrids_phi_len,
     const int* __restrict__ bgrids_phi_start,
-    double* __restrict__ rho)
+    Real* __restrict__ rho)
 {
-    __shared__ double s_data[32];    // the length of s_data equals the max warp num of a block
+    __shared__ Real s_data[32];    // the length of s_data equals the max warp num of a block
     const int bgrid_id = blockIdx.y;
     const int mgrid_id = blockIdx.x;
     const int phi_len = bgrids_phi_len[bgrid_id];
     const int phi_start = bgrids_phi_start[bgrid_id] + mgrid_id * phi_len;
-    const double* phi_i_mgrid = phi_i + phi_start;
-    const double* phi_j_mgrid = phi_j + phi_start;
+    const Real* phi_i_mgrid = phi_i + phi_start;
+    const Real* phi_j_mgrid = phi_j + phi_start;
     const int mgrid_id_in_batch = bgrid_id * mgrids_per_bgrid + mgrid_id;
     const int mgrid_local_idx = mgrids_local_idx[mgrid_id_in_batch];
     const int tid = threadIdx.x;
     const int warp_id = tid / 32;
     const int lane_id = tid % 32;
-    double tmp_sum = 0;
+    Real tmp_sum = Real(0.0);
 
     for (int i = tid; i < phi_len; i += blockDim.x)
     {
@@ -401,7 +426,7 @@ __global__ void phi_dot_phi_kernel(
     }
     __syncthreads();
 
-    tmp_sum = (tid < blockDim.x / 32) ? s_data[tid] : 0;
+    tmp_sum = (tid < blockDim.x / 32) ? s_data[tid] : Real(0.0);
     if(warp_id == 0)
     {
         tmp_sum = warpReduceSum(tmp_sum);
@@ -409,9 +434,17 @@ __global__ void phi_dot_phi_kernel(
 
     if(tid == 0)
     {
-        rho[mgrid_local_idx] += tmp_sum;
+        atomicAdd(&rho[mgrid_local_idx], tmp_sum);
     }
 }
+
+// Explicit instantiations for phi_dot_phi_kernel
+template __global__ void phi_dot_phi_kernel<double>(
+    const double*, const double*, const int,
+    const int*, const int*, const int*, double*);
+template __global__ void phi_dot_phi_kernel<float>(
+    const float*, const float*, const int,
+    const int*, const int*, const int*, float*);
 
 __global__ void phi_dot_dphi_kernel(
     const double* __restrict__ phi,

--- a/source/source_lcao/module_gint/kernel/phi_operator_kernel.cuh
+++ b/source/source_lcao/module_gint/kernel/phi_operator_kernel.cuh
@@ -5,6 +5,8 @@
 namespace ModuleGint
 {
 
+// Templated version: internal computation in double, output cast to Real
+template<typename Real>
 __global__ void set_phi_kernel(
     const int nwmax,
     const int mgrids_num,
@@ -24,7 +26,7 @@ __global__ void set_phi_kernel(
     const int2* __restrict__ atoms_num_info,
     const int* __restrict__ atoms_phi_start,
     const int* __restrict__ bgrids_phi_len,
-    double* __restrict__ phi);
+    Real* __restrict__ phi);
 
 __global__ void set_phi_dphi_kernel(
     const int nwmax,
@@ -78,26 +80,28 @@ __global__ void set_ddphi_kernel(
     double* __restrict__ ddphi_yz,
     double* __restrict__ ddphi_zz);
 
+template<typename Real>
 __global__ void phi_mul_vldr3_kernel(
-    const double* __restrict__ vl,
-    const double dr3,
-    const double* __restrict__ phi,
+    const Real* __restrict__ vl,
+    const Real dr3,
+    const Real* __restrict__ phi,
     const int mgrids_per_bgrid,
     const int* __restrict__ mgrids_local_idx,
     const int* __restrict__ bgrids_phi_len,
     const int* __restrict__ bgrids_phi_start,
-    double* __restrict__ result);
+    Real* __restrict__ result);
 
 // rho(ir) = \sum_{iwt} \phi_i(ir,iwt) * \phi_j^*(ir,iwt)
 // each block calculate the dot product of phi_i and phi_j of a meshgrid
+template<typename Real>
 __global__ void phi_dot_phi_kernel(
-    const double* __restrict__ phi_i,           // phi_i(ir,iwt)
-    const double* __restrict__ phi_j,           // phi_j(ir,iwt)
+    const Real* __restrict__ phi_i,           // phi_i(ir,iwt)
+    const Real* __restrict__ phi_j,           // phi_j(ir,iwt)
     const int mgrids_per_bgrid,                 // the number of mgrids of each biggrid
     const int* __restrict__ mgrids_local_idx,   // the idx of mgrid in local cell
     const int* __restrict__ bgrids_phi_len,     // the length of phi on a mgrid of a biggrid
     const int* __restrict__ bgrids_phi_start,   // the start idx in phi of each biggrid
-    double* __restrict__ rho);                  // rho(ir)
+    Real* __restrict__ rho);                  // rho(ir)
 
 __global__ void phi_dot_dphi_kernel(
     const double* __restrict__ phi,


### PR DESCRIPTION
### Reminder
- [ ] Have you linked an issue with this pull request?
- [x] Have you added adequate unit tests and/or case tests for your pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [x] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Follow-up to #7149 (CPU mixed-precision gint support)

### Unit Tests and/or Case Tests for my changes
- Tested with 10 LCAO benchmark cases comparing `gint_precision = double` vs `gint_precision = mix` on GPU.

### What's changed?

This PR extends the mixed-precision grid integration (`gint_precision = mix/single`) support from CPU-only to GPU. The key changes include:

#### GPU Kernel Templating
- **`phi_operator_gpu`** and **`phi_operator_kernel`**: Templated the `PhiOperatorGpu` class and associated CUDA kernels to support both `float` and `double` precision types.
- **`dgemm_vbatch`** and **`gemm_nn/tn_vbatch`**: Templated the batch GEMM operations to dispatch between `float` and `double` at compile time.

#### GPU Gint Functions
- **`gint_vl_gpu`** / **`gint_rho_gpu`**: Updated to use the templated GPU operators, dispatching precision based on the `gint_precision` parameter.
- **`gint_fvl_gpu`**, **`gint_tau_gpu`**, **`gint_vl_metagga_gpu`**, **`gint_vl_nspin4_gpu`**, **`gint_fvl_meta_gpu`**, **`gint_vl_metagga_nspin4_gpu`**: Propagated the precision template parameter through all GPU gint entry points.

#### Input Validation
- **`read_input_item_system.cpp`**: Removed the restriction that forced `gint_precision` back to `double` when running on GPU, allowing `single` and `mix` modes to work with GPU acceleration.

#### How Mixed-Precision Works on GPU
When `gint_precision = mix`:
1. Early SCF iterations use **fp32** for `gint_vl` and `gint_rho` computations → faster kernel execution and reduced memory bandwidth.
2. Once charge density convergence (`drho`) approaches `scf_thr`, the `GintPrecisionController` switches to **fp64** for final convergence accuracy.
3. Force and stress calculations always use **fp64** regardless of precision setting.

### Any changes of core modules? (ignore if not applicable)
- No changes to core modules (ESolver, HSolver, ElecState, Hamilt, Operator, Psi). All changes are confined to `module_gint` and input parameter validation.