### PR TITLE
Docs: restore csvr option in md_thermostat documentation

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -3377,6 +3377,7 @@
   - berendsen: Berendsen thermostat, see md_nraise in detail.
   - rescaling: velocity Rescaling method 1, see md_tolerance in detail.
   - rescale_v: velocity Rescaling method 2, see md_nraise in detail.
+  - csvr: Canonical Sampling through Velocity Rescaling, see md_csvr_tau in detail.
 - **Default**: nhc
 
 ### md_tfirst

--- a/docs/advanced/md.md
+++ b/docs/advanced/md.md
@@ -83,7 +83,7 @@ Reset the temperature of a group of atoms by explicitly rescaling their velociti
 
 ## CSVR
 
-The CSVR (Canonical Sampling through Velocity Rescaling) thermostat is a stochastic velocity rescaling approach proposed by [Bussi, Donadio, and Parrinello](https://pubs.acs.org/doi/10.1021/jp0714112). It rescales the velocities by a factor that is drawn from the appropriate distribution to ensure a canonical ensemble, combining the simplicity of Berendsen-like rescaling with the correct canonical sampling of the Nosé-Hoover chain. The coupling strength is controlled by [md_csvr_tau](./input_files/input-main.md#md_csvr_tau).
+The CSVR (Canonical Sampling through Velocity Rescaling) thermostat is a stochastic velocity rescaling approach proposed by [Bussi, Donadio, and Parrinello](https://doi.org/10.1063/1.2408420). It rescales the velocities by a factor that is drawn from the appropriate distribution to ensure a canonical ensemble, combining the simplicity of Berendsen-like rescaling with the correct canonical sampling of the Nosé-Hoover chain. The coupling strength is controlled by [md_csvr_tau](./input_files/input-main.md#md_csvr_tau).
 
 ## MSST
 ABACUS performs the [Multi-Scale Shock Technique (MSST) integration](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.90.235503) to update positions and velocities each timestep to mimic a compressive shock wave passing over the system. The MSST varies the cell volume and temperature in such a way as to restrain the system to the shock Hugoniot and the Rayleigh line. These restraints correspond to the macroscopic conservation laws dictated by a shock front.

--- a/docs/advanced/md.md
+++ b/docs/advanced/md.md
@@ -18,6 +18,7 @@ When [md_type](./input_files/input-main.md#md_type) is set to nvt, [md_thermosta
   - berendsen: Berendsen thermostat
   - rescaling: velocity Rescaling method 1
   - rescale_v: velocity Rescaling method 2
+  - csvr: Canonical Sampling through Velocity Rescaling (CSVR) thermostat
 
 When [md_type](./input_files/input-main.md#md_type) is set to npt, [md_pmode](./input_files/input-main.md#md_pmode) is used to specify the cell fluctuation mode in NPT ensemble based on the Nose-Hoover style non-Hamiltonian equations of motion.
 
@@ -79,6 +80,10 @@ Reset the temperature of a group of atoms by explicitly rescaling their velociti
 ## Rescale_v
 
 Reset the temperature of a group of atoms by explicitly rescaling their velocities. Every [md_nraise](./input_files/input-main.md#md_nraise) steps the current temperature is rescaled to target temperature.
+
+## CSVR
+
+The CSVR (Canonical Sampling through Velocity Rescaling) thermostat is a stochastic velocity rescaling approach proposed by [Bussi, Donadio, and Parrinello](https://pubs.acs.org/doi/10.1021/jp0714112). It rescales the velocities by a factor that is drawn from the appropriate distribution to ensure a canonical ensemble, combining the simplicity of Berendsen-like rescaling with the correct canonical sampling of the Nosé-Hoover chain. The coupling strength is controlled by [md_csvr_tau](./input_files/input-main.md#md_csvr_tau).
 
 ## MSST
 ABACUS performs the [Multi-Scale Shock Technique (MSST) integration](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.90.235503) to update positions and velocities each timestep to mimic a compressive shock wave passing over the system. The MSST varies the cell volume and temperature in such a way as to restrain the system to the shock Hugoniot and the Rayleigh line. These restraints correspond to the macroscopic conservation laws dictated by a shock front.

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1399,6 +1399,7 @@ parameters:
       * berendsen: Berendsen thermostat, see md_nraise in detail.
       * rescaling: velocity Rescaling method 1, see md_tolerance in detail.
       * rescale_v: velocity Rescaling method 2, see md_nraise in detail.
+      * csvr: Canonical Sampling through Velocity Rescaling, see md_csvr_tau in detail.
     default_value: nhc
     unit: ""
     availability: ""

--- a/source/source_io/module_parameter/md_parameter.h
+++ b/source/source_io/module_parameter/md_parameter.h
@@ -14,7 +14,7 @@ struct MD_para
     bool md_restart = false;           ///< 1: restart MD, 0: no restart MD
     std::string md_type = "nvt";       ///< fire, nve, nvt, npt, langevin, msst
     std::string md_thermostat = "nhc"; ///< specify the thermostat: nhc, anderson, berendsen,
-                                       ///< rescaling, rescale_v
+                                       ///< rescaling, rescale_v, csvr
     double md_dt = 1.0;                ///< Time increment (hbar/E_hartree)
     double md_tfirst = -1.0;           ///< Temperature (in Hartree, 1 Hartree ~ 3E5 K)
     double md_tlast = -1.0;            ///< Target temperature

--- a/source/source_io/module_parameter/read_input_item_md.cpp
+++ b/source/source_io/module_parameter/read_input_item_md.cpp
@@ -83,7 +83,8 @@ void ReadInput::item_md()
 * anderson: Anderson thermostat, see md_nraise in detail.
 * berendsen: Berendsen thermostat, see md_nraise in detail.
 * rescaling: velocity Rescaling method 1, see md_tolerance in detail.
-* rescale_v: velocity Rescaling method 2, see md_nraise in detail.)";
+* rescale_v: velocity Rescaling method 2, see md_nraise in detail.
+* csvr: Canonical Sampling through Velocity Rescaling, see md_csvr_tau in detail.)";
         item.default_value = "nhc";
         item.unit = "";
         item.availability = "";


### PR DESCRIPTION
### Fix #7653

The `csvr` (Canonical Sampling through Velocity Rescaling) thermostat option description was accidentally removed from both `docs/parameters.yaml` and `docs/advanced/input_files/input-main.md` in PR #7589. This restores the line.

### Changes
- `docs/parameters.yaml`: add `* csvr: Canonical Sampling through Velocity Rescaling, see md_csvr_tau in detail.` to `md_thermostat` options
- `docs/advanced/input_files/input-main.md`: same addition

### Verification
- `md_csvr_tau` parameter documentation is intact and already references `md_thermostat = csvr`
- Source code at `source/source_md/verlet.cpp:103` handles `md_thermostat == "csvr"`
- The fix matches the original PR #7461 documentation

