### PR TITLE
Refactor: remove some unhealthy include dependencies

### DIFF
--- a/source/source_esolver/esolver_fp.h
+++ b/source/source_esolver/esolver_fp.h
@@ -9,6 +9,7 @@
 #include "source_estate/elecstate.h" // electronic states
 #include "source_estate/module_charge/charge_extra.h" // charge extrapolation
 #include "source_hamilt/module_surchem/surchem.h" // solvation model
+#include "source_pw/module_pwdft/parallel_grid.h" // Parallel_Grid (value member below)
 #include "source_pw/module_pwdft/vl_pw.h" // local pseudopotential
 #include "source_pw/module_pwdft/structure_factor.h" // structure factor
 

--- a/source/source_hamilt/module_surchem/cal_pseudo.cpp
+++ b/source/source_hamilt/module_surchem/cal_pseudo.cpp
@@ -1,5 +1,7 @@
 #include "surchem.h"
 
+#include "source_pw/module_pwdft/structure_factor.h" // Structure_Factor member access (sf->strucFac)
+
 // atom_in surchem::GetAtom;
 
 void surchem::gauss_charge(const UnitCell& cell,

--- a/source/source_hamilt/module_surchem/surchem.h
+++ b/source/source_hamilt/module_surchem/surchem.h
@@ -6,8 +6,11 @@
 #include "source_base/matrix.h"
 #include "source_basis/module_pw/pw_basis.h"
 #include "source_cell/unitcell.h"
-#include "source_pw/module_pwdft/parallel_grid.h"
-#include "source_pw/module_pwdft/structure_factor.h"
+
+// Used below only as pointer/reference parameters; forward-declare instead of
+// including the (heavy) source_pw headers, which created a hamilt -> pw back-edge.
+class Parallel_Grid;
+class Structure_Factor;
 
 class surchem
 {

--- a/source/source_hamilt/module_surchem/surchem.h
+++ b/source/source_hamilt/module_surchem/surchem.h
@@ -7,8 +7,6 @@
 #include "source_basis/module_pw/pw_basis.h"
 #include "source_cell/unitcell.h"
 
-// Used below only as pointer/reference parameters; forward-declare instead of
-// including the (heavy) source_pw headers, which created a hamilt -> pw back-edge.
 class Parallel_Grid;
 class Structure_Factor;
 

--- a/source/source_hamilt/module_surchem/surchem.h
+++ b/source/source_hamilt/module_surchem/surchem.h
@@ -7,6 +7,7 @@
 #include "source_basis/module_pw/pw_basis.h"
 #include "source_cell/unitcell.h"
 
+// forward-declared: used below only as pointer/reference
 class Parallel_Grid;
 class Structure_Factor;
 

--- a/source/source_pw/module_pwdft/forces.cpp
+++ b/source/source_pw/module_pwdft/forces.cpp
@@ -17,6 +17,7 @@
 #include "source_estate/module_pot/gatefield.h"
 #include "source_hamilt/module_ewald/H_Ewald_pw.h"
 #include "source_hamilt/module_surchem/surchem.h"
+#include "source_pw/module_pwdft/structure_factor.h" // Structure_Factor member access (p_sf->strucFac)
 #include "source_hamilt/module_vdw/vdw.h"
 
 #ifdef _OPENMP

--- a/source/source_pw/module_pwdft/hamilt_pw.h
+++ b/source/source_pw/module_pwdft/hamilt_pw.h
@@ -4,7 +4,6 @@
 #include "source_base/kernels/math_kernel_op.h"
 #include "source_base/macros.h"
 #include "source_cell/klist.h"
-#include "source_esolver/esolver_ks_pw.h"
 #include "source_estate/module_pot/potential_new.h"
 #include "source_hamilt/hamilt.h"
 #include "source_lcao/module_dftu/dftu.h" // mohan add 2025-11-06


### PR DESCRIPTION
HamiltPW does not reference any ESolver symbol; the include of source_esolver/esolver_ks_pw.h was unused. Removing it cuts the only source_pw -> source_esolver back-edge (an operator header depending on its driver) and drops 15 transitively-included headers from every consumer of hamilt_pw.h (fan 114 -> 99).

All types named in the header (UnitCell, ModulePW::PW_Basis_K, etc.) remain provided by klist.h / vnl_pw.h -> structure_factor.h.

‎source/source_hamilt/module_surchem/surchem.h also get a header removal.

Because the codes are getting complex in some modules, so I'm starting the refactor work from simpler files instead of a whole folder.