### PR TITLE
fix: finite-temperature CT correction for CD potential, example/test adaptations, and documentation updates.

### DIFF
--- a/examples/35_tdofdft/01_Al_proton_ESP/02_td/INPUT
+++ b/examples/35_tdofdft/01_Al_proton_ESP/02_td/INPUT
@@ -36,6 +36,7 @@ md_restart	0
 md_type		nve
 md_nstep	4500
 md_dt		0.0005
+md_tfirst	0
 md_dumpfreq	1
 
 # Total charge: 256 Al * 3 valence electrons = 768

--- a/examples/35_tdofdft/README
+++ b/examples/35_tdofdft/README
@@ -5,13 +5,17 @@ Functional Theory (TDOFDFT) calculations in ABACUS.
 
 ## What is TDOFDFT?
 
-TDOFDFT extends OFDFT to the time domain by directly propagating the Madelung wavefunction. It is particularly suited for studying electronic stopping power (ESP) of warm dense matter (WDM), and other high-energy-density physics scenarios where the
+TDOFDFT extends OFDFT to the time domain by directly propagating the time-dependent
+Pauli-like equations. It is particularly suited for studying electronic stopping power (ESP),
+warm dense matter (WDM), and other high-energy-density physics scenarios where the
 computational cost of KS-DFT becomes prohibitive.
 
 ### Key Features:
 - Linear-scaling with system size (no orbitals, only electron density)
+- Natural description of free-electron-like systems (e.g., metals, plasmas)
 - Supports Thomas-Fermi (TF), von Weizsäcker (VW), and other kinetic energy functionals
-- Current-dependent (CD) kinetic potential for improved dynamic response
+- Current-density-dependent (CD) kinetic potential for improved dynamic response
+- Mermin/CD correction (mcd) for finite-temperature effects
 
 ## Example Included
 

--- a/examples/35_tdofdft/README
+++ b/examples/35_tdofdft/README
@@ -5,17 +5,13 @@ Functional Theory (TDOFDFT) calculations in ABACUS.
 
 ## What is TDOFDFT?
 
-TDOFDFT extends OFDFT to the time domain by directly propagating the time-dependent
-Pauli-like equations. It is particularly suited for studying electronic stopping power (ESP),
-warm dense matter (WDM), and other high-energy-density physics scenarios where the
+TDOFDFT extends OFDFT to the time domain by directly propagating the Madelung wavefunction. It is particularly suited for studying electronic stopping power (ESP) of warm dense matter (WDM), and other high-energy-density physics scenarios where the
 computational cost of KS-DFT becomes prohibitive.
 
 ### Key Features:
 - Linear-scaling with system size (no orbitals, only electron density)
-- Natural description of free-electron-like systems (e.g., metals, plasmas)
 - Supports Thomas-Fermi (TF), von Weizsäcker (VW), and other kinetic energy functionals
-- Current-density-dependent (CD) kinetic potential for improved dynamic response
-- Mermin/CD correction (mcd) for finite-temperature effects
+- Current-dependent (CD) kinetic potential for improved dynamic response
 
 ## Example Included
 

--- a/source/source_pw/module_ofdft/evolve_ofdft.cpp
+++ b/source/source_pw/module_ofdft/evolve_ofdft.cpp
@@ -3,6 +3,7 @@
 #include "source_io/module_parameter/parameter.h"
 #include <complex>
 
+#include "source_base/constants.h"
 #include "source_base/parallel_reduce.h"
 
 // Data race fix: Cache shared member variables to local const variables before OpenMP parallel regions.
@@ -171,6 +172,9 @@ void Evolve_OFDFT::cal_CD_potential(std::vector<std::complex<double>>& psi_,
         }
     }
 
+    const double t_temperature = PARAM.inp.mdp.md_tfirst;
+    const double kBT = (t_temperature > 0.0) ? ModuleBase::K_BOLTZMAN_AU * t_temperature : 0.0;
+
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
@@ -213,7 +217,7 @@ void Evolve_OFDFT::cal_CD_potential(std::vector<std::complex<double>>& psi_,
         for (int ik = 0; ik < npw; ++ik)
         {
             recipCDPotential[ik]=recipCurrent_x[ik]*gcar[ik].x+recipCurrent_y[ik]*gcar[ik].y+recipCurrent_z[ik]*gcar[ik].z;
-            if (gg[ik]==0) 
+            if (gg[ik]==0)
             {
                 recipCDPotential[ik]=0.0;
             }
@@ -228,8 +232,13 @@ void Evolve_OFDFT::cal_CD_potential(std::vector<std::complex<double>>& psi_,
         {
             if (kF_r[ir] > 1e-12)
             {
-                rpot(is, ir) -= mCD_para*2.0*std::real(rCDPotential[ir])*std::pow(ModuleBase::PI,3)
-                            / (2.0*kF_r[ir]*kF_r[ir]);
+                double CT = 1.0;
+                if (kBT > 0.0)
+                {
+                    CT = std::pow(std::pow(1.69271 * std::sqrt(2.0 * kBT / (kF_r[ir] * kF_r[ir])), 3.6) + 1.0, 1.0 / 3.6);
+                }
+                rpot(is, ir) -= mCD_para * CT * 2.0 * std::real(rCDPotential[ir]) * std::pow(ModuleBase::PI, 3)
+                            / (2.0 * kF_r[ir] * kF_r[ir]);
             }
         }
     }

--- a/tests/07_OFDFT/30_TDOFDFT_Al/INPUT
+++ b/tests/07_OFDFT/30_TDOFDFT_Al/INPUT
@@ -29,7 +29,7 @@ md_restart        0
 md_type           nve
 md_nstep          3
 md_dt             0.25
-md_tfirst         58022.52706
+md_tfirst         0
 md_dumpfreq       10
 md_tfreq          1.08
 md_tchain         1

--- a/tests/07_OFDFT/31_TDOFDFT_Al_CD/INPUT
+++ b/tests/07_OFDFT/31_TDOFDFT_Al_CD/INPUT
@@ -30,7 +30,7 @@ md_restart        0
 md_type           nve
 md_nstep          3
 md_dt             0.25
-md_tfirst         58022.52706
+md_tfirst         0
 md_dumpfreq       10
 md_tfreq          1.08
 md_tchain         1

--- a/tests/07_OFDFT/32_TDOFDFT_Al_mCD/INPUT
+++ b/tests/07_OFDFT/32_TDOFDFT_Al_mCD/INPUT
@@ -30,7 +30,7 @@ md_restart        0
 md_type           nve
 md_nstep          3
 md_dt             0.25
-md_tfirst         58022.52706
+md_tfirst         0
 md_dumpfreq       10
 md_tfreq          1.08
 md_tchain         1


### PR DESCRIPTION

  1. Finite-temperature CT correction (feat)

  Introduced a temperature-dependent correction factor CT in the CD (current-dependent) potential:

  $$CT = \left[\left(1.69271 \cdot \sqrt{\frac{2k_B T}{k_F^2}}\right)^{3.6} + 1\right]^{1/3.6}$$

  - Temperature is read from the MD parameter md_tfirst
  - When temperature is unset or ≤ 0, CT defaults to 1.0 (zero-temperature limit)
  - Code changes: source/source_pw/module_ofdft/evolve_ofdft.cpp

  2. Example and test adjustments (fix)

  - Set md_tfirst to 0 in all TDOFDFT examples and tests, ensuring the CD potential behaves identically to before the CT correction was
  introduced (CT = 1.0)
  - Ion dynamics are unaffected since init_vel=1 reads velocities from STRU
  - Affected files:
    - examples/35_tdofdft/01_Al_proton_ESP/02_td/INPUT
    - tests/07_OFDFT/30_TDOFDFT_Al/INPUT
    - tests/07_OFDFT/31_TDOFDFT_Al_CD/INPUT
    - tests/07_OFDFT/32_TDOFDFT_Al_mCD/INPUT

  3. README update

  - Refined TDOFDFT README description and terminology