### PR TITLE
Refactor: drop source_cell dependency on serialization_cereal (cell->lcao)

### DIFF
--- a/source/source_cell/bcast_cell.cpp
+++ b/source/source_cell/bcast_cell.cpp
@@ -1,13 +1,30 @@
-#include "unitcell.h"   
+#include "unitcell.h"
 #include "source_base/parallel_common.h"
 #include "source_io/module_parameter/parameter.h"
-#ifdef __EXX
-#include "source_lcao/module_ri/serialization_cereal.h"
-#endif
 #include "source_hamilt/module_xc/exx_info.h" // use GlobalC::exx_info
+
+#include <string>
+#include <vector>
 
 namespace unitcell
 {
+#if defined(__MPI) && defined(__EXX)
+    // Broadcast a vector<string> from rank 0 to all ranks.
+    // Replaces the former cereal-based ModuleBase::bcast_data_cereal, which
+    // was only ever used here to broadcast plain lists of ABFS file names and
+    // pulled source_cell into a dependency on source_lcao/module_ri.
+    static void bcast_string_vector(std::vector<std::string>& v)
+    {
+        int size = static_cast<int>(v.size());
+        Parallel_Common::bcast_int(size);
+        v.resize(size);
+        for (int i = 0; i < size; ++i)
+        {
+            Parallel_Common::bcast_string(v[i]);
+        }
+    }
+#endif
+
     void bcast_atoms_tau(Atom* atoms,
                          const int ntype)
     {
@@ -112,15 +129,9 @@ namespace unitcell
         }
 
         #ifdef __EXX
-        ModuleBase::bcast_data_cereal(GlobalC::exx_info.info_ri.files_abfs,
-                                      MPI_COMM_WORLD,
-                                      0);
-        ModuleBase::bcast_data_cereal(GlobalC::exx_info.info_opt_abfs.files_abfs,
-                                      MPI_COMM_WORLD,
-                                      0);
-        ModuleBase::bcast_data_cereal(GlobalC::exx_info.info_opt_abfs.files_jles,
-                                      MPI_COMM_WORLD,
-                                      0);
+        bcast_string_vector(GlobalC::exx_info.info_ri.files_abfs);
+        bcast_string_vector(GlobalC::exx_info.info_opt_abfs.files_abfs);
+        bcast_string_vector(GlobalC::exx_info.info_opt_abfs.files_jles);
         #endif
         return;
     #endif


### PR DESCRIPTION
## Background

Part of an incremental effort to untangle the `source_*` module dependency graph, so that lower layers (data structures) stop depending upward on higher layers (methods). See the module-layering discussion for the broader plan.

`source_cell` (a foundational L1 data-structure module) currently has several reverse/lateral edges into higher layers. This PR removes one of them: the direct `source_cell -> source_lcao` include edge.

## What this changes

`source/source_cell/bcast_cell.cpp` included `source_lcao/module_ri/serialization_cereal.h` **only** to call `ModuleBase::bcast_data_cereal` on three ABFS file-name lists:

- `exx_info.info_ri.files_abfs`
- `exx_info.info_opt_abfs.files_abfs`
- `exx_info.info_opt_abfs.files_jles`

All three are plain `std::vector<std::string>`, so a full cereal (de)serialization round-trip is unnecessary here. This PR replaces those calls with a small local `bcast_string_vector` helper built on `Parallel_Common::bcast_int` / `bcast_string` — mirroring how `ucell.orbital_fn` is already broadcast a few lines above.

## Behaviour

Unchanged: still a broadcast from rank 0 to all ranks. Only the transport mechanism (cereal binary archive over `MPI_CHAR` vs. per-string `bcast_string`) differs; the resulting data on every rank is identical.

## Verification

`-fsyntax-only` passes in two configurations:
- default defines (no `__EXX`)
- with `-D__EXX` added

(The only warning emitted is a pre-existing one in `source_base/math_erf_complex.h`, unrelated to this change.)

## Scope note

This removes the **direct** `serialization_cereal.h` include. `bcast_cell.cpp` still transitively reaches `source_lcao/module_ri` through `exx_info.h` (which itself pulls in `conv_coulomb_pot_k.h`); decoupling that is a separate, larger change and is intentionally out of scope here.