### PR TITLE
Test: Use environment variable instead to allow OpenMPI run as root

### DIFF
--- a/source/source_lcao/module_operator_lcao/test/parallel_operator_tests.sh
+++ b/source/source_lcao/module_operator_lcao/test/parallel_operator_tests.sh
@@ -3,20 +3,24 @@
 np=`cat /proc/cpuinfo | grep "cpu cores" | uniq| awk '{print $NF}'`
 echo "nprocs in this machine is $np"
 
+# Allow OpenMPI run as root
+export OMPI_ALLOW_RUN_AS_ROOT=1
+export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+
 for i in 2 3 4; do
     if [[ $i -gt $np ]];then
         continue
     fi
     echo "TEST in parallel, nprocs=$i"
-    mpirun --allow-run-as-root -np $i ./MODULE_LCAO_operator_overlap_cd_test
+    mpirun -np $i ./MODULE_LCAO_operator_overlap_cd_test
     e1=$?
-    mpirun --allow-run-as-root -np $i ./MODULE_LCAO_operator_overlap_test
+    mpirun -np $i ./MODULE_LCAO_operator_overlap_test
     e2=$?
-    mpirun --allow-run-as-root -np $i ./MODULE_LCAO_operator_ekinetic_test
+    mpirun -np $i ./MODULE_LCAO_operator_ekinetic_test
     e3=$?
-    mpirun --allow-run-as-root -np $i ./MODULE_LCAO_operator_nonlocal_test
+    mpirun -np $i ./MODULE_LCAO_operator_nonlocal_test
     e4=$?
-    mpirun --allow-run-as-root -np $i ./MODULE_LCAO_operator_T_NL_cd_test
+    mpirun -np $i ./MODULE_LCAO_operator_T_NL_cd_test
     e5=$?
     if [[ $e1 -ne 0 || $e2 -ne 0 || $e3 -ne 0 || $e4 -ne 0 || $e5 -ne 0 ]]; then
         echo -e "\e[1;33m [  FAILED  ] \e[0m"\

--- a/tests/17_DS_DFTU/run_scf_nscf.sh
+++ b/tests/17_DS_DFTU/run_scf_nscf.sh
@@ -31,6 +31,10 @@ MPI_NP="${2:-4}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEST_DIR="$(pwd)"
 
+# Allow OpenMPI run as root
+export OMPI_ALLOW_RUN_AS_ROOT=1
+export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+
 echo "========================================"
 echo " SCF + NSCF Workflow"
 echo "========================================"
@@ -94,7 +98,7 @@ echo "-----------------"
 echo ""
 echo "[1/4] Running SCF calculation..."
 cd "${SCF_DIR}"
-mpirun -np ${MPI_NP} --allow-run-as-root "${ABACUS}" > scf.log 2>&1 || {
+mpirun -np ${MPI_NP} "${ABACUS}" > scf.log 2>&1 || {
     echo "ERROR: SCF calculation failed!"
     echo "Check ${SCF_DIR}/scf.log for details"
     cd "${TEST_DIR}"
@@ -146,7 +150,7 @@ fi
 # Step 4: Run NSCF calculation
 # -------------------------------------------------------
 echo "[3/4] Running NSCF calculation..."
-mpirun -np ${MPI_NP} --allow-run-as-root "${ABACUS}" > nscf.log 2>&1 || {
+mpirun -np ${MPI_NP} "${ABACUS}" > nscf.log 2>&1 || {
     echo "ERROR: NSCF calculation failed!"
     echo "Check ${TEST_DIR}/nscf.log for details"
     exit 1


### PR DESCRIPTION
Only OpenMPI supports the `--allow-run-as-root` flag, so the tests would fail whenever ABACUS is built with another MPI implementation, such as MPICH or Intel MPI. Using environment variables avoids the need for this flag; other MPI implementations and programs will simply ignore these variables, thereby avoiding errors caused by an unrecognized `--allow-run-as-root` option.