### PR TITLE
Modify headers in source_basis to lower the dependency's depth

### DIFF
--- a/source/source_base/test/math_ylmreal_test.cpp
+++ b/source/source_base/test/math_ylmreal_test.cpp
@@ -4,7 +4,6 @@
 #include"../matrix.h"
 #include"gtest/gtest.h"
 #include<math.h>
-#include "source_psi/psi.h"
 
 #define doublethreshold 1e-12
 

--- a/source/source_base/test/math_ylmreal_test.cpp
+++ b/source/source_base/test/math_ylmreal_test.cpp
@@ -4,6 +4,7 @@
 #include"../matrix.h"
 #include"gtest/gtest.h"
 #include<math.h>
+#include "source_base/module_device/types.h"
 
 #define doublethreshold 1e-12
 

--- a/source/source_basis/module_ao/ORB_atomic.cpp
+++ b/source/source_basis/module_ao/ORB_atomic.cpp
@@ -1,6 +1,5 @@
 #include "ORB_atomic.h"
 
-#include "source_io/module_parameter/parameter.h"
 Numerical_Orbital_AtomRelation Numerical_Orbital::NOAR;
 
 Numerical_Orbital::Numerical_Orbital()

--- a/source/source_basis/module_ao/test/ORB_atomic_lm_test.cpp
+++ b/source/source_basis/module_ao/test/ORB_atomic_lm_test.cpp
@@ -1,8 +1,6 @@
 #include "gtest/gtest.h"
 #include "source_base/math_integral.h"
-#define private public
-#include "source_io/module_parameter/parameter.h"
-#undef private
+#include "source_base/global_variable.h"
 #include <algorithm>
 #include <string>
 #include <vector>

--- a/source/source_basis/module_ao/test/ORB_nonlocal_lm_test.cpp
+++ b/source/source_basis/module_ao/test/ORB_nonlocal_lm_test.cpp
@@ -1,8 +1,5 @@
 #include "gtest/gtest.h"
 #include "source_base/global_function.h"
-#define private public
-#include "source_io/module_parameter/parameter.h"
-#undef private
 #include "source_base/global_variable.h"
 #include "source_base/math_integral.h"
 #include <fstream>

--- a/source/source_basis/module_nao/beta_radials.cpp
+++ b/source/source_basis/module_nao/beta_radials.cpp
@@ -1,6 +1,5 @@
 #include "source_basis/module_nao/beta_radials.h"
 
-#include "source_io/module_parameter/parameter.h"
 #include "source_base/global_variable.h"
 #include "source_base/parallel_common.h"
 #include "source_base/tool_quit.h"

--- a/source/source_basis/module_pw/kernels/pw_op.h
+++ b/source/source_basis/module_pw/kernels/pw_op.h
@@ -1,7 +1,6 @@
 #ifndef MODULE_PW_MULTI_DEVICE_H
 #define MODULE_PW_MULTI_DEVICE_H
 
-#include "source_psi/psi.h"
 #include <complex>
 
 namespace ModulePW {

--- a/source/source_basis/module_pw/kernels/pw_op.h
+++ b/source/source_basis/module_pw/kernels/pw_op.h
@@ -1,6 +1,8 @@
 #ifndef MODULE_PW_MULTI_DEVICE_H
 #define MODULE_PW_MULTI_DEVICE_H
 
+#include "source_base/module_device/types.h"
+
 #include <complex>
 
 namespace ModulePW {

--- a/source/source_basis/module_pw/pw_basis_k.h
+++ b/source/source_basis/module_pw/pw_basis_k.h
@@ -2,7 +2,6 @@
 #define PWBASISK_H
 
 #include "pw_basis.h"
-#include "source_psi/psi.h"
 #include "source_base/module_device/device.h"
 namespace ModulePW
 {


### PR DESCRIPTION
Why so many #define private public in test files😅