### PR TITLE
Fix: resolve undefined variable and early termination in aveElecStatPot.py

### DIFF
--- a/tools/02_postprocessing/average_pot/aveElecStatPot.py
+++ b/tools/02_postprocessing/average_pot/aveElecStatPot.py
@@ -4,6 +4,10 @@ import numpy as np
 import matplotlib.pyplot as plt
 from scipy.interpolate import interp1d
 
+input_file = None
+output_file = None
+output_png = None
+
 current_dir = os.getcwd()
 
 if os.path.exists(os.path.join(current_dir, "ElecStaticPot.cube")):
@@ -15,16 +19,20 @@ else:
         dir_path = os.path.join(current_dir, dir_name)
 
         if os.path.isdir(dir_path) and dir_name.startswith("OUT."):
-            input_file = os.path.join(dir_path, "ElecStaticPot.cube")
-            output_file = os.path.join(dir_path, "ElecStaticPot_AVE")
-            output_png = os.path.join(dir_path, "ElecStaticPot-vs-Z.png") 
-            if os.path.exists(input_file):
+            candidate_file = os.path.join(dir_path, "ElecStaticPot.cube")
+            if os.path.exists(candidate_file):
+                input_file = candidate_file
+                output_file = os.path.join(dir_path, "ElecStaticPot_AVE")
+                output_png = os.path.join(dir_path, "ElecStaticPot-vs-Z.png") 
                 print(f"Processeding: {input_file}")
                 break
-            else:
-                print(f"File does not exist: {input_file}")
-                sys.exit()
-                        
+                
+if input_file is None:
+    print("Error: 'ElecStaticPot.cube' was not found in the current directory or any 'OUT.*' subdirectories.", file=sys.stderr)
+    print("Please check if ABACUS has completed successfully with 'out_pot' enabled (e.g., set to 2).", file=sys.stderr)
+    sys.exit(1)
+
+
 with open(input_file, 'r') as inpt:
     temp = inpt.readlines()
 


### PR DESCRIPTION
### Linked Issue
Fixes #7559

### Description
This PR addresses two logical issues in the `aveElecStatPot.py` script that could cause it to crash or exit prematurely when searching for `ElecStaticPot.cube`:

1. **Premature Termination (Early `sys.exit`):**
   Previously, the script would immediately exit (`sys.exit()`) if the first matching `OUT.*` subdirectory scanned did not contain `ElecStaticPot.cube`. This prevented the script from checking subsequent `OUT.*` directories that might actually contain the target file.

2. **NameError (Undefined `input_file`):**
   If no `ElecStaticPot.cube` was present in the root directory, and no `OUT.*` subdirectories existed, the nested search loop was never executed. Consequently, `input_file` was never defined, resulting in a `NameError` when the script reached the `with open(input_file, 'r')` block.

### Changes Made
- Initialized `input_file`, `output_file`, and `output_png` to `None` to prevent `NameError`.
- Updated the directory scanning logic so that the script continues searching through all candidate `OUT.*` directories rather than exiting immediately on the first miss.
- Added a unified check after the search block: if the file cannot be found anywhere, the script now exits cleanly with an informative error message.