### PR TITLE
fix: C++11 compatibility - replace structured bindings with iterator …

### DIFF
--- a/source/source_base/parallel_2d.h
+++ b/source/source_base/parallel_2d.h
@@ -74,7 +74,44 @@ class Parallel_2D
         return nb;
     };
 
+    /// number of processes in row dimension of the MPI Cartesian grid
+    int get_dim0() const
+    {
+        return dim0;
+    };
+
+    /// number of processes in column dimension of the MPI Cartesian grid
+    int get_dim1() const
+    {
+        return dim1;
+    };
+
+    /// row coordinate in the BLACS grid
+    int get_coord_row() const
+    {
+        return coord[0];
+    };
+
+    /// column coordinate in the BLACS grid
+    int get_coord_col() const
+    {
+        return coord[1];
+    };
+
+    /// whether the parallelization is in serial mode
+    bool get_is_serial() const
+    {
+        return is_serial;
+    };
+
 #ifdef __MPI
+
+    /// ScaLAPACK descriptor
+    const int* get_desc() const
+    {
+        return desc;
+    };
+
     /**
      * @brief Initialize a BLACS grid with the given MPI communicator
      * and set up the info of a block-cyclic distribution.

--- a/source/source_base/parallel_reduce.cpp
+++ b/source/source_base/parallel_reduce.cpp
@@ -4,23 +4,119 @@
 
 #include <vector>
 
-template <>
-void Parallel_Reduce::reduce_all<int>(int& object)
+#ifdef __MPI
+const MPI_Datatype Parallel_Reduce::MPI_Type<int>::value = MPI_INT;
+const MPI_Datatype Parallel_Reduce::MPI_Type<double>::value = MPI_DOUBLE;
+const MPI_Datatype Parallel_Reduce::MPI_Type<float>::value = MPI_FLOAT;
+const MPI_Datatype Parallel_Reduce::MPI_Type<std::complex<double>>::value = MPI_DOUBLE_COMPLEX;
+const MPI_Datatype Parallel_Reduce::MPI_Type<std::complex<float>>::value = MPI_C_FLOAT_COMPLEX;
+const MPI_Datatype Parallel_Reduce::MPI_Type<long long>::value = MPI_LONG_LONG;
+#endif
+
+template <typename T>
+void Parallel_Reduce::reduce_all(T& object)
 {
 #ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_Type<T>::value, MPI_SUM, MPI_COMM_WORLD);
 #endif
-    return;
 }
 
-template <>
-void Parallel_Reduce::reduce_all<long long>(long long& object)
+template <typename T>
+void Parallel_Reduce::reduce_all(T* object, const int n)
 {
 #ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_Type<T>::value, MPI_SUM, MPI_COMM_WORLD);
 #endif
-    return;
 }
+
+template <typename T>
+void Parallel_Reduce::reduce_pool(T& object)
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_Type<T>::value, MPI_SUM, POOL_WORLD);
+#endif
+}
+
+template <typename T>
+void Parallel_Reduce::reduce_pool(T* object, const int n)
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_Type<T>::value, MPI_SUM, POOL_WORLD);
+#endif
+}
+
+template <typename T>
+void Parallel_Reduce::reduce_min(T& v)
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_Type<T>::value, MPI_MIN, MPI_COMM_WORLD);
+#endif
+}
+
+template <typename T>
+void Parallel_Reduce::reduce_max(T& v)
+{
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_Type<T>::value, MPI_MAX, MPI_COMM_WORLD);
+#endif
+}
+
+template <typename T>
+void Parallel_Reduce::reduce_min_pool(const int& nproc_in_pool, T& v)
+{
+    if (nproc_in_pool == 1)
+    {
+        return;
+    }
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_Type<T>::value, MPI_MIN, POOL_WORLD);
+#endif
+}
+
+template <typename T>
+void Parallel_Reduce::reduce_max_pool(const int& nproc_in_pool, T& v)
+{
+    if (nproc_in_pool == 1)
+    {
+        return;
+    }
+#ifdef __MPI
+    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_Type<T>::value, MPI_MAX, POOL_WORLD);
+#endif
+}
+
+template void Parallel_Reduce::reduce_all<int>(int&);
+template void Parallel_Reduce::reduce_all<double>(double&);
+template void Parallel_Reduce::reduce_all<float>(float&);
+template void Parallel_Reduce::reduce_all<std::complex<double>>(std::complex<double>&);
+template void Parallel_Reduce::reduce_all<std::complex<float>>(std::complex<float>&);
+template void Parallel_Reduce::reduce_all<long long>(long long&);
+
+template void Parallel_Reduce::reduce_all<int>(int*, const int);
+template void Parallel_Reduce::reduce_all<double>(double*, const int);
+template void Parallel_Reduce::reduce_all<float>(float*, const int);
+template void Parallel_Reduce::reduce_all<std::complex<double>>(std::complex<double>*, const int);
+template void Parallel_Reduce::reduce_all<std::complex<float>>(std::complex<float>*, const int);
+template void Parallel_Reduce::reduce_all<long long>(long long*, const int);
+
+template void Parallel_Reduce::reduce_pool<float>(float&);
+template void Parallel_Reduce::reduce_pool<double>(double&);
+template void Parallel_Reduce::reduce_pool<std::complex<double>>(std::complex<double>&);
+
+template void Parallel_Reduce::reduce_pool<int>(int*, const int);
+template void Parallel_Reduce::reduce_pool<double>(double*, const int);
+template void Parallel_Reduce::reduce_pool<std::complex<float>>(std::complex<float>*, const int);
+template void Parallel_Reduce::reduce_pool<std::complex<double>>(std::complex<double>*, const int);
+
+template void Parallel_Reduce::reduce_min<int>(int&);
+template void Parallel_Reduce::reduce_min<float>(float&);
+template void Parallel_Reduce::reduce_min<double>(double&);
+
+template void Parallel_Reduce::reduce_max<float>(float&);
+template void Parallel_Reduce::reduce_max<double>(double&);
+
+template void Parallel_Reduce::reduce_min_pool<double>(const int&, double&);
+template void Parallel_Reduce::reduce_max_pool<double>(const int&, double&);
 
 void Parallel_Reduce::reduce_int_diag(int& object)
 {
@@ -30,55 +126,10 @@ void Parallel_Reduce::reduce_int_diag(int& object)
     return;
 }
 
-template <>
-void Parallel_Reduce::reduce_all<double>(double& object)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
-#endif
-    return;
-}
-
-template <>
-void Parallel_Reduce::reduce_all<float>(float& object)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_FLOAT, MPI_SUM, MPI_COMM_WORLD);
-#endif
-    return;
-}
-
-template <>
-void Parallel_Reduce::reduce_all<int>(int* object, const int n)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
-#endif
-    return;
-}
-
-template <>
-void Parallel_Reduce::reduce_all<long long>(long long* object, const int n)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
-#endif
-    return;
-}
-
 void Parallel_Reduce::reduce_int_grid(int* object, const int n)
 {
 #ifdef __MPI
     MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_SUM, GRID_WORLD);
-#endif
-    return;
-}
-
-template <>
-void Parallel_Reduce::reduce_all<double>(double* object, const int n)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
 #endif
     return;
 }
@@ -99,46 +150,9 @@ void Parallel_Reduce::reduce_double_diag(double* object, const int n)
     return;
 }
 
-template <>
-void Parallel_Reduce::reduce_pool<float>(float& object)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_FLOAT, MPI_SUM, POOL_WORLD);
-#endif
-    return;
-}
-
-template <>
-void Parallel_Reduce::reduce_pool<double>(double& object)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE, MPI_SUM, POOL_WORLD);
-#endif
-    return;
-}
-
-template <>
-void Parallel_Reduce::reduce_pool<int>(int* object, const int n)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_INT, MPI_SUM, POOL_WORLD);
-#endif
-}
-
-template <>
-void Parallel_Reduce::reduce_pool<double>(double* object, const int n)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE, MPI_SUM, POOL_WORLD);
-#endif
-    return;
-}
-
-// (1) the value is same in each pool.
-// (2) we need to reduce the value from different pool.
 void Parallel_Reduce::reduce_double_allpool(const int& npool, const int& nproc_in_pool, double& object)
 {
-    if (npool == 1) 
+    if (npool == 1)
     {
         return;
     }
@@ -148,11 +162,9 @@ void Parallel_Reduce::reduce_double_allpool(const int& npool, const int& nproc_i
 #endif
 }
 
-// (1) the value is same in each pool.
-// (2) we need to reduce the value from different pool.
 void Parallel_Reduce::reduce_double_allpool(const int& npool, const int& nproc_in_pool, double* object, const int n)
 {
-    if (npool == 1) 
+    if (npool == 1)
     {
         return;
     }
@@ -166,72 +178,6 @@ void Parallel_Reduce::reduce_double_allpool(const int& npool, const int& nproc_i
 #endif
 }
 
-template <>
-void Parallel_Reduce::reduce_all<std::complex<double>>(std::complex<double>& object)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_COMM_WORLD);
-#endif
-    return;
-}
-
-// LiuXh add 2019-07-16
-template <>
-void Parallel_Reduce::reduce_all<std::complex<double>>(std::complex<double>* object, const int n)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_COMM_WORLD);
-#endif
-    return;
-}
-
-
-template <>
-void Parallel_Reduce::reduce_all<std::complex<float>>(std::complex<float>& object)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_C_FLOAT_COMPLEX, MPI_SUM, MPI_COMM_WORLD);
-#endif
-    return;
-}
-
-// LiuXh add 2019-07-16
-template <>
-void Parallel_Reduce::reduce_all<std::complex<float>>(std::complex<float>* object, const int n)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_C_FLOAT_COMPLEX, MPI_SUM, MPI_COMM_WORLD);
-#endif
-    return;
-}
-
-template <>
-void Parallel_Reduce::reduce_pool<std::complex<double>>(std::complex<double>& object)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &object, 1, MPI_DOUBLE_COMPLEX, MPI_SUM, POOL_WORLD);
-#endif
-    return;
-}
-
-template <>
-void Parallel_Reduce::reduce_pool<std::complex<float>>(std::complex<float>* object, const int n)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_C_FLOAT_COMPLEX, MPI_SUM, POOL_WORLD);
-#endif
-    return;
-}
-
-template <>
-void Parallel_Reduce::reduce_pool<std::complex<double>>(std::complex<double>* object, const int n)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, object, n, MPI_DOUBLE_COMPLEX, MPI_SUM, POOL_WORLD);
-#endif
-    return;
-}
-
 void Parallel_Reduce::gather_int_all(int& v, int* all)
 {
 #ifdef __MPI
@@ -239,67 +185,4 @@ void Parallel_Reduce::gather_int_all(int& v, int* all)
     MPI_Allgather(&v, 1, MPI_INT, all, 1, MPI_INT, MPI_COMM_WORLD);
 #endif
     return;
-}
-
-template <>
-void Parallel_Reduce::reduce_min<int>(int& v)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
-#endif
-}
-
-template <>
-void Parallel_Reduce::reduce_min<float>(float& v)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_FLOAT, MPI_MIN, MPI_COMM_WORLD);
-#endif
-}
-
-template <>
-void Parallel_Reduce::reduce_min<double>(double& v)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
-#endif
-}
-
-template <>
-void Parallel_Reduce::reduce_max<float>(float& v)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_FLOAT, MPI_MAX, MPI_COMM_WORLD);
-#endif
-}
-
-template <>
-void Parallel_Reduce::reduce_max<double>(double& v)
-{
-#ifdef __MPI
-    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
-#endif
-}
-
-template <>
-void Parallel_Reduce::reduce_max_pool<double>(const int& nproc_in_pool, double& v)
-{
-#ifdef __MPI
-    if (nproc_in_pool == 1) 
-    {
-        return;
-    }
-    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_DOUBLE, MPI_MAX, POOL_WORLD);
-#endif
-}
-template <>
-void Parallel_Reduce::reduce_min_pool<double>(const int& nproc_in_pool, double& v)
-{
-#ifdef __MPI
-    if (nproc_in_pool == 1) 
-    {
-        return;
-    }
-    MPI_Allreduce(MPI_IN_PLACE, &v, 1, MPI_DOUBLE, MPI_MIN, POOL_WORLD);
-#endif
 }

--- a/source/source_base/parallel_reduce.h
+++ b/source/source_base/parallel_reduce.h
@@ -8,10 +8,50 @@
 #include <cassert>
 #include <complex>
 
-// using std::complex;
-
 namespace Parallel_Reduce
 {
+
+#ifdef __MPI
+template <typename T>
+struct MPI_Type;
+
+template <>
+struct MPI_Type<int>
+{
+    static const MPI_Datatype value;
+};
+
+template <>
+struct MPI_Type<double>
+{
+    static const MPI_Datatype value;
+};
+
+template <>
+struct MPI_Type<float>
+{
+    static const MPI_Datatype value;
+};
+
+template <>
+struct MPI_Type<std::complex<double>>
+{
+    static const MPI_Datatype value;
+};
+
+template <>
+struct MPI_Type<std::complex<float>>
+{
+    static const MPI_Datatype value;
+};
+
+template <>
+struct MPI_Type<long long>
+{
+    static const MPI_Datatype value;
+};
+#endif
+
 /// reduce in all process
 template <typename T>
 void reduce_all(T& object);


### PR DESCRIPTION
…access

- Replace C++17 structured bindings in dspin_lcao.cpp with C++11-compatible iterator syntax
- Add getter methods to Parallel_2D class for better encapsulation

### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
