### PR TITLE
Refactor: move read_orb from source_estate to source_cell (#7634)

### DIFF
--- a/source/source_cell/CMakeLists.txt
+++ b/source/source_cell/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(
     unitcell.cpp
     read_atoms.cpp
     read_atoms_helper.cpp
+    read_orb.cpp
     setup_nonlocal.cpp
     klist.cpp
     parallel_kpoints.cpp

--- a/source/source_cell/read_atoms_helper.cpp
+++ b/source/source_cell/read_atoms_helper.cpp
@@ -5,7 +5,7 @@
 #include "source_base/mathzone.h"
 #include "read_stru.h"
 #include "print_cell.h"
-#include "source_estate/read_orb.h"
+#include "read_orb.h"
 #include <cmath>
 #include <iostream>
 #include <sstream>
@@ -519,7 +519,7 @@ bool read_atom_type_header(int it, UnitCell& ucell,
     if ((PARAM.inp.basis_type == "lcao")||(PARAM.inp.basis_type == "lcao_in_pw"))
     {
         std::string orbital_file = PARAM.inp.orbital_dir + ucell.orbital_fn[it];
-        bool normal = elecstate::read_orb_file(it, orbital_file, ofs_running, &(ucell.atoms[it]));
+        bool normal = unitcell::read_orb_file(it, orbital_file, ofs_running, &(ucell.atoms[it]));
         if(!normal)
         {
             return false;
@@ -530,7 +530,7 @@ bool read_atom_type_header(int it, UnitCell& ucell,
         if ((PARAM.inp.init_wfc.substr(0, 3) == "nao") || PARAM.inp.onsite_radius > 0.0)
         {
             std::string orbital_file = PARAM.inp.orbital_dir + ucell.orbital_fn[it];
-            bool normal = elecstate::read_orb_file(it, orbital_file, ofs_running, &(ucell.atoms[it]));
+            bool normal = unitcell::read_orb_file(it, orbital_file, ofs_running, &(ucell.atoms[it]));
             if(!normal)
             {
                 return false;

--- a/source/source_cell/read_orb.cpp
+++ b/source/source_cell/read_orb.cpp
@@ -1,7 +1,7 @@
 #include "read_orb.h"
 #include "source_base/formatter.h"
 
-namespace elecstate {
+namespace unitcell {
     bool read_orb_file(int it, std::string &orb_file, std::ofstream &ofs_running, Atom* atom)
     {
     // the maximum L is 9 like cc-pV9Z, according to the 
@@ -14,7 +14,7 @@ namespace elecstate {
     {
         std::cout << " Element index " << it+1 << std::endl;
         std::cout << " orbital file: " << orb_file << std::endl;
-        ModuleBase::WARNING("elecstate::read_orb_file", 
+        ModuleBase::WARNING("unitcell::read_orb_file", 
                                 "cannot open the ORBITAL file (NAO basis sets)");
         return false;
     }
@@ -55,7 +55,7 @@ namespace elecstate {
             }
             if (!valid)
             {
-                ModuleBase::WARNING("elecstate::read_orb_file", 
+                ModuleBase::WARNING("unitcell::read_orb_file", 
                                          "ABACUS does not support NAO with L > 9, "
                                          "or an invalid orbital label is found in the ORBITAL file.");
                 return false;
@@ -65,7 +65,7 @@ namespace elecstate {
     ifs.close();
     if(!atom->nw)
     {
-		ModuleBase::WARNING("elecstate::read_orb_file","get nw = 0, check the ORBITAL file");
+		ModuleBase::WARNING("unitcell::read_orb_file","get nw = 0, check the ORBITAL file");
 		return false;
     }
     return true;

--- a/source/source_cell/read_orb.h
+++ b/source/source_cell/read_orb.h
@@ -1,9 +1,9 @@
 #ifndef READ_ORB_H
 #define READ_ORB_H
 
-#include "source_cell/unitcell.h"
+#include "unitcell.h"
 
-namespace elecstate 
+namespace unitcell
 {
 
     /**

--- a/source/source_cell/test/CMakeLists.txt
+++ b/source/source_cell/test/CMakeLists.txt
@@ -43,7 +43,7 @@ list(APPEND cell_simple_srcs
     ../../source_estate/read_pseudo.cpp
     ../../source_estate/cal_wfc.cpp
     ../../source_estate/cal_nelec_nband.cpp
-    ../../source_estate/read_orb.cpp
+    ../read_orb.cpp
     ../sep.cpp
     ../sep_cell.cpp
 )

--- a/source/source_cell/test/CMakeLists.txt
+++ b/source/source_cell/test/CMakeLists.txt
@@ -108,6 +108,7 @@ AddTest(
   LIBS parameter base device
   SOURCES read_atoms_helper_test.cpp
     ../read_atoms_helper.cpp
+    ../read_orb.cpp
     ../read_stru.cpp
     ../print_cell.cpp
     ../atom_spec.cpp

--- a/source/source_cell/test/unitcell_test.cpp
+++ b/source/source_cell/test/unitcell_test.cpp
@@ -4,7 +4,7 @@
 #include "source_io/module_parameter/parameter.h"
 #undef private
 #include "source_estate/cal_ux.h"
-#include "source_estate/read_orb.h"
+#include "source_cell/read_orb.h"
 #include "source_estate/read_pseudo.h"
 #include "source_cell/read_stru.h"
 #include "source_cell/print_cell.h"
@@ -1088,7 +1088,7 @@ TEST_F(UcellTest, ReadOrbFile)
     std::string orb_file = "./support/C.orb";
     std::ofstream ofs_running;
     ofs_running.open("tmp_readorbfile");
-    bool result = elecstate::read_orb_file(0, orb_file, ofs_running, &(ucell->atoms[0]));
+    bool result = unitcell::read_orb_file(0, orb_file, ofs_running, &(ucell->atoms[0]));
     ofs_running << " result=" << result << std::endl;
     EXPECT_TRUE(result);
     ofs_running.close();
@@ -1828,7 +1828,7 @@ TEST_F(UcellTest, ReadOrbFileWarning)
     std::ofstream ofs_running;
     ofs_running.open("tmp_readorbfilewarning");
     testing::internal::CaptureStdout();
-    bool result = elecstate::read_orb_file(0, orb_file, ofs_running, &(ucell->atoms[0]));
+    bool result = unitcell::read_orb_file(0, orb_file, ofs_running, &(ucell->atoms[0]));
     output = testing::internal::GetCapturedStdout();
     ofs_running << output << std::endl;
     EXPECT_FALSE(result);

--- a/source/source_cell/test_pw/CMakeLists.txt
+++ b/source/source_cell/test_pw/CMakeLists.txt
@@ -17,7 +17,7 @@ AddTest(
   ../read_stru.cpp   ../read_atom_species.cpp
 	../read_pp_vwr.cpp ../read_pp_blps.cpp
   ../../source_estate/read_pseudo.cpp ../../source_estate/cal_nelec_nband.cpp
-  ../../source_estate/read_orb.cpp    ../print_cell.cpp
+  ../../source_cell/read_orb.cpp    ../print_cell.cpp
   ../../source_estate/cal_wfc.cpp  ../sep.cpp   ../sep_cell.cpp
 )
 

--- a/source/source_estate/CMakeLists.txt
+++ b/source/source_estate/CMakeLists.txt
@@ -39,7 +39,6 @@ list(APPEND objects
     fp_energy.cpp
     occupy.cpp
     cal_ux.cpp
-    read_orb.cpp
     cal_nelec_nband.cpp
     read_pseudo.cpp
     cal_wfc.cpp

--- a/source/source_lcao/module_deepks/test/CMakeLists.txt
+++ b/source/source_lcao/module_deepks/test/CMakeLists.txt
@@ -41,7 +41,7 @@ set(DEEPKS_UNIT_COMMON_SOURCES
     ../../../source_io/module_output/sparse_matrix.cpp
     ../../../source_estate/read_pseudo.cpp
     ../../../source_estate/cal_wfc.cpp
-    ../../../source_estate/read_orb.cpp
+    ../../../source_cell/read_orb.cpp
     ../../../source_estate/cal_nelec_nband.cpp
     ../../../source_estate/module_dm/density_matrix.cpp
     ../../../source_estate/module_dm/density_matrix_io.cpp

--- a/source/source_md/test/CMakeLists.txt
+++ b/source/source_md/test/CMakeLists.txt
@@ -60,7 +60,7 @@ list(APPEND depend_files
   ../../source_estate/read_pseudo.cpp
   ../../source_estate/cal_wfc.cpp
   ../../source_estate/cal_nelec_nband.cpp
-  ../../source_estate/read_orb.cpp
+  ../../source_cell/read_orb.cpp
   ../../source_cell/sep.cpp
   ../../source_cell/sep_cell.cpp
 )

--- a/source/source_pw/module_pwdft/test/CMakeLists.txt
+++ b/source/source_pw/module_pwdft/test/CMakeLists.txt
@@ -55,5 +55,5 @@ AddTest(
 	../../../source_estate/read_pseudo.cpp
 	../../../source_estate/cal_wfc.cpp
 	../../../source_estate/cal_nelec_nband.cpp
-	../../../source_estate/read_orb.cpp
+	../../../source_cell/read_orb.cpp
 )


### PR DESCRIPTION
## Background

Fixes #7634.

`source_cell` is a data-structure layer that should not depend on the higher `source_estate` layer, yet `read_atoms_helper.cpp` called `elecstate::read_orb_file(...)`, pulling `source_cell` back up onto `source_estate` (a circular dependency).

## Root cause

`read_orb_file` is misplaced. It only:
- parses an orbital-file header and writes the results into `Atom` fields (`nw`, `nwl`, `l_nchi`, `label_orb`, `Rcut`) — all `source_cell` data;
- depends solely on `source_cell/unitcell.h` (same layer) and `source_base/formatter.h` (base layer).

Its only non-test caller is `source_cell/read_atoms_helper.cpp`; nothing in `source_estate` uses it. The `elecstate::` namespace was a vestigial label — there is nothing electronic-structure about it.

## Change

- Move `read_orb.{h,cpp}` from `source_estate/` down into `source_cell/`.
- Rename the namespace `elecstate` → `unitcell` to match the module.
- Update the include paths and the two call sites in `read_atoms_helper.cpp`.
- Update every CMake target that compiled the file by its old path (`source_cell/test`, `source_cell/test_pw`, `source_lcao/module_deepks/test`, `source_md/test`, `source_pw/module_pwdft/test`) and the `cell` / `estate` object libraries.

After the change `source_cell` no longer `#include`s `source_estate/...`; `read_orb` only depends downward (`source_base`) and same-layer (`unitcell.h`), so no new cycle is introduced.

## Verification

- Repo-wide grep confirms no remaining `source_estate/read_orb` or `elecstate::read_orb_file` references.
- `g++ -std=c++14 -fsyntax-only -I source` passes on both the moved `read_orb.cpp` and the caller `read_atoms_helper.cpp`.
- Behaviour is unchanged — this is a pure file move + namespace rename with no logic edits. `MODULE_CELL_unitcell_test` covers `read_orb_file` (two cases) and continues to build against the new location.