### PR TITLE
Toolchain: Use "filter_setup" functional for a cleaner setup file

### DIFF
--- a/toolchain/scripts/stage0/install_amd.sh
+++ b/toolchain/scripts/stage0/install_amd.sh
@@ -90,7 +90,7 @@ export AMD_CFLAGS="${AMD_CFLAGS}"
 export AMD_LDFLAGS="${AMD_LDFLAGS}"
 export AMD_LIBS="${AMD_LIBS}"
 EOF
-    cat "${BUILDDIR}/setup_amd" >> ${SETUPFILE}
+    filter_setup "${BUILDDIR}/setup_amd" ${SETUPFILE}
 fi
 
 load "${BUILDDIR}/setup_amd"

--- a/toolchain/scripts/stage0/install_cmake.sh
+++ b/toolchain/scripts/stage0/install_cmake.sh
@@ -133,7 +133,7 @@ if [ "${with_cmake}" != "__DONTUSE__" ]; then
         cat << EOF > "${BUILDDIR}/setup_cmake"
 prepend_path PATH "${pkg_install_dir}/bin"
 EOF
-        cat "${BUILDDIR}/setup_cmake" >> $SETUPFILE
+        filter_setup "${BUILDDIR}/setup_cmake" $SETUPFILE
     fi
 fi
 

--- a/toolchain/scripts/stage0/install_gcc.sh
+++ b/toolchain/scripts/stage0/install_gcc.sh
@@ -231,7 +231,7 @@ export GCC_CFLAGS="${GCC_CFLAGS}"
 export GCC_LDFLAGS="${GCC_LDFLAGS}"
 export TSANFLAGS="${TSANFLAGS}"
 EOF
-    cat "${BUILDDIR}/setup_gcc" >> ${SETUPFILE}
+    filter_setup "${BUILDDIR}/setup_gcc" ${SETUPFILE}
 fi
 
 # ----------------------------------------------------------------------

--- a/toolchain/scripts/stage0/install_intel.sh
+++ b/toolchain/scripts/stage0/install_intel.sh
@@ -94,7 +94,7 @@ export INTEL_CFLAGS="${INTEL_CFLAGS}"
 export INTEL_LDFLAGS="${INTEL_LDFLAGS}"
 export INTEL_LIBS="${INTEL_LIBS}"
 EOF
-    cat "${BUILDDIR}/setup_intel" >> ${SETUPFILE}
+    filter_setup "${BUILDDIR}/setup_intel" ${SETUPFILE}
 fi
 
 load "${BUILDDIR}/setup_intel"

--- a/toolchain/scripts/stage1/install_intelmpi.sh
+++ b/toolchain/scripts/stage1/install_intelmpi.sh
@@ -144,7 +144,7 @@ export CP_CFLAGS="\${CP_CFLAGS} IF_MPI(${INTELMPI_CFLAGS}|)"
 export CP_LDFLAGS="\${CP_LDFLAGS} IF_MPI(${INTELMPI_LDFLAGS}|)"
 export CP_LIBS="\${CP_LIBS} IF_MPI(${INTELMPI_LIBS}|)"
 EOF
-    cat "${BUILDDIR}/setup_intelmpi" >> ${SETUPFILE}
+    filter_setup "${BUILDDIR}/setup_intelmpi" ${SETUPFILE}
 fi
 
 load "${BUILDDIR}/setup_intelmpi"

--- a/toolchain/scripts/stage1/install_mpich.sh
+++ b/toolchain/scripts/stage1/install_mpich.sh
@@ -171,7 +171,7 @@ prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path CPATH "${pkg_install_dir}/include"
 EOF
     fi
-    cat "${BUILDDIR}/setup_mpich" >> ${SETUPFILE}
+    filter_setup "${BUILDDIR}/setup_mpich" ${SETUPFILE}
 fi
 
 # Update leak suppression file

--- a/toolchain/scripts/stage1/install_openmpi.sh
+++ b/toolchain/scripts/stage1/install_openmpi.sh
@@ -207,7 +207,7 @@ prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path CPATH "${pkg_install_dir}/include"
 EOF
         fi
-        cat "${BUILDDIR}/setup_openmpi" >> ${SETUPFILE}
+        filter_setup "${BUILDDIR}/setup_openmpi" ${SETUPFILE}
     fi
 
     # ----------------------------------------------------------------------

--- a/toolchain/scripts/stage2/install_aocl.sh
+++ b/toolchain/scripts/stage2/install_aocl.sh
@@ -66,7 +66,7 @@ export MATH_CFLAGS="\${MATH_CFLAGS} ${AOCL_CFLAGS}"
 export MATH_LDFLAGS="\${MATH_LDFLAGS} ${AOCL_LDFLAGS}"
 export MATH_LIBS="\${MATH_LIBS} ${AOCL_LIBS}"
 EOF
-    cat "${BUILDDIR}/setup_aocl" >> $SETUPFILE
+    filter_setup "${BUILDDIR}/setup_aocl" $SETUPFILE
 fi
 
 load "${BUILDDIR}/setup_aocl"

--- a/toolchain/scripts/stage2/install_mkl.sh
+++ b/toolchain/scripts/stage2/install_mkl.sh
@@ -136,7 +136,7 @@ export FFTW_LDFLAGS="${MKL_LDFLAGS}"
 export FFTW_LIBS="${MKL_LIBS}"
 EOF
     fi
-    cat "${BUILDDIR}/setup_mkl" >> ${SETUPFILE}
+    filter_setup "${BUILDDIR}/setup_mkl" ${SETUPFILE}
 fi
 
 load "${BUILDDIR}/setup_mkl"

--- a/toolchain/scripts/stage2/install_openblas.sh
+++ b/toolchain/scripts/stage2/install_openblas.sh
@@ -184,7 +184,7 @@ export MATH_LIBS="\${MATH_LIBS} ${OPENBLAS_LIBS}"
 prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
-    cat "${BUILDDIR}/setup_openblas" >> $SETUPFILE
+    filter_setup "${BUILDDIR}/setup_openblas" $SETUPFILE
 fi
 
 load "${BUILDDIR}/setup_openblas"

--- a/toolchain/scripts/stage3/install_elpa.sh
+++ b/toolchain/scripts/stage3/install_elpa.sh
@@ -266,7 +266,7 @@ export CP_LDFLAGS="\${CP_LDFLAGS} IF_MPI(${ELPA_LDFLAGS}|)"
 export CP_LIBS="IF_MPI(${ELPA_LIBS}|) \${CP_LIBS}"
 export ELPA_VERSION="${elpa_ver}"
 EOF
-    cat "${BUILDDIR}/setup_elpa" >> $SETUPFILE
+    filter_setup "${BUILDDIR}/setup_elpa" $SETUPFILE
 fi
 
 load "${BUILDDIR}/setup_elpa"

--- a/toolchain/scripts/stage3/install_elpa.sh
+++ b/toolchain/scripts/stage3/install_elpa.sh
@@ -115,19 +115,15 @@ case "$with_elpa" in
                 [ "$TARGET" = "nvidia" ] && [ "$gpu_enabled" != "__TRUE__" ] && continue
                 # disable cpu if cuda is enabled, only install one
                 [ "$TARGET" != "nvidia" ] && [ "$gpu_enabled" = "__TRUE__" ] && continue
-                # extend the pkg_install_dir by TARGET
-                # this linking method is totally different from cp2k toolchain
-                # for cp2k, ref https://github.com/cp2k/cp2k/commit/6fe2fc105b8cded84256248f68c74139dd8fc2e9
-                pkg_install_dir="${pkg_install_dir}/${TARGET}"
 
-                echo "Installing from scratch into ${pkg_install_dir}"
+                echo "Installing from scratch into ${pkg_install_dir}/${TARGET}"
                 mkdir -p "build_${TARGET}"
                 cd "build_${TARGET}"
                 if [ "${with_amd}" != "__DONTUSE__" ] && [ "${WITH_FLANG}" = "yes" ] ; then
                     # special option for flang compiler
                     echo "AMD fortran compiler detected, enable special option operation"
-                    ../configure --prefix="${pkg_install_dir}" \
-                        --libdir="${pkg_install_dir}/lib" \
+                    ../configure --prefix="${pkg_install_dir}/${TARGET}" \
+                        --libdir="${pkg_install_dir}/${TARGET}/lib" \
                         --enable-openmp=${enable_openmp} \
                         --enable-static=no \
                         --enable-shared=yes \
@@ -158,8 +154,8 @@ case "$with_elpa" in
                         -e 's/\\$wl\\$soname //g'
                 else
                     # normal installation
-                    ../configure --prefix="${pkg_install_dir}/" \
-                        --libdir="${pkg_install_dir}/lib" \
+                    ../configure --prefix="${pkg_install_dir}/${TARGET}" \
+                        --libdir="${pkg_install_dir}/${TARGET}/lib" \
                         --enable-openmp=${enable_openmp} \
                         --enable-static=no \
                         --enable-shared=yes \
@@ -187,9 +183,9 @@ case "$with_elpa" in
                 make install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
                 cd ..
                 # link elpa
-                link=${pkg_install_dir}/include/elpa
+                link=${pkg_install_dir}/${TARGET}/include/elpa
                 if [[ ! -d $link ]]; then
-                    ln -s ${pkg_install_dir}/include/elpa_openmp-${elpa_ver}/elpa $link
+                    ln -s ${pkg_install_dir}/${TARGET}/include/elpa_openmp-${elpa_ver}/elpa $link
                 fi
             done
             cd ..
@@ -197,8 +193,9 @@ case "$with_elpa" in
             write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage3/$(basename ${SCRIPT_NAME})"
         fi
         [ "$enable_openmp" != "yes" ] && elpa_dir_openmp=""
-        ELPA_CFLAGS="-I'${pkg_install_dir}/include/elpa${elpa_dir_openmp}-${elpa_ver}/modules' -I'${pkg_install_dir}/include/elpa${elpa_dir_openmp}-${elpa_ver}/elpa'"
-        ELPA_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
+        elpa_include="${pkg_install_dir}/IF_CUDA(nvidia|cpu)/include/elpa${elpa_dir_openmp}-${elpa_ver}"
+        ELPA_CFLAGS="-I'$elpa_include/modules' -I'$elpa_include/elpa'"
+        ELPA_LDFLAGS="-L'${pkg_install_dir}/IF_CUDA(nvidia|cpu)/lib' -Wl,-rpath,'${pkg_install_dir}/IF_CUDA(nvidia|cpu)/lib'"
         ;;
     __SYSTEM__)
         echo "==================== Finding ELPA from system paths ===================="
@@ -246,14 +243,23 @@ prepend_path CPATH "$elpa_include"
 EOF
     if [ "$with_elpa" != "__SYSTEM__" ]; then
         cat << EOF >> "${BUILDDIR}/setup_elpa"
-prepend_path PATH "${pkg_install_dir}/bin"
-prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
-prepend_path CPATH "${pkg_install_dir}/include"
-prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
-prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
-prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
-prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
+prepend_path PATH "${pkg_install_dir}/cpu/bin"
+prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/cpu/lib"
+prepend_path LD_RUN_PATH "${pkg_install_dir}/cpu/lib"
+prepend_path LIBRARY_PATH "${pkg_install_dir}/cpu/lib"
+prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/cpu/lib/pkgconfig"
+prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}/cpu"
 EOF
+        if [ -d ${pkg_install_dir}/nvidia ]; then
+            cat << EOF >> "${BUILDDIR}/setup_elpa"
+prepend_path PATH "${pkg_install_dir}/nvidia/bin"
+prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/nvidia/lib"
+prepend_path LD_RUN_PATH "${pkg_install_dir}/nvidia/lib"
+prepend_path LIBRARY_PATH "${pkg_install_dir}/nvidia/lib"
+prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/nvidia/lib/pkgconfig"
+prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}/nvidia"
+EOF
+        fi
     fi
     cat << EOF >> "${BUILDDIR}/setup_elpa"
 export ELPA_ROOT="${pkg_install_dir}"

--- a/toolchain/scripts/stage3/install_fftw.sh
+++ b/toolchain/scripts/stage3/install_fftw.sh
@@ -146,7 +146,7 @@ export CP_LIBS="${FFTW_LIBS} \${CP_LIBS}"
 export FFTW_ROOT=${FFTW_ROOT:-${pkg_install_dir}}
 export FFTW3_ROOT=${pkg_install_dir}
 EOF
-    cat "${BUILDDIR}/setup_fftw" >> $SETUPFILE
+    filter_setup "${BUILDDIR}/setup_fftw" $SETUPFILE
 fi
 cd "${ROOTDIR}"
 

--- a/toolchain/scripts/stage3/install_libxc.sh
+++ b/toolchain/scripts/stage3/install_libxc.sh
@@ -127,7 +127,7 @@ export CP_LDFLAGS="\${CP_LDFLAGS} ${LIBXC_LDFLAGS}"
 export CP_LIBS="${LIBXC_LIBS} \${CP_LIBS}"
 export LIBXC_ROOT="${pkg_install_dir}"
 EOF
-    cat "${BUILDDIR}/setup_libxc" >> $SETUPFILE
+    filter_setup "${BUILDDIR}/setup_libxc" $SETUPFILE
 fi
 
 load "${BUILDDIR}/setup_libxc"

--- a/toolchain/scripts/stage3/install_scalapack.sh
+++ b/toolchain/scripts/stage3/install_scalapack.sh
@@ -124,7 +124,7 @@ export CP_DFLAGS="\${CP_DFLAGS} IF_MPI(-D__SCALAPACK|)"
 export CP_LDFLAGS="\${CP_LDFLAGS} IF_MPI(${SCALAPACK_LDFLAGS}|)"
 export CP_LIBS="IF_MPI(-lscalapack|) \${CP_LIBS}"
 EOF
-    cat "${BUILDDIR}/setup_scalapack" >> $SETUPFILE
+    filter_setup "${BUILDDIR}/setup_scalapack" $SETUPFILE
 fi
 cd "${ROOTDIR}"
 

--- a/toolchain/scripts/stage4/install_cereal.sh
+++ b/toolchain/scripts/stage4/install_cereal.sh
@@ -112,12 +112,9 @@ EOF
     fi
     cat << EOF >> "${BUILDDIR}/setup_cereal"
 export CEREAL_ROOT="${pkg_install_dir}"
-export CEREAL_CFLAGS="${CEREAL_CFLAGS}"
-export CP_DFLAGS="\${CP_DFLAGS} -D__CEREAL"
-export CP_CFLAGS="\${CP_CFLAGS} ${CEREAL_CFLAGS}"
 export CEREAL_VERSION="${cereal_ver}"
 EOF
-    cat "${BUILDDIR}/setup_cereal" >> $SETUPFILE
+    filter_setup "${BUILDDIR}/setup_cereal" $SETUPFILE
 fi
 
 load "${BUILDDIR}/setup_cereal"

--- a/toolchain/scripts/stage4/install_libcomm.sh
+++ b/toolchain/scripts/stage4/install_libcomm.sh
@@ -112,10 +112,9 @@ prepend_path CPATH "${pkg_install_dir}/include"
 EOF
     fi
     cat << EOF >> "${BUILDDIR}/setup_libcomm"
-export LIBCOMM_CFLAGS="${LIBCOMM_CFLAGS}"
 export LIBCOMM_ROOT="${pkg_install_dir}"
 EOF
-    cat "${BUILDDIR}/setup_libcomm" >> $SETUPFILE
+    filter_setup "${BUILDDIR}/setup_libcomm" $SETUPFILE
 fi
 
 load "${BUILDDIR}/setup_libcomm"

--- a/toolchain/scripts/stage4/install_libnpy.sh
+++ b/toolchain/scripts/stage4/install_libnpy.sh
@@ -104,10 +104,9 @@ prepend_path CPATH "${pkg_install_dir}/include"
 EOF
     fi
     cat << EOF >> "${BUILDDIR}/setup_libnpy"
-export LIBNPY_CFLAGS="${LIBNPY_CFLAGS}"
 export LIBNPY_ROOT="${pkg_install_dir}"
 EOF
-    cat "${BUILDDIR}/setup_libnpy" >> $SETUPFILE
+    filter_setup "${BUILDDIR}/setup_libnpy" $SETUPFILE
 fi
 
 load "${BUILDDIR}/setup_libnpy"

--- a/toolchain/scripts/stage4/install_libri.sh
+++ b/toolchain/scripts/stage4/install_libri.sh
@@ -111,10 +111,9 @@ prepend_path CPATH "${pkg_install_dir}/include"
 EOF
     fi
     cat << EOF >> "${BUILDDIR}/setup_libri"
-export LIBRI_CFLAGS="${LIBRI_CFLAGS}"
 export LIBRI_ROOT="${pkg_install_dir}"
 EOF
-    cat "${BUILDDIR}/setup_libri" >> $SETUPFILE
+    filter_setup "${BUILDDIR}/setup_libri" $SETUPFILE
 fi
 
 load "${BUILDDIR}/setup_libri"

--- a/toolchain/scripts/stage4/install_libtorch.sh
+++ b/toolchain/scripts/stage4/install_libtorch.sh
@@ -109,21 +109,21 @@ prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 prepend_path CPATH "${pkg_install_dir}/include"
 EOF
     fi
+    cat << EOF >> "${BUILDDIR}/setup_libtorch"
+export CP_DFLAGS="\${CP_DFLAGS} -D__LIBTORCH"
+export CXXFLAGS="\${CXXFLAGS} ${LIBTORCH_CXXFLAGS}"
+export CP_LDFLAGS="\${CP_LDFLAGS} ${LIBTORCH_LDFLAGS}"
+EOF
     if [ "$ENABLE_CUDA" = "__TRUE__" ]; then
         cat << EOF >> "${BUILDDIR}/setup_libtorch"
-export CP_DFLAGS="\${CP_DFLAGS} -D__LIBTORCH"
-export CXXFLAGS="\${CXXFLAGS} ${LIBTORCH_CXXFLAGS}"
-export CP_LDFLAGS="\${CP_LDFLAGS} ${LIBTORCH_LDFLAGS}"
 export CP_LIBS="\${CP_LIBS} -lc10 -lc10_cuda -ltorch_cpu -ltorch_cuda -ltorch"
 EOF
+    else
         cat << EOF >> "${BUILDDIR}/setup_libtorch"
-export CP_DFLAGS="\${CP_DFLAGS} -D__LIBTORCH"
-export CXXFLAGS="\${CXXFLAGS} ${LIBTORCH_CXXFLAGS}"
-export CP_LDFLAGS="\${CP_LDFLAGS} ${LIBTORCH_LDFLAGS}"
 export CP_LIBS="\${CP_LIBS} -lc10 -ltorch_cpu -ltorch"
 EOF
-        cat "${BUILDDIR}/setup_libtorch" >> "${SETUPFILE}"
     fi
+    filter_setup "${BUILDDIR}/setup_libtorch" "${SETUPFILE}"
 fi
 
 load "${BUILDDIR}/setup_libtorch"

--- a/toolchain/scripts/stage4/install_nep.sh
+++ b/toolchain/scripts/stage4/install_nep.sh
@@ -128,16 +128,9 @@ prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
   fi
   cat << EOF >> "${BUILDDIR}/setup_nep"
-export NEP_CFLAGS="${NEP_CFLAGS}"
-export NEP_LDFLAGS="${NEP_LDFLAGS}"
-export NEP_LIBS="${NEP_LIBS}"
-export CP_DFLAGS="\${CP_DFLAGS} -D__NEP"
-export CP_CFLAGS="\${CP_CFLAGS} \${NEP_CFLAGS}"
-export CP_LDFLAGS="\${CP_LDFLAGS} \${NEP_LDFLAGS}"
-export CP_LIBS="\${NEP_LIBS} \${CP_LIBS}"
 export NEP_ROOT="${pkg_install_dir}"
 EOF
-  cat "${BUILDDIR}/setup_nep" >> $SETUPFILE
+  filter_setup "${BUILDDIR}/setup_nep" $SETUPFILE
 fi
 
 load "${BUILDDIR}/setup_nep"

--- a/toolchain/scripts/stage4/install_rapidjson.sh
+++ b/toolchain/scripts/stage4/install_rapidjson.sh
@@ -119,12 +119,8 @@ EOF
     fi
     cat << EOF >> "${BUILDDIR}/setup_rapidjson"
 export RAPIDJSON_ROOT="${pkg_install_dir}"
-export RAPIDJSON_CFLAGS="${RAPIDJSON_CFLAGS}"
-export CP_DFLAGS="\${CP_DFLAGS} -D__RAPIDJSON"
-export CP_CFLAGS="\${CP_CFLAGS} ${RAPIDJSON_CFLAGS}"
-export RAPIDJSON_VERSION="${rapidjson_ver}"
 EOF
-    cat "${BUILDDIR}/setup_rapidjson" >> $SETUPFILE
+    filter_setup "${BUILDDIR}/setup_rapidjson" $SETUPFILE
 fi
 
 load "${BUILDDIR}/setup_rapidjson"

--- a/toolchain/scripts/tool_kit.sh
+++ b/toolchain/scripts/tool_kit.sh
@@ -1049,3 +1049,19 @@ write_toolchain_env() {
     export -p
   ) > "${__installdir}/toolchain.env"
 }
+
+# Write a setup file without containing flags unnecessay for building and running ABACUS
+filter_setup() {
+  local source_file="$1"
+  local target_file="$2"
+
+  # Check if setup_xxx file exists
+  if [[ ! -f "$source_file" ]]; then
+    report_error "File '$source_file' does not exist."
+    return 1
+  fi
+
+  local filename=$(basename "$source_file")
+  echo "# ==================== Setup for ${filename#*_} ==================== #" >> "$target_file"
+  sed '/if[[:space:]]/,/^[[:space:]]*fi$/d' "$source_file" | grep -v -E '# For|# Other|with_|FLAGS|LIBS|INCLUDES' >> "$target_file"
+}


### PR DESCRIPTION
note: The flags are not directly deleted in case some other packages in toolchain need some of them since they are written into `install/toolchain.env` anyways.

Also revises ELPA installation in toolchain.