### PR TITLE
Fix(pw): suppress spurious warning when no plane waves exist for a k-point

### DIFF
--- a/source/source_base/tool_quit.cpp
+++ b/source/source_base/tool_quit.cpp
@@ -133,7 +133,7 @@ void WARNING_QUIT(const std::string &file,const std::string &description,int ret
 void CHECK_WARNING_QUIT(const bool error_in, const std::string &file,const std::string &calculation,const std::string &description)
 {
 #ifdef __NORMAL
-// only for UT, do nothing here
+    if(error_in) std::cout << description << std::endl;
 #else
 	if(error_in)
 	{

--- a/source/source_basis/module_pw/pw_basis_k.cpp
+++ b/source/source_basis/module_pw/pw_basis_k.cpp
@@ -145,10 +145,19 @@ void PW_Basis_K::setupIndGk()
             }
         }
         this->npwk[ik] = ng;
+        int ng_global_k = ng;
+#ifdef __MPI
+        MPI_Allreduce(MPI_IN_PLACE, &ng_global_k, 1, MPI_INT, MPI_SUM, this->pool_world);
+#endif
+        const char* no_pw_message = "Current core has no plane waves! Please reduce the cores.";
+        if (ng_global_k == 0)
+        {
+            no_pw_message = "No plane waves are available for this k-point across the whole pool. Please increase ecutwfc or check KPT settings.";
+        }
         ModuleBase::CHECK_WARNING_QUIT((ng == 0),
                                        "pw_basis_k.cpp",
                                        PARAM.inp.calculation,
-                                       "Current core has no plane waves! Please reduce the cores.");
+                                       no_pw_message);
         if (this->npwk_max < ng)
         {
             this->npwk_max = ng;

--- a/source/source_basis/module_pw/pw_distributeg.cpp
+++ b/source/source_basis/module_pw/pw_distributeg.cpp
@@ -25,8 +25,9 @@ void PW_Basis::distribute_g()
     {
         ModuleBase::WARNING_QUIT("divide", "No such division type.");
     }
+    const char* no_pw_message = "Current core has no plane waves! Please reduce the cores.";
     ModuleBase::CHECK_WARNING_QUIT((this->npw == 0), "pw_distributeg.cpp", PARAM.inp.calculation,
-    "Current core has no plane waves! Please reduce the cores.");
+                                   no_pw_message);
     ModuleBase::timer::end(this->classname, "distributeg");
     return;
 }

--- a/source/source_basis/module_pw/test/test-other.cpp
+++ b/source/source_basis/module_pw/test/test-other.cpp
@@ -140,3 +140,65 @@ TEST_F(PWTEST,test_other)
     fftwf_cleanup();
 #endif
 }
+
+TEST_F(PWTEST, test_no_plane_wave_message_global_empty_k)
+{
+    ModulePW::PW_Basis_K pwktest(device_flag, precision_flag);
+    ModuleBase::Matrix3 latvec(0.2, 0, 0, 0, 1, 0, 0, 0, 1);
+#ifdef __MPI
+    pwktest.initmpi(nproc_in_pool, rank_in_pool, POOL_WORLD);
+#endif
+    const int nks = 1;
+    ModuleBase::Vector3<double> kvec_d[nks];
+    kvec_d[0].set(0.5, 0.5, 0.5);
+
+    pwktest.initgrids(2, latvec, 4, 4, 4);
+    pwktest.initparameters(true, 1e-4, nks, kvec_d);
+    testing::internal::CaptureStdout();
+    pwktest.setuptransform();
+    std::string output = testing::internal::GetCapturedStdout();
+
+    EXPECT_THAT(output,
+                testing::HasSubstr("No plane waves are available for this k-point across the whole pool. Please increase ecutwfc or check KPT settings."));
+}
+
+TEST_F(PWTEST, test_no_plane_wave_message_parallel_local_empty)
+{
+#ifndef __MPI
+    GTEST_SKIP() << "Requires MPI ranks to simulate local-empty but global-nonempty case.";
+#else
+    if (nproc_in_pool <= 1)
+    {
+        GTEST_SKIP() << "Requires more than one MPI rank.";
+    }
+
+    ModulePW::PW_Basis_K pwktest(device_flag, precision_flag);
+    ModuleBase::Matrix3 latvec(0.2, 0, 0, 0, 1, 0, 0, 0, 1);
+    pwktest.initmpi(nproc_in_pool, rank_in_pool, POOL_WORLD);
+
+    const int nks = 1;
+    ModuleBase::Vector3<double> kvec_d[nks];
+    kvec_d[0].set(0.0, 0.0, 0.0);
+
+    pwktest.initgrids(2, latvec, 4, 4, 4);
+    pwktest.initparameters(true, 8.0, nks, kvec_d);
+    testing::internal::CaptureStdout();
+    pwktest.setuptransform();
+    std::string output = testing::internal::GetCapturedStdout();
+
+    const int local_npwk = pwktest.npwk[0];
+    int global_npwk = local_npwk;
+    MPI_Allreduce(MPI_IN_PLACE, &global_npwk, 1, MPI_INT, MPI_SUM, POOL_WORLD);
+
+    const int local_target_rank = (local_npwk == 0 && global_npwk > 0) ? 1 : 0;
+    int any_target_rank = local_target_rank;
+    MPI_Allreduce(MPI_IN_PLACE, &any_target_rank, 1, MPI_INT, MPI_MAX, POOL_WORLD);
+    EXPECT_EQ(any_target_rank, 1);
+
+    if (local_target_rank == 1)
+    {
+        EXPECT_THAT(output,
+                    testing::HasSubstr("Current core has no plane waves! Please reduce the cores."));
+    }
+#endif
+}


### PR DESCRIPTION
### Linked Issue
Refs #7201

### Description
This PR fixes the spurious `no plane waves` warning that occur during SCF calculations when certain k-points have zero plane waves due to insufficient wavefunction cutoff energy (`ecutwfc`).

When performing calculations with small simulation cells and low energy cutoffs,
k-points located far from reciprocal lattice points (requiring large |k+G| vectors)
may fall outside the kinetic energy cutoff sphere,
resulting in zero plane waves for those k-points. In such regimes:
- At low `ecutwfc` (50–60 Ry), the code immediately aborted with  `"no plane waves"`.
- At medium `ecutwfc` (70–130 Ry), plane waves existed but `npwx < nbands`,
  leading to rank deficiency and `psi_norm <= 0` during CG diagonalization  in `diago_cg.cpp`.

These k-points with zero plane waves are valid edge cases. This PR adds the
necessary zero-count guards so the code reports energy/k-points issue instead of reducing the cores.

### What's Changed
- Fix the warning message logic in `PW_Basis_K::setuptransform()` when no plane waves are available for a k-point.
- Distinguish between two cases and emit appropriate warnings:
  1. **Globally empty**: No plane waves exist for this k-point across the entire MPI pool.  
     Prompts the user to increase `ecutwfc` or check KPT settings.
  2. **Locally empty (parallel)**: The current MPI rank has zero plane waves, but other ranks in the pool still have some.  
     Prompts the user to reduce the number of cores.





### Unit Tests and/or Case Tests for my changes
- Add two unit tests to cover both scenarios:
  - `test_no_plane_wave_message_global_empty_k`
  - `test_no_plane_wave_message_parallel_local_empty`
