### PR TITLE
Require cuSolverMp 0.9.0 or newer

### DIFF
--- a/cmake/modules/SetupCuSolverMp.cmake
+++ b/cmake/modules/SetupCuSolverMp.cmake
@@ -44,12 +44,19 @@ function(abacus_setup_cusolvermp)
     endif()
   endif()
 
-  # Check minimum version requirement (>= 0.4.0)
-  if(CUSOLVERMP_VERSION_STR AND CUSOLVERMP_VERSION_STR VERSION_LESS "0.4.0")
+  # Check minimum version requirement (>= 0.9.0)
+  if(NOT CUSOLVERMP_VERSION_STR)
+    message(FATAL_ERROR
+      "Unable to detect the cuSOLVERMp version from ${CUSOLVERMP_VERSION_HEADER}. "
+      "ABACUS requires cuSOLVERMp >= 0.9.0."
+    )
+  elseif(CUSOLVERMP_VERSION_STR VERSION_LESS "0.9.0")
     message(FATAL_ERROR
       "cuSOLVERMp version ${CUSOLVERMP_VERSION_STR} is too old. "
-      "ABACUS requires cuSOLVERMp >= 0.4.0 (NVIDIA HPC SDK >= 23.5). "
-      "Please upgrade your NVIDIA HPC SDK installation."
+      "NVIDIA documents an STEDC defect in cuSOLVERMp 0.4.2 through 0.8.0 that affects "
+      "non-power-of-two block sizes and certain 2D process grids; Syevd and "
+      "Sygvd use STEDC internally. "
+      "ABACUS requires cuSOLVERMp >= 0.9.0. Please upgrade cuSOLVERMp."
     )
   endif()
 

--- a/docs/advanced/acceleration/cuda.md
+++ b/docs/advanced/acceleration/cuda.md
@@ -24,6 +24,14 @@ To compile and use ABACUS in CUDA mode, you currently need to have an NVIDIA GPU
 
 - Install a driver and toolkit appropriate for your system (SDK is not necessary)
 
+NVIDIA reports that cuSOLVERMp 0.4.2 through 0.8.0 contain an STEDC defect
+affecting non-power-of-two block sizes and certain 2D process grids. Because
+`Syevd` and `Sygvd` use STEDC internally, affected versions may fail or hang
+during distributed diagonalization. ABACUS therefore requires cuSOLVERMp 0.9.0
+or newer when `ENABLE_CUSOLVERMP=ON`. The recommended stack is cuSOLVERMp 0.9.0
+with cuBLASMp 0.9.1. See the
+[cuSOLVERMp 0.9.0 release notes](https://docs.nvidia.com/cuda/cusolvermp/release_notes/index.html#cusolvermp-v0-9-0)
+for the upstream fix details.
 
 ## Building ABACUS with the GPU support:
 


### PR DESCRIPTION
## Summary

- require a detectable cuSolverMp version of 0.9.0 or newer when `ENABLE_CUSOLVERMP=ON`
- explain the affected upstream versions and failure mode in both the configure diagnostic and CUDA documentation
- recommend cuSolverMp 0.9.0 with cuBLASMp 0.9.1 while leaving the existing NCCL and cuBLASMp version requirements unchanged

Builds that do not enable cuSolverMp are unaffected.

## Why versions below 0.9.0 are rejected

NVIDIA documents that cuSolverMp 0.4.2 through 0.8.0 contain an STEDC defect affecting non-power-of-two block sizes and certain 2D process-grid configurations. `Syevd` and `Sygvd` use STEDC internally, so distributed eigensolves with the affected releases may fail or hang. cuSolverMp 0.9.0 is the first release containing the documented fix, so ABACUS uses it as the minimum supported cuSolverMp version rather than retaining exceptions for known-affected releases.

The failure was also reproduced independently on SAI with NVIDIA's official 16-rank, 4x4-grid `mp_sygvd` sample using cuSolverMp 0.7.2, and in a 16-GPU ABACUS RT-TDDFT run. The corresponding ABACUS case completed after upgrading to cuSolverMp 0.9.0 with cuBLASMp 0.9.1. The detailed diagnosis is tracked in #7657.

NVIDIA release notes: https://docs.nvidia.com/cuda/cusolvermp/release_notes/index.html#cusolvermp-v0-9-0

## Scope

The direct `diago_cusolvermp.cpp` include fix is isolated in #7666. SAI GPU CI and the multinode Si48 smoke are handled separately in #7665. This PR does not add a user override, change NCCL requirements, or add a custom CMake test framework.

## Verification

A configure-level check exercised the revised module with synthetic dependency headers and libraries:

- cuSolverMp setup not invoked: configuration succeeds without inspecting cuSolverMp
- cuSolverMp 0.8.0: rejected with the STEDC diagnostic
- cuSolverMp 0.9.0: accepted with the NCCL backend
- header without version macros: rejected

The supported stack was previously compiled on SAI with cuSolverMp 0.9.0, cuBLASMp 0.9.1, NCCL 2.29.3, CUDA 12.9.1, and OpenMPI 5.0.10, and passed the 2-node/16-GPU Si48 RT-TDDFT smoke in runs 29870131642 and 29870141313.