### PR TITLE
Add NeighborSearch AdjacentAtomInfo compatibility adapter

### DIFF
--- a/source/Makefile.Objects
+++ b/source/Makefile.Objects
@@ -411,6 +411,7 @@ OBJS_NEIGHBOR=sltk_atom.o\
     sltk_atom_arrange.o\
     sltk_grid.o\
     sltk_grid_driver.o\
+    neighlist_adapter.o\
 
 OBJS_NEIGHBOR_SEARCH=neighbor_search.o\
     bin_manager.o\

--- a/source/source_cell/module_neighbor/CMakeLists.txt
+++ b/source/source_cell/module_neighbor/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(
     sltk_atom_arrange.cpp
     sltk_grid.cpp
     sltk_grid_driver.cpp
+    neighlist_adapter.cpp
 )
 
 if(ENABLE_COVERAGE)

--- a/source/source_cell/module_neighbor/neighlist_adapter.cpp
+++ b/source/source_cell/module_neighbor/neighlist_adapter.cpp
@@ -1,0 +1,56 @@
+#include "source_cell/module_neighbor/neighlist_adapter.h"
+
+#include <cassert>
+
+void convert_neighbor_search_to_adjs(const UnitCell& ucell,
+                                     const NeighborSearch& neighbor_search,
+                                     int ntype,
+                                     int nnumber,
+                                     AdjacentAtomInfo& adjs)
+{
+    adjs.clear();
+
+    int center_index = -1;
+    for (int i = 0; i < static_cast<int>(neighbor_search.inside_atoms.size()); ++i)
+    {
+        const NeighborAtom& atom = neighbor_search.inside_atoms[i];
+        if (atom.atom_type == ntype && atom.atom_index == nnumber && atom.cell_x == 0 && atom.cell_y == 0
+            && atom.cell_z == 0)
+        {
+            center_index = i;
+            break;
+        }
+    }
+
+    assert(center_index >= 0);
+    assert(center_index < static_cast<int>(neighbor_search.neighbor_list.numneigh.size()));
+
+    if (center_index >= 0 && center_index < static_cast<int>(neighbor_search.neighbor_list.numneigh.size()))
+    {
+        const int neighbor_count = neighbor_search.neighbor_list.numneigh[center_index];
+        const int* neighbor_ids = neighbor_search.neighbor_list.firstneigh[center_index];
+        assert(neighbor_ids != nullptr || neighbor_count == 0);
+
+        for (int i = 0; neighbor_ids != nullptr && i < neighbor_count; ++i)
+        {
+            const int atom_id = neighbor_ids[i];
+            assert(atom_id >= 0);
+            assert(atom_id < static_cast<int>(neighbor_search.all_atoms.size()));
+
+            const NeighborAtom& atom = neighbor_search.all_atoms[atom_id];
+            adjs.ntype.push_back(atom.atom_type);
+            adjs.natom.push_back(atom.atom_index);
+            adjs.box.push_back(ModuleBase::Vector3<int>(atom.cell_x, atom.cell_y, atom.cell_z));
+            adjs.adjacent_tau.push_back(
+                ModuleBase::Vector3<double>(atom.position_x, atom.position_y, atom.position_z));
+            adjs.adj_num++;
+        }
+    }
+
+    adjs.ntype.push_back(ntype);
+    adjs.natom.push_back(nnumber);
+    adjs.box.push_back(ModuleBase::Vector3<int>(0, 0, 0));
+    adjs.adjacent_tau.push_back(ModuleBase::Vector3<double>(ucell.atoms[ntype].tau[nnumber].x,
+                                                            ucell.atoms[ntype].tau[nnumber].y,
+                                                            ucell.atoms[ntype].tau[nnumber].z));
+}

--- a/source/source_cell/module_neighbor/neighlist_adapter.h
+++ b/source/source_cell/module_neighbor/neighlist_adapter.h
@@ -1,0 +1,13 @@
+#ifndef NEIGHLIST_ADAPTER_H
+#define NEIGHLIST_ADAPTER_H
+
+#include "source_cell/module_neighbor/sltk_grid_driver.h"
+#include "source_cell/module_neighlist/neighbor_search.h"
+
+void convert_neighbor_search_to_adjs(const UnitCell& ucell,
+                                     const NeighborSearch& neighbor_search,
+                                     int ntype,
+                                     int nnumber,
+                                     AdjacentAtomInfo& adjs);
+
+#endif

--- a/source/source_cell/module_neighbor/test/CMakeLists.txt
+++ b/source/source_cell/module_neighbor/test/CMakeLists.txt
@@ -23,3 +23,11 @@ AddTest(
   ../sltk_atom.cpp
   ../../../source_io/module_output/output.cpp
 )
+
+AddTest(
+  TARGET MODULE_CELL_NEIGHBOR_neighlist_adapter
+  LIBS parameter ${math_libs} base device cell_info
+  SOURCES neighlist_adapter_test.cpp ../neighlist_adapter.cpp ../sltk_grid_driver.cpp ../sltk_grid.cpp
+  ../sltk_atom.cpp ../../module_neighlist/neighbor_search.cpp ../../module_neighlist/bin_manager.cpp
+  ../../../source_io/module_output/output.cpp
+)

--- a/source/source_cell/module_neighbor/test/neighlist_adapter_test.cpp
+++ b/source/source_cell/module_neighbor/test/neighlist_adapter_test.cpp
@@ -1,0 +1,234 @@
+#include "../neighlist_adapter.h"
+
+#include "gtest/gtest.h"
+
+#include "prepare_unitcell.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <fstream>
+#include <memory>
+#include <vector>
+
+#ifdef __LCAO
+InfoNonlocal::InfoNonlocal()
+{
+}
+InfoNonlocal::~InfoNonlocal()
+{
+}
+LCAO_Orbitals::LCAO_Orbitals()
+{
+}
+LCAO_Orbitals::~LCAO_Orbitals()
+{
+}
+#endif
+Magnetism::Magnetism()
+{
+    this->tot_mag = 0.0;
+    this->abs_mag = 0.0;
+    this->start_mag = nullptr;
+}
+Magnetism::~Magnetism()
+{
+    delete[] this->start_mag;
+}
+
+namespace
+{
+
+struct AdjEntry
+{
+    int ntype;
+    int natom;
+    ModuleBase::Vector3<int> box;
+    ModuleBase::Vector3<double> tau;
+};
+
+bool AdjEntryLess(const AdjEntry& lhs, const AdjEntry& rhs)
+{
+    if (lhs.ntype != rhs.ntype)
+    {
+        return lhs.ntype < rhs.ntype;
+    }
+    if (lhs.natom != rhs.natom)
+    {
+        return lhs.natom < rhs.natom;
+    }
+    if (lhs.box.x != rhs.box.x)
+    {
+        return lhs.box.x < rhs.box.x;
+    }
+    if (lhs.box.y != rhs.box.y)
+    {
+        return lhs.box.y < rhs.box.y;
+    }
+    return lhs.box.z < rhs.box.z;
+}
+
+std::vector<AdjEntry> CollectNonSelfEntries(const AdjacentAtomInfo& adjs)
+{
+    std::vector<AdjEntry> entries;
+    for (int i = 0; i < adjs.adj_num; ++i)
+    {
+        entries.push_back({adjs.ntype[i], adjs.natom[i], adjs.box[i], adjs.adjacent_tau[i]});
+    }
+    std::sort(entries.begin(), entries.end(), AdjEntryLess);
+    return entries;
+}
+
+void ExpectAdjInfoShape(const AdjacentAtomInfo& adjs)
+{
+    const size_t expected_size = static_cast<size_t>(adjs.adj_num + 1);
+    ASSERT_EQ(adjs.ntype.size(), expected_size);
+    ASSERT_EQ(adjs.natom.size(), expected_size);
+    ASSERT_EQ(adjs.box.size(), expected_size);
+    ASSERT_EQ(adjs.adjacent_tau.size(), expected_size);
+}
+
+void ExpectSelfLast(const AdjacentAtomInfo& adjs, const UnitCell& ucell, int ntype, int nnumber)
+{
+    ExpectAdjInfoShape(adjs);
+    const int self = adjs.adj_num;
+    EXPECT_EQ(adjs.ntype[self], ntype);
+    EXPECT_EQ(adjs.natom[self], nnumber);
+    EXPECT_EQ(adjs.box[self].x, 0);
+    EXPECT_EQ(adjs.box[self].y, 0);
+    EXPECT_EQ(adjs.box[self].z, 0);
+    EXPECT_NEAR(adjs.adjacent_tau[self].x, ucell.atoms[ntype].tau[nnumber].x, 1e-12);
+    EXPECT_NEAR(adjs.adjacent_tau[self].y, ucell.atoms[ntype].tau[nnumber].y, 1e-12);
+    EXPECT_NEAR(adjs.adjacent_tau[self].z, ucell.atoms[ntype].tau[nnumber].z, 1e-12);
+}
+
+void ExpectEquivalentAdjs(const AdjacentAtomInfo& expected, const AdjacentAtomInfo& actual)
+{
+    ExpectAdjInfoShape(expected);
+    ExpectAdjInfoShape(actual);
+    ASSERT_EQ(actual.adj_num, expected.adj_num);
+
+    const std::vector<AdjEntry> expected_entries = CollectNonSelfEntries(expected);
+    const std::vector<AdjEntry> actual_entries = CollectNonSelfEntries(actual);
+    ASSERT_EQ(actual_entries.size(), expected_entries.size());
+
+    for (size_t i = 0; i < expected_entries.size(); ++i)
+    {
+        EXPECT_EQ(actual_entries[i].ntype, expected_entries[i].ntype);
+        EXPECT_EQ(actual_entries[i].natom, expected_entries[i].natom);
+        EXPECT_EQ(actual_entries[i].box.x, expected_entries[i].box.x);
+        EXPECT_EQ(actual_entries[i].box.y, expected_entries[i].box.y);
+        EXPECT_EQ(actual_entries[i].box.z, expected_entries[i].box.z);
+        EXPECT_NEAR(actual_entries[i].tau.x, expected_entries[i].tau.x, 1e-12);
+        EXPECT_NEAR(actual_entries[i].tau.y, expected_entries[i].tau.y, 1e-12);
+        EXPECT_NEAR(actual_entries[i].tau.z, expected_entries[i].tau.z, 1e-12);
+    }
+}
+
+AdjacentAtomInfo BuildGridAdjs(const UnitCell& ucell, double radius_lat0, int ntype, int nnumber)
+{
+    Grid_Driver grid_d(0, 0);
+    std::ofstream ofs("neighlist_adapter_test.out");
+    grid_d.init(ofs, ucell, radius_lat0, true);
+    ofs.close();
+    std::remove("neighlist_adapter_test.out");
+
+    AdjacentAtomInfo adjs;
+    grid_d.Find_atom(ucell, ntype, nnumber, &adjs);
+    return adjs;
+}
+
+AdjacentAtomInfo BuildAdapterAdjs(const UnitCell& ucell, double radius_lat0, int ntype, int nnumber)
+{
+    NeighborSearch neighbor_search;
+    neighbor_search.init(ucell, radius_lat0 * ucell.lat0, 0);
+    neighbor_search.build_neighbors();
+
+    AdjacentAtomInfo adjs;
+    convert_neighbor_search_to_adjs(ucell, neighbor_search, ntype, nnumber, adjs);
+    return adjs;
+}
+
+void ExpectAdapterMatchesGrid(const UnitCell& ucell, double radius_lat0, int ntype, int nnumber)
+{
+    const AdjacentAtomInfo expected = BuildGridAdjs(ucell, radius_lat0, ntype, nnumber);
+    const AdjacentAtomInfo actual = BuildAdapterAdjs(ucell, radius_lat0, ntype, nnumber);
+
+    ExpectEquivalentAdjs(expected, actual);
+    ExpectSelfLast(actual, ucell, ntype, nnumber);
+}
+
+bool HasBoxNeighbor(const AdjacentAtomInfo& adjs, int ntype, int nnumber, int cell_x, int cell_y, int cell_z)
+{
+    for (int i = 0; i < adjs.adj_num; ++i)
+    {
+        if (adjs.ntype[i] == ntype && adjs.natom[i] == nnumber && adjs.box[i].x == cell_x
+            && adjs.box[i].y == cell_y && adjs.box[i].z == cell_z)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+TEST(NeighlistAdapterTest, MatchesGridDriverForSiFixture)
+{
+    std::unique_ptr<UnitCell> ucell(UcellTestLib["Si"].SetUcellInfo());
+
+    ExpectAdapterMatchesGrid(*ucell, 0.5, 0, 0);
+    ExpectAdapterMatchesGrid(*ucell, 0.5, 0, 1);
+}
+
+TEST(NeighlistAdapterTest, PreservesOrthogonalBoundaryImageBoxes)
+{
+    UcellTestPrepare prepare("sc",
+                             2,
+                             false,
+                             false,
+                             false,
+                             "volume",
+                             1.0,
+                             {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0},
+                             {"X"},
+                             {"X.upf"},
+                             {"upf201"},
+                             {"X.orb"},
+                             {2},
+                             {1.0},
+                             "Cartesian",
+                             {0.05, 0.0, 0.0, 0.95, 0.0, 0.0});
+    std::unique_ptr<UnitCell> ucell(prepare.SetUcellInfo());
+
+    ExpectAdapterMatchesGrid(*ucell, 0.2, 0, 0);
+    ExpectAdapterMatchesGrid(*ucell, 0.2, 0, 1);
+
+    const AdjacentAtomInfo atom0_adjs = BuildAdapterAdjs(*ucell, 0.2, 0, 0);
+    const AdjacentAtomInfo atom1_adjs = BuildAdapterAdjs(*ucell, 0.2, 0, 1);
+    EXPECT_TRUE(HasBoxNeighbor(atom0_adjs, 0, 1, -1, 0, 0));
+    EXPECT_TRUE(HasBoxNeighbor(atom1_adjs, 0, 0, 1, 0, 0));
+}
+
+TEST(NeighlistAdapterTest, MatchesGridDriverForSkewedCell)
+{
+    UcellTestPrepare prepare("skew",
+                             2,
+                             false,
+                             false,
+                             false,
+                             "volume",
+                             1.0,
+                             {1.0, 0.2, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0},
+                             {"X"},
+                             {"X.upf"},
+                             {"upf201"},
+                             {"X.orb"},
+                             {2},
+                             {1.0},
+                             "Cartesian",
+                             {0.05, 0.0, 0.0, 0.95, 0.0, 0.0});
+    std::unique_ptr<UnitCell> ucell(prepare.SetUcellInfo());
+
+    ExpectAdapterMatchesGrid(*ucell, 0.3, 0, 0);
+    ExpectAdapterMatchesGrid(*ucell, 0.3, 0, 1);
+}

--- a/source/source_cell/module_neighlist/neighbor_atom.h
+++ b/source/source_cell/module_neighlist/neighbor_atom.h
@@ -12,12 +12,16 @@ public:
     int atom_type;
     int atom_index;
     int atom_id;
+    int cell_x;
+    int cell_y;
+    int cell_z;
     //bool isghost;
     bool is_inside;
 
-    NeighborAtom(double x, double y, double z, int type, int index, int id)
+    NeighborAtom(double x, double y, double z, int type, int index, int id, int cx = 0, int cy = 0, int cz = 0)
         : position_x(x), position_y(y), position_z(z),
-          atom_type(type), atom_index(index), atom_id(id) {}
+          atom_type(type), atom_index(index), atom_id(id),
+          cell_x(cx), cell_y(cy), cell_z(cz), is_inside(false) {}
 };
 
 class InputAtoms

--- a/source/source_cell/module_neighlist/neighbor_search.cpp
+++ b/source/source_cell/module_neighlist/neighbor_search.cpp
@@ -215,7 +215,7 @@ void NeighborSearch::setMemberVariables(const IAtomProvider& ucell)
                         double y = ucell.get_tauu(i,j).y + vec1[1] * ix + vec2[1] * iy + vec3[1] * iz;
                         double z = ucell.get_tauu(i,j).z + vec1[2] * ix + vec2[2] * iy + vec3[2] * iz;
 
-                        NeighborAtom atom(x, y, z, i, j, atom_count);
+                        NeighborAtom atom(x, y, z, i, j, atom_count, ix, iy, iz);
                         if(ix==0&&iy==0&&iz==0)
                         {
                             atom.is_inside = true;

--- a/source/source_cell/module_neighlist/test/neighbor_search_test.cpp
+++ b/source/source_cell/module_neighlist/test/neighbor_search_test.cpp
@@ -135,6 +135,49 @@ TEST(NeighborSearchUnit, CheckExpandAndSetMembers)
     EXPECT_EQ(static_cast<int>(ns.all_atoms.size()), expected);
 }
 
+TEST(NeighborSearchUnit, PeriodicImageMetadata)
+{
+    UnitCellPlus ucell;
+    ucell.lat0 = 1.0;
+    ucell.omega = 1.0;
+    ucell.latvec.e11 = 1; ucell.latvec.e12 = 0; ucell.latvec.e13 = 0;
+    ucell.latvec.e21 = 0; ucell.latvec.e22 = 1; ucell.latvec.e23 = 0;
+    ucell.latvec.e31 = 0; ucell.latvec.e32 = 0; ucell.latvec.e33 = 1;
+
+    ucell.ntype = 1;
+    ucell.na = {1};
+    ucell.nat = 1;
+    ucell.tau = {{0.25, 0.25, 0.25}};
+    ucell.compute_naa();
+
+    NeighborSearch ns;
+    ns.search_radius = 1.0;
+    ns.Check_Expand_Condition(ucell);
+    ns.setMemberVariables(ucell);
+
+    bool found_central = false;
+    bool found_image = false;
+    for (const NeighborAtom& atom : ns.all_atoms)
+    {
+        if (atom.cell_x == 0 && atom.cell_y == 0 && atom.cell_z == 0)
+        {
+            found_central = true;
+            EXPECT_TRUE(atom.is_inside);
+            EXPECT_DOUBLE_EQ(atom.position_x, 0.25);
+        }
+        if (atom.cell_x == 1 && atom.cell_y == -1 && atom.cell_z == 0)
+        {
+            found_image = true;
+            EXPECT_FALSE(atom.is_inside);
+            EXPECT_DOUBLE_EQ(atom.position_x, 1.25);
+            EXPECT_DOUBLE_EQ(atom.position_y, -0.75);
+            EXPECT_DOUBLE_EQ(atom.position_z, 0.25);
+        }
+    }
+    EXPECT_TRUE(found_central);
+    EXPECT_TRUE(found_image);
+}
+
 TEST(NeighborSearchUnit, DistanceBox)
 {
     NeighborSearch ns;


### PR DESCRIPTION
## Summary

Part of #7358.

This PR adds the first compatibility layer needed before `module_neighlist` can be considered as a replacement candidate for the existing `module_neighbor` path.

The change is intentionally small and non-invasive:
- It does not switch any production caller to the new backend.
- It does not modify `Grid_Driver::Find_atom`, `atom_arrange::search`, or `ESolver_LJ`.
- It only adds the metadata and adapter needed to compare `NeighborSearch` output against the existing `AdjacentAtomInfo` contract.

## What changed

- Preserve periodic image offsets in `NeighborAtom` as `cell_x/cell_y/cell_z`.
- Populate those offsets in `NeighborSearch::setMemberVariables`.
- Add `convert_neighbor_search_to_adjs(...)`, which converts `NeighborSearch` results into `AdjacentAtomInfo`.
- Preserve the historical `AdjacentAtomInfo` behavior:
  - `adj_num` counts only non-self neighbors.
  - The center atom is appended as the last entry.
  - The center atom uses `box = (0, 0, 0)`.

## What this PR deliberately does not do

This PR does not attempt a backend switch or broader refactor. In particular, it does not:
- replace the current `Grid_Driver` implementation,
- change LCAO/DeepKS/RT/operator call paths,
- add MPI domain decomposition,
- change LJ behavior,
- address allocator sizing or performance benchmarking.

Those should remain separate follow-up PRs after this adapter is proven.

## Test coverage

I added old-vs-new equivalence tests that compare the adapter output against the existing `Grid_Driver` implementation.

Covered scenarios:
- Existing Si fixture with normal PBC neighbor search.
- Orthogonal two-atom boundary case, explicitly checking periodic image boxes such as `(-1, 0, 0)` and `(1, 0, 0)`.
- Skewed-cell case to verify image metadata and coordinates remain consistent with the old implementation.
- Direct `NeighborSearch` unit coverage proving generated periodic images retain `cell_x/cell_y/cell_z`.

The tests compare neighbor identity using `(type, atom index, box)` and compare coordinates with floating-point tolerance. They also assert the self-last contract.

## Verification

Environment dependencies were installed and the planned CMake/CTest flow was run successfully:

```bash
cmake -B build-neighlist-pr1 -DBUILD_TESTING=ON
cmake --build build-neighlist-pr1 --target MODULE_CELL_NEIGHBOR_neighbor_search MODULE_CELL_NEIGHBOR_neighlist_adapter -j2
ctest --test-dir build-neighlist-pr1 -R "MODULE_CELL_NEIGHBOR_(neighbor_search|neighlist_adapter)" --output-on-failure