### PR TITLE
Add PPCG block subspace solver

### DIFF
--- a/source/source_hsolver/diago_ppcg.cpp
+++ b/source/source_hsolver/diago_ppcg.cpp
@@ -1,0 +1,18 @@
+#include "diago_ppcg.h"
+
+#include "ppcg/diago_ppcg_lapack.hpp"
+#include "ppcg/diago_ppcg_ops.hpp"
+#include "ppcg/diago_ppcg_subspace.hpp"
+#include "ppcg/diago_ppcg_orth.hpp"
+#include "ppcg/diago_ppcg_cg.hpp"
+#include "ppcg/diago_ppcg_diag.hpp"
+
+namespace hsolver {
+
+// =============================================================================
+// Explicit template instantiation (CPU only; extend for GPU as needed)
+// =============================================================================
+template class DiagoPPCG<std::complex<float>,  base_device::DEVICE_CPU>;
+template class DiagoPPCG<std::complex<double>, base_device::DEVICE_CPU>;
+
+} // namespace hsolver

--- a/source/source_hsolver/diago_ppcg.h
+++ b/source/source_hsolver/diago_ppcg.h
@@ -1,0 +1,228 @@
+#ifndef DIAGO_PPCG_H
+#define DIAGO_PPCG_H
+
+#include "source_base/module_device/types.h"
+
+#include <vector>
+#include <functional>
+#include <cmath>
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+#include <numeric>
+#include <complex>
+#include <type_traits>
+
+namespace hsolver {
+
+// -----------------------------------------------------------------------------
+// DiagoPPCG: Projection Preconditioned Conjugate Gradient solver
+// -----------------------------------------------------------------------------
+//
+// Supports two algorithmic strategies:
+//   CONJUGATE_GRADIENT — band-by-band Polak-Ribiere CG with line minimization
+//     (File 2 approach).
+//   BLOCK_SUBSPACE — block subspace diagonalization (File 1 approach).
+//
+// BLOCK_SUBSPACE is the production path used by ks_solver=ppcg.
+// CONJUGATE_GRADIENT is kept as an explicit fallback strategy.
+// -----------------------------------------------------------------------------
+
+enum class PpcgStrategy { BLOCK_SUBSPACE, CONJUGATE_GRADIENT };
+
+namespace base_device = ::base_device;
+
+template <typename T, typename Device>
+class DiagoPPCG
+{
+public:
+    // -------------------------------------------------------------------------
+    // Type aliases
+    // -------------------------------------------------------------------------
+    using Real = typename std::conditional<
+        std::is_same<T, std::complex<double>>::value, double,
+        float>::type;
+    using HPsiFunc = std::function<void(T*, T*, int, int)>;
+    using SPsiFunc = std::function<void(T*, T*, int, int)>;
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+    DiagoPPCG(const Real& diag_thr,
+              const int& diag_iter_max,
+              const int& sbsize,
+              const int& rr_step,
+              const bool gamma_g0_real,
+              const PpcgStrategy strategy = PpcgStrategy::BLOCK_SUBSPACE);
+
+    // -------------------------------------------------------------------------
+    // Main entry point
+    //
+    // Returns average number of subspace iterations per band.
+    // -------------------------------------------------------------------------
+    double diag(const HPsiFunc& hpsi_func,
+                const SPsiFunc& spsi_func,
+                int ld_psi,
+                int nband,
+                int dim,
+                T* psi_in,
+                Real* eigenvalue_in,
+                const std::vector<double>& ethr_band,
+                const Real* prec);
+
+private:
+    // -------------------------------------------------------------------------
+    // Data members
+    // -------------------------------------------------------------------------
+    int maxiter_;
+    int sbsize_;
+    int rr_step_;
+    Real diag_thr_;
+    bool gamma_g0_real_;
+    PpcgStrategy strategy_;
+
+    // Problem dimensions (set in diag())
+    int ld_psi_ = 0;
+    int n_band_ = 0;
+    int n_dim_ = 0;
+
+    // Cached S-operator (null if identity).
+    SPsiFunc spsi_func_;
+
+    // Working storage (column-major: ld_psi_ rows, n_band_ columns).
+    std::vector<T> hpsi_;
+    std::vector<T> spsi_;
+    std::vector<T> w_;       // residual / preconditioned residual
+    std::vector<T> sw_;      // S * w
+    std::vector<T> hw_;      // H * w
+    std::vector<T> p_;       // previous search direction (for block subspace)
+    std::vector<T> sp_;      // S * p
+    std::vector<T> hp_;      // H * p
+
+    // Polak-Ribiere state (CONJUGATE_GRADIENT strategy)
+    std::vector<T> grad_old_;   // previous gradient
+    std::vector<T> z_old_;      // previous preconditioned residual
+    std::vector<Real> beta_denom_;
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+    static inline int idx(int row, int col, int ld)
+    {
+        return row + col * ld;
+    }
+
+    void validate_input(const T* psi_in, const Real* eigenvalue_in,
+                        const std::vector<double>& ethr_band,
+                        const Real* prec) const;
+
+    void force_g0_real(T* x, int ncol) const;
+
+    // S-application (identity fallback if spsi_func is null).
+    void apply_h(const HPsiFunc& hpsi_func, T* psi_in, T* hpsi_out,
+                 int ncol) const;
+    void apply_s(const SPsiFunc& spsi_func, T* psi_in, T* spsi_out,
+                 int ncol) const;
+    void apply_s_current(T* psi_in, T* spsi_out, int ncol) const;
+
+    // Inner product <x|y> (real part only).
+    Real gamma_dot(const T* x, const T* y) const;
+    T complex_dot(const T* x, const T* y) const;
+
+    // Gram matrix: out[i, j] = <a_i | b_j>.
+    void gram(const T* a, const T* b,
+              int ncol_a, int ncol_b,
+              std::vector<T>& out, int ld_out) const;
+
+    // Gather / scatter columns.
+    void copy_cols(const T* src, const std::vector<int>& cols,
+                   std::vector<T>& dst) const;
+    void scatter_cols(T* dst, const std::vector<int>& cols,
+                      const std::vector<T>& src) const;
+
+    // Project x onto vectors orthogonal to the S-orthonormal basis.
+    void project_against(const T* basis, const T* sbasis,
+                         const std::vector<int>& basis_cols,
+                         std::vector<T>& x, std::vector<T>& sx,
+                         const std::vector<int>& x_cols) const;
+
+    // x[c] /= max(prec, eps)  for each active column c.
+    void divide_by_preconditioner(const std::vector<int>& active_cols,
+                                  const Real* prec,
+                                  std::vector<T>& x) const;
+
+    // -------------------------------------------------------------------------
+    // Block-subspace strategy helpers (File 1 style)
+    // -------------------------------------------------------------------------
+    struct SmallSubspace
+    {
+        std::vector<T> k;        // K matrix (projected H)
+        std::vector<T> m;        // M matrix (projected S)
+        std::vector<Real> eval;  // eigenvalues
+        std::vector<Real> w_scale;
+        std::vector<Real> p_scale;
+    };
+
+    void lock_epairs(const std::vector<T>& residual,
+                     const std::vector<double>& ethr_band,
+                     std::vector<int>& active_cols) const;
+
+    void build_small_subspace(const T* psi,
+                              const std::vector<int>& cols,
+                              bool use_p,
+                              SmallSubspace& subspace) const;
+
+    void solve_small_generalized(int dim, SmallSubspace& subspace) const;
+
+    void update_one_block(T* psi,
+                          const std::vector<int>& cols,
+                          int l,
+                          bool use_p,
+                          const SmallSubspace& subspace);
+
+    void right_solve_upper(const std::vector<T>& r, int n,
+                           std::vector<T>& x) const;
+
+    bool is_s_orthonormal(const T* psi, const T* spsi, int ncol) const;
+
+    void s_gram_schmidt(T* psi, T* hpsi, T* spsi, int ncol) const;
+
+    void chol_qr_active(T* psi, const std::vector<int>& active_cols);
+
+    void rayleigh_ritz(T* psi, Real* eigenvalue,
+                       std::vector<int>& active_cols,
+                       const std::vector<double>& ethr_band);
+
+    Real trace_of_active_projected(const T* psi,
+                                    const std::vector<int>& active_cols) const;
+
+    // -------------------------------------------------------------------------
+    // Conjugate-gradient strategy helpers (File 2 style)
+    // -------------------------------------------------------------------------
+    void calc_gradient(const Real* prec,
+                       const T* hpsi,
+                       const T* spsi,
+                       const T* psi,
+                       const Real* eigenvalue,
+                       std::vector<T>& grad) const;
+
+    void orth_gradient(const T* psi, const T* spsi,
+                       std::vector<T>& grad) const;
+
+    void update_polak_ribiere(const std::vector<T>& grad,
+                              std::vector<T>& p,
+                              std::vector<T>& grad_old,
+                              std::vector<T>& z_old,
+                              std::vector<Real>& beta_denom,
+                              const Real* prec) const;
+
+    void line_minimize(T* psi, T* hpsi, T* spsi,
+                       const T* p, const T* hp, const T* sp,
+                       int ncol) const;
+
+    void orth_cholesky(T* psi, T* hpsi, T* spsi, int ncol) const;
+};
+
+} // namespace hsolver
+
+#endif // DIAGO_PPCG_H

--- a/source/source_hsolver/hsolver_pw.cpp
+++ b/source/source_hsolver/hsolver_pw.cpp
@@ -11,6 +11,7 @@
 #include "source_hsolver/diago_cg.h"
 #include "source_hsolver/diago_dav_subspace.h"
 #include "source_hsolver/diago_david.h"
+#include "source_hsolver/diago_ppcg.h"
 #include "source_hsolver/diago_iter_assist.h"
 #include "source_io/module_parameter/parameter.h"
 #include "source_psi/psi.h"
@@ -18,10 +19,72 @@
 
 
 #include <algorithm>
+#include <type_traits>
 #include <vector>
 
 namespace hsolver
 {
+
+namespace
+{
+template <typename T, typename Device, typename Real, typename HPsiFunc, typename SPsiFunc>
+double run_ppcg_pw(const HPsiFunc& hpsi_func,
+                   const SPsiFunc& spsi_func,
+                   const int ld_psi,
+                   const int nband,
+                   const int dim,
+                   T* psi,
+                   Real* eigenvalue,
+                   const std::vector<double>& ethr_band,
+                   const Real* pre_condition,
+                   const double diag_thr,
+                   const int diag_iter_max,
+                   const int pw_diag_ndim,
+                   const bool gamma_only,
+                   std::true_type)
+{
+    const int sbsize = std::max(1, std::min(nband, pw_diag_ndim));
+    const int rr_step = std::max(1, pw_diag_ndim);
+
+    DiagoPPCG<T, Device> ppcg(static_cast<Real>(diag_thr),
+                              diag_iter_max,
+                              sbsize,
+                              rr_step,
+                              gamma_only,
+                              PpcgStrategy::BLOCK_SUBSPACE);
+
+    return ppcg.diag(hpsi_func,
+                     spsi_func,
+                     ld_psi,
+                     nband,
+                     dim,
+                     psi,
+                     eigenvalue,
+                     ethr_band,
+                     pre_condition);
+}
+
+template <typename T, typename Device, typename Real, typename HPsiFunc, typename SPsiFunc>
+double run_ppcg_pw(const HPsiFunc&,
+                   const SPsiFunc&,
+                   const int,
+                   const int,
+                   const int,
+                   T*,
+                   Real*,
+                   const std::vector<double>&,
+                   const Real*,
+                   const double,
+                   const int,
+                   const int,
+                   const bool,
+                   std::false_type)
+{
+    ModuleBase::WARNING_QUIT("HSolverPW::hamiltSolvePsiK",
+                             "PPCG is currently implemented for CPU PW calculations only.");
+    return 0.0;
+}
+} // namespace
 
 template <typename T, typename Device>
 void HSolverPW<T, Device>::cal_smooth_ethr(const double& wk,
@@ -83,7 +146,7 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
     this->nproc_in_pool = nproc_in_pool_in;
 
     // report if the specified diagonalization method is not supported
-    const std::initializer_list<std::string> _methods = {"cg", "dav", "dav_subspace", "bpcg"};
+    const std::initializer_list<std::string> _methods = {"cg", "dav", "dav_subspace", "bpcg", "ppcg"};
     if (std::find(std::begin(_methods), std::end(_methods), this->method) == std::end(_methods))
     {
         ModuleBase::WARNING_QUIT("HSolverPW::solve", "This type of eigensolver is not supported!");
@@ -378,6 +441,24 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm,
                         david_maxiter,
                         ntry_max,
                         notconv_max));
+    }
+    else if (this->method == "ppcg")
+    {
+        DiagoIterAssist<T, Device>::avg_iter += run_ppcg_pw<T, Device, Real>(
+            hpsi_func,
+            spsi_func,
+            psi.get_nbasis(),
+            psi.get_nbands(),
+            psi.get_current_ngk(),
+            psi.get_pointer(),
+            eigenvalue,
+            this->ethr_band,
+            pre_condition.data(),
+            this->diag_thr,
+            this->diag_iter_max,
+            PARAM.inp.pw_diag_ndim,
+            PARAM.globalv.gamma_only_pw,
+            std::is_same<Device, base_device::DEVICE_CPU>());
     }
     ModuleBase::timer::end("HSolverPW", "solve_psik");
     return;

--- a/source/source_hsolver/ppcg/diago_ppcg_cg.hpp
+++ b/source/source_hsolver/ppcg/diago_ppcg_cg.hpp
@@ -1,0 +1,312 @@
+namespace hsolver {
+
+//==============================================================================
+// CONJUGATE_GRADIENT STRATEGY
+//==============================================================================
+
+// ---------------------------------------------------------------------------
+// Compute gradient: grad_i = H|psi_i> - eps_i * S|psi_i>
+// ---------------------------------------------------------------------------
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::calc_gradient(
+    const Real* /*prec*/,
+    const T* hpsi,
+    const T* spsi,
+    const T* /*psi*/,
+    const Real* eigenvalue,
+    std::vector<T>& grad) const
+{
+    grad.assign(ld_psi_ * n_band_, T(0));
+    for (int j = 0; j < n_band_; ++j)
+    {
+        const Real ej = eigenvalue[j];
+        for (int ig = 0; ig < n_dim_; ++ig)
+            grad[idx(ig, j, ld_psi_)] = hpsi[idx(ig, j, ld_psi_)]
+                                      - spsi[idx(ig, j, ld_psi_)] * ej;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Orthogonalize gradient: grad_j -= sum_i <psi_i|grad_j> * S|psi_i>
+// ---------------------------------------------------------------------------
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::orth_gradient(
+    const T* psi, const T* spsi,
+    std::vector<T>& grad) const
+{
+    for (int j = 0; j < n_band_; ++j)
+    {
+        for (int i = 0; i < n_band_; ++i)
+        {
+            // Full complex inner product <psi_i | grad_j>
+            T coeff = 0;
+            const T* pi = psi + i * ld_psi_;
+            const T* gj = grad.data() + j * ld_psi_;
+            for (int ig = 0; ig < n_dim_; ++ig)
+                coeff += std::conj(pi[ig]) * gj[ig];
+            if (std::abs(coeff) <= std::numeric_limits<Real>::epsilon())
+                continue;
+            // grad_j -= S|psi_i> * coeff
+            const T* si = spsi + i * ld_psi_;
+            T* gj_out = grad.data() + j * ld_psi_;
+            for (int ig = 0; ig < n_dim_; ++ig)
+                gj_out[ig] -= si[ig] * coeff;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Polak-Ribiere conjugate gradient update with preconditioning:
+//   z_new = -P^{-1} * r_new
+//   beta = max(0, <z_new, r_new - r_old> / <z_old, r_old>)
+//   d_new = z_new + beta * d_old
+// ---------------------------------------------------------------------------
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::update_polak_ribiere(
+    const std::vector<T>& grad,
+    std::vector<T>& p,
+    std::vector<T>& grad_old,
+    std::vector<T>& z_old,
+    std::vector<Real>& beta_denom,
+    const Real* prec) const
+{
+    const bool first_iter = p.empty();
+    if (first_iter)
+    {
+        p.assign(ld_psi_ * n_band_, T(0));
+        z_old.assign(ld_psi_ * n_band_, T(0));
+        beta_denom.assign(n_band_, std::numeric_limits<Real>::infinity());
+    }
+
+    std::vector<T> z_new(ld_psi_ * n_band_, T(0));
+
+    for (int j = 0; j < n_band_; ++j)
+    {
+        const T* g  = grad.data() + j * ld_psi_;
+        T* pj  = p.data() + j * ld_psi_;
+        T* zn  = z_new.data() + j * ld_psi_;
+        T* zo  = z_old.data() + j * ld_psi_;
+
+        Real beta_num_zr = 0;
+        Real beta_num_zo = 0;
+
+        for (int ig = 0; ig < n_dim_; ++ig)
+        {
+            // z_new = -P^{-1} * grad
+            T z = -g[ig] / std::max(prec[ig], static_cast<Real>(1.0e-12));
+            zn[ig] = z;
+
+            // r_old = -P * z_old (recover old raw residual)
+            T r_old = -prec[ig] * zo[ig];
+
+            beta_num_zr += static_cast<Real>(std::real(z * std::conj(g[ig])));
+            beta_num_zo += static_cast<Real>(std::real(z * std::conj(r_old)));
+        }
+
+        Real beta = 0;
+        const Real denom = beta_denom[j];
+        if (denom > static_cast<Real>(1.0e-30))
+        {
+            beta = (beta_num_zr - beta_num_zo) / denom;
+            if (beta < 0)
+                beta = 0;
+        }
+
+        // d_new = z_new + beta * d_old
+        for (int ig = 0; ig < n_dim_; ++ig)
+            pj[ig] = zn[ig] + beta * pj[ig];
+
+        // Save <z_new, r_new> as denominator for next iteration.
+        beta_denom[j] = beta_num_zr + static_cast<Real>(1.0e-30);
+    }
+
+    // Persist state for next iteration.
+    z_old.swap(z_new);
+    grad_old = grad;
+}
+
+// ---------------------------------------------------------------------------
+// Line minimization along search direction:
+//   For each band j: find optimal step α by minimizing the Rayleigh quotient
+//   in the 2D subspace spanned by |psi_j> and |p_j>.
+//
+//   The Rayleigh quotient:
+//     R(α) = (h_ii + 2α h_ip + α² h_pp) / (s_ii + 2α s_ip + α² s_pp)
+//
+//   Setting dR/dα = 0 gives a QUADRATIC equation A α² + B α + C = 0 with:
+//     A = s_ip * h_pp - h_ip * s_pp
+//     B = s_ii * h_pp - h_ii * s_pp
+//     C = s_ii * h_ip - h_ii * s_ip
+//
+//   The linear approximation α = -C / B (dropping the α² term) picks one of
+//   the two stationary points more-or-less arbitrarily.  For bands far from
+//   convergence this can select the MAXIMUM, driving ψ toward high-energy
+//   states.  We solve the full quadratic and explicitly pick the root with
+//   the lower Rayleigh quotient.
+//
+//   Update: |psi>  += α |p>
+//           H|psi> += α H|p>
+//           S|psi> += α S|p>
+// ---------------------------------------------------------------------------
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::line_minimize(
+    T* psi, T* hpsi, T* spsi,
+    const T* p, const T* hp, const T* sp,
+    int ncol) const
+{
+    for (int j = 0; j < ncol; ++j)
+    {
+        const int off = j * ld_psi_;
+        T* pj  = psi  + off;
+        T* hj  = hpsi + off;
+        T* sj  = spsi + off;
+        const T* pp = p   + off;
+        const T* hpp = hp + off;
+        const T* spp = sp + off;
+
+        Real h_ii = gamma_dot(pj, hj);
+        Real s_ii = gamma_dot(pj, sj);
+        const T h_ip_c = complex_dot(pj, hpp);
+        const T s_ip_c = complex_dot(pj, spp);
+        Real h_pp = gamma_dot(pp, hpp);
+        Real s_pp = gamma_dot(pp, spp);
+
+        // Rotate the search direction so the first-order Rayleigh quotient
+        // derivative is real. The scalar alpha solve below stays unchanged for
+        // real problems, while complex PW states can use a complex step.
+        T phase = T(1);
+        const Real lambda = h_ii / std::max(s_ii, static_cast<Real>(1e-30));
+        const T q = h_ip_c - T(lambda) * s_ip_c;
+        const Real q_abs = std::abs(q);
+        if (q_abs > static_cast<Real>(1e-30))
+            phase = std::conj(q) / q_abs;
+
+        Real h_ip = static_cast<Real>(std::real(phase * h_ip_c));
+        Real s_ip = static_cast<Real>(std::real(phase * s_ip_c));
+
+        // Coefficients of A alpha^2 + B alpha + C = 0
+        const Real A = s_ip * h_pp - h_ip * s_pp;
+        const Real B = s_ii * h_pp - h_ii * s_pp;
+        const Real C = s_ii * h_ip - h_ii * s_ip;
+
+        auto ray_quot = [&](Real a) -> Real {
+            return (h_ii + static_cast<Real>(2) * a * h_ip + a * a * h_pp)
+                 / std::max(s_ii + static_cast<Real>(2) * a * s_ip + a * a * s_pp,
+                            static_cast<Real>(1e-30));
+        };
+
+        Real alpha = 0;
+        Real alpha_linear = (std::abs(B) > static_cast<Real>(1e-30))
+                          ? -C / B : static_cast<Real>(0);
+
+        const Real tol = std::numeric_limits<Real>::epsilon() * static_cast<Real>(100);
+        if (std::abs(A) > tol * std::max(static_cast<Real>(1), std::abs(B)))
+        {
+            const Real disc = B * B - static_cast<Real>(4) * A * C;
+            if (disc >= static_cast<Real>(0))
+            {
+                const Real sqrt_disc = std::sqrt(disc);
+                const Real a1 = (-B + sqrt_disc) / (static_cast<Real>(2) * A);
+                const Real a2 = (-B - sqrt_disc) / (static_cast<Real>(2) * A);
+
+                const Real r1 = ray_quot(a1);
+                const Real r2 = ray_quot(a2);
+                const Real r_lin = ray_quot(alpha_linear);
+
+                if (r1 < r2 && r1 < r_lin)
+                    alpha = a1;
+                else if (r2 < r1 && r2 < r_lin)
+                    alpha = a2;
+                else
+                    alpha = alpha_linear;
+            }
+            else
+            {
+                alpha = alpha_linear;
+            }
+        }
+        else
+        {
+            alpha = alpha_linear;
+        }
+
+        for (int ig = 0; ig < n_dim_; ++ig)
+        {
+            const T step = T(alpha) * phase;
+            pj[ig] += step * pp[ig];
+            hj[ig] += step * hpp[ig];
+            sj[ig] += step * spp[ig];
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cholesky orthonormalization (S-orthonormal):
+//   1. Form S-gram matrix J = psi^H * S * psi
+//   2. Cholesky: J = U^T * U  (upper)
+//   3. Invert U: U^{-1}
+//   4. psi *= U^{-1},  Hpsi *= U^{-1},  Spsi *= U^{-1}
+// ---------------------------------------------------------------------------
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::orth_cholesky(
+    T* psi, T* hpsi, T* spsi, int ncol) const
+{
+    // Save original vectors in case Cholesky fails numerically.
+    std::vector<T> psi_orig(psi, psi + ld_psi_ * ncol);
+    std::vector<T> hpsi_orig(hpsi, hpsi + ld_psi_ * ncol);
+    std::vector<T> spsi_orig(spsi, spsi + ld_psi_ * ncol);
+
+    // Gram matrix of S-orthonormality: J_{ij} = <psi_i | S | psi_j>
+    std::vector<T> gram_s(ncol * ncol, T(0));
+    for (int j = 0; j < ncol; ++j)
+        for (int i = 0; i < ncol; ++i)
+            gram_s[i + j * ncol] = complex_dot(psi + i * ld_psi_,
+                                                spsi + j * ld_psi_);
+
+    bool cholesky_ok = false;
+    try
+    {
+        HermitianLapack<T>::potrf(ncol, gram_s.data());
+        HermitianLapack<T>::trtri(ncol, gram_s.data());
+
+        std::vector<T> tmp(ld_psi_ * ncol, T(0));
+        for (int j = 0; j < ncol; ++j)
+            for (int i = 0; i < ncol; ++i) {
+                const T uinv = gram_s[i + j * ncol];
+                for (int ig = 0; ig < n_dim_; ++ig)
+                    tmp[idx(ig, j, ld_psi_)] += psi[idx(ig, i, ld_psi_)] * uinv;
+            }
+        std::copy(tmp.begin(), tmp.end(), psi);
+
+        set_zero(tmp);
+        for (int j = 0; j < ncol; ++j)
+            for (int i = 0; i < ncol; ++i) {
+                const T uinv = gram_s[i + j * ncol];
+                for (int ig = 0; ig < n_dim_; ++ig)
+                    tmp[idx(ig, j, ld_psi_)] += hpsi[idx(ig, i, ld_psi_)] * uinv;
+            }
+        std::copy(tmp.begin(), tmp.end(), hpsi);
+
+        set_zero(tmp);
+        for (int j = 0; j < ncol; ++j)
+            for (int i = 0; i < ncol; ++i) {
+                const T uinv = gram_s[i + j * ncol];
+                for (int ig = 0; ig < n_dim_; ++ig)
+                    tmp[idx(ig, j, ld_psi_)] += spsi[idx(ig, i, ld_psi_)] * uinv;
+            }
+        std::copy(tmp.begin(), tmp.end(), spsi);
+
+        cholesky_ok = is_s_orthonormal(psi, spsi, ncol);
+    }
+    catch (const std::runtime_error&) { cholesky_ok = false; }
+
+    if (!cholesky_ok)
+    {
+        std::copy(psi_orig.begin(), psi_orig.end(), psi);
+        std::copy(hpsi_orig.begin(), hpsi_orig.end(), hpsi);
+        std::copy(spsi_orig.begin(), spsi_orig.end(), spsi);
+        s_gram_schmidt(psi, hpsi, spsi, ncol);
+    }
+}
+
+} // namespace hsolver

--- a/source/source_hsolver/ppcg/diago_ppcg_diag.hpp
+++ b/source/source_hsolver/ppcg/diago_ppcg_diag.hpp
@@ -1,0 +1,310 @@
+namespace hsolver {
+
+//==============================================================================
+// MAIN DIAGONALIZATION ROUTINE
+//==============================================================================
+template <typename T, typename Device>
+double DiagoPPCG<T, Device>::diag(const HPsiFunc& hpsi_func,
+                                   const SPsiFunc& spsi_func,
+                                   int ld_psi,
+                                   int nband,
+                                   int dim,
+                                   T* psi_in,
+                                   Real* eigenvalue_in,
+                                   const std::vector<double>& ethr_band,
+                                   const Real* prec)
+{
+    ld_psi_ = ld_psi;
+    n_band_ = nband;
+    n_dim_ = dim;
+
+    validate_input(psi_in, eigenvalue_in, ethr_band, prec);
+    spsi_func_ = spsi_func;
+
+    // Allocate working storage.
+    const int ncol = n_band_;
+    const int sz = ld_psi_ * ncol;
+
+    hpsi_.assign(sz, T(0));
+    spsi_.assign(sz, T(0));
+    w_.assign(sz, T(0));
+    sw_.assign(sz, T(0));
+    hw_.assign(sz, T(0));
+    p_.assign(sz, T(0));
+    sp_.assign(sz, T(0));
+    hp_.assign(sz, T(0));
+
+    std::vector<int> all_cols(ncol);
+    std::iota(all_cols.begin(), all_cols.end(), 0);
+
+    force_g0_real(psi_in, ncol);
+    apply_h(hpsi_func, psi_in, hpsi_.data(), ncol);
+    apply_s_current(psi_in, spsi_.data(), ncol);
+
+    double avg_iter = 1.0;
+    int iter = 1;
+    std::vector<int> active_cols;
+
+    std::ofstream residual_trace;
+    if (const char* path = std::getenv("ABACUS_PPCG_RESIDUAL_TRACE"))
+    {
+        // Optional debug trace for plotting PPCG convergence curves.
+        residual_trace.open(path);
+        if (residual_trace)
+            residual_trace << "iteration,stage,max_residual\n";
+    }
+    auto record_residual = [&](int iteration, const char* stage) {
+        if (!residual_trace)
+            return;
+        residual_trace
+            << iteration << ','
+            << stage << ','
+            << max_generalized_residual(hpsi_.data(),
+                                        spsi_.data(),
+                                        eigenvalue_in,
+                                        ld_psi_,
+                                        n_dim_,
+                                        ncol)
+            << '\n';
+    };
+
+    // ---------------------------------------------------------------------------
+    // Strategy dispatch
+    // ---------------------------------------------------------------------------
+    if (strategy_ == PpcgStrategy::BLOCK_SUBSPACE)
+    {
+        // Initialize with Rayleigh-Ritz.
+        rayleigh_ritz(psi_in, eigenvalue_in, active_cols, ethr_band);
+        // Recompute to keep hpsi/spi consistent with rotated psi.
+        apply_h(hpsi_func, psi_in, hpsi_.data(), ncol);
+        apply_s_current(psi_in, spsi_.data(), ncol);
+        record_residual(0, "initial_rr");
+
+        while (!active_cols.empty() && iter <= maxiter_)
+        {
+            const int nact = static_cast<int>(active_cols.size());
+            const int nsb = std::max(1, (nact + sbsize_ - 1) / sbsize_);
+
+            // Precondition the residual.
+            divide_by_preconditioner(active_cols, prec, w_);
+            apply_s_current(w_.data(), sw_.data(), ncol);
+            project_against(psi_in, spsi_.data(), all_cols, w_, sw_, active_cols);
+
+            // Apply H to the search direction.
+            std::vector<T> w_active;
+            copy_cols(w_.data(), active_cols, w_active);
+            force_g0_real(w_active.data(), nact);
+            std::vector<T> hw_active(ld_psi_ * nact, T(0));
+            scatter_cols(w_.data(), active_cols, w_active);
+            apply_h(hpsi_func, w_active.data(), hw_active.data(), nact);
+            scatter_cols(hw_.data(), active_cols, hw_active);
+            apply_s_current(w_.data(), sw_.data(), ncol);
+
+            avg_iter += static_cast<double>(nact) / static_cast<double>(ncol);
+
+            // Use the stable 2-block [psi, w] projected subspace.
+            // The historical p block is kept in the implementation helpers,
+            // but is not enabled in the production path because it can make
+            // the small generalized eigenproblem indefinite on common test
+            // cases.
+            // w is normalized to unit S-norm before building the
+            // Gram matrix (see build_small_subspace), which keeps M
+            // well-conditioned even when residuals are small.
+            const bool use_p_now = false;
+
+            // Block subspace solve.
+            for (int isb = 0; isb < nsb; ++isb)
+            {
+                const int i0 = isb * sbsize_;
+                const int l = std::min(sbsize_, nact - i0);
+                std::vector<int> cols(active_cols.begin() + i0,
+                                      active_cols.begin() + i0 + l);
+
+                SmallSubspace subspace;
+                build_small_subspace(psi_in, cols, use_p_now, subspace);
+                solve_small_generalized((use_p_now ? 3 : 2) * l, subspace);
+                update_one_block(psi_in, cols, l, use_p_now, subspace);
+            }
+
+            // Rayleigh-Ritz after each block update keeps the global subspace
+            // synchronized with the updated active vectors.  The block update
+            // can otherwise drift into an ill-conditioned basis before the next
+            // Ritz rotation.
+            rayleigh_ritz(psi_in, eigenvalue_in, active_cols, ethr_band);
+            apply_h(hpsi_func, psi_in, hpsi_.data(), ncol);
+            apply_s_current(psi_in, spsi_.data(), ncol);
+            record_residual(iter, "rayleigh_ritz");
+
+            ++iter;
+        }
+
+        // Final consistency: ensure hpsi/spi match the converged psi.
+        apply_h(hpsi_func, psi_in, hpsi_.data(), ncol);
+        apply_s_current(psi_in, spsi_.data(), ncol);
+        record_residual(iter - 1, "final");
+    }
+    else // CONJUGATE_GRADIENT
+    {
+        // Initialize with Rayleigh-Ritz — same as BLOCK_SUBSPACE.
+        // Diagonal Rayleigh quotients are poor approximations for random
+        // initial guesses; starting the CG loop with them produces wrong
+        // gradients that drive the search toward high-energy bands.
+        rayleigh_ritz(psi_in, eigenvalue_in, active_cols, ethr_band);
+        apply_h(hpsi_func, psi_in, hpsi_.data(), ncol);
+        apply_s_current(psi_in, spsi_.data(), ncol);
+        record_residual(0, "initial_rr");
+
+        std::vector<T> grad;
+        calc_gradient(prec, hpsi_.data(), spsi_.data(), psi_in,
+                      eigenvalue_in, grad);
+        orth_gradient(psi_in, spsi_.data(), grad);
+
+        std::vector<T> p;
+        grad_old_.clear();
+        z_old_.clear();
+        beta_denom_.clear();
+        update_polak_ribiere(grad, p, grad_old_, z_old_, beta_denom_, prec);
+
+        // CG iteration loop.
+        while (iter <= maxiter_)
+        {
+            // Apply H and S to search direction.
+            std::vector<T> hp(ld_psi_ * ncol, T(0));
+            std::vector<T> sp(ld_psi_ * ncol, T(0));
+            apply_h(hpsi_func, p.data(), hp.data(), ncol);
+            apply_s_current(p.data(), sp.data(), ncol);
+
+            // Line minimization.
+            line_minimize(psi_in, hpsi_.data(), spsi_.data(),
+                          p.data(), hp.data(), sp.data(), ncol);
+
+            const bool do_rr = (iter % rr_step_ == 0);
+            if (do_rr)
+            {
+                // Rayleigh-Ritz: full subspace diagonalization.
+                // We recompute H|psi> and S|psi> first because line_minimize
+                // modified psi.  We do NOT call orth_cholesky here — Cholesky
+                // mixes bands through the upper-triangular U^{-1} factor,
+                // contaminating low-energy bands with high-energy components
+                // and driving the eigenvalues upward.
+                apply_h(hpsi_func, psi_in, hpsi_.data(), ncol);
+                apply_s_current(psi_in, spsi_.data(), ncol);
+
+                std::vector<int> dummy_active;
+                rayleigh_ritz(psi_in, eigenvalue_in, dummy_active, ethr_band);
+
+                // Sync hpsi/spi to the rotated wavefunctions.
+                apply_h(hpsi_func, psi_in, hpsi_.data(), ncol);
+                apply_s_current(psi_in, spsi_.data(), ncol);
+
+                // Reset PR state: the rotation changes the basis,
+                // so old gradients / search directions are invalid.
+                p.clear();
+                grad_old_.clear();
+                z_old_.clear();
+                beta_denom_.clear();
+                record_residual(iter, "rayleigh_ritz");
+            }
+            else
+            {
+                // Cholesky orthonormalization.
+                orth_cholesky(psi_in, hpsi_.data(), spsi_.data(), ncol);
+
+                // After Cholesky the bands are S-orthonormal, but the
+                // upper-triangular U^{-1} transformation mixes high-energy
+                // components into the low-energy bands.  Diagonal Rayleigh
+                // quotients then overestimate the low eigenvalues and
+                // produce wrong gradients that drive the CG search toward
+                // high-energy states.
+                //
+                // Solve the subspace generalized eigenvalue problem to get
+                // correct Ritz values.  We do NOT rotate the states — that
+                // would invalidate the Polak-Ribiere conjugate-direction
+                // accumulators.  The Cholesky basis spans the same subspace,
+                // so the Ritz values are exact for this subspace.
+                std::vector<T> h_sub(ncol * ncol, T(0));
+                std::vector<T> s_sub(ncol * ncol, T(0));
+                for (int jj = 0; jj < ncol; ++jj)
+                {
+                    for (int ii = 0; ii < ncol; ++ii)
+                    {
+                        h_sub[ii + jj * ncol]
+                            = complex_dot(psi_in + ii * ld_psi_,
+                                          hpsi_.data() + jj * ld_psi_);
+                        s_sub[ii + jj * ncol]
+                            = complex_dot(psi_in + ii * ld_psi_,
+                                          spsi_.data() + jj * ld_psi_);
+                    }
+                }
+
+                std::vector<Real> eval_cg(ncol, static_cast<Real>(0));
+                try
+                {
+                    HermitianLapack<T>::sygvd(ncol, h_sub.data(),
+                                              s_sub.data(),
+                                              eval_cg.data());
+                }
+                catch (const std::runtime_error&)
+                {
+                    // Fallback: diagonal Rayleigh quotients.
+                    // h_sub and s_sub may be corrupted by sygvd; re-form them.
+                    for (int jj = 0; jj < ncol; ++jj)
+                    {
+                        for (int ii = 0; ii < ncol; ++ii)
+                        {
+                            h_sub[ii + jj * ncol]
+                                = complex_dot(psi_in + ii * ld_psi_,
+                                              hpsi_.data() + jj * ld_psi_);
+                            s_sub[ii + jj * ncol]
+                                = complex_dot(psi_in + ii * ld_psi_,
+                                              spsi_.data() + jj * ld_psi_);
+                        }
+                    }
+                    for (int ii = 0; ii < ncol; ++ii)
+                        eval_cg[ii] =
+                            static_cast<Real>(std::real(h_sub[ii + ii * ncol]))
+                            / std::max(static_cast<Real>(
+                                           std::real(s_sub[ii + ii * ncol])),
+                                       static_cast<Real>(1e-30));
+                }
+                for (int ii = 0; ii < ncol; ++ii)
+                    eigenvalue_in[ii] = eval_cg[ii];
+                record_residual(iter, "cg_step");
+            }
+
+            // Compute new gradient.
+            calc_gradient(prec, hpsi_.data(), spsi_.data(), psi_in,
+                          eigenvalue_in, grad);
+            orth_gradient(psi_in, spsi_.data(), grad);
+
+            // Polak-Ribiere update.
+            update_polak_ribiere(grad, p, grad_old_, z_old_, beta_denom_, prec);
+
+            // Convergence check.
+            bool all_converged = true;
+            for (int i = 0; i < ncol; ++i)
+            {
+                Real nrm2 = 0;
+                for (int ig = 0; ig < n_dim_; ++ig)
+                    nrm2 += static_cast<Real>(
+                        std::norm(grad[idx(ig, i, ld_psi_)]));
+                if (std::sqrt(nrm2) > std::max(static_cast<Real>(ethr_band[i]),
+                                               diag_thr_))
+                {
+                    all_converged = false;
+                    break;
+                }
+            }
+            if (all_converged)
+                break;
+
+            ++iter;
+        }
+
+        avg_iter = static_cast<double>(iter);
+    }
+
+    return avg_iter;
+}
+
+} // namespace hsolver

--- a/source/source_hsolver/ppcg/diago_ppcg_lapack.hpp
+++ b/source/source_hsolver/ppcg/diago_ppcg_lapack.hpp
@@ -1,0 +1,98 @@
+#include <ATen/kernels/lapack.h>
+
+#include <cstdlib>
+#include <fstream>
+
+namespace hsolver {
+
+// =============================================================================
+// LAPACK wrapper (specialized per real type)
+// =============================================================================
+namespace {
+
+template <typename T, typename Real>
+Real max_generalized_residual(
+    const T* hpsi,
+    const T* spsi,
+    const Real* eigenvalue,
+    int ld,
+    int n_dim,
+    int ncol)
+{
+    Real max_res = 0;
+    for (int j = 0; j < ncol; ++j)
+    {
+        Real nrm2 = 0;
+        for (int ig = 0; ig < n_dim; ++ig)
+        {
+            const T r = hpsi[ig + j * ld] - T(eigenvalue[j]) * spsi[ig + j * ld];
+            nrm2 += static_cast<Real>(std::norm(r));
+        }
+        max_res = std::max(max_res, std::sqrt(nrm2));
+    }
+    return max_res;
+}
+
+template <typename Scalar>
+struct HermitianLapack
+{
+    using Real = typename container::GetTypeReal<Scalar>::type;
+    using Device = container::DEVICE_CPU;
+
+    static void syevd(int n, Scalar* a, Real* w)
+    {
+        container::kernels::lapack_heevd<Scalar, Device>()(n, a, n, w);
+    }
+
+    static void sygvd(int n, Scalar* a, Scalar* b, Real* w)
+    {
+        std::vector<Scalar> eigvec(n * n, Scalar(0));
+        container::kernels::lapack_hegvd<Scalar, Device>()(n, n, a, b, w, eigvec.data());
+        std::copy(eigvec.begin(), eigvec.end(), a);
+    }
+
+    static void potrf(int n, Scalar* a)
+    {
+        Real diag_max = 0;
+        for (int i = 0; i < n; ++i)
+            diag_max = std::max(diag_max, std::abs(a[i + i * n]));
+        std::vector<Scalar> a0(a, a + n * n);
+
+        for (const Real shift : {Real(0), Real(1e-12), Real(1e-10), Real(1e-8),
+                                 Real(1e-6), Real(1e-4), Real(1e-3), Real(1e-2),
+                                 Real(1e-1), Real(1)})
+        {
+            std::copy(a0.begin(), a0.end(), a);
+            if (shift > 0)
+            {
+                for (int i = 0; i < n; ++i)
+                    a[i + i * n] += Scalar(shift * std::max(diag_max, Real(1)), 0);
+            }
+            try
+            {
+                container::kernels::lapack_potrf<Scalar, Device>()('U', n, a, n);
+                return;
+            }
+            catch (const std::runtime_error&)
+            {
+                // Try the next diagonal shift.
+            }
+        }
+        throw std::runtime_error("PPCG: potrf failed.");
+    }
+
+    static void trtri(int n, Scalar* a)
+    {
+        container::kernels::lapack_trtri<Scalar, Device>()('U', 'N', n, a, n);
+    }
+};
+
+template <typename T>
+inline void set_zero(std::vector<T>& x)
+{
+    std::fill(x.begin(), x.end(), T(0));
+}
+
+} // anonymous namespace
+
+} // namespace hsolver

--- a/source/source_hsolver/ppcg/diago_ppcg_ops.hpp
+++ b/source/source_hsolver/ppcg/diago_ppcg_ops.hpp
@@ -1,0 +1,211 @@
+#include "source_base/kernels/math_kernel_op.h"
+
+namespace hsolver {
+
+// =============================================================================
+// Constructor
+// =============================================================================
+template <typename T, typename Device>
+DiagoPPCG<T, Device>::DiagoPPCG(const Real& diag_thr,
+                                 const int& diag_iter_max,
+                                 const int& sbsize,
+                                 const int& rr_step,
+                                 const bool gamma_g0_real,
+                                 const PpcgStrategy strategy)
+    : maxiter_(diag_iter_max),
+      sbsize_(std::max(1, sbsize)),
+      rr_step_(std::max(1, rr_step)),
+      diag_thr_(std::max(diag_thr, static_cast<Real>(1.0e-14))),
+      gamma_g0_real_(gamma_g0_real),
+      strategy_(strategy)
+{
+}
+
+// =============================================================================
+// Input validation
+// =============================================================================
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::validate_input(
+    const T* psi_in,
+    const Real* eigenvalue_in,
+    const std::vector<double>& ethr_band,
+    const Real* prec) const
+{
+    if (psi_in == nullptr || eigenvalue_in == nullptr)
+        throw std::invalid_argument("PPCG: psi/eigenvalue pointer is null.");
+    if (prec == nullptr)
+        throw std::invalid_argument("PPCG: preconditioner pointer is null.");
+    if (ld_psi_ <= 0 || n_band_ <= 0 || n_dim_ <= 0)
+        throw std::invalid_argument("PPCG: invalid dimensions.");
+    if (n_dim_ > ld_psi_)
+        throw std::invalid_argument("PPCG: dim must not exceed ld_psi.");
+    if (ethr_band.size() < static_cast<size_t>(n_band_))
+        throw std::invalid_argument("PPCG: ethr_band size is smaller than nband.");
+}
+
+// =============================================================================
+// Gamma-point symmetry: enforce real-valued first element
+// =============================================================================
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::force_g0_real(T* x, int ncol) const
+{
+    if (!gamma_g0_real_ || n_dim_ <= 0)
+        return;
+    for (int j = 0; j < ncol; ++j)
+        x[idx(0, j, ld_psi_)] = T(std::real(x[idx(0, j, ld_psi_)]), 0.0);
+}
+
+// =============================================================================
+// Operator application
+// =============================================================================
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::apply_h(const HPsiFunc& hpsi_func,
+                                    T* psi_in, T* hpsi_out,
+                                    int ncol) const
+{
+    hpsi_func(psi_in, hpsi_out, ld_psi_, ncol);
+}
+
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::apply_s(const SPsiFunc& spsi_func,
+                                    T* psi_in, T* spsi_out,
+                                    int ncol) const
+{
+    if (spsi_func)
+        spsi_func(psi_in, spsi_out, ld_psi_, ncol);
+    else
+        for (int j = 0; j < ncol; ++j)
+            std::copy(psi_in + j * ld_psi_, psi_in + (j + 1) * ld_psi_,
+                      spsi_out + j * ld_psi_);
+}
+
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::apply_s_current(T* psi_in, T* spsi_out,
+                                            int ncol) const
+{
+    apply_s(spsi_func_, psi_in, spsi_out, ncol);
+}
+
+// =============================================================================
+// Inner product <x|y> (real part only, for Hermitian operators)
+// =============================================================================
+template <typename T, typename Device>
+typename DiagoPPCG<T, Device>::Real
+DiagoPPCG<T, Device>::gamma_dot(const T* x, const T* y) const
+{
+    return ModuleBase::dot_real_op<T, Device>()(n_dim_, x, y, false);
+}
+
+template <typename T, typename Device>
+T DiagoPPCG<T, Device>::complex_dot(const T* x, const T* y) const
+{
+    T acc = T(0);
+    for (int i = 0; i < n_dim_; ++i)
+        acc += std::conj(x[i]) * y[i];
+    return acc;
+}
+
+// =============================================================================
+// Gram matrix: out[i, j] = <a_i | b_j>
+// =============================================================================
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::gram(const T* a, const T* b,
+                                 int ncol_a, int ncol_b,
+                                 std::vector<T>& out,
+                                 int ld_out) const
+{
+    out.assign(ld_out * ncol_b, T(0));
+    for (int jb = 0; jb < ncol_b; ++jb)
+        for (int ia = 0; ia < ncol_a; ++ia)
+            out[ia + jb * ld_out] = complex_dot(a + ia * ld_psi_,
+                                                 b + jb * ld_psi_);
+}
+
+// =============================================================================
+// Column gather: extract selected columns into contiguous storage
+// =============================================================================
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::copy_cols(const T* src,
+                                      const std::vector<int>& cols,
+                                      std::vector<T>& dst) const
+{
+    dst.assign(ld_psi_ * cols.size(), T(0));
+    for (int j = 0; j < static_cast<int>(cols.size()); ++j)
+    {
+        const int c = cols[j];
+        std::copy(src + c * ld_psi_, src + c * ld_psi_ + ld_psi_,
+                  dst.begin() + j * ld_psi_);
+    }
+}
+
+// =============================================================================
+// Column scatter: write contiguous storage back into selected columns
+// =============================================================================
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::scatter_cols(
+    T* dst,
+    const std::vector<int>& cols,
+    const std::vector<T>& src) const
+{
+    for (int j = 0; j < static_cast<int>(cols.size()); ++j)
+    {
+        const int c = cols[j];
+        std::copy(src.begin() + j * ld_psi_,
+                  src.begin() + (j + 1) * ld_psi_,
+                  dst + c * ld_psi_);
+    }
+}
+
+// =============================================================================
+// Project x onto vectors orthogonal to S-orthonormal basis
+// =============================================================================
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::project_against(
+    const T* basis, const T* sbasis,
+    const std::vector<int>& basis_cols,
+    std::vector<T>& x, std::vector<T>& sx,
+    const std::vector<int>& x_cols) const
+{
+    if (basis_cols.empty() || x_cols.empty())
+        return;
+
+    for (const int c : x_cols)
+    {
+        for (const int bc : basis_cols)
+        {
+            // Full complex inner product <basis_bc | sx_c>
+            T coeff = 0;
+            const T* bb = basis + bc * ld_psi_;
+            const T* sc = sx.data() + c * ld_psi_;
+            for (int ig = 0; ig < n_dim_; ++ig)
+                coeff += std::conj(bb[ig]) * sc[ig];
+            if (std::abs(coeff) <= std::numeric_limits<Real>::epsilon())
+                continue;
+            const T* sb = sbasis + bc * ld_psi_;
+            T* xc = x.data() + c * ld_psi_;
+            T* sxc = sx.data() + c * ld_psi_;
+            for (int ig = 0; ig < n_dim_; ++ig)
+            {
+                xc[ig] -= bb[ig] * coeff;
+                sxc[ig] -= sb[ig] * coeff;
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Preconditioner: x[c] /= max(prec, eps) for each active column c
+// =============================================================================
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::divide_by_preconditioner(
+    const std::vector<int>& active_cols,
+    const Real* prec,
+    std::vector<T>& x) const
+{
+    for (const int c : active_cols)
+        for (int ig = 0; ig < n_dim_; ++ig)
+            x[idx(ig, c, ld_psi_)] /=
+                std::max(prec[ig], static_cast<Real>(1.0e-12));
+}
+
+} // namespace hsolver

--- a/source/source_hsolver/ppcg/diago_ppcg_orth.hpp
+++ b/source/source_hsolver/ppcg/diago_ppcg_orth.hpp
@@ -1,0 +1,227 @@
+namespace hsolver {
+
+// ---------------------------------------------------------------------------
+// Back-substitute with upper triangular Cholesky factor: X *= R^{-1}
+// ---------------------------------------------------------------------------
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::right_solve_upper(
+    const std::vector<T>& r, int n, std::vector<T>& x) const
+{
+    std::vector<T> b = x;
+    for (int row = 0; row < n_dim_; ++row)
+    {
+        for (int j = 0; j < n; ++j)
+        {
+            T v = b[idx(row, j, ld_psi_)];
+            for (int k = 0; k < j; ++k)
+                v -= x[idx(row, k, ld_psi_)] * r[k + j * n];
+            x[idx(row, j, ld_psi_)] = v / r[j + j * n];
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Check S-orthonormality of a column block.
+// ---------------------------------------------------------------------------
+template <typename T, typename Device>
+bool DiagoPPCG<T, Device>::is_s_orthonormal(
+    const T* psi, const T* spsi, int ncol) const
+{
+    const Real orth_tol = static_cast<Real>(10)
+                        * std::sqrt(std::numeric_limits<Real>::epsilon());
+    for (int j = 0; j < ncol; ++j)
+    {
+        for (int i = 0; i < ncol; ++i)
+        {
+            const T sij = complex_dot(psi + i * ld_psi_,
+                                      spsi + j * ld_psi_);
+            const T target = (i == j) ? T(1) : T(0);
+            if (std::abs(sij - target) > orth_tol)
+                return false;
+        }
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Iterative S-Gram-Schmidt fallback with one reorthogonalization pass.
+// ---------------------------------------------------------------------------
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::s_gram_schmidt(
+    T* psi, T* hpsi, T* spsi, int ncol) const
+{
+    for (int j = 0; j < ncol; ++j)
+    {
+        for (int pass = 0; pass < 2; ++pass)
+        {
+            apply_s_current(psi + j * ld_psi_, spsi + j * ld_psi_, 1);
+            for (int k = 0; k < j; ++k)
+            {
+                T coeff = complex_dot(psi + k * ld_psi_,
+                                      spsi + j * ld_psi_);
+                for (int ig = 0; ig < n_dim_; ++ig)
+                {
+                    psi [idx(ig, j, ld_psi_)] -= coeff * psi [idx(ig, k, ld_psi_)];
+                    hpsi[idx(ig, j, ld_psi_)] -= coeff * hpsi[idx(ig, k, ld_psi_)];
+                    spsi[idx(ig, j, ld_psi_)] -= coeff * spsi[idx(ig, k, ld_psi_)];
+                }
+            }
+        }
+        apply_s_current(psi + j * ld_psi_, spsi + j * ld_psi_, 1);
+        Real nrm = std::sqrt(std::max(
+            gamma_dot(psi + j * ld_psi_, spsi + j * ld_psi_),
+            static_cast<Real>(1e-30)));
+        Real inv_nrm = static_cast<Real>(1) / nrm;
+        for (int ig = 0; ig < n_dim_; ++ig)
+        {
+            psi [idx(ig, j, ld_psi_)] *= inv_nrm;
+            hpsi[idx(ig, j, ld_psi_)] *= inv_nrm;
+            spsi[idx(ig, j, ld_psi_)] *= inv_nrm;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cholesky QR: S-orthonormalize active columns via Cholesky on S-gram
+// ---------------------------------------------------------------------------
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::chol_qr_active(
+    T* psi, const std::vector<int>& active_cols)
+{
+    if (active_cols.empty())
+        return;
+
+    const int nact = static_cast<int>(active_cols.size());
+    std::vector<T> psi_a, spsi_a, hpsi_a;
+    copy_cols(psi, active_cols, psi_a);
+    copy_cols(spsi_.data(), active_cols, spsi_a);
+    copy_cols(hpsi_.data(), active_cols, hpsi_a);
+
+    std::vector<T> s(nact * nact, T(0));
+    gram(psi_a.data(), spsi_a.data(), nact, nact, s, nact);
+
+    bool cholesky_ok = false;
+    try
+    {
+        HermitianLapack<T>::potrf(nact, s.data());
+        right_solve_upper(s, nact, psi_a);
+        right_solve_upper(s, nact, spsi_a);
+        right_solve_upper(s, nact, hpsi_a);
+        cholesky_ok = is_s_orthonormal(psi_a.data(), spsi_a.data(), nact);
+    }
+    catch (const std::runtime_error&)
+    {
+        cholesky_ok = false;
+    }
+
+    if (!cholesky_ok)
+        s_gram_schmidt(psi_a.data(), hpsi_a.data(), spsi_a.data(), nact);
+
+    scatter_cols(psi, active_cols, psi_a);
+    scatter_cols(spsi_.data(), active_cols, spsi_a);
+    scatter_cols(hpsi_.data(), active_cols, hpsi_a);
+}
+
+// ---------------------------------------------------------------------------
+// Rayleigh-Ritz: full subspace diagonalization + residual computation
+// ---------------------------------------------------------------------------
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::rayleigh_ritz(
+    T* psi, Real* eigenvalue,
+    std::vector<int>& active_cols,
+    const std::vector<double>& ethr_band)
+{
+    std::vector<T> hsub(n_band_ * n_band_, T(0));
+    std::vector<T> ssub(n_band_ * n_band_, T(0));
+    gram(psi, hpsi_.data(), n_band_, n_band_, hsub, n_band_);
+    gram(psi, spsi_.data(), n_band_, n_band_, ssub, n_band_);
+
+    std::vector<Real> eval(n_band_, static_cast<Real>(0));
+    bool sygvd_ok = false;
+    try
+    {
+        HermitianLapack<T>::sygvd(n_band_, hsub.data(), ssub.data(),
+                                  eval.data());
+        sygvd_ok = true;
+    }
+    catch (const std::runtime_error&)
+    {
+        // Fallback: diagonal Rayleigh quotients.
+        // hsub and ssub may be corrupted by sygvd; re-form them.
+        gram(psi, hpsi_.data(), n_band_, n_band_, hsub, n_band_);
+        gram(psi, spsi_.data(), n_band_, n_band_, ssub, n_band_);
+        for (int ii = 0; ii < n_band_; ++ii)
+            eval[ii] = static_cast<Real>(std::real(hsub[ii + ii * n_band_]))
+                     / std::max(static_cast<Real>(
+                                    std::real(ssub[ii + ii * n_band_])),
+                                static_cast<Real>(1e-30));
+    }
+
+    if (sygvd_ok)
+    {
+        std::vector<T> psi_old(psi, psi + ld_psi_ * n_band_);
+        std::vector<T> spsi_old = spsi_;
+        std::vector<T> hpsi_old = hpsi_;
+
+        std::fill(psi, psi + ld_psi_ * n_band_, T(0));
+        set_zero(spsi_);
+        set_zero(hpsi_);
+
+        for (int j = 0; j < n_band_; ++j)
+        {
+            for (int i = 0; i < n_band_; ++i)
+            {
+                const T c = hsub[i + j * n_band_];
+                for (int ig = 0; ig < n_dim_; ++ig)
+                {
+                    psi[ idx(ig, j, ld_psi_)] += psi_old[ idx(ig, i, ld_psi_)] * c;
+                    spsi_[idx(ig, j, ld_psi_)] += spsi_old[idx(ig, i, ld_psi_)] * c;
+                    hpsi_[idx(ig, j, ld_psi_)] += hpsi_old[idx(ig, i, ld_psi_)] * c;
+                }
+            }
+            eigenvalue[j] = eval[j];
+        }
+    }
+    else
+    {
+        // No rotation: just update eigenvalues with Rayleigh quotients.
+        for (int j = 0; j < n_band_; ++j)
+            eigenvalue[j] = eval[j];
+    }
+
+    // Compute residual: w_i = H|psi_i> - eps_i * S|psi_i>
+    set_zero(w_);
+    for (int j = 0; j < n_band_; ++j)
+        for (int ig = 0; ig < n_dim_; ++ig)
+            w_[idx(ig, j, ld_psi_)] = hpsi_[idx(ig, j, ld_psi_)]
+                                    - spsi_[idx(ig, j, ld_psi_)] * eigenvalue[j];
+
+    lock_epairs(w_, ethr_band, active_cols);
+}
+
+// ---------------------------------------------------------------------------
+// Trace of H|psi> within active columns
+// ---------------------------------------------------------------------------
+template <typename T, typename Device>
+typename DiagoPPCG<T, Device>::Real
+DiagoPPCG<T, Device>::trace_of_active_projected(
+    const T* psi, const std::vector<int>& active_cols) const
+{
+    if (active_cols.empty())
+        return static_cast<Real>(0);
+
+    std::vector<T> psi_a, hpsi_a;
+    copy_cols(psi, active_cols, psi_a);
+    copy_cols(hpsi_.data(), active_cols, hpsi_a);
+
+    const int nact = static_cast<int>(active_cols.size());
+    std::vector<T> g(nact * nact, T(0));
+    gram(psi_a.data(), hpsi_a.data(), nact, nact, g, nact);
+
+    Real tr = 0;
+    for (int i = 0; i < nact; ++i)
+        tr += static_cast<Real>(std::real(g[i + i * nact]));
+    return tr;
+}
+
+} // namespace hsolver

--- a/source/source_hsolver/ppcg/diago_ppcg_subspace.hpp
+++ b/source/source_hsolver/ppcg/diago_ppcg_subspace.hpp
@@ -1,0 +1,256 @@
+namespace hsolver {
+
+//==============================================================================
+// BLOCK_SUBSPACE STRATEGY
+//==============================================================================
+
+// ---------------------------------------------------------------------------
+// Lock converged eigenpairs: columns with residual below threshold
+// ---------------------------------------------------------------------------
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::lock_epairs(
+    const std::vector<T>& residual,
+    const std::vector<double>& ethr_band,
+    std::vector<int>& active_cols) const
+{
+    active_cols.clear();
+    for (int j = 0; j < n_band_; ++j)
+    {
+        Real nrm2 = 0;
+        for (int ig = 0; ig < n_dim_; ++ig)
+            nrm2 += static_cast<Real>(std::norm(residual[idx(ig, j, ld_psi_)]));
+        const Real rnrm = std::sqrt(std::max(nrm2, static_cast<Real>(0)));
+        const Real thr = std::max(static_cast<Real>(ethr_band[j]), diag_thr_);
+        if (rnrm > thr)
+            active_cols.push_back(j);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Build K = V^H H V and M = V^H S V where V = [psi, w, p]
+// ---------------------------------------------------------------------------
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::build_small_subspace(
+    const T* psi,
+    const std::vector<int>& cols,
+    bool use_p,
+    SmallSubspace& subspace) const
+{
+    const int l = static_cast<int>(cols.size());
+    const int nblk = use_p ? 3 : 2;
+    const int dim = nblk * l;
+    subspace.k.assign(dim * dim, T(0));
+    subspace.m.assign(dim * dim, T(0));
+    subspace.eval.assign(dim, static_cast<Real>(0));
+    subspace.w_scale.assign(l, static_cast<Real>(1));
+    subspace.p_scale.assign(l, static_cast<Real>(1));
+
+    std::vector<T> psi_l, spsi_l, hpsi_l;
+    std::vector<T> w_l, sw_l, hw_l;
+    std::vector<T> p_l, sp_l, hp_l;
+    copy_cols(psi, cols, psi_l);
+    copy_cols(spsi_.data(), cols, spsi_l);
+    copy_cols(hpsi_.data(), cols, hpsi_l);
+    copy_cols(w_.data(), cols, w_l);
+    copy_cols(sw_.data(), cols, sw_l);
+    copy_cols(hw_.data(), cols, hw_l);
+    if (use_p)
+    {
+        copy_cols(p_.data(), cols, p_l);
+        copy_cols(sp_.data(), cols, sp_l);
+        copy_cols(hp_.data(), cols, hp_l);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Normalize w and p columns to unit S-norm for numerical stability.
+    //
+    // The [w, p] block of the Gram matrix M has entries O(||w||²) which
+    // become tiny when residuals are small, making M nearly singular and
+    // causing sygvd to produce garbage eigenvectors.
+    //
+    // Scaling to unit S-norm keeps M well-conditioned (diagonal ~1) without
+    // changing the subspace.  The Ritz values are identical and the Ritz
+    // vector coefficients in update_one_block automatically compensate.
+    // ---------------------------------------------------------------------------
+    auto scale_to_unit_snorm = [this](std::vector<T>& x, std::vector<T>& sx,
+                                       std::vector<T>& hx, int lcols,
+                                       std::vector<Real>& scale) {
+        for (int j = 0; j < lcols; ++j) {
+            Real sn2 = 0;
+            for (int ig = 0; ig < n_dim_; ++ig)
+                sn2 += std::real(std::conj(x[idx(ig, j, ld_psi_)])
+                                 * sx[idx(ig, j, ld_psi_)]);
+            Real sn = std::sqrt(std::max(sn2, static_cast<Real>(1e-30)));
+            // Only scale if the norm is non-negligible; a near-zero
+            // column is a converged band whose contribution is harmless.
+            if (sn > static_cast<Real>(1e-15)) {
+                Real inv = static_cast<Real>(1) / sn;
+                scale[j] = inv;
+                for (int ig = 0; ig < n_dim_; ++ig) {
+                    x[ idx(ig, j, ld_psi_)]  *= inv;
+                    sx[idx(ig, j, ld_psi_)] *= inv;
+                    hx[idx(ig, j, ld_psi_)] *= inv;
+                }
+            }
+        }
+    };
+    scale_to_unit_snorm(w_l, sw_l, hw_l, l, subspace.w_scale);
+    if (use_p)
+        scale_to_unit_snorm(p_l, sp_l, hp_l, l, subspace.p_scale);
+
+    auto fill_sym = [&](const std::vector<T>& a, const std::vector<T>& b,
+                        int r0, int c0, std::vector<T>& mat)
+    {
+        std::vector<T> g;
+        gram(a.data(), b.data(), l, l, g, l);
+        for (int j = 0; j < l; ++j)
+            for (int i = 0; i < l; ++i)
+            {
+                mat[(r0 + i) + (c0 + j) * dim] = g[i + j * l];
+                mat[(c0 + j) + (r0 + i) * dim] = std::conj(g[i + j * l]);
+            }
+    };
+
+    fill_sym(psi_l, hpsi_l, 0,   0,   subspace.k);
+    fill_sym(psi_l, spsi_l, 0,   0,   subspace.m);
+    fill_sym(w_l,   hw_l,   l,   l,   subspace.k);
+    fill_sym(w_l,   sw_l,   l,   l,   subspace.m);
+    fill_sym(psi_l, hw_l,   0,   l,   subspace.k);
+    fill_sym(psi_l, sw_l,   0,   l,   subspace.m);
+
+    if (use_p)
+    {
+        fill_sym(p_l, hp_l, 2*l, 2*l, subspace.k);
+        fill_sym(p_l, sp_l, 2*l, 2*l, subspace.m);
+        fill_sym(psi_l, hp_l, 0,   2*l, subspace.k);
+        fill_sym(psi_l, sp_l, 0,   2*l, subspace.m);
+        fill_sym(w_l,   hp_l, l,   2*l, subspace.k);
+        fill_sym(w_l,   sp_l, l,   2*l, subspace.m);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Solve K v = λ M v (small generalized eigenvalue problem)
+// ---------------------------------------------------------------------------
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::solve_small_generalized(
+    int dim, SmallSubspace& subspace) const
+{
+    // Try with increasing diagonal shifts; fall back to identity (no update)
+    // if the subspace is too ill-conditioned.
+    // Save originals; sygvd modifies both matrices in-place before it may
+    // fail.
+    const std::vector<T> k0 = subspace.k;
+    const std::vector<T> m0 = subspace.m;
+    const Real shifts[] = {static_cast<Real>(0),
+                           static_cast<Real>(1e-10),
+                           static_cast<Real>(1e-8),
+                           static_cast<Real>(1e-6)};
+    for (const Real shift : shifts)
+    {
+        subspace.k = k0;
+        subspace.m = m0;
+        for (int i = 0; i < dim; ++i)
+            subspace.m[i + i * dim] += T(shift);
+
+        try
+        {
+            HermitianLapack<T>::sygvd(dim, subspace.k.data(),
+                                      subspace.m.data(),
+                                      subspace.eval.data());
+            return;
+        }
+        catch (const std::runtime_error&)
+        {
+            // Try the next diagonal shift.
+        }
+    }
+    // All attempts failed — set eigenvectors to identity (no update).
+    std::fill(subspace.k.begin(), subspace.k.end(), T(0));
+    for (int i = 0; i < dim; ++i)
+        subspace.k[i + i * dim] = T(1);
+    std::fill(subspace.eval.begin(), subspace.eval.end(), static_cast<Real>(0));
+}
+
+// ---------------------------------------------------------------------------
+// Update wavefunctions from small subspace eigenvectors
+// ---------------------------------------------------------------------------
+template <typename T, typename Device>
+void DiagoPPCG<T, Device>::update_one_block(
+    T* psi,
+    const std::vector<int>& cols,
+    int l,
+    bool use_p,
+    const SmallSubspace& subspace)
+{
+    const int dim = (use_p ? 3 : 2) * l;
+    const T* eigvec = subspace.k.data();
+
+    std::vector<T> psi_l, spsi_l, hpsi_l;
+    std::vector<T> w_l, sw_l, hw_l;
+    std::vector<T> p_l, sp_l, hp_l;
+    copy_cols(psi, cols, psi_l);
+    copy_cols(spsi_.data(), cols, spsi_l);
+    copy_cols(hpsi_.data(), cols, hpsi_l);
+    copy_cols(w_.data(), cols, w_l);
+    copy_cols(sw_.data(), cols, sw_l);
+    copy_cols(hw_.data(), cols, hw_l);
+    if (use_p)
+    {
+        copy_cols(p_.data(), cols, p_l);
+        copy_cols(sp_.data(), cols, sp_l);
+        copy_cols(hp_.data(), cols, hp_l);
+    }
+
+    std::vector<T> psi_new(ld_psi_ * l, T(0));
+    std::vector<T> spsi_new(ld_psi_ * l, T(0));
+    std::vector<T> hpsi_new(ld_psi_ * l, T(0));
+    std::vector<T> p_new(ld_psi_ * l, T(0));
+    std::vector<T> sp_new(ld_psi_ * l, T(0));
+    std::vector<T> hp_new(ld_psi_ * l, T(0));
+
+    for (int j = 0; j < l; ++j)
+    {
+        for (int i = 0; i < l; ++i)
+        {
+            const T cpsi = eigvec[i + j * dim];
+            const T cw   = eigvec[(l + i) + j * dim] * subspace.w_scale[i];
+
+            for (int ig = 0; ig < n_dim_; ++ig)
+            {
+                psi_new[idx(ig, j, ld_psi_)]  += psi_l[idx(ig, i, ld_psi_)] * cpsi
+                                                + w_l[ idx(ig, i, ld_psi_)] * cw;
+                spsi_new[idx(ig, j, ld_psi_)] += spsi_l[idx(ig, i, ld_psi_)] * cpsi
+                                                + sw_l[ idx(ig, i, ld_psi_)] * cw;
+                hpsi_new[idx(ig, j, ld_psi_)] += hpsi_l[idx(ig, i, ld_psi_)] * cpsi
+                                                + hw_l[ idx(ig, i, ld_psi_)] * cw;
+                p_new[idx(ig, j, ld_psi_)]    += w_l[ idx(ig, i, ld_psi_)] * cw;
+                sp_new[idx(ig, j, ld_psi_)]   += sw_l[ idx(ig, i, ld_psi_)] * cw;
+                hp_new[idx(ig, j, ld_psi_)]   += hw_l[ idx(ig, i, ld_psi_)] * cw;
+            }
+
+            if (use_p)
+            {
+                const T cp = eigvec[(2*l + i) + j * dim] * subspace.p_scale[i];
+                for (int ig = 0; ig < n_dim_; ++ig)
+                {
+                    psi_new[idx(ig, j, ld_psi_)]  += p_l[ idx(ig, i, ld_psi_)] * cp;
+                    spsi_new[idx(ig, j, ld_psi_)] += sp_l[idx(ig, i, ld_psi_)] * cp;
+                    hpsi_new[idx(ig, j, ld_psi_)] += hp_l[idx(ig, i, ld_psi_)] * cp;
+                    p_new[idx(ig, j, ld_psi_)]    += p_l[ idx(ig, i, ld_psi_)] * cp;
+                    sp_new[idx(ig, j, ld_psi_)]   += sp_l[idx(ig, i, ld_psi_)] * cp;
+                    hp_new[idx(ig, j, ld_psi_)]   += hp_l[idx(ig, i, ld_psi_)] * cp;
+                }
+            }
+        }
+    }
+
+    scatter_cols(psi, cols, psi_new);
+    scatter_cols(spsi_.data(), cols, spsi_new);
+    scatter_cols(hpsi_.data(), cols, hpsi_new);
+    scatter_cols(p_.data(), cols, p_new);
+    scatter_cols(sp_.data(), cols, sp_new);
+    scatter_cols(hp_.data(), cols, hp_new);
+}
+
+} // namespace hsolver

--- a/source/source_hsolver/test/CMakeLists.txt
+++ b/source/source_hsolver/test/CMakeLists.txt
@@ -1,6 +1,6 @@
-abacus_disable_feature_definitions(__CUDA)
-abacus_disable_feature_definitions(__ROCM)
-abacus_disable_feature_definitions(__EXX)
+remove_definitions(-D__CUDA)
+remove_definitions(-D__ROCM)
+remove_definitions(-D__EXX)
 
 if (ENABLE_MPI)
   AddTest(
@@ -76,14 +76,14 @@ if (ENABLE_MPI)
   AddTest(
     TARGET MODULE_HSOLVER_pw
     LIBS parameter  ${math_libs} psi device base container
-    SOURCES test_hsolver_pw.cpp ../hsolver_pw.cpp ../hsolver_lcaopw.cpp ../diago_bpcg.cpp ../diago_dav_subspace.cpp ../diag_const_nums.cpp ../diago_iter_assist.cpp ../para_linear_transform.cpp
+    SOURCES test_hsolver_pw.cpp ../hsolver_pw.cpp ../hsolver_lcaopw.cpp ../diago_bpcg.cpp ../diago_dav_subspace.cpp ../diago_ppcg.cpp ../diag_const_nums.cpp ../diago_iter_assist.cpp ../para_linear_transform.cpp
     ../../source_estate/elecstate_tools.cpp ../../source_estate/occupy.cpp ../../source_base/module_fft/fft_bundle.cpp ../../source_base/module_fft/fft_cpu.cpp
   )
 
   AddTest(
     TARGET MODULE_HSOLVER_sdft
     LIBS parameter  ${math_libs} psi device base container
-    SOURCES test_hsolver_sdft.cpp ../hsolver_pw_sdft.cpp ../hsolver_pw.cpp ../diago_bpcg.cpp ../diago_dav_subspace.cpp ../diag_const_nums.cpp ../diago_iter_assist.cpp ../para_linear_transform.cpp
+    SOURCES test_hsolver_sdft.cpp ../hsolver_pw_sdft.cpp ../hsolver_pw.cpp ../diago_bpcg.cpp ../diago_dav_subspace.cpp ../diago_ppcg.cpp ../diag_const_nums.cpp ../diago_iter_assist.cpp ../para_linear_transform.cpp
                 ../../source_estate/elecstate_tools.cpp ../../source_estate/occupy.cpp ../../source_base/module_fft/fft_bundle.cpp ../../source_base/module_fft/fft_cpu.cpp
     )
 
@@ -121,6 +121,12 @@ if (ENABLE_MPI)
   target_compile_definitions(MODULE_HSOLVER_LCAO_cusolver PRIVATE __CUDA)
   endif()
 endif()
+AddTest(
+  TARGET MODULE_HSOLVER_ppcg
+  LIBS ${math_libs} base device container
+  SOURCES diago_ppcg_test.cpp ../diago_ppcg.cpp
+)
+
 install(FILES H-KPoints-Si2.dat DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 install(FILES H-GammaOnly-Si2.dat DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 install(FILES S-KPoints-Si2.dat DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/source/source_hsolver/test/diago_ppcg_test.cpp
+++ b/source/source_hsolver/test/diago_ppcg_test.cpp
@@ -1,0 +1,2353 @@
+/**
+ * diago_ppcg_test.cpp — unit test for DiagoPPCG solver
+ *
+ * Test matrices (all with S = I):
+ *   1. Tridiagonal Laplacian (1D particle-in-a-box): H[i,i]=2, H[i,i±1]=-1
+ *      Exact λ_k = 2 - 2·cos(k·π/(n+1)).  Realistic but sparse.
+ *   2. Diagonal matrix: H = diag(1, 2, 3, 4, 5)
+ *      Exact eigenvalues are the diagonal entries.  Simplest possible
+ *      smoke test — should converge in very few iterations.
+ *
+ * Tests primarily exercise the production BLOCK_SUBSPACE strategy, with
+ * CONJUGATE_GRADIENT kept available as an explicit fallback path.
+ */
+
+#include "../diago_ppcg.h"
+
+#include <gtest/gtest.h>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <random>
+#include <vector>
+#include <complex>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+using T    = std::complex<double>;
+using Real = double;
+
+// -----------------------------------------------------------------------------
+// Helper: dense H-matrix times a set of column vectors
+// H is stored column-major: H(row, col) = H_data[row + col * n_dim]
+// -----------------------------------------------------------------------------
+static void dense_h_multiply(const T* H_data, int n_dim,
+                              const T* in, T* out, int ld, int ncol)
+{
+    for (int j = 0; j < ncol; ++j) {
+        for (int i = 0; i < n_dim; ++i) {
+            T sum = 0;
+            for (int k = 0; k < n_dim; ++k)
+                sum += H_data[i + k * n_dim] * in[k + j * ld];
+            out[i + j * ld] = sum;
+        }
+    }
+}
+
+// =============================================================================
+// Test fixture: 1D particle-in-a-box (tridiagonal Laplacian)
+// =============================================================================
+class DiagoPPCGTridiagTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim = 10;
+        nband = 3;
+        ld = n_dim;
+
+        // Build tridiagonal H:  H[i,i] = 2, H[i,i±1] = -1
+        H_mat.assign(n_dim * n_dim, T(0));
+        for (int i = 0; i < n_dim; ++i) {
+            H_mat[i + i * n_dim] = T(2.0, 0);
+            if (i > 0)         H_mat[i + (i - 1) * n_dim] = T(-1.0, 0);
+            if (i < n_dim - 1) H_mat[i + (i + 1) * n_dim] = T(-1.0, 0);
+        }
+
+        // Preconditioner — diagonal of H (all 2.0)
+        prec.assign(n_dim, 2.0);
+
+        // Exact reference eigenvalues
+        exact.resize(nband);
+        for (int k = 0; k < nband; ++k)
+            exact[k] = 2.0 - 2.0 * std::cos(static_cast<Real>(k + 1)
+                                            * M_PI / static_cast<Real>(n_dim + 1));
+
+        // Convergence thresholds
+        ethr.assign(nband, 1e-10);
+
+        // Random initial guess (fixed seed for reproducibility)
+        std::mt19937 rng(42);
+        std::uniform_real_distribution<Real> dist(-1.0, 1.0);
+
+        psi.assign(ld * nband, T(0));
+        for (int j = 0; j < nband; ++j)
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] = T(dist(rng), 0.0);
+
+        // Gram-Schmidt orthonormalisation (S = I)
+        for (int j = 0; j < nband; ++j) {
+            for (int k = 0; k < j; ++k) {
+                T dot = 0;
+                for (int i = 0; i < n_dim; ++i)
+                    dot += std::conj(psi[i + k * ld]) * psi[i + j * ld];
+                for (int i = 0; i < n_dim; ++i)
+                    psi[i + j * ld] -= dot * psi[i + k * ld];
+            }
+            Real nrm = 0;
+            for (int i = 0; i < n_dim; ++i)
+                nrm += std::norm(psi[i + j * ld]);
+            nrm = std::sqrt(nrm);
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] /= nrm;
+        }
+    }
+
+    int n_dim, nband, ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGTridiagTest, BlockSubspace)
+{
+    std::vector<T>    psi_run = psi;
+    std::vector<Real> eval(nband, 0.0);
+
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        /* diag_thr = */ 1e-12,
+        /* max_iter = */ 100,
+        /* sbsize   = */ 4,
+        /* rr_step  = */ 4,
+        /* gamma_g0 = */ false,
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE
+    );
+
+    auto h_op = [this](T* in, T* out, int ld_in, int ncol) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ld_in, ncol);
+    };
+
+    double avg_iter = solver.diag(
+        h_op, nullptr, ld, nband, n_dim,
+        psi_run.data(), eval.data(), ethr, prec.data()
+    );
+
+    for (int i = 0; i < nband; ++i) {
+        EXPECT_NEAR(eval[i], exact[i], 1e-8)
+            << "Tridiag BLOCK: eigenvalue[" << i << "] mismatch";
+    }
+    EXPECT_LE(avg_iter, static_cast<double>(100))
+        << "Tridiag BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: diagonal matrix (simplest possible Hamiltonian)
+// =============================================================================
+class DiagoPPCGDiagonalTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim = 5;
+        nband = 3;
+        ld = n_dim;
+
+        // Build diagonal H: H[i,i] = i+1
+        H_mat.assign(n_dim * n_dim, T(0));
+        for (int i = 0; i < n_dim; ++i)
+            H_mat[i + i * n_dim] = T(static_cast<Real>(i + 1), 0);
+
+        // Preconditioner — diagonal of H
+        prec.resize(n_dim);
+        for (int i = 0; i < n_dim; ++i)
+            prec[i] = static_cast<Real>(i + 1);
+
+        // Lowest 3 eigenvalues: 1, 2, 3
+        exact = {1.0, 2.0, 3.0};
+
+        // Convergence thresholds
+        ethr.assign(nband, 1e-10);
+
+        // Random initial guess (fixed seed)
+        std::mt19937 rng(42);
+        std::uniform_real_distribution<Real> dist(-1.0, 1.0);
+
+        psi.assign(ld * nband, T(0));
+        for (int j = 0; j < nband; ++j)
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] = T(dist(rng), 0.0);
+
+        // Gram-Schmidt orthonormalisation (S = I)
+        for (int j = 0; j < nband; ++j) {
+            for (int k = 0; k < j; ++k) {
+                T dot = 0;
+                for (int i = 0; i < n_dim; ++i)
+                    dot += std::conj(psi[i + k * ld]) * psi[i + j * ld];
+                for (int i = 0; i < n_dim; ++i)
+                    psi[i + j * ld] -= dot * psi[i + k * ld];
+            }
+            Real nrm = 0;
+            for (int i = 0; i < n_dim; ++i)
+                nrm += std::norm(psi[i + j * ld]);
+            nrm = std::sqrt(nrm);
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] /= nrm;
+        }
+    }
+
+    int n_dim, nband, ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGDiagonalTest, BlockSubspace)
+{
+    std::vector<T>    psi_run = psi;
+    std::vector<Real> eval(nband, 0.0);
+
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        /* diag_thr = */ 1e-12,
+        /* max_iter = */ 50,
+        /* sbsize   = */ 3,
+        /* rr_step  = */ 3,
+        /* gamma_g0 = */ false,
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE
+    );
+
+    auto h_op = [this](T* in, T* out, int ld_in, int ncol) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ld_in, ncol);
+    };
+
+    double avg_iter = solver.diag(
+        h_op, nullptr, ld, nband, n_dim,
+        psi_run.data(), eval.data(), ethr, prec.data()
+    );
+
+    for (int i = 0; i < nband; ++i) {
+        EXPECT_NEAR(eval[i], exact[i], 1e-8)
+            << "Diagonal BLOCK: eigenvalue[" << i << "] mismatch";
+    }
+    EXPECT_LE(avg_iter, static_cast<double>(50))
+        << "Diagonal BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: 2×2 matrix — smallest non-trivial case
+// H = [[2, 1], [1, 2]], eigenvalues: 1, 3
+// =============================================================================
+class DiagoPPCG2x2Test : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim = 2;
+        nband = 2;
+        ld = n_dim;
+
+        // H = [[2, 1], [1, 2]]
+        H_mat.assign(n_dim * n_dim, T(0));
+        H_mat[0 + 0 * n_dim] = T(2.0, 0);
+        H_mat[1 + 1 * n_dim] = T(2.0, 0);
+        H_mat[0 + 1 * n_dim] = T(1.0, 0);
+        H_mat[1 + 0 * n_dim] = T(1.0, 0);
+
+        prec.assign(n_dim, 2.0);
+
+        // λ₁ = 1, λ₂ = 3
+        exact = {1.0, 3.0};
+
+        ethr.assign(nband, 1e-10);
+
+        std::mt19937 rng(123);
+        std::uniform_real_distribution<Real> dist(-1.0, 1.0);
+
+        psi.assign(ld * nband, T(0));
+        for (int j = 0; j < nband; ++j)
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] = T(dist(rng), 0.0);
+
+        // Gram-Schmidt orthonormalisation (S = I)
+        for (int j = 0; j < nband; ++j) {
+            for (int k = 0; k < j; ++k) {
+                T dot = 0;
+                for (int i = 0; i < n_dim; ++i)
+                    dot += std::conj(psi[i + k * ld]) * psi[i + j * ld];
+                for (int i = 0; i < n_dim; ++i)
+                    psi[i + j * ld] -= dot * psi[i + k * ld];
+            }
+            Real nrm = 0;
+            for (int i = 0; i < n_dim; ++i)
+                nrm += std::norm(psi[i + j * ld]);
+            nrm = std::sqrt(nrm);
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] /= nrm;
+        }
+    }
+
+    int n_dim, nband, ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCG2x2Test, BlockSubspace)
+{
+    std::vector<T>    psi_run = psi;
+    std::vector<Real> eval(nband, 0.0);
+
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        /* diag_thr = */ 1e-12,
+        /* max_iter = */ 50,
+        /* sbsize   = */ 2,
+        /* rr_step  = */ 2,
+        /* gamma_g0 = */ false,
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE
+    );
+
+    auto h_op = [this](T* in, T* out, int ld_in, int ncol) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ld_in, ncol);
+    };
+
+    double avg_iter = solver.diag(
+        h_op, nullptr, ld, nband, n_dim,
+        psi_run.data(), eval.data(), ethr, prec.data()
+    );
+
+    for (int i = 0; i < nband; ++i) {
+        EXPECT_NEAR(eval[i], exact[i], 1e-8)
+            << "2x2 BLOCK: eigenvalue[" << i << "] mismatch";
+    }
+    EXPECT_LE(avg_iter, static_cast<double>(50))
+        << "2x2 BLOCK: too many iterations";
+}
+
+TEST(DiagoPPCGComplexHermitianTest, DefaultKeepsImaginaryProjection)
+{
+    const int n_dim = 2;
+    const int nband = 2;
+    const int ld = n_dim;
+
+    // H = [[2, i], [-i, 3]].  Dropping Im(<x|Hy>) would incorrectly
+    // diagonalize diag(2, 3); the Hermitian eigenvalues are 2.5 +/- sqrt(1.25).
+    std::vector<T> H_mat(n_dim * n_dim, T(0));
+    H_mat[0 + 0 * n_dim] = T(2.0, 0.0);
+    H_mat[1 + 1 * n_dim] = T(3.0, 0.0);
+    H_mat[0 + 1 * n_dim] = T(0.0, 1.0);
+    H_mat[1 + 0 * n_dim] = T(0.0, -1.0);
+
+    std::vector<T> psi(ld * nband, T(0));
+    psi[0 + 0 * ld] = T(1.0, 0.0);
+    psi[1 + 1 * ld] = T(1.0, 0.0);
+
+    std::vector<Real> prec(n_dim, 2.0);
+    std::vector<double> ethr(nband, 1e-12);
+    std::vector<Real> eval(nband, 0.0);
+
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        /* diag_thr = */ 1e-12,
+        /* max_iter = */ 10,
+        /* sbsize   = */ 2,
+        /* rr_step  = */ 1,
+        /* gamma_g0 = */ false
+    );
+
+    auto h_op = [&H_mat, n_dim](T* in, T* out, int ld_in, int ncol) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ld_in, ncol);
+    };
+
+    solver.diag(h_op, nullptr, ld, nband, n_dim,
+                psi.data(), eval.data(), ethr, prec.data());
+
+    const Real delta = std::sqrt(1.25);
+    EXPECT_NEAR(eval[0], 2.5 - delta, 1e-10);
+    EXPECT_NEAR(eval[1], 2.5 + delta, 1e-10);
+}
+
+TEST(DiagoPPCGComplexHermitianTest, BlockSubspaceSmokeNoNaN)
+{
+    const int n_dim = 2;
+    const int nband = 2;
+    const int ld = n_dim;
+
+    std::vector<T> H_mat(n_dim * n_dim, T(0));
+    H_mat[0 + 0 * n_dim] = T(2.0, 0.0);
+    H_mat[1 + 1 * n_dim] = T(3.0, 0.0);
+    H_mat[0 + 1 * n_dim] = T(0.0, 1.0);
+    H_mat[1 + 0 * n_dim] = T(0.0, -1.0);
+
+    std::vector<T> psi(ld * nband, T(0));
+    psi[0 + 0 * ld] = T(1.0, 0.0);
+    psi[1 + 1 * ld] = T(1.0, 0.0);
+
+    std::vector<Real> prec(n_dim, 2.0);
+    std::vector<double> ethr(nband, 1e-10);
+    std::vector<Real> eval(nband, 0.0);
+
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        /* diag_thr = */ 1e-10,
+        /* max_iter = */ 8,
+        /* sbsize   = */ 2,
+        /* rr_step  = */ 1,
+        /* gamma_g0 = */ false,
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE
+    );
+
+    auto h_op = [&H_mat, n_dim](T* in, T* out, int ld_in, int ncol) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ld_in, ncol);
+    };
+
+    solver.diag(h_op, nullptr, ld, nband, n_dim,
+                psi.data(), eval.data(), ethr, prec.data());
+
+    const Real delta = std::sqrt(1.25);
+    for (int i = 0; i < nband; ++i)
+        EXPECT_TRUE(std::isfinite(eval[i])) << "BLOCK_SUBSPACE produced NaN/Inf";
+    EXPECT_NEAR(eval[0], 2.5 - delta, 1e-8);
+    EXPECT_NEAR(eval[1], 2.5 + delta, 1e-8);
+}
+
+// =============================================================================
+// Test fixture: degenerate eigenvalues
+// H = I + J  (identity plus all-ones), 4×4.
+// J has eigenvector [1,1,1,1]^T with eigenvalue 4.
+// All vectors orthogonal to [1,1,1,1]^T are eigenvectors with eigenvalue 0.
+// So H = I + J has: λ₁ = 1 (multiplicity 3), λ₄ = 5.
+// =============================================================================
+class DiagoPPCGDegenerateTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim = 4;
+        nband = 4;
+        ld = n_dim;
+
+        // H = I + J where J is the all-ones matrix
+        H_mat.assign(n_dim * n_dim, T(0));
+        for (int i = 0; i < n_dim; ++i)
+            for (int j = 0; j < n_dim; ++j)
+                H_mat[i + j * n_dim] = T(1.0, 0);  // all-ones J
+        for (int i = 0; i < n_dim; ++i)
+            H_mat[i + i * n_dim] += T(1.0, 0);       // J → I+J
+
+        // Preconditioner: diagonal = 2
+        prec.assign(n_dim, 2.0);
+
+        // λ = {1, 1, 1, 5}
+        exact = {1.0, 1.0, 1.0, 5.0};
+
+        ethr.assign(nband, 1e-10);
+
+        std::mt19937 rng(456);
+        std::uniform_real_distribution<Real> dist(-1.0, 1.0);
+
+        psi.assign(ld * nband, T(0));
+        for (int j = 0; j < nband; ++j)
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] = T(dist(rng), 0.0);
+
+        // Gram-Schmidt (S = I)
+        for (int j = 0; j < nband; ++j) {
+            for (int k = 0; k < j; ++k) {
+                T dot = 0;
+                for (int i = 0; i < n_dim; ++i)
+                    dot += std::conj(psi[i + k * ld]) * psi[i + j * ld];
+                for (int i = 0; i < n_dim; ++i)
+                    psi[i + j * ld] -= dot * psi[i + k * ld];
+            }
+            Real nrm = 0;
+            for (int i = 0; i < n_dim; ++i)
+                nrm += std::norm(psi[i + j * ld]);
+            nrm = std::sqrt(nrm);
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] /= nrm;
+        }
+    }
+
+    int n_dim, nband, ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGDegenerateTest, BlockSubspace)
+{
+    std::vector<T>    psi_run = psi;
+    std::vector<Real> eval(nband, 0.0);
+
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        /* diag_thr = */ 1e-12,
+        /* max_iter = */ 100,
+        /* sbsize   = */ 4,
+        /* rr_step  = */ 4,
+        /* gamma_g0 = */ false,
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE
+    );
+
+    auto h_op = [this](T* in, T* out, int ld_in, int ncol) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ld_in, ncol);
+    };
+
+    double avg_iter = solver.diag(
+        h_op, nullptr, ld, nband, n_dim,
+        psi_run.data(), eval.data(), ethr, prec.data()
+    );
+
+    for (int i = 0; i < nband; ++i) {
+        EXPECT_NEAR(eval[i], exact[i], 1e-8)
+            << "Degenerate BLOCK: eigenvalue[" << i << "] mismatch";
+    }
+    EXPECT_LE(avg_iter, static_cast<double>(100))
+        << "Degenerate BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: larger tridiagonal, more bands
+// 20×20 tridiagonal Laplacian, nband=5.
+// =============================================================================
+class DiagoPPCGLargeTridiagTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim = 20;
+        nband = 5;
+        ld = n_dim;
+
+        H_mat.assign(n_dim * n_dim, T(0));
+        for (int i = 0; i < n_dim; ++i) {
+            H_mat[i + i * n_dim] = T(2.0, 0);
+            if (i > 0)         H_mat[i + (i - 1) * n_dim] = T(-1.0, 0);
+            if (i < n_dim - 1) H_mat[i + (i + 1) * n_dim] = T(-1.0, 0);
+        }
+
+        prec.assign(n_dim, 2.0);
+
+        exact.resize(nband);
+        for (int k = 0; k < nband; ++k)
+            exact[k] = 2.0 - 2.0 * std::cos(static_cast<Real>(k + 1)
+                                            * M_PI / static_cast<Real>(n_dim + 1));
+
+        ethr.assign(nband, 1e-10);
+
+        std::mt19937 rng(789);
+        std::uniform_real_distribution<Real> dist(-1.0, 1.0);
+
+        psi.assign(ld * nband, T(0));
+        for (int j = 0; j < nband; ++j)
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] = T(dist(rng), 0.0);
+
+        for (int j = 0; j < nband; ++j) {
+            for (int k = 0; k < j; ++k) {
+                T dot = 0;
+                for (int i = 0; i < n_dim; ++i)
+                    dot += std::conj(psi[i + k * ld]) * psi[i + j * ld];
+                for (int i = 0; i < n_dim; ++i)
+                    psi[i + j * ld] -= dot * psi[i + k * ld];
+            }
+            Real nrm = 0;
+            for (int i = 0; i < n_dim; ++i)
+                nrm += std::norm(psi[i + j * ld]);
+            nrm = std::sqrt(nrm);
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] /= nrm;
+        }
+    }
+
+    int n_dim, nband, ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGLargeTridiagTest, BlockSubspace)
+{
+    std::vector<T>    psi_run = psi;
+    std::vector<Real> eval(nband, 0.0);
+
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        /* diag_thr = */ 1e-12,
+        /* max_iter = */ 150,
+        /* sbsize   = */ 5,
+        /* rr_step  = */ 5,
+        /* gamma_g0 = */ false,
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE
+    );
+
+    auto h_op = [this](T* in, T* out, int ld_in, int ncol) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ld_in, ncol);
+    };
+
+    double avg_iter = solver.diag(
+        h_op, nullptr, ld, nband, n_dim,
+        psi_run.data(), eval.data(), ethr, prec.data()
+    );
+
+    for (int i = 0; i < nband; ++i) {
+        EXPECT_NEAR(eval[i], exact[i], 1e-8)
+            << "Large Tridiag BLOCK: eigenvalue[" << i << "] mismatch";
+    }
+    EXPECT_LE(avg_iter, static_cast<double>(150))
+        << "Large Tridiag BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: dense matrix with known eigenvalues
+// H = Q^T * D * Q where Q is a known orthogonal matrix (a Givens rotation
+// repeated on different index pairs) and D is diagonal.
+// For an 8×8 case: D = diag(1, 2, 3, 4, 5, 6, 7, 8), then apply several
+// Givens rotations to mix all rows/cols. The exact eigenvalues remain 1..8.
+//
+// This addresses the "full/dense matrix" test that was originally missing.
+// =============================================================================
+class DiagoPPCGDenseTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim = 8;
+        nband = 4;
+        ld = n_dim;
+
+        // Start with diagonal matrix
+        std::vector<Real> dense(n_dim * n_dim, static_cast<Real>(0));
+        for (int i = 0; i < n_dim; ++i)
+            dense[i + i * n_dim] = static_cast<Real>(i + 1);
+
+        // Apply several Givens rotations to make it dense while preserving
+        // eigenvalues. Each rotation: A' = G(i,j,θ)^T * A * G(i,j,θ)
+        auto apply_givens = [&](int p, int q, Real theta) {
+            Real c = std::cos(theta);
+            Real s = std::sin(theta);
+            // Apply to columns
+            for (int i = 0; i < n_dim; ++i) {
+                Real aip = dense[i + p * n_dim];
+                Real aiq = dense[i + q * n_dim];
+                dense[i + p * n_dim] =  c * aip + s * aiq;
+                dense[i + q * n_dim] = -s * aip + c * aiq;
+            }
+            // Apply to rows
+            for (int j = 0; j < n_dim; ++j) {
+                Real apj = dense[p + j * n_dim];
+                Real aqj = dense[q + j * n_dim];
+                dense[p + j * n_dim] = c * apj + s * aqj;
+                dense[q + j * n_dim] = -s * apj + c * aqj;
+            }
+        };
+
+        // Several rotations with different angles to create a genuinely
+        // dense matrix (all off-diagonals become non-zero)
+        std::mt19937 rng_dense(111);
+        std::uniform_real_distribution<Real> angle_dist(
+            static_cast<Real>(0.2), static_cast<Real>(1.3));
+        for (int k = 0; k < 20; ++k) {
+            int p = k % (n_dim - 1);
+            int q = p + 1 + (k / (n_dim - 1)) % (n_dim - 1 - p);
+            if (q >= n_dim) q = n_dim - 1;
+            if (p == q) continue;
+            apply_givens(p, q, angle_dist(rng_dense));
+        }
+
+        // Copy to complex H_mat
+        H_mat.assign(n_dim * n_dim, T(0));
+        for (int i = 0; i < n_dim * n_dim; ++i)
+            H_mat[i] = T(dense[i], 0);
+
+        // Preconditioner: use diagonal of the rotated H
+        prec.resize(n_dim);
+        for (int i = 0; i < n_dim; ++i)
+            prec[i] = std::real(H_mat[i + i * n_dim]);
+
+        // Lowest 4 eigenvalues: 1, 2, 3, 4
+        exact = {1.0, 2.0, 3.0, 4.0};
+
+        ethr.assign(nband, 1e-10);
+
+        std::mt19937 rng_psi(222);
+        std::uniform_real_distribution<Real> dist(-1.0, 1.0);
+
+        psi.assign(ld * nband, T(0));
+        for (int j = 0; j < nband; ++j)
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] = T(dist(rng_psi), 0.0);
+
+        for (int j = 0; j < nband; ++j) {
+            for (int k = 0; k < j; ++k) {
+                T dot = 0;
+                for (int i = 0; i < n_dim; ++i)
+                    dot += std::conj(psi[i + k * ld]) * psi[i + j * ld];
+                for (int i = 0; i < n_dim; ++i)
+                    psi[i + j * ld] -= dot * psi[i + k * ld];
+            }
+            Real nrm = 0;
+            for (int i = 0; i < n_dim; ++i)
+                nrm += std::norm(psi[i + j * ld]);
+            nrm = std::sqrt(nrm);
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] /= nrm;
+        }
+    }
+
+    int n_dim, nband, ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGDenseTest, BlockSubspace)
+{
+    std::vector<T>    psi_run = psi;
+    std::vector<Real> eval(nband, 0.0);
+
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        /* diag_thr = */ 1e-12,
+        /* max_iter = */ 200,
+        /* sbsize   = */ 4,
+        /* rr_step  = */ 4,
+        /* gamma_g0 = */ false,
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE
+    );
+
+    auto h_op = [this](T* in, T* out, int ld_in, int ncol) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ld_in, ncol);
+    };
+
+    double avg_iter = solver.diag(
+        h_op, nullptr, ld, nband, n_dim,
+        psi_run.data(), eval.data(), ethr, prec.data()
+    );
+
+    for (int i = 0; i < nband; ++i) {
+        EXPECT_NEAR(eval[i], exact[i], 1e-8)
+            << "Dense BLOCK: eigenvalue[" << i << "] mismatch";
+    }
+    EXPECT_LE(avg_iter, static_cast<double>(200))
+        << "Dense BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Helper: compute Hψ for eigenvector residual check
+// =============================================================================
+static void compute_residual(const T* H_data, int n_dim,
+                              const T* psi, const Real eval,
+                              int ld, T* residual)
+{
+    // residual = H*psi - eval*psi
+    dense_h_multiply(H_data, n_dim, psi, residual, ld, 1);
+    for (int i = 0; i < n_dim; ++i)
+        residual[i] -= eval * psi[i];
+}
+
+static Real column_norm(const T* x, int n_dim)
+{
+    Real nrm = 0;
+    for (int i = 0; i < n_dim; ++i)
+        nrm += std::norm(x[i]);
+    return std::sqrt(nrm);
+}
+
+// =============================================================================
+// Test fixture: non-trivial S matrix (diagonal overlap, S ≠ I)
+// H = tridiag 6×6 Laplacian, S = diag(1.1, 1.0, 0.9, 1.0, 1.1, 1.0)
+// Tests that the solver correctly handles a non-identity overlap matrix.
+// =============================================================================
+class DiagoPPCGWithSTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim = 6;
+        nband = 3;
+        ld = n_dim;
+
+        // Tridiagonal H
+        H_mat.assign(n_dim * n_dim, T(0));
+        for (int i = 0; i < n_dim; ++i) {
+            H_mat[i + i * n_dim] = T(2.0, 0);
+            if (i > 0)         H_mat[i + (i - 1) * n_dim] = T(-1.0, 0);
+            if (i < n_dim - 1) H_mat[i + (i + 1) * n_dim] = T(-1.0, 0);
+        }
+
+        // S = diag(1.1, 1.0, 0.9, 1.0, 1.1, 1.0)
+        s_diag = {1.1, 1.0, 0.9, 1.0, 1.1, 1.0};
+        S_mat.assign(n_dim * n_dim, T(0));
+        for (int i = 0; i < n_dim; ++i)
+            S_mat[i + i * n_dim] = T(s_diag[i], 0);
+
+        prec.assign(n_dim, 2.0);
+
+        // For non-trivial S, exact eigenvalues are harder analytically.
+        // We skip the absolute eigenvalue comparison and instead verify
+        // the generalized eigenvalue via residual: ||Hψ - εSψ|| < tol.
+        exact = {0.0, 0.0, 0.0};  // placeholder — not checked for WithS
+
+        ethr.assign(nband, 1e-8);
+
+        std::mt19937 rng(333);
+        std::uniform_real_distribution<Real> dist(-1.0, 1.0);
+
+        psi.assign(ld * nband, T(0));
+        for (int j = 0; j < nband; ++j)
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] = T(dist(rng), 0.0);
+
+        // S-orthonormalize initial guess
+        for (int j = 0; j < nband; ++j) {
+            for (int k = 0; k < j; ++k) {
+                T dot = 0;
+                for (int i = 0; i < n_dim; ++i)
+                    dot += std::conj(psi[i + k * ld])
+                         * T(s_diag[i], 0) * psi[i + j * ld];
+                for (int i = 0; i < n_dim; ++i)
+                    psi[i + j * ld] -= dot * psi[i + k * ld];
+            }
+            Real nrm = 0;
+            for (int i = 0; i < n_dim; ++i)
+                nrm += s_diag[i] * std::norm(psi[i + j * ld]);
+            nrm = std::sqrt(nrm);
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] /= nrm;
+        }
+    }
+
+    int n_dim, nband, ld;
+    std::vector<T> H_mat;
+    std::vector<T> S_mat;
+    std::vector<Real> s_diag;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGWithSTest, BlockSubspace)
+{
+    std::vector<T>    psi_run = psi;
+    std::vector<Real> eval(nband, 0.0);
+
+    // S-apply function: S * psi = diag(s_diag) * psi (element-wise)
+    auto spsi_func = [this](T* in, T* out, int ld_in, int ncol) {
+        for (int j = 0; j < ncol; ++j)
+            for (int i = 0; i < n_dim; ++i)
+                out[i + j * ld_in] = T(s_diag[i], 0) * in[i + j * ld_in];
+    };
+
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        /* diag_thr = */ 1e-10,
+        /* max_iter = */ 100,
+        /* sbsize   = */ 3,
+        /* rr_step  = */ 3,
+        /* gamma_g0 = */ false,
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE
+    );
+
+    auto h_op = [this](T* in, T* out, int ld_in, int ncol) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ld_in, ncol);
+    };
+
+    double avg_iter = solver.diag(
+        h_op, spsi_func, ld, nband, n_dim,
+        psi_run.data(), eval.data(), ethr, prec.data()
+    );
+
+    // Eigenvalue check: skip absolute comparison (exact values not
+    // analytically known for non-trivial S). Instead verify via residual.
+    // Just check eigenvalues are reasonable (not NaN, not negative for
+    // this positive-definite problem).
+    for (int i = 0; i < nband; ++i) {
+        EXPECT_GT(eval[i], 0.0)
+            << "WithS BLOCK: eigenvalue[" << i << "] should be positive";
+        EXPECT_LT(eval[i], 10.0)
+            << "WithS BLOCK: eigenvalue[" << i << "] unreasonably large";
+    }
+
+    // Residual check: ||Hψ_i - ε_i S ψ_i|| / |ε_i| < ethr
+    std::vector<T> hpsi(n_dim), spsi(n_dim), res(n_dim);
+    for (int i = 0; i < nband; ++i) {
+        dense_h_multiply(H_mat.data(), n_dim,
+                         psi_run.data() + i * ld, hpsi.data(), n_dim, 1);
+        spsi_func(psi_run.data() + i * ld, spsi.data(), n_dim, 1);
+        for (int j = 0; j < n_dim; ++j)
+            res[j] = hpsi[j] - T(eval[i], 0) * spsi[j];
+        Real res_nrm = column_norm(res.data(), n_dim);
+        EXPECT_LE(res_nrm, std::max(1e-6, 1e2 * ethr[i]))
+            << "WithS BLOCK: residual[" << i << "] too large, r=" << res_nrm;
+    }
+
+    EXPECT_LE(avg_iter, static_cast<double>(100))
+        << "WithS BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: gamma_g0 = true (Gamma-point real constraint)
+// Same tridiagonal Laplacian, but with gamma_g0=true forcing G=0 wavefunctions
+// to stay real-valued. Tests the force_g0_real codepath.
+// =============================================================================
+class DiagoPPCGGammaG0Test : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim = 8;
+        nband = 3;
+        ld = n_dim;
+
+        H_mat.assign(n_dim * n_dim, T(0));
+        for (int i = 0; i < n_dim; ++i) {
+            H_mat[i + i * n_dim] = T(2.0, 0);
+            if (i > 0)         H_mat[i + (i - 1) * n_dim] = T(-1.0, 0);
+            if (i < n_dim - 1) H_mat[i + (i + 1) * n_dim] = T(-1.0, 0);
+        }
+
+        prec.assign(n_dim, 2.0);
+
+        exact.resize(nband);
+        for (int k = 0; k < nband; ++k)
+            exact[k] = 2.0 - 2.0 * std::cos(static_cast<Real>(k + 1)
+                                            * M_PI / static_cast<Real>(n_dim + 1));
+
+        ethr.assign(nband, 1e-10);
+
+        std::mt19937 rng(555);
+        std::uniform_real_distribution<Real> dist(-1.0, 1.0);
+
+        psi.assign(ld * nband, T(0));
+        for (int j = 0; j < nband; ++j)
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] = T(dist(rng), 0.0);
+
+        for (int j = 0; j < nband; ++j) {
+            for (int k = 0; k < j; ++k) {
+                T dot = 0;
+                for (int i = 0; i < n_dim; ++i)
+                    dot += std::conj(psi[i + k * ld]) * psi[i + j * ld];
+                for (int i = 0; i < n_dim; ++i)
+                    psi[i + j * ld] -= dot * psi[i + k * ld];
+            }
+            Real nrm = 0;
+            for (int i = 0; i < n_dim; ++i)
+                nrm += std::norm(psi[i + j * ld]);
+            nrm = std::sqrt(nrm);
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] /= nrm;
+        }
+    }
+
+    int n_dim, nband, ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGGammaG0Test, BlockSubspace)
+{
+    std::vector<T>    psi_run = psi;
+    std::vector<Real> eval(nband, 0.0);
+
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        /* diag_thr = */ 1e-12,
+        /* max_iter = */ 100,
+        /* sbsize   = */ 3,
+        /* rr_step  = */ 3,
+        /* gamma_g0 = */ true,   // <-- Force G=0 wavefunctions to be real
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE
+    );
+
+    auto h_op = [this](T* in, T* out, int ld_in, int ncol) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ld_in, ncol);
+    };
+
+    double avg_iter = solver.diag(
+        h_op, nullptr, ld, nband, n_dim,
+        psi_run.data(), eval.data(), ethr, prec.data()
+    );
+
+    for (int i = 0; i < nband; ++i) {
+        EXPECT_NEAR(eval[i], exact[i], 1e-8)
+            << "GammaG0 BLOCK: eigenvalue[" << i << "] mismatch";
+    }
+
+    // Verify G=0 band (first band) is real
+    Real max_imag = 0;
+    for (int i = 0; i < n_dim; ++i)
+        max_imag = std::max(max_imag, std::abs(std::imag(psi_run[i])));
+    EXPECT_LT(max_imag, 1e-12)
+        << "GammaG0 BLOCK: G=0 band has non-zero imaginary part: " << max_imag;
+
+    EXPECT_LE(avg_iter, static_cast<double>(100))
+        << "GammaG0 BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: single-band (nband = 1)
+// Minimal test — extract only the lowest eigenvalue of a 5×5 tridiagonal
+// Laplacian. This exercises the degenerate code paths for a single band.
+// =============================================================================
+class DiagoPPCGSingleBandTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim = 5;
+        nband = 1;
+        ld = n_dim;
+
+        H_mat.assign(n_dim * n_dim, T(0));
+        for (int i = 0; i < n_dim; ++i) {
+            H_mat[i + i * n_dim] = T(2.0, 0);
+            if (i > 0)         H_mat[i + (i - 1) * n_dim] = T(-1.0, 0);
+            if (i < n_dim - 1) H_mat[i + (i + 1) * n_dim] = T(-1.0, 0);
+        }
+
+        prec.assign(n_dim, 2.0);
+
+        // Lowest eigenvalue of 5×5 tridiagonal Laplacian
+        exact = {2.0 - 2.0 * std::cos(M_PI / 6.0)};
+
+        ethr.assign(nband, 1e-10);
+
+        std::mt19937 rng(42);
+        std::uniform_real_distribution<Real> dist(-1.0, 1.0);
+
+        psi.assign(ld * nband, T(0));
+        for (int i = 0; i < n_dim; ++i)
+            psi[i] = T(dist(rng), 0.0);
+
+        Real nrm = 0;
+        for (int i = 0; i < n_dim; ++i)
+            nrm += std::norm(psi[i]);
+        nrm = std::sqrt(nrm);
+        for (int i = 0; i < n_dim; ++i)
+            psi[i] /= nrm;
+    }
+
+    int n_dim, nband, ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGSingleBandTest, BlockSubspace)
+{
+    std::vector<T>    psi_run = psi;
+    std::vector<Real> eval(nband, 0.0);
+
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        /* diag_thr = */ 1e-12,
+        /* max_iter = */ 50,
+        /* sbsize   = */ 1,
+        /* rr_step  = */ 1,
+        /* gamma_g0 = */ false,
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE
+    );
+
+    auto h_op = [this](T* in, T* out, int ld_in, int ncol) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ld_in, ncol);
+    };
+
+    double avg_iter = solver.diag(
+        h_op, nullptr, ld, nband, n_dim,
+        psi_run.data(), eval.data(), ethr, prec.data()
+    );
+
+    EXPECT_NEAR(eval[0], exact[0], 1e-8)
+        << "SingleBand BLOCK: eigenvalue mismatch";
+    EXPECT_LE(avg_iter, static_cast<double>(50))
+        << "SingleBand BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: eigenvector quality — verify Hψ ≈ εψ and ψ^H ψ = I
+// Uses the 10×10 tridiagonal Laplacian. After convergence, check:
+//   1. ||Hψ_i - ε_i ψ_i|| < tol   for each band
+//   2. |ψ_i^H ψ_j - δ_ij| < tol    for all i,j
+// =============================================================================
+class DiagoPPCGEigenvectorTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim = 10;
+        nband = 3;
+        ld = n_dim;
+
+        H_mat.assign(n_dim * n_dim, T(0));
+        for (int i = 0; i < n_dim; ++i) {
+            H_mat[i + i * n_dim] = T(2.0, 0);
+            if (i > 0)         H_mat[i + (i - 1) * n_dim] = T(-1.0, 0);
+            if (i < n_dim - 1) H_mat[i + (i + 1) * n_dim] = T(-1.0, 0);
+        }
+
+        prec.assign(n_dim, 2.0);
+
+        exact.resize(nband);
+        for (int k = 0; k < nband; ++k)
+            exact[k] = 2.0 - 2.0 * std::cos(static_cast<Real>(k + 1)
+                                            * M_PI / static_cast<Real>(n_dim + 1));
+
+        ethr.assign(nband, 1e-8);
+
+        std::mt19937 rng(888);
+        std::uniform_real_distribution<Real> dist(-1.0, 1.0);
+
+        psi.assign(ld * nband, T(0));
+        for (int j = 0; j < nband; ++j)
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] = T(dist(rng), 0.0);
+
+        for (int j = 0; j < nband; ++j) {
+            for (int k = 0; k < j; ++k) {
+                T dot = 0;
+                for (int i = 0; i < n_dim; ++i)
+                    dot += std::conj(psi[i + k * ld]) * psi[i + j * ld];
+                for (int i = 0; i < n_dim; ++i)
+                    psi[i + j * ld] -= dot * psi[i + k * ld];
+            }
+            Real nrm = 0;
+            for (int i = 0; i < n_dim; ++i)
+                nrm += std::norm(psi[i + j * ld]);
+            nrm = std::sqrt(nrm);
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] /= nrm;
+        }
+    }
+
+    int n_dim, nband, ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGEigenvectorTest, BlockSubspace)
+{
+    std::vector<T>    psi_run = psi;
+    std::vector<Real> eval(nband, 0.0);
+
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        /* diag_thr = */ 1e-12,
+        /* max_iter = */ 100,
+        /* sbsize   = */ 3,
+        /* rr_step  = */ 3,
+        /* gamma_g0 = */ false,
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE
+    );
+
+    auto h_op = [this](T* in, T* out, int ld_in, int ncol) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ld_in, ncol);
+    };
+
+    double avg_iter = solver.diag(
+        h_op, nullptr, ld, nband, n_dim,
+        psi_run.data(), eval.data(), ethr, prec.data()
+    );
+
+    // --- Eigenvalue check ---
+    for (int i = 0; i < nband; ++i) {
+        EXPECT_NEAR(eval[i], exact[i], 1e-8)
+            << "Eigenvec BLOCK: eigenvalue[" << i << "] mismatch";
+    }
+
+    // --- Residual check: ||Hψ_i - ε_i ψ_i|| < 1e-6 ---
+    std::vector<T> hpsi(n_dim), res(n_dim);
+    for (int i = 0; i < nband; ++i) {
+        dense_h_multiply(H_mat.data(), n_dim,
+                         psi_run.data() + i * ld, hpsi.data(), n_dim, 1);
+        for (int j = 0; j < n_dim; ++j)
+            res[j] = hpsi[j] - eval[i] * psi_run[j + i * ld];
+        Real res_nrm = column_norm(res.data(), n_dim);
+        EXPECT_LT(res_nrm, 1e-6)
+            << "Eigenvec BLOCK: residual[" << i << "] too large: " << res_nrm;
+    }
+
+    // --- Orthogonality check: |ψ_i^H ψ_j - δ_ij| < 1e-8 ---
+    for (int i = 0; i < nband; ++i) {
+        for (int j = 0; j < nband; ++j) {
+            T dot = 0;
+            for (int k = 0; k < n_dim; ++k)
+                dot += std::conj(psi_run[k + i * ld]) * psi_run[k + j * ld];
+            if (i == j)
+                EXPECT_NEAR(std::abs(dot), 1.0, 1e-8)
+                    << "Eigenvec BLOCK: ψ[" << i << "] not normalized, |dot|="
+                    << std::abs(dot);
+            else
+                EXPECT_LT(std::abs(dot), 1e-8)
+                    << "Eigenvec BLOCK: ψ[" << i << "] not orthogonal to ψ[" << j
+                    << "], |dot|=" << std::abs(dot);
+        }
+    }
+
+    EXPECT_LE(avg_iter, static_cast<double>(100))
+        << "Eigenvec BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: all eigenvalues of a small matrix (nband = n_dim)
+// 3×3 tridiagonal Laplacian, compute all 3 eigenvalues.
+// Exercises the degenerate case where every band is requested.
+// =============================================================================
+class DiagoPPCGAllBandsTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim = 3;
+        nband = 3;
+        ld = n_dim;
+
+        H_mat.assign(n_dim * n_dim, T(0));
+        for (int i = 0; i < n_dim; ++i) {
+            H_mat[i + i * n_dim] = T(2.0, 0);
+            if (i > 0)         H_mat[i + (i - 1) * n_dim] = T(-1.0, 0);
+            if (i < n_dim - 1) H_mat[i + (i + 1) * n_dim] = T(-1.0, 0);
+        }
+
+        prec.assign(n_dim, 2.0);
+
+        exact.resize(nband);
+        for (int k = 0; k < nband; ++k)
+            exact[k] = 2.0 - 2.0 * std::cos(static_cast<Real>(k + 1)
+                                            * M_PI / static_cast<Real>(n_dim + 1));
+
+        ethr.assign(nband, 1e-10);
+
+        std::mt19937 rng(101);
+        std::uniform_real_distribution<Real> dist(-1.0, 1.0);
+
+        psi.assign(ld * nband, T(0));
+        for (int j = 0; j < nband; ++j)
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] = T(dist(rng), 0.0);
+
+        for (int j = 0; j < nband; ++j) {
+            for (int k = 0; k < j; ++k) {
+                T dot = 0;
+                for (int i = 0; i < n_dim; ++i)
+                    dot += std::conj(psi[i + k * ld]) * psi[i + j * ld];
+                for (int i = 0; i < n_dim; ++i)
+                    psi[i + j * ld] -= dot * psi[i + k * ld];
+            }
+            Real nrm = 0;
+            for (int i = 0; i < n_dim; ++i)
+                nrm += std::norm(psi[i + j * ld]);
+            nrm = std::sqrt(nrm);
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] /= nrm;
+        }
+    }
+
+    int n_dim, nband, ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGAllBandsTest, BlockSubspace)
+{
+    std::vector<T>    psi_run = psi;
+    std::vector<Real> eval(nband, 0.0);
+
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        /* diag_thr = */ 1e-12,
+        /* max_iter = */ 100,
+        /* sbsize   = */ 3,
+        /* rr_step  = */ 3,
+        /* gamma_g0 = */ false,
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE
+    );
+
+    auto h_op = [this](T* in, T* out, int ld_in, int ncol) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ld_in, ncol);
+    };
+
+    double avg_iter = solver.diag(
+        h_op, nullptr, ld, nband, n_dim,
+        psi_run.data(), eval.data(), ethr, prec.data()
+    );
+
+    for (int i = 0; i < nband; ++i) {
+        EXPECT_NEAR(eval[i], exact[i], 1e-8)
+            << "AllBands BLOCK: eigenvalue[" << i << "] mismatch";
+    }
+    EXPECT_LE(avg_iter, static_cast<double>(100))
+        << "AllBands BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: medium-sized tridiagonal (15×15, nband=4)
+// Bridges the gap between the 10×10 and 20×20 tests.
+// =============================================================================
+class DiagoPPCGMediumTridiagTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim = 15;
+        nband = 4;
+        ld = n_dim;
+
+        H_mat.assign(n_dim * n_dim, T(0));
+        for (int i = 0; i < n_dim; ++i) {
+            H_mat[i + i * n_dim] = T(2.0, 0);
+            if (i > 0)         H_mat[i + (i - 1) * n_dim] = T(-1.0, 0);
+            if (i < n_dim - 1) H_mat[i + (i + 1) * n_dim] = T(-1.0, 0);
+        }
+
+        prec.assign(n_dim, 2.0);
+
+        exact.resize(nband);
+        for (int k = 0; k < nband; ++k)
+            exact[k] = 2.0 - 2.0 * std::cos(static_cast<Real>(k + 1)
+                                            * M_PI / static_cast<Real>(n_dim + 1));
+
+        ethr.assign(nband, 1e-10);
+
+        std::mt19937 rng(202);
+        std::uniform_real_distribution<Real> dist(-1.0, 1.0);
+
+        psi.assign(ld * nband, T(0));
+        for (int j = 0; j < nband; ++j)
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] = T(dist(rng), 0.0);
+
+        for (int j = 0; j < nband; ++j) {
+            for (int k = 0; k < j; ++k) {
+                T dot = 0;
+                for (int i = 0; i < n_dim; ++i)
+                    dot += std::conj(psi[i + k * ld]) * psi[i + j * ld];
+                for (int i = 0; i < n_dim; ++i)
+                    psi[i + j * ld] -= dot * psi[i + k * ld];
+            }
+            Real nrm = 0;
+            for (int i = 0; i < n_dim; ++i)
+                nrm += std::norm(psi[i + j * ld]);
+            nrm = std::sqrt(nrm);
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] /= nrm;
+        }
+    }
+
+    int n_dim, nband, ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGMediumTridiagTest, BlockSubspace)
+{
+    std::vector<T>    psi_run = psi;
+    std::vector<Real> eval(nband, 0.0);
+
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        /* diag_thr = */ 1e-12,
+        /* max_iter = */ 120,
+        /* sbsize   = */ 4,
+        /* rr_step  = */ 4,
+        /* gamma_g0 = */ false,
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE
+    );
+
+    auto h_op = [this](T* in, T* out, int ld_in, int ncol) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ld_in, ncol);
+    };
+
+    double avg_iter = solver.diag(
+        h_op, nullptr, ld, nband, n_dim,
+        psi_run.data(), eval.data(), ethr, prec.data()
+    );
+
+    for (int i = 0; i < nband; ++i) {
+        EXPECT_NEAR(eval[i], exact[i], 1e-8)
+            << "Medium Tridiag BLOCK: eigenvalue[" << i << "] mismatch";
+    }
+    EXPECT_LE(avg_iter, static_cast<double>(120))
+        << "Medium Tridiag BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: gamma_g0 = true on a 7×7 tridiagonal, nband=2
+// Verifies eigenvalues are correct and the first band stays real-valued
+// when gamma_g0_real is enabled (H and S are both real-symmetric).
+// =============================================================================
+class DiagoPPCGGammaG0SmallTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim = 7;
+        nband = 2;
+        ld = n_dim;
+
+        H_mat.assign(n_dim * n_dim, T(0));
+        for (int i = 0; i < n_dim; ++i) {
+            H_mat[i + i * n_dim] = T(2.0, 0);
+            if (i > 0)         H_mat[i + (i - 1) * n_dim] = T(-1.0, 0);
+            if (i < n_dim - 1) H_mat[i + (i + 1) * n_dim] = T(-1.0, 0);
+        }
+
+        prec.assign(n_dim, 2.0);
+
+        exact.resize(nband);
+        for (int k = 0; k < nband; ++k)
+            exact[k] = 2.0 - 2.0 * std::cos(static_cast<Real>(k + 1)
+                                            * M_PI / static_cast<Real>(n_dim + 1));
+
+        ethr.assign(nband, 1e-10);
+
+        std::mt19937 rng(404);
+        std::uniform_real_distribution<Real> dist(-1.0, 1.0);
+
+        psi.assign(ld * nband, T(0));
+        for (int j = 0; j < nband; ++j)
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] = T(dist(rng), 0.0);
+
+        for (int j = 0; j < nband; ++j) {
+            for (int k = 0; k < j; ++k) {
+                T dot = 0;
+                for (int i = 0; i < n_dim; ++i)
+                    dot += std::conj(psi[i + k * ld]) * psi[i + j * ld];
+                for (int i = 0; i < n_dim; ++i)
+                    psi[i + j * ld] -= dot * psi[i + k * ld];
+            }
+            Real nrm = 0;
+            for (int i = 0; i < n_dim; ++i)
+                nrm += std::norm(psi[i + j * ld]);
+            nrm = std::sqrt(nrm);
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] /= nrm;
+        }
+    }
+
+    int n_dim, nband, ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGGammaG0SmallTest, BlockSubspace)
+{
+    std::vector<T>    psi_run = psi;
+    std::vector<Real> eval(nband, 0.0);
+
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        /* diag_thr = */ 1e-12,
+        /* max_iter = */ 100,
+        /* sbsize   = */ 2,
+        /* rr_step  = */ 2,
+        /* gamma_g0 = */ true,
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE
+    );
+
+    auto h_op = [this](T* in, T* out, int ld_in, int ncol) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ld_in, ncol);
+    };
+
+    double avg_iter = solver.diag(
+        h_op, nullptr, ld, nband, n_dim,
+        psi_run.data(), eval.data(), ethr, prec.data()
+    );
+
+    for (int i = 0; i < nband; ++i) {
+        EXPECT_NEAR(eval[i], exact[i], 1e-8)
+            << "GammaG0Small BLOCK: eigenvalue[" << i << "] mismatch";
+    }
+
+    // Both bands should be real-valued when gamma_g0_real is true
+    for (int j = 0; j < nband; ++j) {
+        Real max_imag = 0;
+        for (int i = 0; i < n_dim; ++i)
+            max_imag = std::max(max_imag,
+                               std::abs(std::imag(psi_run[i + j * ld])));
+        EXPECT_LT(max_imag, 1e-12)
+            << "GammaG0Small BLOCK: band[" << j
+            << "] has non-zero imaginary part: " << max_imag;
+    }
+
+    EXPECT_LE(avg_iter, static_cast<double>(100))
+        << "GammaG0Small BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: pentadiagonal Toeplitz (discrete biharmonic operator)
+// H[i,i]=6, H[i,i±1]=-4, H[i,i±2]=1.  Eigenvalues:
+// λ_k = 16·sin⁴(k·π / (2·(n+1))),  k = 1,...,n
+// Wider bandwidth (5 vs 3) tests the solver with more off-diagonal coupling.
+// =============================================================================
+class DiagoPPCGPentaTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim = 8;
+        nband = 4;
+        ld = n_dim;
+
+        // H = T² where T is the tridiagonal Laplacian (2 on diag, -1 on off-diag).
+        // The corners of T² have diag=5 (not 6) since (T²)[0,0] = 2² + (-1)² = 5.
+        // Interior: (T²)[i,i] = (-1)² + 2² + (-1)² = 6.
+        H_mat.assign(n_dim * n_dim, T(0));
+        for (int i = 0; i < n_dim; ++i) {
+            H_mat[i + i * n_dim] = T((i == 0 || i == n_dim-1) ? 5.0 : 6.0, 0);
+            if (i >= 1) H_mat[i + (i - 1) * n_dim] = T(-4.0, 0);
+            if (i < n_dim - 1) H_mat[i + (i + 1) * n_dim] = T(-4.0, 0);
+            if (i >= 2) H_mat[i + (i - 2) * n_dim] = T(1.0, 0);
+            if (i < n_dim - 2) H_mat[i + (i + 2) * n_dim] = T(1.0, 0);
+        }
+
+        prec.assign(n_dim, 6.0);
+        prec[0] = 5.0;
+        prec[n_dim - 1] = 5.0;
+
+        exact.resize(nband);
+        for (int k = 0; k < nband; ++k) {
+            Real theta = static_cast<Real>(k + 1) * M_PI
+                       / static_cast<Real>(2 * (n_dim + 1));
+            Real s = std::sin(theta);
+            exact[k] = static_cast<Real>(16) * s * s * s * s;
+        }
+
+        ethr.assign(nband, 1e-10);
+
+        std::mt19937 rng(505);
+        std::uniform_real_distribution<Real> dist(-1.0, 1.0);
+
+        psi.assign(ld * nband, T(0));
+        for (int j = 0; j < nband; ++j)
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] = T(dist(rng), 0.0);
+
+        for (int j = 0; j < nband; ++j) {
+            for (int k = 0; k < j; ++k) {
+                T dot = 0;
+                for (int i = 0; i < n_dim; ++i)
+                    dot += std::conj(psi[i + k * ld]) * psi[i + j * ld];
+                for (int i = 0; i < n_dim; ++i)
+                    psi[i + j * ld] -= dot * psi[i + k * ld];
+            }
+            Real nrm = 0;
+            for (int i = 0; i < n_dim; ++i)
+                nrm += std::norm(psi[i + j * ld]);
+            nrm = std::sqrt(nrm);
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] /= nrm;
+        }
+    }
+
+    int n_dim, nband, ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGPentaTest, BlockSubspace)
+{
+    std::vector<T>    psi_run = psi;
+    std::vector<Real> eval(nband, 0.0);
+
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        /* diag_thr = */ 1e-12,
+        /* max_iter = */ 150,
+        /* sbsize   = */ 4,
+        /* rr_step  = */ 4,
+        /* gamma_g0 = */ false,
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE
+    );
+
+    auto h_op = [this](T* in, T* out, int ld_in, int ncol) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ld_in, ncol);
+    };
+
+    double avg_iter = solver.diag(
+        h_op, nullptr, ld, nband, n_dim,
+        psi_run.data(), eval.data(), ethr, prec.data()
+    );
+
+    for (int i = 0; i < nband; ++i) {
+        EXPECT_NEAR(eval[i], exact[i], 1e-8)
+            << "Penta BLOCK: eigenvalue[" << i << "] mismatch";
+    }
+    EXPECT_LE(avg_iter, static_cast<double>(150))
+        << "Penta BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: gapped spectrum
+// H = diag(0.1, 0.5, 5.0, 6.0, 10.0), nband=3.
+// Large gaps between eigenvalue groups test the solver's band separation.
+// =============================================================================
+class DiagoPCGGappedSpectrumTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim = 5;
+        nband = 3;
+        ld = n_dim;
+
+        H_mat.assign(n_dim * n_dim, T(0));
+        H_mat[0 + 0 * n_dim] = T(0.1, 0);
+        H_mat[1 + 1 * n_dim] = T(0.5, 0);
+        H_mat[2 + 2 * n_dim] = T(5.0, 0);
+        H_mat[3 + 3 * n_dim] = T(6.0, 0);
+        H_mat[4 + 4 * n_dim] = T(10.0, 0);
+
+        prec.assign(n_dim, 1.0);
+
+        exact = {0.1, 0.5, 5.0};
+
+        ethr.assign(nband, 1e-10);
+
+        std::mt19937 rng(606);
+        std::uniform_real_distribution<Real> dist(-1.0, 1.0);
+
+        psi.assign(ld * nband, T(0));
+        for (int j = 0; j < nband; ++j)
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] = T(dist(rng), 0.0);
+
+        for (int j = 0; j < nband; ++j) {
+            for (int k = 0; k < j; ++k) {
+                T dot = 0;
+                for (int i = 0; i < n_dim; ++i)
+                    dot += std::conj(psi[i + k * ld]) * psi[i + j * ld];
+                for (int i = 0; i < n_dim; ++i)
+                    psi[i + j * ld] -= dot * psi[i + k * ld];
+            }
+            Real nrm = 0;
+            for (int i = 0; i < n_dim; ++i)
+                nrm += std::norm(psi[i + j * ld]);
+            nrm = std::sqrt(nrm);
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] /= nrm;
+        }
+    }
+
+    int n_dim, nband, ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPCGGappedSpectrumTest, BlockSubspace)
+{
+    std::vector<T>    psi_run = psi;
+    std::vector<Real> eval(nband, 0.0);
+
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        /* diag_thr = */ 1e-12,
+        /* max_iter = */ 100,
+        /* sbsize   = */ 3,
+        /* rr_step  = */ 3,
+        /* gamma_g0 = */ false,
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE
+    );
+
+    auto h_op = [this](T* in, T* out, int ld_in, int ncol) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ld_in, ncol);
+    };
+
+    double avg_iter = solver.diag(
+        h_op, nullptr, ld, nband, n_dim,
+        psi_run.data(), eval.data(), ethr, prec.data()
+    );
+
+    for (int i = 0; i < nband; ++i) {
+        EXPECT_NEAR(eval[i], exact[i], 1e-8)
+            << "Gapped BLOCK: eigenvalue[" << i << "] mismatch";
+    }
+    EXPECT_LE(avg_iter, static_cast<double>(100))
+        << "Gapped BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: preconditioner stress test
+// Uses the 10×10 tridiagonal Laplacian but with a suboptimal preconditioner:
+// prec[i] = 1.0 instead of 2.0 (the exact diagonal). The solver should still
+// converge, just more slowly. Tests robustness against a bad preconditioner.
+// =============================================================================
+class DiagoPPCGBadPrecTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim = 10;
+        nband = 3;
+        ld = n_dim;
+
+        H_mat.assign(n_dim * n_dim, T(0));
+        for (int i = 0; i < n_dim; ++i) {
+            H_mat[i + i * n_dim] = T(2.0, 0);
+            if (i > 0)         H_mat[i + (i - 1) * n_dim] = T(-1.0, 0);
+            if (i < n_dim - 1) H_mat[i + (i + 1) * n_dim] = T(-1.0, 0);
+        }
+
+        // Bad preconditioner: use 1.0 instead of 2.0
+        prec.assign(n_dim, 1.0);
+
+        exact.resize(nband);
+        for (int k = 0; k < nband; ++k)
+            exact[k] = 2.0 - 2.0 * std::cos(static_cast<Real>(k + 1)
+                                            * M_PI / static_cast<Real>(n_dim + 1));
+
+        ethr.assign(nband, 1e-10);
+
+        std::mt19937 rng(707);
+        std::uniform_real_distribution<Real> dist(-1.0, 1.0);
+
+        psi.assign(ld * nband, T(0));
+        for (int j = 0; j < nband; ++j)
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] = T(dist(rng), 0.0);
+
+        for (int j = 0; j < nband; ++j) {
+            for (int k = 0; k < j; ++k) {
+                T dot = 0;
+                for (int i = 0; i < n_dim; ++i)
+                    dot += std::conj(psi[i + k * ld]) * psi[i + j * ld];
+                for (int i = 0; i < n_dim; ++i)
+                    psi[i + j * ld] -= dot * psi[i + k * ld];
+            }
+            Real nrm = 0;
+            for (int i = 0; i < n_dim; ++i)
+                nrm += std::norm(psi[i + j * ld]);
+            nrm = std::sqrt(nrm);
+            for (int i = 0; i < n_dim; ++i)
+                psi[i + j * ld] /= nrm;
+        }
+    }
+
+    int n_dim, nband, ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGBadPrecTest, BlockSubspace)
+{
+    std::vector<T>    psi_run = psi;
+    std::vector<Real> eval(nband, 0.0);
+
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        /* diag_thr = */ 1e-12,
+        /* max_iter = */ 200,  // more iterations due to bad preconditioner
+        /* sbsize   = */ 4,
+        /* rr_step  = */ 4,
+        /* gamma_g0 = */ false,
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE
+    );
+
+    auto h_op = [this](T* in, T* out, int ld_in, int ncol) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ld_in, ncol);
+    };
+
+    double avg_iter = solver.diag(
+        h_op, nullptr, ld, nband, n_dim,
+        psi_run.data(), eval.data(), ethr, prec.data()
+    );
+
+    for (int i = 0; i < nband; ++i) {
+        EXPECT_NEAR(eval[i], exact[i], 1e-8)
+            << "BadPrec BLOCK: eigenvalue[" << i << "] mismatch";
+    }
+    EXPECT_LE(avg_iter, static_cast<double>(200))
+        << "BadPrec BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: n_dim = 1, nband = 1 — absolute minimum
+// H is a 1×1 matrix [5.0], eigenvalue = 5.0
+// =============================================================================
+class DiagoPPCG1x1Test : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim = 1;
+        nband = 1;
+        ld = n_dim;
+        H_mat = {T(5.0, 0)};
+        prec = {5.0};
+        exact = {5.0};
+        ethr.assign(nband, 1e-10);
+        psi = {T(1.0, 0)};  // already normalized
+    }
+    int n_dim, nband, ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCG1x1Test, BlockSubspace)
+{
+    std::vector<T> psi_run = psi;
+    std::vector<Real> eval(nband, 0.0);
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        1e-12, 10, 1, 1, false,
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE);
+    auto h_op = [this](T* in, T* out, int ldi, int nc) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ldi, nc);
+    };
+    double avg_iter = solver.diag(h_op, nullptr, ld, nband, n_dim,
+        psi_run.data(), eval.data(), ethr, prec.data());
+    EXPECT_NEAR(eval[0], exact[0], 1e-8) << "1x1 BLOCK: mismatch";
+    EXPECT_LE(avg_iter, 10.0) << "1x1 BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: scaled tridiagonal (eigenvalues × 100)
+// H = 100 × tridiag(2, -1, -1). Tests convergence with large eigenvalues.
+// =============================================================================
+class DiagoPPCGScaledTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim = 8;
+        nband = 3;
+        ld = n_dim;
+        H_mat.assign(n_dim * n_dim, T(0));
+        for (int i = 0; i < n_dim; ++i) {
+            H_mat[i + i * n_dim] = T(200.0, 0);
+            if (i > 0)         H_mat[i + (i-1)*n_dim] = T(-100.0, 0);
+            if (i < n_dim-1)   H_mat[i + (i+1)*n_dim] = T(-100.0, 0);
+        }
+        prec.assign(n_dim, 200.0);
+        exact.resize(nband);
+        for (int k = 0; k < nband; ++k)
+            exact[k] = 100.0 * (2.0 - 2.0 * std::cos(
+                static_cast<Real>(k+1)*M_PI/static_cast<Real>(n_dim+1)));
+        ethr.assign(nband, 1e-8);
+        init_psi(808);
+    }
+    void init_psi(int seed) {
+        std::mt19937 rng(seed);
+        std::uniform_real_distribution<Real> dist(-1.0, 1.0);
+        psi.assign(ld*nband, T(0));
+        for (int j=0;j<nband;++j) for(int i=0;i<n_dim;++i)
+            psi[i+j*ld]=T(dist(rng),0.0);
+        for(int j=0;j<nband;++j){for(int k=0;k<j;++k){T d=0;
+            for(int i=0;i<n_dim;++i) d+=std::conj(psi[i+k*ld])*psi[i+j*ld];
+            for(int i=0;i<n_dim;++i) psi[i+j*ld]-=d*psi[i+k*ld];}
+            Real nr=0;for(int i=0;i<n_dim;++i) nr+=std::norm(psi[i+j*ld]);
+            nr=std::sqrt(nr);for(int i=0;i<n_dim;++i) psi[i+j*ld]/=nr;}
+    }
+    int n_dim, nband, ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGScaledTest, BlockSubspace)
+{
+    std::vector<T> psi_run = psi;
+    std::vector<Real> eval(nband, 0.0);
+    hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+        1e-10, 120, 4, 4, false,
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE);
+    auto h_op = [this](T* in, T* out, int ldi, int nc) {
+        dense_h_multiply(H_mat.data(), n_dim, in, out, ldi, nc);
+    };
+    double avg_iter = solver.diag(h_op, nullptr, ld, nband, n_dim,
+        psi_run.data(), eval.data(), ethr, prec.data());
+    for (int i=0;i<nband;++i)
+        EXPECT_NEAR(eval[i], exact[i], 1e-6)
+            << "Scaled BLOCK: eigenvalue["<<i<<"] mismatch";
+    EXPECT_LE(avg_iter, 120.0) << "Scaled BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: many bands (n_dim=12, nband=4)
+// Moderate band-to-dimension ratio (1:3).
+// =============================================================================
+class DiagoPPCGManyBandsTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim = 12;
+        nband = 4;
+        ld = n_dim;
+        H_mat.assign(n_dim*n_dim, T(0));
+        for(int i=0;i<n_dim;++i){H_mat[i+i*n_dim]=T(2.0,0);
+            if(i>0)H_mat[i+(i-1)*n_dim]=T(-1.0,0);
+            if(i<n_dim-1)H_mat[i+(i+1)*n_dim]=T(-1.0,0);}
+        prec.assign(n_dim,2.0);
+        exact.resize(nband);
+        for(int k=0;k<nband;++k)exact[k]=2.0-2.0*std::cos(
+            static_cast<Real>(k+1)*M_PI/static_cast<Real>(n_dim+1));
+        ethr.assign(nband,1e-10);
+        init_psi(909);
+    }
+    void init_psi(int seed){
+        std::mt19937 rng(seed);
+        std::uniform_real_distribution<Real> dist(-1.0,1.0);
+        psi.assign(ld*nband,T(0));
+        for(int j=0;j<nband;++j)for(int i=0;i<n_dim;++i)psi[i+j*ld]=T(dist(rng),0.0);
+        for(int j=0;j<nband;++j){for(int k=0;k<j;++k){T d=0;
+            for(int i=0;i<n_dim;++i)d+=std::conj(psi[i+k*ld])*psi[i+j*ld];
+            for(int i=0;i<n_dim;++i)psi[i+j*ld]-=d*psi[i+k*ld];}
+            Real nr=0;for(int i=0;i<n_dim;++i)nr+=std::norm(psi[i+j*ld]);
+            nr=std::sqrt(nr);for(int i=0;i<n_dim;++i)psi[i+j*ld]/=nr;}
+    }
+    int n_dim,nband,ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGManyBandsTest, BlockSubspace)
+{
+    std::vector<T> psi_run=psi;
+    std::vector<Real> eval(nband,0.0);
+    hsolver::DiagoPPCG<T,hsolver::base_device::DEVICE_CPU> solver(
+        1e-12,150,4,4,false,hsolver::PpcgStrategy::BLOCK_SUBSPACE);
+    auto h_op=[this](T*in,T*out,int ldi,int nc){
+        dense_h_multiply(H_mat.data(),n_dim,in,out,ldi,nc);};
+    double avg_iter=solver.diag(h_op,nullptr,ld,nband,n_dim,
+        psi_run.data(),eval.data(),ethr,prec.data());
+    for(int i=0;i<nband;++i)
+        EXPECT_NEAR(eval[i],exact[i],1e-8)
+            <<"ManyBands BLOCK: eigenvalue["<<i<<"] mismatch";
+    EXPECT_LE(avg_iter,150.0)<<"ManyBands BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: rr_step = 1 (most frequent Rayleigh-Ritz refinement)
+// 8×8 tridiagonal, nband=3. Tests aggressive subspace diagonalization.
+// =============================================================================
+class DiagoPPCGRrStep1Test : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim=8;nband=3;ld=n_dim;
+        H_mat.assign(n_dim*n_dim,T(0));
+        for(int i=0;i<n_dim;++i){H_mat[i+i*n_dim]=T(2.0,0);
+            if(i>0)H_mat[i+(i-1)*n_dim]=T(-1.0,0);
+            if(i<n_dim-1)H_mat[i+(i+1)*n_dim]=T(-1.0,0);}
+        prec.assign(n_dim,2.0);
+        exact.resize(nband);
+        for(int k=0;k<nband;++k)exact[k]=2.0-2.0*std::cos(
+            static_cast<Real>(k+1)*M_PI/static_cast<Real>(n_dim+1));
+        ethr.assign(nband,1e-10);
+        init_psi(111);
+    }
+    void init_psi(int seed){
+        std::mt19937 rng(seed);
+        std::uniform_real_distribution<Real> dist(-1.0,1.0);
+        psi.assign(ld*nband,T(0));
+        for(int j=0;j<nband;++j)for(int i=0;i<n_dim;++i)psi[i+j*ld]=T(dist(rng),0.0);
+        for(int j=0;j<nband;++j){for(int k=0;k<j;++k){T d=0;
+            for(int i=0;i<n_dim;++i)d+=std::conj(psi[i+k*ld])*psi[i+j*ld];
+            for(int i=0;i<n_dim;++i)psi[i+j*ld]-=d*psi[i+k*ld];}
+            Real nr=0;for(int i=0;i<n_dim;++i)nr+=std::norm(psi[i+j*ld]);
+            nr=std::sqrt(nr);for(int i=0;i<n_dim;++i)psi[i+j*ld]/=nr;}
+    }
+    int n_dim,nband,ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGRrStep1Test, BlockSubspace)
+{
+    std::vector<T> psi_run=psi;
+    std::vector<Real> eval(nband,0.0);
+    hsolver::DiagoPPCG<T,hsolver::base_device::DEVICE_CPU> solver(
+        1e-12,100,3,1/*rr_step=1*/,false,
+        hsolver::PpcgStrategy::BLOCK_SUBSPACE);
+    auto h_op=[this](T*in,T*out,int ldi,int nc){
+        dense_h_multiply(H_mat.data(),n_dim,in,out,ldi,nc);};
+    double avg_iter=solver.diag(h_op,nullptr,ld,nband,n_dim,
+        psi_run.data(),eval.data(),ethr,prec.data());
+    for(int i=0;i<nband;++i)
+        EXPECT_NEAR(eval[i],exact[i],1e-8)
+            <<"RrStep1 BLOCK: eigenvalue["<<i<<"] mismatch";
+    EXPECT_LE(avg_iter,100.0)<<"RrStep1 BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: Neumann boundary tridiagonal Laplacian
+// H[0,0]=H[n-1,n-1]=1, interior diag=2, off-diag=-1.
+// Eigenvalues: λ_k = 2 - 2·cos(k·π/n), k=0,1,...,n-1
+// =============================================================================
+class DiagoPPCGNeumannTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim=8;nband=4;ld=n_dim;
+        H_mat.assign(n_dim*n_dim,T(0));
+        for(int i=0;i<n_dim;++i){
+            H_mat[i+i*n_dim]=T((i==0||i==n_dim-1)?1.0:2.0,0);
+            if(i>0)H_mat[i+(i-1)*n_dim]=T(-1.0,0);
+            if(i<n_dim-1)H_mat[i+(i+1)*n_dim]=T(-1.0,0);}
+        prec.assign(n_dim,2.0);prec[0]=1.0;prec[n_dim-1]=1.0;
+        exact.resize(nband);
+        for(int k=0;k<nband;++k)
+            exact[k]=2.0-2.0*std::cos(static_cast<Real>(k)*M_PI
+                                       /static_cast<Real>(n_dim));
+        ethr.assign(nband,1e-10);
+        init_psi(222);
+    }
+    void init_psi(int seed){
+        std::mt19937 rng(seed);
+        std::uniform_real_distribution<Real> dist(-1.0,1.0);
+        psi.assign(ld*nband,T(0));
+        for(int j=0;j<nband;++j)for(int i=0;i<n_dim;++i)psi[i+j*ld]=T(dist(rng),0.0);
+        for(int j=0;j<nband;++j){for(int k=0;k<j;++k){T d=0;
+            for(int i=0;i<n_dim;++i)d+=std::conj(psi[i+k*ld])*psi[i+j*ld];
+            for(int i=0;i<n_dim;++i)psi[i+j*ld]-=d*psi[i+k*ld];}
+            Real nr=0;for(int i=0;i<n_dim;++i)nr+=std::norm(psi[i+j*ld]);
+            nr=std::sqrt(nr);for(int i=0;i<n_dim;++i)psi[i+j*ld]/=nr;}
+    }
+    int n_dim,nband,ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGNeumannTest, BlockSubspace)
+{
+    std::vector<T> psi_run=psi;
+    std::vector<Real> eval(nband,0.0);
+    hsolver::DiagoPPCG<T,hsolver::base_device::DEVICE_CPU> solver(
+        1e-12,100,4,4,false,hsolver::PpcgStrategy::BLOCK_SUBSPACE);
+    auto h_op=[this](T*in,T*out,int ldi,int nc){
+        dense_h_multiply(H_mat.data(),n_dim,in,out,ldi,nc);};
+    double avg_iter=solver.diag(h_op,nullptr,ld,nband,n_dim,
+        psi_run.data(),eval.data(),ethr,prec.data());
+    for(int i=0;i<nband;++i)
+        EXPECT_NEAR(eval[i],exact[i],1e-8)
+            <<"Neumann BLOCK: eigenvalue["<<i<<"] mismatch";
+    EXPECT_LE(avg_iter,100.0)<<"Neumann BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: tight convergence threshold (ethr = 1e-14)
+// 6×6 tridiagonal, nband=2. Tests deep convergence.
+// =============================================================================
+class DiagoPPCGTightEthrTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim=6;nband=2;ld=n_dim;
+        H_mat.assign(n_dim*n_dim,T(0));
+        for(int i=0;i<n_dim;++i){H_mat[i+i*n_dim]=T(2.0,0);
+            if(i>0)H_mat[i+(i-1)*n_dim]=T(-1.0,0);
+            if(i<n_dim-1)H_mat[i+(i+1)*n_dim]=T(-1.0,0);}
+        prec.assign(n_dim,2.0);
+        exact.resize(nband);
+        for(int k=0;k<nband;++k)exact[k]=2.0-2.0*std::cos(
+            static_cast<Real>(k+1)*M_PI/static_cast<Real>(n_dim+1));
+        ethr.assign(nband,1e-14);
+        init_psi(333);
+    }
+    void init_psi(int seed){
+        std::mt19937 rng(seed);
+        std::uniform_real_distribution<Real> dist(-1.0,1.0);
+        psi.assign(ld*nband,T(0));
+        for(int j=0;j<nband;++j)for(int i=0;i<n_dim;++i)psi[i+j*ld]=T(dist(rng),0.0);
+        for(int j=0;j<nband;++j){for(int k=0;k<j;++k){T d=0;
+            for(int i=0;i<n_dim;++i)d+=std::conj(psi[i+k*ld])*psi[i+j*ld];
+            for(int i=0;i<n_dim;++i)psi[i+j*ld]-=d*psi[i+k*ld];}
+            Real nr=0;for(int i=0;i<n_dim;++i)nr+=std::norm(psi[i+j*ld]);
+            nr=std::sqrt(nr);for(int i=0;i<n_dim;++i)psi[i+j*ld]/=nr;}
+    }
+    int n_dim,nband,ld;
+    std::vector<T> H_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGTightEthrTest, BlockSubspace)
+{
+    std::vector<T> psi_run=psi;
+    std::vector<Real> eval(nband,0.0);
+    hsolver::DiagoPPCG<T,hsolver::base_device::DEVICE_CPU> solver(
+        1e-14,200,3,3,false,hsolver::PpcgStrategy::BLOCK_SUBSPACE);
+    auto h_op=[this](T*in,T*out,int ldi,int nc){
+        dense_h_multiply(H_mat.data(),n_dim,in,out,ldi,nc);};
+    double avg_iter=solver.diag(h_op,nullptr,ld,nband,n_dim,
+        psi_run.data(),eval.data(),ethr,prec.data());
+    for(int i=0;i<nband;++i)
+        EXPECT_NEAR(eval[i],exact[i],1e-8)
+            <<"TightEthr BLOCK: eigenvalue["<<i<<"] mismatch";
+    EXPECT_LE(avg_iter,200.0)<<"TightEthr BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Test fixture: non-diagonal S matrix (tridiagonal overlap)
+// H = tridiag(2,-1,-1), S = tridiag(1.0, 0.2, 0.2) — both tridiagonal.
+// Verifies S-orthogonalization with a non-diagonal S.
+// =============================================================================
+class DiagoPPCGTridiagSTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        n_dim=6;nband=2;ld=n_dim;
+        H_mat.assign(n_dim*n_dim,T(0));
+        for(int i=0;i<n_dim;++i){H_mat[i+i*n_dim]=T(2.0,0);
+            if(i>0)H_mat[i+(i-1)*n_dim]=T(-1.0,0);
+            if(i<n_dim-1)H_mat[i+(i+1)*n_dim]=T(-1.0,0);}
+        S_mat.assign(n_dim*n_dim,T(0));
+        for(int i=0;i<n_dim;++i){S_mat[i+i*n_dim]=T(1.0,0);
+            if(i>0){S_mat[i+(i-1)*n_dim]=T(0.2,0);
+                     S_mat[(i-1)+i*n_dim]=T(0.2,0);}}
+        prec.assign(n_dim,2.0);
+        // Exact eigenvalues unknown analytically for generalized problem
+        // with non-diagonal S. Just check convergence via residual.
+        exact={0.0,0.0};
+        ethr.assign(nband,1e-8);
+        init_psi(444);
+    }
+    void init_psi(int seed){
+        std::mt19937 rng(seed);
+        std::uniform_real_distribution<Real> dist(-1.0,1.0);
+        psi.assign(ld*nband,T(0));
+        for(int j=0;j<nband;++j)for(int i=0;i<n_dim;++i)psi[i+j*ld]=T(dist(rng),0.0);
+        // S-orthonormalize: S = tridiag(1.0, 0.2, 0.2)
+        for(int j=0;j<nband;++j){for(int k=0;k<j;++k){T d=0;
+            for(int i=0;i<n_dim;++i){
+                T si=0;si+=T(1.0,0)*psi[i+k*ld];
+                if(i>0)si+=T(0.2,0)*psi[(i-1)+k*ld];
+                if(i<n_dim-1)si+=T(0.2,0)*psi[(i+1)+k*ld];
+                d+=std::conj(si)*psi[i+j*ld];}
+            for(int i=0;i<n_dim;++i)psi[i+j*ld]-=d*psi[i+k*ld];}
+            Real nr=0;for(int i=0;i<n_dim;++i){
+                T si=0;si+=T(1.0,0)*psi[i+j*ld];
+                if(i>0)si+=T(0.2,0)*psi[(i-1)+j*ld];
+                if(i<n_dim-1)si+=T(0.2,0)*psi[(i+1)+j*ld];
+                nr+=std::real(std::conj(psi[i+j*ld])*si);}
+            nr=std::sqrt(nr);for(int i=0;i<n_dim;++i)psi[i+j*ld]/=nr;}
+    }
+    int n_dim,nband,ld;
+    std::vector<T> H_mat;
+    std::vector<T> S_mat;
+    std::vector<Real> prec;
+    std::vector<Real> exact;
+    std::vector<double> ethr;
+    std::vector<T> psi;
+};
+
+TEST_F(DiagoPPCGTridiagSTest, BlockSubspace)
+{
+    std::vector<T> psi_run=psi;
+    std::vector<Real> eval(nband,0.0);
+    auto spsi_func=[this](T*in,T*out,int ldi,int nc){
+        for(int j=0;j<nc;++j)for(int i=0;i<n_dim;++i){
+            out[i+j*ldi]=T(1.0,0)*in[i+j*ldi];
+            if(i>0)out[i+j*ldi]+=T(0.2,0)*in[(i-1)+j*ldi];
+            if(i<n_dim-1)out[i+j*ldi]+=T(0.2,0)*in[(i+1)+j*ldi];}};
+    hsolver::DiagoPPCG<T,hsolver::base_device::DEVICE_CPU> solver(
+        1e-10,150,3,3,false,hsolver::PpcgStrategy::BLOCK_SUBSPACE);
+    auto h_op=[this](T*in,T*out,int ldi,int nc){
+        dense_h_multiply(H_mat.data(),n_dim,in,out,ldi,nc);};
+    double avg_iter=solver.diag(h_op,spsi_func,ld,nband,n_dim,
+        psi_run.data(),eval.data(),ethr,prec.data());
+    // Check eigenvalues are positive and reasonable
+    for(int i=0;i<nband;++i){EXPECT_GT(eval[i],0.0);
+        EXPECT_LT(eval[i],5.0);}
+    // Residual check
+    std::vector<T> hpsi(n_dim),spsi(n_dim),res(n_dim);
+    for(int i=0;i<nband;++i){
+        dense_h_multiply(H_mat.data(),n_dim,psi_run.data()+i*ld,
+                         hpsi.data(),n_dim,1);
+        spsi_func(psi_run.data()+i*ld,spsi.data(),n_dim,1);
+        for(int j=0;j<n_dim;++j)res[j]=hpsi[j]-T(eval[i],0)*spsi[j];
+        Real rn=column_norm(res.data(),n_dim);
+        EXPECT_LT(rn,1e-4)<<"TridiagS BLOCK: residual["<<i<<"] too large: "<<rn;}
+    EXPECT_LE(avg_iter,150.0)<<"TridiagS BLOCK: too many iterations";
+}
+
+// =============================================================================
+// Performance benchmark: PPCG vs BLOCK vs Davidson comparison
+//
+// Runs PPCG on random sparse symmetric matrices of various sizes (matching
+// the BLOCK/Davidson test sizes: npw=100,200,500) and reports avg_iter and
+// wall-clock time.  avg_iter is the primary metric — it counts the average
+// number of H·psi applications per band.
+//
+// Typical results from the existing BLOCK/Davidson tests (for reference):
+//   BLOCK:       avg_iter ~ 20-50  on random sparse, ~ 5-15 on tridiagonal
+//   Davidson: avg_iter ~ 15-40  on random sparse (but each iter is heavier)
+//   PPCG:     avg_iter ~ 2-10  on tridiagonal/diagonal, varies with sparsity
+//
+// This test is DISABLED by default (too slow for CI).  Run manually with
+//   --gtest_also_run_disabled_tests --gtest_filter='*Benchmark*'
+// =============================================================================
+class DiagoPPCGBenchmarkTest : public ::testing::Test
+{
+protected:
+    void SetUp() override {}
+
+    // Generate a random sparse symmetric matrix of size n with given sparsity.
+    // sparsity=0 means dense, sparsity=80 means 80% zeros.
+    static void make_random_hamilt(int n, int sparsity_pct,
+                                   std::vector<T>& H, std::vector<Real>& prec)
+    {
+        H.assign(n * n, T(0));
+        std::mt19937 rng(static_cast<unsigned>(n * 100 + sparsity_pct));
+        std::uniform_real_distribution<Real> dist(-1.0, 1.0);
+        int nnz = 0;
+        for (int i = 0; i < n; ++i) {
+            for (int j = i; j < n; ++j) {
+                if (i != j && (rng() % 100) < sparsity_pct) continue;
+                Real val = (i == j) ? std::abs(dist(rng)) * n + 1.0
+                                    : dist(rng) * 0.5;
+                H[i + j * n] = T(val, 0);
+                if (i != j) H[j + i * n] = T(val, 0);
+                if (val != 0) ++nnz;
+            }
+        }
+        // Simple diagonal preconditioner
+        prec.resize(n);
+        for (int i = 0; i < n; ++i)
+            prec[i] = std::max(std::real(H[i + i * n]), 1e-6);
+    }
+
+    // Run PPCG and return {avg_iter, wall_sec}.
+    static std::pair<double,double> run_ppcg(
+        int n, int nband, const std::vector<T>& H,
+        const std::vector<Real>& prec)
+    {
+        int ld = n;
+        std::mt19937 rng(42);
+        std::uniform_real_distribution<Real> dist(-1.0, 1.0);
+        std::vector<T> psi(ld * nband, T(0));
+        for (int j = 0; j < nband; ++j)
+            for (int i = 0; i < n; ++i)
+                psi[i + j * ld] = T(dist(rng), 0.0);
+        // GS orthonormalize
+        for (int j = 0; j < nband; ++j) {
+            for (int k = 0; k < j; ++k) {
+                T d = 0;
+                for (int i = 0; i < n; ++i)
+                    d += std::conj(psi[i + k * ld]) * psi[i + j * ld];
+                for (int i = 0; i < n; ++i)
+                    psi[i + j * ld] -= d * psi[i + k * ld];
+            }
+            Real nr = 0;
+            for (int i = 0; i < n; ++i) nr += std::norm(psi[i + j * ld]);
+            nr = std::sqrt(nr);
+            for (int i = 0; i < n; ++i) psi[i + j * ld] /= nr;
+        }
+
+        std::vector<Real> eval(nband, 0.0);
+        std::vector<double> ethr(nband, 1e-4);
+        auto h_op = [&H, n](T* in, T* out, int ldi, int nc) {
+            dense_h_multiply(H.data(), n, in, out, ldi, nc);
+        };
+
+        hsolver::DiagoPPCG<T, hsolver::base_device::DEVICE_CPU> solver(
+            1e-8, 500, nband, std::min(nband, 4), false,
+            hsolver::PpcgStrategy::BLOCK_SUBSPACE);
+
+        auto t0 = std::chrono::high_resolution_clock::now();
+        double avg_iter = solver.diag(h_op, nullptr, ld, nband, n,
+            psi.data(), eval.data(), ethr, prec.data());
+        auto t1 = std::chrono::high_resolution_clock::now();
+        double wall = std::chrono::duration<double>(t1 - t0).count();
+        return {avg_iter, wall};
+    }
+};
+
+TEST_F(DiagoPPCGBenchmarkTest, DISABLED_FullBenchmark)
+{
+    struct Case { int n; int nband; int sparsity; };
+    std::vector<Case> cases = {
+        { 50,  10,  0},
+        { 50,  10, 60},
+        {100,  10,  0},
+        {100,  10, 60},
+        {100,  10, 80},
+        {200,  10, 60},
+        {200,  10, 80},
+        {500,  10, 80},
+    };
+
+    std::cout << "\n========== PPCG Performance Benchmark ==========\n";
+    std::cout << " n_dim  nband  sparsity   avg_iter   wall_time(s)\n";
+    std::cout << "-------------------------------------------------\n";
+    for (auto& c : cases) {
+        std::vector<T> H;
+        std::vector<Real> prec;
+        make_random_hamilt(c.n, c.sparsity, H, prec);
+        const std::pair<double, double> result = run_ppcg(c.n, c.nband, H, prec);
+        const double avg_iter = result.first;
+        const double wall = result.second;
+        printf(" %5d   %3d     %2d%%       %6.1f      %7.4f\n",
+               c.n, c.nband, c.sparsity, avg_iter, wall);
+    }
+    std::cout << "=================================================\n";
+    SUCCEED();
+}
+
+// Quick benchmark: just one representative case, fast enough for CI.
+TEST_F(DiagoPPCGBenchmarkTest, QuickBenchmark)
+{
+    std::vector<T> H;
+    std::vector<Real> prec;
+    make_random_hamilt(80, 60, H, prec);
+    const std::pair<double, double> result = run_ppcg(80, 8, H, prec);
+    const double avg_iter = result.first;
+    const double wall = result.second;
+    std::cout << "[PPCG QuickBench] n=80 nband=8 sparsity=60%"
+              << " avg_iter=" << avg_iter << " wall=" << wall << "s\n";
+    EXPECT_LE(avg_iter, 500.0) << "PPCG did not converge within 500 iters";
+    SUCCEED();
+}
+
+int main(int argc, char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- add the PPCG diagonalization solver and wire it into the PW hsolver path
- split PPCG implementation details into focused headers under source/source_hsolver/ppcg
- use ATen/container LAPACK kernels and ModuleBase vector dot kernels where applicable
- make the block-subspace strategy the PPCG production path and add PPCG coverage

## Tests
- ctest --test-dir build-ppcg-openmp -R MODULE_HSOLVER_ppcg --output-on-failure
- ctest --test-dir build-ppcg-openmp -R MODULE_HSOLVER_pw --output-on-failure
- OMP_NUM_THREADS=4 ./build-ppcg-openmp/source/source_hsolver/test/MODULE_HSOLVER_ppcg --gtest_also_run_disabled_tests --gtest_filter=DiagoPPCGBenchmarkTest.DISABLED_FullBenchmark --gtest_brief=1