### PR TITLE
fix(dsp): correct dspDestoryHandle to use cluster ID (MY_RANK % dsp_count)

### DIFF
--- a/source/source_main/driver_run.cpp
+++ b/source/source_main/driver_run.cpp
@@ -150,6 +150,6 @@ void Driver::finalize_hardware()
 
 #ifdef __DSP
     std::cout << " ** Closing DSP Hardware..." << std::endl;
-    mtfunc::dspDestoryHandle(GlobalV::MY_RANK);
+    mtfunc::dspDestoryHandle(GlobalV::MY_RANK % PARAM.inp.dsp_count);
 #endif
 }


### PR DESCRIPTION
## Summary

Closes #7269
Fix DSP segfault during memory statistics on multi-node runs (issue #7269).

## Details

`dspDestoryHandle(GlobalV::MY_RANK)` in `driver_run.cpp:153` uses the raw MPI rank as the DSP cluster handle ID, but `dspInitHandle()` uses `MY_RANK % dsp_count`. When `MY_RANK >= dsp_count`, destroying an uninitialized handle corrupts the heap. This manifests as a `cfree()` crash during `Memory::print_all()` at program exit.

## Change

Fix dsp rank when handle destroyed:
```cpp
// Before (broken):
mtfunc::dspDestoryHandle(GlobalV::MY_RANK);

// After (fixed):
mtfunc::dspDestoryHandle(GlobalV::MY_RANK % PARAM.inp.dsp_count);
```

> [!NOTE]
> Need to verify on DSP device. 
