### PR TITLE
[Fix] Better regular match of ABACUS VERSION NUMBER for abacuslite

### DIFF
--- a/interfaces/ASE_interface/abacuslite/core.py
+++ b/interfaces/ASE_interface/abacuslite/core.py
@@ -66,7 +66,7 @@ def switch_io_backend_version(version: str) -> bool:
     for detailed discussion, see issue #7260
     '''
     global __LEGACYIO__
-    m = re.match(r'^v(\d+)\.(\d+)\.(\d+)(\.\d+|\-(alpha|beta|rc)\.\d+)?$', version)
+    m = re.match(r'^v(\d+)\.(\d+)\.(\d+)(\.\d+|\-(alpha|beta|rc)\.\d+|\-(alpha|beta|rc)\d+)?$', version)
     assert m, f'Invalid format of version number, please check file version.h'
     assert int(m.group(1)) >= 3, f'ABACUS v2.x is not supported'
     if int(m.group(2)) >= 11:


### PR DESCRIPTION
### Reminder
- [v ] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [v ] I have linked an issue or explained why this PR does not need one.
- [ ] I have added adequate unit tests and/or case tests, or explained why not.
- [ ] I have listed the exact verification commands run and their results.
- [ ] I have described user-visible behavior changes, including INPUT parameter changes.
- [ ] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [ ] I have requested any needed governance exception below.

### Linked Issue
Just a typo.

### Unit Tests and/or Case Tests for my changes
- Commands run: N\A
- Result summary: N\A
- Checks not run, with reason: N\A

### What's changed?
- Just a mini change of regular-match of ABACUS VERSION NUMBER for abacuslite.

### Governance Notes
- INPUT/docs changes: No
- Core module impact: No
- Exceptions requested:
