### PR TITLE
Toolchain: Enable float FFTW linking for building with MKL

### DIFF
--- a/toolchain/build_abacus_gcc-mkl.sh
+++ b/toolchain/build_abacus_gcc-mkl.sh
@@ -39,6 +39,7 @@ cmake -B $BUILD_DIR -DCMAKE_INSTALL_PREFIX=$PREFIX \
         -DCMAKE_CXX_COMPILER=g++ \
         -DMPI_CXX_COMPILER=mpicxx \
         -DMKLROOT=$MKLROOT \
+        -DENABLE_FLOAT_FFTW=ON \
         -DELPA_DIR=$ELPA \
         -DCEREAL_INCLUDE_DIR=$CEREAL \
         -DLibxc_DIR=$LIBXC \

--- a/toolchain/build_abacus_intel.sh
+++ b/toolchain/build_abacus_intel.sh
@@ -40,6 +40,7 @@ cmake -B $BUILD_DIR -DCMAKE_INSTALL_PREFIX=$PREFIX \
         -DCMAKE_CXX_COMPILER=icpx \
         -DMPI_CXX_COMPILER=mpiicpx \
         -DMKLROOT=$MKLROOT \
+        -DENABLE_FLOAT_FFTW=ON \
         -DELPA_DIR=$ELPA \
         -DCEREAL_INCLUDE_DIR=$CEREAL \
         -DLibxc_DIR=$LIBXC \


### PR DESCRIPTION
MKL supports both single and double precision at the same time, so adding `-DENABLE_FLOAT_FFTW=ON` flag is of no harm. It wasn't added to GNU toolchain building script in case some people link the FFTW package installed by their own (it's easy via simply passing `--with-fftw=system` to the end of `./toolchain_gnu.sh` command) with no single precision support (its single/double precision does not share the same configuration and cannot be compiled at once).