### PR TITLE
Relax PR metadata governance checks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,51 +1,15 @@
-### Reminder
-- [ ] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
-- [ ] I have linked an issue or explained why this PR does not need one.
-- [ ] I have added adequate unit tests and/or case tests, or explained why not.
-- [ ] I have listed the exact verification commands run and their results.
-- [ ] I have described user-visible behavior changes, including INPUT parameter changes.
-- [ ] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
-- [ ] I have requested any needed governance exception below.
-
 ### Linked Issue
-Fix #...
+Fix #
 
 ### Unit Tests and/or Case Tests for my changes
-- A unit test is added for each new feature or bug fix.
-
-### Exact Verification Performed
 - Commands run:
 - Result summary:
 - Checks not run, with reason:
 
 ### What's changed?
-- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...
+- Example: brief summary of the user-visible or developer-facing change.
 
-### Governance Checklist
-- Global dependencies: no net increase in `GlobalV`, `GlobalC`, or `PARAM` code references, or exception requested below with reason, scope, risk, and cleanup plan.
-- Default parameters: no new default arguments added to existing interfaces, or exception requested below.
-- Headers: no unnecessary header dependencies or `.hpp` propagation, or rationale provided below.
-- Line endings: text files use LF; only `.bat` and `.cmd` use CRLF.
-- Build linkage: new source files are listed in the relevant `CMakeLists.txt`, or rationale provided below.
-- Documentation: behavior/interface changes include documentation updates, or no documentation update is required because ...
-- CodeRabbit: if automatic review has not started and the repository has CodeRabbit installed, request `@coderabbitai review`.
-
-### INPUT Parameter Changes
-- Parameters added/removed/changed:
-- `docs/parameters.yaml` updated: yes/no/not applicable
-- `docs/advanced/input_files/input-main.md` updated: yes/no/not applicable
-- If not updated, explain why no INPUT documentation update is required:
-
-### Core Module Impact
-- Affected core modules:
-- Risk summary:
-- Compatibility or performance impact:
-
-### Governance Exception
-- Rule:
-- Reason:
-- Scope:
-- User or maintenance risk:
-- Why the normal rule cannot be followed now:
-- Follow-up cleanup plan:
-- Requested approver:
+### Governance Notes
+- INPUT/docs changes:
+- Core module impact:
+- Exceptions requested:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,11 @@
-### Checklist
-- [ ] I have linked an issue or explained why none is needed.
-- [ ] I have listed verification commands/results, or explained why checks were not run.
-- [ ] I have described user-visible, INPUT/docs, or core-module impact if applicable.
-- [ ] I have noted any governance exception needed for this PR.
+### Reminder
+- [ ] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
+- [ ] I have linked an issue or explained why this PR does not need one.
+- [ ] I have added adequate unit tests and/or case tests, or explained why not.
+- [ ] I have listed the exact verification commands run and their results.
+- [ ] I have described user-visible behavior changes, including INPUT parameter changes.
+- [ ] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
+- [ ] I have requested any needed governance exception below.
 
 ### Linked Issue
 Fix #

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,9 @@
+### Checklist
+- [ ] I have linked an issue or explained why none is needed.
+- [ ] I have listed verification commands/results, or explained why checks were not run.
+- [ ] I have described user-visible, INPUT/docs, or core-module impact if applicable.
+- [ ] I have noted any governance exception needed for this PR.
+
 ### Linked Issue
 Fix #
 

--- a/docs/developers_guide/agent_governance.md
+++ b/docs/developers_guide/agent_governance.md
@@ -82,7 +82,7 @@ decisions.
 | Test sufficiency | Tests cover important behavior | AI review + human confirmation | AI + human review | medium | human confirmation | semantic review | Not mechanically blocked |
 | INPUT behavior linkage | Parameter metadata/default/type/parser behavior updates YAML and docs | phase-one mechanical + AI review | CI + AI review | high | block | behavior-field diff plus docs/PR body | Comment-only parameter-file changes are not blocked |
 | Documentation sync | Behavior/interface docs updated | phase-one mechanical warning + AI review | CI + AI review | medium | warn | changed paths and PR body | Major behavior changes escalate to reviewers |
-| PR metadata completeness | Issue, tests, behavior, INPUT, core impact, exceptions | phase-one mechanical | CI or GitHub bot | medium | block | PR template fields | Not run by local hook |
+| PR metadata completeness | Issue, tests, behavior, INPUT, core impact, exceptions | phase-one mechanical | CI or GitHub bot | medium | warn | PR template fields | Not run by local hook |
 | AI workflow | Interface lookup, uncertainty, verification report | AI review | AI review | high | warn | review transcript/output | Applies to AI agents |
 | Exceptions | Reason, scope, risk, follow-up plan | human confirmation | human review + CI | high | human confirmation | PR exception section | CI checks presence, not approval |
 

--- a/tools/03_code_analysis/agent_governance_check.py
+++ b/tools/03_code_analysis/agent_governance_check.py
@@ -563,12 +563,11 @@ def check_pr_metadata(findings: List[Finding], body: Optional[str]) -> None:
         add_finding(
             findings,
             "PR metadata completeness",
-            BLOCK,
+            WARN,
             "pull_request.body",
             None,
             "; ".join(reason_parts),
             "Fill the PR template with issue linkage, test evidence, behavior impact, governance notes, and exception details.",
-            allow_exception=False,
         )
 
 

--- a/tools/03_code_analysis/agent_governance_check.py
+++ b/tools/03_code_analysis/agent_governance_check.py
@@ -542,10 +542,6 @@ def check_pr_metadata(findings: List[Finding], body: Optional[str]) -> None:
         "Linked Issue",
         "Unit Tests and/or Case Tests for my changes",
         "What's changed?",
-        "Governance Checklist",
-        "INPUT Parameter Changes",
-        "Core Module Impact",
-        "Governance Exception",
     ]
     sections = pr_sections(body)
     missing = [section for section in required_sections if section not in sections]
@@ -567,7 +563,7 @@ def check_pr_metadata(findings: List[Finding], body: Optional[str]) -> None:
             "pull_request.body",
             None,
             "; ".join(reason_parts),
-            "Fill the PR template with issue linkage, test evidence, behavior impact, governance notes, and exception details.",
+            "Fill the PR template with issue linkage, test evidence, and a concise change summary.",
         )
 
 

--- a/tools/03_code_analysis/test_agent_governance_check.py
+++ b/tools/03_code_analysis/test_agent_governance_check.py
@@ -322,7 +322,7 @@ class AgentGovernanceCheckTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertNotIn("PR metadata completeness", result.stdout)
 
-    def test_accepts_filled_pr_template_fields_from_event_payload(self):
+    def test_accepts_core_pr_template_fields_from_event_payload(self):
         event = self.repo / "event.json"
         event.write_text(
             json.dumps(
@@ -332,15 +332,7 @@ class AgentGovernanceCheckTest(unittest.TestCase):
                         "### Unit Tests and/or Case Tests for my changes\n"
                         "Ran python3 -m unittest tools/03_code_analysis/test_agent_governance_check.py.\n\n"
                         "### What's changed?\n"
-                        "Adds governance checks only; no runtime behavior change.\n\n"
-                        "### Governance Checklist\n"
-                        "Line endings, CMake linkage, and docs rules reviewed.\n\n"
-                        "### INPUT Parameter Changes\n"
-                        "No INPUT parameter changes.\n\n"
-                        "### Core Module Impact\n"
-                        "No core module impact.\n\n"
-                        "### Governance Exception\n"
-                        "No exceptions requested.\n"
+                        "Adds governance checks only; no runtime behavior change.\n"
                     }
                 }
             )
@@ -349,6 +341,7 @@ class AgentGovernanceCheckTest(unittest.TestCase):
         result = self.run_checker("--event-path", str(event))
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertNotIn("PR metadata completeness", result.stdout)
 
     def test_warns_for_source_change_without_test_evidence(self):
         self.write("source/source_base/new_feature.cpp", "int new_feature() { return 1; }\n")

--- a/tools/03_code_analysis/test_agent_governance_check.py
+++ b/tools/03_code_analysis/test_agent_governance_check.py
@@ -343,6 +343,37 @@ class AgentGovernanceCheckTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertNotIn("PR metadata completeness", result.stdout)
 
+    def test_accepts_reminder_style_pr_template_from_event_payload(self):
+        event = self.repo / "event.json"
+        event.write_text(
+            json.dumps(
+                {
+                    "pull_request": {
+                        "body": "### Reminder\n"
+                        "- [ ] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.\n"
+                        "- [ ] I have linked an issue or explained why this PR does not need one.\n"
+                        "- [ ] I have added adequate unit tests and/or case tests, or explained why not.\n"
+                        "- [ ] I have listed the exact verification commands run and their results.\n"
+                        "- [ ] I have described user-visible behavior changes, including INPUT parameter changes.\n"
+                        "- [ ] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.\n"
+                        "- [ ] I have requested any needed governance exception below.\n\n"
+                        "### Linked Issue\nNo issue; governance bootstrap.\n\n"
+                        "### Unit Tests and/or Case Tests for my changes\n"
+                        "Ran python3 -m unittest tools/03_code_analysis/test_agent_governance_check.py.\n\n"
+                        "### What's changed?\n"
+                        "Adds governance checks only; no runtime behavior change.\n\n"
+                        "### Governance Notes\n"
+                        "No INPUT, core module, or exception notes.\n"
+                    }
+                }
+            )
+        )
+
+        result = self.run_checker("--event-path", str(event))
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertNotIn("PR metadata completeness", result.stdout)
+
     def test_warns_for_source_change_without_test_evidence(self):
         self.write("source/source_base/new_feature.cpp", "int new_feature() { return 1; }\n")
         self.write("source/source_base/CMakeLists.txt", "add_library(new_feature new_feature.cpp)\n")

--- a/tools/03_code_analysis/test_agent_governance_check.py
+++ b/tools/03_code_analysis/test_agent_governance_check.py
@@ -277,7 +277,7 @@ class AgentGovernanceCheckTest(unittest.TestCase):
 
         self.assert_blocked_by(result, "INPUT parameter documentation linkage")
 
-    def test_blocks_unfilled_pr_template_fields_from_event_payload(self):
+    def test_warns_for_unfilled_pr_template_fields_from_event_payload(self):
         event = self.repo / "event.json"
         event.write_text(
             json.dumps(
@@ -293,9 +293,9 @@ class AgentGovernanceCheckTest(unittest.TestCase):
 
         result = self.run_checker("--event-path", str(event))
 
-        self.assert_blocked_by(result, "PR metadata completeness")
+        self.assert_warns_with_success(result, "PR metadata completeness")
 
-    def test_blocks_empty_pr_template_from_event_payload(self):
+    def test_warns_for_empty_pr_template_from_event_payload(self):
         for body in ("", None):
             with self.subTest(body=body):
                 event = self.repo / "event.json"
@@ -303,15 +303,15 @@ class AgentGovernanceCheckTest(unittest.TestCase):
 
                 result = self.run_checker("--event-path", str(event))
 
-                self.assert_blocked_by(result, "PR metadata completeness")
+                self.assert_warns_with_success(result, "PR metadata completeness")
 
-    def test_blocks_missing_pr_body_from_event_payload(self):
+    def test_warns_for_missing_pr_body_from_event_payload(self):
         event = self.repo / "event.json"
         event.write_text(json.dumps({"pull_request": {}}))
 
         result = self.run_checker("--event-path", str(event))
 
-        self.assert_blocked_by(result, "PR metadata completeness")
+        self.assert_warns_with_success(result, "PR metadata completeness")
 
     def test_skips_pr_metadata_when_event_payload_is_not_a_pull_request(self):
         event = self.repo / "event.json"


### PR DESCRIPTION
This PR relaxes the agent governance PR-body metadata check and simplifies the default PR template for human contributors.

  ### Checklist
  - [x] I have linked an issue or explained why none is needed.
  - [x] I have listed verification commands/results, or explained why checks were not run.
  - [x] I have described user-visible, INPUT/docs, or core-module impact if applicable.
  - [x] I have noted any governance exception needed for this PR.

  ### Linked Issue
  Fixes #7596.

  ### Unit Tests and/or Case Tests for my changes
  - Commands run: `python3 -m unittest tools/03_code_analysis/test_agent_governance_check.py`
  - Result summary: 38 tests passed.
  - Checks not run, with reason: full project build was not run because this only changes the Python
  governance checker, its unit tests, governance docs, and the PR template.

  ### What's changed?
  - Downgrade `PR metadata completeness` from a blocking error to a warning.
  - Limit the metadata completeness check to the three core PR sections: linked issue, test evidence, and
  change summary.
  - Simplify the PR template from the expanded governance checklist into a concise human-facing template
  with short governance notes.
  - Update tests and governance documentation to match the new warning-level behavior.

  ### Governance Notes
  - INPUT/docs changes: no runtime INPUT parameters changed; governance documentation was updated for the
  severity change.
  - Core module impact: none.
  - Exceptions requested: none.