### PR TITLE
Fix missing direct includes in cuSolverMp diagonalizer

### DIFF
--- a/source/source_hsolver/diago_cusolvermp.cpp
+++ b/source/source_hsolver/diago_cusolvermp.cpp
@@ -3,7 +3,9 @@
 #include "source_io/module_parameter/parameter.h"
 #include "diago_cusolvermp.h"
 
+#include "source_base/module_external/blas_connector.h"
 #include "source_base/timer.h"
+#include "source_base/tool_title.h"
 
 using complex = std::complex<double>;
 


### PR DESCRIPTION
## Summary

- Include the declarations for `BlasConnector::copy()` and `ModuleBase::TITLE()` directly in `diago_cusolvermp.cpp`.
- Normalize the file-ending newline.

This keeps the cuSolverMp translation unit self-contained when `ENABLE_CUSOLVERMP=ON`. Regular CUDA builds do not compile this source unless that option is enabled.

## Build evidence

Before this change:

- Source: `f76b1a142c1ac9d3278b9e61a83edb38958c9f5d`
- [GitHub Actions run 29856565766](https://github.com/Stardust0831/abacus-develop/actions/runs/29856565766), [build job 88722259940](https://github.com/Stardust0831/abacus-develop/actions/runs/29856565766/job/88722259940)
- Slurm build job `690178`: `FAILED 2:0`
- Compilation failed because `ModuleBase::TITLE` and `BlasConnector` were undeclared.

After the equivalent source change:

- Source: `f4371be793b082631355727306700dd84efcc229`
- [GitHub Actions run 29870141313](https://github.com/Stardust0831/abacus-develop/actions/runs/29870141313), [build job 88768006168](https://github.com/Stardust0831/abacus-develop/actions/runs/29870141313/job/88768006168)
- Slurm build job `690473`: `COMPLETED 0:0`
- The log contains `Building ... diago_cusolvermp.cpp.o` and `ABACUS_BUILD_PASSED`.

The overall workflow later reported a separate SDFT numerical test failure; the cuSolverMp-enabled ABACUS build itself completed successfully.