### PR TITLE
[Build] Fix SCALAPACK LIBRARY find logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -555,8 +555,29 @@ elseif(NOT USE_SW)
   find_package(Lapack REQUIRED)
   include_directories(${FFTW3_INCLUDE_DIRS})
   list(APPEND math_libs FFTW3::FFTW3 LAPACK::LAPACK BLAS::BLAS)
-  if(USE_DSP)
-    target_link_libraries(${ABACUS_BIN_NAME} ${SCALAPACK_LIBRARY_DIR})
+  if(SCALAPACK_LIBRARY_DIR)
+    if(IS_DIRECTORY "${SCALAPACK_LIBRARY_DIR}")
+      find_library(
+        USER_SCALAPACK_LIBRARY
+        NAMES scalapack
+        HINTS ${SCALAPACK_LIBRARY_DIR}
+        NO_DEFAULT_PATH
+      )
+      if(NOT USER_SCALAPACK_LIBRARY)
+        message(
+          FATAL_ERROR
+            "SCALAPACK_LIBRARY_DIR is set to '${SCALAPACK_LIBRARY_DIR}', but libscalapack was not found in this directory."
+        )
+      endif()
+      list(APPEND math_libs ${USER_SCALAPACK_LIBRARY})
+    else()
+      list(APPEND math_libs ${SCALAPACK_LIBRARY_DIR})
+    endif()
+  elseif(USE_DSP)
+    message(
+      FATAL_ERROR
+        "USE_DSP is enabled, but SCALAPACK_LIBRARY_DIR is not set. Please provide -DSCALAPACK_LIBRARY_DIR=<scalapack dir or full library path>."
+    )
   else()
     find_package(ScaLAPACK REQUIRED)
     list(APPEND math_libs ScaLAPACK::ScaLAPACK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -559,18 +559,41 @@ elseif(NOT USE_SW)
     if(IS_DIRECTORY "${SCALAPACK_LIBRARY_DIR}")
       find_library(
         USER_SCALAPACK_LIBRARY
-        NAMES scalapack
+        NAMES scalapack scalapack-openmpi scalapack-mpi scalapack-mpich
         HINTS ${SCALAPACK_LIBRARY_DIR}
+        PATH_SUFFIXES lib lib64
         NO_DEFAULT_PATH
       )
-      if(NOT USER_SCALAPACK_LIBRARY)
+      if(USER_SCALAPACK_LIBRARY)
+        list(APPEND math_libs ${USER_SCALAPACK_LIBRARY})
+      else()
+        find_package(ScaLAPACK QUIET)
+        if(ScaLAPACK_FOUND)
+          list(APPEND math_libs ScaLAPACK::ScaLAPACK)
+        else()
+          message(
+            FATAL_ERROR
+              "SCALAPACK_LIBRARY_DIR is set to '${SCALAPACK_LIBRARY_DIR}', but no compatible ScaLAPACK library was found there and find_package(ScaLAPACK) also failed."
+          )
+        endif()
+      endif()
+    else()
+      if(NOT IS_ABSOLUTE "${SCALAPACK_LIBRARY_DIR}")
         message(
           FATAL_ERROR
-            "SCALAPACK_LIBRARY_DIR is set to '${SCALAPACK_LIBRARY_DIR}', but libscalapack was not found in this directory."
+            "SCALAPACK_LIBRARY_DIR is set to '${SCALAPACK_LIBRARY_DIR}', but this is not an absolute library path. Please provide either a directory containing libscalapack or a full absolute path to the ScaLAPACK library file."
+        )
+      elseif(NOT EXISTS "${SCALAPACK_LIBRARY_DIR}")
+        message(
+          FATAL_ERROR
+            "SCALAPACK_LIBRARY_DIR is set to '${SCALAPACK_LIBRARY_DIR}', but this path does not exist. Please provide either a directory containing libscalapack or a full absolute path to the ScaLAPACK library file."
+        )
+      elseif(IS_DIRECTORY "${SCALAPACK_LIBRARY_DIR}")
+        message(
+          FATAL_ERROR
+            "SCALAPACK_LIBRARY_DIR is set to '${SCALAPACK_LIBRARY_DIR}', but this value resolved to a directory in the full-library-path branch. Please provide either a directory containing libscalapack or a full absolute path to the ScaLAPACK library file."
         )
       endif()
-      list(APPEND math_libs ${USER_SCALAPACK_LIBRARY})
-    else()
       list(APPEND math_libs ${SCALAPACK_LIBRARY_DIR})
     endif()
   elseif(USE_DSP)


### PR DESCRIPTION
### Linked Issue
Fix #7213 

### What's changed?
- Now support direct path specification for ScaLAPACK, skipping `find_package` if the path is given.
