### PR TITLE
CMake: Move global compiler flags to target options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,21 +317,10 @@ if(ENABLE_ASAN)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo")
 endif()
 
-if(NOT CMAKE_BUILD_TYPE AND NOT MSVC)
-  add_compile_options(-O3 -g)
-endif()
-
 if(CMAKE_CXX_COMPILER_ID MATCHES Intel)
-  # stick to strict floating point model on Intel Compiler
-  add_compile_options(-fp-model=strict)
-  set(ENABLE_ABACUS_LIBM OFF) # Force turn off ENABLE_ABACUS_LIBM on Intel Compiler
-  set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} -Wno-write-strings "
-  )
-endif()
-
-if(ENABLE_NATIVE_OPTIMIZATION)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -mtune=native")
+  # Force turn off ENABLE_ABACUS_LIBM on Intel Compiler
+  message(WARNING "ENABLE_ABACUS_LIBM is not available with Intel compilers; switching it off")
+  set(ENABLE_ABACUS_LIBM OFF)
 endif()
 
 if(ENABLE_LCAO)
@@ -476,12 +465,6 @@ if(USE_CUDA)
   endif()
   enable_language(CUDA)
   if(USE_CUDA)
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-      set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -g -G" CACHE STRING "CUDA flags for debug build" FORCE)
-    endif()
-    if (ENABLE_OPENMP AND OpenMP_CXX_FOUND)
-      set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=${OpenMP_CXX_FLAGS}" CACHE STRING "CUDA flags" FORCE)
-    endif()
     if (ENABLE_NCCL_PARALLEL_DEVICE)
       include(cmake/modules/SetupNccl.cmake)
       abacus_setup_nccl()

--- a/cmake/CompilerConfiguration.cmake
+++ b/cmake/CompilerConfiguration.cmake
@@ -1,0 +1,47 @@
+include(CheckCXXCompilerFlag)
+
+# Match the existing fallback when no build type is specified, but keep the
+# options scoped to ABACUS targets.
+if(NOT CMAKE_BUILD_TYPE AND NOT MSVC)
+  target_compile_options(abacus_compile_requirements INTERFACE -O3 -g)
+endif()
+
+target_compile_options(abacus_compile_requirements INTERFACE
+  "$<$<COMPILE_LANG_AND_ID:CXX,Intel,IntelLLVM>:-fp-model=strict;-Wno-write-strings>")
+
+if(ENABLE_NATIVE_OPTIMIZATION AND NOT CMAKE_CROSSCOMPILING)
+  set(_abacus_native_candidates)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+     OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(_abacus_native_candidates -march=native -mcpu=native)
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
+    set(_abacus_native_candidates -xHOST)
+  endif()
+  foreach(_flag IN LISTS _abacus_native_candidates)
+    string(MAKE_C_IDENTIFIER "ABACUS_HAS_${_flag}" _var)
+    check_cxx_compiler_flag("${_flag}" ${_var})
+    if(${_var})
+      target_compile_options(abacus_compile_requirements INTERFACE
+        "$<$<COMPILE_LANGUAGE:CXX>:${_flag}>")
+      break()
+    endif()
+  endforeach()
+endif()
+
+if(USE_CUDA)
+  target_compile_options(abacus_compile_requirements INTERFACE
+    "$<$<AND:$<CONFIG:Debug>,$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>>:-g;-G>")
+  if(ENABLE_OPENMP AND OpenMP_CXX_FOUND)
+    separate_arguments(_abacus_openmp_cxx_flags NATIVE_COMMAND
+                       "${OpenMP_CXX_FLAGS}")
+    foreach(_flag IN LISTS _abacus_openmp_cxx_flags)
+      target_compile_options(abacus_compile_requirements INTERFACE
+        "$<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:-Xcompiler=${_flag}>")
+    endforeach()
+  endif()
+endif()
+
+unset(_abacus_native_candidates)
+unset(_abacus_openmp_cxx_flags)
+unset(_flag)
+unset(_var)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -27,6 +27,7 @@
 # complete link closure below.
 add_library(abacus_compile_requirements INTERFACE)
 add_library(abacus::compile_requirements ALIAS abacus_compile_requirements)
+include(CompilerConfiguration)
 
 set(_abacus_feature_definitions
   __FFTW3


### PR DESCRIPTION
Modifying `CMAKE_<LANG>_FLAGS` within project CMake code is widely considered a big no-no. These variables are global user and toolchain configuration inputs: changing them affects every target, may also affect compiler-driven link commands, and can unexpectedly interfere with flags supplied through the command line, presets, or toolchain files. Modifying cached values with `FORCE` is particularly problematic because it overrides user configuration.

This PR moves the project-defined compiler options to the existing `abacus_compile_requirements` interface target and applies them through `target_compile_options()`. This keeps the options target-scoped and allows them to be restricted by language, compiler, and build configuration.

The compiler-specific logic is collected in `cmake/CompilerConfiguration.cmake`, which also provides a central place for broader compiler support and future extensions, although changes to this file should be made with care.

The native optimization handling is also made more portable:

- GNU and Clang-based compilers try `-march=native`, followed by `-mcpu=native`.
- Intel compilers try `-xHost`.
- Only the first supported option is applied.
- Native optimization is skipped when cross-compiling.

This replaces the previous unconditional use of `-march=native -mtune=native`, which is not portable across compiler families and target architectures.