### PR TITLE
fix(dftu): resolve conflict between yukawa_potential and uramping

### DIFF
--- a/source/source_io/module_parameter/read_input_item_exx_dftu.cpp
+++ b/source/source_io/module_parameter/read_input_item_exx_dftu.cpp
@@ -766,6 +766,16 @@ void ReadInput::item_dftu()
         item.default_value = "False";
         item.unit = "";
         item.availability = "";
+        item.check_value = [](const Input_Item& item, const Parameter& para) {
+            if (!item.is_read()) { return; }
+            if (para.inp.yukawa_potential && para.globalv.uramping > 0.01)
+            {
+                ModuleBase::WARNING_QUIT("ReadInput",
+                                         "yukawa_potential and uramping cannot be used together. "
+                                         "yukawa_potential calculates U directly from charge density every iteration, "
+                                         "while uramping gradually increases U from 0. Please set only one of them.");
+            }
+        };
         read_sync_bool(input.yukawa_potential);
         this->add_item(item);
     }

--- a/source/source_lcao/module_dftu/dftu.cpp
+++ b/source/source_lcao/module_dftu/dftu.cpp
@@ -393,6 +393,10 @@ void Plus_U::cal_energy_correction(const UnitCell& ucell,
 
 void Plus_U::uramping_update()
 {
+    // Yukawa calculates U directly every iteration, no need for ramping
+    if (Yukawa) {
+        return;
+    }
     // if uramping < 0.1, use the original U
     if (this->uramping < 0.01) {
         return;
@@ -413,6 +417,10 @@ void Plus_U::uramping_update()
 
 bool Plus_U::u_converged()
 {
+    // Yukawa calculates U directly every iteration, always considered converged
+    if (Yukawa) {
+        return true;
+    }
     for (int i = 0; i < this->U0.size(); i++)
     {
         if (this->U[i] != this->U0[i])


### PR DESCRIPTION
1. Add check_value callback to yukawa_potential to error out when both yukawa_potential and uramping are enabled simultaneously
2. Skip uramping_update() when Yukawa is enabled (U calculated directly from charge density every iteration)
3. Return true from u_converged() when Yukawa is enabled (U is self-consistently calculated, no ramping convergence needed)

### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...(no issue has been found)

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
