### PR TITLE
Refactor: remove source_lcao dependency from source_hsolver

### DIFF
--- a/source/source_estate/elecstate_lcao.cpp
+++ b/source/source_estate/elecstate_lcao.cpp
@@ -7,6 +7,7 @@
 #include "source_io/module_parameter/parameter.h"
 
 #include "source_lcao/module_gint/gint_interface.h"
+#include "source_lcao/rho_tau_lcao.h"
 
 #include <vector>
 
@@ -83,6 +84,15 @@ void ElecStateLCAO<std::complex<double>>::dm2rho(std::vector<std::complex<double
     ModuleBase::WARNING_QUIT("ElecStateLCAO", "pexsi is not completed for multi-k case");
 }
 
+
+template <typename TK>
+void ElecStateLCAO<TK>::dmToRho(std::vector<hamilt::HContainer<double>*>& dmr,
+                                int nspin,
+                                Charge* chr,
+                                bool skip_charge)
+{
+    LCAO_domain::dm2rho(dmr, nspin, chr, skip_charge);
+}
 
 template class ElecStateLCAO<double>;               // Gamma_only case
 template class ElecStateLCAO<std::complex<double>>; // multi-k case

--- a/source/source_estate/elecstate_lcao.h
+++ b/source/source_estate/elecstate_lcao.h
@@ -39,9 +39,22 @@ class ElecStateLCAO : public ElecState
      * @param pexsi_EDM: pointers of energy-weighed density matrix (EDMK) calculated by pexsi, needed by MD, will be
      * stored in DensityMatrix::pexsi_EDM
      */
-	void dm2rho(std::vector<TK*> pexsi_DM, 
-			std::vector<TK*> pexsi_EDM, 
+	void dm2rho(std::vector<TK*> pexsi_DM,
+			std::vector<TK*> pexsi_EDM,
 			DensityMatrix<TK, double>* dm);
+
+    /**
+     * @brief calculate electronic charge density from the density matrix (DMR)
+     *
+     * Thin wrapper over LCAO_domain::dm2rho so that HSolverLCAO delegates the
+     * charge-density calculation through the ElecState interface, mirroring the
+     * plane-wave path (ElecStatePW::psiToRho) and the pexsi branch above. This
+     * keeps the source_lcao dependency out of source_hsolver.
+     */
+    void dmToRho(std::vector<hamilt::HContainer<double>*>& dmr,
+                 int nspin,
+                 Charge* chr,
+                 bool skip_charge = false);
 
 };
 

--- a/source/source_hsolver/hsolver_lcao.cpp
+++ b/source/source_hsolver/hsolver_lcao.cpp
@@ -35,8 +35,6 @@
 #include "source_hsolver/parallel_k2d.h"
 #include "source_io/module_parameter/parameter.h"
 
-#include "source_lcao/rho_tau_lcao.h" // mohan add 20251024
-
 namespace hsolver
 {
 
@@ -103,7 +101,9 @@ void HSolverLCAO<TK, Device>::solve(hamilt::Hamilt<TK>* pHamilt,
         if (!skip_charge)
         {
             // compute charge density from density matrix, mohan update 20251024
-            LCAO_domain::dm2rho(dm.get_DMR_vector(), nspin, &chr);
+            // delegate to ElecStateLCAO to keep the source_lcao dependency out of
+            // source_hsolver (mirrors the pexsi branch below and the PW psiToRho path)
+            dynamic_cast<elecstate::ElecStateLCAO<TK>*>(pes)->dmToRho(dm.get_DMR_vector(), nspin, &chr);
         }
         else
         {


### PR DESCRIPTION
## Background

As part of dependency cleanup for `source_hsolver`, the target is to keep it depending only on `source_estate`, `source_psi`, `source_cell`, `source_basis`, and `source_base` (`source_io` tolerated for now).

A scan showed one direct dependency on `source_lcao`:

- `source/source_hsolver/hsolver_lcao.cpp` → `#include "source_lcao/rho_tau_lcao.h"`, used to call `LCAO_domain::dm2rho` for computing the charge density after solving the Hamiltonian.

## Change

`HSolverLCAO::solve` now delegates the charge-density calculation through a new thin wrapper `ElecStateLCAO::dmToRho`, instead of calling the `source_lcao` free function directly.

- `source_estate/elecstate_lcao.{h,cpp}`: add `dmToRho(...)`, forwarding to `LCAO_domain::dm2rho`. `source_estate` already depends on `source_lcao` (e.g. `module_gint`, `rho_tau_lcao.h`), so this introduces **no new cross-module dependency edge**.
- `source_hsolver/hsolver_lcao.cpp`: call `dynamic_cast<ElecStateLCAO<TK>*>(pes)->dmToRho(...)` and remove the `source_lcao` include.

This mirrors the existing patterns in the codebase:
- the pexsi branch in the same function already delegates via `_pes->dm2rho(...)`;
- the plane-wave path delegates charge computation via `ElecStatePW::psiToRho`.

After this change, `source_hsolver` has no direct `source_lcao` include or `LCAO_domain` reference.

## Notes

- **No functional change** — pure dependency refactor; the same `LCAO_domain::dm2rho` is executed, just reached through the `ElecState` interface.
- The `dynamic_cast` precondition (`pes` is an `ElecStateLCAO` on the LCAO path) is already relied upon by the pre-existing pexsi branch.