### PR TITLE
Libxc: 7.0.0 -> 7.1.2 (toolchain); fix external parameter handling

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -1232,18 +1232,16 @@
 ### xc_exch_ext
 
 - **Type**: Integer followed by Real values
-- **Description**: Customized parameterization on the exchange part of XC functional. The first value should be the LibXC ID of the original functional, and latter values are external parameters. Default values are those of Perdew-Burke-Ernzerhof (PBE) functional. For more information on LibXC ID of functionals, please refer to LibXC. For parameters of functionals of interest, please refer to the source code of LibXC, such as PBE functional interface in LibXC: gga_x_pbe.c.
+- **Description**: Customized parameterization of the exchange part of an XC functional. The first value should be the Libxc ID of the original functional, followed by the complete list of external parameters required by the linked Libxc version. If unset, Libxc's own default parameters are used. For functional IDs and parameter definitions, refer to the Libxc documentation and source code.
 
   > Note: Solely setting this keyword will take no effect on XC functionals. One should also set dft_functional to the corresponding functional to apply the customized parameterization. Presently this feature can only support parameterization on one exchange functional.
-- **Default**: 101 0.8040 0.2195149727645171
 
 ### xc_corr_ext
 
 - **Type**: Integer followed by Real values
-- **Description**: Customized parameterization on the correlation part of XC functional. The first value should be the LibXC ID of the original functional, and latter values are external parameters. Default values are those of Perdew-Burke-Ernzerhof (PBE) functional. For more information on LibXC ID of functionals, please refer to LibXC. For parameters of functionals of interest, please refer to the source code of LibXC, such as PBE functional interface in LibXC: gga_c_pbe.c.
+- **Description**: Customized parameterization of the correlation part of an XC functional. The first value should be the Libxc ID of the original functional, followed by the complete list of external parameters required by the linked Libxc version. If unset, Libxc's own default parameters are used. For functional IDs and parameter definitions, refer to the Libxc documentation and source code.
 
   > Note: Solely setting this keyword will take no effect on XC functionals. One should also set dft_functional to the corresponding functional to apply the customized parameterization. Presently this feature can only support parameterization on one correlation functional.
-- **Default**: 130 0.06672455060314922 0.031090690869654895034 1.0
 
 ### pseudo_rcut
 

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -621,20 +621,20 @@ parameters:
     category: Electronic structure
     type: Integer followed by Real values
     description: |
-      Customized parameterization on the exchange part of XC functional. The first value should be the LibXC ID of the original functional, and latter values are external parameters. Default values are those of Perdew-Burke-Ernzerhof (PBE) functional. For more information on LibXC ID of functionals, please refer to LibXC. For parameters of functionals of interest, please refer to the source code of LibXC, such as PBE functional interface in LibXC: gga_x_pbe.c.
+      Customized parameterization of the exchange part of an XC functional. The first value should be the Libxc ID of the original functional, followed by the complete list of external parameters required by the linked Libxc version. If unset, Libxc's own default parameters are used. For functional IDs and parameter definitions, refer to the Libxc documentation and source code.
 
       [NOTE] Solely setting this keyword will take no effect on XC functionals. One should also set dft_functional to the corresponding functional to apply the customized parameterization. Presently this feature can only support parameterization on one exchange functional.
-    default_value: 101 0.8040 0.2195149727645171
+    default_value: ""
     unit: ""
     availability: ""
   - name: xc_corr_ext
     category: Electronic structure
     type: Integer followed by Real values
     description: |
-      Customized parameterization on the correlation part of XC functional. The first value should be the LibXC ID of the original functional, and latter values are external parameters. Default values are those of Perdew-Burke-Ernzerhof (PBE) functional. For more information on LibXC ID of functionals, please refer to LibXC. For parameters of functionals of interest, please refer to the source code of LibXC, such as PBE functional interface in LibXC: gga_c_pbe.c.
+      Customized parameterization of the correlation part of an XC functional. The first value should be the Libxc ID of the original functional, followed by the complete list of external parameters required by the linked Libxc version. If unset, Libxc's own default parameters are used. For functional IDs and parameter definitions, refer to the Libxc documentation and source code.
 
       [NOTE] Solely setting this keyword will take no effect on XC functionals. One should also set dft_functional to the corresponding functional to apply the customized parameterization. Presently this feature can only support parameterization on one correlation functional.
-    default_value: 130 0.06672455060314922 0.031090690869654895034 1.0
+    default_value: ""
     unit: ""
     availability: ""
   - name: pseudo_rcut

--- a/source/source_hamilt/module_xc/libxc_setup.cpp
+++ b/source/source_hamilt/module_xc/libxc_setup.cpp
@@ -290,33 +290,41 @@ XC_Functional_Libxc::init_func(const std::vector<int> &func_id,
         funcs.push_back({}); // create placeholder
         xc_func_init(&funcs.back(), id, xc_polarized); // instantiate the XC term
 
-        // search for external parameters
-        const std::vector<double> in_built_ext_params = in_built_xc_func_ext_params(id, hybrid_alpha, hse_omega);
-        const std::vector<double> external_ext_params = external_xc_func_ext_params(id);
-        // for temporary use, I name their size as n1 and n2
-        const int n1 = in_built_ext_params.size();
-        const int n2 = external_ext_params.size();
+        // Search for external parameters. User-supplied parameters take precedence
+        // over ABACUS built-in overrides.
+        const std::vector<double> in_built_ext_params
+            = in_built_xc_func_ext_params(id, hybrid_alpha, hse_omega);
+        const std::vector<double> external_ext_params
+            = external_xc_func_ext_params(id);
+        const std::vector<double>& requested_ext_params
+            = external_ext_params.empty() ? in_built_ext_params : external_ext_params;
 
-// #ifdef __DEBUG // will the following assertion cause performance issue?
-        // assert the number of parameters should be either zero or the value from
-        // libxc function xc_func_info_get_n_ext_params, this is to avoid the undefined
-        // behavior of illegal memory access
-        const xc_func_info_type* info = xc_func_get_info(&funcs.back());
-        const int nref = xc_func_info_get_n_ext_params(info);
-        assert ((n1 == 0) || (n1 == nref) || (n2 == 0) || (n2 == nref));
-// #endif
-
-        // external overwrites in-built if the same functional id is found in both maps
-        const double* xc_func_ext_params = 
-            (n2 > 0) ? external_ext_params.data() : 
-            (n1 > 0) ? in_built_ext_params.data() :
-            nullptr; // nullptr if no external parameters are found
-
-        // if there are no external parameters, do nothing, otherwise we set
-        if(xc_func_ext_params != nullptr)
+        if (!requested_ext_params.empty())
         {
-            // set the external parameters
-            xc_func_set_ext_params(&funcs.back(), const_cast<double*>(xc_func_ext_params));
+            const xc_func_info_type* info = xc_func_get_info(&funcs.back());
+            const int nref = xc_func_info_get_n_ext_params(info);
+
+            // xc_func_set_ext_params() reads exactly nref entries. Never pass a
+            // shorter buffer: Libxc may append new parameters in a newer release
+            // (GGA_C_PBE gained _tscale in Libxc 7.1).
+            if (requested_ext_params.size() > static_cast<std::size_t>(nref))
+            {
+                ModuleBase::WARNING_QUIT(
+                    "XC_Functional_Libxc::init_func",
+                    "Too many external parameters for Libxc functional id "
+                        + std::to_string(id) + ": got "
+                        + std::to_string(requested_ext_params.size())
+                        + ", expected at most " + std::to_string(nref) + ".");
+            }
+
+            // Missing trailing parameters retain Libxc's own defaults. This is
+            // backward- and forward-compatible when Libxc appends parameters.
+            std::vector<double> complete_ext_params(
+                nref, static_cast<double>(XC_EXT_PARAMS_DEFAULT));
+            std::copy(requested_ext_params.begin(),
+                      requested_ext_params.end(),
+                      complete_ext_params.begin());
+            xc_func_set_ext_params(&funcs.back(), complete_ext_params.data());
         }
     }
     return funcs;

--- a/source/source_hamilt/module_xc/libxc_setup.cpp
+++ b/source/source_hamilt/module_xc/libxc_setup.cpp
@@ -14,7 +14,6 @@
 #include <regex>
 #include <map>
 #include <algorithm>
-#include <cassert>
 
 bool not_supported_xc_with_laplacian(const std::string& xc_func_in)
 {
@@ -200,7 +199,7 @@ const std::vector<double> in_built_xc_func_ext_params(const int id,
 #ifdef __EXX
         // hybrid functionals
         case XC_HYB_GGA_XC_PBEH:
-            return {hybrid_alpha, hse_omega, hse_omega};
+            return {hybrid_alpha};
         case XC_HYB_GGA_XC_HSE06:
             return {hybrid_alpha, hse_omega, hse_omega};
         // short-range of B88_X
@@ -262,20 +261,19 @@ const std::vector<double> in_built_xc_func_ext_params(const int id,
 
 const std::vector<double> external_xc_func_ext_params(const int id)
 {
-    const std::map<int, std::vector<double>> mymap = {
-        {
-            PARAM.inp.xc_exch_ext[0],
-            std::vector<double>(PARAM.inp.xc_exch_ext.begin()+1,
-                                PARAM.inp.xc_exch_ext.end())
-        },
-        {
-            PARAM.inp.xc_corr_ext[0],
-            std::vector<double>(PARAM.inp.xc_corr_ext.begin()+1,
-                                PARAM.inp.xc_corr_ext.end())
-        }
-     };
-    auto it = mymap.find(id);
-    return (it != mymap.end()) ? it->second : std::vector<double>{};
+    const auto& exch_ext = PARAM.inp.xc_exch_ext;
+    if (!exch_ext.empty() && static_cast<int>(exch_ext.front()) == id)
+    {
+        return {exch_ext.begin() + 1, exch_ext.end()};
+    }
+
+    const auto& corr_ext = PARAM.inp.xc_corr_ext;
+    if (!corr_ext.empty() && static_cast<int>(corr_ext.front()) == id)
+    {
+        return {corr_ext.begin() + 1, corr_ext.end()};
+    }
+
+    return {};
 }
 
 std::vector<xc_func_type> 

--- a/source/source_hamilt/module_xc/libxc_setup.cpp
+++ b/source/source_hamilt/module_xc/libxc_setup.cpp
@@ -304,27 +304,18 @@ XC_Functional_Libxc::init_func(const std::vector<int> &func_id,
             const xc_func_info_type* info = xc_func_get_info(&funcs.back());
             const int nref = xc_func_info_get_n_ext_params(info);
 
-            // xc_func_set_ext_params() reads exactly nref entries. Never pass a
-            // shorter buffer: Libxc may append new parameters in a newer release
-            // (GGA_C_PBE gained _tscale in Libxc 7.1).
-            if (requested_ext_params.size() > static_cast<std::size_t>(nref))
+            // xc_func_set_ext_params() reads exactly nref entries
+            if (requested_ext_params.size() != static_cast<std::size_t>(nref))
             {
                 ModuleBase::WARNING_QUIT(
                     "XC_Functional_Libxc::init_func",
-                    "Too many external parameters for Libxc functional id "
+                    "Invalid number of external parameters for Libxc functional id "
                         + std::to_string(id) + ": got "
                         + std::to_string(requested_ext_params.size())
-                        + ", expected at most " + std::to_string(nref) + ".");
+                        + ", expected " + std::to_string(nref) + ".");
             }
 
-            // Missing trailing parameters retain Libxc's own defaults. This is
-            // backward- and forward-compatible when Libxc appends parameters.
-            std::vector<double> complete_ext_params(
-                nref, static_cast<double>(XC_EXT_PARAMS_DEFAULT));
-            std::copy(requested_ext_params.begin(),
-                      requested_ext_params.end(),
-                      complete_ext_params.begin());
-            xc_func_set_ext_params(&funcs.back(), complete_ext_params.data());
+            xc_func_set_ext_params(&funcs.back(), requested_ext_params.data());
         }
     }
     return funcs;

--- a/source/source_io/module_parameter/input_parameter.h
+++ b/source/source_io/module_parameter/input_parameter.h
@@ -722,14 +722,12 @@ struct Input_para
      * 
      * Likewise, the correlation part can be found in corresponding files.
      * 
-     * PBE functional is used as the default functional for XCPNet.
+     * These vectors are empty unless the user explicitly requests an
+     * override. This leaves the version-specific default parameters under
+     * Libxc's control.
      */
-    // src/gga_x_pbe.c
-    std::vector<double> xc_exch_ext = {
-        101, 0.8040, 0.2195149727645171}; 
-    // src/gga_c_pbe.c
-    std::vector<double> xc_corr_ext = {
-        130, 0.06672455060314922, 0.031090690869654895034, 1.00000}; 
+    std::vector<double> xc_exch_ext = {};
+    std::vector<double> xc_corr_ext = {};
 
     // ==============   #Parameters (24.td-ofdft) ===========================
     bool of_cd = false;          ///< add CD potential or not

--- a/source/source_io/module_parameter/read_input_item_elec_stru.cpp
+++ b/source/source_io/module_parameter/read_input_item_elec_stru.cpp
@@ -354,14 +354,14 @@ The other way is only available when compiling with LIBXC, and it allows for sup
     }
     {
         Input_Item item("xc_exch_ext");
-        item.annotation = "placeholder for xcpnet exchange functional";
+        item.annotation = "customize Libxc exchange functional parameters";
         item.category = "Electronic structure";
         item.type = "Integer followed by Real values";
-        item.description = "Customized parameterization on the exchange part of XC functional. The first value should be the LibXC ID of the original functional, and latter values are external parameters. Default values are those of Perdew-Burke-Ernzerhof (PBE) functional. For more information on LibXC ID of functionals, please refer to LibXC. For parameters of functionals of interest, please refer to the source code of LibXC, such as PBE functional interface in LibXC: gga_x_pbe.c."
+        item.description = "Customized parameterization of the exchange part of an XC functional. The first value should be the Libxc ID of the original functional, followed by the complete list of external parameters required by the linked Libxc version. If unset, Libxc's own default parameters are used. For functional IDs and parameter definitions, refer to the Libxc documentation and source code."
                           "\n\n[NOTE] Solely setting this keyword will take no effect on XC functionals. One should also set "
                           "dft_functional to the corresponding functional to apply the customized parameterization. "
                           "Presently this feature can only support parameterization on one exchange functional.";
-        item.default_value = "101 0.8040 0.2195149727645171";
+        item.default_value = "";
         item.unit = "";
         item.availability = "";
         item.read_value = [](const Input_Item& item, Parameter& para) {
@@ -371,10 +371,15 @@ The other way is only available when compiling with LIBXC, and it allows for sup
                            [](const std::string& str) { return std::stod(str); });
         };
         item.check_value = [](const Input_Item& item, const Parameter& para) {
-            // at least one value should be set
-            if (para.input.xc_exch_ext.empty())
+            if (!item.is_read())
             {
-                ModuleBase::WARNING_QUIT("ReadInput", "xc_exch_ext should not be empty.");
+                return;
+            }
+            if (para.input.xc_exch_ext.size() < 2)
+            {
+                ModuleBase::WARNING_QUIT(
+                    "ReadInput",
+                    "xc_exch_ext requires a Libxc ID followed by external parameters.");
             }
             // the first value is actually an integer, not a double
             const double libxc_id_dbl = para.input.xc_exch_ext[0];
@@ -397,14 +402,14 @@ The other way is only available when compiling with LIBXC, and it allows for sup
     }
     {
         Input_Item item("xc_corr_ext");
-        item.annotation = "placeholder for xcpnet exchange functional";
+        item.annotation = "customize Libxc correlation functional parameters";
         item.category = "Electronic structure";
         item.type = "Integer followed by Real values";
-        item.description = "Customized parameterization on the correlation part of XC functional. The first value should be the LibXC ID of the original functional, and latter values are external parameters. Default values are those of Perdew-Burke-Ernzerhof (PBE) functional. For more information on LibXC ID of functionals, please refer to LibXC. For parameters of functionals of interest, please refer to the source code of LibXC, such as PBE functional interface in LibXC: gga_c_pbe.c."
+        item.description = "Customized parameterization of the correlation part of an XC functional. The first value should be the Libxc ID of the original functional, followed by the complete list of external parameters required by the linked Libxc version. If unset, Libxc's own default parameters are used. For functional IDs and parameter definitions, refer to the Libxc documentation and source code."
                           "\n\n[NOTE] Solely setting this keyword will take no effect on XC functionals. One should also set "
                           "dft_functional to the corresponding functional to apply the customized parameterization. "
                           "Presently this feature can only support parameterization on one correlation functional.";
-        item.default_value = "130 0.06672455060314922 0.031090690869654895034 1.0";
+        item.default_value = "";
         item.unit = "";
         item.availability = "";
         item.read_value = [](const Input_Item& item, Parameter& para) {
@@ -414,10 +419,15 @@ The other way is only available when compiling with LIBXC, and it allows for sup
                            [](const std::string& str) { return std::stod(str); });
         };
         item.check_value = [](const Input_Item& item, const Parameter& para) {
-            // at least one value should be set
-            if (para.input.xc_corr_ext.empty())
+            if (!item.is_read())
             {
-                ModuleBase::WARNING_QUIT("ReadInput", "xc_corr_ext should not be empty.");
+                return;
+            }
+            if (para.input.xc_corr_ext.size() < 2)
+            {
+                ModuleBase::WARNING_QUIT(
+                    "ReadInput",
+                    "xc_corr_ext requires a Libxc ID followed by external parameters.");
             }
             // the first value is actually an integer, not a double
             const double libxc_id_dbl = para.input.xc_corr_ext[0];

--- a/toolchain/scripts/package_versions.sh
+++ b/toolchain/scripts/package_versions.sh
@@ -68,11 +68,11 @@ fftw_main_sha256="5630c24cdeb33b131612f7eb4b1a9934234754f9f388ff8617458d0be6f239
 fftw_alt_ver="3.3.10"
 fftw_alt_sha256="56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467"
 
-# LibXC (supports dual versions) - main=7.0.0, alt=6.2.2
-libxc_main_ver="7.0.0"
-libxc_main_sha256="e9ae69f8966d8de6b7585abd9fab588794ada1fab8f689337959a35abbf9527d"
-libxc_alt_ver="6.2.2"
-libxc_alt_sha256="f72ed08af7b9dff5f57482c5f97bff22c7dc49da9564bc93871997cbda6dacf3"
+# LibXC (supports dual versions) - main=7.1.0, alt=7.0.0
+libxc_main_ver="7.1.2"
+libxc_main_sha256="3915fac94416e4c415534223ea492ad2663f928acf27e98662c861b094a6c306"
+libxc_alt_ver="7.0.0"
+libxc_alt_sha256="e9ae69f8966d8de6b7585abd9fab588794ada1fab8f689337959a35abbf9527d"
 
 # ScaLAPACK (supports dual versions) - main=2.2.2, alt=2.2.1
 scalapack_main_ver="2.2.3"

--- a/toolchain/scripts/stage3/install_libxc.sh
+++ b/toolchain/scripts/stage3/install_libxc.sh
@@ -61,18 +61,16 @@ case "$with_libxc" in
             [ -d libxc-${libxc_ver} ] && rm -rf libxc-${libxc_ver}
             tar -xjf ${libxc_pkg}
             cd libxc-${libxc_ver}
-            # using cmake method to install libxc is neccessary for abacus
             mkdir build 
             cd build
             cmake \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DCMAKE_INSTALL_PREFIX=${pkg_install_dir} \
-                -DBUILD_SHARED_LIBS=YES \
+                -DBUILD_SHARED_LIBS=ON \
                 -DCMAKE_INSTALL_LIBDIR=lib \
                 -DCMAKE_VERBOSE_MAKEFILE=ON \
                 -DENABLE_FORTRAN=ON \
                 -DENABLE_PYTHON=OFF \
-                -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
                 -DBUILD_TESTING=OFF .. \
                 > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
             make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log


### PR DESCRIPTION
Versions of LIBXC have been tested:
5.1.7; 6.2.2; 7.0.0; 7.1.0; 7.1.2

This update might need careful checks from the ABACUS side, especially regarding `module_xc` path. I detected several "fatal deviation" when running integration tests:
```
01_PW
[ERROR     ] Fatal deviation details:
204_PW_SY: etotref cal=-1689.42889973 ref=-1674.11071764 deviation=15.31818209
204_PW_SY: totalstressref cal=298.73181900 ref=290.50831200 deviation=-8.22350700

07_OFDFT
[ERROR     ] Fatal deviation details:
26_OF_MD_LibxcPBE: totalstressref cal=46.96707800 ref=28.58611600 deviation=-18.38096200
```