### PR TITLE
fix: correct Fourier transform sign in k→R density matrix transform

### DIFF
--- a/source/source_estate/module_dm/density_matrix.cpp
+++ b/source/source_estate/module_dm/density_matrix.cpp
@@ -110,13 +110,13 @@ void DensityMatrix_Tools::cal_DMR(
                 for(int ik = 0; ik < dm._nk; ++ik)
                 {
                     if(ik_in >= 0 && ik_in != ik) { continue; }
-                    // cal k_phase
-                    // if TK==std::complex<double>, kphase is e^{ikR}
+                    // Inverse Fourier transform: D(R) = (1/Nk) * sum_k D(k) * exp(-i*k*R)
+                    // See Sec. 3 of nao_lcao_force_stress_derivation.md
                     const ModuleBase::Vector3<double> dR(R_index[0], R_index[1], R_index[2]);
                     const double arg = (dm._kvec_d[ik] * dR) * ModuleBase::TWO_PI;
                     double sinp, cosp;
                     ModuleBase::libm::sincos(arg, &sinp, &cosp);
-                    kphase_vec[ik][iR] = TK(cosp, sinp);
+                    kphase_vec[ik][iR] = TK(cosp, -sinp);
                 }
             }
 
@@ -265,13 +265,13 @@ void DensityMatrix_Tools::cal_DMR_td(
                 for(int ik = 0; ik < dm._nk; ++ik)
                 {
                     if(ik_in >= 0 && ik_in != ik) { continue; }
-                    // cal k_phase
-                    // if TK==std::complex<double>, kphase is e^{ikR}
+                    // Inverse Fourier transform: D(R) = (1/Nk) * sum_k D(k) * exp(-i*k*R)
+                    // See Sec. 3 of nao_lcao_force_stress_derivation.md
                     const ModuleBase::Vector3<double> dR(R_index[0], R_index[1], R_index[2]);
                     const double arg = (dm._kvec_d[ik] * dR) * ModuleBase::TWO_PI;
                     double sinp, cosp;
                     ModuleBase::libm::sincos(arg, &sinp, &cosp);
-                    kphase_vec[ik][iR] = TK(cosp, sinp);
+                    kphase_vec[ik][iR] = TK(cosp, -sinp);
                     if(PARAM.inp.td_stype==2)
                     {
                         //phase for hybrid gauge tddft
@@ -422,13 +422,13 @@ void DensityMatrix_Tools::cal_DMR_full(
             for(int ik = 0; ik < dm._nk; ++ik)
             {
                 if(ik_in >= 0 && ik_in != ik) { continue; }
-                // cal k_phase
-                // if TK==std::complex<double>, kphase is e^{ikR}
-                const ModuleBase::Vector3<double> dR(R_index[0], R_index[1], R_index[2]);
+                // Inverse Fourier transform: D(R) = (1/Nk) * sum_k D(k) * exp(-i*k*R)
+                // See Sec. 3 of nao_lcao_force_stress_derivation.md
+                const ModuleBase::Vector3<double> dR(R_index.x, R_index.y, R_index.z);
                 const double arg = (dm._kvec_d[ik] * dR) * ModuleBase::TWO_PI;
                 double sinp, cosp;
                 ModuleBase::libm::sincos(arg, &sinp, &cosp);
-                kphase_vec[ik][iR] = TK(cosp, sinp);
+                kphase_vec[ik][iR] = TK(cosp, -sinp);
             }
         }
 

--- a/source/source_lcao/module_lr/dm_trans/dmr_complex.cpp
+++ b/source/source_lcao/module_lr/dm_trans/dmr_complex.cpp
@@ -43,13 +43,13 @@ namespace elecstate
                         for (int ik = 0; ik < this->_nk; ++ik)
                         {
                             if (ik_in >= 0 && ik_in != ik) continue;
-                            // cal k_phase
-                            // if TK==std::complex<double>, kphase is e^{ikR}
+                            // Inverse Fourier transform: D(R) = (1/Nk) * sum_k D(k) * exp(-i*k*R)
+                            // See Sec. 3 of nao_lcao_force_stress_derivation.md
                             const ModuleBase::Vector3<double> dR(r_index[0], r_index[1], r_index[2]);
                             const double arg = (this->_kvec_d[ik] * dR) * ModuleBase::TWO_PI;
                             double sinp = 0.0, cosp = 0.0;
                             ModuleBase::libm::sincos(arg, &sinp, &cosp);
-                            const std::complex<double> kphase = std::complex<double>(cosp, sinp);
+                            const std::complex<double> kphase = std::complex<double>(cosp, -sinp);
                             // set DMR element
                             std::complex<double>* tmp_DMR_pointer = tmp_matrix->get_pointer();
                             const std::complex<double>* tmp_DMK_pointer


### PR DESCRIPTION
The inverse Fourier transform from k-space to real-space density matrix used e^{+ikR} instead of the correct e^{-ikR} as specified in nao_lcao_force_stress_derivation.md Section 3.

This caused the stored DMR to be D_{μν}(-R) instead of the required trace-DM D̄_{μν}(R) = D_{νμ}(-R), leading to incorrect nonlocal pseudopotential forces for non-collinear (nspin=4) calculations with SOC.

Changes:
- density_matrix.cpp: Fix sign in cal_DMR(), cal_DMR_td(), cal_DMR_full() from TK(cosp, sinp) to TK(cosp, -sinp)
- dmr_complex.cpp: Fix sign in linear-response cal_DMR() specialization

Verified by Hermiticity check D(R) = D†(-R) at machine precision.

### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you added adequate unit tests and/or case tests for your pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### Unit Tests and/or Case Tests for my changes
- A unit test is added for each new feature or bug fix.

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
