### PR TITLE
Toolchain: Allow controling parallel jobs for ABACUS build after toolchain setup

### DIFF
--- a/toolchain/build_abacus_aocc-aocl.sh
+++ b/toolchain/build_abacus_aocc-aocl.sh
@@ -37,6 +37,30 @@ USE_CUDA=OFF  # set ON to enable gpu-abacus
 # LIBNPY=$INSTALL_DIR/libnpy-1.0.1/include
 # DEEPMD=$HOME/apps/anaconda3/envs/deepmd
 
+NUM_JOBS="$(nproc)"
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -j)
+      if [[ -n "$2" && "$2" =~ ^[0-9]+$ ]]; then
+        NUM_JOBS="${2}"
+        shift 2
+      else
+        echo "ERROR: -j requires a number argument"
+        exit 1
+      fi
+      ;;
+    -j[0-9]*)
+      NUM_JOBS="${1#-j}"
+      shift
+      ;;
+    *)
+      echo "ERROR: Unsupported argument: $1" >&2
+      echo "Usage: $0 [-j N|-jN]" >&2
+      exit 1
+      ;;
+  esac
+done
+
 # if clang++ have problem, switch back to g++
 
 cmake -B $BUILD_DIR -DCMAKE_INSTALL_PREFIX=$PREFIX \
@@ -66,8 +90,7 @@ cmake -B $BUILD_DIR -DCMAKE_INSTALL_PREFIX=$PREFIX \
 # 	      -DDeePMD_DIR=$DEEPMD \
 #         -DENABLE_CUSOLVERMP=ON \
 
-cmake --build $BUILD_DIR -j `nproc` 
-cmake --install $BUILD_DIR 2>/dev/null
+cmake --build $BUILD_DIR --target install -j "${NUM_JOBS}"
 
 # generate abacus_env.sh
 cat << EOF > "${TOOL}/abacus_env.sh"

--- a/toolchain/build_abacus_gcc-aocl.sh
+++ b/toolchain/build_abacus_gcc-aocl.sh
@@ -37,6 +37,30 @@ USE_CUDA=OFF  # set ON to enable gpu-abacus
 # LIBNPY=$INSTALL_DIR/libnpy-1.0.1/include
 # DEEPMD=$HOME/apps/anaconda3/envs/deepmd 
 
+NUM_JOBS="$(nproc)"
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -j)
+      if [[ -n "$2" && "$2" =~ ^[0-9]+$ ]]; then
+        NUM_JOBS="${2}"
+        shift 2
+      else
+        echo "ERROR: -j requires a number argument"
+        exit 1
+      fi
+      ;;
+    -j[0-9]*)
+      NUM_JOBS="${1#-j}"
+      shift
+      ;;
+    *)
+      echo "ERROR: Unsupported argument: $1" >&2
+      echo "Usage: $0 [-j N|-jN]" >&2
+      exit 1
+      ;;
+  esac
+done
+
 cmake -B $BUILD_DIR -DCMAKE_INSTALL_PREFIX=$PREFIX \
         -DCMAKE_CXX_COMPILER=g++ \
         -DMPI_CXX_COMPILER=mpicxx \
@@ -64,8 +88,7 @@ cmake -B $BUILD_DIR -DCMAKE_INSTALL_PREFIX=$PREFIX \
 # 	      -DDeePMD_DIR=$DEEPMD \
 #         -DENABLE_CUSOLVERMP=ON \
 
-cmake --build $BUILD_DIR -j `nproc` 
-cmake --install $BUILD_DIR 2>/dev/null
+cmake --build $BUILD_DIR --target install -j "${NUM_JOBS}"
 
 # generate abacus_env.sh
 cat << EOF > "${TOOL}/abacus_env.sh"

--- a/toolchain/build_abacus_gcc-mkl.sh
+++ b/toolchain/build_abacus_gcc-mkl.sh
@@ -9,7 +9,7 @@
 
 # load system env modules at first
 # module load mkl compiler mpi
-# source path/to/setvars.sh
+# source path/to/mkl/latest/env/vars.sh
 
 ABACUS_DIR=..
 TOOL=$(pwd)
@@ -33,6 +33,30 @@ USE_CUDA=OFF  # set ON to enable gpu-abacus
 # LIBTORCH=$INSTALL_DIR/libtorch-2.1.2/share/cmake/Torch
 # LIBNPY=$INSTALL_DIR/libnpy-1.0.1/include
 # DEEPMD=$HOME/apps/anaconda3/envs/deepmd
+
+NUM_JOBS="$(nproc)"
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -j)
+      if [[ -n "$2" && "$2" =~ ^[0-9]+$ ]]; then
+        NUM_JOBS="${2}"
+        shift 2
+      else
+        echo "ERROR: -j requires a number argument"
+        exit 1
+      fi
+      ;;
+    -j[0-9]*)
+      NUM_JOBS="${1#-j}"
+      shift
+      ;;
+    *)
+      echo "ERROR: Unsupported argument: $1" >&2
+      echo "Usage: $0 [-j N|-jN]" >&2
+      exit 1
+      ;;
+  esac
+done
 
 cmake -B $BUILD_DIR -DCMAKE_INSTALL_PREFIX=$PREFIX \
         -DCMAKE_CXX_COMPILER=g++ \
@@ -60,8 +84,7 @@ cmake -B $BUILD_DIR -DCMAKE_INSTALL_PREFIX=$PREFIX \
 # 	      -DDeePMD_DIR=$DEEPMD \
 #         -DENABLE_CUSOLVERMP=ON \
 
-cmake --build $BUILD_DIR -j `nproc`
-cmake --install $BUILD_DIR 2>/dev/null
+cmake --build $BUILD_DIR --target install -j "${NUM_JOBS}"
 
 # generate abacus_env.sh
 cat << EOF > "${TOOL}/abacus_env.sh"

--- a/toolchain/build_abacus_gnu.sh
+++ b/toolchain/build_abacus_gnu.sh
@@ -35,6 +35,30 @@ USE_CUDA=OFF  # set ON to enable gpu-abacus
 # LIBNPY=$INSTALL_DIR/libnpy-1.0.1/include
 # DEEPMD=$HOME/apps/anaconda3/envs/deepmd #
 
+NUM_JOBS="$(nproc)"
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -j)
+      if [[ -n "$2" && "$2" =~ ^[0-9]+$ ]]; then
+        NUM_JOBS="${2}"
+        shift 2
+      else
+        echo "ERROR: -j requires a number argument"
+        exit 1
+      fi
+      ;;
+    -j[0-9]*)
+      NUM_JOBS="${1#-j}"
+      shift
+      ;;
+    *)
+      echo "ERROR: Unsupported argument: $1" >&2
+      echo "Usage: $0 [-j N|-jN]" >&2
+      exit 1
+      ;;
+  esac
+done
+
 cmake -B $BUILD_DIR -DCMAKE_INSTALL_PREFIX=$PREFIX \
         -DCMAKE_CXX_COMPILER=g++ \
         -DMPI_CXX_COMPILER=mpicxx \
@@ -62,8 +86,7 @@ cmake -B $BUILD_DIR -DCMAKE_INSTALL_PREFIX=$PREFIX \
 # 	      -DDeePMD_DIR=$DEEPMD \
 #         -DENABLE_CUSOLVERMP=ON \
 
-cmake --build $BUILD_DIR -j `nproc` 
-cmake --install $BUILD_DIR 2>/dev/null
+cmake --build $BUILD_DIR --target install -j "${NUM_JOBS}"
 
 # generate abacus_env.sh
 cat << EOF > "${TOOL}/abacus_env.sh"

--- a/toolchain/build_abacus_intel.sh
+++ b/toolchain/build_abacus_intel.sh
@@ -34,6 +34,30 @@ USE_CUDA=OFF  # set ON to enable gpu-abacus
 # LIBNPY=$INSTALL_DIR/libnpy-1.0.1/include
 # DEEPMD=$HOME/apps/anaconda3/envs/deepmd # v3.0 might have problem
 
+NUM_JOBS="$(nproc)"
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -j)
+      if [[ -n "$2" && "$2" =~ ^[0-9]+$ ]]; then
+        NUM_JOBS="${2}"
+        shift 2
+      else
+        echo "ERROR: -j requires a number argument"
+        exit 1
+      fi
+      ;;
+    -j[0-9]*)
+      NUM_JOBS="${1#-j}"
+      shift
+      ;;
+    *)
+      echo "ERROR: Unsupported argument: $1" >&2
+      echo "Usage: $0 [-j N|-jN]" >&2
+      exit 1
+      ;;
+  esac
+done
+
 # Notice: if you are compiling with AMD-CPU or GPU-version ABACUS, then `icpc` and `mpiicpc` compilers are needed 
 cmake -B $BUILD_DIR -DCMAKE_INSTALL_PREFIX=$PREFIX \
         -DCMAKE_CXX_COMPILER=icpx \
@@ -61,8 +85,7 @@ cmake -B $BUILD_DIR -DCMAKE_INSTALL_PREFIX=$PREFIX \
 # 	      -DDeePMD_DIR=$DEEPMD \
 #         -DENABLE_CUSOLVERMP=ON \
 
-cmake --build $BUILD_DIR -j `nproc` 
-cmake --install $BUILD_DIR 2>/dev/null
+cmake --build $BUILD_DIR --target install -j "${NUM_JOBS}"
 
 # generate abacus_env.sh
 cat << EOF > "${TOOL}/abacus_env.sh"

--- a/toolchain/scripts/lib/config_manager.sh
+++ b/toolchain/scripts/lib/config_manager.sh
@@ -711,6 +711,16 @@ config_parse_arguments() {
                     return 1
                 fi
                 ;;
+            -j[0-9]*)
+                local nprocs_overwrite="${1#-j}"
+                if [[ -n "$nprocs_overwrite" && "$nprocs_overwrite" =~ ^[0-9]+$ ]]; then
+                    CONFIG_CACHE["NPROCS_OVERWRITE"]="$nprocs_overwrite"
+                    shift
+                else
+                    report_error $LINENO "-j requires a number argument"
+                    return 1
+                fi
+                ;;
             --dry-run)
                 CONFIG_CACHE["dry_run"]="__TRUE__"
                 shift


### PR DESCRIPTION
Adds `-j N` / `-jN` option to build scripts, make users available to control the number of parallel build jobs instead of always using `nproc`.