### PR TITLE
Remove dependencies in rest files in source_base

### DIFF
--- a/source/source_base/global_file.cpp
+++ b/source/source_base/global_file.cpp
@@ -14,7 +14,6 @@
 #include <cerrno>
 #include <sstream>
 #include "global_function.h"
-#include "source_io/module_parameter/parameter.h"
 #include "global_variable.h"
 #include "source_base/parallel_common.h"
 #include "source_base/parallel_reduce.h"
@@ -31,7 +30,16 @@ void ModuleBase::Global_File::make_dir_out(
     const bool &out_wfc_dir,
     const int rank,
     const bool &restart,
-    const bool out_alllog)
+    const bool out_alllog,
+    const std::string &global_out_dir,
+    const std::string &global_stru_dir,
+    const std::string &global_matrix_dir,
+    const std::string &global_wfc_dir,
+    const std::string &global_mlkedf_descriptor_dir,
+    const std::string &global_deepks_label_elec_dir,
+    const std::string &log_file,
+    const bool of_ml_gene_data,
+    const bool deepks_out_freq_elec)
 {
 //----------------------------------------------------------
 // USE STL FUNCTION
@@ -43,17 +51,16 @@ void ModuleBase::Global_File::make_dir_out(
 #endif
     int make_dir = 0;
 	// mohan update 2011-05-03
-    //std::string command0 =  "test -d " + PARAM.globalv.global_out_dir + " || mkdir " + PARAM.globalv.global_out_dir;
 
 	int times = 0;
 	while(times<GlobalV::NPROC)
 	{
 		if(rank==times)
 		{
-            int ret = mkdir(PARAM.globalv.global_out_dir.c_str(), 0755);
+            int ret = mkdir(global_out_dir.c_str(), 0755);
 			if ( ret == 0 || errno == EEXIST )
 			{
-				std::cout << " MAKE THE DIR         : " << PARAM.globalv.global_out_dir << std::endl;
+				std::cout << " MAKE THE DIR         : " << global_out_dir << std::endl;
 				make_dir = 1;
 			}
 			else
@@ -82,17 +89,16 @@ void ModuleBase::Global_File::make_dir_out(
     if(calculation == "md")
     {
         int make_dir_stru = 0;
-        //std::string command1 =  "test -d " + PARAM.globalv.global_stru_dir + " || mkdir " + PARAM.globalv.global_stru_dir;
 
         times = 0;
         while(times<GlobalV::NPROC)
         {
             if(rank==times)
             {
-                int ret = mkdir(PARAM.globalv.global_stru_dir.c_str(), 0755);
+                int ret = mkdir(global_stru_dir.c_str(), 0755);
                 if ( ret == 0 || errno == EEXIST )
                 {
-                    std::cout << " MAKE THE STRU DIR    : " << PARAM.globalv.global_stru_dir << std::endl;
+                    std::cout << " MAKE THE STRU DIR    : " << global_stru_dir << std::endl;
                     make_dir_stru = 1;
                 }
                 else
@@ -123,17 +129,16 @@ void ModuleBase::Global_File::make_dir_out(
     if((out_dir) && calculation == "md")
     {
         int make_dir_matrix = 0;
-        //std::string command1 =  "test -d " + PARAM.globalv.global_matrix_dir + " || mkdir " + PARAM.globalv.global_matrix_dir;
 
         times = 0;
         while(times<GlobalV::NPROC)
         {
             if(rank==times)
             {
-                int ret = mkdir(PARAM.globalv.global_matrix_dir.c_str(), 0755);
+                int ret = mkdir(global_matrix_dir.c_str(), 0755);
                 if ( ret == 0 || errno == EEXIST )
                 {
-                    std::cout << " MAKE THE MATRIX DIR    : " << PARAM.globalv.global_matrix_dir << std::endl;
+                    std::cout << " MAKE THE MATRIX DIR    : " << global_matrix_dir << std::endl;
                     make_dir_matrix = 1;
                 }
                 else
@@ -163,17 +168,16 @@ void ModuleBase::Global_File::make_dir_out(
     if(out_wfc_dir)
     {
         int make_dir_wfc = 0;
-        //std::string command1 =  "test -d " + PARAM.globalv.global_wfc_dir + " || mkdir " + PARAM.globalv.global_wfc_dir;
 
         times = 0;
         while(times<GlobalV::NPROC)
         {
             if(rank==times)
             {
-                int ret = mkdir(PARAM.globalv.global_wfc_dir.c_str(), 0755);
+                int ret = mkdir(global_wfc_dir.c_str(), 0755);
                 if ( ret == 0 || errno == EEXIST )
                 {
-                    std::cout << " MAKE THE WFC DIR    : " << PARAM.globalv.global_wfc_dir << std::endl;
+                    std::cout << " MAKE THE WFC DIR    : " << global_wfc_dir << std::endl;
                     make_dir_wfc = 1;
                 }
                 else
@@ -200,20 +204,19 @@ void ModuleBase::Global_File::make_dir_out(
 #endif
     }
 
-    if(PARAM.inp.of_ml_gene_data == 1)
+    if(of_ml_gene_data)
     {
         int make_dir_descrip = 0;
-        //std::string command1 =  "test -d " + PARAM.globalv.global_mlkedf_descriptor_dir + " || mkdir " + PARAM.globalv.global_mlkedf_descriptor_dir;
 
         times = 0;
         while(times<GlobalV::NPROC)
         {
             if(rank==times)
             {
-                int ret = mkdir(PARAM.globalv.global_mlkedf_descriptor_dir.c_str(), 0755);
+                int ret = mkdir(global_mlkedf_descriptor_dir.c_str(), 0755);
                 if ( ret == 0 || errno == EEXIST )
                 {
-                    std::cout << " MAKE THE MLKEDF DESCRIPTOR DIR    : " << PARAM.globalv.global_mlkedf_descriptor_dir << std::endl;
+                    std::cout << " MAKE THE MLKEDF DESCRIPTOR DIR    : " << global_mlkedf_descriptor_dir << std::endl;
                     make_dir_descrip = 1;
                 }
                 else
@@ -226,7 +229,7 @@ void ModuleBase::Global_File::make_dir_out(
             Parallel_Reduce::reduce_all(make_dir_descrip);
 #endif
             if(make_dir_descrip > 0)
-            { 
+            {
                 break;
             }
             ++times;
@@ -242,20 +245,19 @@ void ModuleBase::Global_File::make_dir_out(
 #endif
     }
 
-    if(PARAM.inp.deepks_out_freq_elec > 0)
+    if(deepks_out_freq_elec)
     {
         int make_dir_deepks_elec = 0;
-        //std::string command1 =  "test -d " + PARAM.globalv.global_deepks_label_elec_dir + " || mkdir " + PARAM.globalv.global_deepks_label_elec_dir;
 
         times = 0;
         while(times<GlobalV::NPROC)
         {
             if(rank==times)
             {
-                int ret = mkdir(PARAM.globalv.global_deepks_label_elec_dir.c_str(), 0755);
+                int ret = mkdir(global_deepks_label_elec_dir.c_str(), 0755);
                 if ( ret == 0 || errno == EEXIST )
                 {
-                    std::cout << " MAKE THE DEEPKS LABELS (ELEC) DIR    : " << PARAM.globalv.global_deepks_label_elec_dir << std::endl;
+                    std::cout << " MAKE THE DEEPKS LABELS (ELEC) DIR    : " << global_deepks_label_elec_dir << std::endl;
                     make_dir_deepks_elec = 1;
                 }
                 else
@@ -268,7 +270,7 @@ void ModuleBase::Global_File::make_dir_out(
             Parallel_Reduce::reduce_all(make_dir_deepks_elec);
 #endif
             if(make_dir_deepks_elec > 0)
-            { 
+            {
                 break;
             }
             ++times;
@@ -287,53 +289,53 @@ void ModuleBase::Global_File::make_dir_out(
     // mohan add 2010-09-12
     if(out_alllog)
     {
-	    open_log(GlobalV::ofs_running, PARAM.globalv.log_file, calculation, restart);
+	    open_log(GlobalV::ofs_running, log_file, calculation, restart, global_out_dir);
         #if defined(__CUDA) || defined(__ROCM)
-        open_log(GlobalV::ofs_device, "device" + std::to_string(rank) + ".log", calculation, restart);
+        open_log(GlobalV::ofs_device, "device" + std::to_string(rank) + ".log", calculation, restart, global_out_dir);
         #endif
     }
     else
     {
 	    if(rank==0)
 	    {
-		    open_log(GlobalV::ofs_running, PARAM.globalv.log_file, calculation, restart);
+		    open_log(GlobalV::ofs_running, log_file, calculation, restart, global_out_dir);
             #if defined(__CUDA) || defined(__ROCM)
-            open_log(GlobalV::ofs_device, "device.log", calculation, restart);
+            open_log(GlobalV::ofs_device, "device.log", calculation, restart, global_out_dir);
             #endif
 	    }
     }
 
     if(rank==0)
     {
-        open_log(GlobalV::ofs_warning, "warning.log", calculation, restart);
+        open_log(GlobalV::ofs_warning, "warning.log", calculation, restart, global_out_dir);
     }
 
 #ifdef GATHER_INFO
-    open_log(GlobalV::ofs_info, "math_info_" + std::to_string(rank) + ".log", calculation, restart);
+    open_log(GlobalV::ofs_info, "math_info_" + std::to_string(rank) + ".log", calculation, restart, global_out_dir);
 #endif
 
     return;
 }
 
-void ModuleBase::Global_File::make_dir_atom(const std::string &label)
+void ModuleBase::Global_File::make_dir_atom(const std::string &label, const std::string &global_out_dir)
 {
 //----------------------------------------------------------
 // EXPLAIN : generate atom dir for each type of atom
 //----------------------------------------------------------
     std::stringstream ss;
-    ss << PARAM.globalv.global_out_dir << label << "/";
+    ss << global_out_dir << label << "/";
     ModuleBase::GlobalFunc::MAKE_DIR(ss.str());
     return;
 }
 
-void ModuleBase::Global_File::open_log(std::ofstream &ofs, const std::string &fn, const std::string &calculation, const bool &restart)
+void ModuleBase::Global_File::open_log(std::ofstream &ofs, const std::string &fn, const std::string &calculation, const bool &restart, const std::string &global_out_dir)
 {
 //----------------------------------------------------------
 // USE GLOBAL VARIABLE :
-// PARAM.globalv.global_out_dir : (default dir to store "*.log" file)
+// global_out_dir : (default dir to store "*.log" file)
 //----------------------------------------------------------
     std::stringstream ss;
-    ss << PARAM.globalv.global_out_dir << fn;
+    ss << global_out_dir << fn;
 
     if(calculation == "md" && restart)
     {

--- a/source/source_base/global_file.h
+++ b/source/source_base/global_file.h
@@ -26,10 +26,19 @@ namespace Global_File
 		const bool &out_wfc_dir,
 		const int rank,
         const bool &restart,
-		const bool out_alllog = false); 
-	
-	void make_dir_atom(const std::string &label);
-	void open_log ( std::ofstream &ofs, const std::string &fn, const std::string &calculation, const bool &restart);
+		const bool out_alllog,
+		const std::string &global_out_dir,
+		const std::string &global_stru_dir,
+		const std::string &global_matrix_dir,
+		const std::string &global_wfc_dir,
+		const std::string &global_mlkedf_descriptor_dir,
+		const std::string &global_deepks_label_elec_dir,
+		const std::string &log_file,
+		const bool of_ml_gene_data,
+		const bool deepks_out_freq_elec);
+
+	void make_dir_atom(const std::string &label, const std::string &global_out_dir);
+	void open_log ( std::ofstream &ofs, const std::string &fn, const std::string &calculation, const bool &restart, const std::string &global_out_dir);
 	void close_log( std::ofstream &ofs, const std::string &fn);
     void close_all_log(const int rank, const bool out_alllog = false, const std::string& calculation = "md");
 }

--- a/source/source_base/kernels/cuda/math_kernel_op.cu
+++ b/source/source_base/kernels/cuda/math_kernel_op.cu
@@ -1,6 +1,5 @@
 #include "source_base/module_device/memory_op.h"
 #include "source_base/kernels/math_kernel_op.h"
-#include "source_psi/psi.h"
 #include "source_base/tool_quit.h"
 #include "source_base/module_container/base/third_party/cublas.h"
 

--- a/source/source_base/kernels/rocm/math_kernel_op.hip.cu
+++ b/source/source_base/kernels/rocm/math_kernel_op.hip.cu
@@ -1,6 +1,5 @@
 #include "source_base/module_device/memory_op.h"
 #include "source_base/kernels/math_kernel_op.h"
-#include "source_psi/psi.h"
 #include "source_base/tool_quit.h"
 
 #include <base/macros/macros.h>

--- a/source/source_base/parallel_global.cpp
+++ b/source/source_base/parallel_global.cpp
@@ -16,7 +16,6 @@
 #include "source_base/parallel_reduce.h"
 #include "source_base/global_variable.h"
 #include "source_base/tool_quit.h"
-#include "source_main/version.h"
 
 #include <iostream>
 #include <thread>
@@ -174,40 +173,6 @@ void Parallel_Global::read_pal_param(int argc,
     }
 
     NTHREAD_PER_PROC = current_thread_num;
-
-    if (MY_RANK == 0)
-    {
-#ifdef VERSION
-        const char* version = VERSION;
-#else
-        const char* version = "unknown";
-#endif
-#ifdef COMMIT_INFO
-#include "commit.h"
-        const char* commit = COMMIT;
-#else
-        const char* commit = "unknown";
-#endif
-        std::cout << "                                                                                     "
-                  << std::endl
-                  << "                              ABACUS " << version << std::endl
-                  << std::endl
-                  << "               Atomic-orbital Based Ab-initio Computation at UStc                    "
-                  << std::endl
-                  << std::endl
-                  << "                     Website: http://abacus.ustc.edu.cn/                             "
-                  << std::endl
-                  << "               Documentation: https://abacus.deepmodeling.com/                       "
-                  << std::endl
-                  << "                  Repository: https://github.com/abacusmodeling/abacus-develop       "
-                  << std::endl
-                  << "                              https://github.com/deepmodeling/abacus-develop         "
-                  << std::endl
-                  << "                      Commit: " << commit << std::endl
-                  << std::endl;
-        time_t time_now = time(nullptr);
-        std::cout << " " << ctime(&time_now);
-    }
 
     // for test
     /*

--- a/source/source_base/test/global_file_test.cpp
+++ b/source/source_base/test/global_file_test.cpp
@@ -1,8 +1,5 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
-#define private public
-#include "source_io/module_parameter/parameter.h"
-#undef private
 #include "../global_file.h"
 #include "../global_variable.h"
 #include <fstream>
@@ -27,15 +24,21 @@
 class GlobalFile : public testing::Test
 {
 	protected:
+		std::string global_out_dir;
+		std::string global_stru_dir;
+		std::string global_matrix_dir;
+		std::string global_wfc_dir;
+		std::string global_mlkedf_descriptor_dir;
+		std::string global_deepks_label_elec_dir;
 		void SetUp() override
 		{
 				const std::string suffix = "Si";
-				PARAM.sys.global_out_dir = "OUT." + suffix + "/";
-				PARAM.sys.global_stru_dir = PARAM.sys.global_out_dir + "STRU/";
-				PARAM.sys.global_matrix_dir = PARAM.sys.global_out_dir + "matrix/";
-				PARAM.sys.global_wfc_dir = PARAM.sys.global_out_dir + "WFC/";
-				PARAM.sys.global_mlkedf_descriptor_dir = PARAM.sys.global_out_dir + "MLKEDF_Descriptors/";
-				PARAM.sys.global_deepks_label_elec_dir = PARAM.sys.global_out_dir + "DeePKS_Labels_Elec/";
+				global_out_dir = "OUT." + suffix + "/";
+				global_stru_dir = global_out_dir + "STRU/";
+				global_matrix_dir = global_out_dir + "matrix/";
+				global_wfc_dir = global_out_dir + "WFC/";
+				global_mlkedf_descriptor_dir = global_out_dir + "MLKEDF_Descriptors/";
+				global_deepks_label_elec_dir = global_out_dir + "DeePKS_Labels_Elec/";
 		}
 };
 
@@ -43,8 +46,10 @@ TEST_F(GlobalFile,mkdirout)
 {
 	    std::string output;
 	    testing::internal::CaptureStdout();
-	    PARAM.sys.log_file = "running_m_1.log";
-	    ModuleBase::Global_File::make_dir_out("Si","m",false,false,0,true,true);
+	    ModuleBase::Global_File::make_dir_out("Si","m",false,false,0,true,true,
+	        global_out_dir, global_stru_dir, global_matrix_dir, global_wfc_dir,
+	        global_mlkedf_descriptor_dir, global_deepks_label_elec_dir,
+	        "running_m_1.log", false, false);
 	    output = testing::internal::GetCapturedStdout();
 	    EXPECT_THAT(output,testing::HasSubstr("MAKE THE DIR"));
 	    GlobalV::ofs_warning.close();
@@ -54,8 +59,10 @@ TEST_F(GlobalFile,mkdirout)
         remove(dd.c_str());
 
 	    testing::internal::CaptureStdout();
-	    PARAM.sys.log_file = "running_md.log";
-	    ModuleBase::Global_File::make_dir_out("Si","md",false,false,0,true,false);
+	    ModuleBase::Global_File::make_dir_out("Si","md",false,false,0,true,false,
+	        global_out_dir, global_stru_dir, global_matrix_dir, global_wfc_dir,
+	        global_mlkedf_descriptor_dir, global_deepks_label_elec_dir,
+	        "running_md.log", false, false);
 	    output = testing::internal::GetCapturedStdout();
 	    EXPECT_THAT(output,testing::HasSubstr("MAKE THE STRU DIR"));
 	    EXPECT_TRUE(GlobalV::ofs_running.is_open());
@@ -65,8 +72,10 @@ TEST_F(GlobalFile,mkdirout)
         remove(bb.c_str());
 
 	    testing::internal::CaptureStdout();
-	    PARAM.sys.log_file = "running_md_1.log";
-	    ModuleBase::Global_File::make_dir_out("Si","md",true,false,0,true,true);
+	    ModuleBase::Global_File::make_dir_out("Si","md",true,false,0,true,true,
+	        global_out_dir, global_stru_dir, global_matrix_dir, global_wfc_dir,
+	        global_mlkedf_descriptor_dir, global_deepks_label_elec_dir,
+	        "running_md_1.log", false, false);
 	    output = testing::internal::GetCapturedStdout();
 	    EXPECT_THAT(output,testing::HasSubstr("MAKE THE MATRIX DIR"));
 	    EXPECT_TRUE(GlobalV::ofs_running.is_open());
@@ -75,15 +84,14 @@ TEST_F(GlobalFile,mkdirout)
         remove(cc.c_str());
         std::string aa = "OUT.Si/warning.log";
         remove(aa.c_str());
-        rmdir(PARAM.sys.global_stru_dir.c_str());
-        rmdir(PARAM.sys.global_matrix_dir.c_str());
-        rmdir(PARAM.sys.global_out_dir.c_str());
+        rmdir(global_stru_dir.c_str());
+        rmdir(global_matrix_dir.c_str());
+        rmdir(global_out_dir.c_str());
 }
 
 TEST_F(GlobalFile,mkdiratom)
 {
-        PARAM.sys.global_out_dir = "./";
-        ModuleBase::Global_File::make_dir_atom("Si");
+        ModuleBase::Global_File::make_dir_atom("Si", "./");
         int a = access("./Si/",0);
         EXPECT_EQ(a , 0);
         std::string ss = "./Si/";
@@ -92,15 +100,14 @@ TEST_F(GlobalFile,mkdiratom)
 
 TEST_F(GlobalFile,openlog)
 {
-	    PARAM.sys.global_out_dir = "./";
         std::ofstream ofs;
-        ModuleBase::Global_File::open_log(ofs,"Si.log","md",true);
+        ModuleBase::Global_File::open_log(ofs,"Si.log","md",true,"./");
         EXPECT_TRUE(ofs.is_open());
         ofs.close();
-        ModuleBase::Global_File::open_log(ofs,"Si.log","md",false);
+        ModuleBase::Global_File::open_log(ofs,"Si.log","md",false,"./");
         EXPECT_TRUE(ofs.is_open());
         ofs.close();
-        std::string sss = "Si.log"; 
+        std::string sss = "Si.log";
         remove(sss.c_str());
 }
 
@@ -120,7 +127,7 @@ TEST_F(GlobalFile,closelog)
 
 TEST_F(GlobalFile,closealllog)
 {
-		/* 
+		/*
 		For source_io/input.cpp:line3578 close_log() is a void function,
 		All its contents is calling close_all_log() in source_base/global_file.cpp
 		For Input::close_log() what is left to test are the validities of parameters
@@ -130,8 +137,9 @@ TEST_F(GlobalFile,closealllog)
 		std::string header = "running_";
 		std::string tailCpuRank0 = "_cpu0.log";
 		std::string tail = ".log";
-		std::string f1 = header + PARAM.input.calculation + tailCpuRank0;
-		
+		const std::string calculation = "md";
+		std::string f1 = header + calculation + tailCpuRank0;
+
 		if (GlobalV::ofs_running.is_open())
 		{
 			GlobalV::ofs_running.close();
@@ -142,7 +150,7 @@ TEST_F(GlobalFile,closealllog)
 		}
 		GlobalV::ofs_running.open(f1.c_str());
 		GlobalV::ofs_warning.open("warning.log");
-		ModuleBase::Global_File::close_all_log(0,true,PARAM.input.calculation);
+		ModuleBase::Global_File::close_all_log(0,true,calculation);
 		EXPECT_FALSE(GlobalV::ofs_running.is_open());
 		if (GlobalV::ofs_running.is_open())
 		{
@@ -158,7 +166,7 @@ TEST_F(GlobalFile,closealllog)
 		/* Test out_alllog == false case */
 		GlobalV::ofs_running.open("running.log");
 		GlobalV::ofs_warning.open("warning.log");
-		ModuleBase::Global_File::close_all_log(0,false,PARAM.input.calculation);
+		ModuleBase::Global_File::close_all_log(0,false,calculation);
 		EXPECT_FALSE(GlobalV::ofs_running.is_open());
 		if (GlobalV::ofs_running.is_open())
 		{

--- a/source/source_estate/read_pseudo.cpp
+++ b/source/source_estate/read_pseudo.cpp
@@ -41,7 +41,7 @@ void read_pseudo(std::ofstream& ofs, UnitCell& ucell) {
 		{
 			for (int i = 0; i < ucell.ntype; i++) 
 			{
-				ModuleBase::Global_File::make_dir_atom(ucell.atoms[i].label);
+				ModuleBase::Global_File::make_dir_atom(ucell.atoms[i].label, PARAM.globalv.global_out_dir);
             }
 			for (int it = 0; it < ucell.ntype; it++) 
 			{

--- a/source/source_io/module_parameter/read_input.cpp
+++ b/source/source_io/module_parameter/read_input.cpp
@@ -271,7 +271,16 @@ void ReadInput::create_directory(const Parameter& param)
                                           out_wfc_dir,
                                           this->rank,
                                           param.input.mdp.md_restart,
-                                          param.input.out_alllog); // xiaohui add 2013-09-01
+                                          param.input.out_alllog,
+                                          param.globalv.global_out_dir,
+                                          param.globalv.global_stru_dir,
+                                          param.globalv.global_matrix_dir,
+                                          param.globalv.global_wfc_dir,
+                                          param.globalv.global_mlkedf_descriptor_dir,
+                                          param.globalv.global_deepks_label_elec_dir,
+                                          param.globalv.log_file,
+                                          param.input.of_ml_gene_data,
+                                          param.input.deepks_out_freq_elec > 0); // xiaohui add 2013-09-01
     //const std::string ss = "test -d " + PARAM.inp.read_file_dir;
     struct stat st;
     if (stat(PARAM.inp.read_file_dir.c_str(), &st) != 0 || !S_ISDIR(st.st_mode))

--- a/source/source_io/test_serial/read_input_test.cpp
+++ b/source/source_io/test_serial/read_input_test.cpp
@@ -36,7 +36,16 @@ void make_dir_out(const std::string& suffix,
                   const bool& out_wfc_dir,
                   const int rank,
                   const bool& restart,
-                  const bool out_alllog)
+                  const bool out_alllog,
+                  const std::string& global_out_dir,
+                  const std::string& global_stru_dir,
+                  const std::string& global_matrix_dir,
+                  const std::string& global_wfc_dir,
+                  const std::string& global_mlkedf_descriptor_dir,
+                  const std::string& global_deepks_label_elec_dir,
+                  const std::string& log_file,
+                  const bool of_ml_gene_data,
+                  const bool deepks_out_freq_elec)
 {
 }
 } // namespace Global_File

--- a/source/source_main/main.cpp
+++ b/source/source_main/main.cpp
@@ -8,9 +8,50 @@
 #include "source_base/parallel_global.h"
 #include "source_io/parse_args.h"
 #include "source_io/module_parameter/parameter.h"
+#include "source_main/version.h"
 #ifdef _OPENMP
 #include <omp.h>
 #endif
+
+#include <ctime>
+#include <iostream>
+
+namespace
+{
+void print_welcome_banner()
+{
+#ifdef VERSION
+    const char* version = VERSION;
+#else
+    const char* version = "unknown";
+#endif
+#ifdef COMMIT_INFO
+#include "commit.h"
+    const char* commit = COMMIT;
+#else
+    const char* commit = "unknown";
+#endif
+    std::cout << "                                                                                     "
+              << std::endl
+              << "                              ABACUS " << version << std::endl
+              << std::endl
+              << "               Atomic-orbital Based Ab-initio Computation at UStc                    "
+              << std::endl
+              << std::endl
+              << "                     Website: http://abacus.ustc.edu.cn/                             "
+              << std::endl
+              << "               Documentation: https://abacus.deepmodeling.com/                       "
+              << std::endl
+              << "                  Repository: https://github.com/abacusmodeling/abacus-develop       "
+              << std::endl
+              << "                              https://github.com/deepmodeling/abacus-develop         "
+              << std::endl
+              << "                      Commit: " << commit << std::endl
+              << std::endl;
+    time_t time_now = time(nullptr);
+    std::cout << " " << ctime(&time_now);
+}
+} // namespace
 
 int main(int argc, char** argv)
 {
@@ -29,6 +70,10 @@ int main(int argc, char** argv)
     int my_rank = 0;
     int nthread_per_proc = 1;
     Parallel_Global::read_pal_param(argc, argv, nproc, nthread_per_proc, my_rank);
+    if (my_rank == 0)
+    {
+        print_welcome_banner();
+    }
 #ifdef _OPENMP
     // ref: https://www.fftw.org/fftw3_doc/Usage-of-Multi_002dthreaded-FFTW.html
     fftw_init_threads();


### PR DESCRIPTION
About this PR:

global_file.cpp used quite a lot of parameters in parameter.h, now a lot of code is modified to remove this dependency.

parallel_global.cpp contains the content of printing the welcome banner, so it needs to use version.h. I think the banner should be moved to main.cpp, so I did this and removed the dependency in this way.

The psi.h dependency in math_kernel is useless now after all the works before. So I directly removed them,