### PR TITLE
Fix(hsolver): add early PW basis-size guard to report npw<nbands clearly

### DIFF
--- a/source/source_cell/check_atomic_stru.cpp
+++ b/source/source_cell/check_atomic_stru.cpp
@@ -46,7 +46,7 @@ void check_atomic_stru(UnitCell& ucell, const double& factor)
             else
             {
                 std::stringstream mess;
-                mess << "Notice: symbol '" << symbol1 << "' is not an element symbol!!!! ";
+                mess << " Notice: symbol '" << symbol1 << "' is not an element symbol!!!! ";
                 mess << "set the covalent radius to be 0." << std::endl;
                 GlobalV::ofs_running << mess.str();
                 std::cout << mess.str();

--- a/source/source_hsolver/hsolver_pw.cpp
+++ b/source/source_hsolver/hsolver_pw.cpp
@@ -248,6 +248,22 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm,
 #endif
 
     const int cur_nbasis = psi.get_current_nbas();
+    const int dim = psi.get_current_ngk();
+    const int nband = psi.get_nbands();
+
+    // Guard against under-complete PW basis at current k-point.
+    // This case is common in highly compressed cells with low ecutwfc,
+    // and can otherwise fail later with obscure solver-specific messages.
+    if (dim < nband)
+    {
+        std::cout << "\n ERROR in HSolverPW::hamiltSolvePsiK" << std::endl;
+        std::cout << "   solver       = " << this->method << std::endl;
+        std::cout << "   ik (1-based) = " << nk_nums + 1 << std::endl;
+        std::cout << "   npw(dim)     = " << dim << std::endl;
+        std::cout << "   nbands       = " << nband << std::endl;
+        std::cout << "   Suggestion   : increase ecutwfc, reduce nbands, or adjust k-mesh." << std::endl;
+        ModuleBase::WARNING_QUIT("HSolverPW::hamiltSolvePsiK", "insufficient plane-wave basis dimension for requested nbands");
+    }
 
     // Shared matrix-blockvector operators used by all iterative solvers.
     auto hpsi_func = [hm, cur_nbasis](T* psi_in, T* hpsi_out, const int ld_psi, const int nvec) {
@@ -288,8 +304,8 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm,
             cg.diag(hpsi_func,
                     spsi_func,
                     psi.get_nbasis(),
-                    psi.get_nbands(),
-                    psi.get_current_ngk(),
+                          nband,
+                          dim,
                     psi.get_pointer(),
                     eigenvalue,
                     this->ethr_band,


### PR DESCRIPTION
### Linked Issue
Fix #7201

### Description
- Add a pre-check in `HSolverPW` before iterative diagonalization.
- Abort early when current k-point plane-wave dimension is smaller than nbands, and print solver name, k-point index, npw(dim), and nbands with actionable hints.
- Avoid opaque downstream failures such as `psi_norm <= 0.0` in under-complete basis cases.
- Keep behavior unchanged for valid basis dimensions