### PR TITLE
fix: C++11 compatibility - replace structured bindings with iterator …

### DIFF
--- a/source/source_lcao/module_operator_lcao/dspin_lcao.cpp
+++ b/source/source_lcao/module_operator_lcao/dspin_lcao.cpp
@@ -579,8 +579,10 @@ void hamilt::DeltaSpin<hamilt::OperatorLCAO<TK, TR>>::cal_PI_sub(
                                             + kvec_d.z * bi_ad.R_index.z);
             const std::complex<double> phase(cos(arg), sin(arg));
 
-            for (const auto& [iw_global, nlm_vec] : bi_ad.nlm)
+            for (const auto& nlm_pair : bi_ad.nlm)
             {
+                const int iw_global = nlm_pair.first;
+                const std::vector<double>& nlm_vec = nlm_pair.second;
                 // Check if this global orbital index is in our local rows
                 const int iw_local = this->paraV->global2local_row(iw_global);
                 if (iw_local < 0) { continue;


### PR DESCRIPTION
…access

Replace C++17 structured bindings in dspin_lcao.cpp with C++11-compatible iterator syntax to support C++11 compilation standard.

### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
