### PR TITLE
Fix GPU segfaults in PW USPP calculations

### DIFF
--- a/source/source_estate/elecstate_pw.cpp
+++ b/source/source_estate/elecstate_pw.cpp
@@ -360,8 +360,8 @@ void ElecStatePW<T, Device>::cal_becsum(const psi::Psi<T, Device>& psi)
                 std::vector<T> auxk2_host(nbands * nh_atom);
                 // device buffers allocated once per atom type
                 T *aux_gk = nullptr;
-		T *auxk1 = nullptr;
-	  	T *auxk2 = nullptr;
+                T *auxk1 = nullptr;
+                T *auxk2 = nullptr;
                 resmem_complex_op()(auxk1, nbands * nh_atom, "ElecState<PW>::auxk1");
                 resmem_complex_op()(auxk2, nbands * nh_atom, "ElecState<PW>::auxk2");
                 resmem_complex_op()(aux_gk, nh_atom * nh_atom * npol * npol, "ElecState<PW>::aux_gk");

--- a/source/source_estate/elecstate_pw.cpp
+++ b/source/source_estate/elecstate_pw.cpp
@@ -369,6 +369,7 @@ void ElecStatePW<T, Device>::cal_becsum(const psi::Psi<T, Device>& psi)
                     }
                     else
                     {
+                        // TODO: gather auxk from becp on device to skip the H2D→fill→D2H round-trip
                         for (int ih = 0; ih < nh_atom; ih++)
                         {
                             const int ikb = this->ppcell->indv_ijkb0[iat] + ih;
@@ -453,6 +454,7 @@ void ElecStatePW<T, Device>::add_usrho(const psi::Psi<T, Device>& psi)
             std::vector<T> rhog_host(this->rhopw_smooth->npw);
             syncmem_complex_d2h_op()(rhog_host.data(), this->rhog[is], this->rhopw_smooth->npw);
             // CPU real2recip
+            // TODO: replace with cufft to keep rho/rhog on device
             this->rhopw_smooth->real2recip(rho_host.data(), rhog_host.data());
             // H2D rhog back to device
             syncmem_complex_h2d_op()(this->rhog[is], rhog_host.data(), this->rhopw_smooth->npw);
@@ -496,6 +498,7 @@ void ElecStatePW<T, Device>::addusdens_g(const Real* becsum, T** rhog)
     const std::complex<double> ci_tpi = ModuleBase::NEG_IMAG_UNIT * ModuleBase::TWO_PI;
 
     // ---------- all on CPU ----------
+    // TODO: port skk/tbecsum construction and radial_fft_q to device
     std::vector<double> qmod_host(npw);
     std::vector<std::complex<double>> qgm_host(npw);
     for (int ig = 0; ig < npw; ig++)

--- a/source/source_estate/elecstate_pw.cpp
+++ b/source/source_estate/elecstate_pw.cpp
@@ -50,7 +50,7 @@ ElecStatePW<T, Device>::~ElecStatePW()
     }
     if (PARAM.globalv.use_uspp)
     {
-        delmem_var_op()(this->becsum);
+        delmem_var_h_op()(this->becsum);
     }
     delmem_complex_op()(this->wfcr);
     delmem_complex_op()(this->wfcr_another_spin);
@@ -277,11 +277,19 @@ void ElecStatePW<T, Device>::cal_becsum(const psi::Psi<T, Device>& psi)
     const int nbands = psi.get_nbands() * npol;
     const int nkb = this->ppcell->nkb;
     this->vkb = this->ppcell->template get_vkb_data<Real>();
-    T* becp = nullptr;
-    resmem_complex_op()(becp, nbands * nkb, "ElecState<PW>::becp");
     const int nh_tot = this->ppcell->nhm * (this->ppcell->nhm + 1) / 2;
-    resmem_var_op()(becsum, nh_tot * ucell->nat * PARAM.inp.nspin, "ElecState<PW>::becsum");
-    setmem_var_op()(becsum, 0, nh_tot * ucell->nat * PARAM.inp.nspin);
+    // becsum on CPU (forces_us / stress_us use CPU dgemm)
+    resmem_var_h_op()(becsum, nh_tot * ucell->nat * PARAM.inp.nspin, "ElecState<PW>::becsum");
+    setmem_var_h_op()(becsum, 0, nh_tot * ucell->nat * PARAM.inp.nspin);
+
+    // becp: GPU for first gemm, then D2H for CPU loops
+    T* becp_gpu = nullptr;
+    std::vector<T> becp;
+    if (nkb > 0)
+    {
+        resmem_complex_op()(becp_gpu, nbands * nkb, "ElecState<PW>::becp");
+        becp.resize(nbands * nkb);
+    }
 
     for (int ik = 0; ik < psi.get_nk(); ++ik)
     {
@@ -296,41 +304,46 @@ void ElecStatePW<T, Device>::cal_becsum(const psi::Psi<T, Device>& psi)
             this->ppcell->getvnl(this->ctx, *ucell,ik, this->vkb);
         }
 
-        // becp = <beta|psi>
+        // becp = <beta|psi> (GPU gemm)
         char transa = 'C';
         char transb = 'N';
-        if (nbands == 1)
+        if (this->ppcell->nkb > 0)
         {
-            int inc = 1;
-            gemv_op()(transa,
-                      npw,
-                      this->ppcell->nkb,
-                      &one,
-                      this->vkb,
-                      this->ppcell->vkb.nc,
-                      psi_now,
-                      inc,
-                      &zero,
-                      becp,
-                      inc);
+            if (nbands == 1)
+            {
+                int inc = 1;
+                gemv_op()(transa,
+                          npw,
+                          this->ppcell->nkb,
+                          &one,
+                          this->vkb,
+                          this->ppcell->vkbnc,
+                          psi_now,
+                          inc,
+                          &zero,
+                          becp_gpu,
+                          inc);
+            }
+            else
+            {
+                gemm_op()(transa,
+                          transb,
+                          this->ppcell->nkb,
+                          nbands,
+                          npw,
+                          &one,
+                          this->vkb,
+                          this->ppcell->vkbnc,
+                          psi_now,
+                          npwx,
+                          &zero,
+                          becp_gpu,
+                          this->ppcell->nkb);
+            }
+            // D2H: GPU becp → CPU becp
+            syncmem_complex_d2h_op()(becp.data(), becp_gpu, nbands * nkb);
         }
-        else
-        {
-            gemm_op()(transa,
-                      transb,
-                      this->ppcell->nkb,
-                      nbands,
-                      npw,
-                      &one,
-                      this->vkb,
-                      this->ppcell->vkb.nc,
-                      psi_now,
-                      npwx,
-                      &zero,
-                      becp,
-                      this->ppcell->nkb);
-        }
-        Parallel_Reduce::reduce_pool(becp, this->ppcell->nkb * nbands);
+        Parallel_Reduce::reduce_pool(becp.data(), this->ppcell->nkb * nbands);
 
         // sum over bands: \sum_i <psi_i|beta_l><beta_m|psi_i> w_i
         for (int it = 0; it < ucell->ntype; it++)
@@ -338,12 +351,10 @@ void ElecStatePW<T, Device>::cal_becsum(const psi::Psi<T, Device>& psi)
             Atom* atom = &ucell->atoms[it];
             if (atom->ncpp.tvanp)
             {
-                T *auxk1 = nullptr, *auxk2 = nullptr, *aux_gk = nullptr;
-                resmem_complex_op()(auxk1, nbands * atom->ncpp.nh, "ElecState<PW>::auxk1");
-                resmem_complex_op()(auxk2, nbands * atom->ncpp.nh, "ElecState<PW>::auxk2");
-                resmem_complex_op()(aux_gk,
-                                    atom->ncpp.nh * atom->ncpp.nh * npol * npol,
-                                    "ElecState<PW>::aux_gk");
+                const int nh_atom = atom->ncpp.nh;
+                // auxk1, auxk2 on CPU for filling loops
+                std::vector<T> auxk1(nbands * nh_atom);
+                std::vector<T> auxk2(nbands * nh_atom);
                 for (int ia = 0; ia < atom->na; ia++)
                 {
                     const int iat = ucell->itia2iat(it, ia);
@@ -353,7 +364,7 @@ void ElecStatePW<T, Device>::cal_becsum(const psi::Psi<T, Device>& psi)
                     }
                     else
                     {
-                        for (int ih = 0; ih < atom->ncpp.nh; ih++)
+                        for (int ih = 0; ih < nh_atom; ih++)
                         {
                             const int ikb = this->ppcell->indv_ijkb0[iat] + ih;
                             for (int ib = 0; ib < nbands; ib++)
@@ -364,60 +375,62 @@ void ElecStatePW<T, Device>::cal_becsum(const psi::Psi<T, Device>& psi)
                             }
                         }
 
-                        char transa = 'C';
-                        char transb = 'N';
-                        gemm_op()(transa,
-                                  transb,
-                                  atom->ncpp.nh,
-                                  atom->ncpp.nh,
+                        // GPU gemm: aux_gk = auxk1^H * auxk2
+                        T *aux_gk_gpu = nullptr, *auxk1_gpu = nullptr, *auxk2_gpu = nullptr;
+                        resmem_complex_op()(auxk1_gpu, nbands * nh_atom, "ElecState<PW>::auxk1");
+                        resmem_complex_op()(auxk2_gpu, nbands * nh_atom, "ElecState<PW>::auxk2");
+                        resmem_complex_op()(aux_gk_gpu, nh_atom * nh_atom * npol * npol, "ElecState<PW>::aux_gk");
+                        syncmem_complex_h2d_op()(auxk1_gpu, auxk1.data(), nbands * nh_atom);
+                        syncmem_complex_h2d_op()(auxk2_gpu, auxk2.data(), nbands * nh_atom);
+
+                        char transa2 = 'C';
+                        char transb2 = 'N';
+                        gemm_op()(transa2,
+                                  transb2,
+                                  nh_atom,
+                                  nh_atom,
                                   nbands,
                                   &one,
-                                  auxk1,
+                                  auxk1_gpu,
                                   nbands,
-                                  auxk2,
+                                  auxk2_gpu,
                                   nbands,
                                   &zero,
-                                  aux_gk,
-                                  atom->ncpp.nh);
-                    }
+                                  aux_gk_gpu,
+                                  nh_atom);
 
-                    // copy output from GEMM into desired format
-                    if (PARAM.inp.noncolin && !atom->ncpp.has_so)
-                    {
-                    }
-                    else if (PARAM.inp.noncolin && atom->ncpp.has_so)
-                    {
-                    }
-                    else
-                    {
+                        // D2H: GPU aux_gk → CPU
+                        std::vector<T> aux_gk(nh_atom * nh_atom);
+                        syncmem_complex_d2h_op()(aux_gk.data(), aux_gk_gpu, nh_atom * nh_atom);
+
+                        delmem_complex_op()(auxk1_gpu);
+                        delmem_complex_op()(auxk2_gpu);
+                        delmem_complex_op()(aux_gk_gpu);
+
+                        // copy output from GEMM into desired format
                         int ijh = 0;
                         const int index = currect_spin * ucell->nat * nh_tot + iat * nh_tot;
-                        for (int ih = 0; ih < atom->ncpp.nh; ih++)
+                        for (int ih = 0; ih < nh_atom; ih++)
                         {
-                            for (int jh = ih; jh < atom->ncpp.nh; jh++)
+                            for (int jh = ih; jh < nh_atom; jh++)
                             {
-                                // nondiagonal terms summed and collapsed into a
-                                // single index (matrix is symmetric wrt (ih,jh))
                                 if (ih == jh)
                                 {
-                                    becsum[index + ijh] += std::real(aux_gk[ih * atom->ncpp.nh + jh]);
+                                    becsum[index + ijh] += std::real(aux_gk[ih * nh_atom + jh]);
                                 }
                                 else
                                 {
-                                    becsum[index + ijh] += 2.0 * std::real(aux_gk[ih * atom->ncpp.nh + jh]);
+                                    becsum[index + ijh] += 2.0 * std::real(aux_gk[ih * nh_atom + jh]);
                                 }
                                 ijh++;
                             }
                         }
                     }
                 }
-                delmem_complex_op()(auxk1);
-                delmem_complex_op()(auxk2);
-                delmem_complex_op()(aux_gk);
             }
         }
     }
-    delmem_complex_op()(becp);
+    if (becp_gpu != nullptr) delmem_complex_op()(becp_gpu);
 }
 
 template <typename T, typename Device>
@@ -433,7 +446,16 @@ void ElecStatePW<T, Device>::add_usrho(const psi::Psi<T, Device>& psi)
     {
         for (int is = 0; is < PARAM.inp.nspin; is++)
         {
-            this->rhopw_smooth->real2recip(this->rho[is], this->rhog[is]);
+            // D2H rho → CPU buffer (real2recip reads rho via CPU loops)
+            std::vector<Real> rho_host(this->rhopw_smooth->nrxx);
+            syncmem_var_d2h_op()(rho_host.data(), this->rho[is], this->rhopw_smooth->nrxx);
+            // D2H rhog → CPU temp
+            std::vector<T> rhog_host(this->rhopw_smooth->npw);
+            syncmem_complex_d2h_op()(rhog_host.data(), this->rhog[is], this->rhopw_smooth->npw);
+            // CPU real2recip
+            this->rhopw_smooth->real2recip(rho_host.data(), rhog_host.data());
+            // H2D rhog back to GPU
+            syncmem_complex_h2d_op()(this->rhog[is], rhog_host.data(), this->rhopw_smooth->npw);
         }
     }
 
@@ -448,7 +470,16 @@ void ElecStatePW<T, Device>::add_usrho(const psi::Psi<T, Device>& psi)
     {
         for (int is = 0; is < PARAM.inp.nspin; is++)
         {
-            this->charge->rhopw->recip2real(this->rhog[is], this->rho[is]);
+            // D2H rhog → CPU temp (recip2real reads rhog via CPU loops)
+            std::vector<T> rhog_host(this->charge->rhopw->npw);
+            syncmem_complex_d2h_op()(rhog_host.data(), this->rhog[is], this->charge->rhopw->npw);
+            // D2H rho → CPU buffer
+            std::vector<Real> rho_host(this->charge->rhopw->nrxx);
+            syncmem_var_d2h_op()(rho_host.data(), this->rho[is], this->charge->rhopw->nrxx);
+            // CPU recip2real
+            this->charge->rhopw->recip2real(rhog_host.data(), rho_host.data());
+            // H2D rho back to GPU
+            syncmem_var_h2d_op()(this->rho[is], rho_host.data(), this->charge->rhopw->nrxx);
         }
     }
 }
@@ -464,33 +495,38 @@ void ElecStatePW<T, Device>::addusdens_g(const Real* becsum, T** rhog)
     Structure_Factor* psf = this->ppcell->psf;
     const std::complex<double> ci_tpi = ModuleBase::NEG_IMAG_UNIT * ModuleBase::TWO_PI;
 
-    Real* qmod = nullptr;
-    resmem_var_op()(qmod, npw, "ElecState<PW>::qmod");
-    T* qgm = nullptr;
-    resmem_complex_op()(qgm, npw, "ElecState<PW>::qgm");
-    Real* ylmk0 = nullptr;
-    resmem_var_op()(ylmk0, npw * lmaxq * lmaxq, "ElecState<PW>::ylmk0");
-    Real* g = reinterpret_cast<Real*>(this->charge->rhopw->gcar);
-
-    ModuleBase::YlmReal::Ylm_Real(this->ctx, lmaxq * lmaxq, npw, g, ylmk0);
-
+    // ---------- all on CPU ----------
+    // Use double for CPU computations (radial_fft_q non-template version takes double)
+    std::vector<double> qmod_host(npw);
+    std::vector<std::complex<double>> qgm_host(npw);
     for (int ig = 0; ig < npw; ig++)
     {
-        qmod[ig] = static_cast<Real>(this->charge->rhopw->gcar[ig].norm() * ucell->tpiba);
+        qmod_host[ig] = static_cast<double>(this->charge->rhopw->gcar[ig].norm() * ucell->tpiba);
     }
+
+    // ylmk0: compute on GPU then D2H
+    Real* ylmk0_gpu = nullptr;
+    resmem_var_op()(ylmk0_gpu, npw * lmaxq * lmaxq, "ElecState<PW>::ylmk0");
+    Real* g_gpu = nullptr;
+    resmem_var_op()(g_gpu, npw * 3, "ElecState<PW>::g_gpu");
+    syncmem_var_h2d_op()(g_gpu, reinterpret_cast<Real*>(this->charge->rhopw->gcar), npw * 3);
+    ModuleBase::YlmReal::Ylm_Real(this->ctx, lmaxq * lmaxq, npw, g_gpu, ylmk0_gpu);
+    delmem_var_op()(g_gpu);
+    std::vector<Real> ylmk0_host(npw * lmaxq * lmaxq);
+    syncmem_var_d2h_op()(ylmk0_host.data(), ylmk0_gpu, npw * lmaxq * lmaxq);
+    ModuleBase::matrix ylm_mat(lmaxq * lmaxq, npw);
+    for (int i = 0; i < npw * lmaxq * lmaxq; i++) ylm_mat.c[i] = static_cast<double>(ylmk0_host[i]);
 
     for (int it = 0; it < ucell->ntype; it++)
     {
         Atom* atom = &ucell->atoms[it];
         if (atom->ncpp.tvanp)
         {
-            // nij = max number of (ih,jh) pairs per atom type nt
             const int nij = atom->ncpp.nh * (atom->ncpp.nh + 1) / 2;
 
-            T *skk = nullptr, *aux2 = nullptr, *tbecsum = nullptr;
-            resmem_complex_op()(skk, atom->na * npw, "ElecState<PW>::skk");
-            resmem_complex_op()(aux2, nij * npw, "ElecState<PW>::aux2");
-            resmem_complex_op()(tbecsum, PARAM.inp.nspin * atom->na * nij, "ElecState<PW>::tbecsum");
+            // skk, tbecsum: CPU vectors
+            std::vector<std::complex<double>> skk_host(atom->na * npw);
+            std::vector<std::complex<double>> tbecsum_host(PARAM.inp.nspin * atom->na * nij);
             for (int ia = 0; ia < atom->na; ia++)
             {
                 const int iat = ucell->itia2iat(it, ia);
@@ -498,60 +534,54 @@ void ElecStatePW<T, Device>::addusdens_g(const Real* becsum, T** rhog)
                 {
                     for (int ij = 0; ij < nij; ij++)
                     {
-                        tbecsum[is * atom->na * nij + ia * nij + ij]
-                            = static_cast<T>(becsum[is * ucell->nat * nh_tot + iat * nh_tot + ij]);
+                        tbecsum_host[is * atom->na * nij + ia * nij + ij]
+                            = static_cast<std::complex<double>>(becsum[is * ucell->nat * nh_tot + iat * nh_tot + ij]);
                     }
                 }
                 for (int ig = 0; ig < npw; ig++)
                 {
                     double arg = this->charge->rhopw->gcar[ig] * atom->tau[ia];
-                    skk[ia * npw + ig] = static_cast<T>(ModuleBase::libm::exp(ci_tpi * arg));
+                    skk_host[ia * npw + ig] = ModuleBase::libm::exp(ci_tpi * arg);
                 }
             }
 
             for (int is = 0; is < PARAM.inp.nspin; is++)
             {
-                // sum over atoms
+                // CPU BLAS: aux2 = skk * tbecsum^T
+                std::vector<std::complex<double>> aux2_host(nij * npw);
+                const std::complex<double> one_d(1, 0), zero_d(0, 0);
                 char transa = 'N';
                 char transb = 'T';
-                gemm_op()(transa,
-                          transb,
-                          npw,
-                          nij,
-                          atom->na,
-                          &one,
-                          skk,
-                          npw,
-                          &tbecsum[is * atom->na * nij],
-                          nij,
-                          &zero,
-                          aux2,
-                          npw);
+                zgemm_(&transa, &transb, &npw, &nij, &atom->na,
+                       &one_d, skk_host.data(), &npw,
+                       &tbecsum_host[is * atom->na * nij], &nij,
+                       &zero_d, aux2_host.data(), &npw);
 
-                // sum over lm indices of Q_{lm}
+                // D2H rhog
+                std::vector<T> rhog_host(npw);
+                syncmem_complex_d2h_op()(rhog_host.data(), rhog[is], npw);
+
                 int ijh = 0;
                 for (int ih = 0; ih < atom->ncpp.nh; ih++)
                 {
                     for (int jh = ih; jh < atom->ncpp.nh; jh++)
                     {
-                        this->ppcell->radial_fft_q(this->ctx, npw, ih, jh, it, qmod, ylmk0, qgm);
+                        // CPU radial_fft_q (non-template version, double)
+                        this->ppcell->radial_fft_q(npw, ih, jh, it, qmod_host.data(), ylm_mat, qgm_host.data());
                         for (int ig = 0; ig < npw; ig++)
                         {
-                            rhog[is][ig] += qgm[ig] * aux2[ijh * npw + ig];
+                            rhog_host[ig] += static_cast<T>(qgm_host[ig] * aux2_host[ijh * npw + ig]);
                         }
                         ijh++;
                     }
                 }
+                // H2D rhog back
+                syncmem_complex_h2d_op()(rhog[is], rhog_host.data(), npw);
             }
-            delmem_complex_op()(skk);
-            delmem_complex_op()(aux2);
-            delmem_complex_op()(tbecsum);
         }
     }
 
-    delmem_var_op()(qmod);
-    delmem_complex_op()(qgm);
-    delmem_var_op()(ylmk0);
+    delmem_var_op()(ylmk0_gpu);
 }
 
 template class ElecStatePW<std::complex<float>, base_device::DEVICE_CPU>;

--- a/source/source_estate/elecstate_pw.cpp
+++ b/source/source_estate/elecstate_pw.cpp
@@ -282,13 +282,13 @@ void ElecStatePW<T, Device>::cal_becsum(const psi::Psi<T, Device>& psi)
     resmem_var_h_op()(becsum, nh_tot * ucell->nat * PARAM.inp.nspin, "ElecState<PW>::becsum");
     setmem_var_h_op()(becsum, 0, nh_tot * ucell->nat * PARAM.inp.nspin);
 
-    // becp: GPU for first gemm, then D2H for CPU loops
-    T* becp_gpu = nullptr;
-    std::vector<T> becp;
+    // becp: device buffer for gemm, then D2H for host loops
+    T* becp = nullptr;
+    std::vector<T> becp_host;
     if (nkb > 0)
     {
-        resmem_complex_op()(becp_gpu, nbands * nkb, "ElecState<PW>::becp");
-        becp.resize(nbands * nkb);
+        resmem_complex_op()(becp, nbands * nkb, "ElecState<PW>::becp");
+        becp_host.resize(nbands * nkb);
     }
 
     for (int ik = 0; ik < psi.get_nk(); ++ik)
@@ -304,7 +304,7 @@ void ElecStatePW<T, Device>::cal_becsum(const psi::Psi<T, Device>& psi)
             this->ppcell->getvnl(this->ctx, *ucell,ik, this->vkb);
         }
 
-        // becp = <beta|psi> (GPU gemm)
+        // becp = <beta|psi> (device gemm)
         char transa = 'C';
         char transb = 'N';
         if (this->ppcell->nkb > 0)
@@ -321,7 +321,7 @@ void ElecStatePW<T, Device>::cal_becsum(const psi::Psi<T, Device>& psi)
                           psi_now,
                           inc,
                           &zero,
-                          becp_gpu,
+                          becp,
                           inc);
             }
             else
@@ -337,13 +337,13 @@ void ElecStatePW<T, Device>::cal_becsum(const psi::Psi<T, Device>& psi)
                           psi_now,
                           npwx,
                           &zero,
-                          becp_gpu,
+                          becp,
                           this->ppcell->nkb);
             }
-            // D2H: GPU becp → CPU becp
-            syncmem_complex_d2h_op()(becp.data(), becp_gpu, nbands * nkb);
+            // D2H: device becp → host becp_host
+            syncmem_complex_d2h_op()(becp_host.data(), becp, nbands * nkb);
         }
-        Parallel_Reduce::reduce_pool(becp.data(), this->ppcell->nkb * nbands);
+        Parallel_Reduce::reduce_pool(becp_host.data(), this->ppcell->nkb * nbands);
 
         // sum over bands: \sum_i <psi_i|beta_l><beta_m|psi_i> w_i
         for (int it = 0; it < ucell->ntype; it++)
@@ -352,9 +352,14 @@ void ElecStatePW<T, Device>::cal_becsum(const psi::Psi<T, Device>& psi)
             if (atom->ncpp.tvanp)
             {
                 const int nh_atom = atom->ncpp.nh;
-                // auxk1, auxk2 on CPU for filling loops
-                std::vector<T> auxk1(nbands * nh_atom);
-                std::vector<T> auxk2(nbands * nh_atom);
+                // auxk1, auxk2: host buffers for filling loops
+                std::vector<T> auxk1_host(nbands * nh_atom);
+                std::vector<T> auxk2_host(nbands * nh_atom);
+                // device buffers allocated once per atom type
+                T *aux_gk = nullptr, *auxk1 = nullptr, *auxk2 = nullptr;
+                resmem_complex_op()(auxk1, nbands * nh_atom, "ElecState<PW>::auxk1");
+                resmem_complex_op()(auxk2, nbands * nh_atom, "ElecState<PW>::auxk2");
+                resmem_complex_op()(aux_gk, nh_atom * nh_atom * npol * npol, "ElecState<PW>::aux_gk");
                 for (int ia = 0; ia < atom->na; ia++)
                 {
                     const int iat = ucell->itia2iat(it, ia);
@@ -369,19 +374,15 @@ void ElecStatePW<T, Device>::cal_becsum(const psi::Psi<T, Device>& psi)
                             const int ikb = this->ppcell->indv_ijkb0[iat] + ih;
                             for (int ib = 0; ib < nbands; ib++)
                             {
-                                auxk1[ih * nbands + ib] = becp[ib * this->ppcell->nkb + ikb];
-                                auxk2[ih * nbands + ib]
-                                    = becp[ib * this->ppcell->nkb + ikb] * static_cast<Real>(this->wg(ik, ib));
+                                auxk1_host[ih * nbands + ib] = becp_host[ib * this->ppcell->nkb + ikb];
+                                auxk2_host[ih * nbands + ib]
+                                    = becp_host[ib * this->ppcell->nkb + ikb] * static_cast<Real>(this->wg(ik, ib));
                             }
                         }
 
-                        // GPU gemm: aux_gk = auxk1^H * auxk2
-                        T *aux_gk_gpu = nullptr, *auxk1_gpu = nullptr, *auxk2_gpu = nullptr;
-                        resmem_complex_op()(auxk1_gpu, nbands * nh_atom, "ElecState<PW>::auxk1");
-                        resmem_complex_op()(auxk2_gpu, nbands * nh_atom, "ElecState<PW>::auxk2");
-                        resmem_complex_op()(aux_gk_gpu, nh_atom * nh_atom * npol * npol, "ElecState<PW>::aux_gk");
-                        syncmem_complex_h2d_op()(auxk1_gpu, auxk1.data(), nbands * nh_atom);
-                        syncmem_complex_h2d_op()(auxk2_gpu, auxk2.data(), nbands * nh_atom);
+                        // device gemm: aux_gk = auxk1^H * auxk2
+                        syncmem_complex_h2d_op()(auxk1, auxk1_host.data(), nbands * nh_atom);
+                        syncmem_complex_h2d_op()(auxk2, auxk2_host.data(), nbands * nh_atom);
 
                         char transa2 = 'C';
                         char transb2 = 'N';
@@ -391,21 +392,17 @@ void ElecStatePW<T, Device>::cal_becsum(const psi::Psi<T, Device>& psi)
                                   nh_atom,
                                   nbands,
                                   &one,
-                                  auxk1_gpu,
+                                  auxk1,
                                   nbands,
-                                  auxk2_gpu,
+                                  auxk2,
                                   nbands,
                                   &zero,
-                                  aux_gk_gpu,
+                                  aux_gk,
                                   nh_atom);
 
-                        // D2H: GPU aux_gk → CPU
-                        std::vector<T> aux_gk(nh_atom * nh_atom);
-                        syncmem_complex_d2h_op()(aux_gk.data(), aux_gk_gpu, nh_atom * nh_atom);
-
-                        delmem_complex_op()(auxk1_gpu);
-                        delmem_complex_op()(auxk2_gpu);
-                        delmem_complex_op()(aux_gk_gpu);
+                        // D2H: device aux_gk → host
+                        std::vector<T> aux_gk_host(nh_atom * nh_atom);
+                        syncmem_complex_d2h_op()(aux_gk_host.data(), aux_gk, nh_atom * nh_atom);
 
                         // copy output from GEMM into desired format
                         int ijh = 0;
@@ -416,21 +413,24 @@ void ElecStatePW<T, Device>::cal_becsum(const psi::Psi<T, Device>& psi)
                             {
                                 if (ih == jh)
                                 {
-                                    becsum[index + ijh] += std::real(aux_gk[ih * nh_atom + jh]);
+                                    becsum[index + ijh] += std::real(aux_gk_host[ih * nh_atom + jh]);
                                 }
                                 else
                                 {
-                                    becsum[index + ijh] += 2.0 * std::real(aux_gk[ih * nh_atom + jh]);
+                                    becsum[index + ijh] += 2.0 * std::real(aux_gk_host[ih * nh_atom + jh]);
                                 }
                                 ijh++;
                             }
                         }
                     }
                 }
+                delmem_complex_op()(auxk1);
+                delmem_complex_op()(auxk2);
+                delmem_complex_op()(aux_gk);
             }
         }
     }
-    if (becp_gpu != nullptr) delmem_complex_op()(becp_gpu);
+    delmem_complex_op()(becp);
 }
 
 template <typename T, typename Device>
@@ -454,7 +454,7 @@ void ElecStatePW<T, Device>::add_usrho(const psi::Psi<T, Device>& psi)
             syncmem_complex_d2h_op()(rhog_host.data(), this->rhog[is], this->rhopw_smooth->npw);
             // CPU real2recip
             this->rhopw_smooth->real2recip(rho_host.data(), rhog_host.data());
-            // H2D rhog back to GPU
+            // H2D rhog back to device
             syncmem_complex_h2d_op()(this->rhog[is], rhog_host.data(), this->rhopw_smooth->npw);
         }
     }
@@ -503,16 +503,16 @@ void ElecStatePW<T, Device>::addusdens_g(const Real* becsum, T** rhog)
         qmod_host[ig] = static_cast<double>(this->charge->rhopw->gcar[ig].norm() * ucell->tpiba);
     }
 
-    // ylmk0: compute on GPU then D2H
-    Real* ylmk0_gpu = nullptr;
-    resmem_var_op()(ylmk0_gpu, npw * lmaxq * lmaxq, "ElecState<PW>::ylmk0");
-    Real* g_gpu = nullptr;
-    resmem_var_op()(g_gpu, npw * 3, "ElecState<PW>::g_gpu");
-    syncmem_var_h2d_op()(g_gpu, reinterpret_cast<Real*>(this->charge->rhopw->gcar), npw * 3);
-    ModuleBase::YlmReal::Ylm_Real(this->ctx, lmaxq * lmaxq, npw, g_gpu, ylmk0_gpu);
-    delmem_var_op()(g_gpu);
+    // ylmk0: compute on device then D2H
+    Real* ylmk0 = nullptr;
+    resmem_var_op()(ylmk0, npw * lmaxq * lmaxq, "ElecState<PW>::ylmk0");
+    Real* g = nullptr;
+    resmem_var_op()(g, npw * 3, "ElecState<PW>::g");
+    syncmem_var_h2d_op()(g, reinterpret_cast<Real*>(this->charge->rhopw->gcar), npw * 3);
+    ModuleBase::YlmReal::Ylm_Real(this->ctx, lmaxq * lmaxq, npw, g, ylmk0);
+    delmem_var_op()(g);
     std::vector<Real> ylmk0_host(npw * lmaxq * lmaxq);
-    syncmem_var_d2h_op()(ylmk0_host.data(), ylmk0_gpu, npw * lmaxq * lmaxq);
+    syncmem_var_d2h_op()(ylmk0_host.data(), ylmk0, npw * lmaxq * lmaxq);
     std::vector<double> ylmk0_double(npw * lmaxq * lmaxq);
     for (int i = 0; i < npw * lmaxq * lmaxq; i++) ylmk0_double[i] = static_cast<double>(ylmk0_host[i]);
 
@@ -581,7 +581,7 @@ void ElecStatePW<T, Device>::addusdens_g(const Real* becsum, T** rhog)
         }
     }
 
-    delmem_var_op()(ylmk0_gpu);
+    delmem_var_op()(ylmk0);
 }
 
 template class ElecStatePW<std::complex<float>, base_device::DEVICE_CPU>;

--- a/source/source_estate/elecstate_pw.cpp
+++ b/source/source_estate/elecstate_pw.cpp
@@ -128,6 +128,9 @@ void ElecStatePW<T, Device>::psiToRho(const psi::Psi<T, Device>& psi)
         if (PARAM.globalv.double_grid || PARAM.globalv.use_uspp)
         {
             setmem_complex_op()(this->rhog[is], 0, this->charge->rhopw->npw);
+            std::fill(this->charge->rhog[is],
+                      this->charge->rhog[is] + this->charge->rhopw->npw,
+                      std::complex<double>(0, 0));
         }
     }
 
@@ -457,7 +460,7 @@ void ElecStatePW<T, Device>::add_usrho(const psi::Psi<T, Device>& psi)
     // add to the charge density in reciprocal space the part which is due to the US augmentation.
     if (PARAM.globalv.use_uspp)
     {
-        this->addusdens_g(becsum, rhog);
+        this->addusdens_g(becsum, this->charge->rhog);
     }
     // transform back to real space using dense grids
     if (PARAM.globalv.double_grid || PARAM.globalv.use_uspp)
@@ -470,7 +473,7 @@ void ElecStatePW<T, Device>::add_usrho(const psi::Psi<T, Device>& psi)
 }
 
 template <typename T, typename Device>
-void ElecStatePW<T, Device>::addusdens_g(const Real* becsum, T** rhog)
+void ElecStatePW<T, Device>::addusdens_g(const Real* becsum, std::complex<double>** rhog)
 {
     const T one{1, 0};
     const T zero{0, 0};
@@ -542,10 +545,6 @@ void ElecStatePW<T, Device>::addusdens_g(const Real* becsum, T** rhog)
                        &tbecsum_host[is * atom->na * nij], &nij,
                        &zero_d, aux2_host.data(), &npw);
 
-                // D2H rhog
-                std::vector<T> rhog_host(npw);
-                syncmem_complex_d2h_op()(rhog_host.data(), rhog[is], npw);
-
                 int ijh = 0;
                 for (int ih = 0; ih < atom->ncpp.nh; ih++)
                 {
@@ -556,13 +555,11 @@ void ElecStatePW<T, Device>::addusdens_g(const Real* becsum, T** rhog)
                             nullptr, npw, ih, jh, it, qmod_host.data(), ylmk0_double.data(), qgm_host.data());
                         for (int ig = 0; ig < npw; ig++)
                         {
-                            rhog_host[ig] += static_cast<T>(qgm_host[ig] * aux2_host[ijh * npw + ig]);
+                            rhog[is][ig] += qgm_host[ig] * aux2_host[ijh * npw + ig];
                         }
                         ijh++;
                     }
                 }
-                // H2D rhog back
-                syncmem_complex_h2d_op()(rhog[is], rhog_host.data(), npw);
             }
         }
     }

--- a/source/source_estate/elecstate_pw.cpp
+++ b/source/source_estate/elecstate_pw.cpp
@@ -496,7 +496,6 @@ void ElecStatePW<T, Device>::addusdens_g(const Real* becsum, T** rhog)
     const std::complex<double> ci_tpi = ModuleBase::NEG_IMAG_UNIT * ModuleBase::TWO_PI;
 
     // ---------- all on CPU ----------
-    // Use double for CPU computations (radial_fft_q non-template version takes double)
     std::vector<double> qmod_host(npw);
     std::vector<std::complex<double>> qgm_host(npw);
     for (int ig = 0; ig < npw; ig++)
@@ -514,8 +513,8 @@ void ElecStatePW<T, Device>::addusdens_g(const Real* becsum, T** rhog)
     delmem_var_op()(g_gpu);
     std::vector<Real> ylmk0_host(npw * lmaxq * lmaxq);
     syncmem_var_d2h_op()(ylmk0_host.data(), ylmk0_gpu, npw * lmaxq * lmaxq);
-    ModuleBase::matrix ylm_mat(lmaxq * lmaxq, npw);
-    for (int i = 0; i < npw * lmaxq * lmaxq; i++) ylm_mat.c[i] = static_cast<double>(ylmk0_host[i]);
+    std::vector<double> ylmk0_double(npw * lmaxq * lmaxq);
+    for (int i = 0; i < npw * lmaxq * lmaxq; i++) ylmk0_double[i] = static_cast<double>(ylmk0_host[i]);
 
     for (int it = 0; it < ucell->ntype; it++)
     {
@@ -566,8 +565,9 @@ void ElecStatePW<T, Device>::addusdens_g(const Real* becsum, T** rhog)
                 {
                     for (int jh = ih; jh < atom->ncpp.nh; jh++)
                     {
-                        // CPU radial_fft_q (non-template version, double)
-                        this->ppcell->radial_fft_q(npw, ih, jh, it, qmod_host.data(), ylm_mat, qgm_host.data());
+                        // CPU radial_fft_q (template version, DEVICE_CPU)
+                        this->ppcell->template radial_fft_q<double, base_device::DEVICE_CPU>(
+                            nullptr, npw, ih, jh, it, qmod_host.data(), ylmk0_double.data(), qgm_host.data());
                         for (int ig = 0; ig < npw; ig++)
                         {
                             rhog_host[ig] += static_cast<T>(qgm_host[ig] * aux2_host[ijh * npw + ig]);

--- a/source/source_estate/elecstate_pw.cpp
+++ b/source/source_estate/elecstate_pw.cpp
@@ -356,7 +356,9 @@ void ElecStatePW<T, Device>::cal_becsum(const psi::Psi<T, Device>& psi)
                 std::vector<T> auxk1_host(nbands * nh_atom);
                 std::vector<T> auxk2_host(nbands * nh_atom);
                 // device buffers allocated once per atom type
-                T *aux_gk = nullptr, *auxk1 = nullptr, *auxk2 = nullptr;
+                T *aux_gk = nullptr;
+		T *auxk1 = nullptr;
+	  	T *auxk2 = nullptr;
                 resmem_complex_op()(auxk1, nbands * nh_atom, "ElecState<PW>::auxk1");
                 resmem_complex_op()(auxk2, nbands * nh_atom, "ElecState<PW>::auxk2");
                 resmem_complex_op()(aux_gk, nh_atom * nh_atom * npol * npol, "ElecState<PW>::aux_gk");

--- a/source/source_estate/elecstate_pw.cpp
+++ b/source/source_estate/elecstate_pw.cpp
@@ -136,9 +136,7 @@ void ElecStatePW<T, Device>::psiToRho(const psi::Psi<T, Device>& psi)
         psi.fix_k(ik);
         this->updateRhoK(psi);
     }
-
-    this->add_usrho(psi);
-
+    
     if (PARAM.inp.device == "gpu" || PARAM.inp.precision == "single")
     {
         for (int ii = 0; ii < PARAM.inp.nspin; ii++)
@@ -150,6 +148,8 @@ void ElecStatePW<T, Device>::psiToRho(const psi::Psi<T, Device>& psi)
             }
         }
     }
+
+    this->add_usrho(psi);
     this->parallelK();
     ModuleBase::timer::end("ElecStatePW", "psiToRho");
 }
@@ -449,17 +449,7 @@ void ElecStatePW<T, Device>::add_usrho(const psi::Psi<T, Device>& psi)
     {
         for (int is = 0; is < PARAM.inp.nspin; is++)
         {
-            // D2H rho → CPU buffer (real2recip reads rho via CPU loops)
-            std::vector<Real> rho_host(this->rhopw_smooth->nrxx);
-            syncmem_var_d2h_op()(rho_host.data(), this->rho[is], this->rhopw_smooth->nrxx);
-            // D2H rhog → CPU temp
-            std::vector<T> rhog_host(this->rhopw_smooth->npw);
-            syncmem_complex_d2h_op()(rhog_host.data(), this->rhog[is], this->rhopw_smooth->npw);
-            // CPU real2recip
-            // TODO: replace with cufft to keep rho/rhog on device
-            this->rhopw_smooth->real2recip(rho_host.data(), rhog_host.data());
-            // H2D rhog back to device
-            syncmem_complex_h2d_op()(this->rhog[is], rhog_host.data(), this->rhopw_smooth->npw);
+            this->rhopw_smooth->real2recip(this->charge->rho[is], this->charge->rhog[is]);
         }
     }
 
@@ -474,16 +464,7 @@ void ElecStatePW<T, Device>::add_usrho(const psi::Psi<T, Device>& psi)
     {
         for (int is = 0; is < PARAM.inp.nspin; is++)
         {
-            // D2H rhog → CPU temp (recip2real reads rhog via CPU loops)
-            std::vector<T> rhog_host(this->charge->rhopw->npw);
-            syncmem_complex_d2h_op()(rhog_host.data(), this->rhog[is], this->charge->rhopw->npw);
-            // D2H rho → CPU buffer
-            std::vector<Real> rho_host(this->charge->rhopw->nrxx);
-            syncmem_var_d2h_op()(rho_host.data(), this->rho[is], this->charge->rhopw->nrxx);
-            // CPU recip2real
-            this->charge->rhopw->recip2real(rhog_host.data(), rho_host.data());
-            // H2D rho back to GPU
-            syncmem_var_h2d_op()(this->rho[is], rho_host.data(), this->charge->rhopw->nrxx);
+            this->charge->rhopw->recip2real(this->charge->rhog[is], this->charge->rho[is]);
         }
     }
 }

--- a/source/source_estate/elecstate_pw.h
+++ b/source/source_estate/elecstate_pw.h
@@ -72,7 +72,7 @@ class ElecStatePW : public ElecState
 
     //! Non-local pseudopotentials
     //! \sum_lm Q_lm(r) \sum_i <psi_i|beta_l><beta_m|psi_i> w_i
-    void addusdens_g(const Real* becsum, T** rhog);
+    void addusdens_g(const Real* becsum, std::complex<double>** rhog);
 
     Device * ctx = {};
 

--- a/source/source_estate/elecstate_pw.h
+++ b/source/source_estate/elecstate_pw.h
@@ -99,6 +99,17 @@ class ElecStatePW : public ElecState
     using resmem_complex_op = base_device::memory::resize_memory_op<T, Device>;
     using delmem_complex_op = base_device::memory::delete_memory_op<T, Device>;
 
+    using resmem_complex_h_op = base_device::memory::resize_memory_op<T, base_device::DEVICE_CPU>;
+    using delmem_complex_h_op = base_device::memory::delete_memory_op<T, base_device::DEVICE_CPU>;
+    using syncmem_complex_d2h_op = base_device::memory::synchronize_memory_op<T, base_device::DEVICE_CPU, Device>;
+    using syncmem_complex_h2d_op = base_device::memory::synchronize_memory_op<T, Device, base_device::DEVICE_CPU>;
+
+    using resmem_var_h_op = base_device::memory::resize_memory_op<Real, base_device::DEVICE_CPU>;
+    using delmem_var_h_op = base_device::memory::delete_memory_op<Real, base_device::DEVICE_CPU>;
+    using setmem_var_h_op = base_device::memory::set_memory_op<Real, base_device::DEVICE_CPU>;
+    using syncmem_var_h2d_op = base_device::memory::synchronize_memory_op<Real, Device, base_device::DEVICE_CPU>;
+    using syncmem_var_d2h_op = base_device::memory::synchronize_memory_op<Real, base_device::DEVICE_CPU, Device>;
+
     using gemv_op = ModuleBase::gemv_op<T, Device>;
     using gemm_op = ModuleBase::gemm_op<T, Device>;
 };

--- a/source/source_pw/module_pwdft/hamilt_pw.cpp
+++ b/source/source_pw/module_pwdft/hamilt_pw.cpp
@@ -252,7 +252,6 @@ void HamiltPW<T, Device>::sPsi(const T* psi_in, // psi
                     const int nh = atoms->ncpp.nh;
                     T* qqc = nullptr;
                     resmem_complex_op()(qqc, nh * nh, "Hamilt<PW>::qqc");
-		    
 		    std::vector<T> qqc_host(nh*nh);
 		    const double* qq_now_host = &this->ppcell->qq_nt.ptr[it * this->ppcell->nhm * this->ppcell->nhm];
               
@@ -260,13 +259,13 @@ void HamiltPW<T, Device>::sPsi(const T* psi_in, // psi
                     {
                         for (int j = 0; j < nh; j++)
                         {
-			    const int source_index = i * this->ppcell->nhm + j;
-			    const int target_index = i * nh + j;
+				const int source_index = i * this->ppcell->nhm + j;
+				const int target_index = i * nh + j;
 
-			    qqc_host[target_index] = static_cast<Real>(qq_now_host[source_index]) * one;
+				qqc_host[target_index] = static_cast<Real>(qq_now_host[source_index]) * one;
                         }
                     }
-
+		    
 		    syncmem_complex_h2d_op()(qqc, qqc_host.data(), qqc_host.size());
 
                     for (int ia = 0; ia < atoms->na; ia++)

--- a/source/source_pw/module_pwdft/hamilt_pw.cpp
+++ b/source/source_pw/module_pwdft/hamilt_pw.cpp
@@ -252,15 +252,23 @@ void HamiltPW<T, Device>::sPsi(const T* psi_in, // psi
                     const int nh = atoms->ncpp.nh;
                     T* qqc = nullptr;
                     resmem_complex_op()(qqc, nh * nh, "Hamilt<PW>::qqc");
-                    Real* qq_now = &qq_nt[it * this->ppcell->nhm * this->ppcell->nhm];
+		    
+		    std::vector<T> qqc_host(nh*nh);
+		    const double* qq_now_host = &this->ppcell->qq_nt.ptr[it * this->ppcell->nhm * this->ppcell->nhm];
+              
                     for (int i = 0; i < nh; i++)
                     {
                         for (int j = 0; j < nh; j++)
                         {
-                            int index = i * this->ppcell->nhm + j;
-                            qqc[i * nh + j] = qq_now[index] * one;
+			    const int source_index = i * this->ppcell->nhm + j;
+			    const int target_index = i * nh + j;
+
+			    qqc_host[target_index] = static_cast<Real>(qq_now_host[source_index]) * one;
                         }
                     }
+
+		    syncmem_complex_h2d_op()(qqc, qqc_host.data(), qqc_host.size());
+
                     for (int ia = 0; ia < atoms->na; ia++)
                     {
                         const int iat = ucell->itia2iat(it, ia);

--- a/source/source_pw/module_pwdft/hamilt_pw.cpp
+++ b/source/source_pw/module_pwdft/hamilt_pw.cpp
@@ -252,21 +252,21 @@ void HamiltPW<T, Device>::sPsi(const T* psi_in, // psi
                     const int nh = atoms->ncpp.nh;
                     T* qqc = nullptr;
                     resmem_complex_op()(qqc, nh * nh, "Hamilt<PW>::qqc");
-		    std::vector<T> qqc_host(nh*nh);
-		    const double* qq_now_host = &this->ppcell->qq_nt.ptr[it * this->ppcell->nhm * this->ppcell->nhm];
-              
+                    std::vector<T> qqc_host(nh*nh);
+                    const double* qq_now_host = &this->ppcell->qq_nt.ptr[it * this->ppcell->nhm * this->ppcell->nhm];
+
                     for (int i = 0; i < nh; i++)
                     {
                         for (int j = 0; j < nh; j++)
                         {
-				const int source_index = i * this->ppcell->nhm + j;
-				const int target_index = i * nh + j;
+                            const int source_index = i * this->ppcell->nhm + j;
+                            const int target_index = i * nh + j;
 
-				qqc_host[target_index] = static_cast<Real>(qq_now_host[source_index]) * one;
+                            qqc_host[target_index] = static_cast<Real>(qq_now_host[source_index]) * one;
                         }
                     }
-		    
-		    syncmem_complex_h2d_op()(qqc, qqc_host.data(), qqc_host.size());
+
+                    syncmem_complex_h2d_op()(qqc, qqc_host.data(), qqc_host.size());
 
                     for (int ia = 0; ia < atoms->na; ia++)
                     {

--- a/source/source_pw/module_pwdft/hamilt_pw.h
+++ b/source/source_pw/module_pwdft/hamilt_pw.h
@@ -21,6 +21,7 @@ class HamiltPW : public Hamilt<T, Device>
     // return T if T is real type(float, double),
     // otherwise return the real type of T(complex<float>, std::complex<double>)
     using Real = typename GetTypeReal<T>::type;
+    using syncmem_complex_h2d_op = base_device::memory::synchronize_memory_op<T,Device, base_device::DEVICE_CPU>;
 
   public:
     HamiltPW(elecstate::Potential* pot_in,


### PR DESCRIPTION
## Summary

  Fix GPU segfaults in PW USPP calculations caused by CPU code accessing GPU
  memory pointers. Added CPU intermediate buffers and D2H/H2D sync patterns
  in three USPP-specific code paths.

  ## Changes

  - **hamilt_pw**: sPsi reads qq_nt from CPU backup (`qq_nt.ptr`) instead of
    GPU pointer, fills a CPU buffer, then syncs to GPU for cuBLAS.

  - **elecstate_pw (cal_becsum)**: becp computed on GPU via gemm then synced
    to CPU; auxk1/auxk2 use CPU vectors; aux_gk computed on GPU then synced
    to CPU; becsum allocated on CPU (consumed by CPU-only force/stress code).

  - **elecstate_pw (add_usrho)**: Added D2H/H2D wrappers around real2recip
    and recip2real FFT calls, which read/write via CPU loops.

  - **elecstate_pw (addusdens_g)**: Rewritten to use pure CPU computation
    (CPU BLAS zgemm_, CPU radial_fft_q); ylmk0 computed on GPU with H2D'd
    gcar then D2H'd back.

  ## Test plan

  - [ ] Run PW USPP test cases (003, 008, 009) on GPU, verify no segfault
  - [ ] Run compute-sanitizer to confirm 0 GPU memory errors