### PR TITLE
Update version to v3.11.0-beta.4

### DIFF
--- a/source/source_main/version.h
+++ b/source/source_main/version.h
@@ -1,3 +1,3 @@
 #ifndef VERSION
-#define VERSION "v3.11.0-beta.3"
+#define VERSION "v3.11.0-beta.4"
 #endif


### PR DESCRIPTION
Bump version to v3.11.0-beta.4 for tagging the next pre-release.

Includes the 25 PRs merged since v3.11.0-beta.3 (#7418 .. #7438).