### PR TITLE
PPCG: Polak-Ribiere conjugate gradient with soft-locking

### DIFF
--- a/source/source_base/parallel_reduce.cpp
+++ b/source/source_base/parallel_reduce.cpp
@@ -104,6 +104,7 @@ template void Parallel_Reduce::reduce_pool<double>(double&);
 template void Parallel_Reduce::reduce_pool<std::complex<double>>(std::complex<double>&);
 
 template void Parallel_Reduce::reduce_pool<int>(int*, const int);
+template void Parallel_Reduce::reduce_pool<float>(float*, const int);
 template void Parallel_Reduce::reduce_pool<double>(double*, const int);
 template void Parallel_Reduce::reduce_pool<std::complex<float>>(std::complex<float>*, const int);
 template void Parallel_Reduce::reduce_pool<std::complex<double>>(std::complex<double>*, const int);

--- a/source/source_hsolver/CMakeLists.txt
+++ b/source/source_hsolver/CMakeLists.txt
@@ -4,6 +4,7 @@ list(APPEND objects
     diago_david.cpp
     diago_dav_subspace.cpp
     diago_bpcg.cpp
+    diago_ppcg.cpp
     para_linear_transform.cpp
     hsolver_pw.cpp
     hsolver_lcaopw.cpp

--- a/source/source_hsolver/diago_ppcg.cpp
+++ b/source/source_hsolver/diago_ppcg.cpp
@@ -468,4 +468,7 @@ void DiagoPPCG<T, Device>::diag(const HPsiFunc& hpsi_func,
 template class DiagoPPCG<std::complex<float>, base_device::DEVICE_CPU>;
 template class DiagoPPCG<std::complex<double>, base_device::DEVICE_CPU>;
 
+template class DiagoPPCG<std::complex<float>, base_device::DEVICE_GPU>;
+template class DiagoPPCG<std::complex<double>, base_device::DEVICE_GPU>;
+
 } // namespace hsolver

--- a/source/source_hsolver/diago_ppcg.cpp
+++ b/source/source_hsolver/diago_ppcg.cpp
@@ -343,7 +343,7 @@ void DiagoPPCG<T, Device>::diag_hsub(
 {
     this->pmmcn.multiply(1.0, hpsi_in.data<T>(), psi_in.data<T>(), 0.0, hsub_out.data<T>());
 
-    const int n = this->n_band;
+    int n = this->n_band;
     int lwork = 2 * n + n * n;
     if (lwork < 1 + 6 * n + 2 * n * n) {
         lwork = 1 + 6 * n + 2 * n * n;

--- a/source/source_hsolver/diago_ppcg.cpp
+++ b/source/source_hsolver/diago_ppcg.cpp
@@ -15,6 +15,26 @@
 #include <cmath>
 #include <limits>
 
+namespace {
+
+inline void lapack_heevd(char* jobz, char* uplo, int* n,
+                         std::complex<double>* a, int* lda, double* w,
+                         std::complex<double>* work, int* lwork, double* rwork, int* lrwork,
+                         int* iwork, int* liwork, int* info)
+{
+    zheevd_(jobz, uplo, n, a, lda, w, work, lwork, rwork, lrwork, iwork, liwork, info);
+}
+
+inline void lapack_heevd(char* jobz, char* uplo, int* n,
+                         std::complex<float>* a, int* lda, float* w,
+                         std::complex<float>* work, int* lwork, float* rwork, int* lrwork,
+                         int* iwork, int* liwork, int* info)
+{
+    cheevd_(jobz, uplo, n, a, lda, w, work, lwork, rwork, lrwork, iwork, liwork, info);
+}
+
+} // anonymous namespace
+
 namespace hsolver {
 
 template <typename T, typename Device>
@@ -340,13 +360,10 @@ void DiagoPPCG<T, Device>::diag_hsub(
     iwork.zero();
 
     int info = 0;
-    container::lapackConnector::dnevd('V', 'U', n,
-                                       hsub_out.data<T>(), n,
-                                       eigenvalue_out.data<Real>(),
-                                       work.data<T>(), lwork,
-                                       rwork.data<Real>(), lrwork,
-                                       iwork.data<int>(), liwork,
-                                       info);
+    char jobz = 'V', uplo = 'U';
+    lapack_heevd(&jobz, &uplo, &n, hsub_out.data<T>(), &n, eigenvalue_out.data<Real>(),
+                 work.data<T>(), &lwork, rwork.data<Real>(), &lrwork,
+                 iwork.data<int>(), &liwork, &info);
 }
 
 template <typename T, typename Device>

--- a/source/source_hsolver/diago_ppcg.cpp
+++ b/source/source_hsolver/diago_ppcg.cpp
@@ -468,7 +468,4 @@ void DiagoPPCG<T, Device>::diag(const HPsiFunc& hpsi_func,
 template class DiagoPPCG<std::complex<float>, base_device::DEVICE_CPU>;
 template class DiagoPPCG<std::complex<double>, base_device::DEVICE_CPU>;
 
-template class DiagoPPCG<std::complex<float>, base_device::DEVICE_GPU>;
-template class DiagoPPCG<std::complex<double>, base_device::DEVICE_GPU>;
-
 } // namespace hsolver

--- a/source/source_hsolver/diago_ppcg.cpp
+++ b/source/source_hsolver/diago_ppcg.cpp
@@ -11,6 +11,7 @@
 #include <ATen/kernels/blas.h>
 #include <ATen/kernels/lapack.h>
 #include <ATen/ops/einsum_op.h>
+#include <algorithm>
 #include <cmath>
 #include <limits>
 
@@ -24,10 +25,6 @@ DiagoPPCG<T, Device>::DiagoPPCG(const Real* precondition_in)
     this->device_type    = ct::DeviceTypeToEnum<Device>::value;
 
     this->h_prec  = std::move(ct::TensorMap((void *) precondition_in, r_type, device_type, {this->n_basis}));
-
-    this->one = &one_;
-    this->zero = &zero_;
-    this->neg_one = &neg_one_;
 }
 
 template <typename T, typename Device>
@@ -44,7 +41,6 @@ void DiagoPPCG<T, Device>::init_iter(const int nband, const int nband_l, const i
     this->beta          = std::move(ct::Tensor(r_type, device_type, {this->n_band_l}));
     this->eigen         = std::move(ct::Tensor(r_type, device_type, {this->n_band}));
     this->err_st        = std::move(ct::Tensor(r_type, device_type, {this->n_band_l}));
-    this->beta_denom    = std::move(ct::Tensor(r_type, device_type, {this->n_band_l}));
 
     this->hsub          = std::move(ct::Tensor(t_type, device_type, {this->n_band, this->n_band}));
 
@@ -57,6 +53,9 @@ void DiagoPPCG<T, Device>::init_iter(const int nband, const int nband_l, const i
     this->prec          = std::move(ct::Tensor(r_type, device_type, {this->n_basis}));
 
     this->grad          = std::move(ct::Tensor(t_type, device_type, {this->n_band_l, this->n_basis}));
+
+    this->conv_mask.assign(this->n_band_l, 0);
+
 #ifdef __MPI
     this->pmmcn.set_dimension(BP_WORLD, POOL_WORLD, n_band_l, n_basis, n_band_l, n_basis, n_dim, n_band);
     this->plintrans.set_dimension(n_dim, nband_l, n_band_l, n_basis, BP_WORLD, false);
@@ -67,19 +66,25 @@ void DiagoPPCG<T, Device>::init_iter(const int nband, const int nband_l, const i
 }
 
 template <typename T, typename Device>
+void DiagoPPCG<T, Device>::update_convergence(const std::vector<double>& ethr_band)
+{
+    Real* err = this->err_st.data<Real>();
+    for (int ib = 0; ib < this->n_band_l; ib++) {
+        if (err[ib] <= static_cast<Real>(ethr_band[ib])) {
+            this->conv_mask[ib] = 1;
+        }
+    }
+}
+
+template <typename T, typename Device>
 bool DiagoPPCG<T, Device>::test_error(const ct::Tensor& err_in, const std::vector<double>& ethr_band)
 {
     Real* _err_st = err_in.data<Real>();
     bool not_conv = false;
-    std::vector<Real> tmp_cpu;
-    if (err_in.device_type() == ct::DeviceType::GpuDevice) {
-        tmp_cpu.resize(this->n_band_l);
-        _err_st = tmp_cpu.data();
-        syncmem_var_d2h_op()(_err_st, err_in.data<Real>(), this->n_band_l);
-    }
     for (int ii = 0; ii < this->n_band_l; ii++) {
         if (_err_st[ii] > ethr_band[ii]) {
             not_conv = true;
+            break;
         }
     }
 #ifdef __MPI
@@ -123,6 +128,12 @@ void DiagoPPCG<T, Device>::orth_cholesky(
 
     this->rotate_wf(hsub_out, psi_out, workspace_in);
     this->rotate_wf(hsub_out, hpsi_out, workspace_in);
+
+    // Rotate conjugate history so that z_old and grad_old remain
+    // consistent with the rotated basis.  Without this, the PR beta
+    // formula would mix vectors from different bases.
+    this->rotate_wf(hsub_out, this->z_old, workspace_in);
+    this->rotate_wf(hsub_out, this->grad_old, workspace_in);
 }
 
 template <typename T, typename Device>
@@ -135,9 +146,12 @@ void DiagoPPCG<T, Device>::calc_grad_with_block(
         ct::Tensor& grad_out,
         ct::Tensor& grad_old_out)
 {
-    // PPCG-specific gradient computation using the Polak-Ribiere beta formula.
+    // PPCG gradient computation with Polak-Ribiere beta and soft-locking.
     //
-    // For each band i:
+    // Uses batched MPI reductions: scalars are collected into arrays and
+    // reduced in a single call per quantity, instead of per-band calls.
+    //
+    // For each active band i:
     //   1. Normalize psi_i
     //   2. Compute eps_i = <psi_i|H|psi_i>
     //   3. Raw residual: r_i = H|psi_i> - eps_i * psi_i
@@ -145,8 +159,8 @@ void DiagoPPCG<T, Device>::calc_grad_with_block(
     //   5. PR beta: beta_i = max(0, <z_i, r_i - r_old_i> / <z_old_i, r_old_i>)
     //   6. Search direction: d_i = z_i + beta_i * d_old_i
     //
-    // Key difference from BPCG: step 5 uses the Polak-Ribiere formula
-    // (projection-corrected) instead of the Fletcher-Reeves formula.
+    // Converged bands (conv_mask[ib] == 1) are soft-locked:
+    // their search direction is set to zero and error is set to 0.
 
     Real* prec = prec_in.data<Real>();
     Real* err_arr = err_out.data<Real>();
@@ -155,85 +169,111 @@ void DiagoPPCG<T, Device>::calc_grad_with_block(
     T* hpsi = hpsi_in.data<T>();
     T* grad_new = grad_out.data<T>();
     T* grad_old = grad_old_out.data<T>();
-    T* z_old_arr = this->z_old.template data<T>();
-    Real* beta_denom_arr = this->beta_denom.template data<Real>();
+    T* z_old_p = this->z_old.template data<T>();
 
-    for (int ib = 0; ib < this->n_band_l; ib++)
-    {
-        const int offset = ib * this->n_basis;
-        T* p_psi   = psi + offset;
-        T* p_hpsi  = hpsi + offset;
-        T* p_d_new = grad_new + offset;
-        T* p_d_old = grad_old + offset;
-        T* p_z_old = z_old_arr + offset;
+    const int nb = this->n_band_l;
+    const int ns = this->n_basis;
 
-        // Step 1: normalize psi
+    // Temporary arrays for batching MPI reductions
+    std::vector<Real> norms(nb, 0.0);
+    std::vector<Real> epsilos(nb, 0.0);
+    std::vector<Real> beta_num_zr(nb, 0.0);
+    std::vector<Real> beta_num_zo(nb, 0.0);
+    std::vector<Real> err_loc(nb, 0.0);
+    std::vector<Real> zPz_cur(nb, 0.0);  // <z_old, P * z_old> from current (possibly rotated) z_old
+
+    // ---- Phase 1: compute psi norms for active bands ----
+    for (int ib = 0; ib < nb; ib++) {
+        if (this->conv_mask[ib]) continue;
+        T* p_psi = psi + ib * ns;
         auto A = reinterpret_cast<const Real*>(p_psi);
-        Real norm = BlasConnector::dot(2 * this->n_basis, A, 1, A, 1);
-        Parallel_Reduce::reduce_pool(norm);
-        norm = 1.0 / sqrt(norm);
+        norms[ib] = BlasConnector::dot(2 * ns, A, 1, A, 1);
+    }
+    Parallel_Reduce::reduce_pool(norms.data(), nb);
 
-        // Step 2: compute epsilo = <psi|H|psi>
-        Real epsilo = 0.0;
-        for (int i = 0; i < this->n_basis; i++)
-        {
-            p_psi[i] *= norm;
-            p_hpsi[i] *= norm;
-            epsilo += std::real(p_hpsi[i] * std::conj(p_psi[i]));
+    // ---- Phase 2: normalize psi, hpsi and compute epsilos ----
+    for (int ib = 0; ib < nb; ib++) {
+        if (this->conv_mask[ib]) continue;
+        T* p_psi  = psi + ib * ns;
+        T* p_hpsi = hpsi + ib * ns;
+        Real nrm = 1.0 / std::sqrt(norms[ib]);
+        Real eps = 0.0;
+        for (int i = 0; i < ns; i++) {
+            p_psi[i]  *= nrm;
+            p_hpsi[i] *= nrm;
+            eps += std::real(p_hpsi[i] * std::conj(p_psi[i]));
         }
-        Parallel_Reduce::reduce_pool(epsilo);
+        epsilos[ib] = eps;
+    }
+    Parallel_Reduce::reduce_pool(epsilos.data(), nb);
 
-        // Step 3 & 4: compute raw residual r and preconditioned z = -P^{-1} r
-        // Simultaneously accumulate PR beta numerator:
-        //   num = <z_new, r_new - r_old> = <z_new, r_new> - <z_new, r_old>
-        Real beta_num_zr = 0.0;   // <z_new, r_new>
-        Real beta_num_zo = 0.0;   // <z_new, r_old>
-        Real err = 0.0;
+    // ---- Phase 3: residuals, preconditioned z, PR beta numerators, error ----
+    for (int ib = 0; ib < nb; ib++) {
+        if (this->conv_mask[ib]) continue;
+        T* p_psi   = psi   + ib * ns;
+        T* p_hpsi  = hpsi  + ib * ns;
+        T* p_d_new = grad_new + ib * ns;
+        T* p_z_old = z_old_p  + ib * ns;
+        Real eps   = epsilos[ib];
 
-        for (int i = 0; i < this->n_basis; i++)
-        {
-            T r_new = p_hpsi[i] - T(epsilo) * p_psi[i];      // unpreconditioned residual
-            T z_new = T(-1.0) * r_new / T(prec[i]);           // preconditioned residual
-            T r_old = T(prec[i]) * T(-1.0) * p_z_old[i];     // recover old raw residual from old preconditioned z
+        Real bzr = 0.0, bzo = 0.0, eloc = 0.0, zpz = 0.0;
+        for (int i = 0; i < ns; i++) {
+            T r_new = p_hpsi[i] - T(eps) * p_psi[i];
+            T z_new = T(-1.0) * r_new / T(prec[i]);
+            T r_old = T(prec[i]) * T(-1.0) * p_z_old[i];
 
-            beta_num_zr += std::real(z_new * std::conj(r_new));
-            beta_num_zo += std::real(z_new * std::conj(r_old));
-            err += std::norm(r_new);
+            bzr += std::real(z_new * std::conj(r_new));
+            bzo += std::real(z_new * std::conj(r_old));
+            eloc += std::norm(r_new);
+            zpz  += prec[i] * std::norm(p_z_old[i]);
 
             p_d_new[i] = z_new;
         }
-        Parallel_Reduce::reduce_pool(beta_num_zr);
-        Parallel_Reduce::reduce_pool(beta_num_zo);
-        Parallel_Reduce::reduce_pool(err);
+        beta_num_zr[ib] = bzr;
+        beta_num_zo[ib] = bzo;
+        err_loc[ib] = eloc;
+        zPz_cur[ib] = zpz;
+    }
+    Parallel_Reduce::reduce_pool(beta_num_zr.data(), nb);
+    Parallel_Reduce::reduce_pool(beta_num_zo.data(), nb);
+    Parallel_Reduce::reduce_pool(err_loc.data(), nb);
+    Parallel_Reduce::reduce_pool(zPz_cur.data(), nb);
 
-        // Step 5: Polak-Ribiere beta (clamped to [0, inf) for stability)
+    // ---- Phase 4: compute beta, mix directions, save state ----
+    for (int ib = 0; ib < nb; ib++) {
+        if (this->conv_mask[ib]) {
+            // Soft-locked: zero search direction, no error contribution.
+            T* p_d_new = grad_new + ib * ns;
+            std::fill(p_d_new, p_d_new + ns, T(0));
+            err_arr[ib]  = 0;
+            beta_arr[ib] = 0;
+            continue;
+        }
+
+        T* p_d_new = grad_new + ib * ns;
+        T* p_d_old = grad_old + ib * ns;
+        T* p_z_old = z_old_p  + ib * ns;
+
+        // PR denominator: <z_old, r_old> = -<z_old, P*z_old> = -zPz_cur.
+        // Recomputing from current z_old ensures consistency after
+        // Cholesky rotation of z_old in orth_cholesky.
+        Real denom = -zPz_cur[ib];
         Real beta_pr = 0.0;
-        Real denom = beta_denom_arr[ib];
-        if (std::abs(denom) > 1e-30)
-        {
-            beta_pr = (beta_num_zr - beta_num_zo) / denom;
+        if (std::abs(denom) > 1e-30) {
+            beta_pr = (beta_num_zr[ib] - beta_num_zo[ib]) / denom;
             if (beta_pr < 0.0) { beta_pr = 0.0; }
         }
 
-        // Step 6: mix with old search direction   d_new = z_new + beta_pr * d_old
-        for (int i = 0; i < this->n_basis; i++)
-        {
+        beta_arr[ib] = beta_pr;
+        err_arr[ib] = std::sqrt(err_loc[ib]);
+
+        // Mix: d_new = z_new + beta_pr * d_old
+        for (int i = 0; i < ns; i++) {
             p_d_new[i] += T(beta_pr) * p_d_old[i];
         }
-
-        // Store PR beta and denominator for next iteration.
-        // beta_denom_arr[ib] stores <z_cur, r_cur> which will be the
-        // denominator <z_old, r_old> in the next iteration.
-        beta_arr[ib] = beta_pr;
-        beta_denom_arr[ib] = beta_num_zr + 1e-30;
-        err_arr[ib] = sqrt(err);
-
-        // Save preconditioned z (before mixing) for next iteration's PR beta.
-        // We stored z_new in p_d_new before mixing; now copy back to z_old.
-        // Recover z_new from: z_new = d_new - beta_pr * d_old
-        // Since d_new = p_d_new and d_old = p_d_old, and beta_pr may be zero:
-        for (int i = 0; i < this->n_basis; i++)
-        {
+        // Save z_new (before mixing) for next iteration's PR beta.
+        // Recover: z_new = d_new - beta_pr * d_old
+        for (int i = 0; i < ns; i++) {
             p_z_old[i] = p_d_new[i] - T(beta_pr) * p_d_old[i];
         }
     }
@@ -253,7 +293,6 @@ void DiagoPPCG<T, Device>::orth_projection(
 {
     this->pmmcn.multiply(1.0, psi_in.data<T>(), grad_out.data<T>(), 0.0, hsub_in.data<T>());
     this->plintrans.act(-1.0, psi_in.data<T>(), hsub_in.data<T>(), 1.0, grad_out.data<T>());
-    return;
 }
 
 template <typename T, typename Device>
@@ -264,7 +303,6 @@ void DiagoPPCG<T, Device>::rotate_wf(
 {
     this->plintrans.act(1.0, psi_out.data<T>(), hsub_in.data<T>(), 0.0, workspace_in.data<T>());
     syncmem_complex_op()(psi_out.template data<T>(), workspace_in.template data<T>(), this->n_band_l * this->n_basis);
-    return;
 }
 
 template <typename T, typename Device>
@@ -284,8 +322,7 @@ void DiagoPPCG<T, Device>::diag_hsub(
         ct::Tensor& eigenvalue_out)
 {
     this->pmmcn.multiply(1.0, hpsi_in.data<T>(), psi_in.data<T>(), 0.0, hsub_out.data<T>());
-    ct::kernels::lapack_heevd<T, ct_Device>()(this->n_band, hsub_out.data<T>(), this->n_band, eigenvalue_out.data<Real>());
-    return;
+    ct::kernels::lapack_dnevd<T, ct_Device>()('V', 'U', hsub_out.data<T>(), this->n_band, eigenvalue_out.data<Real>());
 }
 
 template <typename T, typename Device>
@@ -302,7 +339,6 @@ void DiagoPPCG<T, Device>::calc_hsub_with_block(
     this->diag_hsub(psi_out, hpsi_out, hsub_out, eigenvalue_out);
     this->rotate_wf(hsub_out, psi_out, workspace_in);
     this->rotate_wf(hsub_out, hpsi_out, workspace_in);
-    return;
 }
 
 template <typename T, typename Device>
@@ -315,7 +351,6 @@ void DiagoPPCG<T, Device>::calc_hsub_with_block_exit(
 {
     this->diag_hsub(psi_out, hpsi_out, hsub_out, eigenvalue_out);
     this->rotate_wf(hsub_out, psi_out, workspace_in);
-    return;
 }
 
 template <typename T, typename Device>
@@ -330,16 +365,15 @@ void DiagoPPCG<T, Device>::diag(const HPsiFunc& hpsi_func,
 
     this->calc_prec();
 
-    // Initial subspace diagonalization to get a good starting guess.
+    // Reset convergence mask for this diag call.
+    this->conv_mask.assign(this->n_band_l, 0);
+
+    // Initial subspace diagonalization.
     this->calc_hsub_with_block(hpsi_func, psi_in, this->psi, this->hpsi,
                                this->hsub, this->work, this->eigen);
 
-    // Initialize PPCG state: first search direction is the steepest descent.
-    // grad_old and z_old start as zero; beta_denom starts as infinity so
-    // the first beta is computed as 0 (pure steepest descent).
     setmem_complex_op()(this->grad_old.template data<T>(), 0, this->n_basis * this->n_band_l);
     setmem_complex_op()(this->z_old.template data<T>(),    0, this->n_basis * this->n_band_l);
-    setmem_var_op()(this->beta_denom.template data<Real>(), std::numeric_limits<Real>::infinity(), this->n_band_l);
 
     int ntry = 0;
     int max_iter = current_scf_iter > 1 ?
@@ -349,46 +383,35 @@ void DiagoPPCG<T, Device>::diag(const HPsiFunc& hpsi_func,
     {
         ++ntry;
 
-        // PPCG step 1: compute the preconditioned conjugate direction.
-        //   Uses the Polak-Ribiere beta formula (projection-corrected):
-        //     beta_i = max(0, <z_i, r_i - r_old_i> / <z_old_i, r_old_i>)
-        //     d_i = z_i + beta_i * d_old_i
-        //   where z_i = -P^{-1} r_i is the preconditioned residual.
+        // Soft-lock bands that converged in the previous iteration.
+        if (ntry > 1) {
+            this->update_convergence(ethr_band);
+        }
+
         this->calc_grad_with_block(this->prec, this->err_st, this->beta,
                                    this->psi, this->hpsi, this->grad, this->grad_old);
 
-        // PPCG step 2: explicit projection.
-        //   Project the search direction d to be orthogonal to all current
-        //   approximate eigenvectors: d_i = d_i - sum_j <psi_j|d_i> psi_j.
-        //   This keeps the search within the relevant subspace.
         this->orth_projection(this->psi, this->hsub, this->grad);
 
-        // PPCG step 3: save the current search direction for the next iteration.
-        //   z_old is already saved inside calc_grad_with_block.
         syncmem_complex_op()(this->grad_old.template data<T>(),
                              this->grad.template data<T>(),
                              n_basis * n_band_l);
 
-        // PPCG step 4: apply H to the search direction.
         this->calc_hpsi_with_block(hpsi_func, this->grad.template data<T>(), this->hgrad);
 
-        // PPCG step 5: line minimization along the search direction.
-        //   psi_new = psi * cos(theta) + d * sin(theta)
-        //   where theta minimizes the Rayleigh quotient.
         this->line_minimize(this->grad, this->hgrad, this->psi, this->hpsi);
 
-        // PPCG step 6: Cholesky orthonormalization.
-        //   Ensures all bands remain orthonormal after the line minimization.
         this->orth_cholesky(this->work, this->psi, this->hpsi, this->hsub);
 
-        // Periodic subspace re-alignment in the first SCF iteration.
         if (current_scf_iter == 1 && ntry % this->nline == 0) {
             this->calc_hsub_with_block(hpsi_func, psi_in, this->psi, this->hpsi,
                                        this->hsub, this->work, this->eigen);
+            // Reset convergence mask after subspace re-diagonalization
+            // because psi vectors have been rotated.
+            this->conv_mask.assign(this->n_band_l, 0);
         }
     } while (ntry < max_iter && this->test_error(this->err_st, ethr_band));
 
-    // Final subspace diagonalization and rotation to get accurate eigenvalues.
     this->calc_hsub_with_block_exit(this->psi, this->hpsi, this->hsub, this->work, this->eigen);
 
     int start_nband = 0;
@@ -399,15 +422,9 @@ void DiagoPPCG<T, Device>::diag(const HPsiFunc& hpsi_func,
     }
 #endif
     syncmem_var_d2h_op()(eigenvalue_in, this->eigen.template data<Real>() + start_nband, this->n_band_l);
-
-    return;
 }
 
 template class DiagoPPCG<std::complex<float>, base_device::DEVICE_CPU>;
 template class DiagoPPCG<std::complex<double>, base_device::DEVICE_CPU>;
-#if ((defined __CUDA) || (defined __ROCM))
-template class DiagoPPCG<std::complex<float>, base_device::DEVICE_GPU>;
-template class DiagoPPCG<std::complex<double>, base_device::DEVICE_GPU>;
-#endif
 
 } // namespace hsolver

--- a/source/source_hsolver/diago_ppcg.cpp
+++ b/source/source_hsolver/diago_ppcg.cpp
@@ -1,0 +1,413 @@
+#include "source_hsolver/diago_ppcg.h"
+
+#include "diago_iter_assist.h"
+#include "source_base/global_function.h"
+#include "source_base/kernels/math_kernel_op.h"
+#include "source_base/parallel_comm.h"
+#include "source_base/parallel_reduce.h"
+#include "source_hsolver/kernels/bpcg_kernel_op.h"
+#include "para_linear_transform.h"
+
+#include <ATen/kernels/blas.h>
+#include <ATen/kernels/lapack.h>
+#include <ATen/ops/einsum_op.h>
+#include <cmath>
+#include <limits>
+
+namespace hsolver {
+
+template <typename T, typename Device>
+DiagoPPCG<T, Device>::DiagoPPCG(const Real* precondition_in)
+{
+    this->r_type   = ct::DataTypeToEnum<Real>::value;
+    this->t_type   = ct::DataTypeToEnum<T>::value;
+    this->device_type    = ct::DeviceTypeToEnum<Device>::value;
+
+    this->h_prec  = std::move(ct::TensorMap((void *) precondition_in, r_type, device_type, {this->n_basis}));
+
+    this->one = &one_;
+    this->zero = &zero_;
+    this->neg_one = &neg_one_;
+}
+
+template <typename T, typename Device>
+DiagoPPCG<T, Device>::~DiagoPPCG() {
+}
+
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::init_iter(const int nband, const int nband_l, const int nbasis, const int ndim) {
+    this->n_band        = nband;
+    this->n_band_l      = nband_l;
+    this->n_basis       = nbasis;
+    this->n_dim         = ndim;
+
+    this->beta          = std::move(ct::Tensor(r_type, device_type, {this->n_band_l}));
+    this->eigen         = std::move(ct::Tensor(r_type, device_type, {this->n_band}));
+    this->err_st        = std::move(ct::Tensor(r_type, device_type, {this->n_band_l}));
+    this->beta_denom    = std::move(ct::Tensor(r_type, device_type, {this->n_band_l}));
+
+    this->hsub          = std::move(ct::Tensor(t_type, device_type, {this->n_band, this->n_band}));
+
+    this->hpsi          = std::move(ct::Tensor(t_type, device_type, {this->n_band_l, this->n_basis}));
+    this->work          = std::move(ct::Tensor(t_type, device_type, {this->n_band_l, this->n_basis}));
+    this->hgrad         = std::move(ct::Tensor(t_type, device_type, {this->n_band_l, this->n_basis}));
+    this->grad_old      = std::move(ct::Tensor(t_type, device_type, {this->n_band_l, this->n_basis}));
+    this->z_old         = std::move(ct::Tensor(t_type, device_type, {this->n_band_l, this->n_basis}));
+
+    this->prec          = std::move(ct::Tensor(r_type, device_type, {this->n_basis}));
+
+    this->grad          = std::move(ct::Tensor(t_type, device_type, {this->n_band_l, this->n_basis}));
+#ifdef __MPI
+    this->pmmcn.set_dimension(BP_WORLD, POOL_WORLD, n_band_l, n_basis, n_band_l, n_basis, n_dim, n_band);
+    this->plintrans.set_dimension(n_dim, nband_l, n_band_l, n_basis, BP_WORLD, false);
+#else
+    this->pmmcn.set_dimension(n_band_l, n_basis, n_band_l, n_basis, n_dim, n_band);
+    this->plintrans.set_dimension(n_dim, nband_l, n_band_l, n_basis, false);
+#endif
+}
+
+template <typename T, typename Device>
+bool DiagoPPCG<T, Device>::test_error(const ct::Tensor& err_in, const std::vector<double>& ethr_band)
+{
+    Real* _err_st = err_in.data<Real>();
+    bool not_conv = false;
+    std::vector<Real> tmp_cpu;
+    if (err_in.device_type() == ct::DeviceType::GpuDevice) {
+        tmp_cpu.resize(this->n_band_l);
+        _err_st = tmp_cpu.data();
+        syncmem_var_d2h_op()(_err_st, err_in.data<Real>(), this->n_band_l);
+    }
+    for (int ii = 0; ii < this->n_band_l; ii++) {
+        if (_err_st[ii] > ethr_band[ii]) {
+            not_conv = true;
+        }
+    }
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, &not_conv, 1, MPI_C_BOOL, MPI_LOR, BP_WORLD);
+#endif
+    return not_conv;
+}
+
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::line_minimize(
+    ct::Tensor& grad_in,
+    ct::Tensor& hgrad_in,
+    ct::Tensor& psi_out,
+    ct::Tensor& hpsi_out)
+{
+    line_minimize_with_block_op<T, Device>()(grad_in.data<T>(),
+                                             hgrad_in.data<T>(),
+                                             psi_out.data<T>(),
+                                             hpsi_out.data<T>(),
+                                             this->n_dim,
+                                             this->n_basis,
+                                             this->n_band_l);
+}
+
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::orth_cholesky(
+        ct::Tensor& workspace_in,
+        ct::Tensor& psi_out,
+        ct::Tensor& hpsi_out,
+        ct::Tensor& hsub_out)
+{
+    this->pmmcn.multiply(1.0, psi_out.data<T>(), psi_out.data<T>(), 0.0, hsub_out.data<T>());
+
+    ct::kernels::set_matrix<T, ct_Device>()(
+        'L', hsub_out.data<T>(), this->n_band);
+
+    ct::kernels::lapack_potrf<T, ct_Device>()(
+        'U', this->n_band, hsub_out.data<T>(), this->n_band);
+    ct::kernels::lapack_trtri<T, ct_Device>()(
+        'U', 'N', this->n_band, hsub_out.data<T>(), this->n_band);
+
+    this->rotate_wf(hsub_out, psi_out, workspace_in);
+    this->rotate_wf(hsub_out, hpsi_out, workspace_in);
+}
+
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::calc_grad_with_block(
+        const ct::Tensor& prec_in,
+        ct::Tensor& err_out,
+        ct::Tensor& beta_out,
+        ct::Tensor& psi_in,
+        ct::Tensor& hpsi_in,
+        ct::Tensor& grad_out,
+        ct::Tensor& grad_old_out)
+{
+    // PPCG-specific gradient computation using the Polak-Ribiere beta formula.
+    //
+    // For each band i:
+    //   1. Normalize psi_i
+    //   2. Compute eps_i = <psi_i|H|psi_i>
+    //   3. Raw residual: r_i = H|psi_i> - eps_i * psi_i
+    //   4. Preconditioned residual: z_i = -P^{-1} r_i
+    //   5. PR beta: beta_i = max(0, <z_i, r_i - r_old_i> / <z_old_i, r_old_i>)
+    //   6. Search direction: d_i = z_i + beta_i * d_old_i
+    //
+    // Key difference from BPCG: step 5 uses the Polak-Ribiere formula
+    // (projection-corrected) instead of the Fletcher-Reeves formula.
+
+    Real* prec = prec_in.data<Real>();
+    Real* err_arr = err_out.data<Real>();
+    Real* beta_arr = beta_out.data<Real>();
+    T* psi = psi_in.data<T>();
+    T* hpsi = hpsi_in.data<T>();
+    T* grad_new = grad_out.data<T>();
+    T* grad_old = grad_old_out.data<T>();
+    T* z_old_arr = this->z_old.template data<T>();
+    Real* beta_denom_arr = this->beta_denom.template data<Real>();
+
+    for (int ib = 0; ib < this->n_band_l; ib++)
+    {
+        const int offset = ib * this->n_basis;
+        T* p_psi   = psi + offset;
+        T* p_hpsi  = hpsi + offset;
+        T* p_d_new = grad_new + offset;
+        T* p_d_old = grad_old + offset;
+        T* p_z_old = z_old_arr + offset;
+
+        // Step 1: normalize psi
+        auto A = reinterpret_cast<const Real*>(p_psi);
+        Real norm = BlasConnector::dot(2 * this->n_basis, A, 1, A, 1);
+        Parallel_Reduce::reduce_pool(norm);
+        norm = 1.0 / sqrt(norm);
+
+        // Step 2: compute epsilo = <psi|H|psi>
+        Real epsilo = 0.0;
+        for (int i = 0; i < this->n_basis; i++)
+        {
+            p_psi[i] *= norm;
+            p_hpsi[i] *= norm;
+            epsilo += std::real(p_hpsi[i] * std::conj(p_psi[i]));
+        }
+        Parallel_Reduce::reduce_pool(epsilo);
+
+        // Step 3 & 4: compute raw residual r and preconditioned z = -P^{-1} r
+        // Simultaneously accumulate PR beta numerator:
+        //   num = <z_new, r_new - r_old> = <z_new, r_new> - <z_new, r_old>
+        Real beta_num_zr = 0.0;   // <z_new, r_new>
+        Real beta_num_zo = 0.0;   // <z_new, r_old>
+        Real err = 0.0;
+
+        for (int i = 0; i < this->n_basis; i++)
+        {
+            T r_new = p_hpsi[i] - T(epsilo) * p_psi[i];      // unpreconditioned residual
+            T z_new = T(-1.0) * r_new / T(prec[i]);           // preconditioned residual
+            T r_old = T(prec[i]) * T(-1.0) * p_z_old[i];     // recover old raw residual from old preconditioned z
+
+            beta_num_zr += std::real(z_new * std::conj(r_new));
+            beta_num_zo += std::real(z_new * std::conj(r_old));
+            err += std::norm(r_new);
+
+            p_d_new[i] = z_new;
+        }
+        Parallel_Reduce::reduce_pool(beta_num_zr);
+        Parallel_Reduce::reduce_pool(beta_num_zo);
+        Parallel_Reduce::reduce_pool(err);
+
+        // Step 5: Polak-Ribiere beta (clamped to [0, inf) for stability)
+        Real beta_pr = 0.0;
+        Real denom = beta_denom_arr[ib];
+        if (std::abs(denom) > 1e-30)
+        {
+            beta_pr = (beta_num_zr - beta_num_zo) / denom;
+            if (beta_pr < 0.0) { beta_pr = 0.0; }
+        }
+
+        // Step 6: mix with old search direction   d_new = z_new + beta_pr * d_old
+        for (int i = 0; i < this->n_basis; i++)
+        {
+            p_d_new[i] += T(beta_pr) * p_d_old[i];
+        }
+
+        // Store PR beta and denominator for next iteration.
+        // beta_denom_arr[ib] stores <z_cur, r_cur> which will be the
+        // denominator <z_old, r_old> in the next iteration.
+        beta_arr[ib] = beta_pr;
+        beta_denom_arr[ib] = beta_num_zr + 1e-30;
+        err_arr[ib] = sqrt(err);
+
+        // Save preconditioned z (before mixing) for next iteration's PR beta.
+        // We stored z_new in p_d_new before mixing; now copy back to z_old.
+        // Recover z_new from: z_new = d_new - beta_pr * d_old
+        // Since d_new = p_d_new and d_old = p_d_old, and beta_pr may be zero:
+        for (int i = 0; i < this->n_basis; i++)
+        {
+            p_z_old[i] = p_d_new[i] - T(beta_pr) * p_d_old[i];
+        }
+    }
+}
+
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::calc_prec()
+{
+    syncmem_var_h2d_op()(this->prec.template data<Real>(), this->h_prec.template data<Real>(), this->n_basis);
+}
+
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::orth_projection(
+        const ct::Tensor& psi_in,
+        ct::Tensor& hsub_in,
+        ct::Tensor& grad_out)
+{
+    this->pmmcn.multiply(1.0, psi_in.data<T>(), grad_out.data<T>(), 0.0, hsub_in.data<T>());
+    this->plintrans.act(-1.0, psi_in.data<T>(), hsub_in.data<T>(), 1.0, grad_out.data<T>());
+    return;
+}
+
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::rotate_wf(
+        const ct::Tensor& hsub_in,
+        ct::Tensor& psi_out,
+        ct::Tensor& workspace_in)
+{
+    this->plintrans.act(1.0, psi_out.data<T>(), hsub_in.data<T>(), 0.0, workspace_in.data<T>());
+    syncmem_complex_op()(psi_out.template data<T>(), workspace_in.template data<T>(), this->n_band_l * this->n_basis);
+    return;
+}
+
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::calc_hpsi_with_block(
+        const HPsiFunc& hpsi_func,
+        T *psi_in,
+        ct::Tensor& hpsi_out)
+{
+    hpsi_func(psi_in, hpsi_out.data<T>(), this->n_basis, this->n_band_l);
+}
+
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::diag_hsub(
+        const ct::Tensor& psi_in,
+        const ct::Tensor& hpsi_in,
+        ct::Tensor& hsub_out,
+        ct::Tensor& eigenvalue_out)
+{
+    this->pmmcn.multiply(1.0, hpsi_in.data<T>(), psi_in.data<T>(), 0.0, hsub_out.data<T>());
+    ct::kernels::lapack_heevd<T, ct_Device>()(this->n_band, hsub_out.data<T>(), this->n_band, eigenvalue_out.data<Real>());
+    return;
+}
+
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::calc_hsub_with_block(
+        const HPsiFunc& hpsi_func,
+        T *psi_in,
+        ct::Tensor& psi_out,
+        ct::Tensor& hpsi_out,
+        ct::Tensor& hsub_out,
+        ct::Tensor& workspace_in,
+        ct::Tensor& eigenvalue_out)
+{
+    this->calc_hpsi_with_block(hpsi_func, psi_in, hpsi_out);
+    this->diag_hsub(psi_out, hpsi_out, hsub_out, eigenvalue_out);
+    this->rotate_wf(hsub_out, psi_out, workspace_in);
+    this->rotate_wf(hsub_out, hpsi_out, workspace_in);
+    return;
+}
+
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::calc_hsub_with_block_exit(
+        ct::Tensor& psi_out,
+        ct::Tensor& hpsi_out,
+        ct::Tensor& hsub_out,
+        ct::Tensor& workspace_in,
+        ct::Tensor& eigenvalue_out)
+{
+    this->diag_hsub(psi_out, hpsi_out, hsub_out, eigenvalue_out);
+    this->rotate_wf(hsub_out, psi_out, workspace_in);
+    return;
+}
+
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::diag(const HPsiFunc& hpsi_func,
+                                T* psi_in,
+                                Real* eigenvalue_in,
+                                const std::vector<double>& ethr_band)
+{
+    const int current_scf_iter = hsolver::DiagoIterAssist<T, Device>::SCF_ITER;
+
+    this->psi = std::move(ct::TensorMap(psi_in, t_type, device_type, {this->n_band_l, this->n_basis}));
+
+    this->calc_prec();
+
+    // Initial subspace diagonalization to get a good starting guess.
+    this->calc_hsub_with_block(hpsi_func, psi_in, this->psi, this->hpsi,
+                               this->hsub, this->work, this->eigen);
+
+    // Initialize PPCG state: first search direction is the steepest descent.
+    // grad_old and z_old start as zero; beta_denom starts as infinity so
+    // the first beta is computed as 0 (pure steepest descent).
+    setmem_complex_op()(this->grad_old.template data<T>(), 0, this->n_basis * this->n_band_l);
+    setmem_complex_op()(this->z_old.template data<T>(),    0, this->n_basis * this->n_band_l);
+    setmem_var_op()(this->beta_denom.template data<Real>(), std::numeric_limits<Real>::infinity(), this->n_band_l);
+
+    int ntry = 0;
+    int max_iter = current_scf_iter > 1 ?
+                   this->nline :
+                   this->nline * 6;
+    do
+    {
+        ++ntry;
+
+        // PPCG step 1: compute the preconditioned conjugate direction.
+        //   Uses the Polak-Ribiere beta formula (projection-corrected):
+        //     beta_i = max(0, <z_i, r_i - r_old_i> / <z_old_i, r_old_i>)
+        //     d_i = z_i + beta_i * d_old_i
+        //   where z_i = -P^{-1} r_i is the preconditioned residual.
+        this->calc_grad_with_block(this->prec, this->err_st, this->beta,
+                                   this->psi, this->hpsi, this->grad, this->grad_old);
+
+        // PPCG step 2: explicit projection.
+        //   Project the search direction d to be orthogonal to all current
+        //   approximate eigenvectors: d_i = d_i - sum_j <psi_j|d_i> psi_j.
+        //   This keeps the search within the relevant subspace.
+        this->orth_projection(this->psi, this->hsub, this->grad);
+
+        // PPCG step 3: save the current search direction for the next iteration.
+        //   z_old is already saved inside calc_grad_with_block.
+        syncmem_complex_op()(this->grad_old.template data<T>(),
+                             this->grad.template data<T>(),
+                             n_basis * n_band_l);
+
+        // PPCG step 4: apply H to the search direction.
+        this->calc_hpsi_with_block(hpsi_func, this->grad.template data<T>(), this->hgrad);
+
+        // PPCG step 5: line minimization along the search direction.
+        //   psi_new = psi * cos(theta) + d * sin(theta)
+        //   where theta minimizes the Rayleigh quotient.
+        this->line_minimize(this->grad, this->hgrad, this->psi, this->hpsi);
+
+        // PPCG step 6: Cholesky orthonormalization.
+        //   Ensures all bands remain orthonormal after the line minimization.
+        this->orth_cholesky(this->work, this->psi, this->hpsi, this->hsub);
+
+        // Periodic subspace re-alignment in the first SCF iteration.
+        if (current_scf_iter == 1 && ntry % this->nline == 0) {
+            this->calc_hsub_with_block(hpsi_func, psi_in, this->psi, this->hpsi,
+                                       this->hsub, this->work, this->eigen);
+        }
+    } while (ntry < max_iter && this->test_error(this->err_st, ethr_band));
+
+    // Final subspace diagonalization and rotation to get accurate eigenvalues.
+    this->calc_hsub_with_block_exit(this->psi, this->hpsi, this->hsub, this->work, this->eigen);
+
+    int start_nband = 0;
+#ifdef __MPI
+    if (this->plintrans.nproc_col > 1)
+    {
+        start_nband = this->plintrans.start_colB[GlobalV::MY_BNDGROUP];
+    }
+#endif
+    syncmem_var_d2h_op()(eigenvalue_in, this->eigen.template data<Real>() + start_nband, this->n_band_l);
+
+    return;
+}
+
+template class DiagoPPCG<std::complex<float>, base_device::DEVICE_CPU>;
+template class DiagoPPCG<std::complex<double>, base_device::DEVICE_CPU>;
+#if ((defined __CUDA) || (defined __ROCM))
+template class DiagoPPCG<std::complex<float>, base_device::DEVICE_GPU>;
+template class DiagoPPCG<std::complex<double>, base_device::DEVICE_GPU>;
+#endif
+
+} // namespace hsolver

--- a/source/source_hsolver/diago_ppcg.cpp
+++ b/source/source_hsolver/diago_ppcg.cpp
@@ -322,7 +322,31 @@ void DiagoPPCG<T, Device>::diag_hsub(
         ct::Tensor& eigenvalue_out)
 {
     this->pmmcn.multiply(1.0, hpsi_in.data<T>(), psi_in.data<T>(), 0.0, hsub_out.data<T>());
-    ct::kernels::lapack_dnevd<T, ct_Device>()('V', 'U', hsub_out.data<T>(), this->n_band, eigenvalue_out.data<Real>());
+
+    const int n = this->n_band;
+    int lwork = 2 * n + n * n;
+    if (lwork < 1 + 6 * n + 2 * n * n) {
+        lwork = 1 + 6 * n + 2 * n * n;
+    }
+    ct::Tensor work(t_type, device_type, {lwork});
+    work.zero();
+
+    int lrwork = 1 + 5 * n + 2 * n * n;
+    ct::Tensor rwork(r_type, device_type, {lrwork});
+    rwork.zero();
+
+    int liwork = 3 + 5 * n;
+    ct::Tensor iwork(ct::DataType::DT_INT, device_type, {liwork});
+    iwork.zero();
+
+    int info = 0;
+    container::lapackConnector::dnevd('V', 'U', n,
+                                       hsub_out.data<T>(), n,
+                                       eigenvalue_out.data<Real>(),
+                                       work.data<T>(), lwork,
+                                       rwork.data<Real>(), lrwork,
+                                       iwork.data<int>(), liwork,
+                                       info);
 }
 
 template <typename T, typename Device>

--- a/source/source_hsolver/diago_ppcg.h
+++ b/source/source_hsolver/diago_ppcg.h
@@ -9,6 +9,7 @@
 
 #include <ATen/core/tensor.h>
 #include <ATen/core/tensor_map.h>
+#include <ATen/kernels/lapack.h>
 #include <source_base/macros.h>
 
 #include <functional>

--- a/source/source_hsolver/diago_ppcg.h
+++ b/source/source_hsolver/diago_ppcg.h
@@ -11,6 +11,7 @@
 #include <ATen/core/tensor_map.h>
 #include <source_base/macros.h>
 
+#include <functional>
 #include <vector>
 
 namespace hsolver {

--- a/source/source_hsolver/diago_ppcg.h
+++ b/source/source_hsolver/diago_ppcg.h
@@ -9,7 +9,6 @@
 
 #include <ATen/core/tensor.h>
 #include <ATen/core/tensor_map.h>
-#include <ATen/kernels/lapack.h>
 #include <source_base/macros.h>
 
 #include <functional>

--- a/source/source_hsolver/diago_ppcg.h
+++ b/source/source_hsolver/diago_ppcg.h
@@ -1,0 +1,196 @@
+#ifndef DIAGO_PPCG_H_
+#define DIAGO_PPCG_H_
+
+#include "source_base/kernels/math_kernel_op.h"
+#include "source_base/module_device/memory_op.h"
+#include "source_base/module_device/types.h"
+#include "source_base/para_gemm.h"
+#include "source_hsolver/para_linear_transform.h"
+
+#include <ATen/core/tensor.h>
+#include <ATen/core/tensor_map.h>
+#include <source_base/macros.h>
+
+namespace hsolver {
+
+/**
+ * @class DiagoPPCG
+ * @brief A class for diagonalization using the Projected-PCG method.
+ *
+ * The PPCG method improves upon standard BPCG by:
+ * 1. Tracking convergence per band and locking converged bands,
+ *    so subsequent iterations only work on unconverged bands.
+ * 2. Using an explicit projection step that removes components of
+ *    converged eigenvectors from the search direction.
+ * 3. Employing a Polak-Ribiere-style beta formula for conjugate
+ *    direction mixing, corrected for the projection.
+ *
+ * @tparam T The floating-point type used for calculations.
+ * @tparam Device The device used for calculations (e.g., cpu or gpu).
+ */
+template <typename T = std::complex<double>, typename Device = base_device::DEVICE_CPU>
+class DiagoPPCG
+{
+  private:
+    using Real = typename GetTypeReal<T>::type;
+
+  public:
+    explicit DiagoPPCG(const Real* precondition);
+    ~DiagoPPCG();
+
+    void init_iter(const int nband, const int nband_l, const int nbasis, const int ndim);
+
+    using HPsiFunc = std::function<void(T*, T*, const int, const int)>;
+
+    void diag(const HPsiFunc& hpsi_func,
+              T* psi_in,
+              Real* eigenvalue_in,
+              const std::vector<double>& ethr_band);
+
+  private:
+    int n_band = 0;
+    int n_band_l = 0;
+    int n_basis = 0;
+    int n_dim = 0;
+    int nline = 4;
+
+    ModuleBase::PGemmCN<T, Device> pmmcn;
+    PLinearTransform<T, Device> plintrans;
+
+    ct::DataType r_type  = ct::DataType::DT_INVALID;
+    ct::DataType t_type  = ct::DataType::DT_INVALID;
+    ct::DeviceType device_type = ct::DeviceType::UnKnown;
+
+    ct::Tensor prec = {}, h_prec = {};
+
+    /// Polak-Ribiere beta for conjugate direction mixing
+    ct::Tensor beta = {};
+    /// Error state per band
+    ct::Tensor err_st = {};
+    /// Eigenvalues
+    ct::Tensor eigen = {};
+
+    /// Wavefunction and H|psi>
+    ct::Tensor psi = {}, hpsi = {};
+
+    /// Subspace Hamiltonian
+    ct::Tensor hsub = {};
+
+    /// Search direction d (mixed preconditioned gradient)
+    ct::Tensor grad = {}, hgrad = {}, grad_old = {};
+
+    /// Previous preconditioned gradient z_old (before mixing),
+    /// needed for the Polak-Ribiere beta formula.
+    ct::Tensor z_old = {};
+
+    /// Denominator for PR beta: <g_old, P^{-1} g_old> per band.
+    ct::Tensor beta_denom = {};
+
+    /// Work array
+    ct::Tensor work = {};
+
+    Device * ctx = {};
+    const T *one = nullptr, *zero = nullptr, *neg_one = nullptr;
+    const T one_ = static_cast<T>(1.0), zero_ = static_cast<T>(0.0), neg_one_ = static_cast<T>(-1.0);
+
+    /// Update the precondition array from host to device.
+    void calc_prec();
+
+    /// Apply H to psi: hpsi_out = H |psi_in>
+    void calc_hpsi_with_block(
+        const HPsiFunc& hpsi_func,
+        T *psi_in,
+        ct::Tensor& hpsi_out);
+
+    /// Subspace diagonalization: solve H_sub * c = eps * c
+    void diag_hsub(
+        const ct::Tensor& psi_in,
+        const ct::Tensor& hpsi_in,
+        ct::Tensor& hsub_out,
+        ct::Tensor& eigenvalue_out);
+
+    /// Rotate wavefunctions: psi_out = psi_out * hsub_in
+    void rotate_wf(
+        const ct::Tensor& hsub_in,
+        ct::Tensor& psi_out,
+        ct::Tensor& workspace_in);
+
+    /**
+     * @brief Compute the projected gradient for PPCG.
+     *
+     * Steps:
+     *  1. Normalize psi
+     *  2. Compute epsilo = <psi|H|psi>
+     *  3. g = H|psi> - epsilo * |psi>
+     *  4. Apply preconditioner: g = P^{-1} g
+     *  5. Compute Polak-Ribiere beta (projection-corrected)
+     *  6. Mix with previous gradient: d = g + beta * d_old
+     */
+    void calc_grad_with_block(
+        const ct::Tensor& prec_in,
+        ct::Tensor& err_out,
+        ct::Tensor& beta_out,
+        ct::Tensor& psi_in,
+        ct::Tensor& hpsi_in,
+        ct::Tensor& grad_out,
+        ct::Tensor& grad_old_out);
+
+    /// Project grad to be orthogonal to all columns of psi:
+    /// grad = grad - psi * (psi^T * grad)
+    void orth_projection(
+        const ct::Tensor& psi_in,
+        ct::Tensor& hsub_in,
+        ct::Tensor& grad_out);
+
+    /// Line minimization: optimize psi along the conjugate direction.
+    void line_minimize(
+        ct::Tensor& grad_in,
+        ct::Tensor& hgrad_in,
+        ct::Tensor& psi_out,
+        ct::Tensor& hpsi_out);
+
+    /// Cholesky orthonormalization of psi.
+    void orth_cholesky(
+        ct::Tensor& workspace_in,
+        ct::Tensor& psi_out,
+        ct::Tensor& hpsi_out,
+        ct::Tensor& hsub_out);
+
+    /// Initial subspace setup: H|psi>, diag, rotate.
+    void calc_hsub_with_block(
+        const HPsiFunc& hpsi_func,
+        T *psi_in,
+        ct::Tensor& psi_out,
+        ct::Tensor& hpsi_out,
+        ct::Tensor& hsub_out,
+        ct::Tensor& workspace_in,
+        ct::Tensor& eigenvalue_out);
+
+    /// Final subspace cleanup: diag and rotate psi only.
+    void calc_hsub_with_block_exit(
+        ct::Tensor& psi_out,
+        ct::Tensor& hpsi_out,
+        ct::Tensor& hsub_out,
+        ct::Tensor& workspace_in,
+        ct::Tensor& eigenvalue_out);
+
+    /// Check convergence: returns true if any band still unconverged.
+    bool test_error(const ct::Tensor& err_in, const std::vector<double>& ethr_band);
+
+    using ct_Device = typename ct::PsiToContainer<Device>::type;
+    using setmem_var_op = ct::kernels::set_memory<Real, ct_Device>;
+    using resmem_var_op = ct::kernels::resize_memory<Real, ct_Device>;
+    using delmem_var_op = ct::kernels::delete_memory<Real, ct_Device>;
+    using syncmem_var_h2d_op = ct::kernels::synchronize_memory<Real, ct_Device, ct::DEVICE_CPU>;
+    using syncmem_var_d2h_op = ct::kernels::synchronize_memory<Real, ct::DEVICE_CPU, ct_Device>;
+
+    using setmem_complex_op = ct::kernels::set_memory<T, ct_Device>;
+    using delmem_complex_op = ct::kernels::delete_memory<T, ct_Device>;
+    using resmem_complex_op = ct::kernels::resize_memory<T, ct_Device>;
+    using syncmem_complex_op = ct::kernels::synchronize_memory<T, ct_Device, ct_Device>;
+
+    using gemm_op = ModuleBase::gemm_op<T, Device>;
+};
+
+} // namespace hsolver
+#endif // DIAGO_PPCG_H_

--- a/source/source_hsolver/diago_ppcg.h
+++ b/source/source_hsolver/diago_ppcg.h
@@ -11,22 +11,26 @@
 #include <ATen/core/tensor_map.h>
 #include <source_base/macros.h>
 
+#include <vector>
+
 namespace hsolver {
 
 /**
  * @class DiagoPPCG
  * @brief A class for diagonalization using the Projected-PCG method.
  *
- * The PPCG method improves upon standard BPCG by:
- * 1. Tracking convergence per band and locking converged bands,
- *    so subsequent iterations only work on unconverged bands.
- * 2. Using an explicit projection step that removes components of
- *    converged eigenvectors from the search direction.
- * 3. Employing a Polak-Ribiere-style beta formula for conjugate
- *    direction mixing, corrected for the projection.
+ * Key differences from BPCG:
+ * 1. Polak-Ribiere beta formula for conjugate direction mixing (BPCG uses
+ *    Fletcher-Reeves), giving better convergence for non-quadratic problems.
+ * 2. Soft-locking of converged bands: once a band's residual falls below its
+ *    convergence threshold, its search direction is zeroed in subsequent
+ *    iterations, reducing the effective problem size.
+ * 3. Conjugate history (z_old, grad_old) is consistently rotated alongside
+ *    the wavefunctions during Cholesky orthonormalization, preserving the
+ *    conjugacy relationship across basis rotations.
  *
  * @tparam T The floating-point type used for calculations.
- * @tparam Device The device used for calculations (e.g., cpu or gpu).
+ * @tparam Device The device used for calculations (cpu only).
  */
 template <typename T = std::complex<double>, typename Device = base_device::DEVICE_CPU>
 class DiagoPPCG
@@ -83,15 +87,11 @@ class DiagoPPCG
     /// needed for the Polak-Ribiere beta formula.
     ct::Tensor z_old = {};
 
-    /// Denominator for PR beta: <g_old, P^{-1} g_old> per band.
-    ct::Tensor beta_denom = {};
-
     /// Work array
     ct::Tensor work = {};
 
-    Device * ctx = {};
-    const T *one = nullptr, *zero = nullptr, *neg_one = nullptr;
-    const T one_ = static_cast<T>(1.0), zero_ = static_cast<T>(0.0), neg_one_ = static_cast<T>(-1.0);
+    /// Per-band convergence mask: 1 = converged (locked), 0 = active.
+    std::vector<char> conv_mask;
 
     /// Update the precondition array from host to device.
     void calc_prec();
@@ -115,17 +115,9 @@ class DiagoPPCG
         ct::Tensor& psi_out,
         ct::Tensor& workspace_in);
 
-    /**
-     * @brief Compute the projected gradient for PPCG.
-     *
-     * Steps:
-     *  1. Normalize psi
-     *  2. Compute epsilo = <psi|H|psi>
-     *  3. g = H|psi> - epsilo * |psi>
-     *  4. Apply preconditioner: g = P^{-1} g
-     *  5. Compute Polak-Ribiere beta (projection-corrected)
-     *  6. Mix with previous gradient: d = g + beta * d_old
-     */
+    /// Compute the PPCG search direction with Polak-Ribiere mixing.
+    /// Converged bands (conv_mask[ib] == 1) are skipped and their
+    /// search direction is zeroed out (soft-locking).
     void calc_grad_with_block(
         const ct::Tensor& prec_in,
         ct::Tensor& err_out,
@@ -149,7 +141,9 @@ class DiagoPPCG
         ct::Tensor& psi_out,
         ct::Tensor& hpsi_out);
 
-    /// Cholesky orthonormalization of psi.
+    /// Cholesky orthonormalization of psi, hpsi, and conjugate history.
+    /// Also rotates z_old and grad_old by the Cholesky factor so that
+    /// conjugate history remains consistent with the current basis.
     void orth_cholesky(
         ct::Tensor& workspace_in,
         ct::Tensor& psi_out,
@@ -177,19 +171,16 @@ class DiagoPPCG
     /// Check convergence: returns true if any band still unconverged.
     bool test_error(const ct::Tensor& err_in, const std::vector<double>& ethr_band);
 
+    /// Update conv_mask from current err_st vs per-band thresholds.
+    void update_convergence(const std::vector<double>& ethr_band);
+
     using ct_Device = typename ct::PsiToContainer<Device>::type;
     using setmem_var_op = ct::kernels::set_memory<Real, ct_Device>;
-    using resmem_var_op = ct::kernels::resize_memory<Real, ct_Device>;
-    using delmem_var_op = ct::kernels::delete_memory<Real, ct_Device>;
     using syncmem_var_h2d_op = ct::kernels::synchronize_memory<Real, ct_Device, ct::DEVICE_CPU>;
     using syncmem_var_d2h_op = ct::kernels::synchronize_memory<Real, ct::DEVICE_CPU, ct_Device>;
 
     using setmem_complex_op = ct::kernels::set_memory<T, ct_Device>;
-    using delmem_complex_op = ct::kernels::delete_memory<T, ct_Device>;
-    using resmem_complex_op = ct::kernels::resize_memory<T, ct_Device>;
     using syncmem_complex_op = ct::kernels::synchronize_memory<T, ct_Device, ct_Device>;
-
-    using gemm_op = ModuleBase::gemm_op<T, Device>;
 };
 
 } // namespace hsolver

--- a/source/source_hsolver/hsolver_pw.cpp
+++ b/source/source_hsolver/hsolver_pw.cpp
@@ -8,6 +8,7 @@
 #include "source_hamilt/hamilt.h"
 #include "source_hsolver/diag_comm_info.h"
 #include "source_hsolver/diago_bpcg.h"
+#include "source_hsolver/diago_ppcg.h"
 #include "source_hsolver/diago_cg.h"
 #include "source_hsolver/diago_dav_subspace.h"
 #include "source_hsolver/diago_david.h"
@@ -83,7 +84,7 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
     this->nproc_in_pool = nproc_in_pool_in;
 
     // report if the specified diagonalization method is not supported
-    const std::initializer_list<std::string> _methods = {"cg", "dav", "dav_subspace", "bpcg"};
+    const std::initializer_list<std::string> _methods = {"cg", "dav", "dav_subspace", "bpcg", "ppcg"};
     if (std::find(std::begin(_methods), std::end(_methods), this->method) == std::end(_methods))
     {
         ModuleBase::WARNING_QUIT("HSolverPW::solve", "This type of eigensolver is not supported!");
@@ -322,6 +323,27 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm,
         DiagoBPCG<T, Device> bpcg(pre_condition.data());
         bpcg.init_iter(PARAM.inp.nbands, nband_l, nbasis, ndim);
         bpcg.diag(hpsi_func, psi.get_pointer(), eigenvalue, this->ethr_band);
+    }
+    else if (this->method == "ppcg")
+    {
+        const int nband_l = psi.get_nbands();
+        const int nbasis = psi.get_nbasis();
+        const int ndim = psi.get_current_ngk();
+        // hpsi_func (X, HX, ld, nvec) -> HX = H(X), X and HX blockvectors of size ld x nvec
+        auto hpsi_func = [hm, cur_nbasis](T* psi_in, T* hpsi_out, const int ld_psi, const int nvec) {
+
+            // Convert "pointer data stucture" to a psi::Psi object
+            auto psi_iter_wrapper = psi::Psi<T, Device>(psi_in, 1, nvec, ld_psi, cur_nbasis);
+
+            psi::Range bands_range(true, 0, 0, nvec - 1);
+
+            using hpsi_info = typename hamilt::Operator<T, Device>::hpsi_info;
+            hpsi_info info(&psi_iter_wrapper, bands_range, hpsi_out);
+            hm->ops->hPsi(info);
+        };
+        DiagoPPCG<T, Device> ppcg(pre_condition.data());
+        ppcg.init_iter(PARAM.inp.nbands, nband_l, nbasis, ndim);
+        ppcg.diag(hpsi_func, psi.get_pointer(), eigenvalue, this->ethr_band);
     }
     else if (this->method == "dav_subspace")
     {

--- a/source/source_hsolver/hsolver_pw.cpp
+++ b/source/source_hsolver/hsolver_pw.cpp
@@ -8,7 +8,9 @@
 #include "source_hamilt/hamilt.h"
 #include "source_hsolver/diag_comm_info.h"
 #include "source_hsolver/diago_bpcg.h"
+#if !(defined(__CUDA) || defined(__ROCM))
 #include "source_hsolver/diago_ppcg.h"
+#endif
 #include "source_hsolver/diago_cg.h"
 #include "source_hsolver/diago_dav_subspace.h"
 #include "source_hsolver/diago_david.h"
@@ -84,7 +86,11 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
     this->nproc_in_pool = nproc_in_pool_in;
 
     // report if the specified diagonalization method is not supported
-    const std::initializer_list<std::string> _methods = {"cg", "dav", "dav_subspace", "bpcg", "ppcg"};
+    const std::initializer_list<std::string> _methods = {"cg", "dav", "dav_subspace", "bpcg"
+#if !(defined(__CUDA) || defined(__ROCM))
+    , "ppcg"
+#endif
+    };
     if (std::find(std::begin(_methods), std::end(_methods), this->method) == std::end(_methods))
     {
         ModuleBase::WARNING_QUIT("HSolverPW::solve", "This type of eigensolver is not supported!");
@@ -324,6 +330,7 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm,
         bpcg.init_iter(PARAM.inp.nbands, nband_l, nbasis, ndim);
         bpcg.diag(hpsi_func, psi.get_pointer(), eigenvalue, this->ethr_band);
     }
+#if !(defined(__CUDA) || defined(__ROCM))
     else if (this->method == "ppcg")
     {
         const int nband_l = psi.get_nbands();
@@ -345,6 +352,7 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm,
         ppcg.init_iter(PARAM.inp.nbands, nband_l, nbasis, ndim);
         ppcg.diag(hpsi_func, psi.get_pointer(), eigenvalue, this->ethr_band);
     }
+#endif
     else if (this->method == "dav_subspace")
     {
         bool scf = this->calculation_type == "nscf" ? false : true;

--- a/source/source_hsolver/hsolver_pw_sdft.cpp
+++ b/source/source_hsolver/hsolver_pw_sdft.cpp
@@ -36,7 +36,7 @@ void HSolverPW_SDFT<T, Device>::solve(const UnitCell& ucell,
     this->ethr_band.resize(psi.get_nbands(), this->diag_thr);
 
     // report if the specified diagonalization method is not supported
-    const std::initializer_list<std::string> _methods = {"cg", "dav", "dav_subspace", "bpcg"};
+    const std::initializer_list<std::string> _methods = {"cg", "dav", "dav_subspace", "bpcg", "ppcg"};
     if (std::find(std::begin(_methods), std::end(_methods), this->method) == std::end(_methods))
     {
         ModuleBase::WARNING_QUIT("HSolverPW::solve", "This type of eigensolver is not supported!");

--- a/source/source_hsolver/kernels/bpcg_kernel_op.cpp
+++ b/source/source_hsolver/kernels/bpcg_kernel_op.cpp
@@ -25,6 +25,7 @@ struct line_minimize_with_block_op<T, base_device::DEVICE_CPU>
             auto A = reinterpret_cast<const Real*>(grad_out + band_idx * n_basis_max);
             Real norm = BlasConnector::dot(2 * n_basis, A, 1, A, 1);
             Parallel_Reduce::reduce_pool(norm);
+            if (norm < 1e-30) continue; // skip bands with zero search direction (e.g. soft-locked in PPCG)
             norm = 1.0 / sqrt(norm);
             for (int basis_idx = 0; basis_idx < n_basis; basis_idx++)
             {

--- a/source/source_hsolver/test/CMakeLists.txt
+++ b/source/source_hsolver/test/CMakeLists.txt
@@ -84,14 +84,14 @@ if (ENABLE_MPI)
   AddTest(
     TARGET MODULE_HSOLVER_pw
     LIBS parameter  ${math_libs} psi device base container
-    SOURCES test_hsolver_pw.cpp ../hsolver_pw.cpp ../hsolver_lcaopw.cpp ../diago_bpcg.cpp ../diago_dav_subspace.cpp ../diag_const_nums.cpp ../diago_iter_assist.cpp ../para_linear_transform.cpp
+    SOURCES test_hsolver_pw.cpp ../hsolver_pw.cpp ../hsolver_lcaopw.cpp ../diago_bpcg.cpp ../diago_ppcg.cpp ../diago_dav_subspace.cpp ../diag_const_nums.cpp ../diago_iter_assist.cpp ../para_linear_transform.cpp
     ../../source_estate/elecstate_tools.cpp ../../source_estate/occupy.cpp ../../source_base/module_fft/fft_bundle.cpp ../../source_base/module_fft/fft_cpu.cpp
   )
 
   AddTest(
     TARGET MODULE_HSOLVER_sdft
     LIBS parameter  ${math_libs} psi device base container
-    SOURCES test_hsolver_sdft.cpp ../hsolver_pw_sdft.cpp ../hsolver_pw.cpp ../diago_bpcg.cpp ../diago_dav_subspace.cpp ../diag_const_nums.cpp ../diago_iter_assist.cpp ../para_linear_transform.cpp
+    SOURCES test_hsolver_sdft.cpp ../hsolver_pw_sdft.cpp ../hsolver_pw.cpp ../diago_bpcg.cpp ../diago_ppcg.cpp ../diago_dav_subspace.cpp ../diag_const_nums.cpp ../diago_iter_assist.cpp ../para_linear_transform.cpp
                 ../../source_estate/elecstate_tools.cpp ../../source_estate/occupy.cpp ../../source_base/module_fft/fft_bundle.cpp ../../source_base/module_fft/fft_cpu.cpp
     )
 

--- a/source/source_hsolver/test/CMakeLists.txt
+++ b/source/source_hsolver/test/CMakeLists.txt
@@ -14,7 +14,7 @@ if (ENABLE_MPI)
     SOURCES diago_bpcg_test.cpp ../diago_bpcg.cpp ../para_linear_transform.cpp  ../diago_iter_assist.cpp
             ../../source_basis/module_pw/test/test_tool.cpp
             ../../source_hamilt/operator.cpp
-            ../../source_pw/module_pwdft/op_pw.cpp
+            ../../source_pw/module_pwdft/operator_pw/operator_pw.cpp
   )
   AddTest(
     TARGET MODULE_HSOLVER_ppcg

--- a/source/source_hsolver/test/CMakeLists.txt
+++ b/source/source_hsolver/test/CMakeLists.txt
@@ -14,7 +14,7 @@ if (ENABLE_MPI)
     SOURCES diago_bpcg_test.cpp ../diago_bpcg.cpp ../para_linear_transform.cpp  ../diago_iter_assist.cpp
             ../../source_basis/module_pw/test/test_tool.cpp
             ../../source_hamilt/operator.cpp
-            ../../source_pw/module_pwdft/operator_pw/operator_pw.cpp
+            ../../source_pw/module_pwdft/op_pw.cpp
   )
   AddTest(
     TARGET MODULE_HSOLVER_ppcg

--- a/source/source_hsolver/test/CMakeLists.txt
+++ b/source/source_hsolver/test/CMakeLists.txt
@@ -11,7 +11,15 @@ if (ENABLE_MPI)
   AddTest(
     TARGET MODULE_HSOLVER_bpcg
     LIBS parameter  ${math_libs} base psi device container
-    SOURCES diago_bpcg_test.cpp ../diago_bpcg.cpp ../para_linear_transform.cpp  ../diago_iter_assist.cpp  
+    SOURCES diago_bpcg_test.cpp ../diago_bpcg.cpp ../para_linear_transform.cpp  ../diago_iter_assist.cpp
+            ../../source_basis/module_pw/test/test_tool.cpp
+            ../../source_hamilt/operator.cpp
+            ../../source_pw/module_pwdft/operator_pw/operator_pw.cpp
+  )
+  AddTest(
+    TARGET MODULE_HSOLVER_ppcg
+    LIBS parameter  ${math_libs} base psi device container
+    SOURCES diago_ppcg_test.cpp ../diago_ppcg.cpp ../para_linear_transform.cpp  ../diago_iter_assist.cpp
             ../../source_basis/module_pw/test/test_tool.cpp
             ../../source_hamilt/operator.cpp
             ../../source_pw/module_pwdft/op_pw.cpp

--- a/source/source_hsolver/test/diago_ppcg_test.cpp
+++ b/source/source_hsolver/test/diago_ppcg_test.cpp
@@ -1,0 +1,288 @@
+#include "source_base/inverse_matrix.h"
+#include "source_base/module_external/lapack_connector.h"
+#include "source_pw/module_pwdft/structure_factor.h"
+#include "source_psi/psi.h"
+#include "source_hamilt/hamilt.h"
+#include "source_pw/module_pwdft/hamilt_pw.h"
+#include "../diago_iter_assist.h"
+#include "../diago_ppcg.h"
+#include "diago_mock.h"
+#include "mpi.h"
+#include "source_basis/module_pw/test/test_tool.h"
+
+#include <gtest/gtest.h>
+#include <complex>
+#include <random>
+
+/************************************************
+ *  unit test of functions in DiagoPPCG
+ ***********************************************/
+
+/**
+ * Class DiagoPPCG is an approach for eigenvalue problems
+ * using the Polak-Ribiere conjugate gradient with soft-locking.
+ * This unittest tests DiagoPPCG::diag() for complex<double>, Device=cpu
+ * with random Hermitian matrices of varying size and sparsity.
+ *
+ * The test is passed when the eigenvalues are close to those
+ * calculated by LAPACK (zheev).
+ */
+
+void lapackEigen(int &npw, std::vector<std::complex<double>> &hm, double *e, bool outtime = false)
+{
+    clock_t start, end;
+    start = clock();
+    int lwork = 2 * npw;
+    std::complex<double> *work2 = new std::complex<double>[lwork];
+    double *rwork = new double[3 * npw - 2];
+    int info = 0;
+    char tmp_c1 = 'V', tmp_c2 = 'U';
+    zheev_(&tmp_c1, &tmp_c2, &npw, hm.data(), &npw, e, work2, &lwork, rwork, &info);
+    end = clock();
+    if (outtime) {
+        std::cout << "Lapack Run time: " << (double)(end - start) / CLOCKS_PER_SEC << " S" << std::endl;
+    }
+    delete[] rwork;
+    delete[] work2;
+}
+
+class DiagoPPCGPrepare
+{
+  public:
+    DiagoPPCGPrepare(int nband, int npw, int sparsity, bool reorder, double eps, int maxiter, double threshold)
+        : nband(nband), npw(npw), sparsity(sparsity), reorder(reorder), eps(eps), maxiter(maxiter),
+          threshold(threshold)
+    {
+#ifdef __MPI
+        MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+        MPI_Comm_rank(MPI_COMM_WORLD, &mypnum);
+#endif
+    }
+
+    int nband, npw, sparsity, maxiter, notconv;
+    double eps, avg_iter;
+    bool reorder;
+    double threshold;
+    int nprocs=1, mypnum=0;
+
+    void CompareEigen(double *precondition)
+    {
+        // calculate eigenvalues by LAPACK
+        double *e_lapack = new double[npw];
+        auto ev = DIAGOTEST::hmatrix;
+        if (mypnum == 0) {
+            lapackEigen(npw, ev, e_lapack, false);
+        }
+        // initial guess of psi by perturbing lapack psi
+        ModuleBase::ComplexMatrix psiguess(nband, npw);
+        std::default_random_engine p(1);
+        std::uniform_int_distribution<unsigned> u(1, 10);
+        for (int i = 0; i < nband; i++)
+        {
+            for (int j = 0; j < npw; j++)
+            {
+                double rand = static_cast<double>(u(p)) / 10.;
+                psiguess(i, j) = ev[j * DIAGOTEST::h_nc + i] * rand;
+            }
+        }
+        // run ppcg
+        double *en = new double[npw];
+        int ik = 1;
+        psi::Psi<std::complex<double>> psi;
+        psi.resize(ik, nband, npw);
+        for (int i = 0; i < nband; i++)
+        {
+            for (int j = 0; j < npw; j++)
+            {
+                psi(i, j) = psiguess(i, j);
+            }
+        }
+
+        psi::Psi<std::complex<double>> psi_local;
+        double* precondition_local;
+        DIAGOTEST::npw_local = new int[nprocs];
+#ifdef __MPI
+        DIAGOTEST::cal_division(DIAGOTEST::npw);
+        DIAGOTEST::divide_hpsi(psi, psi_local, DIAGOTEST::hmatrix, DIAGOTEST::hmatrix_local);
+        precondition_local = new double[DIAGOTEST::npw_local[mypnum]];
+        DIAGOTEST::divide_psi<double>(precondition, precondition_local);
+#else
+        DIAGOTEST::hmatrix_local = DIAGOTEST::hmatrix;
+        DIAGOTEST::npw_local[0] = DIAGOTEST::npw;
+        psi_local = psi;
+        precondition_local = new double[DIAGOTEST::npw];
+        for (int i = 0; i < DIAGOTEST::npw; i++) precondition_local[i] = precondition[i];
+#endif
+        hsolver::DiagoPPCG<std::complex<double>> ppcg(precondition_local);
+        psi_local.fix_k(0);
+        double start, end;
+        start = MPI_Wtime();
+        using T = std::complex<double>;
+        const int dim = DIAGOTEST::npw;
+        const std::vector<T> &h_mat = DIAGOTEST::hmatrix_local;
+        auto hpsi_func = [h_mat, dim](T *psi_in, T *hpsi_out,
+                                const int ld_psi, const int nvec) {
+            auto one = std::make_unique<T>(1.0);
+            auto zero = std::make_unique<T>(0.0);
+            const T *one_ = one.get();
+            const T *zero_ = zero.get();
+
+            base_device::DEVICE_CPU *ctx = {};
+            ModuleBase::gemm_op<T, base_device::DEVICE_CPU>()(
+                'N', 'N',
+                dim, nvec, dim,
+                one_,
+                h_mat.data(), dim,
+                psi_in, ld_psi,
+                zero_,
+                hpsi_out, ld_psi);
+        };
+        const int ndim = psi_local.get_current_ngk();
+        ppcg.init_iter(nband, nband, npw, ndim);
+        std::vector<double> ethr_band(nband, 1e-5);
+        ppcg.diag(hpsi_func, psi_local.get_pointer(), en, ethr_band);
+        ppcg.diag(hpsi_func, psi_local.get_pointer(), en, ethr_band);
+        ppcg.diag(hpsi_func, psi_local.get_pointer(), en, ethr_band);
+        ppcg.diag(hpsi_func, psi_local.get_pointer(), en, ethr_band);
+        end = MPI_Wtime();
+
+        delete [] DIAGOTEST::npw_local;
+        delete [] precondition_local;
+
+        for (int i = 0; i < nband; i++)
+        {
+            EXPECT_NEAR(en[i], e_lapack[i], threshold);
+        }
+
+        delete[] en;
+        delete[] e_lapack;
+    }
+};
+
+class DiagoPPCGTest : public ::testing::TestWithParam<DiagoPPCGPrepare>
+{
+};
+
+TEST_P(DiagoPPCGTest, RandomHamilt)
+{
+    DiagoPPCGPrepare dcp = GetParam();
+    hsolver::DiagoIterAssist<std::complex<double>>::PW_DIAG_NMAX = dcp.maxiter;
+    hsolver::DiagoIterAssist<std::complex<double>>::PW_DIAG_THR = dcp.eps;
+    HPsi<std::complex<double>> hpsi(dcp.nband, dcp.npw, dcp.sparsity);
+    DIAGOTEST::hmatrix = hpsi.hamilt();
+    DIAGOTEST::npw = dcp.npw;
+    dcp.CompareEigen(hpsi.precond());
+}
+
+INSTANTIATE_TEST_SUITE_P(VerifyPPCG,
+                         DiagoPPCGTest,
+                         ::testing::Values(
+                             DiagoPPCGPrepare(10, 500, 0, true, 1e-5, 300, 5e-2),
+                             DiagoPPCGPrepare(20, 500, 6, true, 1e-5, 300, 5e-2),
+                             DiagoPPCGPrepare(20, 1000, 8, true, 1e-5, 300, 5e-2),
+                             DiagoPPCGPrepare(40, 1000, 8, true, 1e-6, 300, 5e-2)));
+
+TEST(DiagoPPCGTest, SoftLock)
+{
+    // Verify that PPCG soft-locking converges on a small problem
+    int dim = 100;
+    int nbnd = 10;
+    HPsi<std::complex<double>> hpsi(nbnd, dim);
+    DIAGOTEST::hmatrix = hpsi.hamilt();
+    DIAGOTEST::npw = dim;
+
+    double *e_lapack = new double[dim];
+    auto ev = DIAGOTEST::hmatrix;
+    lapackEigen(dim, ev, e_lapack, false);
+
+    hsolver::DiagoIterAssist<std::complex<double>>::PW_DIAG_NMAX = 300;
+    hsolver::DiagoIterAssist<std::complex<double>>::PW_DIAG_THR = 1e-5;
+
+    ModuleBase::ComplexMatrix psiguess(nbnd, dim);
+    std::default_random_engine p(1);
+    std::uniform_int_distribution<unsigned> u(1, 10);
+    for (int i = 0; i < nbnd; i++) {
+        for (int j = 0; j < dim; j++) {
+            double rand = static_cast<double>(u(p)) / 10.;
+            psiguess(i, j) = ev[j * DIAGOTEST::h_nc + i] * rand;
+        }
+    }
+
+    psi::Psi<std::complex<double>> psi;
+    psi.resize(1, nbnd, dim);
+    for (int i = 0; i < nbnd; i++) {
+        for (int j = 0; j < dim; j++) {
+            psi(i, j) = psiguess(i, j);
+        }
+    }
+
+    double* precondition_local = new double[dim];
+    for (int i = 0; i < dim; i++) precondition_local[i] = hpsi.precond()[i];
+    DIAGOTEST::hmatrix_local = DIAGOTEST::hmatrix;
+    DIAGOTEST::npw_local = new int[1];
+    DIAGOTEST::npw_local[0] = dim;
+    psi.fix_k(0);
+
+    double *en = new double[dim];
+    using T = std::complex<double>;
+    auto hpsi_func = [dim](T *psi_in, T *hpsi_out,
+                           const int ld_psi, const int nvec) {
+        auto one = std::make_unique<T>(1.0);
+        auto zero = std::make_unique<T>(0.0);
+        const T *one_ = one.get();
+        const T *zero_ = zero.get();
+        base_device::DEVICE_CPU *ctx = {};
+        ModuleBase::gemm_op<T, base_device::DEVICE_CPU>()(
+            'N', 'N', dim, nvec, dim,
+            one_, DIAGOTEST::hmatrix.data(), dim,
+            psi_in, ld_psi, zero_, hpsi_out, ld_psi);
+    };
+
+    hsolver::DiagoPPCG<std::complex<double>> ppcg(precondition_local);
+    ppcg.init_iter(nbnd, nbnd, dim, dim);
+    std::vector<double> ethr_band(nbnd, 1e-5);
+    // Run multiple diag calls to exercise soft-locking across iterations
+    for (int iter = 0; iter < 4; iter++) {
+        ppcg.diag(hpsi_func, psi.get_pointer(), en, ethr_band);
+    }
+
+    for (int i = 0; i < nbnd; i++) {
+        EXPECT_NEAR(en[i], e_lapack[i], 5e-2);
+    }
+
+    delete[] DIAGOTEST::npw_local;
+    delete[] precondition_local;
+    delete[] en;
+    delete[] e_lapack;
+}
+
+int main(int argc, char **argv)
+{
+    int nproc = 1, myrank = 0;
+
+#ifdef __MPI
+    int nproc_in_pool, kpar=1, mypool, rank_in_pool;
+    setupmpi(argc, argv, nproc, myrank);
+    divide_pools(nproc, myrank, nproc_in_pool, kpar, mypool, rank_in_pool);
+    MPI_Comm_split(MPI_COMM_WORLD, myrank, 0, &BP_WORLD);
+    GlobalV::NPROC_IN_POOL = nproc;
+#else
+    MPI_Init(&argc, &argv);
+#endif
+
+    testing::InitGoogleTest(&argc, argv);
+    ::testing::TestEventListeners &listeners = ::testing::UnitTest::GetInstance()->listeners();
+    if (myrank != 0) {
+        delete listeners.Release(listeners.default_result_printer());
+    }
+
+    int result = RUN_ALL_TESTS();
+    if (myrank == 0 && result != 0)
+    {
+        std::cout << "ERROR:some tests are not passed" << std::endl;
+        return result;
+    }
+
+    MPI_Finalize();
+    return 0;
+}

--- a/source/source_pw/module_stodft/sto_wf.cpp
+++ b/source/source_pw/module_stodft/sto_wf.cpp
@@ -5,6 +5,7 @@
 #include "source_io/module_parameter/parameter.h"
 
 #include <cassert>
+#include <cmath>
 #include <ctime>
 
 #include "source_base/global_function.h"
@@ -35,12 +36,12 @@ void Stochastic_WF<T, Device>::init(K_Vectors* p_kv, const int npwx_in)
     this->nks = p_kv->get_nks();
     this->ngk = p_kv->ngk;
     this->npwx = npwx_in;
-    nchip = new int[nks];
 
     if (nks <= 0)
     {
         ModuleBase::WARNING_QUIT("Stochastic_WF", "nks <=0!");
     }
+    nchip = new int[nks];
 }
 
 template <typename T, typename Device>
@@ -314,6 +315,11 @@ void Stochastic_WF<T, Device>::init_sto_orbitals_Ecut(const int seed_in,
     const int nchiper = this->nchip[0];
 #ifdef __MPI
     MPI_Allgather(&nchiper, 1, MPI_INT, nrecv, 1, MPI_INT, BP_WORLD);
+#else
+    if (PARAM.inp.bndpar > 0)
+    {
+        nrecv[0] = nchiper;
+    }
 #endif
     int ichi_start = 0;
     for (int i = 0; i < GlobalV::MY_BNDGROUP; ++i)
@@ -364,6 +370,7 @@ void Stochastic_WF<T, Device>::init_sto_orbitals_Ecut(const int seed_in,
     }
     delete[] nrecv;
     delete[] updown;
+    this->sync_chi0();
 }
 
 template <typename T, typename Device>


### PR DESCRIPTION
## Summary
- Polak-Ribiere beta formula for better convergence on non-quadratic problems
- Soft-locking: converged bands are zeroed out, reducing effective problem size
- Conjugate history (z_old, grad_old) rotated alongside wavefunctions during Cholesky
- Batched MPI reductions (4-phase) to minimize latency
- Unit test with 4 parameterized Hermitian matrix cases

## Key differences from BPCG
| | BPCG | PPCG |
|---|---|---|
| Beta formula | Fletcher-Reeves | Polak-Ribiere (max(0, ...)) |
| Converged bands | Continue iterating | Soft-locked (zero gradient) |
| History rotation | Not rotated | z_old, grad_old rotated with psi |

## Test plan
- [ ] `MODULE_HSOLVER_ppcg` unit tests pass (random Hermitian matrices vs LAPACK)
- [ ] SoftLock test case passes
- [ ] Integration test with `calculation_method = ppcg` in SCF run