### PR TITLE
[Fix] Raise `WARNING QUIT` while setting `kpar>1` and `use_k_continuity=1` at the same time

### DIFF
--- a/source/source_io/module_parameter/read_input_item_elec_stru.cpp
+++ b/source/source_io/module_parameter/read_input_item_elec_stru.cpp
@@ -1085,6 +1085,9 @@ Use case: When experimental or high-level theoretical results suggest that the S
             if (para.input.use_k_continuity && para.input.calculation == "nscf") {
                 ModuleBase::WARNING_QUIT("ReadInput", "use_k_continuity cannot work for NSCF calculation");
             }
+            if (para.input.use_k_continuity && para.input.kpar > 1) {
+                ModuleBase::WARNING_QUIT("ReadInput", "use_k_continuity cannot work for k-point parallel calculation");
+            }
             if (para.input.use_k_continuity && para.input.nspin == 2) {
                 ModuleBase::WARNING_QUIT("ReadInput", "use_k_continuity cannot work for spin-polarized calculation");
             }


### PR DESCRIPTION
### Linked Issue
Fix #7398 .

### Unit Tests and/or Case Tests for my changes
- No unit test is added up to now.

### Any changes of core modules? (ignore if not applicable)
- No