### PR TITLE
Refactor: read EXX ABFS/JLE file lists via UnitCell, fully decouple source_cell (#7598)

### DIFF
--- a/source/source_cell/bcast_cell.cpp
+++ b/source/source_cell/bcast_cell.cpp
@@ -6,6 +6,20 @@
 
 namespace unitcell
 {
+#ifdef __MPI
+    // Broadcast a vector<string> (size then elements) from rank 0 to all ranks.
+    static void bcast_string_vector(std::vector<std::string>& v)
+    {
+        int size = static_cast<int>(v.size());
+        Parallel_Common::bcast_int(size);
+        v.resize(size);
+        for (int i = 0; i < size; ++i)
+        {
+            Parallel_Common::bcast_string(v[i]);
+        }
+    }
+#endif
+
     void bcast_atoms_tau(Atom* atoms,
                          const int ntype)
     {
@@ -112,6 +126,10 @@ namespace unitcell
         {
             Parallel_Common::bcast_string(ucell.orbital_fn[i]);
         }
+
+        // ABFS/JLE orbital-file lists (read from STRU on rank 0, used by LCAO EXX)
+        bcast_string_vector(ucell.abfs_orbital_files);
+        bcast_string_vector(ucell.jle_orbital_files);
         return;
     #endif
     }

--- a/source/source_cell/read_atom_species.cpp
+++ b/source/source_cell/read_atom_species.cpp
@@ -3,7 +3,6 @@
 #include <sstream>
 
 #include "source_base/tool_title.h"
-#include "source_hamilt/module_xc/exx_info.h" // use GlobalC::exx_info
 
 namespace unitcell
 {
@@ -106,33 +105,27 @@ bool read_atom_species(std::ifstream& ifa,
     }
 #ifdef __LCAO
     // Peize Lin add 2016-09-23
-#ifdef __MPI 
-#ifdef __EXX
-    if( GlobalC::exx_info.info_global.cal_exx || rpa )
+    // Read the ABFS/JLE orbital filenames (used by LCAO EXX) into the UnitCell.
+    // The EXX layer copies these into the global Exx_Info during its own setup, so
+    // source_cell does not depend on the XC module. Absent sections are no-ops.
+    if( ModuleBase::GlobalFunc::SCAN_LINE_BEGIN(ifa, "ABFS_ORBITAL") )
     {
-        if( ModuleBase::GlobalFunc::SCAN_LINE_BEGIN(ifa, "ABFS_ORBITAL") )
+        for(int i=0; i<ntype; i++)
         {
-            for(int i=0; i<ntype; i++)
-            {
-                std::string ofile;
-                ifa >> ofile;
-                GlobalC::exx_info.info_ri.files_abfs.push_back(ofile);
-                GlobalC::exx_info.info_opt_abfs.files_abfs.push_back(ofile);
-            }
-        }
-        if( ModuleBase::GlobalFunc::SCAN_LINE_BEGIN(ifa, "ABFS_JLES_ORBITAL") )
-        {
-            for(int i=0; i<ntype; i++)
-            {
-                std::string ofile;
-                ifa >> ofile;
-                GlobalC::exx_info.info_opt_abfs.files_jles.push_back(ofile);
-            }
+            std::string ofile;
+            ifa >> ofile;
+            ucell.abfs_orbital_files.push_back(ofile);
         }
     }
-
-#endif // __EXX
-#endif // __MPI
+    if( ModuleBase::GlobalFunc::SCAN_LINE_BEGIN(ifa, "ABFS_JLES_ORBITAL") )
+    {
+        for(int i=0; i<ntype; i++)
+        {
+            std::string ofile;
+            ifa >> ofile;
+            ucell.jle_orbital_files.push_back(ofile);
+        }
+    }
 #endif // __LCAO
     return true;
 }

--- a/source/source_cell/unitcell.h
+++ b/source/source_cell/unitcell.h
@@ -233,6 +233,8 @@ class UnitCell : public AtomProvider {
 
     std::vector<std::string> orbital_fn;  // filenames of orbitals, liuyu add 2022-10-19
     std::string  descriptor_file; // filenames of descriptor_file, liuyu add 2023-04-06
+    std::vector<std::string> abfs_orbital_files; // ABFS orbital filenames read from STRU "ABFS_ORBITAL" (used by LCAO EXX)
+    std::vector<std::string> jle_orbital_files;  // JLE orbital filenames read from STRU "ABFS_JLES_ORBITAL" (used by LCAO EXX)
 
     void set_iat2itia();
 

--- a/source/source_esolver/esolver_ks_lcao.cpp
+++ b/source/source_esolver/esolver_ks_lcao.cpp
@@ -53,7 +53,7 @@ void ESolver_KS_LCAO<TK, TR>::before_all_runners(UnitCell& ucell, const Input_pa
     ModuleBase::timer::start("ESolver_KS_LCAO", "before_all_runners");
 
     // 0) init EXX - moved from constructor to ensure GlobalC::exx_info.info_global is already set
-    this->exx_nao.init();
+    this->exx_nao.init(ucell);
 
     // 1) before_all_runners in ESolver_KS
     ESolver_KS::before_all_runners(ucell, inp);

--- a/source/source_lcao/setup_exx.cpp
+++ b/source/source_lcao/setup_exx.cpp
@@ -3,41 +3,6 @@
 #ifdef __EXX
 #include "source_lcao/module_ri/Exx_LRI_interface.h"
 #include "source_hamilt/module_xc/exx_info.h" // use the global Exx_Info
-#if defined(__MPI)
-#include "source_base/parallel_common.h"
-#include <string>
-#include <vector>
-#endif
-#endif
-
-#ifdef __EXX
-#if defined(__MPI)
-namespace
-{
-    // Broadcast a vector<string> from rank 0 to all ranks.
-    // Moved here from source_cell/bcast_cell.cpp so that source_cell no longer
-    // depends on the XC module just to distribute these ABFS file-name lists.
-    void bcast_string_vector(std::vector<std::string>& v)
-    {
-        int size = static_cast<int>(v.size());
-        Parallel_Common::bcast_int(size);
-        v.resize(size);
-        for (int i = 0; i < size; ++i)
-        {
-            Parallel_Common::bcast_string(v[i]);
-        }
-    }
-} // namespace
-#endif
-
-void bcast_exx_file_lists()
-{
-#if defined(__MPI)
-    bcast_string_vector(GlobalC::exx_info.info_ri.files_abfs);
-    bcast_string_vector(GlobalC::exx_info.info_opt_abfs.files_abfs);
-    bcast_string_vector(GlobalC::exx_info.info_opt_abfs.files_jles);
-#endif
-}
 #endif
 
 template <typename TK>
@@ -48,7 +13,7 @@ Exx_NAO<TK>::~Exx_NAO(){}
 
 
 template <typename TK>
-void Exx_NAO<TK>::init()
+void Exx_NAO<TK>::init(const UnitCell& ucell)
 {
 #ifdef __EXX
     // 1. currently this initialization must be put in constructor rather than `before_all_runners()`
@@ -57,9 +22,13 @@ void Exx_NAO<TK>::init()
     // 2. always construct but only initialize when if(cal_exx) is true
     //  because some members like two_level_step are used outside if(cal_exx)
 
-    // Distribute the ABFS/JLE file lists (read from STRU on rank 0) to all ranks
-    // before Exx_LRI copies info_ri below.
-    bcast_exx_file_lists();
+    // The ABFS/JLE orbital-file lists are read from STRU into the UnitCell (and
+    // broadcast with it). Copy them into the EXX info here, before Exx_LRI copies
+    // info_ri below. This keeps the EXX-specific routing (which list feeds info_ri
+    // vs info_opt_abfs) in the LCAO EXX layer, so source_cell stays decoupled.
+    GlobalC::exx_info.info_ri.files_abfs = ucell.abfs_orbital_files;
+    GlobalC::exx_info.info_opt_abfs.files_abfs = ucell.abfs_orbital_files;
+    GlobalC::exx_info.info_opt_abfs.files_jles = ucell.jle_orbital_files;
 
     if (GlobalC::exx_info.info_ri.real_number)
     {

--- a/source/source_lcao/setup_exx.h
+++ b/source/source_lcao/setup_exx.h
@@ -28,7 +28,7 @@ class Exx_NAO
     std::shared_ptr<Exx_LRI_Interface<TK, std::complex<double>>> exc = nullptr;
 #endif
 
-    void init();
+    void init(const UnitCell& ucell);
 
 	void before_runner(
 			UnitCell& ucell, // unitcell
@@ -46,19 +46,6 @@ class Exx_NAO
 			const Input_para& inp);
 
 };
-
-#ifdef __EXX
-/**
- * @brief Broadcast the ABFS/JLE orbital-file lists held in the global Exx_Info instance.
- *
- * The lists are read from STRU on rank 0 during setup_cell and must be
- * distributed to all ranks before the LCAO EXX/RI module consumes them.
- * This logic lives here (rather than in source_cell or the generic XC module)
- * because the ABFS/JLE orbital files are an LCAO-only concept. It is invoked at
- * the start of Exx_NAO::init(), before Exx_LRI copies info_ri.
- */
-void bcast_exx_file_lists();
-#endif
 
 
 #endif


### PR DESCRIPTION
## Background

Related to #7598 (source_cell should not depend back on higher layers).

After the earlier cleanups (#7633/#7636/#7637 relocations, #7635 broadcast move), the **only** remaining reverse dependency in non-test `source_cell` was:

```
source/source_cell/read_atom_species.cpp
    #include "source_hamilt/module_xc/exx_info.h"   // writes GlobalC::exx_info
```

`read_atom_species` parsed the STRU `ABFS_ORBITAL` / `ABFS_JLES_ORBITAL` sections and pushed the filenames straight into `GlobalC::exx_info.info_ri` / `info_opt_abfs` — the STRU parser (geometry layer) writing into the XC module's global state.

## Change

Route the lists through `UnitCell`, where STRU orbital-file names already live (`orbital_fn`, `descriptor_file`):

- `UnitCell` gains neutral members `abfs_orbital_files` / `jle_orbital_files`.
- `read_atom_species` parses the sections into those members; the `exx_info.h` include and the `cal_exx || rpa` guard are removed (an absent section is a no-op via `SCAN_LINE_BEGIN`).
- `bcast_cell` broadcasts the two members as part of `bcast_unitcell`.
- `Exx_NAO::init(ucell)` copies them into `GlobalC::exx_info` before `Exx_LRI` copies `info_ri`, keeping the EXX-specific routing (which list feeds `info_ri` vs `info_opt_abfs`) in the LCAO EXX layer.

Data flow:
```
read_atom_species → UnitCell members → bcast_unitcell (all ranks) → Exx_NAO::init copies → exx_info → Exx_LRI / opt-ABFs / RPA
```

Because the lists now travel inside the already-broadcast `UnitCell`, the dedicated `bcast_exx_file_lists()` added in #7635 is redundant and removed.

## Result

`source_cell` (non-test) now `#include`s only `source_base` and itself — the reverse-dependency goal of #7598 is met. (Test files still cross layers to build fixtures, which is conventional.)

## Timing / correctness

`init(ucell)` runs in `ESolver_KS_LCAO::before_all_runners` (reused by TDDFT / DM2rho / DoubleXC; LR reuses the moved `Exx_LRI`), on all ranks, after `driver_run` has called `setup_cell` (which reads STRU on rank 0 and broadcasts `UnitCell`), and before every consumer:
- RI-EXX: the copy is immediately before `Exx_LRI` copies `info_ri`.
- opt-ABFs: `generate_matrix` runs later in the same `before_all_runners`.
- RPA: `RPA_LRI(GlobalC::exx_info.info_ri)` is built during SCF, later still.

Behaviour is preserved. The `cal_exx` guard removal is a no-op in practice: when EXX/RPA is off the ABFS lists are simply unused (Exx_LRI is constructed but not run).

## Verification

- Repo-wide grep: non-test `source_cell` has no remaining `exx_info`/`GlobalC::exx` reference; no dangling `bcast_exx_file_lists`.
- `g++ -std=c++14 -fsyntax-only` passes on `read_atom_species.cpp` (with `__LCAO`), `bcast_cell.cpp` (with `__MPI`, stubbed `mpi.h`), and the `init()` copy logic compiled against the real `exx_info` + `UnitCell` structs. `setup_exx.cpp`/esolver pull LibRI and are exercised by CI.
- No unit test asserts on the ABFS lists and no STRU fixture contains the sections, so no test behaviour changes.

## Minor note

The now-unused `rpa` parameter of `read_atom_species` is left in place to avoid rippling the `setup_cell` signature; it can be dropped in a follow-up.