### PR TITLE
Docs: update BPCG solver guidance

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -1152,9 +1152,9 @@
   For plane-wave basis,
 
   - cg: The conjugate-gradient (CG) method.
-  - bpcg: The BPCG method, which is a block-parallel Conjugate Gradient (CG) method, typically exhibits higher acceleration in a GPU environment.
   - dav: The Davidson algorithm.
   - dav_subspace: The Davidson algorithm without orthogonalization operation, this method is the most recommended for efficiency. `pw_diag_ndim` can be set to 2 for this method.
+  - bpcg: The BPCG method, which is a block-parallel Conjugate Gradient (CG) method, typically exhibits higher acceleration in a GPU environment. The BPCG method is currently under testing and is not recommended for use.
 
   For numerical atomic orbitals basis,
 

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -533,9 +533,9 @@ parameters:
       For plane-wave basis,
 
       * cg: The conjugate-gradient (CG) method.
-      * bpcg: The BPCG method, which is a block-parallel Conjugate Gradient (CG) method, typically exhibits higher acceleration in a GPU environment.
       * dav: The Davidson algorithm.
       * dav_subspace: The Davidson algorithm without orthogonalization operation, this method is the most recommended for efficiency. `pw_diag_ndim` can be set to 2 for this method.
+      * bpcg: The BPCG method, which is a block-parallel Conjugate Gradient (CG) method, typically exhibits higher acceleration in a GPU environment. The BPCG method is currently under testing and is not recommended for use.
 
       For numerical atomic orbitals basis,
 

--- a/source/source_io/module_parameter/read_input_item_elec_stru.cpp
+++ b/source/source_io/module_parameter/read_input_item_elec_stru.cpp
@@ -53,9 +53,9 @@ void ReadInput::item_elec_stru()
 For plane-wave basis,
 
 * cg: The conjugate-gradient (CG) method.
-* bpcg: The BPCG method, which is a block-parallel Conjugate Gradient (CG) method, typically exhibits higher acceleration in a GPU environment.
 * dav: The Davidson algorithm.
 * dav_subspace: The Davidson algorithm without orthogonalization operation, this method is the most recommended for efficiency. `pw_diag_ndim` can be set to 2 for this method.
+* bpcg: The BPCG method, which is a block-parallel Conjugate Gradient (CG) method, typically exhibits higher acceleration in a GPU environment. The BPCG method is currently under testing and is not recommended for use.
 
 For numerical atomic orbitals basis,
 


### PR DESCRIPTION
### Reminder
  - [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
  - [x] I have linked an issue or explained why this PR does not need one.
  - [x] I have added adequate unit tests and/or case tests, or explained why not.
  - [x] I have listed the exact verification commands run and their results.
  - [x] I have described user-visible behavior changes, including INPUT parameter changes.
  - [x] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
  - [x] I have requested any needed governance exception below.

  ### Linked Issue
  N/A — documentation-only correction.

  ### Unit Tests and/or Case Tests for my changes
  - Commands run:
    - `cmake -B build-docs -DENABLE_MPI=OFF -DENABLE_LCAO=OFF -DBUILD_TESTING=OFF -DENABLE_LIBXC=OFF -DENABLE_DFTD4=OFF -DGIT_SUBMODULE=OFF
    -DCMAKE_BUILD_TYPE=Release`
    - `cmake --build build-docs -j8`
    - `./build-docs/abacus_pw_ser --version`
    - `./build-docs/abacus_pw_ser --generate-parameters-yaml > docs/parameters.yaml`
    - `python3 -c "import yaml; d=yaml.safe_load(open('docs/parameters.yaml')); print(len(d['parameters']), 'parameters')"`
    - `python3 docs/generate_input_main.py docs/parameters.yaml --output docs/advanced/input_files/input-main.md`
    - `./build-docs/abacus_pw_ser -h ks_solver`
    - `./build-docs/abacus_pw_ser --generate-parameters-yaml > /tmp/parameters_generated.yaml`
    - `diff -u docs/parameters.yaml /tmp/parameters_generated.yaml`
    - `python3 docs/generate_input_main.py docs/parameters.yaml --output /tmp/input-main-generated.md`
    - `diff -u docs/advanced/input_files/input-main.md /tmp/input-main-generated.md`
    - `git diff --check`
    - `git diff --cached --check`
    - `python3 tools/03_code_analysis/agent_governance_check.py --staged`
    - `python3 tools/03_code_analysis/agent_governance_check.py --base upstream/develop --head HEAD --format text`
  - Result summary:
    - Build and documentation generation passed.
    - YAML parsed successfully: `519 parameters`.
    - `input-main.md` regenerated successfully: `Total: 519 documented parameters`, `Categories: 34`.
    - CLI help for `ks_solver` shows PW order `cg`, `dav`, `dav_subspace`, `bpcg` and includes `currently under testing` / `not recommended
    for use`.
    - Regenerated YAML and Markdown matched the checked-in files.
    - Whitespace checks passed.
    - Governance checker reported only the expected test-evidence warning for a source metadata documentation change.
  - Checks not run, with reason:
    - Unit and case tests were not run because this is a documentation-only correction to INPUT metadata and does not modify solver
    implementation, input validation, defaults, or runtime behavior.

  ### What's changed?
  - Moved `bpcg` to the end of the PW `ks_solver` list, after `dav_subspace`.
  - Kept the existing GPU acceleration description.
  - Added that BPCG is currently under testing and is not recommended for use.
  - Regenerated `docs/parameters.yaml` and `docs/advanced/input_files/input-main.md`.
  - No runtime behavior or core solver logic was changed.

  ### Governance Notes
  - INPUT/docs changes:
    - Updated `ks_solver` description metadata in `source/source_io/module_parameter/read_input_item_elec_stru.cpp`.
    - Synced `docs/parameters.yaml` and `docs/advanced/input_files/input-main.md`.
  - Core module impact:
    - No core-module logic impact. The only `source/` change is INPUT help/metadata text.
  - Exceptions requested:
    - None.
