### PR TITLE
refactor(estate): slim elecstate.h via forward declarations

### DIFF
--- a/source/source_esolver/esolver_double_xc.cpp
+++ b/source/source_esolver/esolver_double_xc.cpp
@@ -1,4 +1,7 @@
 #include "esolver_double_xc.h"
+#include "source_basis/module_pw/pw_basis.h" // IWYU: was transitively via elecstate.h
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
+#include "source_estate/module_pot/potential_new.h" // IWYU: was transitively via elecstate.h
 #include "source_hamilt/module_xc/xc_functional.h"
 #include "source_hamilt/module_ewald/H_Ewald_pw.h"
 #include "source_hamilt/module_vdw/vdw.h"

--- a/source/source_esolver/esolver_double_xc.cpp
+++ b/source/source_esolver/esolver_double_xc.cpp
@@ -1,4 +1,5 @@
 #include "esolver_double_xc.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_basis/module_pw/pw_basis.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_pot/potential_new.h" // IWYU: was transitively via elecstate.h

--- a/source/source_esolver/esolver_double_xc.h
+++ b/source/source_esolver/esolver_double_xc.h
@@ -2,6 +2,7 @@
 #define ESOLVER_DOUBLE_XC_H
 
 #include "source_esolver/esolver_ks_lcao.h"
+#include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 
 namespace ModuleESolver
 {

--- a/source/source_esolver/esolver_fp.cpp
+++ b/source/source_esolver/esolver_fp.cpp
@@ -1,4 +1,5 @@
 #include "esolver_fp.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_estate/cal_ux.h"

--- a/source/source_esolver/esolver_fp.cpp
+++ b/source/source_esolver/esolver_fp.cpp
@@ -1,4 +1,5 @@
 #include "esolver_fp.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_estate/cal_ux.h"
 #include "source_estate/module_charge/symmetry_rho.h"

--- a/source/source_esolver/esolver_fp.h
+++ b/source/source_esolver/esolver_fp.h
@@ -6,6 +6,7 @@
 #include "source_base/timer_wrapper.h"
 
 #include "source_basis/module_pw/pw_basis.h" // plane wave basis
+#include "source_cell/klist.h" // K_Vectors kv value member (no longer via elecstate.h)
 #include "source_estate/elecstate.h" // electronic states
 #include "source_estate/module_charge/charge_extra.h" // charge extrapolation
 #include "source_hamilt/module_surchem/surchem.h" // solvation model

--- a/source/source_esolver/esolver_fp.h
+++ b/source/source_esolver/esolver_fp.h
@@ -2,6 +2,7 @@
 #define ESOLVER_FP_H
 
 #include "esolver.h"
+#include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/timer_wrapper.h"
 

--- a/source/source_esolver/esolver_gets.cpp
+++ b/source/source_esolver/esolver_gets.cpp
@@ -1,4 +1,5 @@
 #include "esolver_gets.h"
+#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "source_base/timer.h"
 #include "source_cell/module_neighbor/sltk_atom_arrange.h"

--- a/source/source_esolver/esolver_gets.cpp
+++ b/source/source_esolver/esolver_gets.cpp
@@ -1,5 +1,5 @@
 #include "esolver_gets.h"
-#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/timer.h"
 #include "source_cell/module_neighbor/sltk_atom_arrange.h"

--- a/source/source_esolver/esolver_gets.cpp
+++ b/source/source_esolver/esolver_gets.cpp
@@ -1,4 +1,5 @@
 #include "esolver_gets.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/timer.h"

--- a/source/source_esolver/esolver_ks.cpp
+++ b/source/source_esolver/esolver_ks.cpp
@@ -1,4 +1,5 @@
 #include "esolver_ks.h"
+#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 #include "source_base/timer_wrapper.h"
 
 // for jason output information

--- a/source/source_esolver/esolver_ks.cpp
+++ b/source/source_esolver/esolver_ks.cpp
@@ -1,5 +1,4 @@
 #include "esolver_ks.h"
-#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 #include "source_base/timer_wrapper.h"
 
 // for jason output information

--- a/source/source_esolver/esolver_ks_lcao.cpp
+++ b/source/source_esolver/esolver_ks_lcao.cpp
@@ -1,4 +1,5 @@
 #include "esolver_ks_lcao.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_base/module_external/blacs_connector.h"
 #include "source_cell/module_neighbor/sltk_atom_arrange.h"
 #include "source_estate/elecstate_tools.h"

--- a/source/source_esolver/esolver_ks_lcao.cpp
+++ b/source/source_esolver/esolver_ks_lcao.cpp
@@ -1,4 +1,5 @@
 #include "esolver_ks_lcao.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_base/module_external/blacs_connector.h"
 #include "source_cell/module_neighbor/sltk_atom_arrange.h"

--- a/source/source_esolver/esolver_ks_lcaopw.cpp
+++ b/source/source_esolver/esolver_ks_lcaopw.cpp
@@ -1,4 +1,5 @@
 #include "esolver_ks_lcaopw.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_pw/module_pwdft/elecond.h"
 #include "source_io/module_parameter/input_conv.h"

--- a/source/source_esolver/esolver_ks_lcaopw.cpp
+++ b/source/source_esolver/esolver_ks_lcaopw.cpp
@@ -1,4 +1,5 @@
 #include "esolver_ks_lcaopw.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_pw/module_pwdft/elecond.h"

--- a/source/source_esolver/esolver_ks_pw.cpp
+++ b/source/source_esolver/esolver_ks_pw.cpp
@@ -1,4 +1,5 @@
 #include "esolver_ks_pw.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_pot/potential_new.h" // IWYU: was transitively via elecstate.h
 

--- a/source/source_esolver/esolver_ks_pw.cpp
+++ b/source/source_esolver/esolver_ks_pw.cpp
@@ -1,4 +1,6 @@
 #include "esolver_ks_pw.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
+#include "source_estate/module_pot/potential_new.h" // IWYU: was transitively via elecstate.h
 
 #include "source_estate/cal_ux.h"
 #include "source_estate/elecstate_pw.h"

--- a/source/source_esolver/esolver_of.cpp
+++ b/source/source_esolver/esolver_of.cpp
@@ -1,4 +1,5 @@
 #include "esolver_of.h"
+#include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "source_io/module_parameter/parameter.h"
 #include "source_io/module_output/cube_io.h"

--- a/source/source_esolver/esolver_of.cpp
+++ b/source/source_esolver/esolver_of.cpp
@@ -1,4 +1,6 @@
 #include "esolver_of.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
+#include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "source_io/module_parameter/parameter.h"

--- a/source/source_esolver/esolver_of_interface.cpp
+++ b/source/source_esolver/esolver_of_interface.cpp
@@ -1,4 +1,5 @@
 #include "esolver_of.h"
+#include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 #include "source_io/module_parameter/parameter.h"
 
 namespace ModuleESolver

--- a/source/source_esolver/esolver_of_tool.cpp
+++ b/source/source_esolver/esolver_of_tool.cpp
@@ -1,4 +1,5 @@
 #include "esolver_of.h"
+#include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 #include "source_base/formatter.h"
 #include "source_base/memory_recorder.h"
 #include "source_estate/module_pot/efield.h"

--- a/source/source_esolver/esolver_of_tool.cpp
+++ b/source/source_esolver/esolver_of_tool.cpp
@@ -1,4 +1,5 @@
 #include "esolver_of.h"
+#include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 #include "source_base/formatter.h"
 #include "source_base/memory_recorder.h"

--- a/source/source_esolver/esolver_sdft_pw.cpp
+++ b/source/source_esolver/esolver_sdft_pw.cpp
@@ -1,4 +1,5 @@
 #include "esolver_sdft_pw.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/global_variable.h"

--- a/source/source_esolver/esolver_sdft_pw.cpp
+++ b/source/source_esolver/esolver_sdft_pw.cpp
@@ -1,4 +1,5 @@
 #include "esolver_sdft_pw.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/global_variable.h"
 #include "source_base/memory_recorder.h"

--- a/source/source_esolver/lcao_others.cpp
+++ b/source/source_esolver/lcao_others.cpp
@@ -1,4 +1,5 @@
 #include "source_esolver/esolver_ks_lcao.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/cal_ux.h"
 #include "source_estate/module_charge/symmetry_rho.h"
 #include "source_lcao/hamilt_lcao.h"

--- a/source/source_esolver/pw_others.cpp
+++ b/source/source_esolver/pw_others.cpp
@@ -1,5 +1,5 @@
 #include "esolver_ks_pw.h"
-#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_base/module_device/device.h"
 #include "source_io/module_bessel/numerical_basis.h"
 #include "source_io/module_bessel/numerical_descriptor.h"

--- a/source/source_esolver/pw_others.cpp
+++ b/source/source_esolver/pw_others.cpp
@@ -1,4 +1,5 @@
 #include "esolver_ks_pw.h"
+#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 #include "source_base/module_device/device.h"
 #include "source_io/module_bessel/numerical_basis.h"
 #include "source_io/module_bessel/numerical_descriptor.h"

--- a/source/source_esolver/pw_others.cpp
+++ b/source/source_esolver/pw_others.cpp
@@ -1,4 +1,5 @@
 #include "esolver_ks_pw.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_base/module_device/device.h"
 #include "source_io/module_bessel/numerical_basis.h"

--- a/source/source_estate/elecstate.cpp
+++ b/source/source_estate/elecstate.cpp
@@ -2,10 +2,31 @@
 #include "source_io/module_parameter/parameter.h"
 #include "source_base/parallel_reduce.h"
 #include "source_base/tool_title.h"
+#include "source_estate/module_charge/charge.h"
+#include "module_pot/potential_new.h"
+#include "source_basis/module_pw/pw_basis.h"
+#include "source_basis/module_pw/pw_basis_big.h"
 #include "occupy.h"
 
 namespace elecstate
 {
+
+ElecState::ElecState(Charge* chr_in, ModulePW::PW_Basis* rhopw_in, ModulePW::PW_Basis_Big* bigpw_in)
+{
+    this->charge = chr_in;
+    this->charge->set_rhopw(rhopw_in);
+    this->bigpw = bigpw_in;
+    this->eferm.two_efermi = PARAM.globalv.two_fermi;
+}
+
+ElecState::~ElecState()
+{
+    if (this->pot != nullptr)
+    {
+        delete this->pot;
+        this->pot = nullptr;
+    }
+}
 
 const double* ElecState::getRho(int spin) const
 {

--- a/source/source_estate/elecstate.h
+++ b/source/source_estate/elecstate.h
@@ -6,6 +6,14 @@
 #include "source_psi/psi.h" // Psi<T> appears in virtual method signatures; psi.h is light (own_fan=2)
 #include "source_io/module_parameter/parameter.h" // PARAM/Input_para; kept (own_fan=4, cheap) to avoid churning ~120 downstream PARAM users
 
+// Base-layer leaf utilities (own_fan~0) that the old heavy includes used to
+// pull in transitively. Kept here so the ~100 downstream files using TITLE /
+// WARNING_QUIT / timer / GlobalFunc / Memory do not each need a new include;
+// global_function.h also transitively provides tool_title.h and tool_quit.h.
+#include "source_base/global_function.h"
+#include "source_base/timer.h"
+#include "source_base/memory_recorder.h"
+
 #include <complex>
 #include <string>
 #include <vector>

--- a/source/source_estate/elecstate.h
+++ b/source/source_estate/elecstate.h
@@ -3,6 +3,7 @@
 
 #include "fp_energy.h"
 #include "source_base/matrix.h"
+#include "source_psi/psi.h" // Psi<T> appears in virtual method signatures; psi.h is light (own_fan=2)
 
 #include <complex>
 #include <string>
@@ -24,15 +25,6 @@ namespace ModulePW
 class PW_Basis;
 class PW_Basis_Big;
 } // namespace ModulePW
-namespace base_device
-{
-struct DEVICE_CPU;
-}
-namespace psi
-{
-template <typename T, typename Device = base_device::DEVICE_CPU>
-class Psi;
-}
 
 namespace elecstate
 {

--- a/source/source_estate/elecstate.h
+++ b/source/source_estate/elecstate.h
@@ -2,14 +2,42 @@
 #define ELECSTATE_H
 
 #include "fp_energy.h"
-#include "source_cell/klist.h"
-#include "source_estate/module_charge/charge.h"
-#include "source_io/module_parameter/parameter.h"
-#include "source_psi/psi.h"
-#include "module_pot/potential_new.h"
+#include "source_base/matrix.h"
+
+#include <complex>
+#include <string>
+#include <vector>
+
+// Forward declarations keep this widely-included header lightweight; the
+// corresponding full definitions are pulled in by elecstate.cpp instead.
+class Charge;
+class K_Vectors;
+class UnitCell;
+class Parallel_Grid;
+struct Input_para;
+namespace ModuleBase
+{
+class ComplexMatrix;
+}
+namespace ModulePW
+{
+class PW_Basis;
+class PW_Basis_Big;
+} // namespace ModulePW
+namespace base_device
+{
+struct DEVICE_CPU;
+}
+namespace psi
+{
+template <typename T, typename Device = base_device::DEVICE_CPU>
+class Psi;
+}
 
 namespace elecstate
 {
+
+class Potential;
 
 class ElecState
 {
@@ -17,21 +45,8 @@ class ElecState
     ElecState()
     {
     }
-    ElecState(Charge* chr_in, ModulePW::PW_Basis* rhopw_in, ModulePW::PW_Basis_Big* bigpw_in)
-    {
-        this->charge = chr_in;
-        this->charge->set_rhopw(rhopw_in);
-        this->bigpw = bigpw_in;
-        this->eferm.two_efermi = PARAM.globalv.two_fermi;
-    }
-    virtual ~ElecState()
-    {
-        if (this->pot != nullptr)
-        {
-            delete this->pot;
-            this->pot = nullptr;
-        }
-    }
+    ElecState(Charge* chr_in, ModulePW::PW_Basis* rhopw_in, ModulePW::PW_Basis_Big* bigpw_in);
+    virtual ~ElecState();
     void init_ks(Charge* chr_in, // pointer for class Charge
                  const K_Vectors* klist_in,
                  int nk_in, // number of k points

--- a/source/source_estate/elecstate.h
+++ b/source/source_estate/elecstate.h
@@ -4,18 +4,20 @@
 #include "fp_energy.h"
 #include "source_base/matrix.h"
 #include "source_psi/psi.h" // Psi<T> appears in virtual method signatures; psi.h is light (own_fan=2)
+#include "source_io/module_parameter/parameter.h" // PARAM/Input_para; kept (own_fan=4, cheap) to avoid churning ~120 downstream PARAM users
 
 #include <complex>
 #include <string>
 #include <vector>
 
-// Forward declarations keep this widely-included header lightweight; the
-// corresponding full definitions are pulled in by elecstate.cpp instead.
+// The heavy data headers (potential_new own_fan=58, klist=42, charge=37) are
+// forward-declared instead of included; their full definitions are pulled in by
+// elecstate.cpp. parameter.h is kept above because dropping it saves only 4 fan
+// but would force ~120 downstream files to add their own include.
 class Charge;
 class K_Vectors;
 class UnitCell;
 class Parallel_Grid;
-struct Input_para;
 namespace ModuleBase
 {
 class ComplexMatrix;

--- a/source/source_estate/elecstate_energy.cpp
+++ b/source/source_estate/elecstate_energy.cpp
@@ -5,6 +5,7 @@
 #include "makov_payne.h"
 #include "source_hamilt/module_xc/xc_functional.h"
 #include "source_estate/module_pot/H_Hartree_pw.h"
+#include "module_pot/potential_new.h" // ElecState::pot is now fwd-declared in elecstate.h
 #include "source_io/module_parameter/parameter.h"
 
 #include <cmath>

--- a/source/source_estate/elecstate_energy.cpp
+++ b/source/source_estate/elecstate_energy.cpp
@@ -1,4 +1,7 @@
 #include "elecstate.h"
+#include "source_basis/module_pw/pw_basis.h" // IWYU: was transitively via elecstate.h
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
+#include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 #include "source_base/global_variable.h"
 #include "source_base/parallel_comm.h"
 #include "source_base/parallel_reduce.h"

--- a/source/source_estate/elecstate_energy.cpp
+++ b/source/source_estate/elecstate_energy.cpp
@@ -1,4 +1,5 @@
 #include "elecstate.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_basis/module_pw/pw_basis.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h

--- a/source/source_estate/elecstate_energy_terms.cpp
+++ b/source/source_estate/elecstate_energy_terms.cpp
@@ -1,5 +1,6 @@
 #include "elecstate.h"
 #include "source_base/parallel_reduce.h"
+#include "module_pot/potential_new.h" // ElecState::pot is now fwd-declared in elecstate.h
 #include "source_estate/module_pot/H_Hartree_pw.h"
 #include "source_estate/module_pot/efield.h"
 #include "source_estate/module_pot/gatefield.h"

--- a/source/source_estate/elecstate_energy_terms.cpp
+++ b/source/source_estate/elecstate_energy_terms.cpp
@@ -1,4 +1,6 @@
 #include "elecstate.h"
+#include "source_basis/module_pw/pw_basis.h" // IWYU: was transitively via elecstate.h
+#include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 #include "source_base/parallel_reduce.h"
 #include "module_pot/potential_new.h" // ElecState::pot is now fwd-declared in elecstate.h
 #include "source_estate/module_pot/H_Hartree_pw.h"

--- a/source/source_estate/elecstate_lcao.cpp
+++ b/source/source_estate/elecstate_lcao.cpp
@@ -1,4 +1,5 @@
 #include "source_estate/elecstate_lcao.h"
+#include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/cal_dm.h"
 #include "source_base/timer.h"
 #include "source_estate/module_dm/cal_dm_psi.h"

--- a/source/source_estate/elecstate_print.cpp
+++ b/source/source_estate/elecstate_print.cpp
@@ -1,4 +1,5 @@
 #include "elecstate.h"
+#include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 #include "source_base/formatter.h"
 #include "source_base/global_variable.h"
 #include "source_base/parallel_common.h"

--- a/source/source_estate/elecstate_pw.cpp
+++ b/source/source_estate/elecstate_pw.cpp
@@ -1,4 +1,7 @@
 #include "elecstate_pw.h"
+#include "source_basis/module_pw/pw_basis.h" // IWYU: was transitively via elecstate.h
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
+#include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/constants.h"
 #include "source_base/libm/libm.h"

--- a/source/source_estate/elecstate_pw.cpp
+++ b/source/source_estate/elecstate_pw.cpp
@@ -1,4 +1,5 @@
 #include "elecstate_pw.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_basis/module_pw/pw_basis.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h

--- a/source/source_estate/elecstate_pw_cal_tau.cpp
+++ b/source/source_estate/elecstate_pw_cal_tau.cpp
@@ -1,4 +1,6 @@
 #include "elecstate_pw.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_charge/charge.h" // IWYU: elecstate.h no longer provides this transitively
 
 namespace elecstate {

--- a/source/source_estate/elecstate_pw_cal_tau.cpp
+++ b/source/source_estate/elecstate_pw_cal_tau.cpp
@@ -1,4 +1,6 @@
 #include "elecstate_pw.h"
+#include "source_estate/module_charge/charge.h" // IWYU: elecstate.h no longer provides this transitively
+#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 
 namespace elecstate {
 

--- a/source/source_estate/elecstate_pw_cal_tau.cpp
+++ b/source/source_estate/elecstate_pw_cal_tau.cpp
@@ -1,6 +1,5 @@
 #include "elecstate_pw.h"
 #include "source_estate/module_charge/charge.h" // IWYU: elecstate.h no longer provides this transitively
-#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 
 namespace elecstate {
 

--- a/source/source_estate/elecstate_pw_sdft.cpp
+++ b/source/source_estate/elecstate_pw_sdft.cpp
@@ -1,4 +1,5 @@
 #include "./elecstate_pw_sdft.h"
+#include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/global_function.h"
 #include "source_base/global_variable.h"

--- a/source/source_estate/elecstate_tools.cpp
+++ b/source/source_estate/elecstate_tools.cpp
@@ -1,5 +1,4 @@
 #include "elecstate_tools.h"
-#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 #include "occupy.h"
 #include "source_base/parallel_reduce.h"
 namespace elecstate

--- a/source/source_estate/elecstate_tools.cpp
+++ b/source/source_estate/elecstate_tools.cpp
@@ -1,4 +1,5 @@
 #include "elecstate_tools.h"
+#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 #include "occupy.h"
 #include "source_base/parallel_reduce.h"
 namespace elecstate

--- a/source/source_estate/elecstate_tools.cpp
+++ b/source/source_estate/elecstate_tools.cpp
@@ -1,4 +1,5 @@
 #include "elecstate_tools.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "occupy.h"
 #include "source_base/parallel_reduce.h"
 namespace elecstate

--- a/source/source_estate/init_scf.cpp
+++ b/source/source_estate/init_scf.cpp
@@ -1,4 +1,7 @@
 #include "elecstate.h"
+#include "module_pot/potential_new.h"                // ElecState::pot is now fwd-declared in elecstate.h
+#include "source_estate/module_charge/charge.h"      // ElecState::charge is now fwd-declared in elecstate.h
+#include "source_io/module_parameter/parameter.h"    // PARAM is no longer pulled in via elecstate.h
 #include "source_io/module_chgpot/write_init.h"
 
 namespace elecstate

--- a/source/source_estate/init_scf.cpp
+++ b/source/source_estate/init_scf.cpp
@@ -1,7 +1,6 @@
 #include "elecstate.h"
 #include "module_pot/potential_new.h"                // ElecState::pot is now fwd-declared in elecstate.h
 #include "source_estate/module_charge/charge.h"      // ElecState::charge is now fwd-declared in elecstate.h
-#include "source_io/module_parameter/parameter.h"    // PARAM is no longer pulled in via elecstate.h
 #include "source_io/module_chgpot/write_init.h"
 
 namespace elecstate

--- a/source/source_estate/module_charge/chgmixing.cpp
+++ b/source/source_estate/module_charge/chgmixing.cpp
@@ -1,4 +1,5 @@
 #include "source_estate/module_charge/chgmixing.h"
+#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 #include "source_estate/update_pot.h"
 #include "source_lcao/module_dftu/dftu.h"
 #include "source_lcao/module_deltaspin/spin_constrain.h"

--- a/source/source_estate/module_charge/chgmixing.cpp
+++ b/source/source_estate/module_charge/chgmixing.cpp
@@ -1,5 +1,4 @@
 #include "source_estate/module_charge/chgmixing.h"
-#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 #include "source_estate/update_pot.h"
 #include "source_lcao/module_dftu/dftu.h"
 #include "source_lcao/module_deltaspin/spin_constrain.h"

--- a/source/source_estate/module_dm/init_dm.cpp
+++ b/source/source_estate/module_dm/init_dm.cpp
@@ -1,6 +1,5 @@
 #include "source_estate/module_dm/init_dm.h"
 #include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
-#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 #include "source_estate/module_dm/cal_dm_psi.h"
 #include "source_estate/elecstate_tools.h"
 #include "source_estate/cal_ux.h"

--- a/source/source_estate/module_dm/init_dm.cpp
+++ b/source/source_estate/module_dm/init_dm.cpp
@@ -1,4 +1,6 @@
 #include "source_estate/module_dm/init_dm.h"
+#include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
+#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 #include "source_estate/module_dm/cal_dm_psi.h"
 #include "source_estate/elecstate_tools.h"
 #include "source_estate/cal_ux.h"

--- a/source/source_estate/module_pot/pot_ml_exx.h
+++ b/source/source_estate/module_pot/pot_ml_exx.h
@@ -4,6 +4,7 @@
 #ifdef __MLALGO
 
 #include "pot_base.h"
+#include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 #include "source_io/module_ml/cal_mlkedf_descriptors.h"
 #include "source_pw/module_ofdft/ml_base.h"
 

--- a/source/source_estate/setup_estate_pw.cpp
+++ b/source/source_estate/setup_estate_pw.cpp
@@ -1,4 +1,5 @@
 #include "source_estate/setup_estate_pw.h"
+#include "source_estate/module_pot/potential_new.h" // new elecstate::Potential (was transitively via elecstate.h)
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/elecstate_pw.h"
 #include "source_estate/elecstate_pw_sdft.h"

--- a/source/source_estate/setup_estate_pw.cpp
+++ b/source/source_estate/setup_estate_pw.cpp
@@ -1,4 +1,5 @@
 #include "source_estate/setup_estate_pw.h"
+#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 #include "source_estate/elecstate_pw.h"
 #include "source_estate/elecstate_pw_sdft.h"
 #include "source_estate/elecstate_tools.h"

--- a/source/source_estate/setup_estate_pw.cpp
+++ b/source/source_estate/setup_estate_pw.cpp
@@ -1,5 +1,4 @@
 #include "source_estate/setup_estate_pw.h"
-#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 #include "source_estate/elecstate_pw.h"
 #include "source_estate/elecstate_pw_sdft.h"
 #include "source_estate/elecstate_tools.h"

--- a/source/source_estate/setup_estate_pw.cpp
+++ b/source/source_estate/setup_estate_pw.cpp
@@ -1,4 +1,5 @@
 #include "source_estate/setup_estate_pw.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/elecstate_pw.h"
 #include "source_estate/elecstate_pw_sdft.h"
 #include "source_estate/elecstate_tools.h"

--- a/source/source_estate/setup_estate_pw.h
+++ b/source/source_estate/setup_estate_pw.h
@@ -9,6 +9,7 @@
 #include "source_pw/module_pwdft/vsep_pw.h"
 
 class pseudopot_cell_vnl;
+class surchem; // used only as a reference param below (was transitively via elecstate.h)
 
 namespace elecstate
 {

--- a/source/source_estate/test/elecstate_base_test.cpp
+++ b/source/source_estate/test/elecstate_base_test.cpp
@@ -1,4 +1,5 @@
 #include "gmock/gmock.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "gtest/gtest.h"
 #include <string>
 #define private public

--- a/source/source_estate/test/elecstate_base_test.cpp
+++ b/source/source_estate/test/elecstate_base_test.cpp
@@ -5,6 +5,8 @@
 #define protected public
 #include "source_estate/elecstate.h"
 #include "source_estate/elecstate_tools.h"
+#include "source_estate/module_charge/charge.h"   // new Charge / charge->rho (no longer via elecstate.h)
+#include "source_estate/module_pot/potential_new.h" // Potential (no longer via elecstate.h)
 #include "source_estate/occupy.h"
 #include "source_io/module_parameter/parameter.h"
 #include "source_base/module_fft/fft_bundle.h"

--- a/source/source_estate/test/elecstate_print_test.cpp
+++ b/source/source_estate/test/elecstate_print_test.cpp
@@ -1,6 +1,7 @@
 #include <string>
 
 #include "gmock/gmock.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "gtest/gtest.h"
 #define private public
 #include "source_cell/klist.h"

--- a/source/source_estate/test/elecstate_pw_test.cpp
+++ b/source/source_estate/test/elecstate_pw_test.cpp
@@ -1,6 +1,8 @@
 #include <string>
 
 #include "gmock/gmock.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
+#include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 #include "gtest/gtest.h"
 #define private public
 #define protected public

--- a/source/source_estate/update_pot.cpp
+++ b/source/source_estate/update_pot.cpp
@@ -1,4 +1,5 @@
 #include "source_estate/update_pot.h"
+#include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 #include "source_estate/cal_ux.h"
 
 void elecstate::update_pot(UnitCell& ucell, // unitcell 

--- a/source/source_hsolver/hsolver_lcaopw.h
+++ b/source/source_hsolver/hsolver_lcaopw.h
@@ -4,6 +4,11 @@
 #include "source_estate/elecstate.h"
 #include "source_hamilt/hamilt.h"
 #include "source_base/macros.h"
+
+// Used only as a pointer member/param; forward-declared instead of including
+// pw_basis_k.h. Was previously reachable transitively through elecstate.h.
+namespace ModulePW { class PW_Basis_K; }
+
 namespace hsolver
 {
 

--- a/source/source_hsolver/hsolver_pw.cpp
+++ b/source/source_hsolver/hsolver_pw.cpp
@@ -1,4 +1,5 @@
 #include "hsolver_pw.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "source_base/parallel_comm.h"

--- a/source/source_hsolver/hsolver_pw.cpp
+++ b/source/source_hsolver/hsolver_pw.cpp
@@ -1,4 +1,5 @@
 #include "hsolver_pw.h"
+#include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "source_base/parallel_comm.h"
 #include "source_base/global_variable.h"

--- a/source/source_hsolver/hsolver_pw_sdft.cpp
+++ b/source/source_hsolver/hsolver_pw_sdft.cpp
@@ -1,4 +1,5 @@
 #include "hsolver_pw_sdft.h"
+#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "source_base/global_function.h"
 #include "source_base/parallel_device.h"

--- a/source/source_hsolver/hsolver_pw_sdft.cpp
+++ b/source/source_hsolver/hsolver_pw_sdft.cpp
@@ -1,5 +1,5 @@
 #include "hsolver_pw_sdft.h"
-#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
+#include "source_estate/module_pot/potential_new.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/global_function.h"
 #include "source_base/parallel_device.h"

--- a/source/source_hsolver/test/hsolver_supplementary_mock.h
+++ b/source/source_hsolver/test/hsolver_supplementary_mock.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "source_estate/elecstate_pw.h"
+#include "source_estate/module_charge/charge.h" // IWYU: elecstate.h no longer provides this transitively
 
 namespace elecstate
 {

--- a/source/source_hsolver/test/test_hsolver_pw.cpp
+++ b/source/source_hsolver/test/test_hsolver_pw.cpp
@@ -5,6 +5,7 @@
 #define private public
 #define protected public
 #include "source_io/module_parameter/parameter.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_hsolver/hsolver_pw.h"
 #include "source_hsolver/hsolver_lcaopw.h"
 #include "hsolver_supplementary_mock.h"

--- a/source/source_hsolver/test/test_hsolver_pw.cpp
+++ b/source/source_hsolver/test/test_hsolver_pw.cpp
@@ -5,6 +5,7 @@
 #define private public
 #define protected public
 #include "source_io/module_parameter/parameter.h"
+#include "source_estate/module_pot/potential_new.h" // new elecstate::Potential (was transitively via elecstate.h)
 #include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_hsolver/hsolver_pw.h"
 #include "source_hsolver/hsolver_lcaopw.h"

--- a/source/source_hsolver/test/test_hsolver_sdft.cpp
+++ b/source/source_hsolver/test/test_hsolver_sdft.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #define private public
 #include "source_io/module_parameter/parameter.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #undef private
 #include <vector>
 

--- a/source/source_io/module_chgpot/write_init.cpp
+++ b/source/source_io/module_chgpot/write_init.cpp
@@ -15,6 +15,7 @@
 // =====================================================================
 
 #include "source_io/module_chgpot/write_init.h"
+#include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 #include "source_io/module_output/cube_io.h"
 #include "source_base/tool_quit.h"
 

--- a/source/source_io/module_ctrl/ctrl_iter_lcao.cpp
+++ b/source/source_io/module_ctrl/ctrl_iter_lcao.cpp
@@ -1,4 +1,5 @@
 #include "ctrl_iter_lcao.h" // use ctrl_iter_lcao() 
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/global_variable.h" // use GlobalC

--- a/source/source_io/module_ctrl/ctrl_iter_lcao.cpp
+++ b/source/source_io/module_ctrl/ctrl_iter_lcao.cpp
@@ -1,4 +1,5 @@
 #include "ctrl_iter_lcao.h" // use ctrl_iter_lcao() 
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/global_variable.h" // use GlobalC
 #ifdef __MLALGO

--- a/source/source_io/module_ctrl/ctrl_output_fp.cpp
+++ b/source/source_io/module_ctrl/ctrl_output_fp.cpp
@@ -1,4 +1,6 @@
 #include "ctrl_output_fp.h" // use ctrl_output_fp()
+#include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
+#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 #include "../module_output/cube_io.h" // use write_vdata_palgrid
 #include "../module_dipole/dipole_io.h" // use write_dipole
 #include "source_estate/module_charge/symmetry_rho.h" // use Symmetry_rho

--- a/source/source_io/module_ctrl/ctrl_output_fp.cpp
+++ b/source/source_io/module_ctrl/ctrl_output_fp.cpp
@@ -1,6 +1,6 @@
 #include "ctrl_output_fp.h" // use ctrl_output_fp()
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
-#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 #include "../module_output/cube_io.h" // use write_vdata_palgrid
 #include "../module_dipole/dipole_io.h" // use write_dipole
 #include "source_estate/module_charge/symmetry_rho.h" // use Symmetry_rho

--- a/source/source_io/module_ctrl/ctrl_output_fp.h
+++ b/source/source_io/module_ctrl/ctrl_output_fp.h
@@ -3,6 +3,8 @@
 
 #include "source_estate/elecstate_lcao.h"
 
+class surchem; // used only as a reference param below (was transitively via elecstate.h)
+
 namespace ModuleIO
 {
 

--- a/source/source_io/module_ctrl/ctrl_output_pw.cpp
+++ b/source/source_io/module_ctrl/ctrl_output_pw.cpp
@@ -1,4 +1,5 @@
 #include "ctrl_output_pw.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "../module_wf/write_wfc_pw.h" // use write_wfc_pw

--- a/source/source_io/module_ctrl/ctrl_output_pw.cpp
+++ b/source/source_io/module_ctrl/ctrl_output_pw.cpp
@@ -1,4 +1,5 @@
 #include "ctrl_output_pw.h"
+#include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "../module_wf/write_wfc_pw.h" // use write_wfc_pw
 #include "../module_dos/write_dos_pw.h" // use write_dos_pw

--- a/source/source_io/module_ctrl/ctrl_output_pw.h
+++ b/source/source_io/module_ctrl/ctrl_output_pw.h
@@ -6,6 +6,8 @@
 #include "source_estate/elecstate_lcao.h"     // use pelec
 #include "source_psi/setup_psi_pw.h" // use Setup_Psi class
 
+class surchem; // used only as a reference param below (was transitively via elecstate.h)
+
 namespace ModuleIO
 {
 

--- a/source/source_io/module_ctrl/ctrl_runner_lcao.h
+++ b/source/source_io/module_ctrl/ctrl_runner_lcao.h
@@ -10,6 +10,8 @@
 #include "source_lcao/setup_exx.h" // for exx, mohan add 20251018
 #include "source_lcao/setup_dm.h" // for density matrix, mohan add 20251103
 
+class surchem; // used only as a reference param below (was transitively via elecstate.h)
+
 namespace ModuleIO
 {
 

--- a/source/source_io/module_ctrl/ctrl_scf_lcao.cpp
+++ b/source/source_io/module_ctrl/ctrl_scf_lcao.cpp
@@ -1,4 +1,5 @@
 #include "ctrl_scf_lcao.h" // use ctrl_scf_lcao()
+#include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "source_base/formatter.h"
 #include "source_estate/elecstate_lcao.h" // use elecstate::ElecState

--- a/source/source_io/module_ctrl/ctrl_scf_lcao.cpp
+++ b/source/source_io/module_ctrl/ctrl_scf_lcao.cpp
@@ -1,4 +1,5 @@
 #include "ctrl_scf_lcao.h" // use ctrl_scf_lcao()
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 

--- a/source/source_io/module_ctrl/ctrl_scf_lcao.cpp
+++ b/source/source_io/module_ctrl/ctrl_scf_lcao.cpp
@@ -1,4 +1,5 @@
 #include "ctrl_scf_lcao.h" // use ctrl_scf_lcao()
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "source_base/formatter.h"

--- a/source/source_io/module_current/td_current_io.cpp
+++ b/source/source_io/module_current/td_current_io.cpp
@@ -1,4 +1,5 @@
 #include "td_current_io.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/global_function.h"
 #include "source_base/global_variable.h"

--- a/source/source_io/module_current/td_current_io.cpp
+++ b/source/source_io/module_current/td_current_io.cpp
@@ -1,4 +1,5 @@
 #include "td_current_io.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/global_function.h"

--- a/source/source_io/module_current/td_current_io_comm.cpp
+++ b/source/source_io/module_current/td_current_io_comm.cpp
@@ -1,4 +1,5 @@
 #include "source_base/global_function.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_base/global_variable.h"
 #include "source_base/libm/libm.h"
 #include "source_base/module_external/lapack_connector.h"

--- a/source/source_io/module_current/td_current_io_comm.cpp
+++ b/source/source_io/module_current/td_current_io_comm.cpp
@@ -1,4 +1,5 @@
 #include "source_base/global_function.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_base/global_variable.h"
 #include "source_base/libm/libm.h"

--- a/source/source_io/module_dos/cal_ldos.cpp
+++ b/source/source_io/module_dos/cal_ldos.cpp
@@ -1,4 +1,5 @@
 #include "cal_ldos.h"
+#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "cal_dos.h"
 #include "../module_output/cube_io.h"

--- a/source/source_io/module_dos/cal_ldos.cpp
+++ b/source/source_io/module_dos/cal_ldos.cpp
@@ -1,5 +1,6 @@
 #include "cal_ldos.h"
-#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
+#include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 
 #include "cal_dos.h"
 #include "../module_output/cube_io.h"

--- a/source/source_io/module_dos/cal_ldos.cpp
+++ b/source/source_io/module_dos/cal_ldos.cpp
@@ -1,4 +1,5 @@
 #include "cal_ldos.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 

--- a/source/source_io/module_energy/write_proj_band_lcao.cpp
+++ b/source/source_io/module_energy/write_proj_band_lcao.cpp
@@ -1,4 +1,5 @@
 #include "write_proj_band_lcao.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_io/module_parameter/parameter.h"

--- a/source/source_io/module_energy/write_proj_band_lcao.cpp
+++ b/source/source_io/module_energy/write_proj_band_lcao.cpp
@@ -1,4 +1,5 @@
 #include "write_proj_band_lcao.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_io/module_parameter/parameter.h"
 #include "source_base/global_function.h"

--- a/source/source_io/module_ml/cal_mlkedf_descriptors.cpp
+++ b/source/source_io/module_ml/cal_mlkedf_descriptors.cpp
@@ -1,4 +1,5 @@
 #include "cal_mlkedf_descriptors.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_charge/charge.h" // IWYU: elecstate.h no longer provides this transitively
 
 namespace ModuleIO

--- a/source/source_io/module_ml/cal_mlkedf_descriptors.cpp
+++ b/source/source_io/module_ml/cal_mlkedf_descriptors.cpp
@@ -1,4 +1,5 @@
 #include "cal_mlkedf_descriptors.h"
+#include "source_estate/module_charge/charge.h" // IWYU: elecstate.h no longer provides this transitively
 
 namespace ModuleIO
 {

--- a/source/source_io/module_ml/write_mlkedf_descriptors.cpp
+++ b/source/source_io/module_ml/write_mlkedf_descriptors.cpp
@@ -1,6 +1,7 @@
 #ifdef __MLALGO
 
 #include "write_mlkedf_descriptors.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 
 #include "npy.hpp"

--- a/source/source_io/module_ml/write_mlkedf_descriptors.cpp
+++ b/source/source_io/module_ml/write_mlkedf_descriptors.cpp
@@ -1,6 +1,7 @@
 #ifdef __MLALGO
 
 #include "write_mlkedf_descriptors.h"
+#include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 
 #include "npy.hpp"
 #include "source_estate/module_charge/symmetry_rho.h"

--- a/source/source_io/module_wf/get_wf_lcao.cpp
+++ b/source/source_io/module_wf/get_wf_lcao.cpp
@@ -1,4 +1,5 @@
 #include "get_wf_lcao.h"
+#include "source_estate/module_charge/charge.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "source_base/module_external/blacs_connector.h"
 #include "source_io/module_output/cube_io.h"

--- a/source/source_io/module_wf/get_wf_lcao.cpp
+++ b/source/source_io/module_wf/get_wf_lcao.cpp
@@ -1,4 +1,5 @@
 #include "get_wf_lcao.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_charge/charge.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "source_base/module_external/blacs_connector.h"

--- a/source/source_io/module_wf/get_wf_lcao.h
+++ b/source/source_io/module_wf/get_wf_lcao.h
@@ -4,6 +4,10 @@
 #include "source_estate/elecstate.h"
 #include "source_basis/module_ao/parallel_orbitals.h"
 
+// Used only as a pointer param; forward-declared instead of including
+// pw_basis_k.h. Was previously reachable transitively through elecstate.h.
+namespace ModulePW { class PW_Basis_K; }
+
 class Get_wf_lcao
 {
   public:

--- a/source/source_lcao/FORCE_STRESS.cpp
+++ b/source/source_lcao/FORCE_STRESS.cpp
@@ -1,4 +1,5 @@
 #include "FORCE_STRESS.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/parallel_reduce.h"
 #include "source_lcao/module_dftu/dftu.h" //Quxin add for DFT+U on 20201029

--- a/source/source_lcao/FORCE_STRESS.cpp
+++ b/source/source_lcao/FORCE_STRESS.cpp
@@ -1,4 +1,5 @@
 #include "FORCE_STRESS.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/parallel_reduce.h"

--- a/source/source_lcao/FORCE_gamma.cpp
+++ b/source/source_lcao/FORCE_gamma.cpp
@@ -1,4 +1,5 @@
 #include "FORCE.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_base/memory_recorder.h"
 #include "source_base/parallel_reduce.h"
 #include "source_base/timer.h"

--- a/source/source_lcao/FORCE_k.cpp
+++ b/source/source_lcao/FORCE_k.cpp
@@ -1,4 +1,5 @@
 #include "FORCE.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_base/memory_recorder.h"
 #include "source_base/parallel_reduce.h"
 #include "source_base/timer.h"

--- a/source/source_lcao/LCAO_set.cpp
+++ b/source/source_lcao/LCAO_set.cpp
@@ -1,4 +1,5 @@
 #include "source_lcao/LCAO_set.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_io/module_parameter/parameter.h"
 #include "source_psi/setup_psi.h" // use Setup_Psi
 #include "source_io/module_wf/read_wfc_nao.h" // use read_wfc_nao

--- a/source/source_lcao/LCAO_set.cpp
+++ b/source/source_lcao/LCAO_set.cpp
@@ -1,4 +1,5 @@
 #include "source_lcao/LCAO_set.h"
+#include "source_estate/module_pot/potential_new.h" // new elecstate::Potential (was transitively via elecstate.h)
 #include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_io/module_parameter/parameter.h"
 #include "source_psi/setup_psi.h" // use Setup_Psi

--- a/source/source_lcao/edm.cpp
+++ b/source/source_lcao/edm.cpp
@@ -1,4 +1,5 @@
 #include "FORCE.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_dm/cal_dm_psi.h"
 #include "source_estate/elecstate_lcao.h"
 #include "source_base/memory_recorder.h"

--- a/source/source_lcao/hamilt_lcao.cpp
+++ b/source/source_lcao/hamilt_lcao.cpp
@@ -1,4 +1,5 @@
 #include "source_lcao/hamilt_lcao.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/global_variable.h"
 #include "source_base/memory_recorder.h"

--- a/source/source_lcao/module_deltaspin/init_sc.cpp
+++ b/source/source_lcao/module_deltaspin/init_sc.cpp
@@ -1,4 +1,5 @@
 #include "spin_constrain.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 /**
  * @file init_sc.cpp

--- a/source/source_lcao/module_deltaspin/spin_constrain.cpp
+++ b/source/source_lcao/module_deltaspin/spin_constrain.cpp
@@ -1,4 +1,5 @@
 #include "spin_constrain.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/formatter.h"
 #include "source_lcao/module_operator_lcao/dspin_lcao.h"

--- a/source/source_lcao/module_deltaspin/spin_constrain.h
+++ b/source/source_lcao/module_deltaspin/spin_constrain.h
@@ -56,6 +56,11 @@
 #include "source_estate/module_dm/density_matrix.h" // mohan add 2025-11-02
 #endif
 
+// Used only as a pointer member/param below; forward-declared instead of
+// including pw_basis_k.h (own_fan=24). Was previously reachable transitively
+// through elecstate.h's heavy includes.
+namespace ModulePW { class PW_Basis_K; }
+
 namespace spinconstrain
 {
 

--- a/source/source_lcao/module_dftu/dftu_force.cpp
+++ b/source/source_lcao/module_dftu/dftu_force.cpp
@@ -1,4 +1,5 @@
 #include "source_io/module_parameter/parameter.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #ifdef __LCAO
 #include "dftu.h"

--- a/source/source_lcao/module_dftu/dftu_force.cpp
+++ b/source/source_lcao/module_dftu/dftu_force.cpp
@@ -1,4 +1,5 @@
 #include "source_io/module_parameter/parameter.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #ifdef __LCAO

--- a/source/source_lcao/module_lr/esolver_lrtd_lcao.cpp
+++ b/source/source_lcao/module_lr/esolver_lrtd_lcao.cpp
@@ -1,4 +1,5 @@
 #include "esolver_lrtd_lcao.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "utils/lr_util.h"
 #include "hamilt_casida.h"
 #include "hamilt_ulr.hpp"

--- a/source/source_lcao/module_lr/esolver_lrtd_lcao.cpp
+++ b/source/source_lcao/module_lr/esolver_lrtd_lcao.cpp
@@ -1,4 +1,6 @@
 #include "esolver_lrtd_lcao.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
+#include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "utils/lr_util.h"
 #include "hamilt_casida.h"

--- a/source/source_lcao/module_operator_lcao/dspin_lcao.cpp
+++ b/source/source_lcao/module_operator_lcao/dspin_lcao.cpp
@@ -1,4 +1,5 @@
 #include "dspin_lcao.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_lcao/module_deltaspin/spin_constrain.h"
 #include "source_base/timer.h"
 #include "source_base/memory_recorder.h"

--- a/source/source_lcao/module_rdmft/rdmft.cpp
+++ b/source/source_lcao/module_rdmft/rdmft.cpp
@@ -5,6 +5,7 @@
 
 #include "rdmft.h"
 #include "source_lcao/module_rdmft/rdmft_tools.h"
+#include "source_io/module_parameter/parameter.h" // PARAM (no longer via elecstate.h)
 #include "source_base/timer.h"
 #include "source_base/parallel_reduce.h"
 #include "source_cell/module_symmetry/symmetry.h"

--- a/source/source_lcao/module_rdmft/rdmft.cpp
+++ b/source/source_lcao/module_rdmft/rdmft.cpp
@@ -5,7 +5,6 @@
 
 #include "rdmft.h"
 #include "source_lcao/module_rdmft/rdmft_tools.h"
-#include "source_io/module_parameter/parameter.h" // PARAM (no longer via elecstate.h)
 #include "source_base/timer.h"
 #include "source_base/parallel_reduce.h"
 #include "source_cell/module_symmetry/symmetry.h"

--- a/source/source_lcao/module_rdmft/rdmft.cpp
+++ b/source/source_lcao/module_rdmft/rdmft.cpp
@@ -4,6 +4,8 @@
 //==========================================================
 
 #include "rdmft.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_lcao/module_rdmft/rdmft_tools.h"
 #include "source_base/timer.h"
 #include "source_base/parallel_reduce.h"

--- a/source/source_lcao/module_rdmft/rdmft_pot.cpp
+++ b/source/source_lcao/module_rdmft/rdmft_pot.cpp
@@ -4,6 +4,7 @@
 //==========================================================
 
 #include "rdmft.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_lcao/module_rdmft/rdmft_tools.h"
 #include "source_psi/psi.h"
 #include "source_estate/module_dm/cal_dm_psi.h"

--- a/source/source_lcao/module_rdmft/update_state_rdmft.cpp
+++ b/source/source_lcao/module_rdmft/update_state_rdmft.cpp
@@ -4,6 +4,8 @@
 //==========================================================
 
 #include "rdmft.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_pot/potential_new.h" // IWYU: was transitively via elecstate.h
 #include "source_lcao/module_rdmft/rdmft_tools.h"

--- a/source/source_lcao/module_rdmft/update_state_rdmft.cpp
+++ b/source/source_lcao/module_rdmft/update_state_rdmft.cpp
@@ -4,6 +4,8 @@
 //==========================================================
 
 #include "rdmft.h"
+#include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
+#include "source_estate/module_pot/potential_new.h" // IWYU: was transitively via elecstate.h
 #include "source_lcao/module_rdmft/rdmft_tools.h"
 #include "source_estate/module_dm/cal_dm_psi.h"
 #include "source_estate/module_dm/density_matrix.h"

--- a/source/source_lcao/module_ri/Exx_LRI_interface.hpp
+++ b/source/source_lcao/module_ri/Exx_LRI_interface.hpp
@@ -1,6 +1,7 @@
 #ifndef EXX_LRI_INTERFACE_HPP
 #define EXX_LRI_INTERFACE_HPP
 #include "source_io/module_parameter/parameter.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "Exx_LRI_interface.h"

--- a/source/source_lcao/module_ri/Exx_LRI_interface.hpp
+++ b/source/source_lcao/module_ri/Exx_LRI_interface.hpp
@@ -1,6 +1,7 @@
 #ifndef EXX_LRI_INTERFACE_HPP
 #define EXX_LRI_INTERFACE_HPP
 #include "source_io/module_parameter/parameter.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "Exx_LRI_interface.h"
 #include "source_lcao/module_ri/exx_abfs-jle.h"

--- a/source/source_lcao/module_ri/RPA_LRI.hpp
+++ b/source/source_lcao/module_ri/RPA_LRI.hpp
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <vector>
 #include "source_lcao/module_ri/module_exx_symmetry/symmetry_rotation.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "RPA_LRI.h"
 #include "source_basis/module_ao/element_basis_index-ORB.h"

--- a/source/source_lcao/module_ri/RPA_LRI.hpp
+++ b/source/source_lcao/module_ri/RPA_LRI.hpp
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <vector>
 #include "source_lcao/module_ri/module_exx_symmetry/symmetry_rotation.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "RPA_LRI.h"

--- a/source/source_lcao/module_ri/RPA_LRI.hpp
+++ b/source/source_lcao/module_ri/RPA_LRI.hpp
@@ -18,6 +18,7 @@
 #include "source_basis/module_ao/element_basis_index-ORB.h"
 #include "source_estate/elecstate_lcao.h"
 #include "source_io/module_parameter/parameter.h"
+#include "source_psi/psi.h" // psi.get_nbasis() (no longer via elecstate.h)
 
 #if defined(__GLIBC__)
 #include <malloc.h>

--- a/source/source_lcao/module_ri/exx_lip.hpp
+++ b/source/source_lcao/module_ri/exx_lip.hpp
@@ -8,6 +8,7 @@
 #define EXX_LIP_HPP
 
 #include "exx_lip.h"
+#include "source_basis/module_pw/pw_basis.h" // IWYU: was transitively via elecstate.h
 #include "source_base/vector3.h"
 #include "source_base/global_function.h"
 #include "source_base/vector3.h"

--- a/source/source_lcao/setup_dm.cpp
+++ b/source/source_lcao/setup_dm.cpp
@@ -1,4 +1,5 @@
 #include "source_lcao/setup_dm.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/cal_dm.h"
 #include "source_base/timer.h"
 #include "source_estate/module_dm/cal_dm_psi.h"

--- a/source/source_main/driver_run.cpp
+++ b/source/source_main/driver_run.cpp
@@ -1,4 +1,5 @@
 #include "source_main/driver.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/check_atomic_stru.h"
 #include "source_cell/module_neighbor/sltk_atom_arrange.h"
 #include "source_relax/relax_driver.h"

--- a/source/source_pw/module_ofdft/evolve_ofdft.cpp
+++ b/source/source_pw/module_ofdft/evolve_ofdft.cpp
@@ -1,4 +1,5 @@
 #include "evolve_ofdft.h"
+#include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "source_io/module_parameter/parameter.h"
 #include <complex>

--- a/source/source_pw/module_ofdft/of_stress_pw.cpp
+++ b/source/source_pw/module_ofdft/of_stress_pw.cpp
@@ -1,4 +1,5 @@
 #include "of_stress_pw.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/timer.h"
 #include "source_hamilt/module_vdw/vdw.h"

--- a/source/source_pw/module_pwdft/elecond.cpp
+++ b/source/source_pw/module_pwdft/elecond.cpp
@@ -1,4 +1,5 @@
 #include "elecond.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/global_function.h"
 #include "source_base/global_variable.h"

--- a/source/source_pw/module_pwdft/exx_helper.cpp
+++ b/source/source_pw/module_pwdft/exx_helper.cpp
@@ -1,4 +1,5 @@
 #include "exx_helper.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_io/module_parameter/parameter.h" // use PARAM
 #include "source_hamilt/module_xc/exx_info.h" // use GlobalC::exx_info
 #include "source_hamilt/module_xc/xc_functional.h" // use XC_Functional

--- a/source/source_pw/module_pwdft/forces.cpp
+++ b/source/source_pw/module_pwdft/forces.cpp
@@ -1,4 +1,7 @@
 #include "forces.h"
+#include "source_basis/module_pw/pw_basis.h" // IWYU: was transitively via elecstate.h
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
+#include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/global_variable.h"
 #include "source_base/parallel_reduce.h"

--- a/source/source_pw/module_pwdft/forces.h
+++ b/source/source_pw/module_pwdft/forces.h
@@ -15,6 +15,7 @@
 #include "source_lcao/module_dftu/dftu.h" // mohan add 2025-11-06
 
 class pseudopot_cell_vnl;
+class surchem; // used only as a reference param below (was transitively via elecstate.h)
 
 template <typename FPTYPE, typename Device = base_device::DEVICE_CPU>
 class Forces

--- a/source/source_pw/module_pwdft/forces_cc.cpp
+++ b/source/source_pw/module_pwdft/forces_cc.cpp
@@ -1,4 +1,5 @@
 #include "forces.h"
+#include "source_basis/module_pw/pw_basis.h" // IWYU: was transitively via elecstate.h
 #include "stress_func.h"
 #include "source_base/parallel_reduce.h"
 #include "source_io/module_parameter/parameter.h"

--- a/source/source_pw/module_pwdft/forces_cc.cpp
+++ b/source/source_pw/module_pwdft/forces_cc.cpp
@@ -1,4 +1,5 @@
 #include "forces.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_basis/module_pw/pw_basis.h" // IWYU: was transitively via elecstate.h
 #include "stress_func.h"
 #include "source_base/parallel_reduce.h"

--- a/source/source_pw/module_pwdft/forces_scc.cpp
+++ b/source/source_pw/module_pwdft/forces_scc.cpp
@@ -1,4 +1,5 @@
 #include "forces.h"
+#include "source_basis/module_pw/pw_basis.h" // IWYU: was transitively via elecstate.h
 #include "source_base/parallel_reduce.h"
 #include "source_io/module_output/output_log.h"
 #include "stress_func.h"

--- a/source/source_pw/module_pwdft/forces_scc.cpp
+++ b/source/source_pw/module_pwdft/forces_scc.cpp
@@ -1,4 +1,5 @@
 #include "forces.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_basis/module_pw/pw_basis.h" // IWYU: was transitively via elecstate.h
 #include "source_base/parallel_reduce.h"
 #include "source_io/module_output/output_log.h"

--- a/source/source_pw/module_pwdft/forces_us.cpp
+++ b/source/source_pw/module_pwdft/forces_us.cpp
@@ -1,4 +1,5 @@
 #include "forces.h"
+#include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 #include "source_base/parallel_reduce.h"
 #include "source_pw/module_pwdft/vnl_pw.h"
 #include "source_base/libm/libm.h"

--- a/source/source_pw/module_pwdft/forces_us.cpp
+++ b/source/source_pw/module_pwdft/forces_us.cpp
@@ -1,4 +1,6 @@
 #include "forces.h"
+#include "source_basis/module_pw/pw_basis.h" // IWYU: was transitively via elecstate.h
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 #include "source_base/parallel_reduce.h"
 #include "source_pw/module_pwdft/vnl_pw.h"

--- a/source/source_pw/module_pwdft/hamilt_pw.cpp
+++ b/source/source_pw/module_pwdft/hamilt_pw.cpp
@@ -1,4 +1,5 @@
 #include "hamilt_pw.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "op_pw_ekin.h"
 #include "op_pw_exx.h"

--- a/source/source_pw/module_pwdft/onsite_proj.cpp
+++ b/source/source_pw/module_pwdft/onsite_proj.cpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <tuple>
 #include "source_pw/module_pwdft/onsite_proj.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_pw/module_pwdft/onsite_proj_print.h"
 #include "source_lcao/module_dftu/dftu.h"
 #include "source_lcao/module_deltaspin/spin_constrain.h"

--- a/source/source_pw/module_pwdft/onsite_proj.cpp
+++ b/source/source_pw/module_pwdft/onsite_proj.cpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <tuple>
 #include "source_pw/module_pwdft/onsite_proj.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
 #include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_pw/module_pwdft/onsite_proj_print.h"
 #include "source_lcao/module_dftu/dftu.h"

--- a/source/source_pw/module_pwdft/op_pw_proj.cpp
+++ b/source/source_pw/module_pwdft/op_pw_proj.cpp
@@ -1,4 +1,5 @@
 #include "op_pw_proj.h"
+#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "source_base/timer.h"
 #include "source_base/parallel_reduce.h"

--- a/source/source_pw/module_pwdft/op_pw_proj.cpp
+++ b/source/source_pw/module_pwdft/op_pw_proj.cpp
@@ -1,5 +1,4 @@
 #include "op_pw_proj.h"
-#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "source_base/timer.h"
 #include "source_base/parallel_reduce.h"

--- a/source/source_pw/module_pwdft/op_pw_proj.cpp
+++ b/source/source_pw/module_pwdft/op_pw_proj.cpp
@@ -1,4 +1,5 @@
 #include "op_pw_proj.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/timer.h"
 #include "source_base/parallel_reduce.h"

--- a/source/source_pw/module_pwdft/setup_pot.cpp
+++ b/source/source_pw/module_pwdft/setup_pot.cpp
@@ -1,6 +1,5 @@
 #include "source_pw/module_pwdft/setup_pot.h"
 #include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
-#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "source_estate/module_charge/symmetry_rho.h"
 #include "source_lcao/module_deltaspin/spin_constrain.h"

--- a/source/source_pw/module_pwdft/setup_pot.cpp
+++ b/source/source_pw/module_pwdft/setup_pot.cpp
@@ -1,4 +1,6 @@
 #include "source_pw/module_pwdft/setup_pot.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "source_estate/module_charge/symmetry_rho.h"

--- a/source/source_pw/module_pwdft/setup_pot.cpp
+++ b/source/source_pw/module_pwdft/setup_pot.cpp
@@ -1,4 +1,6 @@
 #include "source_pw/module_pwdft/setup_pot.h"
+#include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
+#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "source_estate/module_charge/symmetry_rho.h"
 #include "source_lcao/module_deltaspin/spin_constrain.h"

--- a/source/source_pw/module_pwdft/stress_exx.cpp
+++ b/source/source_pw/module_pwdft/stress_exx.cpp
@@ -1,5 +1,6 @@
 #include "source_hamilt/module_xc/exx_info.h"
-#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
+#include "source_basis/module_pw/pw_basis.h" // IWYU: was transitively via elecstate.h
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "op_pw_exx.h"
 #include "source_base/parallel_common.h"
 #include "source_base/parallel_reduce.h"

--- a/source/source_pw/module_pwdft/stress_exx.cpp
+++ b/source/source_pw/module_pwdft/stress_exx.cpp
@@ -1,4 +1,5 @@
 #include "source_hamilt/module_xc/exx_info.h"
+#include "source_io/module_parameter/parameter.h" // IWYU: elecstate.h no longer provides this transitively
 #include "op_pw_exx.h"
 #include "source_base/parallel_common.h"
 #include "source_base/parallel_reduce.h"

--- a/source/source_pw/module_pwdft/stress_pw.cpp
+++ b/source/source_pw/module_pwdft/stress_pw.cpp
@@ -1,4 +1,5 @@
 #include "stress_pw.h"
+#include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "source_base/timer.h"
 #include "source_base/global_variable.h" // use GlobalC

--- a/source/source_pw/module_pwdft/stress_pw.cpp
+++ b/source/source_pw/module_pwdft/stress_pw.cpp
@@ -1,4 +1,5 @@
 #include "stress_pw.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 
 #include "source_base/timer.h"

--- a/source/source_pw/module_pwdft/stress_us.cpp
+++ b/source/source_pw/module_pwdft/stress_us.cpp
@@ -1,4 +1,5 @@
 #include "source_base/libm/libm.h"
+#include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 #include "source_base/parallel_reduce.h"
 #include "source_io/module_parameter/parameter.h"
 #include "source_base/math_polyint.h"

--- a/source/source_pw/module_pwdft/stress_us.cpp
+++ b/source/source_pw/module_pwdft/stress_us.cpp
@@ -1,4 +1,6 @@
 #include "source_base/libm/libm.h"
+#include "source_basis/module_pw/pw_basis.h" // IWYU: was transitively via elecstate.h
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_estate/module_pot/potential_new.h" // IWYU: elecstate.h no longer provides this transitively
 #include "source_base/parallel_reduce.h"
 #include "source_io/module_parameter/parameter.h"

--- a/source/source_pw/module_stodft/sto_forces.cpp
+++ b/source/source_pw/module_stodft/sto_forces.cpp
@@ -1,4 +1,5 @@
 #include "sto_forces.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/mathzone.h"
 #include "source_cell/module_symmetry/symmetry.h"

--- a/source/source_pw/module_stodft/sto_iter.cpp
+++ b/source/source_pw/module_stodft/sto_iter.cpp
@@ -1,4 +1,6 @@
 #include "sto_iter.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
+#include "source_estate/module_charge/charge.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/kernels/math_kernel_op.h"
 #include "source_base/para_gemm.h"

--- a/source/source_pw/module_stodft/sto_stress_pw.cpp
+++ b/source/source_pw/module_stodft/sto_stress_pw.cpp
@@ -1,4 +1,5 @@
 #include "sto_stress_pw.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 
 #include "source_base/parallel_reduce.h"
 #include "source_base/timer.h"

--- a/source/source_pw/module_stodft/test/test_hamilt_sto.cpp
+++ b/source/source_pw/module_stodft/test/test_hamilt_sto.cpp
@@ -1,4 +1,6 @@
 #include "../hamilt_sdft_pw.h"
+#include "source_cell/klist.h" // IWYU: was transitively via elecstate.h
+#include "source_estate/module_pot/potential_new.h" // IWYU: was transitively via elecstate.h
 #include "source_hamilt/operator.h"
 
 #include "gtest/gtest.h"

--- a/source/source_relax/ions_move_lbfgs.cpp
+++ b/source/source_relax/ions_move_lbfgs.cpp
@@ -1,4 +1,5 @@
 #include "ions_move_lbfgs.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "matrix_methods.h"
 #include "source_io/module_parameter/parameter.h"
 #include "ions_move_basic.h"

--- a/source/source_relax/relax_driver.cpp
+++ b/source/source_relax/relax_driver.cpp
@@ -1,4 +1,5 @@
 #include "relax_driver.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_base/global_file.h"
 #include "source_io/module_output/cif_io.h"
 #include "source_io/module_json/output_info.h"

--- a/source/source_relax/relax_nsync.cpp
+++ b/source/source_relax/relax_nsync.cpp
@@ -1,4 +1,5 @@
 #include "relax_nsync.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "source_base/global_function.h"
 #include "source_base/global_variable.h"
 #include "source_io/module_parameter/parameter.h"

--- a/source/source_relax/test/ions_move_methods_test.cpp
+++ b/source/source_relax/test/ions_move_methods_test.cpp
@@ -1,4 +1,5 @@
 #include "for_test.h"
+#include "source_cell/unitcell.h" // IWYU: was transitively via elecstate.h
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #define private public


### PR DESCRIPTION
Reduce the transitive include weight of source_estate/elecstate.h. It previously pulled in 68 headers (chain depth 11) by including parameter.h, potential_new.h, klist.h, charge.h and psi.h directly.

Parameter.h can't be removed now temporarily because it is included in too many files😅, this will be done later