### PR TITLE
Optimize WARNING_QUIT fatal-exit output

### DIFF
--- a/source/source_base/test/math_chebyshev_test.cpp
+++ b/source/source_base/test/math_chebyshev_test.cpp
@@ -385,7 +385,7 @@ TEST_F(MathChebyshevTest, recurs)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(ModuleBase::Chebyshev<double> noneche(0), ::testing::ExitedWithCode(1), "");
     std::string output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+    EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
     int norder = 100;
     p_chetest = new ModuleBase::Chebyshev<double>(norder);

--- a/source/source_base/test/tool_check_test.cpp
+++ b/source/source_base/test/tool_check_test.cpp
@@ -61,7 +61,7 @@ TEST_F(ToolCheckTest, Name)
 	testing::internal::CaptureStdout();
 	EXPECT_EXIT(ModuleBase::CHECK_NAME(ifs, "abacus"), ::testing::ExitedWithCode(1), "");
 	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("NOTICE"));
+	EXPECT_THAT(output,testing::HasSubstr("ERROR"));
 	ifs.close();
 }
 
@@ -82,7 +82,7 @@ TEST_F(ToolCheckTest, Int)
 	testing::internal::CaptureStdout();
 	EXPECT_EXIT(ModuleBase::CHECK_INT(ifs, 80), ::testing::ExitedWithCode(1), "");
 	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("NOTICE"));
+	EXPECT_THAT(output,testing::HasSubstr("ERROR"));
 	ifs.close();
 }
 
@@ -103,7 +103,7 @@ TEST_F(ToolCheckTest, Double)
 	testing::internal::CaptureStdout();
 	EXPECT_EXIT(ModuleBase::CHECK_DOUBLE(ifs, 0.22998), ::testing::ExitedWithCode(1), "");
 	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("NOTICE"));
+	EXPECT_THAT(output,testing::HasSubstr("ERROR"));
 	ifs.close();
 }
 
@@ -124,6 +124,6 @@ TEST_F(ToolCheckTest, String)
 	testing::internal::CaptureStdout();
 	EXPECT_EXIT(ModuleBase::CHECK_STRING(ifs, "scf"), ::testing::ExitedWithCode(1), "");
 	output = testing::internal::GetCapturedStdout();
-	EXPECT_THAT(output,testing::HasSubstr("NOTICE"));
+	EXPECT_THAT(output,testing::HasSubstr("ERROR"));
 	ifs.close();
 }

--- a/source/source_base/test/tool_quit_test.cpp
+++ b/source/source_base/test/tool_quit_test.cpp
@@ -78,8 +78,9 @@ TEST_F(ToolQuitTest,warningquit)
 	EXPECT_EXIT(ModuleBase::WARNING_QUIT("INPUT","bad input parameter"),
 			::testing::ExitedWithCode(1), "");
 	output = testing::internal::GetCapturedStdout();
-	// test output on screening
-	EXPECT_THAT(output,testing::HasSubstr("TIME STATISTICS"));
+	// error exits should keep the error message visible and skip timer output
+	EXPECT_THAT(output, testing::HasSubstr("ERROR"));
+	EXPECT_THAT(output, testing::Not(testing::HasSubstr("TIME STATISTICS")));
 	GlobalV::ofs_warning.close();
 	GlobalV::ofs_running.close();
 	ifs.open("warning.log");
@@ -101,8 +102,9 @@ TEST_F(ToolQuitTest,warningquit_with_ret)
 	EXPECT_EXIT(ModuleBase::WARNING_QUIT("INPUT","bad input parameter",1),
 			::testing::ExitedWithCode(1), "");
 	output = testing::internal::GetCapturedStdout();
-	// test output on screening
-	EXPECT_THAT(output,testing::HasSubstr("TIME STATISTICS"));
+	// error exits should keep the error message visible and skip timer output
+	EXPECT_THAT(output, testing::HasSubstr("ERROR"));
+	EXPECT_THAT(output, testing::Not(testing::HasSubstr("TIME STATISTICS")));
 	GlobalV::ofs_warning.close();
 	GlobalV::ofs_running.close();
 	ifs.open("warning.log");

--- a/source/source_base/tool_quit.cpp
+++ b/source/source_base/tool_quit.cpp
@@ -1,4 +1,5 @@
 #include "tool_quit.h"
+#include <cstdlib>
 #ifdef __MPI
 #include "mpi.h"
 #endif
@@ -18,6 +19,22 @@ namespace
 {
 std::string g_quit_out_dir;
 std::string g_quit_calculation;
+
+[[noreturn]] void quit_impl(const int ret, const bool print_timer)
+{
+#ifdef __NORMAL
+    (void)print_timer;
+#else
+    if (print_timer)
+    {
+        ModuleBase::timer::finish(GlobalV::ofs_running, GlobalV::MY_RANK == 0, false);
+        std::cout << " See output information in : " << g_quit_out_dir << std::endl;
+    }
+    ModuleBase::Global_File::close_all_log(GlobalV::MY_RANK);
+#endif
+
+    std::exit(ret);
+}
 }
 
 void set_quit_out_dir(const std::string& dir)
@@ -64,35 +81,13 @@ void QUIT()
 
 void QUIT(int ret)
 {
-
-#ifdef __NORMAL
-#else
-    ModuleBase::timer::finish(GlobalV::ofs_running , !GlobalV::MY_RANK, false);
-    ModuleBase::Global_File::close_all_log(GlobalV::MY_RANK);
-    std::cout<<" See output information in : "<<g_quit_out_dir<<std::endl;
-#endif
-
-    exit(ret);
+    quit_impl(ret, true);
 }
 
 
 void WARNING_QUIT(const std::string &file,const std::string &description)
 {
-	WARNING_QUIT(file, description, 1);
-
-	#ifdef __MPI /* if it is MPI run, finalize first, then exit */
-	std::cout << "Detecting if MPI has been initialized..." << std::endl;
-	int is_initialized = 0;
-    MPI_Initialized(&is_initialized);
-	if (is_initialized) {
-		std::cout << "Terminating ABACUS with multiprocessing environment." << std::endl;
-		MPI_Finalize();
-	}
-	else{
-		std::cout << "MPI has not been initialized. Quit normally." << std::endl;
-	}
-	/* but seems this is the only correct way to terminate the MPI */
-#endif
+    WARNING_QUIT(file, description, 1);
 }
 
 void WARNING_QUIT(const std::string &file,const std::string &description,int ret)
@@ -100,7 +95,7 @@ void WARNING_QUIT(const std::string &file,const std::string &description,int ret
 #ifdef __NORMAL
 
 	std::cout << " ---------------------------------------------------------" << std::endl;
-	std::cout << "                         !NOTICE!                         " << std::endl;
+	std::cout << "                         !ERROR!                          " << std::endl;
 	std::cout << " ---------------------------------------------------------" << std::endl;
     std::cout << " For detailed manual of ABACUS, please see the website" << std::endl;
     std::cout << " https://abacus.deepmodeling.com" << std::endl;
@@ -110,10 +105,11 @@ void WARNING_QUIT(const std::string &file,const std::string &description,int ret
 #else
 	std::cout << " " << std::endl;
 	std::cout << " ---------------------------------------------------------" << std::endl;
-	std::cout << "                         !NOTICE!                         " << std::endl;
+	std::cout << "                         !ERROR!                          " << std::endl;
 	std::cout << " ---------------------------------------------------------" << std::endl;
 	std::cout << " " << std::endl;
 	std::cout << " " << description << std::endl;
+	std::cout << " " << std::endl;
 	std::cout << " CHECK IN FILE : " << g_quit_out_dir << "warning.log" << std::endl;
 	std::cout << " " << std::endl;
 	std::cout << " For detailed manual of ABACUS, please see the website" << std::endl;
@@ -121,15 +117,16 @@ void WARNING_QUIT(const std::string &file,const std::string &description,int ret
 	std::cout << " For any questions, propose issues on the website" << std::endl;
 	std::cout << " https://github.com/deepmodeling/abacus-develop/issues" << std::endl;
 	std::cout << " ---------------------------------------------------------" << std::endl;
-	std::cout << "                         !NOTICE!                         " << std::endl;
+	std::cout << "                         !ERROR!                          " << std::endl;
 	std::cout << " ---------------------------------------------------------" << std::endl;
 
 
 	GlobalV::ofs_running << " ---------------------------------------------------------" << std::endl;
-	GlobalV::ofs_running << "                         !NOTICE!                         " << std::endl;
+	GlobalV::ofs_running << "                         !ERROR!                          " << std::endl;
 	GlobalV::ofs_running << " ---------------------------------------------------------" << std::endl;
 	GlobalV::ofs_running << std::endl;
 	GlobalV::ofs_running << " " << description << std::endl;
+	GlobalV::ofs_running << std::endl;
 	GlobalV::ofs_running << " CHECK IN FILE : " << g_quit_out_dir << "warning.log" << std::endl;
 	GlobalV::ofs_running << std::endl;
 	GlobalV::ofs_running << " For detailed manual of ABACUS, please see the website" << std::endl;
@@ -137,7 +134,7 @@ void WARNING_QUIT(const std::string &file,const std::string &description,int ret
 	GlobalV::ofs_running << " For any questions, propose issues on the website" << std::endl;
 	GlobalV::ofs_running << " https://github.com/deepmodeling/abacus-develop/issues" << std::endl;
 	GlobalV::ofs_running << " ---------------------------------------------------------" << std::endl;
-	GlobalV::ofs_running << "                         NOTICE                           " << std::endl;
+	GlobalV::ofs_running << "                         !ERROR!                          " << std::endl;
 	GlobalV::ofs_running << " ---------------------------------------------------------" << std::endl;
 
 	WARNING(file,description);
@@ -145,7 +142,7 @@ void WARNING_QUIT(const std::string &file,const std::string &description,int ret
 
 #endif
 
-    QUIT(ret);
+    quit_impl(ret, false);
 }
 
 //Check and print warning information for all cores.

--- a/source/source_basis/module_pw/test/test-other.cpp
+++ b/source/source_basis/module_pw/test/test-other.cpp
@@ -29,7 +29,7 @@ TEST_F(PWTEST,test_other)
     testing::internal::CaptureStdout();
     EXPECT_EXIT(pwtest.setuptransform(), ::testing::ExitedWithCode(1), "");
     string output = testing::internal::GetCapturedStdout();
-    EXPECT_THAT(output,testing::HasSubstr("NOTICE"));
+    EXPECT_THAT(output,testing::HasSubstr("ERROR"));
 
     int nks = 2;
     ModuleBase::Vector3<double> *kvec_d = new ModuleBase::Vector3<double>[nks];

--- a/source/source_io/test_serial/read_input_item_test.cpp
+++ b/source/source_io/test_serial/read_input_item_test.cpp
@@ -50,20 +50,20 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.calculation = "gen_bessel";
         param.input.basis_type = "lcao";
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.calculation = "none";
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
 
     { // esolver_type
@@ -72,13 +72,13 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.esolver_type = "dp";
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.esolver_type = "lr";
         param.input.calculation = "scf";
@@ -97,7 +97,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // smearing_method
         auto it = find_label("smearing_method", readinput.input_lists);
@@ -105,7 +105,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // kspacing
         auto it = find_label("kspacing", readinput.input_lists);
@@ -118,19 +118,19 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.read_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.kspacing = {0, -1, 1};
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.kspacing = {0, 1, 2};
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // nbands
         auto it = find_label("nbands", readinput.input_lists);
@@ -138,7 +138,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // symmetry
         auto it = find_label("symmetry", readinput.input_lists);
@@ -177,14 +177,14 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.nelec = 100;
         param.input.nbands = 5;
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // bndpar
         auto it = find_label("bndpar", readinput.input_lists);
@@ -205,7 +205,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // mem_saver
         auto it = find_label("mem_saver", readinput.input_lists);
@@ -225,7 +225,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.gint_precision = "mix";
         param.input.basis_type = "pw";
@@ -233,7 +233,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // diag_proc
         auto it = find_label("diago_proc", readinput.input_lists);
@@ -271,7 +271,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // pw_diag_thr
         auto it = find_label("pw_diag_thr", readinput.input_lists);
@@ -287,7 +287,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // scf_thr
         auto it = find_label("scf_thr", readinput.input_lists);
@@ -348,7 +348,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // chg_extrap
         auto it = find_label("chg_extrap", readinput.input_lists);
@@ -404,14 +404,14 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.basis_type = "pw";
         param.input.out_dos = 3;
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // out_ldos
         auto it = find_label("out_ldos", readinput.input_lists);
@@ -429,13 +429,13 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.read_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.out_ldos = {5, 5};
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // stm_bias
         auto it = find_label("stm_bias", readinput.input_lists);
@@ -455,19 +455,19 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.read_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.stm_bias = {1.0, 0.1, 0.0};
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.stm_bias = {1.0, 0.0, 2.0};
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // ldos_line
         auto it = find_label("ldos_line", readinput.input_lists);
@@ -491,13 +491,13 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.read_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.ldos_line = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 0};
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // out_band
         auto it = find_label("out_band", readinput.input_lists);
@@ -515,7 +515,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.read_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.calculation = "get_wf";
         param.input.out_band = {1, 2};
@@ -534,7 +534,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // read_file_dir
         auto it = find_label("read_file_dir", readinput.input_lists);
@@ -554,7 +554,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // ny
         auto it = find_label("ny", readinput.input_lists);
@@ -563,7 +563,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // nz
         auto it = find_label("nz", readinput.input_lists);
@@ -572,7 +572,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // ndx
         auto it = find_label("ndx", readinput.input_lists);
@@ -587,14 +587,14 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.ndx = 1;
         param.input.nx = 2;
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // ndy
         auto it = find_label("ndy", readinput.input_lists);
@@ -609,14 +609,14 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.ndy = 1;
         param.input.ny = 2;
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // ndz
         auto it = find_label("ndz", readinput.input_lists);
@@ -631,14 +631,14 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.ndz = 1;
         param.input.nz = 2;
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // cell_factor
         auto it = find_label("cell_factor", readinput.input_lists);
@@ -687,28 +687,28 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.ks_solver = "cg";
         param.input.basis_type = "lcao";
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.ks_solver = "scalapack_gvx";
         param.input.basis_type = "lcao";
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.ks_solver = "cg";
         param.input.basis_type = "lcao_in_pw";
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // relax_nmax
         auto it = find_label("relax_nmax", readinput.input_lists);
@@ -752,14 +752,14 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.fixed_axes = "volume";
         param.input.relax_new = false;
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // fixed_ibrav
         auto it = find_label("fixed_ibrav", readinput.input_lists);
@@ -768,14 +768,14 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.fixed_ibrav = true;
         param.input.latname = "none";
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // fixed_atoms
         auto it = find_label("fixed_atoms", readinput.input_lists);
@@ -784,7 +784,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // relax_method
         auto it = find_label("relax_method", readinput.input_lists);
@@ -792,7 +792,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { //relax_new
         auto it = find_label("relax_new", readinput.input_lists);
@@ -863,7 +863,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // nbands_sto
         auto it = find_label("nbands_sto", readinput.input_lists);
@@ -891,7 +891,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         it->second.str_values = {"all"};
         it->second.get_final_value(it->second, param);
@@ -914,7 +914,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // gamma_only
         auto it = find_label("gamma_only", readinput.input_lists);
@@ -935,7 +935,7 @@ TEST_F(InputTest, Item_test)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.reset_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
     }
     { // out_mat_r
@@ -988,7 +988,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // dm_to_rho
         auto it = find_label("dm_to_rho", readinput.input_lists);
@@ -997,7 +997,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.dm_to_rho = true;
         param.input.gamma_only = true;
@@ -1005,7 +1005,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
 #ifndef __USECNPY
         param.input.dm_to_rho = true;
@@ -1013,7 +1013,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 #endif
     }
     { // out_wfc_lcao
@@ -1027,14 +1027,14 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.out_wfc_lcao = 1;
         param.input.basis_type = "pw";
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // bx
         auto it = find_label("bx", readinput.input_lists);
@@ -1042,7 +1042,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.bx = 2;
         param.input.basis_type = "pw";
@@ -1057,7 +1057,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // bz
         auto it = find_label("bz", readinput.input_lists);
@@ -1065,7 +1065,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // mixing_beta
         auto it = find_label("mixing_beta", readinput.input_lists);
@@ -1109,7 +1109,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // efield_dir
         auto it = find_label("efield_dir", readinput.input_lists);
@@ -1119,7 +1119,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // vdw_s6
         auto it = find_label("vdw_s6", readinput.input_lists);
@@ -1183,7 +1183,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // vdw_r0_unit
         auto it = find_label("vdw_r0_unit", readinput.input_lists);
@@ -1191,7 +1191,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // vdw_cutoff_type
         auto it = find_label("vdw_cutoff_type", readinput.input_lists);
@@ -1199,7 +1199,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // vdw_cutoff_radius
         auto it = find_label("vdw_cutoff_radius", readinput.input_lists);
@@ -1228,7 +1228,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // vdw_radius_unit
         auto it = find_label("vdw_radius_unit", readinput.input_lists);
@@ -1236,7 +1236,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // vdw_cn_thr
         auto it = find_label("vdw_cn_thr", readinput.input_lists);
@@ -1244,7 +1244,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // vdw_cn_thr_unit
         auto it = find_label("vdw_cn_thr_unit", readinput.input_lists);
@@ -1252,7 +1252,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // vdw_cutoff_period
         auto it = find_label("vdw_cutoff_period", readinput.input_lists);
@@ -1266,13 +1266,13 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.read_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.vdw_cutoff_period = {-1, 1, 1};
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // exx_fock_alpha
         auto it = find_label("exx_fock_alpha", readinput.input_lists);
@@ -1361,7 +1361,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // exx_real_number
         auto it = find_label("exx_real_number", readinput.input_lists);
@@ -1423,7 +1423,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // exx_opt_orb_ecut
         auto it = find_label("exx_opt_orb_ecut", readinput.input_lists);
@@ -1431,7 +1431,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // exx_opt_orb_tolerence
         auto it = find_label("exx_opt_orb_tolerence", readinput.input_lists);
@@ -1439,7 +1439,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // exx_symmetry_realspace
         auto it = find_label("exx_symmetry_realspace", readinput.input_lists);
@@ -1454,7 +1454,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // berry_phase
         auto it = find_label("berry_phase", readinput.input_lists);
@@ -1467,13 +1467,13 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.calculation = "scf";
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.basis_type = "lcao_in_pw";
         param.input.calculation = "nscf";
@@ -1559,14 +1559,14 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.ntype = 2;
         param.sys.hubbard_u = {1.0, -1.0};
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // orbital_corr
         auto it = find_label("orbital_corr", readinput.input_lists);
@@ -1578,14 +1578,14 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.ntype = 2;
         param.input.orbital_corr = {1, 4};
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // bessel_nao_ecut
         auto it = find_label("bessel_nao_ecut", readinput.input_lists);
@@ -1598,7 +1598,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // bessel_nao_rcut
         auto it = find_label("bessel_nao_rcut", readinput.input_lists);
@@ -1606,7 +1606,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // bessel_descriptor_ecut
         auto it = find_label("bessel_descriptor_ecut", readinput.input_lists);
@@ -1619,7 +1619,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // bessel_descriptor_rcut
         auto it = find_label("bessel_descriptor_rcut", readinput.input_lists);
@@ -1627,7 +1627,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // sc_mag_switch
         auto it = find_label("sc_mag_switch", readinput.input_lists);
@@ -1641,7 +1641,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // nsc
         auto it = find_label("nsc", readinput.input_lists);
@@ -1649,7 +1649,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // nsc_min
         auto it = find_label("nsc_min", readinput.input_lists);
@@ -1657,7 +1657,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // sc_scf_nmin
         auto it = find_label("sc_scf_nmin", readinput.input_lists);
@@ -1665,7 +1665,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // alpha_trial
         auto it = find_label("alpha_trial", readinput.input_lists);
@@ -1673,7 +1673,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // sccut
         auto it = find_label("sccut", readinput.input_lists);
@@ -1681,7 +1681,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // sc_scf_thr
         auto it = find_label("sc_scf_thr", readinput.input_lists);
@@ -1689,7 +1689,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // qo_thr
         auto it = find_label("qo_thr", readinput.input_lists);
@@ -1726,7 +1726,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.reset_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // qo_screening_coeff
         auto it = find_label("qo_screening_coeff", readinput.input_lists);
@@ -1752,19 +1752,19 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.reset_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.qo_screening_coeff = {0.2, -0.1};
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.qo_screening_coeff = {0.2, 1e-8};
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // md_nstep
         auto it = find_label("md_nstep", readinput.input_lists);
@@ -1808,7 +1808,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // lj_rcut
         auto it = find_label("lj_rcut", readinput.input_lists);
@@ -1819,14 +1819,14 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
 
         param.input.mdp.lj_rcut = {1.0, 2.0, -1.0};
         it->second.str_values = {"1.0", "2.0", "-1.0"};
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // lj_epsilon
         auto it = find_label("lj_epsilon", readinput.input_lists);
@@ -1837,7 +1837,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // lj_sigma
         auto it = find_label("lj_sigma", readinput.input_lists);
@@ -1848,7 +1848,7 @@ TEST_F(InputTest, Item_test2)
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+        EXPECT_THAT(output, testing::HasSubstr("ERROR"));
     }
     { // nocc 
         auto it = find_label("nocc", readinput.input_lists);


### PR DESCRIPTION
This PR makes `WARNING_QUIT` output better match its behavior.

`WARNING_QUIT` exits with a non-zero status, so the screen banner is changed from `NOTICE` to `ERROR`. It also no longer prints `TIME STATISTICS` after the fatal message, keeping the actual error easier to find in failed runs.

Normal `QUIT()` behavior is unchanged.