### PR TITLE
perf: avoid redundant dp.compute() across MPI ranks

### DIFF
--- a/source/source_esolver/esolver_dp.cpp
+++ b/source/source_esolver/esolver_dp.cpp
@@ -59,7 +59,15 @@ void ESolver_DP::runner(UnitCell& ucell, const int istep)
     ModuleBase::TITLE("ESolver_DP", "runner");
     ModuleBase::timer::start("ESolver_DP", "runner");
 
+    // cell and coord are only needed by dp.compute() on rank 0
     std::vector<double> cell(9, 0.0);
+    std::vector<double> coord(3 * ucell.nat, 0.0);
+    int iat = 0;
+
+#ifdef __MPI
+    if (GlobalV::MY_RANK == 0)
+    {
+#endif
     cell[0] = ucell.latvec.e11 * ucell.lat0_angstrom;
     cell[1] = ucell.latvec.e12 * ucell.lat0_angstrom;
     cell[2] = ucell.latvec.e13 * ucell.lat0_angstrom;
@@ -70,8 +78,6 @@ void ESolver_DP::runner(UnitCell& ucell, const int istep)
     cell[7] = ucell.latvec.e32 * ucell.lat0_angstrom;
     cell[8] = ucell.latvec.e33 * ucell.lat0_angstrom;
 
-    std::vector<double> coord(3 * ucell.nat, 0.0);
-    int iat = 0;
     for (int it = 0; it < ucell.ntype; ++it)
     {
         for (int ia = 0; ia < ucell.atoms[it].na; ++ia)
@@ -83,6 +89,9 @@ void ESolver_DP::runner(UnitCell& ucell, const int istep)
         }
     }
     assert(ucell.nat == iat);
+#ifdef __MPI
+    }
+#endif
 
 #ifdef __DPMD
     std::vector<double> f, v;

--- a/source/source_esolver/esolver_dp.cpp
+++ b/source/source_esolver/esolver_dp.cpp
@@ -90,7 +90,27 @@ void ESolver_DP::runner(UnitCell& ucell, const int istep)
     dp_force.zero_out();
     dp_virial.zero_out();
 
+#ifdef __MPI
+    if (GlobalV::MY_RANK == 0)
+    {
+        dp.compute(dp_potential, f, v, coord, atype, cell, fparam, aparam);
+    }
+    // broadcast sizes first (only rank 0 has them after dp.compute)
+    int f_size = f.size();
+    int v_size = v.size();
+    Parallel_Common::bcast_int(f_size);
+    Parallel_Common::bcast_int(v_size);
+    if (GlobalV::MY_RANK != 0)
+    {
+        f.resize(f_size);
+        v.resize(v_size);
+    }
+    Parallel_Common::bcast_double(dp_potential);
+    Parallel_Common::bcast_double(f.data(), f_size);
+    Parallel_Common::bcast_double(v.data(), v_size);
+#else
     dp.compute(dp_potential, f, v, coord, atype, cell, fparam, aparam);
+#endif
 
     // rescale the energy, force, and stress
     const double fact_e = rescaling / ModuleBase::Ry_to_eV;
@@ -203,3 +223,4 @@ void ESolver_DP::type_map(const UnitCell& ucell)
     assert(ucell.nat == iat);
 }
 #endif
+


### PR DESCRIPTION
### Problem
In `ESolver_DP::runner()`, every MPI rank calls `dp.compute()` independently with identical input, producing the same energy, forces, and virial. With N ranks, this results in N-fold redundant computation, and multiple concurrent deepmd inference calls cause CPU contention.

### Solution
Only rank 0 calls `dp.compute()`, then broadcasts results via `MPI_Bcast`. Implemented with `#ifdef __MPI` guards — serial builds are unaffected.

### Performance (864 Al atoms, 100 MD steps)
| np | Before | After |
|----|--------|-------|
| 1  | 34s    | 33s   |
| 2  | 39s    | 33s   |
| 4  | 55s    | 23s   |
| 8  | 102s   | 28s   |

### Checklist
- [ ] No linked issue (standalone optimization)
- [ ] No new tests needed — computation results are mathematically identical
- [ ] No behavioral changes
- [ ] No core module changes
