### PR TITLE
Do not output time.json. If timer information is required, please extract it from running.log instead.

### DIFF
--- a/source/source_base/timer.cpp
+++ b/source/source_base/timer.cpp
@@ -348,7 +348,7 @@ void timer::print_all(std::ofstream &ofs, const bool check_end)
 	const std::string table = "\nTIME STATISTICS\n" + time_statistics.str();
 	std::cout<<table<<std::endl;
 	ofs<<table<<std::endl;
-	write_to_json("time.json");
+	// write_to_json("time.json");
 
 }
 }


### PR DESCRIPTION
Do not output time.json. If timer information is required, please extract it from running.log instead.