### PR TITLE
Support non-ASCII (CJK) paths in Windows installer

### DIFF
--- a/tools/windows/install-abacus.bat
+++ b/tools/windows/install-abacus.bat
@@ -1,5 +1,11 @@
 @echo off
 setlocal EnableExtensions EnableDelayedExpansion
+REM Force UTF-8 so paths containing non-ASCII (e.g. CJK) characters survive
+REM round-tripping through wsl.exe. WSL_UTF8 makes wsl.exe emit UTF-8 when
+REM its stdout is piped (otherwise it emits UTF-16LE and `for /f` mangles
+REM the result); chcp 65001 lets cmd decode that UTF-8 cleanly.
+chcp 65001 >nul
+set "WSL_UTF8=1"
 title ABACUS for Windows (WSL2) Installer
 
 set "DISTRO=Ubuntu-22.04"
@@ -128,10 +134,14 @@ REM --- 6. Install Windows-side launchers ---
 if not exist "%BIN_DIR%" mkdir "%BIN_DIR%"
 
 > "%BIN_DIR%\abacus.cmd" echo @echo off
+>> "%BIN_DIR%\abacus.cmd" echo chcp 65001 ^>nul
+>> "%BIN_DIR%\abacus.cmd" echo set "WSL_UTF8=1"
 >> "%BIN_DIR%\abacus.cmd" echo set "WSLENV=OMP_NUM_THREADS:MKL_NUM_THREADS:OPENBLAS_NUM_THREADS:%%WSLENV%%"
 >> "%BIN_DIR%\abacus.cmd" echo wsl -d %DISTRO% --cd "%%CD%%" -- abacus %%*
 
 > "%BIN_DIR%\abacus-mpi.cmd" echo @echo off
+>> "%BIN_DIR%\abacus-mpi.cmd" echo chcp 65001 ^>nul
+>> "%BIN_DIR%\abacus-mpi.cmd" echo set "WSL_UTF8=1"
 >> "%BIN_DIR%\abacus-mpi.cmd" echo set "WSLENV=OMP_NUM_THREADS:MKL_NUM_THREADS:OPENBLAS_NUM_THREADS:%%WSLENV%%"
 >> "%BIN_DIR%\abacus-mpi.cmd" echo wsl -d %DISTRO% --cd "%%CD%%" -- abacus-mpi %%*
 

--- a/tools/windows/uninstall-abacus.bat
+++ b/tools/windows/uninstall-abacus.bat
@@ -1,5 +1,9 @@
 @echo off
 setlocal EnableExtensions EnableDelayedExpansion
+REM Force UTF-8 so paths with non-ASCII (e.g. CJK) characters survive
+REM round-tripping through wsl.exe (see install-abacus.bat for details).
+chcp 65001 >nul
+set "WSL_UTF8=1"
 title ABACUS Uninstaller
 
 set "DISTRO=Ubuntu-22.04"


### PR DESCRIPTION
Force UTF-8 at the top of install-abacus.bat, uninstall-abacus.bat, and the generated abacus.cmd / abacus-mpi.cmd launchers via `chcp 65001` and `set WSL_UTF8=1`. Without these, wsl.exe emits UTF-16LE when its stdout is piped, so the `for /f` that captures `wslpath` output mangles any CJK characters in the repository or case directory path, and the launchers' `wsl --cd "%CD%"` fails from a Chinese-named directory.
