### PR TITLE
CMake: migrate cuSolverMp feature definitions after #7671

### DIFF
--- a/cmake/modules/SetupCuBlasMp.cmake
+++ b/cmake/modules/SetupCuBlasMp.cmake
@@ -5,8 +5,6 @@
 include_guard(GLOBAL)
 
 function(abacus_setup_cublasmp)
-  abacus_add_feature_definitions(__CUBLASMP)
-
   # 1. Search for cuBLASMp library and header files
   # libcublasmp.so
   find_library(CUBLASMP_LIBRARY NAMES cublasmp

--- a/cmake/modules/SetupCuSolverMp.cmake
+++ b/cmake/modules/SetupCuSolverMp.cmake
@@ -5,8 +5,6 @@
 include_guard(GLOBAL)
 
 function(abacus_setup_cusolvermp)
-  abacus_add_feature_definitions(__CUSOLVERMP)
-
   # Find cuSOLVERMp first, then decide communicator backend.
   find_library(CUSOLVERMP_LIBRARY NAMES cusolverMp
       HINTS ${CAL_CUSOLVERMP_PATH} ${NVHPC_ROOT_DIR}
@@ -82,8 +80,6 @@ function(abacus_setup_cusolvermp)
   # - _use_cal=ON  -> cal communicator backend
   # - _use_cal=OFF -> NCCL communicator backend
   if(_use_cal)
-    abacus_add_feature_definitions(__USE_CAL)
-
     find_library(CAL_LIBRARY NAMES cal
         HINTS ${CAL_CUSOLVERMP_PATH} ${NVHPC_ROOT_DIR}
         PATH_SUFFIXES lib lib64 math_libs/lib64)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -50,6 +50,9 @@ set(_abacus_feature_definitions
   $<$<BOOL:${USE_CUDA}>:__CUDA>
   $<$<BOOL:${USE_CUDA}>:__UT_USE_CUDA>
   $<$<BOOL:${ENABLE_NCCL_PARALLEL_DEVICE}>:__NCCL_PARALLEL_DEVICE>
+  $<$<BOOL:${ENABLE_CUSOLVERMP}>:__CUSOLVERMP>
+  $<$<BOOL:${ENABLE_CUBLASMP}>:__CUBLASMP>
+  $<$<BOOL:${_use_cal}>:__USE_CAL>
   $<$<BOOL:${USE_ROCM}>:__ROCM>
   $<$<BOOL:${USE_ROCM}>:__UT_USE_ROCM>
   $<$<BOOL:${USE_ROCM}>:__HIP_PLATFORM_HCC__>


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have linked an issue or explained why this PR does not need one.
- [x] I have added adequate unit tests and/or case tests, or explained why not.
- [x] I have listed the exact verification commands run and their results.
- [x] I have described user-visible behavior changes, including INPUT parameter changes.
- [x] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [x] I have requested any needed governance exception below.

### Linked Issue
No separate issue is needed because this is a focused CMake regression introduced by #7671 with a known cause, a minimal fix, and before/after validation evidence.

### Unit Tests and/or Case Tests for my changes
- Commands run: `python3 tools/03_code_analysis/agent_governance_check.py --base upstream/develop --head HEAD --format text`; `git diff --check upstream/develop..HEAD`; a repository search for stale `abacus_add_feature_definitions` calls; and a stable patch-id comparison against validated commit `320bf1709`.
- Result summary: the governance check reported no findings, the diff check passed, no stale helper calls remain, and the current commit has the same stable patch ID as `320bf1709`. Fork run [30249299891](https://github.com/Stardust0831/abacus-develop/actions/runs/30249299891) configured, built, and installed ABACUS successfully with this patch and passed the 1-GPU, 2-GPU, and 4-GPU test groups.
- Regression evidence: fork run [30238875596](https://github.com/Stardust0831/abacus-develop/actions/runs/30238875596) failed during configuration because `SetupCuSolverMp.cmake` called the helper removed by #7671.
- Checks not run, with reason: a fresh local CMake configuration was attempted but `cmake` is not installed in the local environment; the available Docker CLI cannot access the Docker daemon. The dependency-complete SAI run above provides the end-to-end configuration and build evidence.

### What's changed?
- Remove the remaining `abacus_add_feature_definitions` calls from the cuSolverMp and cuBLASMp setup modules.
- Add `__CUSOLVERMP`, `__CUBLASMP`, and `__USE_CAL` to the centralized feature-definition list introduced by #7671, preserving the original option and backend conditions.
- Restore cuSolverMp-enabled CMake configuration without reintroducing the removed global helper.

### Governance Notes
- INPUT/docs changes: none; this change restores build configuration and does not change INPUT behavior or user-facing interfaces.
- Core module impact: none; no C++ implementation or core-module interface is changed.
- Exceptions requested: none.
