### PR TITLE
fix(debug): remove incorrect assert for nullptr in Overlap and EKinet…

### DIFF
--- a/source/source_lcao/module_operator_lcao/ekinetic.cpp
+++ b/source/source_lcao/module_operator_lcao/ekinetic.cpp
@@ -22,7 +22,6 @@ hamilt::EKinetic<hamilt::OperatorLCAO<TK, TR>>::EKinetic(
     this->ucell = ucell_in;
 #ifdef __DEBUG
     assert(this->ucell != nullptr);
-    assert(this->hsk != nullptr);
 #endif
     // initialize HR to allocate sparse Ekinetic matrix memory
     // Only initialize if hR_in is not nullptr (for force calculation, hR_in can be nullptr)

--- a/source/source_lcao/module_operator_lcao/overlap.cpp
+++ b/source/source_lcao/module_operator_lcao/overlap.cpp
@@ -106,7 +106,6 @@ hamilt::Overlap<hamilt::OperatorLCAO<TK, TR>>::Overlap(HS_Matrix_K<TK>* hsk_in,
     this->SR = SR_in;
 #ifdef __DEBUG
     assert(this->ucell != nullptr);
-    assert(this->SR != nullptr);
 #endif
     // Initialize SR to allocate sparse overlap matrix memory.
     // Only initialize if SR_in is not nullptr (for force calculation, SR_in can be nullptr).


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #7021

### Unit Tests and/or Case Tests for my changes
No additional tests required. This is a simple fix removing incorrect assert statements.

### What's changed?
- Remove `assert(this->SR != nullptr)` in Overlap constructor
- Remove `assert(this->hsk != nullptr)` in EKinetic constructor
- These pointers can be nullptr in normal operation (e.g., for force calculation), so the assert was incorrectly triggering when `-DDEBUG_INFO=ON`

### Any changes of core modules? (ignore if not applicable)
No changes to core modules. Only removed incorrect assert statements in constructors