### PR TITLE
Remove parameter.h include of files in source_base

### DIFF
--- a/source/source_base/module_device/memory_op.cpp
+++ b/source/source_base/module_device/memory_op.cpp
@@ -4,8 +4,6 @@
 #include "source_base/tool_threading.h"
 #ifdef __DSP
 #include "source_base/kernels/dsp/dsp_connector.h"
-#include "source_base/global_variable.h"
-#include "source_io/module_parameter/parameter.h"
 #endif
 
 #include <complex>
@@ -444,6 +442,16 @@ template struct delete_memory_op<std::complex<double>, base_device::DEVICE_GPU>;
 
 #ifdef __DSP
 
+namespace
+{
+int g_dsp_cluster_id = 0;
+}
+
+void set_dsp_cluster_id(int id)
+{
+    g_dsp_cluster_id = id;
+}
+
 template <typename FPTYPE>
 struct resize_memory_op_mt<FPTYPE, base_device::DEVICE_CPU>
 {
@@ -453,7 +461,7 @@ struct resize_memory_op_mt<FPTYPE, base_device::DEVICE_CPU>
         {
             mtfunc::free_ht(arr);
         }
-        arr = (FPTYPE*)mtfunc::malloc_ht(sizeof(FPTYPE) * size, GlobalV::MY_RANK % PARAM.inp.dsp_count);
+        arr = (FPTYPE*)mtfunc::malloc_ht(sizeof(FPTYPE) * size, g_dsp_cluster_id);
         std::string record_string;
         if (record_in != nullptr)
         {

--- a/source/source_base/module_device/memory_op.h
+++ b/source/source_base/module_device/memory_op.h
@@ -220,6 +220,11 @@ struct delete_memory_op<FPTYPE, base_device::DEVICE_GPU>
 
 #ifdef __DSP
 
+/// @brief Inject the DSP cluster id used by mt-allocator (mtfunc::malloc_ht).
+/// Caller-injected (typically once after input parameters are read).
+/// Defaults to 0 if never set.
+void set_dsp_cluster_id(int id);
+
 template <typename FPTYPE, typename Device>
 struct resize_memory_op_mt
 {

--- a/source/source_base/module_external/blas_connector.h
+++ b/source/source_base/module_external/blas_connector.h
@@ -426,6 +426,16 @@ public:
 
 	static
 	void vector_add_vector(const int& dim, std::complex<double> *result, const std::complex<double> *vector1, const double constant1, const std::complex<double> *vector2, const double constant2, base_device::AbacusDevice_t device_type = base_device::AbacusDevice_t::CpuDevice);
+
+#ifdef __DSP
+	/// @brief Inject the DSP cluster id used by mt-allocator BLAS kernels.
+	/// Caller-injected (typically once after input parameters are read).
+	/// Defaults to 0 if never set.
+	static void set_dsp_cluster_id(int id);
+
+private:
+	static int dsp_cluster_id_;
+#endif
 };
 
 #ifdef __CUDA

--- a/source/source_base/module_external/blas_connector_matrix.cpp
+++ b/source/source_base/module_external/blas_connector_matrix.cpp
@@ -3,8 +3,13 @@
 
 #ifdef __DSP
 #include "source_base/kernels/dsp/dsp_connector.h"
-#include "source_base/global_variable.h"
-#include "source_io/module_parameter/parameter.h"
+
+int BlasConnector::dsp_cluster_id_ = 0;
+
+void BlasConnector::set_dsp_cluster_id(int id)
+{
+    dsp_cluster_id_ = id;
+}
 #endif
 
 #ifdef __CUDA
@@ -31,7 +36,7 @@ void BlasConnector::gemm(const char transa, const char transb, const int m, cons
 	else if (device_type == base_device::AbacusDevice_t::DspDevice){
 		mtfunc::sgemm_mth_(&transb, &transa, &n, &m, &k,
 		&alpha, b, &ldb, a, &lda,
-		&beta, c, &ldc, GlobalV::MY_RANK % PARAM.inp.dsp_count);
+		&beta, c, &ldc, BlasConnector::dsp_cluster_id_);
 	}
 #endif
 #ifdef __CUDA
@@ -68,7 +73,7 @@ void BlasConnector::gemm(const char transa,
 #ifdef __DSP
     else if (device_type == base_device::AbacusDevice_t::DspDevice)
     {
-        mtfunc::dgemm_mth_(&transb, &transa, &n, &m, &k, &alpha, b, &ldb, a, &lda, &beta, c, &ldc, GlobalV::MY_RANK % PARAM.inp.dsp_count);
+        mtfunc::dgemm_mth_(&transb, &transa, &n, &m, &k, &alpha, b, &ldb, a, &lda, &beta, c, &ldc, BlasConnector::dsp_cluster_id_);
     }
 #endif
     else if (device_type == base_device::AbacusDevice_t::GpuDevice)
@@ -107,7 +112,7 @@ void BlasConnector::gemm(const char transa,
 #ifdef __DSP
     else if (device_type == base_device::AbacusDevice_t::DspDevice)
     {
-        mtfunc::cgemm_pack_mth_(&transb, &transa, &n, &m, &k, &alpha, b, &ldb, a, &lda, &beta, c, &ldc, GlobalV::MY_RANK % PARAM.inp.dsp_count);
+        mtfunc::cgemm_pack_mth_(&transb, &transa, &n, &m, &k, &alpha, b, &ldb, a, &lda, &beta, c, &ldc, BlasConnector::dsp_cluster_id_);
         // cgemm_mth_ for raw dsp mth;
         // cgemm_pack_mth_ for dsp mth with memcpy to DSP buffer
     }
@@ -160,7 +165,7 @@ void BlasConnector::gemm(const char transa,
 #ifdef __DSP
     else if (device_type == base_device::AbacusDevice_t::DspDevice)
     {
-        mtfunc::zgemm_pack_mth_(&transb, &transa, &n, &m, &k, &alpha, b, &ldb, a, &lda, &beta, c, &ldc, GlobalV::MY_RANK % PARAM.inp.dsp_count);
+        mtfunc::zgemm_pack_mth_(&transb, &transa, &n, &m, &k, &alpha, b, &ldb, a, &lda, &beta, c, &ldc, BlasConnector::dsp_cluster_id_);
         // zgemm_mth_ for raw dsp mth;
         // zgemm_pack_mth_ for dsp mth with memcpy to DSP buffer
     }
@@ -205,7 +210,7 @@ void BlasConnector::gemm_cm(const char transa, const char transb, const int m, c
 	else if (device_type == base_device::AbacusDevice_t::DspDevice){
 		mtfunc::sgemm_mth_(&transb, &transa, &m, &n, &k,
 		&alpha, a, &lda, b, &ldb,
-		&beta, c, &ldc, GlobalV::MY_RANK % PARAM.inp.dsp_count);
+		&beta, c, &ldc, BlasConnector::dsp_cluster_id_);
 	}
 #endif
 #ifdef __CUDA
@@ -242,7 +247,7 @@ void BlasConnector::gemm_cm(const char transa,
 #ifdef __DSP
     else if (device_type == base_device::AbacusDevice_t::DspDevice)
     {
-        mtfunc::dgemm_mth_(&transa, &transb, &m, &n, &k, &alpha, a, &lda, b, &ldb, &beta, c, &ldc, GlobalV::MY_RANK % PARAM.inp.dsp_count);
+        mtfunc::dgemm_mth_(&transa, &transb, &m, &n, &k, &alpha, a, &lda, b, &ldb, &beta, c, &ldc, BlasConnector::dsp_cluster_id_);
     }
 #endif
 #ifdef __CUDA
@@ -281,7 +286,7 @@ void BlasConnector::gemm_cm(const char transa,
 #ifdef __DSP
     else if (device_type == base_device::AbacusDevice_t::DspDevice)
     {
-        mtfunc::cgemm_pack_mth_(&transa, &transb, &m, &n, &k, &alpha, a, &lda, b, &ldb, &beta, c, &ldc, GlobalV::MY_RANK % PARAM.inp.dsp_count);
+        mtfunc::cgemm_pack_mth_(&transa, &transb, &m, &n, &k, &alpha, a, &lda, b, &ldb, &beta, c, &ldc, BlasConnector::dsp_cluster_id_);
         // cgemm_mth_ for raw dsp mth;
         // cgemm_pack_mth_ for dsp mth with memcpy to DSP buffer
     }
@@ -334,7 +339,7 @@ void BlasConnector::gemm_cm(const char transa,
 #ifdef __DSP
     else if (device_type == base_device::AbacusDevice_t::DspDevice)
     {
-        mtfunc::zgemm_pack_mth_(&transa, &transb, &m, &n, &k, &alpha, a, &lda, b, &ldb, &beta, c, &ldc, GlobalV::MY_RANK % PARAM.inp.dsp_count);
+        mtfunc::zgemm_pack_mth_(&transa, &transb, &m, &n, &k, &alpha, a, &lda, b, &ldb, &beta, c, &ldc, BlasConnector::dsp_cluster_id_);
         // zgemm_mth_ for raw dsp mth;
         // zgemm_pack_mth_ for dsp mth with memcpy to DSP buffer
     }
@@ -527,7 +532,7 @@ void BlasConnector::gemv(const char trans, const int m, const int n,
                           &beta,
                           Y,
                           &incy,
-                          GlobalV::MY_RANK % PARAM.inp.dsp_count);
+                          BlasConnector::dsp_cluster_id_);
     }
 #endif
 #ifdef __CUDA
@@ -561,7 +566,7 @@ void BlasConnector::gemv(const char trans, const int m, const int n,
                           &beta,
                           Y,
                           &incy,
-                          GlobalV::MY_RANK % PARAM.inp.dsp_count);
+                          BlasConnector::dsp_cluster_id_);
     }
 #endif
 #ifdef __CUDA
@@ -595,7 +600,7 @@ void BlasConnector::gemv(const char trans, const int m, const int n,
                           &beta,
                           Y,
                           &incy,
-                          GlobalV::MY_RANK % PARAM.inp.dsp_count);
+                          BlasConnector::dsp_cluster_id_);
     }
 #endif
 #ifdef __CUDA
@@ -631,7 +636,7 @@ void BlasConnector::gemv(const char trans, const int m, const int n,
                           &beta,
                           Y,
                           &incy,
-                          GlobalV::MY_RANK % PARAM.inp.dsp_count);
+                          BlasConnector::dsp_cluster_id_);
     }
 #endif
 #ifdef __CUDA

--- a/source/source_base/test/global_function_test.cpp
+++ b/source/source_base/test/global_function_test.cpp
@@ -1,8 +1,5 @@
 #include "../global_function.h"
 #include "../global_variable.h"
-#define private public
-#include "source_io/module_parameter/parameter.h"
-#undef private
 #include "../vector3.h"
 #include "../tool_quit.h"
 #include <string>
@@ -60,7 +57,7 @@
  *   - print out warning info in running.log file
  * - COPYARRAY
  *   - copy complex or double arrays
- * - IS_COLUMN_MAJOR_KS_SOLVER(PARAM.input.ks_solver)
+ * - IS_COLUMN_MAJOR_KS_SOLVER(ks_solver)
  *   - judge whether the KS_SOLVER is column major
  * - VECTOR_TO_PTR
  *   - get a copy of the ptr of a vector
@@ -662,8 +659,7 @@ TEST_F(GlobalFunctionTest, COPYARRAY)
 
 TEST_F(GlobalFunctionTest,IsColumnMajor)
 {
-	PARAM.input.ks_solver = "genelpa";
-	EXPECT_TRUE(ModuleBase::GlobalFunc::IS_COLUMN_MAJOR_KS_SOLVER(PARAM.input.ks_solver));
+	EXPECT_TRUE(ModuleBase::GlobalFunc::IS_COLUMN_MAJOR_KS_SOLVER("genelpa"));
 }
 
 TEST_F(GlobalFunctionTest,Vector2Ptr)

--- a/source/source_base/test/tool_quit_test.cpp
+++ b/source/source_base/test/tool_quit_test.cpp
@@ -1,8 +1,5 @@
 #include "../tool_quit.h"
 #include "../global_variable.h"
-#define private public
-#include "source_io/module_parameter/parameter.h"
-#undef private
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #ifdef __MPI
@@ -35,7 +32,7 @@ class ToolQuitTest : public testing::Test
 	{
 		GlobalV::ofs_warning.open("warning.log");
 		GlobalV::ofs_running.open("running.log");
-		PARAM.sys.global_out_dir = "OUT/";
+		ModuleBase::set_quit_out_dir("OUT/");
 	}
 	void TearDown()
 	{

--- a/source/source_base/timer.cpp
+++ b/source/source_base/timer.cpp
@@ -17,7 +17,6 @@
 
 #if defined(__CUDA) && defined(__USE_NVTX)
 #include "source_base/module_device/cuda_compat.h"
-#include "source_io/module_parameter/parameter.h"
 #endif
 
 namespace ModuleBase
@@ -27,6 +26,7 @@ namespace ModuleBase
 // EXPLAIN :
 //----------------------------------------------------------
 bool timer::disabled = false;
+bool timer::enable_nvtx_ = false;
 size_t timer::n_now = 0;
 std::map<std::string,std::map<std::string,timer::Timer_One>> timer::timer_pool;
 
@@ -99,7 +99,7 @@ void timer::start(const std::string &class_name,const std::string &name)
     ++timer_one.calls;
     timer_one.start_flag = false;
     #if defined(__CUDA) && defined(__USE_NVTX)
-    if (PARAM.inp.timer_enable_nvtx){
+    if (enable_nvtx_){
         std::string label = class_name + ":" + name;
         nvtxRangePushA(label.data());
     }
@@ -143,7 +143,7 @@ void timer::end(const std::string &class_name,const std::string &name)
     #endif
     timer_one.start_flag = true;
     #if defined(__CUDA) && defined(__USE_NVTX)
-    if (PARAM.inp.timer_enable_nvtx)
+    if (enable_nvtx_)
         { nvtxRangePop(); }
     #endif
 }

--- a/source/source_base/timer.h
+++ b/source/source_base/timer.h
@@ -64,6 +64,15 @@ class timer
     }
 
     /**
+     * @brief Toggle NVTX range emission for CUDA profiling.
+     * Caller-injected; only consulted when built with __CUDA && __USE_NVTX.
+     */
+    static void set_nvtx_enabled(bool b)
+    {
+        enable_nvtx_ = b;
+    }
+
+    /**
      * @brief Disable time computation
      *
      */
@@ -100,6 +109,11 @@ class timer
      *
      */
     static bool disabled;
+
+    /**
+     * @brief Member variable: NVTX range emission toggle (CUDA profiling only).
+     */
+    static bool enable_nvtx_;
 
     /**
      * @brief Member variable: the index of clocks

--- a/source/source_base/tool_quit.cpp
+++ b/source/source_base/tool_quit.cpp
@@ -7,7 +7,6 @@
 
 #else
 #include "global_variable.h"
-#include "source_io/module_parameter/parameter.h"
 #include "global_file.h"
 #include "timer.h"
 #include "memory.h"
@@ -15,6 +14,16 @@
 
 namespace ModuleBase
 {
+namespace
+{
+std::string g_quit_out_dir;
+}
+
+void set_quit_out_dir(const std::string& dir)
+{
+    g_quit_out_dir = dir;
+}
+
 //==========================================================
 // GLOBAL FUNCTION :
 // NAME : WARNING( write information into GlobalV::ofs_warning)
@@ -49,7 +58,7 @@ void QUIT(int ret)
 #else
     ModuleBase::timer::finish(GlobalV::ofs_running , !GlobalV::MY_RANK, false);
     ModuleBase::Global_File::close_all_log(GlobalV::MY_RANK);
-    std::cout<<" See output information in : "<<PARAM.globalv.global_out_dir<<std::endl;
+    std::cout<<" See output information in : "<<g_quit_out_dir<<std::endl;
 #endif
 
     exit(ret);
@@ -94,7 +103,7 @@ void WARNING_QUIT(const std::string &file,const std::string &description,int ret
 	std::cout << " ---------------------------------------------------------" << std::endl;
 	std::cout << " " << std::endl;
 	std::cout << " " << description << std::endl;
-	std::cout << " CHECK IN FILE : " << PARAM.globalv.global_out_dir << "warning.log" << std::endl;
+	std::cout << " CHECK IN FILE : " << g_quit_out_dir << "warning.log" << std::endl;
 	std::cout << " " << std::endl;
 	std::cout << " For detailed manual of ABACUS, please see the website" << std::endl;
 	std::cout << " https://abacus.deepmodeling.com" << std::endl;
@@ -110,7 +119,7 @@ void WARNING_QUIT(const std::string &file,const std::string &description,int ret
 	GlobalV::ofs_running << " ---------------------------------------------------------" << std::endl;
 	GlobalV::ofs_running << std::endl;
 	GlobalV::ofs_running << " " << description << std::endl;
-	GlobalV::ofs_running << " CHECK IN FILE : " << PARAM.globalv.global_out_dir << "warning.log" << std::endl;
+	GlobalV::ofs_running << " CHECK IN FILE : " << g_quit_out_dir << "warning.log" << std::endl;
 	GlobalV::ofs_running << std::endl;
 	GlobalV::ofs_running << " For detailed manual of ABACUS, please see the website" << std::endl;
 	GlobalV::ofs_running << " https://abacus.deepmodeling.com" << std::endl;
@@ -121,7 +130,7 @@ void WARNING_QUIT(const std::string &file,const std::string &description,int ret
 	GlobalV::ofs_running << " ---------------------------------------------------------" << std::endl;
 
 	WARNING(file,description);
-    GlobalV::ofs_running<<" Check in file : "<<PARAM.globalv.global_out_dir<<"warning.log"<<std::endl;
+    GlobalV::ofs_running<<" Check in file : "<<g_quit_out_dir<<"warning.log"<<std::endl;
 
 #endif
 
@@ -141,21 +150,21 @@ void CHECK_WARNING_QUIT(const bool error_in, const std::string &file,const std::
 		std::cout.clear();
 		if(!GlobalV::ofs_running.is_open())
 		{
-			std::string logfile = PARAM.globalv.global_out_dir + "running_" + calculation + ".log";
+			std::string logfile = g_quit_out_dir + "running_" + calculation + ".log";
 			GlobalV::ofs_running.open( logfile.c_str(), std::ios::app );
 		}
 		if(!GlobalV::ofs_warning.is_open())
 		{
-			std::string warningfile = PARAM.globalv.global_out_dir + "warning.log";
+			std::string warningfile = g_quit_out_dir + "warning.log";
 			GlobalV::ofs_warning.open( warningfile.c_str(), std::ios::app );
 		}
 
 		//print error information
 		std::cout << " ---------------------------------------------------------" << std::endl;
 		std::cout << " ERROR! " << description << std::endl;
-		std::cout << " CHECK IN FILE : " << PARAM.globalv.global_out_dir << "warning.log" << std::endl;
+		std::cout << " CHECK IN FILE : " << g_quit_out_dir << "warning.log" << std::endl;
 		std::cout << " ---------------------------------------------------------" << std::endl;
-		GlobalV::ofs_running << " ERROR! CHECK IN FILE : " << PARAM.globalv.global_out_dir << "warning.log" << std::endl;
+		GlobalV::ofs_running << " ERROR! CHECK IN FILE : " << g_quit_out_dir << "warning.log" << std::endl;
 		GlobalV::ofs_warning << std::endl;
 		GlobalV::ofs_warning << " ERROR! " << file << ", core " << GlobalV::MY_RANK+1 << ": " << description << std::endl;
 		GlobalV::ofs_warning << std::endl;

--- a/source/source_base/tool_quit.h
+++ b/source/source_base/tool_quit.h
@@ -29,6 +29,15 @@ namespace ModuleBase
 void WARNING(const std::string &file, const std::string &description);
 
 /**
+ * @brief Inject the global output directory used by QUIT/WARNING_QUIT/CHECK_WARNING_QUIT
+ *        for log path resolution and user-facing messages.
+ *
+ * Caller-injected (typically once after input parameters are read).
+ * If never set, paths fall back to CWD.
+ */
+void set_quit_out_dir(const std::string& dir);
+
+/**
  * @brief Close .log files and exit
  *
  */

--- a/source/source_main/driver.cpp
+++ b/source/source_main/driver.cpp
@@ -14,6 +14,7 @@
 #include "source_base/parallel_global.h"
 #ifdef __DSP
 #include "source_base/module_device/memory_op.h"
+#include "source_base/module_external/blas_connector.h"
 #endif
 
 Driver::Driver()
@@ -130,6 +131,7 @@ void Driver::reading()
 
 #ifdef __DSP
     base_device::memory::set_dsp_cluster_id(GlobalV::MY_RANK % PARAM.inp.dsp_count);
+    BlasConnector::set_dsp_cluster_id(GlobalV::MY_RANK % PARAM.inp.dsp_count);
 #endif
 
     // (2) create the output directory, running_*.log and print info

--- a/source/source_main/driver.cpp
+++ b/source/source_main/driver.cpp
@@ -119,6 +119,8 @@ void Driver::reading()
     ModuleIO::ReadInput input(PARAM.globalv.myrank);
     input.read_parameters(PARAM, PARAM.globalv.global_in_card);
 
+    ModuleBase::set_quit_out_dir(PARAM.globalv.global_out_dir);
+
 #if defined(__CUDA) && defined(__USE_NVTX)
     ModuleBase::timer::set_nvtx_enabled(PARAM.inp.timer_enable_nvtx);
 #endif

--- a/source/source_main/driver.cpp
+++ b/source/source_main/driver.cpp
@@ -12,6 +12,9 @@
 #include "source_io/module_parameter/parameter.h"
 #include "source_main/version.h"
 #include "source_base/parallel_global.h"
+#ifdef __DSP
+#include "source_base/module_device/memory_op.h"
+#endif
 
 Driver::Driver()
 {
@@ -123,6 +126,10 @@ void Driver::reading()
 
 #if defined(__CUDA) && defined(__USE_NVTX)
     ModuleBase::timer::set_nvtx_enabled(PARAM.inp.timer_enable_nvtx);
+#endif
+
+#ifdef __DSP
+    base_device::memory::set_dsp_cluster_id(GlobalV::MY_RANK % PARAM.inp.dsp_count);
 #endif
 
     // (2) create the output directory, running_*.log and print info

--- a/source/source_main/driver.cpp
+++ b/source/source_main/driver.cpp
@@ -119,6 +119,10 @@ void Driver::reading()
     ModuleIO::ReadInput input(PARAM.globalv.myrank);
     input.read_parameters(PARAM, PARAM.globalv.global_in_card);
 
+#if defined(__CUDA) && defined(__USE_NVTX)
+    ModuleBase::timer::set_nvtx_enabled(PARAM.inp.timer_enable_nvtx);
+#endif
+
     // (2) create the output directory, running_*.log and print info
     input.create_directory(PARAM);
     this->print_start_info();


### PR DESCRIPTION
About this PR:

Because modules in source_base is quite basic, so changing the function parameters directly will lead to a extremely huge change in the whole project.

So I added static variables, then injecting them when reading INPUT instead of directly using global variables or input parameters. In this way these files can get rid of having to include parameter.h to get the parameter.


About variables:

g_xxx means global_xxx


And the next PR is about global_file.cpp. It will affect a huge amount of files so it will not included in this PR.