### PR TITLE
Refactor: move EXX file-list broadcast out of source_cell (#7635)

### DIFF
--- a/source/source_cell/bcast_cell.cpp
+++ b/source/source_cell/bcast_cell.cpp
@@ -1,30 +1,11 @@
 #include "unitcell.h"
 #include "source_base/parallel_common.h"
 
-#include "source_hamilt/module_xc/exx_info.h" // use GlobalC::exx_info
-
 #include <string>
 #include <vector>
 
 namespace unitcell
 {
-#if defined(__MPI) && defined(__EXX)
-    // Broadcast a vector<string> from rank 0 to all ranks.
-    // Replaces the former cereal-based ModuleBase::bcast_data_cereal, which
-    // was only ever used here to broadcast plain lists of ABFS file names and
-    // pulled source_cell into a dependency on source_lcao/module_ri.
-    static void bcast_string_vector(std::vector<std::string>& v)
-    {
-        int size = static_cast<int>(v.size());
-        Parallel_Common::bcast_int(size);
-        v.resize(size);
-        for (int i = 0; i < size; ++i)
-        {
-            Parallel_Common::bcast_string(v[i]);
-        }
-    }
-#endif
-
     void bcast_atoms_tau(Atom* atoms,
                          const int ntype)
     {
@@ -131,12 +112,6 @@ namespace unitcell
         {
             Parallel_Common::bcast_string(ucell.orbital_fn[i]);
         }
-
-        #ifdef __EXX
-        bcast_string_vector(GlobalC::exx_info.info_ri.files_abfs);
-        bcast_string_vector(GlobalC::exx_info.info_opt_abfs.files_abfs);
-        bcast_string_vector(GlobalC::exx_info.info_opt_abfs.files_jles);
-        #endif
         return;
     #endif
     }

--- a/source/source_lcao/setup_exx.cpp
+++ b/source/source_lcao/setup_exx.cpp
@@ -2,6 +2,42 @@
 
 #ifdef __EXX
 #include "source_lcao/module_ri/Exx_LRI_interface.h"
+#include "source_hamilt/module_xc/exx_info.h" // use the global Exx_Info
+#if defined(__MPI)
+#include "source_base/parallel_common.h"
+#include <string>
+#include <vector>
+#endif
+#endif
+
+#ifdef __EXX
+#if defined(__MPI)
+namespace
+{
+    // Broadcast a vector<string> from rank 0 to all ranks.
+    // Moved here from source_cell/bcast_cell.cpp so that source_cell no longer
+    // depends on the XC module just to distribute these ABFS file-name lists.
+    void bcast_string_vector(std::vector<std::string>& v)
+    {
+        int size = static_cast<int>(v.size());
+        Parallel_Common::bcast_int(size);
+        v.resize(size);
+        for (int i = 0; i < size; ++i)
+        {
+            Parallel_Common::bcast_string(v[i]);
+        }
+    }
+} // namespace
+#endif
+
+void bcast_exx_file_lists()
+{
+#if defined(__MPI)
+    bcast_string_vector(GlobalC::exx_info.info_ri.files_abfs);
+    bcast_string_vector(GlobalC::exx_info.info_opt_abfs.files_abfs);
+    bcast_string_vector(GlobalC::exx_info.info_opt_abfs.files_jles);
+#endif
+}
 #endif
 
 template <typename TK>
@@ -20,6 +56,11 @@ void Exx_NAO<TK>::init()
     //  which cause the failure of the subsequent procedure reused by ESolver_LCAO_TDDFT
     // 2. always construct but only initialize when if(cal_exx) is true
     //  because some members like two_level_step are used outside if(cal_exx)
+
+    // Distribute the ABFS/JLE file lists (read from STRU on rank 0) to all ranks
+    // before Exx_LRI copies info_ri below.
+    bcast_exx_file_lists();
+
     if (GlobalC::exx_info.info_ri.real_number)
     {
         this->exd = std::make_shared<Exx_LRI_Interface<TK, double>>(GlobalC::exx_info.info_ri, GlobalC::exx_info.info_global);

--- a/source/source_lcao/setup_exx.h
+++ b/source/source_lcao/setup_exx.h
@@ -47,5 +47,18 @@ class Exx_NAO
 
 };
 
+#ifdef __EXX
+/**
+ * @brief Broadcast the ABFS/JLE orbital-file lists held in the global Exx_Info instance.
+ *
+ * The lists are read from STRU on rank 0 during setup_cell and must be
+ * distributed to all ranks before the LCAO EXX/RI module consumes them.
+ * This logic lives here (rather than in source_cell or the generic XC module)
+ * because the ABFS/JLE orbital files are an LCAO-only concept. It is invoked at
+ * the start of Exx_NAO::init(), before Exx_LRI copies info_ri.
+ */
+void bcast_exx_file_lists();
+#endif
+
 
 #endif


### PR DESCRIPTION
## Background

Fixes #7635.

`source_cell` is a data-structure layer that should not depend on a higher layer. `bcast_cell.cpp` violated this by reaching into `GlobalC::exx_info` (owned by `source_hamilt/module_xc`) to broadcast the ABFS/JLE orbital-file lists:

```cpp
#include "source_hamilt/module_xc/exx_info.h" // use GlobalC::exx_info
...
bcast_string_vector(GlobalC::exx_info.info_ri.files_abfs);
bcast_string_vector(GlobalC::exx_info.info_opt_abfs.files_abfs);
bcast_string_vector(GlobalC::exx_info.info_opt_abfs.files_jles);
```

## Data lifecycle

These lists live in `GlobalC::exx_info` and flow:

1. **Populate** (rank 0): `source_cell/read_atom_species.cpp` parses `ABFS_ORBITAL` / `ABFS_JLES_ORBITAL` from STRU during `setup_cell`.
2. **Broadcast** (all ranks): previously in `bcast_cell.cpp` — the coupling this PR removes.
3. **Consume**: the LCAO EXX/RI code — `Exx_LRI` (RI-EXX), `Exx_Opt_Orb::generate_matrix` (opt-ABFs), `RPA_LRI::postSCF` (RPA).

## Change

The ABFS/JLE orbital files are an **LCAO-only** concept, so the broadcast belongs with the LCAO EXX manager, not in `source_cell` or the generic XC module:

- Add `bcast_exx_file_lists()` in `source_lcao/setup_exx.{h,cpp}`.
- Invoke it at the **start of `Exx_NAO::init()`**, before `Exx_LRI` copies `info_ri`.
- Remove the `exx_info.h` include, the `bcast_string_vector` helper, and the three broadcast calls from `bcast_cell.cpp`.

`Exx_NAO::init()` is called from `ESolver_KS_LCAO::before_all_runners` — reused by TDDFT / DM2rho / DoubleXC (they call the base), while LR reuses the already-built `Exx_LRI` via `move_exx_lri`. It runs on all ranks, after `setup_cell` populated the lists on rank 0 (driver calls `setup_cell` before `before_all_runners`), and before every consumer:

- RI-EXX: the `Exx_LRI` copy of `info_ri` happens right after the broadcast inside `init()`.
- opt-ABFs: `generate_matrix` runs later in the same `before_all_runners`.
- RPA: `RPA_LRI(GlobalC::exx_info.info_ri)` is built in `ctrl_scf_lcao` during the SCF run, after `before_all_runners`.

After this, `bcast_cell.cpp` no longer depends on any higher layer.

## Behaviour

Preserved. The broadcast still runs after the rank-0 populate and before any EXX consumption. The previous per-ionic-step re-broadcast (via `bcast_unitcell` in `update_cell.cpp` during relax/MD) is dropped, which is behaviour-neutral because the file lists are static once read from STRU.

Because `__EXX` implies `__LCAO` (LibRI requires `ENABLE_LCAO`), `setup_exx.cpp` is always built whenever the broadcast is compiled.

## Verification

- Repo-wide grep confirms `bcast_cell.cpp` has no remaining `exx`/`GlobalC` reference; the only remaining `exx_info` user in `source_cell` is `read_atom_species.cpp` (write side — see note).
- `g++ -std=c++14 -fsyntax-only` passes on the broadcast function body compiled against the real `exx_info` structs (MPI headers stubbed locally). `setup_exx.cpp` itself pulls LibRI/cereal and so is exercised by CI rather than locally.

## Note (out of scope)

The **write side** — `source_cell/read_atom_species.cpp` parsing the ABFS STRU sections into `GlobalC::exx_info` — still couples `source_cell` to the XC layer. #7635 is specifically about the broadcast in `bcast_cell.cpp`; moving the ABFS STRU-section parsing out of `source_cell` is larger and best handled as a follow-up.

## Global dependency budget (governance)

This PR is migration-neutral for the `GlobalV::`/`GlobalC::`/`PARAM` budget: the three `GlobalC::exx_info` broadcast calls are **moved** from `bcast_cell.cpp` to `setup_exx.cpp` (-3/+3, net zero in code), and `source_cell` is fully decoupled from the XC layer. No new global-state coupling is introduced.
