### PR TITLE
Fix: Prevent MPI communicator growth in LCAO matrix output

### DIFF
--- a/source/source_io/module_dhs/write_dH.cpp
+++ b/source/source_io/module_dhs/write_dH.cpp
@@ -48,7 +48,6 @@ void write_dh_perI(WriteDHParams& params,
 
 #ifdef __MPI
     Parallel_Orbitals serialV;
-    serialV.init(nbasis, nbasis, nbasis, pv.comm());
     serialV.set_serial(nbasis, nbasis);
     serialV.set_atomic_trace(params.iat2iwt, nat, nbasis);
 #endif

--- a/source/source_io/module_dm/write_dmr.cpp
+++ b/source/source_io/module_dm/write_dmr.cpp
@@ -95,7 +95,6 @@ void write_dmr(const std::vector<hamilt::HContainer<double>*> dmr,
         // gather the parallel matrix to serial matrix
 #ifdef __MPI
         Parallel_Orbitals serialV;
-        serialV.init(nbasis, nbasis, nbasis, paraV.comm());
         serialV.set_serial(nbasis, nbasis);
         serialV.set_atomic_trace(iat2iwt, nat, nbasis);
         hamilt::HContainer<double> dm_serial(&serialV);

--- a/source/source_io/module_hs/write_HS_R.cpp
+++ b/source/source_io/module_hs/write_HS_R.cpp
@@ -316,7 +316,6 @@ void ModuleIO::write_hsr(const std::vector<hamilt::HContainer<TR>*>& hr_vec,
 
 #ifdef __MPI
         Parallel_Orbitals serialV;
-        serialV.init(nbasis, nbasis, nbasis, paraV.comm());
         serialV.set_serial(nbasis, nbasis);
         serialV.set_atomic_trace(iat2iwt, nat, nbasis);
         hamilt::HContainer<TR> hr_serial(&serialV);
@@ -339,7 +338,6 @@ void ModuleIO::write_hsr(const std::vector<hamilt::HContainer<TR>*>& hr_vec,
 
 #ifdef __MPI
         Parallel_Orbitals serialV;
-        serialV.init(nbasis, nbasis, nbasis, paraV.comm());
         serialV.set_serial(nbasis, nbasis);
         serialV.set_atomic_trace(iat2iwt, nat, nbasis);
         hamilt::HContainer<TR> sr_serial(&serialV);
@@ -410,7 +408,6 @@ void ModuleIO::write_matrix_r(const std::string& matrix_label,
         // Gather parallel matrix to serial
 #ifdef __MPI
         Parallel_Orbitals serialV;
-        serialV.init(nbasis, nbasis, nbasis, paraV.comm());
         serialV.set_serial(nbasis, nbasis);
         serialV.set_atomic_trace(iat2iwt, nat, nbasis);
         

--- a/source/source_io/module_hs/write_H_terms.cpp
+++ b/source/source_io/module_hs/write_H_terms.cpp
@@ -78,7 +78,6 @@ static void gather_and_write(const std::string& prefix,
     const int nbasis = hR.get_nbasis();
 #ifdef __MPI
     Parallel_Orbitals serialV;
-    serialV.init(nbasis, nbasis, nbasis, pv.comm());
     serialV.set_serial(nbasis, nbasis);
     serialV.set_atomic_trace(iat2iwt, nat, nbasis);
     hamilt::HContainer<double> hr_serial(&serialV);

--- a/source/source_lcao/module_deepks/LCAO_deepks_interface.cpp
+++ b/source/source_lcao/module_deepks/LCAO_deepks_interface.cpp
@@ -528,7 +528,6 @@ void LCAO_Deepks_Interface<TK, TR>::out_deepks_labels(const double& etot,
                 const int nbasis = hR_tot->get_nbasis();
 #ifdef __MPI
                 Parallel_Orbitals serialV;
-                serialV.init(nbasis, nbasis, nbasis, ParaV->comm());
                 serialV.set_serial(nbasis, nbasis);
                 serialV.set_atomic_trace(ucell.get_iat2iwt(), ucell.nat, nbasis);
                 hamilt::HContainer<TR> hR_serial(&serialV);

--- a/source/source_lcao/module_operator_lcao/overlap.cpp
+++ b/source/source_lcao/module_operator_lcao/overlap.cpp
@@ -413,11 +413,9 @@ void hamilt::Overlap<hamilt::OperatorLCAO<TK, TR>>::output_SR_async_csr(const in
 
 #ifdef __MPI
     // Gather distributed SR_async to rank 0 for serial output
-    const Parallel_Orbitals* paraV = SR_async->get_paraV();
     const int nbasis = SR_async->get_nbasis();
 
     Parallel_Orbitals serial_paraV;
-    serial_paraV.init(nbasis, nbasis, nbasis, paraV->comm());
     serial_paraV.set_serial(nbasis, nbasis);
     serial_paraV.set_atomic_trace(this->ucell->get_iat2iwt(), this->ucell->nat, nbasis);
 


### PR DESCRIPTION
### What's changed?

This bug was discovered by @ESROAMER when an LCAO RT-TDDFT calculation failed at approximately electronic step 2370 with:

```text
Too many communicators (0/32768 free on this process; ignore_id=0)
```

LCAO matrix-output code created a temporary BLACS process grid for each serial gather and then immediately called `set_serial()`. `set_serial()` overwrote the BLACS context with `-1`, so the temporary context could no longer be released. Repeated DMR or H/S(R) output during RT-TDDFT therefore consumed MPI communicator contexts until MPI failed.

The affected output paths now construct their temporary `Parallel_Orbitals` distributions directly with `set_serial()`. This is sufficient for `gatherParallels()`, which performs the data transfer independently of a BLACS context. The same redundant pattern was removed from DMR, H/S(R), derivative-H, decomposed-H, DeePKS H(R), and asynchronous-overlap output paths.

There is no change to matrix values, output formats, filenames, output frequency semantics, numerical solver behavior, or INPUT parameters.

### Unit Tests and/or Case Tests for my changes

<img width="2479" height="976" alt="image" src="https://github.com/user-attachments/assets/9241c55e-e6c8-474d-aef5-03821d902158" />

The figure is plotted directly from the PMPI logs. In two-rank, nine-step RT-TDDFT runs, DMR and H/S(R) output previously added 4 and 8 live communicators per electronic step, respectively, or 12 when combined. After the fix, all output cases match the control and finish with `created=41, freed=41, live=0` on each rank.

The generated DMR and H/S(R) CSR files are byte-for-byte unchanged.

### Governance Notes

- INPUT/docs changes: None.
- Core module impact: The numerical ESolver, HSolver, ElecState, Hamilt, and Psi paths are unchanged. The only operator-side change is in the optional asynchronous-overlap CSR output path.
- Exceptions requested: None.
