### PR TITLE
Toolchain: Remove redundant exporting variables

### DIFF
--- a/toolchain/scripts/package_versions.sh
+++ b/toolchain/scripts/package_versions.sh
@@ -75,10 +75,10 @@ libxc_alt_ver="6.2.2"
 libxc_alt_sha256="f72ed08af7b9dff5f57482c5f97bff22c7dc49da9564bc93871997cbda6dacf3"
 
 # ScaLAPACK (supports dual versions) - main=2.2.2, alt=2.2.1
-scalapack_main_ver="2.2.2"
-scalapack_main_sha256="a2f0c9180a210bf7ffe126c9cb81099cf337da1a7120ddb4cbe4894eb7b7d022"
-scalapack_alt_ver="2.2.1"
-scalapack_alt_sha256="4aede775fdb28fa44b331875730bcd5bab130caaec225fadeccf424c8fcb55aa"
+scalapack_main_ver="2.2.3"
+scalapack_main_sha256="5d93701eca663925e98010dd8d0f45fd79b2191d74e5afa5711d587370a8b9dd"
+scalapack_alt_ver="2.2.2"
+scalapack_alt_sha256="a2f0c9180a210bf7ffe126c9cb81099cf337da1a7120ddb4cbe4894eb7b7d022"
 
 # =============================================================================
 # STAGE 4: Advanced Feature Libraries

--- a/toolchain/scripts/stage0/install_amd.sh
+++ b/toolchain/scripts/stage0/install_amd.sh
@@ -85,15 +85,6 @@ export FC="${FC}"
 export F90="${F90}"
 export F77="${F77}"
 EOF
-    if [ "${with_amd}" != "__SYSTEM__" ]; then
-        cat << EOF >> "${BUILDDIR}/setup_amd"
-prepend_path PATH "${pkg_install_dir}/bin"
-prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
-prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
-prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
-prepend_path CPATH "${pkg_install_dir}/include"
-EOF
-    fi
     cat << EOF >> "${BUILDDIR}/setup_amd"
 export AMD_CFLAGS="${AMD_CFLAGS}"
 export AMD_LDFLAGS="${AMD_LDFLAGS}"

--- a/toolchain/scripts/stage0/install_cmake.sh
+++ b/toolchain/scripts/stage0/install_cmake.sh
@@ -91,7 +91,7 @@ case "${with_cmake}" in
         fi
         pkg_install_dir="${INSTALLDIR}/cmake-${cmake_ver}"
         #pkg_install_dir="${HOME}/apps/cmake/${cmake_ver}"
-        install_lock_file="$pkg_install_dir/install_successful"
+        install_lock_file="${pkg_install_dir}/install_successful"
         cmake_pkg="cmake-${cmake_ver}-${cmake_arch}.${cmake_ext}"
         if verify_checksums "${install_lock_file}"; then
             echo "cmake-${cmake_ver} is already installed, skipping it."

--- a/toolchain/scripts/stage0/install_cmake.sh
+++ b/toolchain/scripts/stage0/install_cmake.sh
@@ -138,7 +138,6 @@ if [ "${with_cmake}" != "__DONTUSE__" ]; then
     if [ "${with_cmake}" != "__SYSTEM__" ]; then
         cat << EOF > "${BUILDDIR}/setup_cmake"
 prepend_path PATH "${pkg_install_dir}/bin"
-export PATH="${pkg_install_dir}/bin":\${PATH}
 EOF
         cat "${BUILDDIR}/setup_cmake" >> $SETUPFILE
     fi

--- a/toolchain/scripts/stage0/install_gcc.sh
+++ b/toolchain/scripts/stage0/install_gcc.sh
@@ -49,7 +49,7 @@ case "${with_gcc}" in
         repack_filename="gcc-${gcc_ver}-with-prereq.tar.gz"
         repkg_install_dir="${INSTALLDIR}/${repack_filename}"
         #pkg_install_dir="${HOME}/apps/gcc/${gcc_ver}"
-        install_lock_file="$pkg_install_dir/install_successful"
+        install_lock_file="${pkg_install_dir}/install_successful"
         if verify_checksums "${install_lock_file}"; then
             echo "gcc-${gcc_ver} is already installed, skipping it."
         else

--- a/toolchain/scripts/stage0/install_gcc.sh
+++ b/toolchain/scripts/stage0/install_gcc.sh
@@ -229,13 +229,6 @@ prepend_path LD_RUN_PATH "${pkg_install_dir}/lib64"
 prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path LIBRARY_PATH "${pkg_install_dir}/lib64"
 prepend_path CPATH "${pkg_install_dir}/include"
-export LD_LIBRARY_PATH="${pkg_install_dir}/lib":\${LD_LIBRARY_PATH}
-export LD_LIBRARY_PATH="${pkg_install_dir}/lib64":\${LD_LIBRARY_PATH}
-export LD_RUN_PATH="${pkg_install_dir}/lib":\${LD_RUN_PATH}
-export LD_RUN_PATH="${pkg_install_dir}/lib64":\${LD_RUN_PATH}
-export LIBRARY_PATH="${pkg_install_dir}/lib":\${LIBRARY_PATH}
-export LIBRARY_PATH="${pkg_install_dir}/lib64":\${LIBRARY_PATH}
-export CPATH="${pkg_install_dir}/include":\${CPATH}
 EOF
     fi
     cat << EOF >> "${BUILDDIR}/setup_gcc"

--- a/toolchain/scripts/stage0/install_intel.sh
+++ b/toolchain/scripts/stage0/install_intel.sh
@@ -89,15 +89,6 @@ export FC="${FC}"
 export F90="${F90}"
 export F77="${F77}"
 EOF
-    if [ "${with_intel}" != "__SYSTEM__" ]; then
-        cat << EOF >> "${BUILDDIR}/setup_intel"
-prepend_path PATH "${pkg_install_dir}/bin"
-prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
-prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
-prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
-prepend_path CPATH "${pkg_install_dir}/include"
-EOF
-    fi
     cat << EOF >> "${BUILDDIR}/setup_intel"
 export INTEL_CFLAGS="${INTEL_CFLAGS}"
 export INTEL_LDFLAGS="${INTEL_LDFLAGS}"

--- a/toolchain/scripts/stage1/install_intelmpi.sh
+++ b/toolchain/scripts/stage1/install_intelmpi.sh
@@ -144,16 +144,6 @@ export CP_CFLAGS="\${CP_CFLAGS} IF_MPI(${INTELMPI_CFLAGS}|)"
 export CP_LDFLAGS="\${CP_LDFLAGS} IF_MPI(${INTELMPI_LDFLAGS}|)"
 export CP_LIBS="\${CP_LIBS} IF_MPI(${INTELMPI_LIBS}|)"
 EOF
-    if [ "${with_intelmpi}" != "__SYSTEM__" ]; then
-        cat << EOF >> "${BUILDDIR}/setup_intelmpi"
-prepend_path PATH "${pkg_install_dir}/bin"
-export PATH="${pkg_install_dir}/bin":\${PATH}
-export LD_LIBRARY_PATH="${pkg_install_dir}/lib":\${LD_LIBRARY_PATH}
-export LD_RUN_PATH="${pkg_install_dir}/lib":\${LD_RUN_PATH}
-export LIBRARY_PATH="${pkg_install_dir}/lib":\${LIBRARY_PATH}
-export CPATH="${pkg_install_dir}/include":\${CPATH}
-EOF
-    fi
     cat "${BUILDDIR}/setup_intelmpi" >> ${SETUPFILE}
 fi
 

--- a/toolchain/scripts/stage1/install_mpich.sh
+++ b/toolchain/scripts/stage1/install_mpich.sh
@@ -176,10 +176,10 @@ EOF
     if [ "${with_mpich}" != "__SYSTEM__" ]; then
         cat << EOF >> "${BUILDDIR}/setup_mpich"
 prepend_path PATH "${pkg_install_dir}/bin"
-prepend_path LD_LIBRARY_PATH="${pkg_install_dir}/lib":\${LD_LIBRARY_PATH}
-prepend_path LD_RUN_PATH="${pkg_install_dir}/lib":\${LD_RUN_PATH}
-prepend_path LIBRARY_PATH="${pkg_install_dir}/lib":\${LIBRARY_PATH}
-prepend_path CPATH="${pkg_install_dir}/include":\${CPATH}
+prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
+prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path CPATH "${pkg_install_dir}/include"
 EOF
     fi
     cat "${BUILDDIR}/setup_mpich" >> ${SETUPFILE}

--- a/toolchain/scripts/stage1/install_mpich.sh
+++ b/toolchain/scripts/stage1/install_mpich.sh
@@ -176,11 +176,10 @@ EOF
     if [ "${with_mpich}" != "__SYSTEM__" ]; then
         cat << EOF >> "${BUILDDIR}/setup_mpich"
 prepend_path PATH "${pkg_install_dir}/bin"
-export PATH="${pkg_install_dir}/bin":\${PATH}
-export LD_LIBRARY_PATH="${pkg_install_dir}/lib":\${LD_LIBRARY_PATH}
-export LD_RUN_PATH="${pkg_install_dir}/lib":\${LD_RUN_PATH}
-export LIBRARY_PATH="${pkg_install_dir}/lib":\${LIBRARY_PATH}
-export CPATH="${pkg_install_dir}/include":\${CPATH}
+prepend_path LD_LIBRARY_PATH="${pkg_install_dir}/lib":\${LD_LIBRARY_PATH}
+prepend_path LD_RUN_PATH="${pkg_install_dir}/lib":\${LD_RUN_PATH}
+prepend_path LIBRARY_PATH="${pkg_install_dir}/lib":\${LIBRARY_PATH}
+prepend_path CPATH="${pkg_install_dir}/include":\${CPATH}
 EOF
     fi
     cat "${BUILDDIR}/setup_mpich" >> ${SETUPFILE}

--- a/toolchain/scripts/stage1/install_mpich.sh
+++ b/toolchain/scripts/stage1/install_mpich.sh
@@ -48,7 +48,7 @@ case "${with_mpich}" in
         echo "==================== Installing MPICH ===================="
         pkg_install_dir="${INSTALLDIR}/mpich-${mpich_ver}"
         #pkg_install_dir="${HOME}/apps/mpich/${mpich_ver}-intel"
-        install_lock_file="$pkg_install_dir/install_successful"
+        install_lock_file="${pkg_install_dir}/install_successful"
         url="https://www.mpich.org/static/downloads/${mpich_ver}/${mpich_pkg}"
         if verify_checksums "${install_lock_file}"; then
             echo "mpich-${mpich_ver} is already installed, skipping it."

--- a/toolchain/scripts/stage1/install_openmpi.sh
+++ b/toolchain/scripts/stage1/install_openmpi.sh
@@ -205,10 +205,10 @@ EOF
         if [ "${with_openmpi}" != "__SYSTEM__" ]; then
             cat << EOF >> "${BUILDDIR}/setup_openmpi"
 prepend_path PATH "${pkg_install_dir}/bin"
-prepend_path LD_LIBRARY_PATH="${pkg_install_dir}/lib":\${LD_LIBRARY_PATH}
-prepend_path LD_RUN_PATH="${pkg_install_dir}/lib":\${LD_RUN_PATH}
-prepend_path LIBRARY_PATH="${pkg_install_dir}/lib":\${LIBRARY_PATH}
-prepend_path CPATH="${pkg_install_dir}/include":\${CPATH}
+prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
+prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path CPATH "${pkg_install_dir}/include"
 EOF
         fi
         cat "${BUILDDIR}/setup_openmpi" >> ${SETUPFILE}

--- a/toolchain/scripts/stage1/install_openmpi.sh
+++ b/toolchain/scripts/stage1/install_openmpi.sh
@@ -47,7 +47,7 @@ case "${with_openmpi}" in
     __INSTALL__)
         echo "==================== Installing OpenMPI ===================="
         pkg_install_dir="${INSTALLDIR}/openmpi-${openmpi_ver}"
-        install_lock_file="$pkg_install_dir/install_successful"
+        install_lock_file="${pkg_install_dir}/install_successful"
         url="https://download.open-mpi.org/release/open-mpi/v${openmpi_ver%.*}/${openmpi_pkg}"
         if verify_checksums "${install_lock_file}"; then
             echo "openmpi-${openmpi_ver} is already installed, skipping it."

--- a/toolchain/scripts/stage1/install_openmpi.sh
+++ b/toolchain/scripts/stage1/install_openmpi.sh
@@ -205,12 +205,10 @@ EOF
         if [ "${with_openmpi}" != "__SYSTEM__" ]; then
             cat << EOF >> "${BUILDDIR}/setup_openmpi"
 prepend_path PATH "${pkg_install_dir}/bin"
-export PATH="${pkg_install_dir}/bin":\${PATH}
-export LD_LIBRARY_PATH="${pkg_install_dir}/lib":\${LD_LIBRARY_PATH}
-export LD_RUN_PATH="${pkg_install_dir}/lib":\${LD_RUN_PATH}
-export LIBRARY_PATH="${pkg_install_dir}/lib":\${LIBRARY_PATH}
-export CPATH="${pkg_install_dir}/include":\${CPATH}
-
+prepend_path LD_LIBRARY_PATH="${pkg_install_dir}/lib":\${LD_LIBRARY_PATH}
+prepend_path LD_RUN_PATH="${pkg_install_dir}/lib":\${LD_RUN_PATH}
+prepend_path LIBRARY_PATH="${pkg_install_dir}/lib":\${LIBRARY_PATH}
+prepend_path CPATH="${pkg_install_dir}/include":\${CPATH}
 EOF
         fi
         cat "${BUILDDIR}/setup_openmpi" >> ${SETUPFILE}

--- a/toolchain/scripts/stage2/install_aocl.sh
+++ b/toolchain/scripts/stage2/install_aocl.sh
@@ -57,24 +57,6 @@ case "${with_aocl}" in
         ;;
 esac
 if [ "$with_aocl" != "__DONTUSE__" ]; then
-    if [ "$with_aocl" != "__SYSTEM__" ]; then
-        cat << EOF > "${BUILDDIR}/setup_aocl"
-prepend_path LD_LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
-prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
-prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
-prepend_path CPATH "$pkg_install_dir/include"
-export LD_LIBRARY_PATH="$pkg_install_dir/lib:"\${LD_LIBRARY_PATH}
-export LD_RUN_PATH="$pkg_install_dir/lib:"\${LD_RUN_PATH}
-export LIBRARY_PATH="$pkg_install_dir/lib:"\${LIBRARY_PATH}
-export CPATH="$pkg_install_dir/include:"\${CPATH}
-export PKG_CONFIG_PATH="$pkg_install_dir/lib/pkgconfig:"\${PKG_CONFIG_PATH}
-export CMAKE_PREFIX_PATH="$pkg_install_dir:"\${CMAKE_PREFIX_PATH}
-export AOCL_ROOT=${pkg_install_dir}
-EOF
-        cat "${BUILDDIR}/setup_aocl" >> $SETUPFILE
-    fi
     cat << EOF >> "${BUILDDIR}/setup_aocl"
 export AOCL_ROOT="${pkg_install_dir}"
 export AOCL_CFLAGS="${AOCL_CFLAGS}"

--- a/toolchain/scripts/stage2/install_openblas.sh
+++ b/toolchain/scripts/stage2/install_openblas.sh
@@ -178,13 +178,6 @@ prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
 prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
 prepend_path CPATH "$pkg_install_dir/include"
-export LD_LIBRARY_PATH="$pkg_install_dir/lib:"\${LD_LIBRARY_PATH}
-export LD_RUN_PATH="$pkg_install_dir/lib:"\${LD_RUN_PATH}
-export LIBRARY_PATH="$pkg_install_dir/lib:"\${LIBRARY_PATH}
-export CPATH="$pkg_install_dir/include:"\${CPATH}
-export PKG_CONFIG_PATH="$pkg_install_dir/lib/pkgconfig:"\${PKG_CONFIG_PATH}
-export CMAKE_PREFIX_PATH="$pkg_install_dir:"\${CMAKE_PREFIX_PATH}
-export OPENBLAS_ROOT=${pkg_install_dir}
 EOF
         cat "${BUILDDIR}/setup_openblas" >> $SETUPFILE
     fi

--- a/toolchain/scripts/stage2/install_openblas.sh
+++ b/toolchain/scripts/stage2/install_openblas.sh
@@ -46,7 +46,7 @@ case "${with_openblas}" in
     __INSTALL__)
         echo "==================== Installing OpenBLAS ===================="
         pkg_install_dir="${INSTALLDIR}/openblas-${openblas_ver}"
-        install_lock_file="$pkg_install_dir/install_successful"
+        install_lock_file="${pkg_install_dir}/install_successful"
         if verify_checksums "${install_lock_file}"; then
             echo "openblas-${openblas_ver} is already installed, skipping it."
         else
@@ -172,12 +172,12 @@ esac
 if [ "$with_openblas" != "__DONTUSE__" ]; then
     if [ "$with_openblas" != "__SYSTEM__" ]; then
         cat << EOF > "${BUILDDIR}/setup_openblas"
-prepend_path LD_LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
-prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
-prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
-prepend_path CPATH "$pkg_install_dir/include"
+prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
+prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
+prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
+prepend_path CPATH "${pkg_install_dir}/include"
 EOF
         cat "${BUILDDIR}/setup_openblas" >> $SETUPFILE
     fi
@@ -191,8 +191,8 @@ export MATH_LDFLAGS="\${MATH_LDFLAGS} ${OPENBLAS_LDFLAGS}"
 export MATH_LIBS="\${MATH_LIBS} ${OPENBLAS_LIBS}"
 export PKG_CONFIG_PATH="${pkg_install_dir}/lib/pkgconfig"
 export CMAKE_PREFIX_PATH="${pkg_install_dir}"
-prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
-prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
+prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
+prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
 fi
 

--- a/toolchain/scripts/stage2/install_openblas.sh
+++ b/toolchain/scripts/stage2/install_openblas.sh
@@ -175,8 +175,6 @@ if [ "$with_openblas" != "__DONTUSE__" ]; then
 prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
 prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
-prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
-prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 prepend_path CPATH "${pkg_install_dir}/include"
 EOF
         cat "${BUILDDIR}/setup_openblas" >> $SETUPFILE
@@ -189,8 +187,6 @@ export OPENBLAS_LIBS="${OPENBLAS_LIBS}"
 export MATH_CFLAGS="\${MATH_CFLAGS} ${OPENBLAS_CFLAGS}"
 export MATH_LDFLAGS="\${MATH_LDFLAGS} ${OPENBLAS_LDFLAGS}"
 export MATH_LIBS="\${MATH_LIBS} ${OPENBLAS_LIBS}"
-export PKG_CONFIG_PATH="${pkg_install_dir}/lib/pkgconfig"
-export CMAKE_PREFIX_PATH="${pkg_install_dir}"
 prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF

--- a/toolchain/scripts/stage3/install_elpa.sh
+++ b/toolchain/scripts/stage3/install_elpa.sh
@@ -257,18 +257,11 @@ prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
 prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
 prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
-export PATH="$pkg_install_dir/bin":\${PATH}
-export LD_LIBRARY_PATH="$pkg_install_dir/lib":\${LD_LIBRARY_PATH}
-export LD_RUN_PATH="$pkg_install_dir/lib":\${LD_RUN_PATH}
-export LIBRARY_PATH="$pkg_install_dir/lib":\${LIBRARY_PATH}
-export CPATH="$pkg_install_dir/include":\${CPATH}
-export PKG_CONFIG_PATH="$pkg_install_dir/lib/pkgconfig":\${PKG_CONFIG_PATH}
-export CMAKE_PREFIX_PATH="$pkg_install_dir":\${CMAKE_PREFIX_PATH}
-export ELPA_ROOT="$pkg_install_dir"
 EOF
         cat "${BUILDDIR}/setup_elpa" >> $SETUPFILE
     fi
     cat << EOF >> "${BUILDDIR}/setup_elpa"
+export ELPA_ROOT="$pkg_install_dir"
 export ELPA_CFLAGS="${ELPA_CFLAGS}"
 export ELPA_LDFLAGS="${ELPA_LDFLAGS}"
 export ELPA_LIBS="${ELPA_LIBS}"
@@ -276,7 +269,6 @@ export CP_DFLAGS="\${CP_DFLAGS} IF_MPI(-D__ELPA IF_CUDA(-D__ELPA_NVIDIA_GPU|)|)"
 export CP_CFLAGS="\${CP_CFLAGS} IF_MPI(${ELPA_CFLAGS}|)"
 export CP_LDFLAGS="\${CP_LDFLAGS} IF_MPI(${ELPA_LDFLAGS}|)"
 export CP_LIBS="IF_MPI(${ELPA_LIBS}|) \${CP_LIBS}"
-export ELPA_ROOT="$pkg_install_dir"
 export ELPA_VERSION="${elpa_ver}"
 EOF
 

--- a/toolchain/scripts/stage3/install_elpa.sh
+++ b/toolchain/scripts/stage3/install_elpa.sh
@@ -57,7 +57,7 @@ case "$with_elpa" in
         echo "==================== Installing ELPA ===================="
         pkg_install_dir="${INSTALLDIR}/elpa-${elpa_ver}"
         #pkg_install_dir="${HOME}/lib/elpa/${elpa_ver}-gcc8"
-        install_lock_file="$pkg_install_dir/install_successful"
+        install_lock_file="${pkg_install_dir}/install_successful"
         enable_openmp="yes"
 
         # specific settings needed on CRAY Linux Environment
@@ -250,18 +250,18 @@ prepend_path CPATH "$elpa_include"
 EOF
     if [ "$with_elpa" != "__SYSTEM__" ]; then
         cat << EOF >> "${BUILDDIR}/setup_elpa"
-prepend_path PATH "$pkg_install_dir/bin"
-prepend_path LD_LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path CPATH "$pkg_install_dir/include"
-prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
-prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
-prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
+prepend_path PATH "${pkg_install_dir}/bin"
+prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path CPATH "${pkg_install_dir}/include"
+prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
+prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
+prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
         cat "${BUILDDIR}/setup_elpa" >> $SETUPFILE
     fi
     cat << EOF >> "${BUILDDIR}/setup_elpa"
-export ELPA_ROOT="$pkg_install_dir"
+export ELPA_ROOT="${pkg_install_dir}"
 export ELPA_CFLAGS="${ELPA_CFLAGS}"
 export ELPA_LDFLAGS="${ELPA_LDFLAGS}"
 export ELPA_LIBS="${ELPA_LIBS}"

--- a/toolchain/scripts/stage3/install_fftw.sh
+++ b/toolchain/scripts/stage3/install_fftw.sh
@@ -45,7 +45,7 @@ case "$with_fftw" in
         require_env MPI_LIBS
         echo "==================== Installing FFTW ===================="
         pkg_install_dir="${INSTALLDIR}/fftw-${fftw_ver}"
-        install_lock_file="$pkg_install_dir/install_successful"
+        install_lock_file="${pkg_install_dir}/install_successful"
         if verify_checksums "${install_lock_file}"; then
             echo "fftw-${fftw_ver} is already installed, skipping it."
         else
@@ -128,12 +128,12 @@ if [ "$with_fftw" != "__DONTUSE__" ]; then
     FFTW_LIBS+="-lfftw3 -lfftw3_omp"
     if [ "$with_fftw" != "__SYSTEM__" ]; then
        cat << EOF > "${BUILDDIR}/setup_fftw"
-prepend_path LD_LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
-prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path CPATH "$pkg_install_dir/include"
-prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
-prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
+prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
+prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path CPATH "${pkg_install_dir}/include"
+prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
+prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
     fi
     # we may also want to cover FFT_SG

--- a/toolchain/scripts/stage3/install_fftw.sh
+++ b/toolchain/scripts/stage3/install_fftw.sh
@@ -134,12 +134,6 @@ prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
 prepend_path CPATH "$pkg_install_dir/include"
 prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
-export LD_LIBRARY_PATH="$pkg_install_dir/lib":\${LD_LIBRARY_PATH}
-export LD_RUN_PATH="$pkg_install_dir/lib":\${LD_RUN_PATH}
-export LIBRARY_PATH="$pkg_install_dir/lib":\${LIBRARY_PATH}
-export CPATH="$pkg_install_dir/include":\${CPATH}
-export PKG_CONFIG_PATH="$pkg_install_dir/lib/pkgconfig":\${PKG_CONFIG_PATH}
-export CMAKE_PREFIX_PATH="$pkg_install_dir":\${CMAKE_PREFIX_PATH}
 EOF
     fi
     # we may also want to cover FFT_SG

--- a/toolchain/scripts/stage3/install_libxc.sh
+++ b/toolchain/scripts/stage3/install_libxc.sh
@@ -77,6 +77,7 @@ case "$with_libxc" in
                 -DCMAKE_VERBOSE_MAKEFILE=ON \
                 -DENABLE_FORTRAN=ON \
                 -DENABLE_PYTHON=OFF \
+                -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
                 -DBUILD_TESTING=OFF .. \
                 > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
             make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log

--- a/toolchain/scripts/stage3/install_libxc.sh
+++ b/toolchain/scripts/stage3/install_libxc.sh
@@ -119,12 +119,6 @@ prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
 prepend_path CPATH "$pkg_install_dir/include"
 prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
-export LD_LIBRARY_PATH="$pkg_install_dir/lib":\${LD_LIBRARY_PATH}
-export LD_RUN_PATH="$pkg_install_dir/lib":\${LD_RUN_PATH}
-export LIBRARY_PATH="$pkg_install_dir/lib":\${LIBRARY_PATH}
-export CPATH="$pkg_install_dir/include":\${CPATH}
-export PKG_CONFIG_PATH="$pkg_install_dir/lib/pkgconfig":\${PKG_CONFIG_PATH}
-export CMAKE_PREFIX_PATH="$pkg_install_dir":\${CMAKE_PREFIX_PATH}
 EOF
         cat "${BUILDDIR}/setup_libxc" >> $SETUPFILE
     fi

--- a/toolchain/scripts/stage3/install_libxc.sh
+++ b/toolchain/scripts/stage3/install_libxc.sh
@@ -47,7 +47,7 @@ case "$with_libxc" in
         echo "==================== Installing LIBXC ===================="
         pkg_install_dir="${INSTALLDIR}/libxc-${libxc_ver}"
         #pkg_install_dir="${HOME}/lib/libxc/${libxc_ver}-gcc8"
-        install_lock_file="$pkg_install_dir/install_successful"
+        install_lock_file="${pkg_install_dir}/install_successful"
         if verify_checksums "${install_lock_file}"; then
             echo "libxc-${libxc_ver} is already installed, skipping it."
         else
@@ -113,12 +113,12 @@ if [ "$with_libxc" != "__DONTUSE__" ]; then
     LIBXC_LIBS="-lxcf03 -lxc"
     if [ "$with_libxc" != "__SYSTEM__" ]; then
         cat << EOF > "${BUILDDIR}/setup_libxc"
-prepend_path LD_LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
-prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path CPATH "$pkg_install_dir/include"
-prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
-prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
+prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
+prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path CPATH "${pkg_install_dir}/include"
+prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
+prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
         cat "${BUILDDIR}/setup_libxc" >> $SETUPFILE
     fi
@@ -130,7 +130,7 @@ export CP_DFLAGS="\${CP_DFLAGS} -D__LIBXC"
 export CP_CFLAGS="\${CP_CFLAGS} ${LIBXC_CFLAGS}"
 export CP_LDFLAGS="\${CP_LDFLAGS} ${LIBXC_LDFLAGS}"
 export CP_LIBS="${LIBXC_LIBS} \${CP_LIBS}"
-export LIBXC_ROOT="$pkg_install_dir"
+export LIBXC_ROOT="${pkg_install_dir}"
 EOF
 fi
 

--- a/toolchain/scripts/stage3/install_scalapack.sh
+++ b/toolchain/scripts/stage3/install_scalapack.sh
@@ -44,7 +44,7 @@ case "${with_scalapack}" in
     __INSTALL__)
         echo "==================== Installing ScaLAPACK ===================="
         pkg_install_dir="${INSTALLDIR}/scalapack-${scalapack_ver}"
-        install_lock_file="$pkg_install_dir/install_successful"
+        install_lock_file="${pkg_install_dir}/install_successful"
         if verify_checksums "${install_lock_file}"; then
             echo "scalapack-${scalapack_ver} is already installed, skipping it."
         else

--- a/toolchain/scripts/stage3/install_scalapack.sh
+++ b/toolchain/scripts/stage3/install_scalapack.sh
@@ -126,7 +126,6 @@ EOF
 export SCALAPACK_ROOT="${pkg_install_dir}"
 export SCALAPACK_LDFLAGS="${SCALAPACK_LDFLAGS}"
 export SCALAPACK_LIBS="${SCALAPACK_LIBS}"
-export SCALAPACK_ROOT="${pkg_install_dir}"
 export CP_DFLAGS="\${CP_DFLAGS} IF_MPI(-D__SCALAPACK|)"
 export CP_LDFLAGS="\${CP_LDFLAGS} IF_MPI(${SCALAPACK_LDFLAGS}|)"
 export CP_LIBS="IF_MPI(-lscalapack|) \${CP_LIBS}"

--- a/toolchain/scripts/stage3/install_scalapack.sh
+++ b/toolchain/scripts/stage3/install_scalapack.sh
@@ -119,16 +119,11 @@ prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
 prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
-export LD_LIBRARY_PATH="${pkg_install_dir}/lib":\${LD_LIBRARY_PATH}
-export LD_RUN_PATH="${pkg_install_dir}/lib":\${LD_RUN_PATH}
-export LIBRARY_PATH="${pkg_install_dir}/lib":\${LIBRARY_PATH}
-export PKG_CONFIG_PATH="${pkg_install_dir}/lib/pkgconfig":\${PKG_CONFIG_PATH}
-export CMAKE_PREFIX_PATH="${pkg_install_dir}":\${CMAKE_PREFIX_PATH}
-export SCALAPACK_ROOT="${pkg_install_dir}"
 EOF
         cat "${BUILDDIR}/setup_scalapack" >> $SETUPFILE
     fi
     cat << EOF >> "${BUILDDIR}/setup_scalapack"
+export SCALAPACK_ROOT="${pkg_install_dir}"
 export SCALAPACK_LDFLAGS="${SCALAPACK_LDFLAGS}"
 export SCALAPACK_LIBS="${SCALAPACK_LIBS}"
 export SCALAPACK_ROOT="${pkg_install_dir}"

--- a/toolchain/scripts/stage4/install_cereal.sh
+++ b/toolchain/scripts/stage4/install_cereal.sh
@@ -113,10 +113,7 @@ if [ "$with_cereal" != "__DONTUSE__" ]; then
     if [ "$with_cereal" != "__SYSTEM__" ]; then
         cat << EOF > "${BUILDDIR}/setup_cereal"
 prepend_path CPATH "$pkg_install_dir/include"
-prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}/include"
-export CPATH="${pkg_install_dir}/include":\${CPATH}
-export CMAKE_PREFIX_PATH="${pkg_install_dir}/include":\${CMAKE_PREFIX_PATH}
-export CEREAL_ROOT="$pkg_install_dir"
+prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
     else
         cat << EOF > "${BUILDDIR}/setup_cereal"
@@ -125,6 +122,7 @@ EOF
     fi
     cat "${BUILDDIR}/setup_cereal" >> $SETUPFILE
     cat << EOF >> "${BUILDDIR}/setup_cereal"
+export CEREAL_ROOT="$pkg_install_dir"
 export CEREAL_CFLAGS="${CEREAL_CFLAGS}"
 export CP_DFLAGS="\${CP_DFLAGS} -D__CEREAL"
 export CP_CFLAGS="\${CP_CFLAGS} ${CEREAL_CFLAGS}"

--- a/toolchain/scripts/stage4/install_cereal.sh
+++ b/toolchain/scripts/stage4/install_cereal.sh
@@ -115,10 +115,6 @@ if [ "$with_cereal" != "__DONTUSE__" ]; then
 prepend_path CPATH "${pkg_install_dir}/include"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
-    else
-        cat << EOF > "${BUILDDIR}/setup_cereal"
-export CEREAL_ROOT="${pkg_install_dir}"
-EOF
     fi
     cat "${BUILDDIR}/setup_cereal" >> $SETUPFILE
     cat << EOF >> "${BUILDDIR}/setup_cereal"

--- a/toolchain/scripts/stage4/install_cereal.sh
+++ b/toolchain/scripts/stage4/install_cereal.sh
@@ -46,7 +46,7 @@ case "$with_cereal" in
         echo "==================== Installing CEREAL ===================="
         pkg_install_dir="${INSTALLDIR}/$dirname"
         #pkg_install_dir="${HOME}/lib/cereal/${cereal_ver}"
-        install_lock_file="$pkg_install_dir/install_successful"
+        install_lock_file="${pkg_install_dir}/install_successful"
         # url construction rules:
         # - Branch names (master, main, develop) without v prefix
         # - Version tags (e.g., 1.0.0) with v prefix
@@ -93,7 +93,7 @@ case "$with_cereal" in
             # cereal/cereal.hpp -> remove /cereal/cereal.hpp -> get include dir -> get parent dir
             cereal_include_dir="$(dirname "$(dirname "$cereal_header_path")")"
             pkg_install_dir="$(dirname "$cereal_include_dir")"
-            echo "Found cereal at: $pkg_install_dir"
+            echo "Found cereal at: ${pkg_install_dir}"
             CEREAL_CFLAGS="-I'${cereal_include_dir}'"
         else
             report_error "Cannot find cereal/cereal.hpp in system paths"
@@ -112,17 +112,17 @@ esac
 if [ "$with_cereal" != "__DONTUSE__" ]; then
     if [ "$with_cereal" != "__SYSTEM__" ]; then
         cat << EOF > "${BUILDDIR}/setup_cereal"
-prepend_path CPATH "$pkg_install_dir/include"
+prepend_path CPATH "${pkg_install_dir}/include"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
     else
         cat << EOF > "${BUILDDIR}/setup_cereal"
-export CEREAL_ROOT="$pkg_install_dir"
+export CEREAL_ROOT="${pkg_install_dir}"
 EOF
     fi
     cat "${BUILDDIR}/setup_cereal" >> $SETUPFILE
     cat << EOF >> "${BUILDDIR}/setup_cereal"
-export CEREAL_ROOT="$pkg_install_dir"
+export CEREAL_ROOT="${pkg_install_dir}"
 export CEREAL_CFLAGS="${CEREAL_CFLAGS}"
 export CP_DFLAGS="\${CP_DFLAGS} -D__CEREAL"
 export CP_CFLAGS="\${CP_CFLAGS} ${CEREAL_CFLAGS}"

--- a/toolchain/scripts/stage4/install_libcomm.sh
+++ b/toolchain/scripts/stage4/install_libcomm.sh
@@ -116,7 +116,6 @@ if [ "$with_libcomm" != "__DONTUSE__" ]; then
     if [ "$with_libcomm" != "__SYSTEM__" ]; then
         cat << EOF > "${BUILDDIR}/setup_libcomm"
 prepend_path CPATH "$pkg_install_dir/include"
-export CPATH="${pkg_install_dir}/include":\${CPATH}
 EOF
         cat "${BUILDDIR}/setup_libcomm" >> $SETUPFILE
     fi

--- a/toolchain/scripts/stage4/install_libcomm.sh
+++ b/toolchain/scripts/stage4/install_libcomm.sh
@@ -50,7 +50,7 @@ case "$with_libcomm" in
         echo "==================== Installing LIBCOMM ===================="
         pkg_install_dir="${INSTALLDIR}/$dirname"
         #pkg_install_dir="${HOME}/lib/libcomm/${libcomm_ver}"
-        install_lock_file="$pkg_install_dir/install_successful"
+        install_lock_file="${pkg_install_dir}/install_successful"
         # url="https://github.com/abacusmodeling/LibComm/archive/refs/tags/v${libcomm_ver}.tar.gz"
         # url construction rules:
         # - Branch names (master, main, develop) without v prefix
@@ -96,7 +96,7 @@ case "$with_libcomm" in
             # Comm/Comm_Tools.h -> remove /Comm/Comm_Tools.h -> get include dir -> get parent dir
             libcomm_include_dir="$(dirname "$(dirname "$libcomm_header_path")")"
             pkg_install_dir="$(dirname "$libcomm_include_dir")"
-            echo "Found libcomm at: $pkg_install_dir"
+            echo "Found libcomm at: ${pkg_install_dir}"
             LIBCOMM_CFLAGS="-I'${libcomm_include_dir}'"
         else
             report_error "Cannot find Comm/Comm_Tools.h in system paths"
@@ -115,13 +115,13 @@ esac
 if [ "$with_libcomm" != "__DONTUSE__" ]; then
     if [ "$with_libcomm" != "__SYSTEM__" ]; then
         cat << EOF > "${BUILDDIR}/setup_libcomm"
-prepend_path CPATH "$pkg_install_dir/include"
+prepend_path CPATH "${pkg_install_dir}/include"
 EOF
         cat "${BUILDDIR}/setup_libcomm" >> $SETUPFILE
     fi
     cat << EOF >> "${BUILDDIR}/setup_libcomm"
 export LIBCOMM_CFLAGS="${libcomm_CFLAGS}"
-export LIBCOMM_ROOT="$pkg_install_dir"
+export LIBCOMM_ROOT="${pkg_install_dir}"
 EOF
 fi
 

--- a/toolchain/scripts/stage4/install_libcomm.sh
+++ b/toolchain/scripts/stage4/install_libcomm.sh
@@ -41,7 +41,6 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_libcomm" ] && rm "${BUILDDIR}/setup_libcomm"
 
-libcomm_CFLAGS=""
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
@@ -120,7 +119,7 @@ EOF
         cat "${BUILDDIR}/setup_libcomm" >> $SETUPFILE
     fi
     cat << EOF >> "${BUILDDIR}/setup_libcomm"
-export LIBCOMM_CFLAGS="${libcomm_CFLAGS}"
+export LIBCOMM_CFLAGS="${LIBCOMM_CFLAGS}"
 export LIBCOMM_ROOT="${pkg_install_dir}"
 EOF
 fi

--- a/toolchain/scripts/stage4/install_libnpy.sh
+++ b/toolchain/scripts/stage4/install_libnpy.sh
@@ -49,7 +49,7 @@ case "$with_libnpy" in
         echo "==================== Installing LIBNPY ===================="
         pkg_install_dir="${INSTALLDIR}/$dirname"
         #pkg_install_dir="${HOME}/lib/libnpy/${libnpy_ver}"
-        install_lock_file="$pkg_install_dir/install_successful"
+        install_lock_file="${pkg_install_dir}/install_successful"
         url="https://codeload.github.com/llohse/libnpy/tar.gz/v${libnpy_ver}"
         if verify_checksums "${install_lock_file}"; then
             echo "$dirname is already installed, skipping it."
@@ -87,7 +87,7 @@ case "$with_libnpy" in
             # npy.hpp -> get include dir -> get parent dir
             libnpy_include_dir="$(dirname "$libnpy_header_path")"
             pkg_install_dir="$(dirname "$libnpy_include_dir")"
-            echo "Found libnpy at: $pkg_install_dir"
+            echo "Found libnpy at: ${pkg_install_dir}"
             LIBNPY_CFLAGS="-I'${libnpy_include_dir}'"
         else
             report_error "Cannot find npy.hpp in system paths"
@@ -106,13 +106,13 @@ esac
 if [ "$with_libnpy" != "__DONTUSE__" ]; then
     if [ "$with_libnpy" != "__SYSTEM__" ]; then
         cat << EOF > "${BUILDDIR}/setup_libnpy"
-prepend_path CPATH "$pkg_install_dir/include"
+prepend_path CPATH "${pkg_install_dir}/include"
 EOF
         cat "${BUILDDIR}/setup_libnpy" >> $SETUPFILE
     fi
     cat << EOF >> "${BUILDDIR}/setup_libnpy"
 export LIBNPY_CFLAGS="${LIBNPY_CFLAGS}"
-export LIBNPY_ROOT="$pkg_install_dir"
+export LIBNPY_ROOT="${pkg_install_dir}"
 EOF
 fi
 

--- a/toolchain/scripts/stage4/install_libnpy.sh
+++ b/toolchain/scripts/stage4/install_libnpy.sh
@@ -107,7 +107,6 @@ if [ "$with_libnpy" != "__DONTUSE__" ]; then
     if [ "$with_libnpy" != "__SYSTEM__" ]; then
         cat << EOF > "${BUILDDIR}/setup_libnpy"
 prepend_path CPATH "$pkg_install_dir/include"
-export CPATH="${pkg_install_dir}/include":\${CPATH}
 EOF
         cat "${BUILDDIR}/setup_libnpy" >> $SETUPFILE
     fi

--- a/toolchain/scripts/stage4/install_libri.sh
+++ b/toolchain/scripts/stage4/install_libri.sh
@@ -49,7 +49,7 @@ case "$with_libri" in
         dirname="LibRI-${libri_ver}"
         pkg_install_dir="${INSTALLDIR}/$dirname"
         #pkg_install_dir="${HOME}/lib/libri/${libri_ver}"
-        install_lock_file="$pkg_install_dir/install_successful"
+        install_lock_file="${pkg_install_dir}/install_successful"
         # url construction rules:
         # - Branch names (master, main, develop) without v prefix
         # - Version tags (e.g., 1.0.0) with v prefix
@@ -95,7 +95,7 @@ case "$with_libri" in
             # RI/version.h -> remove /RI/version.h -> get include dir -> get parent dir
             libri_include_dir="$(dirname "$(dirname "$libri_header_path")")"
             pkg_install_dir="$(dirname "$libri_include_dir")"
-            echo "Found libri at: $pkg_install_dir"
+            echo "Found libri at: ${pkg_install_dir}"
             LIBRI_CFLAGS="-I'${libri_include_dir}'"
         else
             report_error "Cannot find RI/version.h in system paths"
@@ -114,13 +114,13 @@ esac
 if [ "$with_libri" != "__DONTUSE__" ]; then
     if [ "$with_libri" != "__SYSTEM__" ]; then
         cat << EOF > "${BUILDDIR}/setup_libri"
-prepend_path CPATH "$pkg_install_dir/include"
+prepend_path CPATH "${pkg_install_dir}/include"
 EOF
         cat "${BUILDDIR}/setup_libri" >> $SETUPFILE
     fi
     cat << EOF >> "${BUILDDIR}/setup_libri"
 export LIBRI_CFLAGS="${libri_CFLAGS}"
-export LIBRI_ROOT="$pkg_install_dir"
+export LIBRI_ROOT="${pkg_install_dir}"
 EOF
 fi
 

--- a/toolchain/scripts/stage4/install_libri.sh
+++ b/toolchain/scripts/stage4/install_libri.sh
@@ -39,7 +39,6 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_libri" ] && rm "${BUILDDIR}/setup_libri"
 
-libri_CFLAGS=""
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
@@ -119,7 +118,7 @@ EOF
         cat "${BUILDDIR}/setup_libri" >> $SETUPFILE
     fi
     cat << EOF >> "${BUILDDIR}/setup_libri"
-export LIBRI_CFLAGS="${libri_CFLAGS}"
+export LIBRI_CFLAGS="${LIBRI_CFLAGS}"
 export LIBRI_ROOT="${pkg_install_dir}"
 EOF
 fi

--- a/toolchain/scripts/stage4/install_libri.sh
+++ b/toolchain/scripts/stage4/install_libri.sh
@@ -115,7 +115,6 @@ if [ "$with_libri" != "__DONTUSE__" ]; then
     if [ "$with_libri" != "__SYSTEM__" ]; then
         cat << EOF > "${BUILDDIR}/setup_libri"
 prepend_path CPATH "$pkg_install_dir/include"
-export CPATH="${pkg_install_dir}/include":\${CPATH}
 EOF
         cat "${BUILDDIR}/setup_libri" >> $SETUPFILE
     fi

--- a/toolchain/scripts/stage4/install_libtorch.sh
+++ b/toolchain/scripts/stage4/install_libtorch.sh
@@ -111,6 +111,7 @@ prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
 prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
+prepend_path CPATH "${pkg_install_dir}/include"
 EOF
     fi
     if [ "$ENABLE_CUDA" = "__TRUE__" ]; then

--- a/toolchain/scripts/stage4/install_libtorch.sh
+++ b/toolchain/scripts/stage4/install_libtorch.sh
@@ -109,8 +109,8 @@ if [ "$with_libtorch" != "__DONTUSE__" ]; then
 prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
 prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
-prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
-prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
+prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
+prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
     fi
     if [ "$ENABLE_CUDA" = "__TRUE__" ]; then

--- a/toolchain/scripts/stage4/install_libtorch.sh
+++ b/toolchain/scripts/stage4/install_libtorch.sh
@@ -111,12 +111,6 @@ prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
 prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
-export LD_LIBRARY_PATH="${pkg_install_dir}/lib":\${LD_LIBRARY_PATH}
-export LD_RUN_PATH="${pkg_install_dir}/lib":\${LD_RUN_PATH}
-export LIBRARY_PATH="${pkg_install_dir}/lib":\${LIBRARY_PATH}
-export CPATH="${pkg_install_dir}/include":\${CPATH}
-export PKG_CONFIG_PATH="${pkg_install_dir}/lib/pkgconfig":\${PKG_CONFIG_PATH}
-export CMAKE_PREFIX_PATH="${pkg_install_dir}":\${CMAKE_PREFIX_PATH}
 EOF
     fi
     if [ "$ENABLE_CUDA" = "__TRUE__" ]; then

--- a/toolchain/scripts/stage4/install_nep.sh
+++ b/toolchain/scripts/stage4/install_nep.sh
@@ -30,7 +30,7 @@ case "$with_nep" in
     echo "==================== Installing NEP (CPU version) ===================="
     dirname="NEP_CPU-${nep_ver}"
     pkg_install_dir="${INSTALLDIR}/${dirname}"
-    install_lock_file="$pkg_install_dir/install_successful"
+    install_lock_file="${pkg_install_dir}/install_successful"
     filename="nep-${nep_ver}.tar.gz"
     url="https://codeload.github.com/brucefan1983/NEP_CPU/tar.gz/${nep_ver}"
 
@@ -125,11 +125,11 @@ if [ "$with_nep" != "__DONTUSE__" ]; then
   NEP_LIBS="-lnep"
   if [ "$with_nep" != "__SYSTEM__" ]; then
     cat << EOF > "${BUILDDIR}/setup_nep"
-prepend_path LD_LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
-prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path CPATH "$pkg_install_dir/include"
-prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
+prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
+prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path CPATH "${pkg_install_dir}/include"
+prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
     cat "${BUILDDIR}/setup_nep" >> $SETUPFILE
   fi
@@ -141,7 +141,7 @@ export CP_DFLAGS="\${CP_DFLAGS} -D__NEP"
 export CP_CFLAGS="\${CP_CFLAGS} \${NEP_CFLAGS}"
 export CP_LDFLAGS="\${CP_LDFLAGS} \${NEP_LDFLAGS}"
 export CP_LIBS="\${NEP_LIBS} \${CP_LIBS}"
-export NEP_ROOT="$pkg_install_dir"
+export NEP_ROOT="${pkg_install_dir}"
 EOF
 fi
 

--- a/toolchain/scripts/stage4/install_nep.sh
+++ b/toolchain/scripts/stage4/install_nep.sh
@@ -130,11 +130,6 @@ prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
 prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
 prepend_path CPATH "$pkg_install_dir/include"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
-export LD_LIBRARY_PATH="$pkg_install_dir/lib":\${LD_LIBRARY_PATH}
-export LD_RUN_PATH="$pkg_install_dir/lib":\${LD_RUN_PATH}
-export LIBRARY_PATH="$pkg_install_dir/lib":\${LIBRARY_PATH}
-export CPATH="$pkg_install_dir/include":\${CPATH}
-export CMAKE_PREFIX_PATH="$pkg_install_dir":\${CMAKE_PREFIX_PATH}
 EOF
     cat "${BUILDDIR}/setup_nep" >> $SETUPFILE
   fi

--- a/toolchain/scripts/stage4/install_rapidjson.sh
+++ b/toolchain/scripts/stage4/install_rapidjson.sh
@@ -121,9 +121,6 @@ if [ "$with_rapidjson" != "__DONTUSE__" ]; then
         cat << EOF > "${BUILDDIR}/setup_rapidjson"
 prepend_path CPATH "$pkg_install_dir/include"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
-export CPATH="$pkg_install_dir/include":\${CPATH}
-export CMAKE_PREFIX_PATH="$pkg_install_dir":\${CMAKE_PREFIX_PATH}
-export RAPIDJSON_ROOT="$pkg_install_dir"
 EOF
     else
         cat << EOF > "${BUILDDIR}/setup_rapidjson"
@@ -132,6 +129,7 @@ EOF
     fi
     cat "${BUILDDIR}/setup_rapidjson" >> $SETUPFILE
     cat << EOF >> "${BUILDDIR}/setup_rapidjson"
+export RAPIDJSON_ROOT="$pkg_install_dir"
 export RAPIDJSON_CFLAGS="${RAPIDJSON_CFLAGS}"
 export CP_DFLAGS="\${CP_DFLAGS} -D__RAPIDJSON"
 export CP_CFLAGS="\${CP_CFLAGS} ${RAPIDJSON_CFLAGS}"

--- a/toolchain/scripts/stage4/install_rapidjson.sh
+++ b/toolchain/scripts/stage4/install_rapidjson.sh
@@ -122,10 +122,6 @@ if [ "$with_rapidjson" != "__DONTUSE__" ]; then
 prepend_path CPATH "${pkg_install_dir}/include"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
-    else
-        cat << EOF > "${BUILDDIR}/setup_rapidjson"
-export RAPIDJSON_ROOT="${pkg_install_dir}"
-EOF
     fi
     cat "${BUILDDIR}/setup_rapidjson" >> $SETUPFILE
     cat << EOF >> "${BUILDDIR}/setup_rapidjson"

--- a/toolchain/scripts/stage4/install_rapidjson.sh
+++ b/toolchain/scripts/stage4/install_rapidjson.sh
@@ -47,7 +47,7 @@ case "$with_rapidjson" in
         dirname="rapidjson-${rapidjson_ver}"
         pkg_install_dir="${INSTALLDIR}/$dirname"
         #pkg_install_dir="${HOME}/lib/rapidjson/${rapidjson_ver}"
-        install_lock_file="$pkg_install_dir/install_successful"
+        install_lock_file="${pkg_install_dir}/install_successful"
         # url construction rules:
         # - Branch names (master, main, develop) without v prefix
         # - Version tags (e.g., 1.0.0) with v prefix
@@ -100,7 +100,7 @@ EOF
             # rapidjson/rapidjson.h -> remove /rapidjson/rapidjson.h -> get include dir -> get parent dir
             rapidjson_include_dir="$(dirname "$(dirname "$rapidjson_header_path")")"
             pkg_install_dir="$(dirname "$rapidjson_include_dir")"
-            echo "Found rapidjson at: $pkg_install_dir"
+            echo "Found rapidjson at: ${pkg_install_dir}"
             RAPIDJSON_CFLAGS="-I'${rapidjson_include_dir}'"
         else
             report_error "Cannot find rapidjson/rapidjson.h in system paths"
@@ -119,17 +119,17 @@ esac
 if [ "$with_rapidjson" != "__DONTUSE__" ]; then
     if [ "$with_rapidjson" != "__SYSTEM__" ]; then
         cat << EOF > "${BUILDDIR}/setup_rapidjson"
-prepend_path CPATH "$pkg_install_dir/include"
-prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
+prepend_path CPATH "${pkg_install_dir}/include"
+prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
     else
         cat << EOF > "${BUILDDIR}/setup_rapidjson"
-export RAPIDJSON_ROOT="$pkg_install_dir"
+export RAPIDJSON_ROOT="${pkg_install_dir}"
 EOF
     fi
     cat "${BUILDDIR}/setup_rapidjson" >> $SETUPFILE
     cat << EOF >> "${BUILDDIR}/setup_rapidjson"
-export RAPIDJSON_ROOT="$pkg_install_dir"
+export RAPIDJSON_ROOT="${pkg_install_dir}"
 export RAPIDJSON_CFLAGS="${RAPIDJSON_CFLAGS}"
 export CP_DFLAGS="\${CP_DFLAGS} -D__RAPIDJSON"
 export CP_CFLAGS="\${CP_CFLAGS} ${RAPIDJSON_CFLAGS}"

--- a/toolchain/scripts/tool_kit.sh
+++ b/toolchain/scripts/tool_kit.sh
@@ -743,7 +743,7 @@ remove_path() {
   __path=${__path//:$__directory:/:}
   __path=${__path#$__directory:}
   __path=${__path%:$__directory}
-  __path=$(echo "$__path" | sed "s:^$__directory\$::g")
+  __path=$(echo "$__path" | sed "s#^$__directory\$##g")
   eval $__path_name=\"$__path\"
   export $__path_name
 }


### PR DESCRIPTION
* Remove redundant exporting variables
* For CMake 4.x compatibility: Add `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` flag to libXC installing script, and update ScaLAPACK to version 2.2.3.

Resolves #7226.