### PR TITLE
[Fix] Avoid redundant vkb CPU allocation on GPU path and fix Velocity operator data source

### DIFF
--- a/source/source_pw/module_pwdft/op_pw_vel.cpp
+++ b/source/source_pw/module_pwdft/op_pw_vel.cpp
@@ -35,7 +35,6 @@ Velocity<FPTYPE, Device>::~Velocity()
     delmem_var_op()(this->gx_);
     delmem_var_op()(this->gy_);
     delmem_var_op()(this->gz_);
-    delmem_complex_op()(vkb_);
     delmem_complex_op()(gradvkb_);
 }
 
@@ -70,11 +69,8 @@ void Velocity<FPTYPE, Device>::init(const int ik_in)
         if (std::is_same<Device, base_device::DEVICE_GPU>::value || std::is_same<FPTYPE, float>::value)
         {
             const int nkb = this->ppcell->nkb;
-            // vkb
-            resmem_complex_op()(vkb_, nkb * npwk_max);
-            castmem_complex_h2d_op()(vkb_, this->ppcell->vkb.c, nkb * npwk_max);
 
-            // gradvkb
+            // gradvkb only exists on CPU, must copy to device
             resmem_complex_op()(gradvkb_, 3 * nkb * npwk_max);
             castmem_complex_h2d_op()(gradvkb_, this->ppcell->gradvkb.ptr, 3 * nkb * npwk_max);
         }
@@ -135,11 +131,10 @@ void Velocity<FPTYPE, Device>::act(const psi::Psi<std::complex<FPTYPE>, Device>*
     Complex one = 1.0;
     Complex zero = 0.0;
 
-    Complex* vkb_d = reinterpret_cast<Complex*>(this->ppcell->vkb.c);
+    Complex* vkb_d = this->ppcell->template get_vkb_data<FPTYPE>();
     Complex* gradvkb_d = reinterpret_cast<Complex*>(this->ppcell->gradvkb.ptr);
     if (std::is_same<Device, base_device::DEVICE_GPU>::value || std::is_same<FPTYPE, float>::value)
     {
-        vkb_d = vkb_;
         gradvkb_d = gradvkb_;
     }
 

--- a/source/source_pw/module_pwdft/op_pw_vel.h
+++ b/source/source_pw/module_pwdft/op_pw_vel.h
@@ -59,7 +59,6 @@ class Velocity
     FPTYPE* gx_ = nullptr; ///<[Device, npwx] x component of G+K
     FPTYPE* gy_ = nullptr; ///<[Device, npwx] y component of G+K
     FPTYPE* gz_ = nullptr; ///<[Device, npwx] z component of G+K
-    std::complex<FPTYPE>* vkb_ = nullptr;     ///<[Device, nkb * npwk_max] nonlocal pseudopotential vkb
     std::complex<FPTYPE>* gradvkb_ = nullptr; ///<[Device, 3*nkb * npwk_max] gradient of nonlocal pseudopotential gradvkb
     FPTYPE* deeq_ = nullptr;                  ///<[Device] D matrix for nonlocal pseudopotential
     

--- a/source/source_pw/module_pwdft/vnl_pw.cpp
+++ b/source/source_pw/module_pwdft/vnl_pw.cpp
@@ -216,7 +216,18 @@ void pseudopot_cell_vnl::init(const UnitCell& ucell,
     int npwx = this->wfcpw->npwk_max;
     if (nkb > 0 && allocate_vkb)
     {
-        vkb.create(nkb, npwx);
+        // On GPU, vkb.c (CPU memory) is never used: getvnl writes to separately
+        // allocated GPU buffers (c_vkb/z_vkb). Only dimensions are needed for BLAS LDA.
+        if (this->use_gpu_)
+        {
+            vkb.nr = nkb;
+            vkb.nc = npwx;
+            vkb.size = nkb * npwx;
+        }
+        else
+        {
+            vkb.create(nkb, npwx);
+        }
         ModuleBase::Memory::record("VNL::vkb", nkb * npwx * sizeof(std::complex<double>));
     }
 


### PR DESCRIPTION
## Summary
- Skip CPU memory allocation of `vkb.create()` on GPU path in `vnl_pw.cpp`.
  On GPU, `getvnl` writes to separately allocated GPU buffers (`c_vkb`/`z_vkb`),
  so the CPU `vkb.c` was never used. Only set dimensions (`nr`/`nc`/`size`) which
  are still needed for BLAS leading dimension parameters.
- Remove redundant `vkb_` member from the Velocity operator and use
  `get_vkb_data<FPTYPE>()` directly. This fixes a latent bug where the Velocity
  operator was reading from `vkb.c` (uninitialized on GPU/float paths) instead
  of the GPU/float buffer that `getvnl` actually wrote to.

## Test plan
- [ ] CPU double: scf + band velocity calculation regression
- [ ] GPU double: scf + band velocity calculation correctness
- [ ] CPU float: scf correctness
- [ ] GPU float: scf correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)