### PR TITLE
Add WFN-history backend for Gamma-only NAO calculations

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -856,11 +856,14 @@
 - **Type**: String
 - **Description**: Wavefunction extrapolation method for LCAO calculations.
 
-  - none: Disable wavefunction-based extrapolation.
-  - use_prev_wf: Use the previous ionic step wavefunctions as the initial guess.
+  - none: Disable wavefunction-based extrapolation and use chg_extrap instead.
+  - use_prev_wf: Restore the previous converged ionic-step wavefunctions,
+  reorthonormalize their occupied subspace in the current AO metric, and rebuild rho.
 
+  The first ionic step uses the normal init_wfc/init_chg initialization because no
+  history exists yet. From the second ionic step onward, the selected WFN method
+  must succeed; ABACUS does not silently fall back to charge-density extrapolation.
   This option is currently limited to Gamma-only LCAO calculations.
-  The k-point, ASPC, and GExt_PROJ paths will be enabled by later updates.
 - **Default**: none
 
 ### nb2d

--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -36,6 +36,7 @@
     - [cell\_factor](#cell_factor)
     - [dm\_to\_rho](#dm_to_rho)
     - [chg\_extrap](#chg_extrap)
+    - [wfc\_extrap](#wfc_extrap)
     - [nb2d](#nb2d)
     - [cal\_symm\_repr](#cal_symm_repr)
   - [Input files](#input-files)
@@ -849,6 +850,18 @@
 - **Type**: String
 - **Description**: Charge extrapolation method for MD and relaxation calculations.
 - **Default**: default
+
+### wfc_extrap
+
+- **Type**: String
+- **Description**: Wavefunction extrapolation method for LCAO calculations.
+
+  - none: Disable wavefunction-based extrapolation.
+  - use_prev_wf: Use the previous ionic step wavefunctions as the initial guess.
+
+  This option is currently limited to Gamma-only LCAO calculations.
+  The k-point, ASPC, and GExt_PROJ paths will be enabled by later updates.
+- **Default**: none
 
 ### nb2d
 

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -339,11 +339,14 @@ parameters:
     description: |
       Wavefunction extrapolation method for LCAO calculations.
 
-      * none: Disable wavefunction-based extrapolation.
-      * use_prev_wf: Use the previous ionic step wavefunctions as the initial guess.
+      * none: Disable wavefunction-based extrapolation and use chg_extrap instead.
+      * use_prev_wf: Restore the previous converged ionic-step wavefunctions,
+        reorthonormalize their occupied subspace in the current AO metric, and rebuild rho.
 
+      The first ionic step uses the normal init_wfc/init_chg initialization because no
+      history exists yet. From the second ionic step onward, the selected WFN method
+      must succeed; ABACUS does not silently fall back to charge-density extrapolation.
       This option is currently limited to Gamma-only LCAO calculations.
-      The k-point, ASPC, and GExt_PROJ paths will be enabled by later updates.
     default_value: none
     unit: ""
     availability: ""

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -333,6 +333,20 @@ parameters:
     default_value: default
     unit: ""
     availability: ""
+  - name: wfc_extrap
+    category: System variables
+    type: String
+    description: |
+      Wavefunction extrapolation method for LCAO calculations.
+
+      * none: Disable wavefunction-based extrapolation.
+      * use_prev_wf: Use the previous ionic step wavefunctions as the initial guess.
+
+      This option is currently limited to Gamma-only LCAO calculations.
+      The k-point, ASPC, and GExt_PROJ paths will be enabled by later updates.
+    default_value: none
+    unit: ""
+    availability: ""
   - name: ecutwfc
     category: Plane wave related variables
     type: Real

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -691,6 +691,8 @@ if(ENABLE_LCAO)
     ${ABACUS_BIN_NAME}
     PRIVATE
       hamilt_lcao
+      operator_ks_lcao
+      lcao_extrap
       tddft
       orb
       gint

--- a/source/source_esolver/esolver_fp.cpp
+++ b/source/source_esolver/esolver_fp.cpp
@@ -181,8 +181,20 @@ void ESolver_FP::before_scf(UnitCell& ucell, const int istep)
     if (ucell.ionic_position_updated)
     {
         this->CE.update_all_dis(ucell);
-        this->CE.extrapolate_charge(&this->Pgrid, ucell, &this->chr, &this->sf,
-                                    GlobalV::ofs_running, GlobalV::ofs_warning);
+
+        const bool skip_charge_extrap_for_wfc = PARAM.inp.basis_type == "lcao"
+                                                && PARAM.inp.wfc_extrap != "none"
+                                                && istep > 0;
+        if (skip_charge_extrap_for_wfc)
+        {
+            GlobalV::ofs_running << " charge density extrapolation is skipped because wfc_extrap = "
+                                 << PARAM.inp.wfc_extrap << "." << std::endl;
+        }
+        else
+        {
+            this->CE.extrapolate_charge(&this->Pgrid, ucell, &this->chr, &this->sf,
+                                        GlobalV::ofs_running, GlobalV::ofs_warning);
+        }
     }
 
     //! Evaluate the vdW correction once for this ionic configuration.

--- a/source/source_esolver/esolver_fp.cpp
+++ b/source/source_esolver/esolver_fp.cpp
@@ -73,7 +73,9 @@ void ESolver_FP::before_all_runners(BaseCell& basecell, const Input_para& inp)
     this->sf.set(this->pw_rhod, inp.nbspline);
 
     //! 4) init charge extrapolation
-    this->CE.Init_CE(inp.nspin, ucell.nat, this->pw_rhod->nrxx, inp.chg_extrap);
+    this->use_wfc_extrapolation_ = inp.wfc_extrap != "none";
+    this->CE.Init_CE(inp.nspin, ucell.nat, this->pw_rhod->nrxx,
+                     this->use_wfc_extrapolation_ ? "none" : inp.chg_extrap);
 
     //! 5) symmetry analysis should be performed every time the cell is changed
     if (ModuleSymmetry::Symmetry::symm_flag == 1)
@@ -180,19 +182,13 @@ void ESolver_FP::before_scf(UnitCell& ucell, const int istep)
     // charge extrapolation
     if (ucell.ionic_position_updated)
     {
-        this->CE.update_all_dis(ucell);
-
-        const bool skip_charge_extrap_for_wfc = PARAM.inp.basis_type == "lcao"
-                                                && PARAM.inp.wfc_extrap != "none"
-                                                && istep > 0;
-        if (skip_charge_extrap_for_wfc)
+        if (this->use_wfc_extrapolation_)
         {
             this->sf.setup(&ucell, this->Pgrid, this->pw_rhod);
-            GlobalV::ofs_running << " charge density extrapolation is skipped because wfc_extrap = "
-                                 << PARAM.inp.wfc_extrap << "." << std::endl;
         }
         else
         {
+            this->CE.update_all_dis(ucell);
             this->CE.extrapolate_charge(&this->Pgrid, ucell, &this->chr, &this->sf,
                                         GlobalV::ofs_running, GlobalV::ofs_warning);
         }

--- a/source/source_esolver/esolver_fp.cpp
+++ b/source/source_esolver/esolver_fp.cpp
@@ -187,6 +187,7 @@ void ESolver_FP::before_scf(UnitCell& ucell, const int istep)
                                                 && istep > 0;
         if (skip_charge_extrap_for_wfc)
         {
+            this->sf.setup(&ucell, this->Pgrid, this->pw_rhod);
             GlobalV::ofs_running << " charge density extrapolation is skipped because wfc_extrap = "
                                  << PARAM.inp.wfc_extrap << "." << std::endl;
         }

--- a/source/source_esolver/esolver_fp.h
+++ b/source/source_esolver/esolver_fp.h
@@ -82,6 +82,7 @@ class ESolver_FP : public ESolver
 
     //! charge extrapolation method
     Charge_Extra CE;
+    bool use_wfc_extrapolation_ = false;
 
     //! solvent model
     surchem solvent;

--- a/source/source_esolver/esolver_ks_lcao.cpp
+++ b/source/source_esolver/esolver_ks_lcao.cpp
@@ -90,8 +90,6 @@ void ESolver_KS_LCAO<TK, TR>::before_all_runners(BaseCell& basecell, const Input
     LCAO_domain::set_psi_occ_dm_chg<TK>(this->kv, this->psi, this->pv, this->pelec,
       this->dmat, this->chr, inp);
 
-    this->wf_history_lcao_.set_method(ModuleExtrap::wfc_extrap_method_from_string(inp.wfc_extrap));
-
     LCAO_domain::set_pot<TK>(ucell, this->kv, this->sf, *this->pw_rho, *this->pw_rhod,
       this->pelec, this->orb_, this->pv, this->locpp, this->dftu,
       this->solvent, this->exx_nao, this->deepks, inp);
@@ -205,13 +203,13 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(UnitCell& ucell, const int istep)
     }
     else if(PARAM.inp.esolver_type!="tddft")//initialize DMR from WFN history if required
     {
-        if (!this->wf_history_lcao_.initialize_gamma_density(
-                *hamilt_lcao, this->pv, *(this->psi), this->pelec->wg, *(this->dmat.dm), this->chr,
-                PARAM.inp.nspin, PARAM.inp.ks_solver))
+        if (this->use_wfc_extrapolation_)
         {
-            // 13.1.2) two cases are considered:
-            // 1. DMK in DensityMatrix is not empty (istep > 0), then DMR is initialized by DMK
-            // 2. DMK in DensityMatrix is empty (istep == 0), then DMR is initialized by zeros
+            this->wf_history_lcao_.initialize_gamma_density(
+                *hamilt_lcao, this->pv, *(this->psi), this->pelec->wg, *(this->dmat.dm), this->chr);
+        }
+        else
+        {
             this->dmat.dm->cal_DMR();
         }
     }
@@ -579,7 +577,7 @@ void ESolver_KS_LCAO<TK, TR>::after_scf(UnitCell& ucell, const int istep, const 
             this->rdmft_solver, this->deepks, this->exx_nao,
             this->conv_esolver, this->scf_nmax_flag, istep);
 
-    if (conv_esolver && this->psi != nullptr)
+    if (conv_esolver && this->psi != nullptr && this->use_wfc_extrapolation_)
     {
         this->wf_history_lcao_.update_after_scf(istep, *(this->psi), this->pelec->wg);
     }

--- a/source/source_esolver/esolver_ks_lcao.cpp
+++ b/source/source_esolver/esolver_ks_lcao.cpp
@@ -216,7 +216,8 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(UnitCell& ucell, const int istep)
     {
         if (this->wf_history_lcao_ != nullptr)
         {
-            initialized_by_wfc_extrap = this->wf_history_lcao_->initialize_gamma_density(
+            initialized_by_wfc_extrap = ModuleExtrap::initialize_gamma_density_from_history<TK, TR>(
+                *this->wf_history_lcao_,
                 *hamilt_lcao,
                 this->pv,
                 *(this->psi),

--- a/source/source_esolver/esolver_ks_lcao.cpp
+++ b/source/source_esolver/esolver_ks_lcao.cpp
@@ -100,7 +100,7 @@ void ESolver_KS_LCAO<TK, TR>::before_all_runners(BaseCell& basecell, const Input
     const auto wfc_extrap_method = ModuleExtrap::wfc_extrap_method_from_string(inp.wfc_extrap);
     if (wfc_extrap_method != ModuleExtrap::WfcExtrapMethod::None)
     {
-        this->wf_history_lcao_ = std::make_unique<ModuleExtrap::WfHistoryLCAO<TK>>(wfc_extrap_method);
+        this->wf_history_lcao_.reset(new ModuleExtrap::WfHistoryLCAO<TK>(wfc_extrap_method));
         GlobalV::ofs_running << " WFN extrapolation method: "
                              << ModuleExtrap::to_string(wfc_extrap_method) << std::endl;
     }
@@ -220,7 +220,7 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(UnitCell& ucell, const int istep)
     }
     else if(PARAM.inp.esolver_type!="tddft")//initialize DMR from WFN history if required
     {
-        if constexpr (std::is_same<TK, double>::value)
+        if (std::is_same<TK, double>::value)
         {
             if (this->wf_history_lcao_ != nullptr)
             {

--- a/source/source_esolver/esolver_ks_lcao.cpp
+++ b/source/source_esolver/esolver_ks_lcao.cpp
@@ -17,8 +17,10 @@
 #include "../source_lcao/module_ri/exx_opt_orb.h"
 #endif
 #include "source_lcao/module_rdmft/rdmft.h"
+#include "source_lcao/module_extrap/wf_history_lcao.h"
 #include "source_estate/module_charge/chgmixing.h" // use charge mixing, mohan add 20251006
 #include "source_estate/module_dm/init_dm.h" // init dm from electronic wave functions
+#include "source_estate/module_dm/cal_dm_psi.h" // rebuild DMK from extrapolated WFN
 #include "source_io/module_ctrl/ctrl_runner_lcao.h" // use ctrl_runner_lcao() 
 #include "source_io/module_ctrl/ctrl_iter_lcao.h" // use ctrl_iter_lcao() 
 #include "source_io/module_ctrl/ctrl_scf_lcao.h" // use ctrl_scf_lcao()
@@ -26,6 +28,8 @@
 #include "source_lcao/rho_tau_lcao.h" // mohan add 20251024
 #include "source_lcao/LCAO_set.h" // mohan add 20251111
 #include "source_psi/setup_psi.h" // use Setup_Psi for deallocate_psi
+
+#include <type_traits>
 
 namespace ModuleESolver
 {
@@ -87,6 +91,14 @@ void ESolver_KS_LCAO<TK, TR>::before_all_runners(BaseCell& basecell, const Input
 
     LCAO_domain::set_psi_occ_dm_chg<TK>(this->kv, this->psi, this->pv, this->pelec,
       this->dmat, this->chr, inp);
+
+    const auto wfc_extrap_method = ModuleExtrap::wfc_extrap_method_from_string(inp.wfc_extrap);
+    if (wfc_extrap_method != ModuleExtrap::WfcExtrapMethod::None)
+    {
+        this->wf_history_lcao_ = std::make_unique<ModuleExtrap::WfHistoryLCAO<TK>>(wfc_extrap_method);
+        GlobalV::ofs_running << " WFN extrapolation method: "
+                             << ModuleExtrap::to_string(wfc_extrap_method) << std::endl;
+    }
 
     LCAO_domain::set_pot<TK>(ucell, this->kv, this->sf, *this->pw_rho, *this->pw_rhod,
       this->pelec, this->orb_, this->pv, this->locpp, this->dftu,
@@ -181,6 +193,8 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(UnitCell& ucell, const int istep)
     }
     this->dmat.dm->init_DMR(*hamilt_lcao->getHR());
 
+    bool initialized_by_wfc_extrap = false;
+
     // 13.1) decide the strategy for initializing DMR and HR
     if(istep == 0)//if the first scf step, readin DMR from file,
     {
@@ -199,12 +213,50 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(UnitCell& ucell, const int istep)
                 this->chr, PARAM.inp.ks_solver);
         }
     }
-    else if(PARAM.inp.esolver_type!="tddft")//if not, use the DMR calculated from last step
+    else if(PARAM.inp.esolver_type!="tddft")//if not, initialize DMR from WFN history or last-step DMK
     {
-        // 13.1.2) two cases are considered:
-        // 1. DMK in DensityMatrix is not empty (istep > 0), then DMR is initialized by DMK
-        // 2. DMK in DensityMatrix is empty (istep == 0), then DMR is initialized by zeros
-        this->dmat.dm->cal_DMR();
+        if constexpr (std::is_same<TK, double>::value)
+        {
+            if (this->wf_history_lcao_ != nullptr)
+            {
+                // Refresh the current Gamma-only overlap matrix before reusing the
+                // previous WFN.  The restored WFN is accepted only after it satisfies
+                // C^T S_now C = I in ModuleExtrap::try_use_prev_wf_gamma().
+                hamilt_lcao->updateSk(0, 0);
+                const ModuleExtrap::WfExtrapApplyResult wfc_result
+                    = this->wf_history_lcao_->try_use_prev_wf_gamma(hamilt_lcao->getSk(),
+                                                                     *(this->psi),
+                                                                     this->pelec->wg);
+                if (wfc_result.ok())
+                {
+                    elecstate::cal_dm_psi(this->dmat.dm->get_paraV_pointer(),
+                                          this->pelec->wg,
+                                          *(this->psi),
+                                          *(this->dmat.dm));
+                    this->dmat.dm->cal_DMR();
+                    LCAO_domain::dm2rho(this->dmat.dm->get_DMR_vector(), PARAM.inp.nspin, &this->chr);
+                    initialized_by_wfc_extrap = true;
+
+                    GlobalV::ofs_running << " WFN extrapolation: use_prev_wf from ionic step "
+                                         << wfc_result.snapshot_istep
+                                         << ", max |C^T S C - I| = "
+                                         << wfc_result.max_orthonormality_deviation << std::endl;
+                }
+                else if (wfc_result.status != ModuleExtrap::WfcExtrapStatus::EmptyHistory)
+                {
+                    GlobalV::ofs_running << " WFN extrapolation: fallback to density-matrix initialization ("
+                                         << ModuleExtrap::to_string(wfc_result.status) << ")" << std::endl;
+                }
+            }
+        }
+
+        if (!initialized_by_wfc_extrap)
+        {
+            // 13.1.2) two cases are considered:
+            // 1. DMK in DensityMatrix is not empty (istep > 0), then DMR is initialized by DMK
+            // 2. DMK in DensityMatrix is empty (istep == 0), then DMR is initialized by zeros
+            this->dmat.dm->cal_DMR();
+        }
     }
     // 13.2) init_scf, should be before_scf? mohan add 2025-03-10
     elecstate::init_scf(ucell, this->Pgrid, this->sf.strucFac, this->locpp.numeric,
@@ -569,6 +621,11 @@ void ESolver_KS_LCAO<TK, TR>::after_scf(UnitCell& ucell, const int istep, const 
             this->pw_rhod, this->locpp.vloc, this->solvent,
             this->rdmft_solver, this->deepks, this->exx_nao,
             this->conv_esolver, this->scf_nmax_flag, istep);
+
+    if (conv_esolver && this->wf_history_lcao_ != nullptr && this->psi != nullptr)
+    {
+        this->wf_history_lcao_->update_after_scf(istep, *(this->psi), this->pelec->wg);
+    }
 
     //! 3) Clean up RA, which is used to serach for adjacent atoms
     if (!PARAM.inp.cal_force && !PARAM.inp.cal_stress)

--- a/source/source_esolver/esolver_ks_lcao.cpp
+++ b/source/source_esolver/esolver_ks_lcao.cpp
@@ -1,4 +1,5 @@
 #include "esolver_ks_lcao.h"
+#include "source_base/global_function.h"
 #include "source_base/module_external/blacs_connector.h"
 #include "source_cell/module_neighbor/sltk_atom_arrange.h"
 #include "source_estate/elecstate_tools.h"
@@ -233,24 +234,38 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(UnitCell& ucell, const int istep)
                     ModuleBase::WARNING_QUIT("ESolver_KS_LCAO::before_scf",
                                              "Failed to access the LCAO operator chain for WFN extrapolation.");
                 }
+                ModuleBase::timer::start("WFN_Extrap", "prepare_overlap");
                 lcao_op->contributeHR();
-                hamilt_lcao->updateSk(0, 0);
+                // Refresh the current Gamma-only overlap matrix before reusing the previous WFN.
+                // The layout must follow the active LCAO solver because the WFN orthonormalizer
+                // assembles distributed local blocks using the same column/row-major convention.
+                const int sk_layout =
+                    ModuleBase::GlobalFunc::IS_COLUMN_MAJOR_KS_SOLVER(PARAM.inp.ks_solver) ? 1 : 0;
+                hamilt_lcao->updateSk(0, sk_layout);
+                ModuleBase::timer::end("WFN_Extrap", "prepare_overlap");
+
+                ModuleBase::timer::start("WFN_Extrap", "apply");
                 const ModuleExtrap::WfExtrapApplyResult wfc_result
                     = this->wf_history_lcao_->try_use_prev_wf_gamma(hamilt_lcao->getSk(),
+                                                                     this->pv,
                                                                      *(this->psi),
                                                                      this->pelec->wg);
+                ModuleBase::timer::end("WFN_Extrap", "apply");
                 if (wfc_result.ok())
                 {
+                    ModuleBase::timer::start("WFN_Extrap", "rebuild_density");
                     elecstate::cal_dm_psi(this->dmat.dm->get_paraV_pointer(),
                                           this->pelec->wg,
                                           *(this->psi),
                                           *(this->dmat.dm));
                     this->dmat.dm->cal_DMR();
                     LCAO_domain::dm2rho(this->dmat.dm->get_DMR_vector(), PARAM.inp.nspin, &this->chr);
+                    ModuleBase::timer::end("WFN_Extrap", "rebuild_density");
                     initialized_by_wfc_extrap = true;
 
                     GlobalV::ofs_running << " WFN extrapolation: use_prev_wf from ionic step "
                                          << wfc_result.snapshot_istep
+                                         << ", active bands = " << wfc_result.nactive_bands
                                          << ", max |C^T S C - I| = "
                                          << wfc_result.max_orthonormality_deviation << std::endl;
                 }

--- a/source/source_esolver/esolver_ks_lcao.cpp
+++ b/source/source_esolver/esolver_ks_lcao.cpp
@@ -18,6 +18,7 @@
 #endif
 #include "source_lcao/module_rdmft/rdmft.h"
 #include "source_lcao/module_extrap/wf_history_lcao.h"
+#include "source_lcao/module_operator_lcao/operator_lcao.h" // build overlap SR before WFN reorthonormalization
 #include "source_estate/module_charge/chgmixing.h" // use charge mixing, mohan add 20251006
 #include "source_estate/module_dm/init_dm.h" // init dm from electronic wave functions
 #include "source_estate/module_dm/cal_dm_psi.h" // rebuild DMK from extrapolated WFN
@@ -29,6 +30,9 @@
 #include "source_lcao/LCAO_set.h" // mohan add 20251111
 #include "source_psi/setup_psi.h" // use Setup_Psi for deallocate_psi
 
+#include <iomanip>
+#include <sstream>
+#include <string>
 #include <type_traits>
 
 namespace ModuleESolver
@@ -213,15 +217,23 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(UnitCell& ucell, const int istep)
                 this->chr, PARAM.inp.ks_solver);
         }
     }
-    else if(PARAM.inp.esolver_type!="tddft")//if not, initialize DMR from WFN history or last-step DMK
+    else if(PARAM.inp.esolver_type!="tddft")//initialize DMR from WFN history if required
     {
         if constexpr (std::is_same<TK, double>::value)
         {
             if (this->wf_history_lcao_ != nullptr)
             {
-                // Refresh the current Gamma-only overlap matrix before reusing the
-                // previous WFN.  The restored WFN is accepted only after it satisfies
-                // C^T S_now C = I in ModuleExtrap::try_use_prev_wf_gamma().
+                // The newly-created HamiltLCAO has allocated S(R), but the actual
+                // overlap values are normally filled later by updateHk() inside the
+                // eigensolver.  WFN extrapolation needs S before entering SCF, so build
+                // only the overlap real-space matrix here and then fold it to S(Gamma).
+                auto* lcao_op = dynamic_cast<hamilt::OperatorLCAO<TK, TR>*>(hamilt_lcao->getOperator());
+                if (lcao_op == nullptr)
+                {
+                    ModuleBase::WARNING_QUIT("ESolver_KS_LCAO::before_scf",
+                                             "Failed to access the LCAO operator chain for WFN extrapolation.");
+                }
+                lcao_op->contributeHR();
                 hamilt_lcao->updateSk(0, 0);
                 const ModuleExtrap::WfExtrapApplyResult wfc_result
                     = this->wf_history_lcao_->try_use_prev_wf_gamma(hamilt_lcao->getSk(),
@@ -242,11 +254,36 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(UnitCell& ucell, const int istep)
                                          << ", max |C^T S C - I| = "
                                          << wfc_result.max_orthonormality_deviation << std::endl;
                 }
-                else if (wfc_result.status != ModuleExtrap::WfcExtrapStatus::EmptyHistory)
+                else
                 {
-                    GlobalV::ofs_running << " WFN extrapolation: fallback to density-matrix initialization ("
-                                         << ModuleExtrap::to_string(wfc_result.status) << ")" << std::endl;
+                    std::ostringstream oss;
+                    oss << std::scientific << std::setprecision(16);
+                    oss << "WFN extrapolation failed with status: "
+                        << ModuleExtrap::to_string(wfc_result.status) << "\n\n"
+                        << " snapshot_istep=" << wfc_result.snapshot_istep << "\n"
+                        << " failed_state=" << wfc_result.failed_state << "\n"
+                        << " failed_pivot_index=" << wfc_result.failed_pivot_index << "\n"
+                        << " failed_pivot=" << wfc_result.failed_pivot << "\n"
+                        << " nstate=" << wfc_result.nstate << "\n"
+                        << " nbands=" << wfc_result.nbands << "\n"
+                        << " nbasis=" << wfc_result.nbasis << "\n"
+                        << " min_metric_diag=" << wfc_result.min_metric_diag << "\n"
+                        << " max_metric_diag=" << wfc_result.max_metric_diag << "\n"
+                        << " max_metric_abs=" << wfc_result.max_metric_abs << "\n"
+                        << " max_metric_asymmetry=" << wfc_result.max_metric_asymmetry << "\n"
+                        << " max_orthonormality_deviation="
+                        << wfc_result.max_orthonormality_deviation << "\n";
+                    const std::string message = oss.str();
+                    ModuleBase::WARNING_QUIT("ESolver_KS_LCAO::before_scf", message);
                 }
+            }
+        }
+        else
+        {
+            if (this->wf_history_lcao_ != nullptr)
+            {
+                ModuleBase::WARNING_QUIT("ESolver_KS_LCAO::before_scf",
+                                         "WFN extrapolation is currently supported only for the real Gamma-only NAO path.");
             }
         }
 

--- a/source/source_esolver/esolver_ks_lcao.cpp
+++ b/source/source_esolver/esolver_ks_lcao.cpp
@@ -19,10 +19,8 @@
 #endif
 #include "source_lcao/module_rdmft/rdmft.h"
 #include "source_lcao/module_extrap/wf_history_lcao.h"
-#include "source_lcao/module_operator_lcao/operator_lcao.h" // build overlap SR before WFN reorthonormalization
 #include "source_estate/module_charge/chgmixing.h" // use charge mixing, mohan add 20251006
 #include "source_estate/module_dm/init_dm.h" // init dm from electronic wave functions
-#include "source_estate/module_dm/cal_dm_psi.h" // rebuild DMK from extrapolated WFN
 #include "source_io/module_ctrl/ctrl_runner_lcao.h" // use ctrl_runner_lcao() 
 #include "source_io/module_ctrl/ctrl_iter_lcao.h" // use ctrl_iter_lcao() 
 #include "source_io/module_ctrl/ctrl_scf_lcao.h" // use ctrl_scf_lcao()
@@ -31,10 +29,6 @@
 #include "source_lcao/LCAO_set.h" // mohan add 20251111
 #include "source_psi/setup_psi.h" // use Setup_Psi for deallocate_psi
 
-#include <iomanip>
-#include <sstream>
-#include <string>
-#include <type_traits>
 
 namespace ModuleESolver
 {
@@ -220,86 +214,17 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(UnitCell& ucell, const int istep)
     }
     else if(PARAM.inp.esolver_type!="tddft")//initialize DMR from WFN history if required
     {
-        if (std::is_same<TK, double>::value)
+        if (this->wf_history_lcao_ != nullptr)
         {
-            if (this->wf_history_lcao_ != nullptr)
-            {
-                // The newly-created HamiltLCAO has allocated S(R), but the actual
-                // overlap values are normally filled later by updateHk() inside the
-                // eigensolver.  WFN extrapolation needs S before entering SCF, so build
-                // only the overlap real-space matrix here and then fold it to S(Gamma).
-                auto* lcao_op = dynamic_cast<hamilt::OperatorLCAO<TK, TR>*>(hamilt_lcao->getOperator());
-                if (lcao_op == nullptr)
-                {
-                    ModuleBase::WARNING_QUIT("ESolver_KS_LCAO::before_scf",
-                                             "Failed to access the LCAO operator chain for WFN extrapolation.");
-                }
-                ModuleBase::timer::start("WFN_Extrap", "prepare_overlap");
-                lcao_op->contributeHR();
-                // Refresh the current Gamma-only overlap matrix before reusing the previous WFN.
-                // The layout must follow the active LCAO solver because the WFN orthonormalizer
-                // assembles distributed local blocks using the same column/row-major convention.
-                const int sk_layout =
-                    ModuleBase::GlobalFunc::IS_COLUMN_MAJOR_KS_SOLVER(PARAM.inp.ks_solver) ? 1 : 0;
-                hamilt_lcao->updateSk(0, sk_layout);
-                ModuleBase::timer::end("WFN_Extrap", "prepare_overlap");
-
-                ModuleBase::timer::start("WFN_Extrap", "apply");
-                const ModuleExtrap::WfExtrapApplyResult wfc_result
-                    = this->wf_history_lcao_->try_use_prev_wf_gamma(hamilt_lcao->getSk(),
-                                                                     this->pv,
-                                                                     *(this->psi),
-                                                                     this->pelec->wg);
-                ModuleBase::timer::end("WFN_Extrap", "apply");
-                if (wfc_result.ok())
-                {
-                    ModuleBase::timer::start("WFN_Extrap", "rebuild_density");
-                    elecstate::cal_dm_psi(this->dmat.dm->get_paraV_pointer(),
-                                          this->pelec->wg,
-                                          *(this->psi),
-                                          *(this->dmat.dm));
-                    this->dmat.dm->cal_DMR();
-                    LCAO_domain::dm2rho(this->dmat.dm->get_DMR_vector(), PARAM.inp.nspin, &this->chr);
-                    ModuleBase::timer::end("WFN_Extrap", "rebuild_density");
-                    initialized_by_wfc_extrap = true;
-
-                    GlobalV::ofs_running << " WFN extrapolation: use_prev_wf from ionic step "
-                                         << wfc_result.snapshot_istep
-                                         << ", active bands = " << wfc_result.nactive_bands
-                                         << ", max |C^T S C - I| = "
-                                         << wfc_result.max_orthonormality_deviation << std::endl;
-                }
-                else
-                {
-                    std::ostringstream oss;
-                    oss << std::scientific << std::setprecision(16);
-                    oss << "WFN extrapolation failed with status: "
-                        << ModuleExtrap::to_string(wfc_result.status) << "\n\n"
-                        << " snapshot_istep=" << wfc_result.snapshot_istep << "\n"
-                        << " failed_state=" << wfc_result.failed_state << "\n"
-                        << " failed_pivot_index=" << wfc_result.failed_pivot_index << "\n"
-                        << " failed_pivot=" << wfc_result.failed_pivot << "\n"
-                        << " nstate=" << wfc_result.nstate << "\n"
-                        << " nbands=" << wfc_result.nbands << "\n"
-                        << " nbasis=" << wfc_result.nbasis << "\n"
-                        << " min_metric_diag=" << wfc_result.min_metric_diag << "\n"
-                        << " max_metric_diag=" << wfc_result.max_metric_diag << "\n"
-                        << " max_metric_abs=" << wfc_result.max_metric_abs << "\n"
-                        << " max_metric_asymmetry=" << wfc_result.max_metric_asymmetry << "\n"
-                        << " max_orthonormality_deviation="
-                        << wfc_result.max_orthonormality_deviation << "\n";
-                    const std::string message = oss.str();
-                    ModuleBase::WARNING_QUIT("ESolver_KS_LCAO::before_scf", message);
-                }
-            }
-        }
-        else
-        {
-            if (this->wf_history_lcao_ != nullptr)
-            {
-                ModuleBase::WARNING_QUIT("ESolver_KS_LCAO::before_scf",
-                                         "WFN extrapolation is currently supported only for the real Gamma-only NAO path.");
-            }
+            initialized_by_wfc_extrap = this->wf_history_lcao_->initialize_gamma_density(
+                *hamilt_lcao,
+                this->pv,
+                *(this->psi),
+                this->pelec->wg,
+                *(this->dmat.dm),
+                this->chr,
+                PARAM.inp.nspin,
+                PARAM.inp.ks_solver);
         }
 
         if (!initialized_by_wfc_extrap)

--- a/source/source_esolver/esolver_ks_lcao.cpp
+++ b/source/source_esolver/esolver_ks_lcao.cpp
@@ -18,7 +18,6 @@
 #include "../source_lcao/module_ri/exx_opt_orb.h"
 #endif
 #include "source_lcao/module_rdmft/rdmft.h"
-#include "source_lcao/module_extrap/wf_history_lcao.h"
 #include "source_estate/module_charge/chgmixing.h" // use charge mixing, mohan add 20251006
 #include "source_estate/module_dm/init_dm.h" // init dm from electronic wave functions
 #include "source_io/module_ctrl/ctrl_runner_lcao.h" // use ctrl_runner_lcao() 
@@ -91,13 +90,7 @@ void ESolver_KS_LCAO<TK, TR>::before_all_runners(BaseCell& basecell, const Input
     LCAO_domain::set_psi_occ_dm_chg<TK>(this->kv, this->psi, this->pv, this->pelec,
       this->dmat, this->chr, inp);
 
-    const auto wfc_extrap_method = ModuleExtrap::wfc_extrap_method_from_string(inp.wfc_extrap);
-    if (wfc_extrap_method != ModuleExtrap::WfcExtrapMethod::None)
-    {
-        this->wf_history_lcao_.reset(new ModuleExtrap::WfHistoryLCAO<TK>(wfc_extrap_method));
-        GlobalV::ofs_running << " WFN extrapolation method: "
-                             << ModuleExtrap::to_string(wfc_extrap_method) << std::endl;
-    }
+    this->wf_history_lcao_.set_method(ModuleExtrap::wfc_extrap_method_from_string(inp.wfc_extrap));
 
     LCAO_domain::set_pot<TK>(ucell, this->kv, this->sf, *this->pw_rho, *this->pw_rhod,
       this->pelec, this->orb_, this->pv, this->locpp, this->dftu,
@@ -192,8 +185,6 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(UnitCell& ucell, const int istep)
     }
     this->dmat.dm->init_DMR(*hamilt_lcao->getHR());
 
-    bool initialized_by_wfc_extrap = false;
-
     // 13.1) decide the strategy for initializing DMR and HR
     if(istep == 0)//if the first scf step, readin DMR from file,
     {
@@ -214,21 +205,9 @@ void ESolver_KS_LCAO<TK, TR>::before_scf(UnitCell& ucell, const int istep)
     }
     else if(PARAM.inp.esolver_type!="tddft")//initialize DMR from WFN history if required
     {
-        if (this->wf_history_lcao_ != nullptr)
-        {
-            initialized_by_wfc_extrap = ModuleExtrap::initialize_gamma_density_from_history<TK, TR>(
-                *this->wf_history_lcao_,
-                *hamilt_lcao,
-                this->pv,
-                *(this->psi),
-                this->pelec->wg,
-                *(this->dmat.dm),
-                this->chr,
-                PARAM.inp.nspin,
-                PARAM.inp.ks_solver);
-        }
-
-        if (!initialized_by_wfc_extrap)
+        if (!this->wf_history_lcao_.initialize_gamma_density(
+                *hamilt_lcao, this->pv, *(this->psi), this->pelec->wg, *(this->dmat.dm), this->chr,
+                PARAM.inp.nspin, PARAM.inp.ks_solver))
         {
             // 13.1.2) two cases are considered:
             // 1. DMK in DensityMatrix is not empty (istep > 0), then DMR is initialized by DMK
@@ -600,9 +579,9 @@ void ESolver_KS_LCAO<TK, TR>::after_scf(UnitCell& ucell, const int istep, const 
             this->rdmft_solver, this->deepks, this->exx_nao,
             this->conv_esolver, this->scf_nmax_flag, istep);
 
-    if (conv_esolver && this->wf_history_lcao_ != nullptr && this->psi != nullptr)
+    if (conv_esolver && this->psi != nullptr)
     {
-        this->wf_history_lcao_->update_after_scf(istep, *(this->psi), this->pelec->wg);
+        this->wf_history_lcao_.update_after_scf(istep, *(this->psi), this->pelec->wg);
     }
 
     //! 3) Clean up RA, which is used to serach for adjacent atoms

--- a/source/source_esolver/esolver_ks_lcao.h
+++ b/source/source_esolver/esolver_ks_lcao.h
@@ -21,6 +21,12 @@ template <typename T, typename TR>
 class ESolver_LR;
 }
 
+namespace ModuleExtrap
+{
+template <typename TK>
+class WfHistoryLCAO;
+}
+
 //-----------------------------------
 // ESolver for LCAO
 //-----------------------------------
@@ -80,6 +86,11 @@ class ESolver_KS_LCAO : public ESolver_KS
 
     //! Add density matrix class, mohan add 2025-10-30
     LCAO_domain::Setup_DM<TK> dmat;
+
+    //! Optional NAO wavefunction-history extrapolation state.
+    //! The object owns only copied wavefunction snapshots; transient objects such as
+    //! Psi, HamiltLCAO, DensityMatrix, and Charge are passed in only when needed.
+    std::unique_ptr<ModuleExtrap::WfHistoryLCAO<TK>> wf_history_lcao_;
 
 
     // For deepks method, mohan add 2025-10-08

--- a/source/source_esolver/esolver_ks_lcao.h
+++ b/source/source_esolver/esolver_ks_lcao.h
@@ -10,6 +10,7 @@
 #include "source_lcao/setup_exx.h" // for exx, mohan add 20251008
 #include "source_lcao/module_rdmft/rdmft.h" // rdmft
 #include "source_lcao/setup_dm.h" // mohan add 2025-10-30
+#include "source_lcao/module_extrap/wf_history_lcao.h"
 
 #include <memory>
 
@@ -19,12 +20,6 @@ namespace LR
 {
 template <typename T, typename TR>
 class ESolver_LR;
-}
-
-namespace ModuleExtrap
-{
-template <typename TK>
-class WfHistoryLCAO;
 }
 
 //-----------------------------------
@@ -87,10 +82,7 @@ class ESolver_KS_LCAO : public ESolver_KS
     //! Add density matrix class, mohan add 2025-10-30
     LCAO_domain::Setup_DM<TK> dmat;
 
-    //! Optional NAO wavefunction-history extrapolation state.
-    //! The object owns only copied wavefunction snapshots; transient objects such as
-    //! Psi, HamiltLCAO, DensityMatrix, and Charge are passed in only when needed.
-    std::unique_ptr<ModuleExtrap::WfHistoryLCAO<TK>> wf_history_lcao_;
+    ModuleExtrap::WfHistoryLCAO<TK> wf_history_lcao_;
 
 
     // For deepks method, mohan add 2025-10-08

--- a/source/source_io/module_parameter/input_parameter.h
+++ b/source/source_io/module_parameter/input_parameter.h
@@ -50,6 +50,7 @@ struct Input_para
     std::string init_chg = "atomic";    ///< "file","atomic"
     bool dm_to_rho = false;             ///< read density matrix from npz format and calculate charge density
     std::string chg_extrap = "default"; ///< xiaohui modify 2015-02-01
+    std::string wfc_extrap = "none";   ///< wavefunction extrapolation method for LCAO calculations
     bool init_vel = false;              ///< read velocity from STRU or not  liuyu 2021-07-14
 
     std::string input_file = "INPUT";   ///< input file name

--- a/source/source_io/module_parameter/read_input_item_system.cpp
+++ b/source/source_io/module_parameter/read_input_item_system.cpp
@@ -927,11 +927,14 @@ Available options are:
         item.type = "String";
         item.description = R"(Wavefunction extrapolation method for LCAO calculations.
 
-* none: Disable wavefunction-based extrapolation.
-* use_prev_wf: Use the previous ionic step wavefunctions as the initial guess.
+* none: Disable wavefunction-based extrapolation and use chg_extrap instead.
+* use_prev_wf: Restore the previous converged ionic-step wavefunctions,
+  reorthonormalize their occupied subspace in the current AO metric, and rebuild rho.
 
-This option is currently limited to Gamma-only LCAO calculations.
-The k-point, ASPC, and GExt_PROJ paths will be enabled by later updates.)";
+The first ionic step uses the normal init_wfc/init_chg initialization because no
+history exists yet. From the second ionic step onward, the selected WFN method
+must succeed; ABACUS does not silently fall back to charge-density extrapolation.
+This option is currently limited to Gamma-only LCAO calculations.)";
         item.default_value = "none";
         read_sync_string(input.wfc_extrap);
         item.check_value = [](const Input_Item& item, const Parameter& para) {

--- a/source/source_io/module_parameter/read_input_item_system.cpp
+++ b/source/source_io/module_parameter/read_input_item_system.cpp
@@ -921,6 +921,47 @@ Available options are:
         this->add_item(item);
     }
     {
+        Input_Item item("wfc_extrap");
+        item.annotation = "none; use_prev_wf";
+        item.category = "System variables";
+        item.type = "String";
+        item.description = R"(Wavefunction extrapolation method for LCAO calculations.
+
+* none: Disable wavefunction-based extrapolation.
+* use_prev_wf: Use the previous ionic step wavefunctions as the initial guess.
+
+This option is currently limited to Gamma-only LCAO calculations.
+The k-point, ASPC, and GExt_PROJ paths will be enabled by later updates.)";
+        item.default_value = "none";
+        read_sync_string(input.wfc_extrap);
+        item.check_value = [](const Input_Item& item, const Parameter& para) {
+            if (para.input.wfc_extrap != "none" && para.input.wfc_extrap != "use_prev_wf")
+            {
+                ModuleBase::WARNING_QUIT("ReadInput", "wfc_extrap should be none or use_prev_wf");
+            }
+            if (para.input.wfc_extrap == "use_prev_wf")
+            {
+                if (para.input.basis_type != "lcao")
+                {
+                    ModuleBase::WARNING_QUIT("ReadInput", "WFN-based extrapolation is available only for LCAO");
+                }
+                if (!para.input.gamma_only)
+                {
+                    ModuleBase::WARNING_QUIT("ReadInput", "WFN-based extrapolation is not implemented for k-points");
+                }
+                if (para.input.esolver_type == "tddft")
+                {
+                    ModuleBase::WARNING_QUIT("ReadInput", "WFN-based extrapolation is not implemented for tddft");
+                }
+                if (para.input.nspin == 4)
+                {
+                    ModuleBase::WARNING_QUIT("ReadInput", "WFN-based extrapolation is not implemented for nspin = 4");
+                }
+            }
+        };
+        this->add_item(item);
+    }
+    {
         Input_Item item("ecutwfc");
         item.annotation = "energy cutoff for wave functions";
         item.category = "Plane wave related variables";

--- a/source/source_io/test/read_input_ptest.cpp
+++ b/source/source_io/test/read_input_ptest.cpp
@@ -182,6 +182,7 @@ TEST_F(InputParaTest, ParaRead)
     EXPECT_EQ(param.inp.mem_saver, 0);
     EXPECT_EQ(param.inp.init_chg, "atomic");
     EXPECT_EQ(param.inp.chg_extrap, "atomic");
+    EXPECT_EQ(param.inp.wfc_extrap, "use_prev_wf");
     EXPECT_EQ(param.inp.out_freq_elec, 50);
     EXPECT_EQ(param.inp.out_freq_ion, 0);
     EXPECT_EQ(param.inp.out_freq_td, 0);

--- a/source/source_io/test/support/INPUT
+++ b/source/source_io/test/support/INPUT
@@ -57,6 +57,7 @@ scf_thr_type                   2 #type of the criterion of scf_thr, 1: reci drho
 init_wfc                       atomic #start wave functions are from 'atomic', 'atomic+random', 'random' or 'file'
 init_chg                       atomic #start charge is from 'atomic' or file
 chg_extrap                     atomic #atomic; first-order; second-order; dm:coefficients of SIA
+wfc_extrap                     use_prev_wf #Gamma-only LCAO wavefunction initialization
 out_chg                        0 #>0 output charge density for selected electron steps
 out_pot                        2 #output realspace potential
 out_wfc_pw                     0 #output wave functions

--- a/source/source_lcao/CMakeLists.txt
+++ b/source/source_lcao/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(module_deltaspin)
 
 if(ENABLE_LCAO)
     add_subdirectory(module_operator_lcao)
+    add_subdirectory(module_extrap)
     list(APPEND objects
         hamilt_lcao.cpp
         module_operator_lcao/operator_lcao.cpp

--- a/source/source_lcao/CMakeLists.txt
+++ b/source/source_lcao/CMakeLists.txt
@@ -32,6 +32,8 @@ if(ENABLE_LCAO)
         module_operator_lcao/dftu_lcao.cpp
         module_operator_lcao/dftu_fs.cpp
         module_operator_lcao/operator_fs_utils.cpp
+        module_extrap/wf_history_lcao.cpp
+        module_extrap/wf_orthonormalize_lcao.cpp
         dftu_lcao.cpp
         pulay_fs_center2.cpp
         FORCE_STRESS.cpp

--- a/source/source_lcao/CMakeLists.txt
+++ b/source/source_lcao/CMakeLists.txt
@@ -6,34 +6,8 @@ add_subdirectory(module_deltaspin)
 if(ENABLE_LCAO)
     add_subdirectory(module_operator_lcao)
     add_subdirectory(module_extrap)
-    list(APPEND objects
+    set(hamilt_lcao_sources
         hamilt_lcao.cpp
-        module_operator_lcao/operator_lcao.cpp
-        module_operator_lcao/veff_lcao.cpp
-        module_operator_lcao/veff_dh.cpp
-        module_operator_lcao/meta_lcao.cpp
-        module_operator_lcao/op_dftu_lcao.cpp
-        module_operator_lcao/deepks_lcao.cpp
-        module_operator_lcao/op_exx_lcao.cpp
-        module_operator_lcao/overlap.cpp
-        module_operator_lcao/overlap_fs.cpp
-        module_operator_lcao/ekinetic.cpp
-        module_operator_lcao/ekinetic_fs.cpp
-        module_operator_lcao/ekinetic_dh.cpp
-        module_operator_lcao/nonlocal.cpp
-        module_operator_lcao/nonlocal_dh.cpp
-        module_operator_lcao/nonlocal_fs.cpp
-        module_operator_lcao/td_ekinetic_lcao.cpp
-        module_operator_lcao/td_nonlocal_lcao.cpp
-        module_operator_lcao/td_pot_hybrid.cpp
-        module_operator_lcao/td_pot_hybrid_fs.cpp
-        module_operator_lcao/dspin_lcao.cpp
-        module_operator_lcao/dspin_fs.cpp
-        module_operator_lcao/dftu_lcao.cpp
-        module_operator_lcao/dftu_fs.cpp
-        module_operator_lcao/operator_fs_utils.cpp
-        module_extrap/wf_history_lcao.cpp
-        module_extrap/wf_orthonormalize_lcao.cpp
         dftu_lcao.cpp
         pulay_fs_center2.cpp
         FORCE_STRESS.cpp
@@ -47,9 +21,9 @@ if(ENABLE_LCAO)
         spar_st.cpp
         spar_u.cpp
         LCAO_set.cpp
-		LCAO_set_fs.cpp
-		LCAO_set_st.cpp
-		LCAO_nl_mu.cpp	
+        LCAO_set_fs.cpp
+        LCAO_set_st.cpp
+        LCAO_nl_mu.cpp
         LCAO_set_zero.cpp
         LCAO_allocate.cpp
         LCAO_set_mat2d.cpp
@@ -59,7 +33,7 @@ if(ENABLE_LCAO)
         setup_deepks.cpp
         setup_dm.cpp
         rho_tau_lcao.cpp
-		record_adj.cpp
+        record_adj.cpp
         center2_orb.cpp
         center2_orb-orb11.cpp
         center2_orb-orb21.cpp
@@ -70,7 +44,7 @@ if(ENABLE_LCAO)
     add_library(
         hamilt_lcao
         OBJECT
-        ${objects}
+        ${hamilt_lcao_sources}
     )
 
     if(ENABLE_COVERAGE)

--- a/source/source_lcao/module_extrap/CMakeLists.txt
+++ b/source/source_lcao/module_extrap/CMakeLists.txt
@@ -1,4 +1,4 @@
-list(APPEND objects
+set(objects
     wf_history_lcao.cpp
     wf_orthonormalize_lcao.cpp
 )

--- a/source/source_lcao/module_extrap/CMakeLists.txt
+++ b/source/source_lcao/module_extrap/CMakeLists.txt
@@ -1,5 +1,6 @@
 list(APPEND objects
     wf_history_lcao.cpp
+    wf_orthonormalize_lcao.cpp
 )
 
 add_library(

--- a/source/source_lcao/module_extrap/CMakeLists.txt
+++ b/source/source_lcao/module_extrap/CMakeLists.txt
@@ -9,6 +9,10 @@ add_library(
     ${objects}
 )
 
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()
+
 if(ENABLE_COVERAGE)
   add_coverage(lcao_extrap)
 endif()

--- a/source/source_lcao/module_extrap/CMakeLists.txt
+++ b/source/source_lcao/module_extrap/CMakeLists.txt
@@ -1,0 +1,13 @@
+list(APPEND objects
+    wf_history_lcao.cpp
+)
+
+add_library(
+    lcao_extrap
+    OBJECT
+    ${objects}
+)
+
+if(ENABLE_COVERAGE)
+  add_coverage(lcao_extrap)
+endif()

--- a/source/source_lcao/module_extrap/CMakeLists.txt
+++ b/source/source_lcao/module_extrap/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(
     OBJECT
     wf_history_lcao.cpp
     wf_orthonormalize_lcao.cpp
+    wf_density_init_lcao.cpp
 )
 
 if(BUILD_TESTING)

--- a/source/source_lcao/module_extrap/CMakeLists.txt
+++ b/source/source_lcao/module_extrap/CMakeLists.txt
@@ -1,12 +1,8 @@
-set(objects
-    wf_history_lcao.cpp
-    wf_orthonormalize_lcao.cpp
-)
-
 add_library(
     lcao_extrap
     OBJECT
-    ${objects}
+    wf_history_lcao.cpp
+    wf_orthonormalize_lcao.cpp
 )
 
 if(BUILD_TESTING)

--- a/source/source_lcao/module_extrap/test/CMakeLists.txt
+++ b/source/source_lcao/module_extrap/test/CMakeLists.txt
@@ -1,0 +1,9 @@
+AddTest(
+  TARGET MODULE_LCAO_extrap_test
+  LIBS parameter ${math_libs} psi base device
+  SOURCES
+    wf_extrap_test.cpp
+    ../wf_history_lcao.cpp
+    ../wf_orthonormalize_lcao.cpp
+    ${ABACUS_SOURCE_DIR}/source_basis/module_ao/parallel_orbitals.cpp
+)

--- a/source/source_lcao/module_extrap/test/wf_extrap_test.cpp
+++ b/source/source_lcao/module_extrap/test/wf_extrap_test.cpp
@@ -14,6 +14,9 @@ namespace
 constexpr int nstate = 1;
 constexpr int nbands = 3;
 constexpr int nbasis = 3;
+constexpr double occupation_threshold = 1.0e-12;
+constexpr double pivot_threshold = 1.0e-14;
+constexpr double check_tolerance = 1.0e-8;
 
 void initialize_serial_orbitals(Parallel_Orbitals& pv)
 {
@@ -72,6 +75,14 @@ const std::vector<double> coeff = {
     7.0, 8.0, 9.0,
 };
 
+ModuleExtrap::WfOrthonormalizeResult reorthonormalize(const Parallel_Orbitals& pv,
+                                                       psi::Psi<double>& wfc,
+                                                       const ModuleBase::matrix& occupations)
+{
+    return ModuleExtrap::reorthonormalize_gamma_lcao(overlap.data(), pv, wfc, occupations,
+                                                      occupation_threshold, pivot_threshold, check_tolerance);
+}
+
 } // namespace
 
 TEST(WfSnapshotLCAO, OwnsAndRestoresData)
@@ -102,8 +113,7 @@ TEST(WfOrthonormalizeLCAO, ReorthonormalizesOccupiedSubspace)
     psi::Psi<double> wfc = make_psi(coeff);
     const ModuleBase::matrix occupations = make_occupations();
 
-    const ModuleExtrap::WfOrthonormalizeResult result
-        = ModuleExtrap::reorthonormalize_gamma_lcao(overlap.data(), pv, wfc, occupations);
+    const ModuleExtrap::WfOrthonormalizeResult result = reorthonormalize(pv, wfc, occupations);
 
     ASSERT_TRUE(result.ok());
     EXPECT_EQ(result.nstate, nstate);
@@ -133,8 +143,7 @@ TEST(WfOrthonormalizeLCAO, DoesNotModifyPsiOnFailure)
     psi::Psi<double> wfc = make_psi(rank_deficient_coeff);
     const ModuleBase::matrix occupations = make_occupations();
 
-    const ModuleExtrap::WfOrthonormalizeResult result
-        = ModuleExtrap::reorthonormalize_gamma_lcao(overlap.data(), pv, wfc, occupations);
+    const ModuleExtrap::WfOrthonormalizeResult result = reorthonormalize(pv, wfc, occupations);
 
     EXPECT_EQ(result.status, ModuleExtrap::WfcExtrapStatus::OrthogonalizationFailed);
     for (std::size_t i = 0; i < rank_deficient_coeff.size(); ++i)
@@ -143,12 +152,45 @@ TEST(WfOrthonormalizeLCAO, DoesNotModifyPsiOnFailure)
     }
 }
 
+TEST(WfOrthonormalizeLCAO, HandlesBandDistributedCoefficients)
+{
+    Parallel_Orbitals pv;
+    initialize_serial_orbitals(pv);
+    pv.ncol_bands = 2;
+    pv.nbands = 2;
+#ifdef __MPI
+    pv.desc_wfc[3] = 2;
+#endif
+    psi::Psi<double> wfc(nstate, 2, nbasis, nbasis, true);
+    wfc.set_all_psi(coeff.data(), 2 * nbasis);
+
+    const ModuleExtrap::WfOrthonormalizeResult result = reorthonormalize(pv, wfc, make_occupations());
+    EXPECT_TRUE(result.ok());
+}
+
+TEST(WfHistoryLCAO, ReportsMissingHistory)
+{
+    Parallel_Orbitals pv;
+    initialize_serial_orbitals(pv);
+    ModuleExtrap::WfHistoryLCAO<double> history;
+    psi::Psi<double> predicted = make_psi(coeff);
+
+    const ModuleExtrap::WfExtrapApplyResult result
+        = history.try_use_prev_wf_gamma(overlap.data(),
+                                        pv,
+                                        predicted,
+                                        make_occupations(),
+                                        pivot_threshold,
+                                        check_tolerance);
+    EXPECT_EQ(result.status, ModuleExtrap::WfcExtrapStatus::EmptyHistory);
+}
+
 TEST(WfHistoryLCAO, UsesLatestOwnedSnapshot)
 {
     Parallel_Orbitals pv;
     initialize_serial_orbitals(pv);
     const ModuleBase::matrix occupations = make_occupations();
-    ModuleExtrap::WfHistoryLCAO<double> history(ModuleExtrap::WfcExtrapMethod::UsePrevWf, 2);
+    ModuleExtrap::WfHistoryLCAO<double> history;
 
     psi::Psi<double> first = make_psi(coeff);
     history.update_after_scf(3, first, occupations);
@@ -164,15 +206,16 @@ TEST(WfHistoryLCAO, UsesLatestOwnedSnapshot)
 
     psi::Psi<double> predicted(nstate, nbands, nbasis, nbasis, true);
     const ModuleExtrap::WfExtrapApplyResult result
-        = history.try_use_prev_wf_gamma(overlap.data(), pv, predicted, occupations);
+        = history.try_use_prev_wf_gamma(overlap.data(),
+                                        pv,
+                                        predicted,
+                                        occupations,
+                                        pivot_threshold,
+                                        check_tolerance);
 
     ASSERT_TRUE(result.ok());
     EXPECT_EQ(result.snapshot_istep, 4);
-    EXPECT_EQ(history.size(), 2U);
     EXPECT_NEAR(metric_element(predicted, overlap, 0, 0), 1.0, 1.0e-10);
     EXPECT_NEAR(metric_element(predicted, overlap, 1, 1), 1.0, 1.0e-10);
     EXPECT_NEAR(metric_element(predicted, overlap, 0, 1), 0.0, 1.0e-10);
-
-    history.set_max_depth(1);
-    EXPECT_EQ(history.size(), 1U);
 }

--- a/source/source_lcao/module_extrap/test/wf_extrap_test.cpp
+++ b/source/source_lcao/module_extrap/test/wf_extrap_test.cpp
@@ -1,0 +1,178 @@
+#include "source_lcao/module_extrap/wf_history_lcao.h"
+#include "source_lcao/module_extrap/wf_orthonormalize_lcao.h"
+#include "source_lcao/module_extrap/wf_snapshot_lcao.h"
+
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace
+{
+
+constexpr int nstate = 1;
+constexpr int nbands = 3;
+constexpr int nbasis = 3;
+
+void initialize_serial_orbitals(Parallel_Orbitals& pv)
+{
+    pv.set_serial(nbasis, nbasis);
+    pv.ncol_bands = nbands;
+    pv.nrow_bands = nbasis;
+    pv.nbands = nbands;
+#ifdef __MPI
+    // get_wfc_global_nbands() reads desc_wfc in MPI-enabled builds even when
+    // this test deliberately uses the serial distribution.
+    pv.desc_wfc[2] = nbasis;
+    pv.desc_wfc[3] = nbands;
+#endif
+}
+
+psi::Psi<double> make_psi(const std::vector<double>& coeff)
+{
+    psi::Psi<double> wfc(nstate, nbands, nbasis, nbasis, true);
+    wfc.set_all_psi(coeff.data(), coeff.size());
+    return wfc;
+}
+
+ModuleBase::matrix make_occupations()
+{
+    ModuleBase::matrix occupations(nstate, 2);
+    occupations(0, 0) = 1.0;
+    occupations(0, 1) = 1.0;
+    return occupations;
+}
+
+double metric_element(const psi::Psi<double>& wfc,
+                      const std::vector<double>& overlap,
+                      const int ib,
+                      const int jb)
+{
+    double value = 0.0;
+    for (int mu = 0; mu < nbasis; ++mu)
+    {
+        for (int nu = 0; nu < nbasis; ++nu)
+        {
+            value += wfc(0, ib, mu) * overlap[mu * nbasis + nu] * wfc(0, jb, nu);
+        }
+    }
+    return value;
+}
+
+const std::vector<double> overlap = {
+    2.0, 0.2, 0.0,
+    0.2, 1.5, 0.1,
+    0.0, 0.1, 1.0,
+};
+
+const std::vector<double> coeff = {
+    1.0, 0.2, 0.1,
+    0.3, 1.0, 0.2,
+    7.0, 8.0, 9.0,
+};
+
+} // namespace
+
+TEST(WfSnapshotLCAO, OwnsAndRestoresData)
+{
+    psi::Psi<double> wfc = make_psi(coeff);
+    ModuleBase::matrix occupations = make_occupations();
+    ModuleExtrap::WfSnapshotLCAO<double> snapshot(7, wfc, occupations);
+
+    wfc(0, 0, 0) = -100.0;
+    occupations(0, 0) = 0.0;
+
+    EXPECT_EQ(snapshot.istep, 7);
+    EXPECT_DOUBLE_EQ(snapshot.coeff.front(), coeff.front());
+    EXPECT_DOUBLE_EQ(snapshot.wg(0, 0), 1.0);
+
+    psi::Psi<double> restored(nstate, nbands, nbasis, nbasis, true);
+    ASSERT_TRUE(snapshot.load_to(restored));
+    for (std::size_t i = 0; i < coeff.size(); ++i)
+    {
+        EXPECT_DOUBLE_EQ(restored.get_pointer()[i], coeff[i]);
+    }
+}
+
+TEST(WfOrthonormalizeLCAO, ReorthonormalizesOccupiedSubspace)
+{
+    Parallel_Orbitals pv;
+    initialize_serial_orbitals(pv);
+    psi::Psi<double> wfc = make_psi(coeff);
+    const ModuleBase::matrix occupations = make_occupations();
+
+    const ModuleExtrap::WfOrthonormalizeResult result
+        = ModuleExtrap::reorthonormalize_gamma_lcao(overlap.data(), pv, wfc, occupations);
+
+    ASSERT_TRUE(result.ok());
+    EXPECT_EQ(result.nstate, nstate);
+    EXPECT_EQ(result.nbasis, nbasis);
+    EXPECT_EQ(result.nactive_bands, 2);
+    EXPECT_LT(result.max_deviation, 1.0e-10);
+
+    EXPECT_NEAR(metric_element(wfc, overlap, 0, 0), 1.0, 1.0e-10);
+    EXPECT_NEAR(metric_element(wfc, overlap, 1, 1), 1.0, 1.0e-10);
+    EXPECT_NEAR(metric_element(wfc, overlap, 0, 1), 0.0, 1.0e-10);
+
+    // The third band has no occupation entry and must not be modified.
+    EXPECT_DOUBLE_EQ(wfc(0, 2, 0), 7.0);
+    EXPECT_DOUBLE_EQ(wfc(0, 2, 1), 8.0);
+    EXPECT_DOUBLE_EQ(wfc(0, 2, 2), 9.0);
+}
+
+TEST(WfOrthonormalizeLCAO, DoesNotModifyPsiOnFailure)
+{
+    Parallel_Orbitals pv;
+    initialize_serial_orbitals(pv);
+    const std::vector<double> rank_deficient_coeff = {
+        1.0, 0.0, 0.0,
+        1.0, 0.0, 0.0,
+        7.0, 8.0, 9.0,
+    };
+    psi::Psi<double> wfc = make_psi(rank_deficient_coeff);
+    const ModuleBase::matrix occupations = make_occupations();
+
+    const ModuleExtrap::WfOrthonormalizeResult result
+        = ModuleExtrap::reorthonormalize_gamma_lcao(overlap.data(), pv, wfc, occupations);
+
+    EXPECT_EQ(result.status, ModuleExtrap::WfcExtrapStatus::OrthogonalizationFailed);
+    for (std::size_t i = 0; i < rank_deficient_coeff.size(); ++i)
+    {
+        EXPECT_DOUBLE_EQ(wfc.get_pointer()[i], rank_deficient_coeff[i]);
+    }
+}
+
+TEST(WfHistoryLCAO, UsesLatestOwnedSnapshot)
+{
+    Parallel_Orbitals pv;
+    initialize_serial_orbitals(pv);
+    const ModuleBase::matrix occupations = make_occupations();
+    ModuleExtrap::WfHistoryLCAO<double> history(ModuleExtrap::WfcExtrapMethod::UsePrevWf, 2);
+
+    psi::Psi<double> first = make_psi(coeff);
+    history.update_after_scf(3, first, occupations);
+
+    std::vector<double> second_coeff = coeff;
+    second_coeff[0] = 0.8;
+    second_coeff[1] = 0.4;
+    psi::Psi<double> second = make_psi(second_coeff);
+    history.update_after_scf(4, second, occupations);
+
+    // Mutating the source after insertion must not alter the stored snapshot.
+    second.zero_out();
+
+    psi::Psi<double> predicted(nstate, nbands, nbasis, nbasis, true);
+    const ModuleExtrap::WfExtrapApplyResult result
+        = history.try_use_prev_wf_gamma(overlap.data(), pv, predicted, occupations);
+
+    ASSERT_TRUE(result.ok());
+    EXPECT_EQ(result.snapshot_istep, 4);
+    EXPECT_EQ(history.size(), 2U);
+    EXPECT_NEAR(metric_element(predicted, overlap, 0, 0), 1.0, 1.0e-10);
+    EXPECT_NEAR(metric_element(predicted, overlap, 1, 1), 1.0, 1.0e-10);
+    EXPECT_NEAR(metric_element(predicted, overlap, 0, 1), 0.0, 1.0e-10);
+
+    history.set_max_depth(1);
+    EXPECT_EQ(history.size(), 1U);
+}

--- a/source/source_lcao/module_extrap/wf_density_init_lcao.cpp
+++ b/source/source_lcao/module_extrap/wf_density_init_lcao.cpp
@@ -1,0 +1,114 @@
+#include "source_lcao/module_extrap/wf_history_lcao.h"
+
+#include "source_base/global_function.h"
+#include "source_base/global_variable.h"
+#include "source_base/timer.h"
+#include "source_base/tool_quit.h"
+#include "source_estate/module_dm/cal_dm_psi.h"
+#include "source_lcao/hamilt_lcao.h"
+#include "source_lcao/module_operator_lcao/operator_lcao.h"
+#include "source_lcao/rho_tau_lcao.h"
+
+#include <complex>
+#include <iomanip>
+#include <sstream>
+
+namespace ModuleExtrap
+{
+
+namespace
+{
+
+std::string wfc_extrapolation_failure_message(const WfExtrapApplyResult& result)
+{
+    std::ostringstream oss;
+    oss << std::scientific << std::setprecision(16);
+    oss << "WFN extrapolation failed with status: " << to_string(result.status) << "\n\n"
+        << " snapshot_istep=" << result.snapshot_istep << "\n"
+        << " failed_state=" << result.failed_state << "\n"
+        << " failed_pivot_index=" << result.failed_pivot_index << "\n"
+        << " failed_pivot=" << result.failed_pivot << "\n"
+        << " nstate=" << result.nstate << "\n"
+        << " nbands=" << result.nbands << "\n"
+        << " nbasis=" << result.nbasis << "\n"
+        << " min_metric_diag=" << result.min_metric_diag << "\n"
+        << " max_metric_diag=" << result.max_metric_diag << "\n"
+        << " max_metric_abs=" << result.max_metric_abs << "\n"
+        << " max_metric_asymmetry=" << result.max_metric_asymmetry << "\n"
+        << " max_orthonormality_deviation=" << result.max_orthonormality_deviation << "\n";
+    return oss.str();
+}
+
+} // namespace
+
+template <typename TK, typename TR>
+bool initialize_gamma_density_from_history(WfHistoryLCAO<TK>&,
+                                           hamilt::HamiltLCAO<TK, TR>&,
+                                           const Parallel_Orbitals&,
+                                           psi::Psi<TK>&,
+                                           const ModuleBase::matrix&,
+                                           elecstate::DensityMatrix<TK, double>&,
+                                           Charge&,
+                                           const int,
+                                           const std::string&)
+{
+    ModuleBase::WARNING_QUIT("initialize_gamma_density_from_history",
+                             "WFN extrapolation is currently supported only for the real Gamma-only NAO path.");
+    return false;
+}
+
+template <>
+bool initialize_gamma_density_from_history<double, double>(WfHistoryLCAO<double>& history,
+                                                            hamilt::HamiltLCAO<double, double>& hamiltonian,
+                                                            const Parallel_Orbitals& pv,
+                                                            psi::Psi<double>& psi,
+                                                            const ModuleBase::matrix& wg_now,
+                                                            elecstate::DensityMatrix<double, double>& dmat,
+                                                            Charge& charge,
+                                                            const int nspin,
+                                                            const std::string& ks_solver)
+{
+    auto* lcao_op = dynamic_cast<hamilt::OperatorLCAO<double, double>*>(hamiltonian.getOperator());
+    if (lcao_op == nullptr)
+    {
+        ModuleBase::WARNING_QUIT("initialize_gamma_density_from_history",
+                                 "Failed to access the LCAO operator chain for WFN extrapolation.");
+    }
+
+    ModuleBase::timer::start("WFN_Extrap", "prepare_overlap");
+    lcao_op->contributeHR();
+    const int sk_layout = ModuleBase::GlobalFunc::IS_COLUMN_MAJOR_KS_SOLVER(ks_solver) ? 1 : 0;
+    hamiltonian.updateSk(0, sk_layout);
+    ModuleBase::timer::end("WFN_Extrap", "prepare_overlap");
+
+    ModuleBase::timer::start("WFN_Extrap", "apply");
+    const WfExtrapApplyResult result = history.try_use_prev_wf_gamma(hamiltonian.getSk(), pv, psi, wg_now);
+    ModuleBase::timer::end("WFN_Extrap", "apply");
+    if (!result.ok())
+    {
+        ModuleBase::WARNING_QUIT("initialize_gamma_density_from_history",
+                                 wfc_extrapolation_failure_message(result));
+    }
+
+    ModuleBase::timer::start("WFN_Extrap", "rebuild_density");
+    elecstate::cal_dm_psi(dmat.get_paraV_pointer(), wg_now, psi, dmat);
+    dmat.cal_DMR();
+    LCAO_domain::dm2rho(dmat.get_DMR_vector(), nspin, &charge);
+    ModuleBase::timer::end("WFN_Extrap", "rebuild_density");
+
+    GlobalV::ofs_running << " WFN extrapolation: use_prev_wf from ionic step " << result.snapshot_istep
+                         << ", active bands = " << result.nactive_bands
+                         << ", max |C^T S C - I| = " << result.max_orthonormality_deviation << std::endl;
+    return true;
+}
+
+template bool initialize_gamma_density_from_history<std::complex<double>, double>(
+    WfHistoryLCAO<std::complex<double>>&, hamilt::HamiltLCAO<std::complex<double>, double>&,
+    const Parallel_Orbitals&, psi::Psi<std::complex<double>>&, const ModuleBase::matrix&,
+    elecstate::DensityMatrix<std::complex<double>, double>&, Charge&, int, const std::string&);
+template bool initialize_gamma_density_from_history<std::complex<double>, std::complex<double>>(
+    WfHistoryLCAO<std::complex<double>>&, hamilt::HamiltLCAO<std::complex<double>, std::complex<double>>&,
+    const Parallel_Orbitals&, psi::Psi<std::complex<double>>&, const ModuleBase::matrix&,
+    elecstate::DensityMatrix<std::complex<double>, double>&, Charge&, int, const std::string&);
+
+} // namespace ModuleExtrap

--- a/source/source_lcao/module_extrap/wf_density_init_lcao.cpp
+++ b/source/source_lcao/module_extrap/wf_density_init_lcao.cpp
@@ -1,7 +1,5 @@
 #include "source_lcao/module_extrap/wf_history_lcao.h"
 
-#include "source_base/global_function.h"
-#include "source_base/global_variable.h"
 #include "source_base/timer.h"
 #include "source_base/tool_quit.h"
 #include "source_estate/module_dm/cal_dm_psi.h"
@@ -35,44 +33,45 @@ std::string wfc_extrapolation_failure_message(const WfExtrapApplyResult& result)
         << " max_metric_diag=" << result.max_metric_diag << "\n"
         << " max_metric_abs=" << result.max_metric_abs << "\n"
         << " max_metric_asymmetry=" << result.max_metric_asymmetry << "\n"
-        << " max_orthonormality_deviation=" << result.max_orthonormality_deviation << "\n";
+        << " max_orthonormality_deviation=" << result.max_orthonormality_deviation << "\n"
+        << "No fallback was attempted; set wfc_extrap to none to use chg_extrap.\n";
     return oss.str();
 }
 
 } // namespace
 
 template <typename TK>
-bool WfHistoryLCAO<TK>::initialize_gamma_density(hamilt::Hamilt<TK>&,
+void WfHistoryLCAO<TK>::initialize_gamma_density(hamilt::Hamilt<TK>&,
                                                   const Parallel_Orbitals&,
                                                   psi::Psi<TK>&,
                                                   const ModuleBase::matrix&,
                                                   elecstate::DensityMatrix<TK, double>&,
-                                                  Charge&,
-                                                  const int,
-                                                  const std::string&)
+                                                  Charge&)
 {
-    if (!this->enabled() || this->empty())
+    if (!this->has_snapshot_)
     {
-        return false;
+        ModuleBase::WARNING_QUIT("WfHistoryLCAO::initialize_gamma_density",
+                                 "wfc_extrap was selected, but no converged wavefunction history is available. "
+                                 "No fallback was attempted; set wfc_extrap to none to use chg_extrap.");
     }
     ModuleBase::WARNING_QUIT("WfHistoryLCAO::initialize_gamma_density",
-                             "WFN extrapolation is currently supported only for the real Gamma-only NAO path.");
-    return false;
+                             "WFN extrapolation is supported only for the real Gamma-only NAO path. "
+                             "No fallback was attempted; set wfc_extrap to none to use chg_extrap.");
 }
 
 template <>
-bool WfHistoryLCAO<double>::initialize_gamma_density(hamilt::Hamilt<double>& hamiltonian,
+void WfHistoryLCAO<double>::initialize_gamma_density(hamilt::Hamilt<double>& hamiltonian,
                                                        const Parallel_Orbitals& pv,
                                                        psi::Psi<double>& psi,
                                                        const ModuleBase::matrix& wg_now,
                                                        elecstate::DensityMatrix<double, double>& dmat,
-                                                       Charge& charge,
-                                                       const int nspin,
-                                                       const std::string& ks_solver)
+                                                       Charge& charge)
 {
-    if (!this->enabled() || this->empty())
+    if (!this->has_snapshot_)
     {
-        return false;
+        ModuleBase::WARNING_QUIT("WfHistoryLCAO::initialize_gamma_density",
+                                 "wfc_extrap was selected, but no converged wavefunction history is available. "
+                                 "No fallback was attempted; set wfc_extrap to none to use chg_extrap.");
     }
 
     auto* hamilt_lcao = dynamic_cast<hamilt::HamiltLCAO<double, double>*>(&hamiltonian);
@@ -91,12 +90,12 @@ bool WfHistoryLCAO<double>::initialize_gamma_density(hamilt::Hamilt<double>& ham
 
     ModuleBase::timer::start("WFN_Extrap", "prepare_overlap");
     lcao_op->contributeHR();
-    const int sk_layout = ModuleBase::GlobalFunc::IS_COLUMN_MAJOR_KS_SOLVER(ks_solver) ? 1 : 0;
-    hamilt_lcao->updateSk(0, sk_layout);
+    hamilt_lcao->updateSk(0, 1);
     ModuleBase::timer::end("WFN_Extrap", "prepare_overlap");
 
     ModuleBase::timer::start("WFN_Extrap", "apply");
-    const WfExtrapApplyResult result = this->try_use_prev_wf_gamma(hamilt_lcao->getSk(), pv, psi, wg_now);
+    const WfExtrapApplyResult result
+        = this->try_use_prev_wf_gamma(hamilt_lcao->getSk(), pv, psi, wg_now, 1.0e-14, 1.0e-8);
     ModuleBase::timer::end("WFN_Extrap", "apply");
     if (!result.ok())
     {
@@ -107,18 +106,12 @@ bool WfHistoryLCAO<double>::initialize_gamma_density(hamilt::Hamilt<double>& ham
     ModuleBase::timer::start("WFN_Extrap", "rebuild_density");
     elecstate::cal_dm_psi(dmat.get_paraV_pointer(), wg_now, psi, dmat);
     dmat.cal_DMR();
-    LCAO_domain::dm2rho(dmat.get_DMR_vector(), nspin, &charge);
+    LCAO_domain::dm2rho(dmat.get_DMR_vector(), charge.nspin, &charge);
     ModuleBase::timer::end("WFN_Extrap", "rebuild_density");
-
-    GlobalV::ofs_running << " WFN extrapolation: use_prev_wf from ionic step " << result.snapshot_istep
-                         << ", active bands = " << result.nactive_bands
-                         << ", max |C^T S C - I| = " << result.max_orthonormality_deviation << std::endl;
-    return true;
 }
 
-template bool WfHistoryLCAO<std::complex<double>>::initialize_gamma_density(
+template void WfHistoryLCAO<std::complex<double>>::initialize_gamma_density(
     hamilt::Hamilt<std::complex<double>>&, const Parallel_Orbitals&, psi::Psi<std::complex<double>>&,
-    const ModuleBase::matrix&, elecstate::DensityMatrix<std::complex<double>, double>&, Charge&, int,
-    const std::string&);
+    const ModuleBase::matrix&, elecstate::DensityMatrix<std::complex<double>, double>&, Charge&);
 
 } // namespace ModuleExtrap

--- a/source/source_lcao/module_extrap/wf_density_init_lcao.cpp
+++ b/source/source_lcao/module_extrap/wf_density_init_lcao.cpp
@@ -41,52 +41,66 @@ std::string wfc_extrapolation_failure_message(const WfExtrapApplyResult& result)
 
 } // namespace
 
-template <typename TK, typename TR>
-bool initialize_gamma_density_from_history(WfHistoryLCAO<TK>&,
-                                           hamilt::HamiltLCAO<TK, TR>&,
-                                           const Parallel_Orbitals&,
-                                           psi::Psi<TK>&,
-                                           const ModuleBase::matrix&,
-                                           elecstate::DensityMatrix<TK, double>&,
-                                           Charge&,
-                                           const int,
-                                           const std::string&)
+template <typename TK>
+bool WfHistoryLCAO<TK>::initialize_gamma_density(hamilt::Hamilt<TK>&,
+                                                  const Parallel_Orbitals&,
+                                                  psi::Psi<TK>&,
+                                                  const ModuleBase::matrix&,
+                                                  elecstate::DensityMatrix<TK, double>&,
+                                                  Charge&,
+                                                  const int,
+                                                  const std::string&)
 {
-    ModuleBase::WARNING_QUIT("initialize_gamma_density_from_history",
+    if (!this->enabled() || this->empty())
+    {
+        return false;
+    }
+    ModuleBase::WARNING_QUIT("WfHistoryLCAO::initialize_gamma_density",
                              "WFN extrapolation is currently supported only for the real Gamma-only NAO path.");
     return false;
 }
 
 template <>
-bool initialize_gamma_density_from_history<double, double>(WfHistoryLCAO<double>& history,
-                                                            hamilt::HamiltLCAO<double, double>& hamiltonian,
-                                                            const Parallel_Orbitals& pv,
-                                                            psi::Psi<double>& psi,
-                                                            const ModuleBase::matrix& wg_now,
-                                                            elecstate::DensityMatrix<double, double>& dmat,
-                                                            Charge& charge,
-                                                            const int nspin,
-                                                            const std::string& ks_solver)
+bool WfHistoryLCAO<double>::initialize_gamma_density(hamilt::Hamilt<double>& hamiltonian,
+                                                       const Parallel_Orbitals& pv,
+                                                       psi::Psi<double>& psi,
+                                                       const ModuleBase::matrix& wg_now,
+                                                       elecstate::DensityMatrix<double, double>& dmat,
+                                                       Charge& charge,
+                                                       const int nspin,
+                                                       const std::string& ks_solver)
 {
-    auto* lcao_op = dynamic_cast<hamilt::OperatorLCAO<double, double>*>(hamiltonian.getOperator());
+    if (!this->enabled() || this->empty())
+    {
+        return false;
+    }
+
+    auto* hamilt_lcao = dynamic_cast<hamilt::HamiltLCAO<double, double>*>(&hamiltonian);
+    if (hamilt_lcao == nullptr)
+    {
+        ModuleBase::WARNING_QUIT("WfHistoryLCAO::initialize_gamma_density",
+                                 "Failed to access the Gamma-only LCAO Hamiltonian for WFN extrapolation.");
+    }
+
+    auto* lcao_op = dynamic_cast<hamilt::OperatorLCAO<double, double>*>(hamilt_lcao->getOperator());
     if (lcao_op == nullptr)
     {
-        ModuleBase::WARNING_QUIT("initialize_gamma_density_from_history",
+        ModuleBase::WARNING_QUIT("WfHistoryLCAO::initialize_gamma_density",
                                  "Failed to access the LCAO operator chain for WFN extrapolation.");
     }
 
     ModuleBase::timer::start("WFN_Extrap", "prepare_overlap");
     lcao_op->contributeHR();
     const int sk_layout = ModuleBase::GlobalFunc::IS_COLUMN_MAJOR_KS_SOLVER(ks_solver) ? 1 : 0;
-    hamiltonian.updateSk(0, sk_layout);
+    hamilt_lcao->updateSk(0, sk_layout);
     ModuleBase::timer::end("WFN_Extrap", "prepare_overlap");
 
     ModuleBase::timer::start("WFN_Extrap", "apply");
-    const WfExtrapApplyResult result = history.try_use_prev_wf_gamma(hamiltonian.getSk(), pv, psi, wg_now);
+    const WfExtrapApplyResult result = this->try_use_prev_wf_gamma(hamilt_lcao->getSk(), pv, psi, wg_now);
     ModuleBase::timer::end("WFN_Extrap", "apply");
     if (!result.ok())
     {
-        ModuleBase::WARNING_QUIT("initialize_gamma_density_from_history",
+        ModuleBase::WARNING_QUIT("WfHistoryLCAO::initialize_gamma_density",
                                  wfc_extrapolation_failure_message(result));
     }
 
@@ -102,13 +116,9 @@ bool initialize_gamma_density_from_history<double, double>(WfHistoryLCAO<double>
     return true;
 }
 
-template bool initialize_gamma_density_from_history<std::complex<double>, double>(
-    WfHistoryLCAO<std::complex<double>>&, hamilt::HamiltLCAO<std::complex<double>, double>&,
-    const Parallel_Orbitals&, psi::Psi<std::complex<double>>&, const ModuleBase::matrix&,
-    elecstate::DensityMatrix<std::complex<double>, double>&, Charge&, int, const std::string&);
-template bool initialize_gamma_density_from_history<std::complex<double>, std::complex<double>>(
-    WfHistoryLCAO<std::complex<double>>&, hamilt::HamiltLCAO<std::complex<double>, std::complex<double>>&,
-    const Parallel_Orbitals&, psi::Psi<std::complex<double>>&, const ModuleBase::matrix&,
-    elecstate::DensityMatrix<std::complex<double>, double>&, Charge&, int, const std::string&);
+template bool WfHistoryLCAO<std::complex<double>>::initialize_gamma_density(
+    hamilt::Hamilt<std::complex<double>>&, const Parallel_Orbitals&, psi::Psi<std::complex<double>>&,
+    const ModuleBase::matrix&, elecstate::DensityMatrix<std::complex<double>, double>&, Charge&, int,
+    const std::string&);
 
 } // namespace ModuleExtrap

--- a/source/source_lcao/module_extrap/wf_extrap_method.h
+++ b/source/source_lcao/module_extrap/wf_extrap_method.h
@@ -12,6 +12,15 @@ enum class WfcExtrapMethod
     UsePrevWf
 };
 
+enum class WfcExtrapStatus
+{
+    Success,
+    DimensionMismatch,
+    InvalidInput,
+    Unsupported,
+    OrthogonalizationFailed
+};
+
 inline WfcExtrapMethod wfc_extrap_method_from_string(const std::string& method)
 {
     if (method == "use_prev_wf")
@@ -30,6 +39,25 @@ inline const char* to_string(const WfcExtrapMethod method) noexcept
     case WfcExtrapMethod::None:
     default:
         return "none";
+    }
+}
+
+inline const char* to_string(const WfcExtrapStatus status) noexcept
+{
+    switch (status)
+    {
+    case WfcExtrapStatus::Success:
+        return "success";
+    case WfcExtrapStatus::DimensionMismatch:
+        return "dimension_mismatch";
+    case WfcExtrapStatus::InvalidInput:
+        return "invalid_input";
+    case WfcExtrapStatus::Unsupported:
+        return "unsupported";
+    case WfcExtrapStatus::OrthogonalizationFailed:
+        return "orthogonalization_failed";
+    default:
+        return "unknown";
     }
 }
 

--- a/source/source_lcao/module_extrap/wf_extrap_method.h
+++ b/source/source_lcao/module_extrap/wf_extrap_method.h
@@ -1,0 +1,38 @@
+#ifndef SOURCE_LCAO_MODULE_EXTRAP_WF_EXTRAP_METHOD_H
+#define SOURCE_LCAO_MODULE_EXTRAP_WF_EXTRAP_METHOD_H
+
+#include <string>
+
+namespace ModuleExtrap
+{
+
+enum class WfcExtrapMethod
+{
+    None,
+    UsePrevWf
+};
+
+inline WfcExtrapMethod wfc_extrap_method_from_string(const std::string& method)
+{
+    if (method == "use_prev_wf")
+    {
+        return WfcExtrapMethod::UsePrevWf;
+    }
+    return WfcExtrapMethod::None;
+}
+
+inline const char* to_string(const WfcExtrapMethod method) noexcept
+{
+    switch (method)
+    {
+    case WfcExtrapMethod::UsePrevWf:
+        return "use_prev_wf";
+    case WfcExtrapMethod::None:
+    default:
+        return "none";
+    }
+}
+
+} // namespace ModuleExtrap
+
+#endif // SOURCE_LCAO_MODULE_EXTRAP_WF_EXTRAP_METHOD_H

--- a/source/source_lcao/module_extrap/wf_extrap_method.h
+++ b/source/source_lcao/module_extrap/wf_extrap_method.h
@@ -15,6 +15,8 @@ enum class WfcExtrapMethod
 enum class WfcExtrapStatus
 {
     Success,
+    Disabled,
+    EmptyHistory,
     DimensionMismatch,
     InvalidInput,
     Unsupported,
@@ -48,6 +50,10 @@ inline const char* to_string(const WfcExtrapStatus status) noexcept
     {
     case WfcExtrapStatus::Success:
         return "success";
+    case WfcExtrapStatus::Disabled:
+        return "disabled";
+    case WfcExtrapStatus::EmptyHistory:
+        return "empty_history";
     case WfcExtrapStatus::DimensionMismatch:
         return "dimension_mismatch";
     case WfcExtrapStatus::InvalidInput:

--- a/source/source_lcao/module_extrap/wf_extrap_status.h
+++ b/source/source_lcao/module_extrap/wf_extrap_status.h
@@ -1,21 +1,12 @@
-#ifndef SOURCE_LCAO_MODULE_EXTRAP_WF_EXTRAP_METHOD_H
-#define SOURCE_LCAO_MODULE_EXTRAP_WF_EXTRAP_METHOD_H
-
-#include <string>
+#ifndef SOURCE_LCAO_MODULE_EXTRAP_WF_EXTRAP_STATUS_H
+#define SOURCE_LCAO_MODULE_EXTRAP_WF_EXTRAP_STATUS_H
 
 namespace ModuleExtrap
 {
 
-enum class WfcExtrapMethod
-{
-    None,
-    UsePrevWf
-};
-
 enum class WfcExtrapStatus
 {
     Success,
-    Disabled,
     EmptyHistory,
     DimensionMismatch,
     InvalidInput,
@@ -23,35 +14,12 @@ enum class WfcExtrapStatus
     OrthogonalizationFailed
 };
 
-inline WfcExtrapMethod wfc_extrap_method_from_string(const std::string& method)
-{
-    if (method == "use_prev_wf")
-    {
-        return WfcExtrapMethod::UsePrevWf;
-    }
-    return WfcExtrapMethod::None;
-}
-
-inline const char* to_string(const WfcExtrapMethod method) noexcept
-{
-    switch (method)
-    {
-    case WfcExtrapMethod::UsePrevWf:
-        return "use_prev_wf";
-    case WfcExtrapMethod::None:
-    default:
-        return "none";
-    }
-}
-
 inline const char* to_string(const WfcExtrapStatus status) noexcept
 {
     switch (status)
     {
     case WfcExtrapStatus::Success:
         return "success";
-    case WfcExtrapStatus::Disabled:
-        return "disabled";
     case WfcExtrapStatus::EmptyHistory:
         return "empty_history";
     case WfcExtrapStatus::DimensionMismatch:
@@ -69,4 +37,4 @@ inline const char* to_string(const WfcExtrapStatus status) noexcept
 
 } // namespace ModuleExtrap
 
-#endif // SOURCE_LCAO_MODULE_EXTRAP_WF_EXTRAP_METHOD_H
+#endif // SOURCE_LCAO_MODULE_EXTRAP_WF_EXTRAP_STATUS_H

--- a/source/source_lcao/module_extrap/wf_history_lcao.cpp
+++ b/source/source_lcao/module_extrap/wf_history_lcao.cpp
@@ -1,7 +1,10 @@
 #include "source_lcao/module_extrap/wf_history_lcao.h"
 
+#include "source_lcao/module_extrap/wf_orthonormalize_lcao.h"
+
 #include <algorithm>
 #include <complex>
+#include <type_traits>
 
 namespace ModuleExtrap
 {
@@ -82,6 +85,86 @@ bool WfHistoryLCAO<TK>::latest_snapshot(WfSnapshotLCAO<TK>& snapshot) const
     }
     snapshot = this->snapshots_.back();
     return true;
+}
+
+template <typename TK>
+WfExtrapApplyResult WfHistoryLCAO<TK>::try_use_prev_wf_gamma(const double* current_overlap,
+                                                             psi::Psi<double>& psi,
+                                                             const ModuleBase::matrix& wg_now,
+                                                             const double pivot_threshold,
+                                                             const double check_tolerance)
+{
+    WfExtrapApplyResult result;
+
+    if constexpr (!std::is_same<TK, double>::value)
+    {
+        result.status = WfcExtrapStatus::Unsupported;
+        return result;
+    }
+    else
+    {
+        if (this->method_ != WfcExtrapMethod::UsePrevWf)
+        {
+            result.status = WfcExtrapStatus::Disabled;
+            return result;
+        }
+
+        if (this->snapshots_.empty())
+        {
+            result.status = WfcExtrapStatus::EmptyHistory;
+            return result;
+        }
+
+        if (current_overlap == nullptr || !(pivot_threshold >= 0.0) || !(check_tolerance > 0.0))
+        {
+            result.status = WfcExtrapStatus::InvalidInput;
+            return result;
+        }
+
+        // The first PR only supports the real Gamma-only path.  In this path the
+        // first Psi dimension may label spin channels, but not physical k-points.
+        if (!psi.get_k_first())
+        {
+            result.status = WfcExtrapStatus::Unsupported;
+            return result;
+        }
+
+        const WfSnapshotLCAO<TK>& snapshot = this->snapshots_.back();
+        result.snapshot_istep = snapshot.istep;
+
+        if (!snapshot.compatible_with(psi, wg_now))
+        {
+            result.status = WfcExtrapStatus::DimensionMismatch;
+            return result;
+        }
+
+        // Work on an owned trial Psi first.  The caller's Psi is not overwritten
+        // unless the stored WFN can be loaded and reorthonormalized successfully.
+        psi::Psi<double> psi_trial(psi);
+        if (!snapshot.load_to(psi_trial))
+        {
+            result.status = WfcExtrapStatus::DimensionMismatch;
+            return result;
+        }
+
+        const WfOrthonormalizeResult orth_result = reorthonormalize_gamma_lcao(current_overlap,
+                                                                               psi_trial,
+                                                                               pivot_threshold,
+                                                                               check_tolerance);
+        if (!orth_result.ok())
+        {
+            result.status = orth_result.status;
+            result.failed_state = orth_result.failed_state;
+            result.max_orthonormality_deviation = orth_result.max_deviation;
+            return result;
+        }
+
+        psi = psi_trial;
+        result.status = WfcExtrapStatus::Success;
+        result.failed_state = -1;
+        result.max_orthonormality_deviation = orth_result.max_deviation;
+        return result;
+    }
 }
 
 template <typename TK>

--- a/source/source_lcao/module_extrap/wf_history_lcao.cpp
+++ b/source/source_lcao/module_extrap/wf_history_lcao.cpp
@@ -89,6 +89,7 @@ bool WfHistoryLCAO<TK>::latest_snapshot(WfSnapshotLCAO<TK>& snapshot) const
 
 template <typename TK>
 WfExtrapApplyResult WfHistoryLCAO<TK>::try_use_prev_wf_gamma(const double* current_overlap,
+                                                             const Parallel_Orbitals& pv,
                                                              psi::Psi<double>& psi,
                                                              const ModuleBase::matrix& wg_now,
                                                              const double pivot_threshold,
@@ -148,6 +149,7 @@ WfExtrapApplyResult WfHistoryLCAO<TK>::try_use_prev_wf_gamma(const double* curre
         }
 
         const WfOrthonormalizeResult orth_result = reorthonormalize_gamma_lcao(current_overlap,
+                                                                               pv,
                                                                                psi_trial,
                                                                                snapshot.wg,
                                                                                1.0e-12,

--- a/source/source_lcao/module_extrap/wf_history_lcao.cpp
+++ b/source/source_lcao/module_extrap/wf_history_lcao.cpp
@@ -149,12 +149,24 @@ WfExtrapApplyResult WfHistoryLCAO<TK>::try_use_prev_wf_gamma(const double* curre
 
         const WfOrthonormalizeResult orth_result = reorthonormalize_gamma_lcao(current_overlap,
                                                                                psi_trial,
+                                                                               snapshot.wg,
+                                                                               1.0e-12,
                                                                                pivot_threshold,
                                                                                check_tolerance);
         if (!orth_result.ok())
         {
             result.status = orth_result.status;
             result.failed_state = orth_result.failed_state;
+            result.failed_pivot_index = orth_result.failed_pivot_index;
+            result.failed_pivot = orth_result.failed_pivot;
+            result.min_metric_diag = orth_result.min_metric_diag;
+            result.max_metric_diag = orth_result.max_metric_diag;
+            result.max_metric_abs = orth_result.max_metric_abs;
+            result.max_metric_asymmetry = orth_result.max_metric_asymmetry;
+            result.nstate = orth_result.nstate;
+            result.nbands = orth_result.nbands;
+            result.nbasis = orth_result.nbasis;
+            result.nactive_bands = orth_result.nactive_bands;
             result.max_orthonormality_deviation = orth_result.max_deviation;
             return result;
         }
@@ -162,6 +174,10 @@ WfExtrapApplyResult WfHistoryLCAO<TK>::try_use_prev_wf_gamma(const double* curre
         psi = psi_trial;
         result.status = WfcExtrapStatus::Success;
         result.failed_state = -1;
+        result.nstate = orth_result.nstate;
+        result.nbands = orth_result.nbands;
+        result.nbasis = orth_result.nbasis;
+        result.nactive_bands = orth_result.nactive_bands;
         result.max_orthonormality_deviation = orth_result.max_deviation;
         return result;
     }

--- a/source/source_lcao/module_extrap/wf_history_lcao.cpp
+++ b/source/source_lcao/module_extrap/wf_history_lcao.cpp
@@ -3,89 +3,16 @@
 #include "source_lcao/module_extrap/wf_orthonormalize_lcao.h"
 #include "source_base/timer.h"
 
-#include <algorithm>
 #include <complex>
 
 namespace ModuleExtrap
 {
 
-
-template <typename TK>
-WfHistoryLCAO<TK>::WfHistoryLCAO(const WfcExtrapMethod method, const std::size_t max_depth)
-    : method_(method), max_depth_(std::max<std::size_t>(max_depth, 1))
-{
-}
-
-template <typename TK>
-WfcExtrapMethod WfHistoryLCAO<TK>::method() const noexcept
-{
-    return this->method_;
-}
-
-template <typename TK>
-bool WfHistoryLCAO<TK>::enabled() const noexcept
-{
-    return this->method_ != WfcExtrapMethod::None;
-}
-
-template <typename TK>
-std::size_t WfHistoryLCAO<TK>::size() const noexcept
-{
-    return this->snapshots_.size();
-}
-
-template <typename TK>
-std::size_t WfHistoryLCAO<TK>::max_depth() const noexcept
-{
-    return this->max_depth_;
-}
-
-template <typename TK>
-bool WfHistoryLCAO<TK>::empty() const noexcept
-{
-    return this->snapshots_.empty();
-}
-
-template <typename TK>
-void WfHistoryLCAO<TK>::set_method(const WfcExtrapMethod method) noexcept
-{
-    this->method_ = method;
-}
-
-template <typename TK>
-void WfHistoryLCAO<TK>::set_max_depth(const std::size_t max_depth)
-{
-    this->max_depth_ = std::max<std::size_t>(max_depth, 1);
-    this->prune_history();
-}
-
-template <typename TK>
-void WfHistoryLCAO<TK>::clear() noexcept
-{
-    this->snapshots_.clear();
-}
-
 template <typename TK>
 void WfHistoryLCAO<TK>::update_after_scf(const int istep, const psi::Psi<TK>& psi, const ModuleBase::matrix& wg)
 {
-    if (!this->enabled())
-    {
-        return;
-    }
-
-    this->snapshots_.emplace_back(istep, psi, wg);
-    this->prune_history();
-}
-
-template <typename TK>
-bool WfHistoryLCAO<TK>::latest_snapshot(WfSnapshotLCAO<TK>& snapshot) const
-{
-    if (this->snapshots_.empty())
-    {
-        return false;
-    }
-    snapshot = this->snapshots_.back();
-    return true;
+    this->snapshot_.save(istep, psi, wg);
+    this->has_snapshot_ = true;
 }
 
 template <typename TK>
@@ -111,13 +38,7 @@ WfExtrapApplyResult WfHistoryLCAO<double>::try_use_prev_wf_gamma(const double* c
 {
     WfExtrapApplyResult result;
 
-    if (this->method_ != WfcExtrapMethod::UsePrevWf)
-    {
-        result.status = WfcExtrapStatus::Disabled;
-        return result;
-    }
-
-    if (this->snapshots_.empty())
+    if (!this->has_snapshot_)
     {
         result.status = WfcExtrapStatus::EmptyHistory;
         return result;
@@ -137,7 +58,7 @@ WfExtrapApplyResult WfHistoryLCAO<double>::try_use_prev_wf_gamma(const double* c
         return result;
     }
 
-    const WfSnapshotLCAO<double>& snapshot = this->snapshots_.back();
+    const WfSnapshotLCAO<double>& snapshot = this->snapshot_;
     result.snapshot_istep = snapshot.istep;
 
     if (!snapshot.compatible_with(psi, wg_now))
@@ -194,16 +115,6 @@ WfExtrapApplyResult WfHistoryLCAO<double>::try_use_prev_wf_gamma(const double* c
     result.nactive_bands = orth_result.nactive_bands;
     result.max_orthonormality_deviation = orth_result.max_deviation;
     return result;
-}
-
-
-template <typename TK>
-void WfHistoryLCAO<TK>::prune_history()
-{
-    while (this->snapshots_.size() > this->max_depth_)
-    {
-        this->snapshots_.pop_front();
-    }
 }
 
 template class WfHistoryLCAO<double>;

--- a/source/source_lcao/module_extrap/wf_history_lcao.cpp
+++ b/source/source_lcao/module_extrap/wf_history_lcao.cpp
@@ -1,6 +1,7 @@
 #include "source_lcao/module_extrap/wf_history_lcao.h"
 
 #include "source_lcao/module_extrap/wf_orthonormalize_lcao.h"
+#include "source_base/timer.h"
 
 #include <algorithm>
 #include <complex>
@@ -142,12 +143,16 @@ WfExtrapApplyResult WfHistoryLCAO<TK>::try_use_prev_wf_gamma(const double* curre
         // Work on an owned trial Psi first.  The caller's Psi is not overwritten
         // unless the stored WFN can be loaded and reorthonormalized successfully.
         psi::Psi<double> psi_trial(psi);
-        if (!snapshot.load_to(psi_trial))
+        ModuleBase::timer::start("WFN_Extrap", "restore_snapshot");
+        const bool snapshot_loaded = snapshot.load_to(psi_trial);
+        ModuleBase::timer::end("WFN_Extrap", "restore_snapshot");
+        if (!snapshot_loaded)
         {
             result.status = WfcExtrapStatus::DimensionMismatch;
             return result;
         }
 
+        ModuleBase::timer::start("WFN_Extrap", "orthonormalize");
         const WfOrthonormalizeResult orth_result = reorthonormalize_gamma_lcao(current_overlap,
                                                                                pv,
                                                                                psi_trial,
@@ -155,6 +160,7 @@ WfExtrapApplyResult WfHistoryLCAO<TK>::try_use_prev_wf_gamma(const double* curre
                                                                                1.0e-12,
                                                                                pivot_threshold,
                                                                                check_tolerance);
+        ModuleBase::timer::end("WFN_Extrap", "orthonormalize");
         if (!orth_result.ok())
         {
             result.status = orth_result.status;

--- a/source/source_lcao/module_extrap/wf_history_lcao.cpp
+++ b/source/source_lcao/module_extrap/wf_history_lcao.cpp
@@ -1,14 +1,47 @@
 #include "source_lcao/module_extrap/wf_history_lcao.h"
 
 #include "source_lcao/module_extrap/wf_orthonormalize_lcao.h"
+#include "source_base/global_function.h"
+#include "source_base/global_variable.h"
 #include "source_base/timer.h"
+#include "source_base/tool_quit.h"
+#include "source_estate/module_dm/cal_dm_psi.h"
+#include "source_lcao/hamilt_lcao.h"
+#include "source_lcao/module_operator_lcao/operator_lcao.h"
+#include "source_lcao/rho_tau_lcao.h"
 
 #include <algorithm>
 #include <complex>
-#include <type_traits>
+#include <iomanip>
+#include <sstream>
 
 namespace ModuleExtrap
 {
+
+namespace
+{
+
+std::string wfc_extrapolation_failure_message(const WfExtrapApplyResult& result)
+{
+    std::ostringstream oss;
+    oss << std::scientific << std::setprecision(16);
+    oss << "WFN extrapolation failed with status: " << to_string(result.status) << "\n\n"
+        << " snapshot_istep=" << result.snapshot_istep << "\n"
+        << " failed_state=" << result.failed_state << "\n"
+        << " failed_pivot_index=" << result.failed_pivot_index << "\n"
+        << " failed_pivot=" << result.failed_pivot << "\n"
+        << " nstate=" << result.nstate << "\n"
+        << " nbands=" << result.nbands << "\n"
+        << " nbasis=" << result.nbasis << "\n"
+        << " min_metric_diag=" << result.min_metric_diag << "\n"
+        << " max_metric_diag=" << result.max_metric_diag << "\n"
+        << " max_metric_abs=" << result.max_metric_abs << "\n"
+        << " max_metric_asymmetry=" << result.max_metric_asymmetry << "\n"
+        << " max_orthonormality_deviation=" << result.max_orthonormality_deviation << "\n";
+    return oss.str();
+}
+
+} // namespace
 
 template <typename TK>
 WfHistoryLCAO<TK>::WfHistoryLCAO(const WfcExtrapMethod method, const std::size_t max_depth)
@@ -194,6 +227,71 @@ WfExtrapApplyResult WfHistoryLCAO<double>::try_use_prev_wf_gamma(const double* c
     result.nactive_bands = orth_result.nactive_bands;
     result.max_orthonormality_deviation = orth_result.max_deviation;
     return result;
+}
+
+template <typename TK>
+bool WfHistoryLCAO<TK>::initialize_gamma_density(hamilt::Hamilt<TK>&,
+                                                  const Parallel_Orbitals&,
+                                                  psi::Psi<TK>&,
+                                                  const ModuleBase::matrix&,
+                                                  elecstate::DensityMatrix<TK, double>&,
+                                                  Charge&,
+                                                  const int,
+                                                  const std::string&)
+{
+    ModuleBase::WARNING_QUIT("WfHistoryLCAO::initialize_gamma_density",
+                             "WFN extrapolation is currently supported only for the real Gamma-only NAO path.");
+}
+
+template <>
+bool WfHistoryLCAO<double>::initialize_gamma_density(hamilt::Hamilt<double>& hamiltonian,
+                                                       const Parallel_Orbitals& pv,
+                                                       psi::Psi<double>& psi,
+                                                       const ModuleBase::matrix& wg_now,
+                                                       elecstate::DensityMatrix<double, double>& dmat,
+                                                       Charge& charge,
+                                                       const int nspin,
+                                                       const std::string& ks_solver)
+{
+    auto* hamilt_lcao = dynamic_cast<hamilt::HamiltLCAO<double, double>*>(&hamiltonian);
+    if (hamilt_lcao == nullptr)
+    {
+        ModuleBase::WARNING_QUIT("WfHistoryLCAO::initialize_gamma_density",
+                                 "Failed to access the Gamma-only LCAO Hamiltonian for WFN extrapolation.");
+    }
+
+    auto* lcao_op = dynamic_cast<hamilt::OperatorLCAO<double, double>*>(hamilt_lcao->getOperator());
+    if (lcao_op == nullptr)
+    {
+        ModuleBase::WARNING_QUIT("WfHistoryLCAO::initialize_gamma_density",
+                                 "Failed to access the LCAO operator chain for WFN extrapolation.");
+    }
+
+    ModuleBase::timer::start("WFN_Extrap", "prepare_overlap");
+    lcao_op->contributeHR();
+    const int sk_layout = ModuleBase::GlobalFunc::IS_COLUMN_MAJOR_KS_SOLVER(ks_solver) ? 1 : 0;
+    hamilt_lcao->updateSk(0, sk_layout);
+    ModuleBase::timer::end("WFN_Extrap", "prepare_overlap");
+
+    ModuleBase::timer::start("WFN_Extrap", "apply");
+    const WfExtrapApplyResult result = this->try_use_prev_wf_gamma(hamilt_lcao->getSk(), pv, psi, wg_now);
+    ModuleBase::timer::end("WFN_Extrap", "apply");
+    if (!result.ok())
+    {
+        ModuleBase::WARNING_QUIT("WfHistoryLCAO::initialize_gamma_density",
+                                 wfc_extrapolation_failure_message(result));
+    }
+
+    ModuleBase::timer::start("WFN_Extrap", "rebuild_density");
+    elecstate::cal_dm_psi(dmat.get_paraV_pointer(), wg_now, psi, dmat);
+    dmat.cal_DMR();
+    LCAO_domain::dm2rho(dmat.get_DMR_vector(), nspin, &charge);
+    ModuleBase::timer::end("WFN_Extrap", "rebuild_density");
+
+    GlobalV::ofs_running << " WFN extrapolation: use_prev_wf from ionic step " << result.snapshot_istep
+                         << ", active bands = " << result.nactive_bands
+                         << ", max |C^T S C - I| = " << result.max_orthonormality_deviation << std::endl;
+    return true;
 }
 
 template <typename TK>

--- a/source/source_lcao/module_extrap/wf_history_lcao.cpp
+++ b/source/source_lcao/module_extrap/wf_history_lcao.cpp
@@ -1,47 +1,14 @@
 #include "source_lcao/module_extrap/wf_history_lcao.h"
 
 #include "source_lcao/module_extrap/wf_orthonormalize_lcao.h"
-#include "source_base/global_function.h"
-#include "source_base/global_variable.h"
 #include "source_base/timer.h"
-#include "source_base/tool_quit.h"
-#include "source_estate/module_dm/cal_dm_psi.h"
-#include "source_lcao/hamilt_lcao.h"
-#include "source_lcao/module_operator_lcao/operator_lcao.h"
-#include "source_lcao/rho_tau_lcao.h"
 
 #include <algorithm>
 #include <complex>
-#include <iomanip>
-#include <sstream>
 
 namespace ModuleExtrap
 {
 
-namespace
-{
-
-std::string wfc_extrapolation_failure_message(const WfExtrapApplyResult& result)
-{
-    std::ostringstream oss;
-    oss << std::scientific << std::setprecision(16);
-    oss << "WFN extrapolation failed with status: " << to_string(result.status) << "\n\n"
-        << " snapshot_istep=" << result.snapshot_istep << "\n"
-        << " failed_state=" << result.failed_state << "\n"
-        << " failed_pivot_index=" << result.failed_pivot_index << "\n"
-        << " failed_pivot=" << result.failed_pivot << "\n"
-        << " nstate=" << result.nstate << "\n"
-        << " nbands=" << result.nbands << "\n"
-        << " nbasis=" << result.nbasis << "\n"
-        << " min_metric_diag=" << result.min_metric_diag << "\n"
-        << " max_metric_diag=" << result.max_metric_diag << "\n"
-        << " max_metric_abs=" << result.max_metric_abs << "\n"
-        << " max_metric_asymmetry=" << result.max_metric_asymmetry << "\n"
-        << " max_orthonormality_deviation=" << result.max_orthonormality_deviation << "\n";
-    return oss.str();
-}
-
-} // namespace
 
 template <typename TK>
 WfHistoryLCAO<TK>::WfHistoryLCAO(const WfcExtrapMethod method, const std::size_t max_depth)
@@ -229,70 +196,6 @@ WfExtrapApplyResult WfHistoryLCAO<double>::try_use_prev_wf_gamma(const double* c
     return result;
 }
 
-template <typename TK>
-bool WfHistoryLCAO<TK>::initialize_gamma_density(hamilt::Hamilt<TK>&,
-                                                  const Parallel_Orbitals&,
-                                                  psi::Psi<TK>&,
-                                                  const ModuleBase::matrix&,
-                                                  elecstate::DensityMatrix<TK, double>&,
-                                                  Charge&,
-                                                  const int,
-                                                  const std::string&)
-{
-    ModuleBase::WARNING_QUIT("WfHistoryLCAO::initialize_gamma_density",
-                             "WFN extrapolation is currently supported only for the real Gamma-only NAO path.");
-}
-
-template <>
-bool WfHistoryLCAO<double>::initialize_gamma_density(hamilt::Hamilt<double>& hamiltonian,
-                                                       const Parallel_Orbitals& pv,
-                                                       psi::Psi<double>& psi,
-                                                       const ModuleBase::matrix& wg_now,
-                                                       elecstate::DensityMatrix<double, double>& dmat,
-                                                       Charge& charge,
-                                                       const int nspin,
-                                                       const std::string& ks_solver)
-{
-    auto* hamilt_lcao = dynamic_cast<hamilt::HamiltLCAO<double, double>*>(&hamiltonian);
-    if (hamilt_lcao == nullptr)
-    {
-        ModuleBase::WARNING_QUIT("WfHistoryLCAO::initialize_gamma_density",
-                                 "Failed to access the Gamma-only LCAO Hamiltonian for WFN extrapolation.");
-    }
-
-    auto* lcao_op = dynamic_cast<hamilt::OperatorLCAO<double, double>*>(hamilt_lcao->getOperator());
-    if (lcao_op == nullptr)
-    {
-        ModuleBase::WARNING_QUIT("WfHistoryLCAO::initialize_gamma_density",
-                                 "Failed to access the LCAO operator chain for WFN extrapolation.");
-    }
-
-    ModuleBase::timer::start("WFN_Extrap", "prepare_overlap");
-    lcao_op->contributeHR();
-    const int sk_layout = ModuleBase::GlobalFunc::IS_COLUMN_MAJOR_KS_SOLVER(ks_solver) ? 1 : 0;
-    hamilt_lcao->updateSk(0, sk_layout);
-    ModuleBase::timer::end("WFN_Extrap", "prepare_overlap");
-
-    ModuleBase::timer::start("WFN_Extrap", "apply");
-    const WfExtrapApplyResult result = this->try_use_prev_wf_gamma(hamilt_lcao->getSk(), pv, psi, wg_now);
-    ModuleBase::timer::end("WFN_Extrap", "apply");
-    if (!result.ok())
-    {
-        ModuleBase::WARNING_QUIT("WfHistoryLCAO::initialize_gamma_density",
-                                 wfc_extrapolation_failure_message(result));
-    }
-
-    ModuleBase::timer::start("WFN_Extrap", "rebuild_density");
-    elecstate::cal_dm_psi(dmat.get_paraV_pointer(), wg_now, psi, dmat);
-    dmat.cal_DMR();
-    LCAO_domain::dm2rho(dmat.get_DMR_vector(), nspin, &charge);
-    ModuleBase::timer::end("WFN_Extrap", "rebuild_density");
-
-    GlobalV::ofs_running << " WFN extrapolation: use_prev_wf from ionic step " << result.snapshot_istep
-                         << ", active bands = " << result.nactive_bands
-                         << ", max |C^T S C - I| = " << result.max_orthonormality_deviation << std::endl;
-    return true;
-}
 
 template <typename TK>
 void WfHistoryLCAO<TK>::prune_history()

--- a/source/source_lcao/module_extrap/wf_history_lcao.cpp
+++ b/source/source_lcao/module_extrap/wf_history_lcao.cpp
@@ -89,99 +89,94 @@ bool WfHistoryLCAO<TK>::latest_snapshot(WfSnapshotLCAO<TK>& snapshot) const
 }
 
 template <typename TK>
-WfExtrapApplyResult WfHistoryLCAO<TK>::try_use_prev_wf_gamma(const double* current_overlap,
-                                                             const Parallel_Orbitals& pv,
-                                                             psi::Psi<double>& psi,
-                                                             const ModuleBase::matrix& wg_now,
-                                                             const double pivot_threshold,
-                                                             const double check_tolerance)
+WfExtrapApplyResult WfHistoryLCAO<TK>::try_use_prev_wf_gamma(const TK*,
+                                                             const Parallel_Orbitals&,
+                                                             psi::Psi<TK>&,
+                                                             const ModuleBase::matrix&,
+                                                             const double,
+                                                             const double)
+{
+    WfExtrapApplyResult result;
+    result.status = WfcExtrapStatus::Unsupported;
+    return result;
+}
+
+template <>
+WfExtrapApplyResult WfHistoryLCAO<double>::try_use_prev_wf_gamma(const double* current_overlap,
+                                                                 const Parallel_Orbitals& pv,
+                                                                 psi::Psi<double>& psi,
+                                                                 const ModuleBase::matrix& wg_now,
+                                                                 const double pivot_threshold,
+                                                                 const double check_tolerance)
 {
     WfExtrapApplyResult result;
 
-    if constexpr (!std::is_same<TK, double>::value)
+    if (this->method_ != WfcExtrapMethod::UsePrevWf)
+    {
+        result.status = WfcExtrapStatus::Disabled;
+        return result;
+    }
+
+    if (this->snapshots_.empty())
+    {
+        result.status = WfcExtrapStatus::EmptyHistory;
+        return result;
+    }
+
+    if (current_overlap == nullptr || !(pivot_threshold >= 0.0) || !(check_tolerance > 0.0))
+    {
+        result.status = WfcExtrapStatus::InvalidInput;
+        return result;
+    }
+
+    // The first PR only supports the real Gamma-only path. In this path the
+    // first Psi dimension may label spin channels, but not physical k-points.
+    if (!psi.get_k_first())
     {
         result.status = WfcExtrapStatus::Unsupported;
         return result;
     }
-    else
+
+    const WfSnapshotLCAO<double>& snapshot = this->snapshots_.back();
+    result.snapshot_istep = snapshot.istep;
+
+    if (!snapshot.compatible_with(psi, wg_now))
     {
-        if (this->method_ != WfcExtrapMethod::UsePrevWf)
-        {
-            result.status = WfcExtrapStatus::Disabled;
-            return result;
-        }
+        result.status = WfcExtrapStatus::DimensionMismatch;
+        return result;
+    }
 
-        if (this->snapshots_.empty())
-        {
-            result.status = WfcExtrapStatus::EmptyHistory;
-            return result;
-        }
+    // Work on an owned trial Psi first. The caller's Psi is not overwritten
+    // unless the stored WFN can be loaded and reorthonormalized successfully.
+    psi::Psi<double> psi_trial(psi);
+    ModuleBase::timer::start("WFN_Extrap", "restore_snapshot");
+    const bool snapshot_loaded = snapshot.load_to(psi_trial);
+    ModuleBase::timer::end("WFN_Extrap", "restore_snapshot");
+    if (!snapshot_loaded)
+    {
+        result.status = WfcExtrapStatus::DimensionMismatch;
+        return result;
+    }
 
-        if (current_overlap == nullptr || !(pivot_threshold >= 0.0) || !(check_tolerance > 0.0))
-        {
-            result.status = WfcExtrapStatus::InvalidInput;
-            return result;
-        }
-
-        // The first PR only supports the real Gamma-only path.  In this path the
-        // first Psi dimension may label spin channels, but not physical k-points.
-        if (!psi.get_k_first())
-        {
-            result.status = WfcExtrapStatus::Unsupported;
-            return result;
-        }
-
-        const WfSnapshotLCAO<TK>& snapshot = this->snapshots_.back();
-        result.snapshot_istep = snapshot.istep;
-
-        if (!snapshot.compatible_with(psi, wg_now))
-        {
-            result.status = WfcExtrapStatus::DimensionMismatch;
-            return result;
-        }
-
-        // Work on an owned trial Psi first.  The caller's Psi is not overwritten
-        // unless the stored WFN can be loaded and reorthonormalized successfully.
-        psi::Psi<double> psi_trial(psi);
-        ModuleBase::timer::start("WFN_Extrap", "restore_snapshot");
-        const bool snapshot_loaded = snapshot.load_to(psi_trial);
-        ModuleBase::timer::end("WFN_Extrap", "restore_snapshot");
-        if (!snapshot_loaded)
-        {
-            result.status = WfcExtrapStatus::DimensionMismatch;
-            return result;
-        }
-
-        ModuleBase::timer::start("WFN_Extrap", "orthonormalize");
-        const WfOrthonormalizeResult orth_result = reorthonormalize_gamma_lcao(current_overlap,
-                                                                               pv,
-                                                                               psi_trial,
-                                                                               snapshot.wg,
-                                                                               1.0e-12,
-                                                                               pivot_threshold,
-                                                                               check_tolerance);
-        ModuleBase::timer::end("WFN_Extrap", "orthonormalize");
-        if (!orth_result.ok())
-        {
-            result.status = orth_result.status;
-            result.failed_state = orth_result.failed_state;
-            result.failed_pivot_index = orth_result.failed_pivot_index;
-            result.failed_pivot = orth_result.failed_pivot;
-            result.min_metric_diag = orth_result.min_metric_diag;
-            result.max_metric_diag = orth_result.max_metric_diag;
-            result.max_metric_abs = orth_result.max_metric_abs;
-            result.max_metric_asymmetry = orth_result.max_metric_asymmetry;
-            result.nstate = orth_result.nstate;
-            result.nbands = orth_result.nbands;
-            result.nbasis = orth_result.nbasis;
-            result.nactive_bands = orth_result.nactive_bands;
-            result.max_orthonormality_deviation = orth_result.max_deviation;
-            return result;
-        }
-
-        psi = psi_trial;
-        result.status = WfcExtrapStatus::Success;
-        result.failed_state = -1;
+    ModuleBase::timer::start("WFN_Extrap", "orthonormalize");
+    const WfOrthonormalizeResult orth_result = reorthonormalize_gamma_lcao(current_overlap,
+                                                                           pv,
+                                                                           psi_trial,
+                                                                           snapshot.wg,
+                                                                           1.0e-12,
+                                                                           pivot_threshold,
+                                                                           check_tolerance);
+    ModuleBase::timer::end("WFN_Extrap", "orthonormalize");
+    if (!orth_result.ok())
+    {
+        result.status = orth_result.status;
+        result.failed_state = orth_result.failed_state;
+        result.failed_pivot_index = orth_result.failed_pivot_index;
+        result.failed_pivot = orth_result.failed_pivot;
+        result.min_metric_diag = orth_result.min_metric_diag;
+        result.max_metric_diag = orth_result.max_metric_diag;
+        result.max_metric_abs = orth_result.max_metric_abs;
+        result.max_metric_asymmetry = orth_result.max_metric_asymmetry;
         result.nstate = orth_result.nstate;
         result.nbands = orth_result.nbands;
         result.nbasis = orth_result.nbasis;
@@ -189,6 +184,16 @@ WfExtrapApplyResult WfHistoryLCAO<TK>::try_use_prev_wf_gamma(const double* curre
         result.max_orthonormality_deviation = orth_result.max_deviation;
         return result;
     }
+
+    psi = psi_trial;
+    result.status = WfcExtrapStatus::Success;
+    result.failed_state = -1;
+    result.nstate = orth_result.nstate;
+    result.nbands = orth_result.nbands;
+    result.nbasis = orth_result.nbasis;
+    result.nactive_bands = orth_result.nactive_bands;
+    result.max_orthonormality_deviation = orth_result.max_deviation;
+    return result;
 }
 
 template <typename TK>

--- a/source/source_lcao/module_extrap/wf_history_lcao.cpp
+++ b/source/source_lcao/module_extrap/wf_history_lcao.cpp
@@ -1,0 +1,99 @@
+#include "source_lcao/module_extrap/wf_history_lcao.h"
+
+#include <algorithm>
+#include <complex>
+
+namespace ModuleExtrap
+{
+
+template <typename TK>
+WfHistoryLCAO<TK>::WfHistoryLCAO(const WfcExtrapMethod method, const std::size_t max_depth)
+    : method_(method), max_depth_(std::max<std::size_t>(max_depth, 1))
+{
+}
+
+template <typename TK>
+WfcExtrapMethod WfHistoryLCAO<TK>::method() const noexcept
+{
+    return this->method_;
+}
+
+template <typename TK>
+bool WfHistoryLCAO<TK>::enabled() const noexcept
+{
+    return this->method_ != WfcExtrapMethod::None;
+}
+
+template <typename TK>
+std::size_t WfHistoryLCAO<TK>::size() const noexcept
+{
+    return this->snapshots_.size();
+}
+
+template <typename TK>
+std::size_t WfHistoryLCAO<TK>::max_depth() const noexcept
+{
+    return this->max_depth_;
+}
+
+template <typename TK>
+bool WfHistoryLCAO<TK>::empty() const noexcept
+{
+    return this->snapshots_.empty();
+}
+
+template <typename TK>
+void WfHistoryLCAO<TK>::set_method(const WfcExtrapMethod method) noexcept
+{
+    this->method_ = method;
+}
+
+template <typename TK>
+void WfHistoryLCAO<TK>::set_max_depth(const std::size_t max_depth)
+{
+    this->max_depth_ = std::max<std::size_t>(max_depth, 1);
+    this->prune_history();
+}
+
+template <typename TK>
+void WfHistoryLCAO<TK>::clear() noexcept
+{
+    this->snapshots_.clear();
+}
+
+template <typename TK>
+void WfHistoryLCAO<TK>::update_after_scf(const int istep, const psi::Psi<TK>& psi, const ModuleBase::matrix& wg)
+{
+    if (!this->enabled())
+    {
+        return;
+    }
+
+    this->snapshots_.emplace_back(istep, psi, wg);
+    this->prune_history();
+}
+
+template <typename TK>
+bool WfHistoryLCAO<TK>::latest_snapshot(WfSnapshotLCAO<TK>& snapshot) const
+{
+    if (this->snapshots_.empty())
+    {
+        return false;
+    }
+    snapshot = this->snapshots_.back();
+    return true;
+}
+
+template <typename TK>
+void WfHistoryLCAO<TK>::prune_history()
+{
+    while (this->snapshots_.size() > this->max_depth_)
+    {
+        this->snapshots_.pop_front();
+    }
+}
+
+template class WfHistoryLCAO<double>;
+template class WfHistoryLCAO<std::complex<double>>;
+
+} // namespace ModuleExtrap

--- a/source/source_lcao/module_extrap/wf_history_lcao.h
+++ b/source/source_lcao/module_extrap/wf_history_lcao.h
@@ -14,7 +14,19 @@ struct WfExtrapApplyResult
 {
     WfcExtrapStatus status = WfcExtrapStatus::Disabled;
     double max_orthonormality_deviation = 0.0;
+
+    // Propagated diagnostics from WfOrthonormalizeResult.
+    double failed_pivot = 0.0;
+    double min_metric_diag = 0.0;
+    double max_metric_diag = 0.0;
+    double max_metric_abs = 0.0;
+    double max_metric_asymmetry = 0.0;
     int failed_state = -1;
+    int failed_pivot_index = -1;
+    int nstate = 0;
+    int nbands = 0;
+    int nbasis = 0;
+    int nactive_bands = 0;
     int snapshot_istep = -1;
 
     bool ok() const noexcept

--- a/source/source_lcao/module_extrap/wf_history_lcao.h
+++ b/source/source_lcao/module_extrap/wf_history_lcao.h
@@ -1,0 +1,46 @@
+#ifndef SOURCE_LCAO_MODULE_EXTRAP_WF_HISTORY_LCAO_H
+#define SOURCE_LCAO_MODULE_EXTRAP_WF_HISTORY_LCAO_H
+
+#include "source_lcao/module_extrap/wf_extrap_method.h"
+#include "source_lcao/module_extrap/wf_snapshot_lcao.h"
+
+#include <cstddef>
+#include <deque>
+
+namespace ModuleExtrap
+{
+
+template <typename TK>
+class WfHistoryLCAO
+{
+  public:
+    explicit WfHistoryLCAO(WfcExtrapMethod method = WfcExtrapMethod::None, std::size_t max_depth = 1);
+
+    WfcExtrapMethod method() const noexcept;
+    bool enabled() const noexcept;
+
+    std::size_t size() const noexcept;
+    std::size_t max_depth() const noexcept;
+    bool empty() const noexcept;
+
+    void set_method(WfcExtrapMethod method) noexcept;
+    void set_max_depth(std::size_t max_depth);
+    void clear() noexcept;
+
+    void update_after_scf(const int istep, const psi::Psi<TK>& psi, const ModuleBase::matrix& wg);
+
+    // Return a copy of the most recent snapshot.  This avoids exposing an internal
+    // pointer/reference whose lifetime would be invalidated by the next history update.
+    bool latest_snapshot(WfSnapshotLCAO<TK>& snapshot) const;
+
+  private:
+    void prune_history();
+
+    WfcExtrapMethod method_ = WfcExtrapMethod::None;
+    std::size_t max_depth_ = 1;
+    std::deque<WfSnapshotLCAO<TK>> snapshots_;
+};
+
+} // namespace ModuleExtrap
+
+#endif // SOURCE_LCAO_MODULE_EXTRAP_WF_HISTORY_LCAO_H

--- a/source/source_lcao/module_extrap/wf_history_lcao.h
+++ b/source/source_lcao/module_extrap/wf_history_lcao.h
@@ -4,15 +4,10 @@
 #include "source_lcao/module_extrap/wf_extrap_method.h"
 #include "source_lcao/module_extrap/wf_snapshot_lcao.h"
 #include "source_basis/module_ao/parallel_orbitals.h"
+#include "source_hamilt/hamilt.h"
 #include <cstddef>
 #include <deque>
 #include <string>
-
-namespace hamilt
-{
-template <typename TK, typename TR>
-class HamiltLCAO;
-}
 
 namespace elecstate
 {
@@ -93,6 +88,15 @@ class WfHistoryLCAO
                                               double pivot_threshold = 1.0e-14,
                                               double check_tolerance = 1.0e-8);
 
+    bool initialize_gamma_density(hamilt::Hamilt<TK>& hamiltonian,
+                                  const Parallel_Orbitals& pv,
+                                  psi::Psi<TK>& psi,
+                                  const ModuleBase::matrix& wg_now,
+                                  elecstate::DensityMatrix<TK, double>& dmat,
+                                  Charge& charge,
+                                  int nspin,
+                                  const std::string& ks_solver);
+
   private:
     void prune_history();
 
@@ -100,23 +104,6 @@ class WfHistoryLCAO
     std::size_t max_depth_ = 1;
     std::deque<WfSnapshotLCAO<TK>> snapshots_;
 };
-
-/**
- * Restore a Gamma-only WFN snapshot and rebuild the corresponding density.
- *
- * This runtime integration is kept outside WfHistoryLCAO so the history and
- * orthonormalization core remains independently unit-testable.
- */
-template <typename TK, typename TR>
-bool initialize_gamma_density_from_history(WfHistoryLCAO<TK>& history,
-                                           hamilt::HamiltLCAO<TK, TR>& hamiltonian,
-                                           const Parallel_Orbitals& pv,
-                                           psi::Psi<TK>& psi,
-                                           const ModuleBase::matrix& wg_now,
-                                           elecstate::DensityMatrix<TK, double>& dmat,
-                                           Charge& charge,
-                                           int nspin,
-                                           const std::string& ks_solver);
 
 } // namespace ModuleExtrap
 

--- a/source/source_lcao/module_extrap/wf_history_lcao.h
+++ b/source/source_lcao/module_extrap/wf_history_lcao.h
@@ -72,9 +72,9 @@ class WfHistoryLCAO
      * complex WFN snapshots, per-k S(k), and phase/convention handling, and should be
      * added in a separate path instead of silently reusing this helper.
      */
-    WfExtrapApplyResult try_use_prev_wf_gamma(const double* current_overlap,
+    WfExtrapApplyResult try_use_prev_wf_gamma(const TK* current_overlap,
                                               const Parallel_Orbitals& pv,
-                                              psi::Psi<double>& psi,
+                                              psi::Psi<TK>& psi,
                                               const ModuleBase::matrix& wg_now,
                                               double pivot_threshold = 1.0e-14,
                                               double check_tolerance = 1.0e-8);

--- a/source/source_lcao/module_extrap/wf_history_lcao.h
+++ b/source/source_lcao/module_extrap/wf_history_lcao.h
@@ -1,14 +1,10 @@
 #ifndef SOURCE_LCAO_MODULE_EXTRAP_WF_HISTORY_LCAO_H
 #define SOURCE_LCAO_MODULE_EXTRAP_WF_HISTORY_LCAO_H
 
-#include "source_lcao/module_extrap/wf_extrap_method.h"
+#include "source_lcao/module_extrap/wf_extrap_status.h"
 #include "source_lcao/module_extrap/wf_snapshot_lcao.h"
 #include "source_basis/module_ao/parallel_orbitals.h"
 #include "source_hamilt/hamilt.h"
-#include <cstddef>
-#include <deque>
-#include <string>
-
 namespace elecstate
 {
 template <typename TK, typename TR>
@@ -22,7 +18,7 @@ namespace ModuleExtrap
 
 struct WfExtrapApplyResult
 {
-    WfcExtrapStatus status = WfcExtrapStatus::Disabled;
+    WfcExtrapStatus status = WfcExtrapStatus::InvalidInput;
     double max_orthonormality_deviation = 0.0;
 
     // Propagated diagnostics from WfOrthonormalizeResult.
@@ -49,24 +45,9 @@ template <typename TK>
 class WfHistoryLCAO
 {
   public:
-    explicit WfHistoryLCAO(WfcExtrapMethod method = WfcExtrapMethod::None, std::size_t max_depth = 1);
-
-    WfcExtrapMethod method() const noexcept;
-    bool enabled() const noexcept;
-
-    std::size_t size() const noexcept;
-    std::size_t max_depth() const noexcept;
-    bool empty() const noexcept;
-
-    void set_method(WfcExtrapMethod method) noexcept;
-    void set_max_depth(std::size_t max_depth);
-    void clear() noexcept;
+    WfHistoryLCAO() = default;
 
     void update_after_scf(const int istep, const psi::Psi<TK>& psi, const ModuleBase::matrix& wg);
-
-    // Return a copy of the most recent snapshot.  This avoids exposing an internal
-    // pointer/reference whose lifetime would be invalidated by the next history update.
-    bool latest_snapshot(WfSnapshotLCAO<TK>& snapshot) const;
 
     /**
      * Restore the latest Gamma-only NAO wavefunction and reorthonormalize it with
@@ -85,24 +66,19 @@ class WfHistoryLCAO
                                               const Parallel_Orbitals& pv,
                                               psi::Psi<TK>& psi,
                                               const ModuleBase::matrix& wg_now,
-                                              double pivot_threshold = 1.0e-14,
-                                              double check_tolerance = 1.0e-8);
+                                              double pivot_threshold,
+                                              double check_tolerance);
 
-    bool initialize_gamma_density(hamilt::Hamilt<TK>& hamiltonian,
+    void initialize_gamma_density(hamilt::Hamilt<TK>& hamiltonian,
                                   const Parallel_Orbitals& pv,
                                   psi::Psi<TK>& psi,
                                   const ModuleBase::matrix& wg_now,
                                   elecstate::DensityMatrix<TK, double>& dmat,
-                                  Charge& charge,
-                                  int nspin,
-                                  const std::string& ks_solver);
+                                  Charge& charge);
 
   private:
-    void prune_history();
-
-    WfcExtrapMethod method_ = WfcExtrapMethod::None;
-    std::size_t max_depth_ = 1;
-    std::deque<WfSnapshotLCAO<TK>> snapshots_;
+    bool has_snapshot_ = false;
+    WfSnapshotLCAO<TK> snapshot_;
 };
 
 } // namespace ModuleExtrap

--- a/source/source_lcao/module_extrap/wf_history_lcao.h
+++ b/source/source_lcao/module_extrap/wf_history_lcao.h
@@ -3,6 +3,7 @@
 
 #include "source_lcao/module_extrap/wf_extrap_method.h"
 #include "source_lcao/module_extrap/wf_snapshot_lcao.h"
+#include "source_basis/module_ao/parallel_orbitals.h"
 
 #include <cstddef>
 #include <deque>
@@ -72,6 +73,7 @@ class WfHistoryLCAO
      * added in a separate path instead of silently reusing this helper.
      */
     WfExtrapApplyResult try_use_prev_wf_gamma(const double* current_overlap,
+                                              const Parallel_Orbitals& pv,
                                               psi::Psi<double>& psi,
                                               const ModuleBase::matrix& wg_now,
                                               double pivot_threshold = 1.0e-14,

--- a/source/source_lcao/module_extrap/wf_history_lcao.h
+++ b/source/source_lcao/module_extrap/wf_history_lcao.h
@@ -10,6 +10,19 @@
 namespace ModuleExtrap
 {
 
+struct WfExtrapApplyResult
+{
+    WfcExtrapStatus status = WfcExtrapStatus::Disabled;
+    double max_orthonormality_deviation = 0.0;
+    int failed_state = -1;
+    int snapshot_istep = -1;
+
+    bool ok() const noexcept
+    {
+        return this->status == WfcExtrapStatus::Success;
+    }
+};
+
 template <typename TK>
 class WfHistoryLCAO
 {
@@ -32,6 +45,25 @@ class WfHistoryLCAO
     // Return a copy of the most recent snapshot.  This avoids exposing an internal
     // pointer/reference whose lifetime would be invalidated by the next history update.
     bool latest_snapshot(WfSnapshotLCAO<TK>& snapshot) const;
+
+    /**
+     * Restore the latest Gamma-only NAO wavefunction and reorthonormalize it with
+     * the current overlap matrix.
+     *
+     * This method only updates the Psi object after the full restore and
+     * reorthonormalization path succeeds.  DMK/DMR/rho rebuilding is deliberately
+     * left to the ESolver integration layer, where the existing density-matrix code
+     * can be called with the same control flow as the current initialization path.
+     *
+     * The first PR only supports the real Gamma-only path.  Multi-k support requires
+     * complex WFN snapshots, per-k S(k), and phase/convention handling, and should be
+     * added in a separate path instead of silently reusing this helper.
+     */
+    WfExtrapApplyResult try_use_prev_wf_gamma(const double* current_overlap,
+                                              psi::Psi<double>& psi,
+                                              const ModuleBase::matrix& wg_now,
+                                              double pivot_threshold = 1.0e-14,
+                                              double check_tolerance = 1.0e-8);
 
   private:
     void prune_history();

--- a/source/source_lcao/module_extrap/wf_history_lcao.h
+++ b/source/source_lcao/module_extrap/wf_history_lcao.h
@@ -4,9 +4,19 @@
 #include "source_lcao/module_extrap/wf_extrap_method.h"
 #include "source_lcao/module_extrap/wf_snapshot_lcao.h"
 #include "source_basis/module_ao/parallel_orbitals.h"
+#include "source_hamilt/hamilt.h"
 
 #include <cstddef>
 #include <deque>
+#include <string>
+
+namespace elecstate
+{
+template <typename TK, typename TR>
+class DensityMatrix;
+}
+
+class Charge;
 
 namespace ModuleExtrap
 {
@@ -78,6 +88,23 @@ class WfHistoryLCAO
                                               const ModuleBase::matrix& wg_now,
                                               double pivot_threshold = 1.0e-14,
                                               double check_tolerance = 1.0e-8);
+
+    /**
+     * Initialize the Gamma-only charge density from the latest WFN snapshot.
+     *
+     * The real Gamma-only implementation prepares the current overlap, restores
+     * and reorthonormalizes the previous WFN, and rebuilds DMK, DMR, and rho.
+     * Unsupported paths terminate with a clear diagnostic rather than silently
+     * falling back to charge-density extrapolation.
+     */
+    bool initialize_gamma_density(hamilt::Hamilt<TK>& hamiltonian,
+                                  const Parallel_Orbitals& pv,
+                                  psi::Psi<TK>& psi,
+                                  const ModuleBase::matrix& wg_now,
+                                  elecstate::DensityMatrix<TK, double>& dmat,
+                                  Charge& charge,
+                                  int nspin,
+                                  const std::string& ks_solver);
 
   private:
     void prune_history();

--- a/source/source_lcao/module_extrap/wf_history_lcao.h
+++ b/source/source_lcao/module_extrap/wf_history_lcao.h
@@ -4,11 +4,15 @@
 #include "source_lcao/module_extrap/wf_extrap_method.h"
 #include "source_lcao/module_extrap/wf_snapshot_lcao.h"
 #include "source_basis/module_ao/parallel_orbitals.h"
-#include "source_hamilt/hamilt.h"
-
 #include <cstddef>
 #include <deque>
 #include <string>
+
+namespace hamilt
+{
+template <typename TK, typename TR>
+class HamiltLCAO;
+}
 
 namespace elecstate
 {
@@ -89,23 +93,6 @@ class WfHistoryLCAO
                                               double pivot_threshold = 1.0e-14,
                                               double check_tolerance = 1.0e-8);
 
-    /**
-     * Initialize the Gamma-only charge density from the latest WFN snapshot.
-     *
-     * The real Gamma-only implementation prepares the current overlap, restores
-     * and reorthonormalizes the previous WFN, and rebuilds DMK, DMR, and rho.
-     * Unsupported paths terminate with a clear diagnostic rather than silently
-     * falling back to charge-density extrapolation.
-     */
-    bool initialize_gamma_density(hamilt::Hamilt<TK>& hamiltonian,
-                                  const Parallel_Orbitals& pv,
-                                  psi::Psi<TK>& psi,
-                                  const ModuleBase::matrix& wg_now,
-                                  elecstate::DensityMatrix<TK, double>& dmat,
-                                  Charge& charge,
-                                  int nspin,
-                                  const std::string& ks_solver);
-
   private:
     void prune_history();
 
@@ -113,6 +100,23 @@ class WfHistoryLCAO
     std::size_t max_depth_ = 1;
     std::deque<WfSnapshotLCAO<TK>> snapshots_;
 };
+
+/**
+ * Restore a Gamma-only WFN snapshot and rebuild the corresponding density.
+ *
+ * This runtime integration is kept outside WfHistoryLCAO so the history and
+ * orthonormalization core remains independently unit-testable.
+ */
+template <typename TK, typename TR>
+bool initialize_gamma_density_from_history(WfHistoryLCAO<TK>& history,
+                                           hamilt::HamiltLCAO<TK, TR>& hamiltonian,
+                                           const Parallel_Orbitals& pv,
+                                           psi::Psi<TK>& psi,
+                                           const ModuleBase::matrix& wg_now,
+                                           elecstate::DensityMatrix<TK, double>& dmat,
+                                           Charge& charge,
+                                           int nspin,
+                                           const std::string& ks_solver);
 
 } // namespace ModuleExtrap
 

--- a/source/source_lcao/module_extrap/wf_orthonormalize_lcao.cpp
+++ b/source/source_lcao/module_extrap/wf_orthonormalize_lcao.cpp
@@ -401,8 +401,19 @@ WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
     const int nbasis_global = pv.get_global_row_size();
     const int ncoeff_global_basis = pv.get_global_col_size();
     const int ncoeff_global_bands = pv.get_wfc_global_nbands();
-    const bool coeff_columns_are_basis = (ncoeff_local == pv.get_col_size());
-    const bool coeff_columns_are_bands = (ncoeff_local == pv.ncol_bands);
+    int layout_matches[2] = {
+        ncoeff_local == pv.get_col_size(),
+        ncoeff_local == pv.ncol_bands,
+    };
+#ifdef __MPI
+    const MPI_Comm comm = pv.comm();
+    if (comm != MPI_COMM_NULL)
+    {
+        MPI_Allreduce(MPI_IN_PLACE, layout_matches, 2, MPI_INT, MPI_MIN, comm);
+    }
+#endif
+    const bool coeff_columns_are_basis = layout_matches[0] != 0;
+    const bool coeff_columns_are_bands = layout_matches[1] != 0;
     const int ncoeff_global = coeff_columns_are_basis ? ncoeff_global_basis : ncoeff_global_bands;
     result.nstate = nstate;
     result.nbands = ncoeff_global;
@@ -410,7 +421,9 @@ WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
 
     if (nstate <= 0 || ncoeff_local <= 0 || nbasis_local <= 0 || nbasis_global <= 0 || ncoeff_global <= 0
         || ncoeff_global > nbasis_global || pv.get_row_size() != nbasis_local
-        || pv.get_global_col_size() != nbasis_global || (!coeff_columns_are_basis && !coeff_columns_are_bands))
+        || pv.get_global_col_size() != nbasis_global || (!coeff_columns_are_basis && !coeff_columns_are_bands)
+        || (coeff_columns_are_basis && coeff_columns_are_bands
+            && ncoeff_global_basis != ncoeff_global_bands))
     {
         result.status = WfcExtrapStatus::DimensionMismatch;
         return result;

--- a/source/source_lcao/module_extrap/wf_orthonormalize_lcao.cpp
+++ b/source/source_lcao/module_extrap/wf_orthonormalize_lcao.cpp
@@ -1,4 +1,5 @@
 #include "source_lcao/module_extrap/wf_orthonormalize_lcao.h"
+#include "source_base/timer.h"
 
 #include <algorithm>
 #include <cmath>
@@ -13,6 +14,24 @@ namespace ModuleExtrap
 {
 namespace
 {
+
+class TimerGuard
+{
+  public:
+    TimerGuard(const char* group, const char* name) : group_(group), name_(name)
+    {
+        ModuleBase::timer::start(group_, name_);
+    }
+
+    ~TimerGuard()
+    {
+        ModuleBase::timer::end(group_, name_);
+    }
+
+  private:
+    const char* group_;
+    const char* name_;
+};
 
 inline std::size_t idx(const int row, const int col, const int ncol) noexcept
 {
@@ -234,6 +253,7 @@ WfcExtrapStatus assemble_global_overlap(const double* overlap,
                                         const Parallel_Orbitals& pv,
                                         std::vector<double>& overlap_global)
 {
+    TimerGuard timer("WFN_Extrap", "assemble_overlap");
     const int nbasis_global = pv.get_global_row_size();
     if (overlap == nullptr || nbasis_global <= 0 || pv.get_global_col_size() != nbasis_global)
     {
@@ -284,6 +304,7 @@ WfcExtrapStatus assemble_global_coeff_active(const double* coeff_local,
                                              const bool coeff_columns_are_basis,
                                              std::vector<double>& coeff_global)
 {
+    TimerGuard timer("WFN_Extrap", "assemble_coeff");
     const int nbasis_global = pv.get_global_row_size();
     if (coeff_local == nullptr || nbasis_global <= 0 || ncoeff_local <= 0 || nbasis_local <= 0
         || nactive_bands < 0 || pv.get_row_size() != nbasis_local)
@@ -320,6 +341,7 @@ void scatter_global_coeff_active(const std::vector<double>& coeff_global,
                                  const bool coeff_columns_are_basis,
                                  double* coeff_local)
 {
+    TimerGuard timer("WFN_Extrap", "scatter_coeff");
     const int nbasis_global = pv.get_global_row_size();
     for (int ib_local = 0; ib_local < ncoeff_local; ++ib_local)
     {
@@ -435,29 +457,33 @@ WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
             return result;
         }
 
-        std::vector<double> metric;
-        build_overlap_in_band_space(overlap_global.data(), coeff_global.data(), nactive_bands, nbasis_global, metric);
-        fill_metric_diagnostics(metric, nactive_bands, result);
-
-        if (!cholesky_lower_in_place(metric, nactive_bands, pivot_threshold, result))
+        double max_dev = 0.0;
         {
-            result.status = WfcExtrapStatus::OrthogonalizationFailed;
-            result.failed_state = istate;
-            return result;
-        }
+            TimerGuard timer("WFN_Extrap", "cholesky_transform");
+            std::vector<double> metric;
+            build_overlap_in_band_space(overlap_global.data(), coeff_global.data(), nactive_bands, nbasis_global, metric);
+            fill_metric_diagnostics(metric, nactive_bands, result);
 
-        apply_inverse_cholesky_left(metric, coeff_global.data(), nactive_bands, nbasis_global);
+            if (!cholesky_lower_in_place(metric, nactive_bands, pivot_threshold, result))
+            {
+                result.status = WfcExtrapStatus::OrthogonalizationFailed;
+                result.failed_state = istate;
+                return result;
+            }
 
-        const double max_dev = max_orthonormality_deviation(overlap_global.data(),
-                                                            coeff_global.data(),
-                                                            nactive_bands,
-                                                            nbasis_global);
-        if (!std::isfinite(max_dev) || max_dev > check_tolerance)
-        {
-            result.status = WfcExtrapStatus::OrthogonalizationFailed;
-            result.failed_state = istate;
-            result.max_deviation = max_dev;
-            return result;
+            apply_inverse_cholesky_left(metric, coeff_global.data(), nactive_bands, nbasis_global);
+
+            max_dev = max_orthonormality_deviation(overlap_global.data(),
+                                                   coeff_global.data(),
+                                                   nactive_bands,
+                                                   nbasis_global);
+            if (!std::isfinite(max_dev) || max_dev > check_tolerance)
+            {
+                result.status = WfcExtrapStatus::OrthogonalizationFailed;
+                result.failed_state = istate;
+                result.max_deviation = max_dev;
+                return result;
+            }
         }
         max_deviation_all = std::max(max_deviation_all, max_dev);
 

--- a/source/source_lcao/module_extrap/wf_orthonormalize_lcao.cpp
+++ b/source/source_lcao/module_extrap/wf_orthonormalize_lcao.cpp
@@ -1,5 +1,6 @@
 #include "source_lcao/module_extrap/wf_orthonormalize_lcao.h"
 #include "source_base/timer.h"
+#include "source_base/module_external/blas_connector.h"
 
 #include <algorithm>
 #include <cmath>
@@ -67,36 +68,54 @@ void build_overlap_in_band_space(const double* overlap,
                                  const double* coeff,
                                  const int nactive_bands,
                                  const int nbasis,
+                                 std::vector<double>& coeff_s,
                                  std::vector<double>& metric)
 {
-    metric.assign(static_cast<std::size_t>(nactive_bands) * static_cast<std::size_t>(nactive_bands), 0.0);
-    std::vector<double> coeff_s(static_cast<std::size_t>(nactive_bands) * static_cast<std::size_t>(nbasis), 0.0);
+    coeff_s.resize(static_cast<std::size_t>(nactive_bands) * static_cast<std::size_t>(nbasis));
+    metric.resize(static_cast<std::size_t>(nactive_bands) * static_cast<std::size_t>(nactive_bands));
 
-    // Coefficients are stored as a row-major band-by-basis matrix C.  Build the
-    // band-space metric explicitly as O = C S C^T to avoid ambiguity about the
-    // row-major layout when using Fortran BLAS wrappers.
+    // All three arrays use row-major storage here:
+    //   C       : nactive_bands x nbasis
+    //   S       : nbasis x nbasis
+    //   O = CSC^T: nactive_bands x nactive_bands
+    // BlasConnector::gemm provides the row-major interface and handles the
+    // conversion to the underlying Fortran BLAS convention.
+    BlasConnector::gemm('N',
+                        'N',
+                        nactive_bands,
+                        nbasis,
+                        nbasis,
+                        1.0,
+                        coeff,
+                        nbasis,
+                        overlap,
+                        nbasis,
+                        0.0,
+                        coeff_s.data(),
+                        nbasis);
+    BlasConnector::gemm('N',
+                        'T',
+                        nactive_bands,
+                        nactive_bands,
+                        nbasis,
+                        1.0,
+                        coeff_s.data(),
+                        nbasis,
+                        coeff,
+                        nbasis,
+                        0.0,
+                        metric.data(),
+                        nactive_bands);
+
+    // O is mathematically symmetric.  Enforce symmetry explicitly so that the
+    // Cholesky path and diagnostics do not depend on round-off differences
+    // between the two BLAS-computed triangles.
     for (int ib = 0; ib < nactive_bands; ++ib)
     {
-        for (int mu = 0; mu < nbasis; ++mu)
+        for (int jb = 0; jb < ib; ++jb)
         {
-            double value = 0.0;
-            for (int nu = 0; nu < nbasis; ++nu)
-            {
-                value += coeff[idx(ib, nu, nbasis)] * overlap[idx(nu, mu, nbasis)];
-            }
-            coeff_s[idx(ib, mu, nbasis)] = value;
-        }
-    }
-
-    for (int ib = 0; ib < nactive_bands; ++ib)
-    {
-        for (int jb = 0; jb <= ib; ++jb)
-        {
-            double value = 0.0;
-            for (int mu = 0; mu < nbasis; ++mu)
-            {
-                value += coeff_s[idx(ib, mu, nbasis)] * coeff[idx(jb, mu, nbasis)];
-            }
+            const double value = 0.5 * (metric[idx(ib, jb, nactive_bands)]
+                                      + metric[idx(jb, ib, nactive_bands)]);
             metric[idx(ib, jb, nactive_bands)] = value;
             metric[idx(jb, ib, nactive_bands)] = value;
         }
@@ -206,10 +225,11 @@ void apply_inverse_cholesky_left(const std::vector<double>& lower,
 double max_orthonormality_deviation(const double* overlap,
                                     const double* coeff,
                                     const int nactive_bands,
-                                    const int nbasis)
+                                    const int nbasis,
+                                    std::vector<double>& coeff_s,
+                                    std::vector<double>& metric)
 {
-    std::vector<double> metric;
-    build_overlap_in_band_space(overlap, coeff, nactive_bands, nbasis, metric);
+    build_overlap_in_band_space(overlap, coeff, nactive_bands, nbasis, coeff_s, metric);
 
     double max_dev = 0.0;
     for (int i = 0; i < nactive_bands; ++i)
@@ -426,6 +446,8 @@ WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
 
     double max_deviation_all = 0.0;
     int max_active_bands = 0;
+    std::vector<double> coeff_s_workspace;
+    std::vector<double> metric_workspace;
     for (int istate = 0; istate < nstate; ++istate)
     {
         double* coeff_local = trial.data()
@@ -460,23 +482,29 @@ WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
         double max_dev = 0.0;
         {
             TimerGuard timer("WFN_Extrap", "cholesky_transform");
-            std::vector<double> metric;
-            build_overlap_in_band_space(overlap_global.data(), coeff_global.data(), nactive_bands, nbasis_global, metric);
-            fill_metric_diagnostics(metric, nactive_bands, result);
+            build_overlap_in_band_space(overlap_global.data(),
+                                        coeff_global.data(),
+                                        nactive_bands,
+                                        nbasis_global,
+                                        coeff_s_workspace,
+                                        metric_workspace);
+            fill_metric_diagnostics(metric_workspace, nactive_bands, result);
 
-            if (!cholesky_lower_in_place(metric, nactive_bands, pivot_threshold, result))
+            if (!cholesky_lower_in_place(metric_workspace, nactive_bands, pivot_threshold, result))
             {
                 result.status = WfcExtrapStatus::OrthogonalizationFailed;
                 result.failed_state = istate;
                 return result;
             }
 
-            apply_inverse_cholesky_left(metric, coeff_global.data(), nactive_bands, nbasis_global);
+            apply_inverse_cholesky_left(metric_workspace, coeff_global.data(), nactive_bands, nbasis_global);
 
             max_dev = max_orthonormality_deviation(overlap_global.data(),
                                                    coeff_global.data(),
                                                    nactive_bands,
-                                                   nbasis_global);
+                                                   nbasis_global,
+                                                   coeff_s_workspace,
+                                                   metric_workspace);
             if (!std::isfinite(max_dev) || max_dev > check_tolerance)
             {
                 result.status = WfcExtrapStatus::OrthogonalizationFailed;

--- a/source/source_lcao/module_extrap/wf_orthonormalize_lcao.cpp
+++ b/source/source_lcao/module_extrap/wf_orthonormalize_lcao.cpp
@@ -2,7 +2,12 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <vector>
+
+#ifdef __MPI
+#include <mpi.h>
+#endif
 
 namespace ModuleExtrap
 {
@@ -199,9 +204,144 @@ double max_orthonormality_deviation(const double* overlap,
     return max_dev;
 }
 
+
+WfcExtrapStatus allreduce_dense_vector(std::vector<double>& values, const Parallel_Orbitals& pv)
+{
+#ifdef __MPI
+    if (!pv.is_serial)
+    {
+        const MPI_Comm comm = pv.comm();
+        if (comm == MPI_COMM_NULL)
+        {
+            return WfcExtrapStatus::InvalidInput;
+        }
+        if (values.size() > static_cast<std::size_t>(std::numeric_limits<int>::max()))
+        {
+            return WfcExtrapStatus::InvalidInput;
+        }
+        MPI_Allreduce(MPI_IN_PLACE,
+                      values.data(),
+                      static_cast<int>(values.size()),
+                      MPI_DOUBLE,
+                      MPI_SUM,
+                      comm);
+    }
+#endif
+    return WfcExtrapStatus::Success;
+}
+
+WfcExtrapStatus assemble_global_overlap(const double* overlap,
+                                        const Parallel_Orbitals& pv,
+                                        std::vector<double>& overlap_global)
+{
+    const int nbasis_global = pv.get_global_row_size();
+    if (overlap == nullptr || nbasis_global <= 0 || pv.get_global_col_size() != nbasis_global)
+    {
+        return WfcExtrapStatus::DimensionMismatch;
+    }
+
+    overlap_global.assign(static_cast<std::size_t>(nbasis_global) * static_cast<std::size_t>(nbasis_global), 0.0);
+
+    const int nrow_local = pv.get_row_size();
+    const int ncol_local = pv.get_col_size();
+    for (int icol = 0; icol < ncol_local; ++icol)
+    {
+        const int icol_global = pv.local2global_col(icol);
+        for (int irow = 0; irow < nrow_local; ++irow)
+        {
+            const int irow_global = pv.local2global_row(irow);
+            // ABACUS/ScaLAPACK local matrices are stored column-major:
+            // local(irow, icol) -> overlap[icol * nrow_local + irow].
+            overlap_global[idx(irow_global, icol_global, nbasis_global)]
+                = overlap[static_cast<std::size_t>(icol) * static_cast<std::size_t>(nrow_local)
+                          + static_cast<std::size_t>(irow)];
+        }
+    }
+
+    return allreduce_dense_vector(overlap_global, pv);
+}
+
+int local_band_to_global(const int ib_local, const Parallel_Orbitals& pv)
+{
+    return (ib_local / pv.nb * pv.dim1 + pv.coord[1]) * pv.nb + ib_local % pv.nb;
+}
+
+int local_wfc_col_to_global(const int ib_local, const Parallel_Orbitals& pv, const bool coeff_columns_are_basis)
+{
+    // Gamma-only direct diagonalization solvers store Psi columns with the same
+    // distribution as the AO/basis columns, i.e. local Psi column -> global basis
+    // column.  Other NAO paths may store only the requested band columns; in that
+    // case the band-column distribution follows the ScaLAPACK formula used by
+    // Parallel_Orbitals::set_nloc_wfc_Eij().
+    return coeff_columns_are_basis ? pv.local2global_col(ib_local) : local_band_to_global(ib_local, pv);
+}
+
+WfcExtrapStatus assemble_global_coeff_active(const double* coeff_local,
+                                             const Parallel_Orbitals& pv,
+                                             const int ncoeff_local,
+                                             const int nbasis_local,
+                                             const int nactive_bands,
+                                             const bool coeff_columns_are_basis,
+                                             std::vector<double>& coeff_global)
+{
+    const int nbasis_global = pv.get_global_row_size();
+    if (coeff_local == nullptr || nbasis_global <= 0 || ncoeff_local <= 0 || nbasis_local <= 0
+        || nactive_bands < 0 || pv.get_row_size() != nbasis_local)
+    {
+        return WfcExtrapStatus::DimensionMismatch;
+    }
+
+    coeff_global.assign(static_cast<std::size_t>(nactive_bands) * static_cast<std::size_t>(nbasis_global), 0.0);
+
+    for (int ib_local = 0; ib_local < ncoeff_local; ++ib_local)
+    {
+        const int ib_global = local_wfc_col_to_global(ib_local, pv, coeff_columns_are_basis);
+        if (ib_global >= nactive_bands)
+        {
+            continue;
+        }
+        for (int mu_local = 0; mu_local < nbasis_local; ++mu_local)
+        {
+            const int mu_global = pv.local2global_row(mu_local);
+            coeff_global[idx(ib_global, mu_global, nbasis_global)]
+                = coeff_local[static_cast<std::size_t>(ib_local) * static_cast<std::size_t>(nbasis_local)
+                              + static_cast<std::size_t>(mu_local)];
+        }
+    }
+
+    return allreduce_dense_vector(coeff_global, pv);
+}
+
+void scatter_global_coeff_active(const std::vector<double>& coeff_global,
+                                 const Parallel_Orbitals& pv,
+                                 const int ncoeff_local,
+                                 const int nbasis_local,
+                                 const int nactive_bands,
+                                 const bool coeff_columns_are_basis,
+                                 double* coeff_local)
+{
+    const int nbasis_global = pv.get_global_row_size();
+    for (int ib_local = 0; ib_local < ncoeff_local; ++ib_local)
+    {
+        const int ib_global = local_wfc_col_to_global(ib_local, pv, coeff_columns_are_basis);
+        if (ib_global >= nactive_bands)
+        {
+            continue;
+        }
+        for (int mu_local = 0; mu_local < nbasis_local; ++mu_local)
+        {
+            const int mu_global = pv.local2global_row(mu_local);
+            coeff_local[static_cast<std::size_t>(ib_local) * static_cast<std::size_t>(nbasis_local)
+                        + static_cast<std::size_t>(mu_local)]
+                = coeff_global[idx(ib_global, mu_global, nbasis_global)];
+        }
+    }
+}
+
 } // namespace
 
 WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
+                                                   const Parallel_Orbitals& pv,
                                                    psi::Psi<double>& wfc,
                                                    const ModuleBase::matrix& occupations,
                                                    const double occupation_threshold,
@@ -217,13 +357,21 @@ WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
     }
 
     const int nstate = wfc.get_nk();
-    const int nbands = wfc.get_nbands();
-    const int nbasis = wfc.get_nbasis();
+    const int ncoeff_local = wfc.get_nbands();
+    const int nbasis_local = wfc.get_nbasis();
+    const int nbasis_global = pv.get_global_row_size();
+    const int ncoeff_global_basis = pv.get_global_col_size();
+    const int ncoeff_global_bands = pv.get_wfc_global_nbands();
+    const bool coeff_columns_are_basis = (ncoeff_local == pv.get_col_size());
+    const bool coeff_columns_are_bands = (ncoeff_local == pv.ncol_bands);
+    const int ncoeff_global = coeff_columns_are_basis ? ncoeff_global_basis : ncoeff_global_bands;
     result.nstate = nstate;
-    result.nbands = nbands;
-    result.nbasis = nbasis;
+    result.nbands = ncoeff_global;
+    result.nbasis = nbasis_global;
 
-    if (nstate <= 0 || nbands <= 0 || nbasis <= 0 || nbands > nbasis)
+    if (nstate <= 0 || ncoeff_local <= 0 || nbasis_local <= 0 || nbasis_global <= 0 || ncoeff_global <= 0
+        || ncoeff_global > nbasis_global || pv.get_row_size() != nbasis_local
+        || pv.get_global_col_size() != nbasis_global || (!coeff_columns_are_basis && !coeff_columns_are_bands))
     {
         result.status = WfcExtrapStatus::DimensionMismatch;
         return result;
@@ -241,6 +389,13 @@ WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
         return result;
     }
 
+    std::vector<double> overlap_global;
+    result.status = assemble_global_overlap(overlap, pv, overlap_global);
+    if (!result.ok())
+    {
+        return result;
+    }
+
     // Operate on a full owned copy first.  The caller's Psi is overwritten only after
     // all state/spin channels pass the positive-definiteness and residual checks.
     std::vector<double> trial(wfc.size(), 0.0);
@@ -251,11 +406,11 @@ WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
     int max_active_bands = 0;
     for (int istate = 0; istate < nstate; ++istate)
     {
-        double* coeff = trial.data()
-                      + static_cast<std::size_t>(istate) * static_cast<std::size_t>(nbands)
-                            * static_cast<std::size_t>(nbasis);
+        double* coeff_local = trial.data()
+                            + static_cast<std::size_t>(istate) * static_cast<std::size_t>(ncoeff_local)
+                                  * static_cast<std::size_t>(nbasis_local);
 
-        const int nactive_bands = active_bands_for_state(occupations, istate, nbands, occupation_threshold);
+        const int nactive_bands = active_bands_for_state(occupations, istate, ncoeff_global, occupation_threshold);
         max_active_bands = std::max(max_active_bands, nactive_bands);
         result.nactive_bands = nactive_bands;
 
@@ -266,8 +421,22 @@ WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
             continue;
         }
 
+        std::vector<double> coeff_global;
+        result.status = assemble_global_coeff_active(coeff_local,
+                                                     pv,
+                                                     ncoeff_local,
+                                                     nbasis_local,
+                                                     nactive_bands,
+                                                     coeff_columns_are_basis,
+                                                     coeff_global);
+        if (!result.ok())
+        {
+            result.failed_state = istate;
+            return result;
+        }
+
         std::vector<double> metric;
-        build_overlap_in_band_space(overlap, coeff, nactive_bands, nbasis, metric);
+        build_overlap_in_band_space(overlap_global.data(), coeff_global.data(), nactive_bands, nbasis_global, metric);
         fill_metric_diagnostics(metric, nactive_bands, result);
 
         if (!cholesky_lower_in_place(metric, nactive_bands, pivot_threshold, result))
@@ -277,9 +446,12 @@ WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
             return result;
         }
 
-        apply_inverse_cholesky_left(metric, coeff, nactive_bands, nbasis);
+        apply_inverse_cholesky_left(metric, coeff_global.data(), nactive_bands, nbasis_global);
 
-        const double max_dev = max_orthonormality_deviation(overlap, coeff, nactive_bands, nbasis);
+        const double max_dev = max_orthonormality_deviation(overlap_global.data(),
+                                                            coeff_global.data(),
+                                                            nactive_bands,
+                                                            nbasis_global);
         if (!std::isfinite(max_dev) || max_dev > check_tolerance)
         {
             result.status = WfcExtrapStatus::OrthogonalizationFailed;
@@ -288,6 +460,14 @@ WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
             return result;
         }
         max_deviation_all = std::max(max_deviation_all, max_dev);
+
+        scatter_global_coeff_active(coeff_global,
+                                    pv,
+                                    ncoeff_local,
+                                    nbasis_local,
+                                    nactive_bands,
+                                    coeff_columns_are_basis,
+                                    coeff_local);
     }
 
     wfc.set_all_psi(trial.data(), trial.size());

--- a/source/source_lcao/module_extrap/wf_orthonormalize_lcao.cpp
+++ b/source/source_lcao/module_extrap/wf_orthonormalize_lcao.cpp
@@ -1,7 +1,5 @@
 #include "source_lcao/module_extrap/wf_orthonormalize_lcao.h"
 
-#include "source_base/module_external/blas_connector.h"
-
 #include <algorithm>
 #include <cmath>
 #include <vector>
@@ -16,61 +14,104 @@ inline std::size_t idx(const int row, const int col, const int ncol) noexcept
     return static_cast<std::size_t>(row) * static_cast<std::size_t>(ncol) + static_cast<std::size_t>(col);
 }
 
+int active_bands_for_state(const ModuleBase::matrix& occupations,
+                           const int istate,
+                           const int nbands,
+                           const double occupation_threshold)
+{
+    if (occupations.c == nullptr || occupations.nr <= istate || occupations.nc <= 0)
+    {
+        return nbands;
+    }
+
+    // In ABACUS, Psi may contain more local eigenvectors than the occupation
+    // matrix explicitly stores.  This is already supported by cal_dm_psi(),
+    // which simply ignores local bands without a corresponding global weight.
+    const int nband_with_occupation = std::min(nbands, occupations.nc);
+    int nactive = 0;
+    for (int ib = 0; ib < nband_with_occupation; ++ib)
+    {
+        if (std::abs(occupations(istate, ib)) > occupation_threshold)
+        {
+            nactive = ib + 1;
+        }
+    }
+    return nactive;
+}
+
 void build_overlap_in_band_space(const double* overlap,
                                  const double* coeff,
-                                 const int nbands,
+                                 const int nactive_bands,
                                  const int nbasis,
                                  std::vector<double>& metric)
 {
-    metric.assign(static_cast<std::size_t>(nbands) * static_cast<std::size_t>(nbands), 0.0);
-    std::vector<double> coeff_s(static_cast<std::size_t>(nbands) * static_cast<std::size_t>(nbasis), 0.0);
+    metric.assign(static_cast<std::size_t>(nactive_bands) * static_cast<std::size_t>(nactive_bands), 0.0);
+    std::vector<double> coeff_s(static_cast<std::size_t>(nactive_bands) * static_cast<std::size_t>(nbasis), 0.0);
 
-    const double one = 1.0;
-    const double zero = 0.0;
-
-    // Coefficients are stored as a row-major band-by-basis matrix X.  With the
-    // current row-major overlap S, the band-space metric is O = X S X^T.
-    BlasConnector::gemm('N',
-                        'N',
-                        nbands,
-                        nbasis,
-                        nbasis,
-                        one,
-                        coeff,
-                        nbasis,
-                        overlap,
-                        nbasis,
-                        zero,
-                        coeff_s.data(),
-                        nbasis);
-
-    BlasConnector::gemm('N',
-                        'T',
-                        nbands,
-                        nbands,
-                        nbasis,
-                        one,
-                        coeff_s.data(),
-                        nbasis,
-                        coeff,
-                        nbasis,
-                        zero,
-                        metric.data(),
-                        nbands);
-
-    // Remove tiny asymmetry introduced by BLAS roundoff before the Cholesky step.
-    for (int i = 0; i < nbands; ++i)
+    // Coefficients are stored as a row-major band-by-basis matrix C.  Build the
+    // band-space metric explicitly as O = C S C^T to avoid ambiguity about the
+    // row-major layout when using Fortran BLAS wrappers.
+    for (int ib = 0; ib < nactive_bands; ++ib)
     {
-        for (int j = 0; j < i; ++j)
+        for (int mu = 0; mu < nbasis; ++mu)
         {
-            const double value = 0.5 * (metric[idx(i, j, nbands)] + metric[idx(j, i, nbands)]);
-            metric[idx(i, j, nbands)] = value;
-            metric[idx(j, i, nbands)] = value;
+            double value = 0.0;
+            for (int nu = 0; nu < nbasis; ++nu)
+            {
+                value += coeff[idx(ib, nu, nbasis)] * overlap[idx(nu, mu, nbasis)];
+            }
+            coeff_s[idx(ib, mu, nbasis)] = value;
+        }
+    }
+
+    for (int ib = 0; ib < nactive_bands; ++ib)
+    {
+        for (int jb = 0; jb <= ib; ++jb)
+        {
+            double value = 0.0;
+            for (int mu = 0; mu < nbasis; ++mu)
+            {
+                value += coeff_s[idx(ib, mu, nbasis)] * coeff[idx(jb, mu, nbasis)];
+            }
+            metric[idx(ib, jb, nactive_bands)] = value;
+            metric[idx(jb, ib, nactive_bands)] = value;
         }
     }
 }
 
-bool cholesky_lower_in_place(std::vector<double>& metric, const int n, const double pivot_threshold)
+void fill_metric_diagnostics(const std::vector<double>& metric,
+                             const int n,
+                             WfOrthonormalizeResult& result)
+{
+    if (n <= 0 || metric.empty())
+    {
+        return;
+    }
+
+    result.min_metric_diag = metric[idx(0, 0, n)];
+    result.max_metric_diag = metric[idx(0, 0, n)];
+    result.max_metric_abs = 0.0;
+    result.max_metric_asymmetry = 0.0;
+
+    for (int i = 0; i < n; ++i)
+    {
+        const double diag = metric[idx(i, i, n)];
+        result.min_metric_diag = std::min(result.min_metric_diag, diag);
+        result.max_metric_diag = std::max(result.max_metric_diag, diag);
+        for (int j = 0; j < n; ++j)
+        {
+            result.max_metric_abs = std::max(result.max_metric_abs, std::abs(metric[idx(i, j, n)]));
+            result.max_metric_asymmetry = std::max(result.max_metric_asymmetry,
+                                                   std::abs(metric[idx(i, j, n)] - metric[idx(j, i, n)]));
+        }
+    }
+}
+
+bool cholesky_lower_in_place(std::vector<double>& metric,
+                             const int n,
+                             const double pivot_threshold,
+                             WfOrthonormalizeResult& result)
+
 {
     for (int j = 0; j < n; ++j)
     {
@@ -83,6 +124,8 @@ bool cholesky_lower_in_place(std::vector<double>& metric, const int n, const dou
 
         if (!(diag > pivot_threshold) || !std::isfinite(diag))
         {
+            result.failed_pivot_index = j;
+            result.failed_pivot = diag;
             return false;
         }
 
@@ -109,25 +152,27 @@ bool cholesky_lower_in_place(std::vector<double>& metric, const int n, const dou
 
 void apply_inverse_cholesky_left(const std::vector<double>& lower,
                                  double* coeff,
-                                 const int nbands,
+                                 const int nactive_bands,
                                  const int nbasis)
 {
-    std::vector<double> column(static_cast<std::size_t>(nbands), 0.0);
+    std::vector<double> column(static_cast<std::size_t>(nactive_bands), 0.0);
 
-    // Solve L * C_new(:,mu) = C_old(:,mu) for every basis function mu.
+    // Solve L * C_new(:,mu) = C_old(:,mu) for every basis function mu.  Only
+    // occupied/fractionally occupied bands are transformed; unoccupied bands do
+    // not contribute to the density matrix and are left unchanged.
     for (int mu = 0; mu < nbasis; ++mu)
     {
-        for (int ib = 0; ib < nbands; ++ib)
+        for (int ib = 0; ib < nactive_bands; ++ib)
         {
             double value = coeff[idx(ib, mu, nbasis)];
             for (int jb = 0; jb < ib; ++jb)
             {
-                value -= lower[idx(ib, jb, nbands)] * column[jb];
+                value -= lower[idx(ib, jb, nactive_bands)] * column[jb];
             }
-            column[ib] = value / lower[idx(ib, ib, nbands)];
+            column[ib] = value / lower[idx(ib, ib, nactive_bands)];
         }
 
-        for (int ib = 0; ib < nbands; ++ib)
+        for (int ib = 0; ib < nactive_bands; ++ib)
         {
             coeff[idx(ib, mu, nbasis)] = column[ib];
         }
@@ -136,19 +181,19 @@ void apply_inverse_cholesky_left(const std::vector<double>& lower,
 
 double max_orthonormality_deviation(const double* overlap,
                                     const double* coeff,
-                                    const int nbands,
+                                    const int nactive_bands,
                                     const int nbasis)
 {
     std::vector<double> metric;
-    build_overlap_in_band_space(overlap, coeff, nbands, nbasis, metric);
+    build_overlap_in_band_space(overlap, coeff, nactive_bands, nbasis, metric);
 
     double max_dev = 0.0;
-    for (int i = 0; i < nbands; ++i)
+    for (int i = 0; i < nactive_bands; ++i)
     {
-        for (int j = 0; j < nbands; ++j)
+        for (int j = 0; j < nactive_bands; ++j)
         {
             const double expected = (i == j) ? 1.0 : 0.0;
-            max_dev = std::max(max_dev, std::abs(metric[idx(i, j, nbands)] - expected));
+            max_dev = std::max(max_dev, std::abs(metric[idx(i, j, nactive_bands)] - expected));
         }
     }
     return max_dev;
@@ -158,12 +203,14 @@ double max_orthonormality_deviation(const double* overlap,
 
 WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
                                                    psi::Psi<double>& wfc,
+                                                   const ModuleBase::matrix& occupations,
+                                                   const double occupation_threshold,
                                                    const double pivot_threshold,
                                                    const double check_tolerance)
 {
     WfOrthonormalizeResult result;
 
-    if (overlap == nullptr || !(pivot_threshold >= 0.0) || !(check_tolerance > 0.0))
+    if (overlap == nullptr || !(occupation_threshold >= 0.0) || !(pivot_threshold >= 0.0) || !(check_tolerance > 0.0))
     {
         result.status = WfcExtrapStatus::InvalidInput;
         return result;
@@ -172,6 +219,9 @@ WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
     const int nstate = wfc.get_nk();
     const int nbands = wfc.get_nbands();
     const int nbasis = wfc.get_nbasis();
+    result.nstate = nstate;
+    result.nbands = nbands;
+    result.nbasis = nbasis;
 
     if (nstate <= 0 || nbands <= 0 || nbasis <= 0 || nbands > nbasis)
     {
@@ -185,6 +235,12 @@ WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
         return result;
     }
 
+    if (occupations.c == nullptr || occupations.nr < nstate || occupations.nc <= 0)
+    {
+        result.status = WfcExtrapStatus::DimensionMismatch;
+        return result;
+    }
+
     // Operate on a full owned copy first.  The caller's Psi is overwritten only after
     // all state/spin channels pass the positive-definiteness and residual checks.
     std::vector<double> trial(wfc.size(), 0.0);
@@ -192,25 +248,38 @@ WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
     std::copy(coeff_begin, coeff_begin + wfc.size(), trial.begin());
 
     double max_deviation_all = 0.0;
+    int max_active_bands = 0;
     for (int istate = 0; istate < nstate; ++istate)
     {
         double* coeff = trial.data()
                       + static_cast<std::size_t>(istate) * static_cast<std::size_t>(nbands)
                             * static_cast<std::size_t>(nbasis);
 
-        std::vector<double> metric;
-        build_overlap_in_band_space(overlap, coeff, nbands, nbasis, metric);
+        const int nactive_bands = active_bands_for_state(occupations, istate, nbands, occupation_threshold);
+        max_active_bands = std::max(max_active_bands, nactive_bands);
+        result.nactive_bands = nactive_bands;
 
-        if (!cholesky_lower_in_place(metric, nbands, pivot_threshold))
+        // Empty spin channels may occur in edge cases.  They do not contribute to
+        // the density matrix, so there is no occupied subspace to reorthonormalize.
+        if (nactive_bands == 0)
+        {
+            continue;
+        }
+
+        std::vector<double> metric;
+        build_overlap_in_band_space(overlap, coeff, nactive_bands, nbasis, metric);
+        fill_metric_diagnostics(metric, nactive_bands, result);
+
+        if (!cholesky_lower_in_place(metric, nactive_bands, pivot_threshold, result))
         {
             result.status = WfcExtrapStatus::OrthogonalizationFailed;
             result.failed_state = istate;
             return result;
         }
 
-        apply_inverse_cholesky_left(metric, coeff, nbands, nbasis);
+        apply_inverse_cholesky_left(metric, coeff, nactive_bands, nbasis);
 
-        const double max_dev = max_orthonormality_deviation(overlap, coeff, nbands, nbasis);
+        const double max_dev = max_orthonormality_deviation(overlap, coeff, nactive_bands, nbasis);
         if (!std::isfinite(max_dev) || max_dev > check_tolerance)
         {
             result.status = WfcExtrapStatus::OrthogonalizationFailed;
@@ -223,6 +292,7 @@ WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
 
     wfc.set_all_psi(trial.data(), trial.size());
     result.status = WfcExtrapStatus::Success;
+    result.nactive_bands = max_active_bands;
     result.max_deviation = max_deviation_all;
     return result;
 }

--- a/source/source_lcao/module_extrap/wf_orthonormalize_lcao.cpp
+++ b/source/source_lcao/module_extrap/wf_orthonormalize_lcao.cpp
@@ -247,13 +247,9 @@ double max_orthonormality_deviation(const double* overlap,
 WfcExtrapStatus allreduce_dense_vector(std::vector<double>& values, const Parallel_Orbitals& pv)
 {
 #ifdef __MPI
-    if (!pv.is_serial)
+    const MPI_Comm comm = pv.comm();
+    if (comm != MPI_COMM_NULL)
     {
-        const MPI_Comm comm = pv.comm();
-        if (comm == MPI_COMM_NULL)
-        {
-            return WfcExtrapStatus::InvalidInput;
-        }
         if (values.size() > static_cast<std::size_t>(std::numeric_limits<int>::max()))
         {
             return WfcExtrapStatus::InvalidInput;
@@ -303,7 +299,8 @@ WfcExtrapStatus assemble_global_overlap(const double* overlap,
 
 int local_band_to_global(const int ib_local, const Parallel_Orbitals& pv)
 {
-    return (ib_local / pv.nb * pv.dim1 + pv.coord[1]) * pv.nb + ib_local % pv.nb;
+    const int block_size = pv.get_block_size();
+    return (ib_local / block_size * pv.get_dim1() + pv.get_coord_col()) * block_size + ib_local % block_size;
 }
 
 int local_wfc_col_to_global(const int ib_local, const Parallel_Orbitals& pv, const bool coeff_columns_are_basis)

--- a/source/source_lcao/module_extrap/wf_orthonormalize_lcao.cpp
+++ b/source/source_lcao/module_extrap/wf_orthonormalize_lcao.cpp
@@ -1,0 +1,230 @@
+#include "source_lcao/module_extrap/wf_orthonormalize_lcao.h"
+
+#include "source_base/module_external/blas_connector.h"
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace ModuleExtrap
+{
+namespace
+{
+
+inline std::size_t idx(const int row, const int col, const int ncol) noexcept
+{
+    return static_cast<std::size_t>(row) * static_cast<std::size_t>(ncol) + static_cast<std::size_t>(col);
+}
+
+void build_overlap_in_band_space(const double* overlap,
+                                 const double* coeff,
+                                 const int nbands,
+                                 const int nbasis,
+                                 std::vector<double>& metric)
+{
+    metric.assign(static_cast<std::size_t>(nbands) * static_cast<std::size_t>(nbands), 0.0);
+    std::vector<double> coeff_s(static_cast<std::size_t>(nbands) * static_cast<std::size_t>(nbasis), 0.0);
+
+    const double one = 1.0;
+    const double zero = 0.0;
+
+    // Coefficients are stored as a row-major band-by-basis matrix X.  With the
+    // current row-major overlap S, the band-space metric is O = X S X^T.
+    BlasConnector::gemm('N',
+                        'N',
+                        nbands,
+                        nbasis,
+                        nbasis,
+                        one,
+                        coeff,
+                        nbasis,
+                        overlap,
+                        nbasis,
+                        zero,
+                        coeff_s.data(),
+                        nbasis);
+
+    BlasConnector::gemm('N',
+                        'T',
+                        nbands,
+                        nbands,
+                        nbasis,
+                        one,
+                        coeff_s.data(),
+                        nbasis,
+                        coeff,
+                        nbasis,
+                        zero,
+                        metric.data(),
+                        nbands);
+
+    // Remove tiny asymmetry introduced by BLAS roundoff before the Cholesky step.
+    for (int i = 0; i < nbands; ++i)
+    {
+        for (int j = 0; j < i; ++j)
+        {
+            const double value = 0.5 * (metric[idx(i, j, nbands)] + metric[idx(j, i, nbands)]);
+            metric[idx(i, j, nbands)] = value;
+            metric[idx(j, i, nbands)] = value;
+        }
+    }
+}
+
+bool cholesky_lower_in_place(std::vector<double>& metric, const int n, const double pivot_threshold)
+{
+    for (int j = 0; j < n; ++j)
+    {
+        double diag = metric[idx(j, j, n)];
+        for (int k = 0; k < j; ++k)
+        {
+            const double ljk = metric[idx(j, k, n)];
+            diag -= ljk * ljk;
+        }
+
+        if (!(diag > pivot_threshold) || !std::isfinite(diag))
+        {
+            return false;
+        }
+
+        const double ljj = std::sqrt(diag);
+        metric[idx(j, j, n)] = ljj;
+
+        for (int i = j + 1; i < n; ++i)
+        {
+            double value = metric[idx(i, j, n)];
+            for (int k = 0; k < j; ++k)
+            {
+                value -= metric[idx(i, k, n)] * metric[idx(j, k, n)];
+            }
+            metric[idx(i, j, n)] = value / ljj;
+        }
+
+        for (int k = j + 1; k < n; ++k)
+        {
+            metric[idx(j, k, n)] = 0.0;
+        }
+    }
+    return true;
+}
+
+void apply_inverse_cholesky_left(const std::vector<double>& lower,
+                                 double* coeff,
+                                 const int nbands,
+                                 const int nbasis)
+{
+    std::vector<double> column(static_cast<std::size_t>(nbands), 0.0);
+
+    // Solve L * C_new(:,mu) = C_old(:,mu) for every basis function mu.
+    for (int mu = 0; mu < nbasis; ++mu)
+    {
+        for (int ib = 0; ib < nbands; ++ib)
+        {
+            double value = coeff[idx(ib, mu, nbasis)];
+            for (int jb = 0; jb < ib; ++jb)
+            {
+                value -= lower[idx(ib, jb, nbands)] * column[jb];
+            }
+            column[ib] = value / lower[idx(ib, ib, nbands)];
+        }
+
+        for (int ib = 0; ib < nbands; ++ib)
+        {
+            coeff[idx(ib, mu, nbasis)] = column[ib];
+        }
+    }
+}
+
+double max_orthonormality_deviation(const double* overlap,
+                                    const double* coeff,
+                                    const int nbands,
+                                    const int nbasis)
+{
+    std::vector<double> metric;
+    build_overlap_in_band_space(overlap, coeff, nbands, nbasis, metric);
+
+    double max_dev = 0.0;
+    for (int i = 0; i < nbands; ++i)
+    {
+        for (int j = 0; j < nbands; ++j)
+        {
+            const double expected = (i == j) ? 1.0 : 0.0;
+            max_dev = std::max(max_dev, std::abs(metric[idx(i, j, nbands)] - expected));
+        }
+    }
+    return max_dev;
+}
+
+} // namespace
+
+WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
+                                                   psi::Psi<double>& wfc,
+                                                   const double pivot_threshold,
+                                                   const double check_tolerance)
+{
+    WfOrthonormalizeResult result;
+
+    if (overlap == nullptr || !(pivot_threshold >= 0.0) || !(check_tolerance > 0.0))
+    {
+        result.status = WfcExtrapStatus::InvalidInput;
+        return result;
+    }
+
+    const int nstate = wfc.get_nk();
+    const int nbands = wfc.get_nbands();
+    const int nbasis = wfc.get_nbasis();
+
+    if (nstate <= 0 || nbands <= 0 || nbasis <= 0 || nbands > nbasis)
+    {
+        result.status = WfcExtrapStatus::DimensionMismatch;
+        return result;
+    }
+
+    if (!wfc.get_k_first())
+    {
+        result.status = WfcExtrapStatus::Unsupported;
+        return result;
+    }
+
+    // Operate on a full owned copy first.  The caller's Psi is overwritten only after
+    // all state/spin channels pass the positive-definiteness and residual checks.
+    std::vector<double> trial(wfc.size(), 0.0);
+    const double* coeff_begin = wfc.get_pointer() - wfc.get_psi_bias();
+    std::copy(coeff_begin, coeff_begin + wfc.size(), trial.begin());
+
+    double max_deviation_all = 0.0;
+    for (int istate = 0; istate < nstate; ++istate)
+    {
+        double* coeff = trial.data()
+                      + static_cast<std::size_t>(istate) * static_cast<std::size_t>(nbands)
+                            * static_cast<std::size_t>(nbasis);
+
+        std::vector<double> metric;
+        build_overlap_in_band_space(overlap, coeff, nbands, nbasis, metric);
+
+        if (!cholesky_lower_in_place(metric, nbands, pivot_threshold))
+        {
+            result.status = WfcExtrapStatus::OrthogonalizationFailed;
+            result.failed_state = istate;
+            return result;
+        }
+
+        apply_inverse_cholesky_left(metric, coeff, nbands, nbasis);
+
+        const double max_dev = max_orthonormality_deviation(overlap, coeff, nbands, nbasis);
+        if (!std::isfinite(max_dev) || max_dev > check_tolerance)
+        {
+            result.status = WfcExtrapStatus::OrthogonalizationFailed;
+            result.failed_state = istate;
+            result.max_deviation = max_dev;
+            return result;
+        }
+        max_deviation_all = std::max(max_deviation_all, max_dev);
+    }
+
+    wfc.set_all_psi(trial.data(), trial.size());
+    result.status = WfcExtrapStatus::Success;
+    result.max_deviation = max_deviation_all;
+    return result;
+}
+
+} // namespace ModuleExtrap

--- a/source/source_lcao/module_extrap/wf_orthonormalize_lcao.h
+++ b/source/source_lcao/module_extrap/wf_orthonormalize_lcao.h
@@ -2,6 +2,7 @@
 #define SOURCE_LCAO_MODULE_EXTRAP_WF_ORTHONORMALIZE_LCAO_H
 
 #include "source_lcao/module_extrap/wf_extrap_method.h"
+#include "source_basis/module_ao/parallel_orbitals.h"
 #include "source_base/matrix.h"
 #include "source_psi/psi.h"
 
@@ -55,11 +56,15 @@ struct WfOrthonormalizeResult
  * contribute to DMK/DMR/rho and orthonormalizing them can make the metric nearly
  * singular when all basis-sized bands are present.
  *
- * This is a dense serial utility for the first use_prev_wf implementation.  The
- * distributed/k-point path should be implemented separately instead of silently
- * reusing this routine for block-cyclic matrices.
+ * The implementation is MPI-aware for the Gamma-only block-cyclic NAO layout.
+ * It assembles dense global work matrices from distributed local blocks, performs
+ * the small Cholesky transformation redundantly on all ranks, and scatters the
+ * transformed coefficients back to the local Psi layout.  This favors correctness
+ * and a simple reviewable backend over peak performance; a future optimized path
+ * can replace the dense work arrays with fully distributed PBLAS operations.
  */
 WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
+                                                   const Parallel_Orbitals& pv,
                                                    psi::Psi<double>& wfc,
                                                    const ModuleBase::matrix& occupations,
                                                    double occupation_threshold = 1.0e-12,

--- a/source/source_lcao/module_extrap/wf_orthonormalize_lcao.h
+++ b/source/source_lcao/module_extrap/wf_orthonormalize_lcao.h
@@ -1,7 +1,7 @@
 #ifndef SOURCE_LCAO_MODULE_EXTRAP_WF_ORTHONORMALIZE_LCAO_H
 #define SOURCE_LCAO_MODULE_EXTRAP_WF_ORTHONORMALIZE_LCAO_H
 
-#include "source_lcao/module_extrap/wf_extrap_method.h"
+#include "source_lcao/module_extrap/wf_extrap_status.h"
 #include "source_basis/module_ao/parallel_orbitals.h"
 #include "source_base/matrix.h"
 #include "source_psi/psi.h"
@@ -67,9 +67,9 @@ WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
                                                    const Parallel_Orbitals& pv,
                                                    psi::Psi<double>& wfc,
                                                    const ModuleBase::matrix& occupations,
-                                                   double occupation_threshold = 1.0e-12,
-                                                   double pivot_threshold = 1.0e-14,
-                                                   double check_tolerance = 1.0e-8);
+                                                   double occupation_threshold,
+                                                   double pivot_threshold,
+                                                   double check_tolerance);
 
 } // namespace ModuleExtrap
 

--- a/source/source_lcao/module_extrap/wf_orthonormalize_lcao.h
+++ b/source/source_lcao/module_extrap/wf_orthonormalize_lcao.h
@@ -2,6 +2,7 @@
 #define SOURCE_LCAO_MODULE_EXTRAP_WF_ORTHONORMALIZE_LCAO_H
 
 #include "source_lcao/module_extrap/wf_extrap_method.h"
+#include "source_base/matrix.h"
 #include "source_psi/psi.h"
 
 namespace ModuleExtrap
@@ -11,7 +12,21 @@ struct WfOrthonormalizeResult
 {
     WfcExtrapStatus status = WfcExtrapStatus::Success;
     double max_deviation = 0.0;
+
+    // Diagnostics for orthogonalization failures.  These values are kept in the
+    // result object so that the ESolver layer can print them without exposing
+    // implementation details of the orthonormalization helper.
+    double failed_pivot = 0.0;
+    double min_metric_diag = 0.0;
+    double max_metric_diag = 0.0;
+    double max_metric_abs = 0.0;
+    double max_metric_asymmetry = 0.0;
     int failed_state = -1;
+    int failed_pivot_index = -1;
+    int nstate = 0;
+    int nbands = 0;
+    int nbasis = 0;
+    int nactive_bands = 0;
 
     bool ok() const noexcept
     {
@@ -35,12 +50,19 @@ struct WfOrthonormalizeResult
  * k-points.  This routine therefore treats the first Psi dimension as a generic
  * state/channel index.
  *
+ * Only bands with non-negligible occupation are reorthonormalized.  For the
+ * initial-density use case of use_prev_wf, completely unoccupied bands do not
+ * contribute to DMK/DMR/rho and orthonormalizing them can make the metric nearly
+ * singular when all basis-sized bands are present.
+ *
  * This is a dense serial utility for the first use_prev_wf implementation.  The
  * distributed/k-point path should be implemented separately instead of silently
  * reusing this routine for block-cyclic matrices.
  */
 WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
                                                    psi::Psi<double>& wfc,
+                                                   const ModuleBase::matrix& occupations,
+                                                   double occupation_threshold = 1.0e-12,
                                                    double pivot_threshold = 1.0e-14,
                                                    double check_tolerance = 1.0e-8);
 

--- a/source/source_lcao/module_extrap/wf_orthonormalize_lcao.h
+++ b/source/source_lcao/module_extrap/wf_orthonormalize_lcao.h
@@ -1,0 +1,49 @@
+#ifndef SOURCE_LCAO_MODULE_EXTRAP_WF_ORTHONORMALIZE_LCAO_H
+#define SOURCE_LCAO_MODULE_EXTRAP_WF_ORTHONORMALIZE_LCAO_H
+
+#include "source_lcao/module_extrap/wf_extrap_method.h"
+#include "source_psi/psi.h"
+
+namespace ModuleExtrap
+{
+
+struct WfOrthonormalizeResult
+{
+    WfcExtrapStatus status = WfcExtrapStatus::Success;
+    double max_deviation = 0.0;
+    int failed_state = -1;
+
+    bool ok() const noexcept
+    {
+        return this->status == WfcExtrapStatus::Success;
+    }
+};
+
+/**
+ * Reorthonormalize Gamma-only NAO wavefunctions with the current overlap matrix.
+ *
+ * The input wavefunction coefficients are assumed to be stored as band-major rows,
+ * i.e. C(iband, ibasis) for the current Gamma/spin channel.  For each channel this
+ * routine computes
+ *
+ *     O = C S C^T
+ *
+ * and applies a Cholesky-based transformation C_new = L^{-1} C, where O = L L^T.
+ * Thus the updated coefficients satisfy C_new S C_new^T = I up to numerical noise.
+ *
+ * In Gamma-only LCAO, Psi::get_nk() may label spin channels rather than physical
+ * k-points.  This routine therefore treats the first Psi dimension as a generic
+ * state/channel index.
+ *
+ * This is a dense serial utility for the first use_prev_wf implementation.  The
+ * distributed/k-point path should be implemented separately instead of silently
+ * reusing this routine for block-cyclic matrices.
+ */
+WfOrthonormalizeResult reorthonormalize_gamma_lcao(const double* overlap,
+                                                   psi::Psi<double>& wfc,
+                                                   double pivot_threshold = 1.0e-14,
+                                                   double check_tolerance = 1.0e-8);
+
+} // namespace ModuleExtrap
+
+#endif // SOURCE_LCAO_MODULE_EXTRAP_WF_ORTHONORMALIZE_LCAO_H

--- a/source/source_lcao/module_extrap/wf_snapshot_lcao.h
+++ b/source/source_lcao/module_extrap/wf_snapshot_lcao.h
@@ -1,0 +1,81 @@
+#ifndef SOURCE_LCAO_MODULE_EXTRAP_WF_SNAPSHOT_LCAO_H
+#define SOURCE_LCAO_MODULE_EXTRAP_WF_SNAPSHOT_LCAO_H
+
+#include "source_base/matrix.h"
+#include "source_psi/psi.h"
+
+#include <cstddef>
+#include <vector>
+
+namespace ModuleExtrap
+{
+
+template <typename TK>
+struct WfSnapshotLCAO
+{
+    int istep = -1;
+    int nstate = 0;
+    int nbands = 0;
+    int nbasis = 0;
+    bool k_first = true;
+
+    std::vector<TK> coeff;
+    ModuleBase::matrix wg;
+
+    WfSnapshotLCAO() = default;
+
+    WfSnapshotLCAO(const int istep_in, const psi::Psi<TK>& psi_in, const ModuleBase::matrix& wg_in)
+    {
+        this->save(istep_in, psi_in, wg_in);
+    }
+
+    void save(const int istep_in, const psi::Psi<TK>& psi_in, const ModuleBase::matrix& wg_in)
+    {
+        this->istep = istep_in;
+        this->nstate = psi_in.get_nk();
+        this->nbands = psi_in.get_nbands();
+        this->nbasis = psi_in.get_nbasis();
+        this->k_first = psi_in.get_k_first();
+        this->wg = wg_in;
+
+        // Psi::get_pointer() returns the pointer at the current fix_k()/fix_b() position.
+        // Subtract psi_bias to copy the full owned coefficient array from its real beginning.
+        const TK* coeff_begin = psi_in.get_pointer() - psi_in.get_psi_bias();
+        this->coeff.assign(coeff_begin, coeff_begin + psi_in.size());
+    }
+
+    bool empty() const noexcept
+    {
+        return this->coeff.empty();
+    }
+
+    std::size_t size() const noexcept
+    {
+        return this->coeff.size();
+    }
+
+    bool compatible_with(const psi::Psi<TK>& psi_now, const ModuleBase::matrix& wg_now) const noexcept
+    {
+        return this->nstate == psi_now.get_nk()
+            && this->nbands == psi_now.get_nbands()
+            && this->nbasis == psi_now.get_nbasis()
+            && this->k_first == psi_now.get_k_first()
+            && this->coeff.size() == psi_now.size()
+            && this->wg.nr == wg_now.nr
+            && this->wg.nc == wg_now.nc;
+    }
+
+    bool load_to(psi::Psi<TK>& psi_out) const
+    {
+        if (this->coeff.size() != psi_out.size())
+        {
+            return false;
+        }
+        psi_out.set_all_psi(this->coeff.data(), this->coeff.size());
+        return true;
+    }
+};
+
+} // namespace ModuleExtrap
+
+#endif // SOURCE_LCAO_MODULE_EXTRAP_WF_SNAPSHOT_LCAO_H

--- a/source/source_lcao/module_operator_lcao/CMakeLists.txt
+++ b/source/source_lcao/module_operator_lcao/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
     operator_ks_lcao
     OBJECT
+    operator_lcao.cpp
     op_exx_lcao.cpp
     op_dftu_lcao.cpp
     meta_lcao.cpp

--- a/tests/02_NAO_Gamma/CASES_CPU.txt
+++ b/tests/02_NAO_Gamma/CASES_CPU.txt
@@ -10,6 +10,7 @@ md_out_hk_syns
 md_out_hk_spin2
 relax_bfgs2
 relax_cell
+relax_wfc_extrap
 relax_old_cg
 relax_out_hk
 relax_out_hk_spin2

--- a/tests/02_NAO_Gamma/relax_wfc_extrap/INPUT
+++ b/tests/02_NAO_Gamma/relax_wfc_extrap/INPUT
@@ -1,0 +1,31 @@
+INPUT_PARAMETERS
+#Parameters	(General)
+suffix            autotest
+pseudo_dir        ../../PP_ORB
+orbital_dir       ../../PP_ORB
+
+nbands            8
+calculation       cell-relax
+#Parameters (Accuracy)
+ecutwfc           20
+scf_nmax          20
+
+basis_type        lcao
+
+cal_stress        1
+stress_thr        0.5
+cal_force         1
+force_thr_ev      0.02
+
+ks_solver         scalapack_gvx
+mixing_type       broyden
+mixing_beta       0.7
+
+gamma_only        1
+
+relax_method      cg
+relax_new         1
+relax_nmax        3
+relax_scale_force  0.4
+
+wfc_extrap       use_prev_wf

--- a/tests/02_NAO_Gamma/relax_wfc_extrap/INPUT
+++ b/tests/02_NAO_Gamma/relax_wfc_extrap/INPUT
@@ -23,8 +23,7 @@ mixing_beta       0.7
 
 gamma_only        1
 
-relax_method      cg
-relax_new         1
+relax_method      cg 2
 relax_nmax        3
 relax_scale_force  0.4
 

--- a/tests/02_NAO_Gamma/relax_wfc_extrap/KPT
+++ b/tests/02_NAO_Gamma/relax_wfc_extrap/KPT
@@ -1,0 +1,4 @@
+K_POINTS
+0
+Gamma
+1 1 1 0 0 0

--- a/tests/02_NAO_Gamma/relax_wfc_extrap/README
+++ b/tests/02_NAO_Gamma/relax_wfc_extrap/README
@@ -1,0 +1,1 @@
+Gamma-only NAO cell relaxation using the previous-step WFN history.

--- a/tests/02_NAO_Gamma/relax_wfc_extrap/STRU
+++ b/tests/02_NAO_Gamma/relax_wfc_extrap/STRU
@@ -1,0 +1,21 @@
+ATOMIC_SPECIES
+Si 1.000 Si_ONCV_PBE-1.0.upf 	#Element, Mass, Pseudopotential
+
+NUMERICAL_ORBITAL
+Si_gga_8au_60Ry_2s2p1d.orb
+
+LATTICE_CONSTANT
+10.21  			#Lattice constant
+
+LATTICE_VECTORS
+0.0 0.5 0.5 		#Lattice vector 1
+0.5 0.0 0.5 		#Lattice vector 2
+0.5 0.5 0.0 		#Lattice vector 3
+
+ATOMIC_POSITIONS
+Cartesian 	#Cartesian(Unit is LATTICE_CONSTANT)
+Si 			#Name of element
+0.0			#Magnetic for this element.
+2			#Number of atoms
+0.00 0.00 0.00 1 1 1	#x,y,z, move_x, move_y, move_z
+0.25 0.25 0.25 1 1 1

--- a/tests/02_NAO_Gamma/relax_wfc_extrap/result.ref
+++ b/tests/02_NAO_Gamma/relax_wfc_extrap/result.ref
@@ -1,0 +1,5 @@
+etotref -204.8271192180719709
+etotperatomref -102.4135596090
+totalforceref 0.000000
+totalstressref 55.075710
+totaltimeref 0.52


### PR DESCRIPTION
This PR introduces an optional WFN-based initialization path for NAO calculations.

A new `wfc_extrap use_prev_wf` path is added. It stores the converged wavefunction from the previous ionic step, rebuilds the current overlap matrix, reorthonormalizes the previous wavefunction with the current overlap matrix, and then reconstructs the density matrix and charge density before entering the normal SCF cycle. When this path is enabled, the existing charge-density extrapolation is skipped, so the initial density is generated from the WFN-history backend instead of being extrapolated directly in real space.

The implementation currently focuses on the Gamma-only backend, including MPI-distributed matrices. This is intended as a common backend for future improvements and more WFN-based predictors such as ASPC and [GExt_PROJ](https://github.com/cp2k/cp2k/pull/5043).

Here's a simple test that shows the accuracy and effectiveness of the WFN-based path: [test.zip](https://github.com/user-attachments/files/28662082/test.zip). The regtesting is left for a next commit.

Still missing:
- [ ] Try take a look if we can further reduce the complication of code.
- [ ] Documentation mention.

What's planned in the future:
- Support for k-points: the case would be more complicated because the backend has to handle complex per-k wavefunctions, k-dependent overlap matrices $S(k)$, local/global k-point ownership, density-matrix reconstruction from all k-points, and PBC phase or convention corrections between ionic steps.

<details>

### Linked Issue
None

### Unit Tests and/or Case Tests for my changes
- Unittest is added in the new minor module
- Regtest: ‎`02_NAO_Gamma/relax_wfc_extrap`

### Exact Verification Performed
- Commands run:
- Result summary:
- Checks not run, with reason:

### What's changed?
- See above.
### Governance Checklist
- Global dependencies: no net increase in `GlobalV`, `GlobalC`, or `PARAM` code references, or exception requested below with reason, scope, risk, and cleanup plan.
- Default parameters: no new default arguments added to existing interfaces, or exception requested below.
- Headers: no unnecessary header dependencies or `.hpp` propagation, or rationale provided below.
- Line endings: text files use LF; only `.bat` and `.cmd` use CRLF.
- Build linkage: new source files are listed in the relevant `source/CMakeLists.txt`, or rationale provided below.
- Documentation: behavior/interface changes include documentation updates [TODO]
- CodeRabbit: if automatic review has not started and the repository has CodeRabbit installed, request `@coderabbitai review`.

### INPUT Parameter Changes
- Parameters added/removed/changed: `wfc_extrap none/use_prev_wf`
- `docs/parameters.yaml` updated: not yet
- `docs/advanced/input_files/input-main.md` updated: not yet
- If not updated, explain why no INPUT documentation update is required:

### Core Module Impact
- Affected core modules: module_lcao
- Risk summary: No risks since this is a new minor module
- Compatibility or performance impact:

### Governance Exception
- Rule:
- Reason:
- Scope:
- User or maintenance risk:
- Why the normal rule cannot be followed now:
- Follow-up cleanup plan:
- Requested approver:

</details>