### PR TITLE
fix(abacus-plot): fix reshape parameter and PDOS plotting issues

### DIFF
--- a/tools/plot-tools/abacus_plot/dos.py
+++ b/tools/plot-tools/abacus_plot/dos.py
@@ -248,7 +248,7 @@ class PDOS(DOS):
             orb['data'] = np.asarray(data, dtype=float)
             self.orbitals.append(orb)
 
-        self.energy = np.reshape(e_list, newshape=(-1, 1)).astype(float)
+        self.energy = np.reshape(e_list, (-1, 1)).astype(float)
 
     def _all_sum(self) -> Tuple[np.ndarray, int]:
         res = np.zeros_like(self.orbitals[0]["data"], dtype=float)
@@ -423,9 +423,9 @@ class PDOS(DOS):
                                       dosplot.plot_params["xlabel_params"])
             else:
                 dosplot.ax.set_xlabel("Energy(eV)", size=25)
-            dosplot.ax = self._plot(dosplot, energy_f, tdos, "TDOS")
+            self._plot(dosplot, energy_f, tdos, "TDOS")
             for elem in dos.keys():
-                dosplot.ax = self._plot(dosplot, energy_f, dos[elem], elem)
+                self._plot(dosplot, energy_f, dos[elem], elem)
             if "notes" in dosplot.plot_params.keys():
                 dosplot._set_figure(energy_range, dos_range,
                                     notes=dosplot.plot_params["notes"])


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #6864

### Unit Tests and/or Case Tests for my changes
No additional tests required. These are simple Python code fixes.

### What's changed?
- Fix `np.reshape()` call in `PDOS._read()` method: remove invalid `newshape` keyword argument that causes TypeError in newer numpy versions
- Fix PDOS plotting in `_parial_plot()` method: remove unnecessary reassignment of `dosplot.ax` after `_plot()` calls, which caused AttributeError when `dosplot.ax` was incorrectly assigned

### Any changes of core modules? (ignore if not applicable)
No changes to core modules. The modifications are only in the `tools/plot-tools/abacus_plot/dos.py` Python script.