### PR TITLE
Refactor init_esolver factory interface

### DIFF
--- a/source/source_esolver/esolver.cpp
+++ b/source/source_esolver/esolver.cpp
@@ -123,7 +123,7 @@ std::string determine_type()
 }
 
 // Some API to operate E_Solver
-ESolver* init_esolver(const Input_para& inp, UnitCell& ucell)
+ESolver* init_esolver(const Input_para& inp)
 {
     // determine type of esolver based on INPUT information
     const std::string esolver_type = determine_type();
@@ -273,58 +273,25 @@ ESolver* init_esolver(const Input_para& inp, UnitCell& ucell)
     }
     else if (esolver_type == "lr_lcao")
     {
-        // use constructor rather than Init function to initialize reference (instead of pointers) to ucell
         if (PARAM.globalv.gamma_only_local)
         {
-            return new LR::ESolver_LR<double, double>(inp, ucell);
+            return new LR::ESolver_LR<double, double>(inp);
         }
         else
         {
-            return new LR::ESolver_LR<std::complex<double>, double>(inp, ucell);
+            return new LR::ESolver_LR<std::complex<double>, double>(inp);
         }
     }
     else if (esolver_type == "ksdft_lr_lcao")
     {
-        // initialize the 1st ESolver_KS
-        ModuleESolver::ESolver* p_esolver = nullptr;
         if (PARAM.globalv.gamma_only_local)
         {
-            p_esolver = new ESolver_KS_LCAO<double, double>();
-        }
-        else if (PARAM.inp.nspin < 4)
-        {
-            p_esolver = new ESolver_KS_LCAO<std::complex<double>, double>();
+            return new LR::ESolver_LR<double, double>(inp);
         }
         else
         {
-            p_esolver = new ESolver_KS_LCAO<std::complex<double>, std::complex<double>>();
+            return new LR::ESolver_LR<std::complex<double>, double>(inp);
         }
-        p_esolver->before_all_runners(ucell, inp);
-        p_esolver->runner(ucell, 0); // scf-only
-
-        // force and stress is not needed currently,
-        // they will be supported after the analytical gradient
-        // of LR-TDDFT is implemented.
-        std::cout << " PREPARING FOR EXCITED STATES." << std::endl;
-        // initialize the 2nd ESolver_LR at the temporary pointer
-	ModuleESolver::ESolver* p_esolver_lr = nullptr;
-	if (PARAM.globalv.gamma_only_local)
-	{
-		p_esolver_lr = new LR::ESolver_LR<double, double>(
-				std::move(*dynamic_cast<ModuleESolver::ESolver_KS_LCAO<double, double>*>(p_esolver)),
-				inp,
-				ucell);
-	}
-	else
-	{
-		p_esolver_lr = new LR::ESolver_LR<std::complex<double>, double>(
-				std::move(*dynamic_cast<ModuleESolver::ESolver_KS_LCAO<std::complex<double>, double>*>(p_esolver)),
-				inp,
-				ucell);
-	}
-	// clean the 1st ESolver_KS and swap the pointer
-	delete p_esolver;
-        return p_esolver_lr;
     }
 #endif
     else if (esolver_type == "ofdft")

--- a/source/source_esolver/esolver.h
+++ b/source/source_esolver/esolver.h
@@ -68,7 +68,7 @@ std::string determine_type();
  *
  * @return [out] A pointer to an ESolver object that will be initialized.
  */
-ESolver* init_esolver(const Input_para& inp, UnitCell& ucell);
+ESolver* init_esolver(const Input_para& inp);
 
 
 

--- a/source/source_lcao/module_lr/esolver_lrtd_lcao.cpp
+++ b/source/source_lcao/module_lr/esolver_lrtd_lcao.cpp
@@ -107,7 +107,7 @@ void LR::ESolver_LR<T, TR>::set_dimension()
     this->nbasis = PARAM.globalv.nlocal;
     // calculate the number of occupied and unoccupied states
     // which determines the basis size of the excited states
-    this->nocc_max = LR_Util::cal_nocc(LR_Util::cal_nelec(ucell));
+    this->nocc_max = LR_Util::cal_nocc(LR_Util::cal_nelec(*this->ucell_));
     this->nocc_in = std::max(1, std::min(input.nocc, this->nocc_max));
     this->nvirt_in = PARAM.inp.nbands - this->nocc_max;   //nbands-nocc
     if (input.nvirt > this->nvirt_in) { GlobalV::ofs_warning << "ESolver_LR: input nvirt is too large to cover by nbands, set nvirt = nbands - nocc = " << this->nvirt_in << std::endl; }
@@ -128,7 +128,7 @@ void LR::ESolver_LR<T, TR>::set_dimension()
         // calculate total number of basis funcs, see https://en.cppreference.com/w/cpp/algorithm/inner_product
         this->nbasis = std::inner_product(input.aims_nbasis.begin(), /* iterator1.begin */
                                           input.aims_nbasis.end(),  /* iterator1.end */
-                                          ucell.atoms,  /* iterator2.begin */
+                                          this->ucell_->atoms,  /* iterator2.begin */
                                           0,  /* init value */
                                           std::plus<int>(), /* iter op1 */
                                           [](const int& a, const Atom& b) { return a * b.na; }); /* iter op2 */
@@ -173,12 +173,35 @@ void LR::ESolver_LR<T, TR>::reset_dim_spin2()
 }
 
 template <typename T, typename TR>
-LR::ESolver_LR<T, TR>::ESolver_LR(ModuleESolver::ESolver_KS_LCAO<T, TR>&& ks_sol,
-    const Input_para& inp, UnitCell& ucell)
-    : input(inp), ucell(ucell)
+LR::ESolver_LR<T, TR>::ESolver_LR(const Input_para& inp)
+    : input(inp)
 #ifdef __EXX
     , exx_info(GlobalC::exx_info)
 #endif
+{
+}
+
+template <typename T, typename TR>
+void LR::ESolver_LR<T, TR>::before_all_runners(UnitCell& ucell, const Input_para& inp)
+{
+    this->ucell_ = &ucell;
+    if (inp.esolver_type == "ks-lr")
+    {
+        ModuleESolver::ESolver_KS_LCAO<T, TR> ks_solver;
+        ks_solver.before_all_runners(ucell, inp);
+        ks_solver.runner(ucell, 0);
+        this->initialize_from_ks_(std::move(ks_solver), ucell, inp);
+    }
+    else
+    {
+        this->initialize_from_unitcell_(ucell, inp);
+    }
+}
+
+template <typename T, typename TR>
+void LR::ESolver_LR<T, TR>::initialize_from_ks_(ModuleESolver::ESolver_KS_LCAO<T, TR>&& ks_sol,
+                                                 UnitCell& ucell,
+                                                 const Input_para& inp)
 {
     ModuleBase::TITLE("ESolver_LR", "ESolver_LR(KS)");
 
@@ -289,10 +312,7 @@ LR::ESolver_LR<T, TR>::ESolver_LR(ModuleESolver::ESolver_KS_LCAO<T, TR>&& ks_sol
 }
 
 template <typename T, typename TR>
-LR::ESolver_LR<T, TR>::ESolver_LR(const Input_para& inp, UnitCell& ucell) : input(inp), ucell(ucell)
-#ifdef __EXX
-, exx_info(GlobalC::exx_info)
-#endif
+void LR::ESolver_LR<T, TR>::initialize_from_unitcell_(UnitCell& ucell, const Input_para& inp)
 {
     ModuleBase::TITLE("ESolver_LR", "ESolver_LR(from scratch)");
     // xc kernel
@@ -392,7 +412,7 @@ LR::ESolver_LR<T, TR>::ESolver_LR(const Input_para& inp, UnitCell& ucell) : inpu
     atom_arrange::search(PARAM.globalv.search_pbc,
                          GlobalV::ofs_running,
                          this->gd,
-                         this->ucell,
+                         *this->ucell_,
                          search_radius,
                          PARAM.inp.test_atom_input);
     gint_info_.reset(
@@ -463,7 +483,7 @@ void LR::ESolver_LR<T, TR>::runner(UnitCell& ucell, const int istep)
                               this->nbasis,
                               this->nocc,
                               this->nvirt,
-                              this->ucell,
+                              *this->ucell_,
                               orb_cutoff_,
                               this->gd,
                               *this->psi_ks,
@@ -493,7 +513,7 @@ void LR::ESolver_LR<T, TR>::runner(UnitCell& ucell, const int istep)
                                 this->nbasis,
                                 this->nocc,
                                 this->nvirt,
-                                this->ucell,
+                                *this->ucell_,
                                 orb_cutoff_,
                                 this->gd,
                                 *this->psi_ks,
@@ -559,7 +579,7 @@ void LR::ESolver_LR<T, TR>::after_all_runners(UnitCell& ucell)
     for (int is = 0;is < this->X.size();++is)
     {
         LR_Spectrum<T> spectrum(nspin, this->nbasis, this->nocc, this->nvirt, *this->pw_rho, *this->psi_ks,
-            this->ucell, this->kv, this->gd, this->orb_cutoff_, this->two_center_bundle_,
+            *this->ucell_, this->kv, this->gd, this->orb_cutoff_, this->two_center_bundle_,
             this->paraX_, this->paraC_, this->paraMat_,
             &this->pelec->ekb.c[is * nstates], this->X[is].template data<T>(), nstates, openshell,
             LR_Util::tolower(input.abs_gauge));
@@ -656,11 +676,11 @@ void LR::ESolver_LR<T, TR>::init_pot(const Charge& chg_gs)
     {
         using ST = PotHxcLR::SpinType;
     case 1:
-        this->pot[0] = std::make_shared<PotHxcLR>(xc_kernel, *this->pw_rho, ucell, chg_gs, Pgrid, ST::S1, input.lr_init_xc_kernel);
+        this->pot[0] = std::make_shared<PotHxcLR>(xc_kernel, *this->pw_rho, *this->ucell_, chg_gs, Pgrid, ST::S1, input.lr_init_xc_kernel);
         break;
     case 2:
-        this->pot[0] = std::make_shared<PotHxcLR>(xc_kernel, *this->pw_rho, ucell, chg_gs, Pgrid, openshell ? ST::S2_updown : ST::S2_singlet, input.lr_init_xc_kernel);
-        this->pot[1] = std::make_shared<PotHxcLR>(xc_kernel, *this->pw_rho, ucell, chg_gs, Pgrid, openshell ? ST::S2_updown : ST::S2_triplet, input.lr_init_xc_kernel);
+        this->pot[0] = std::make_shared<PotHxcLR>(xc_kernel, *this->pw_rho, *this->ucell_, chg_gs, Pgrid, openshell ? ST::S2_updown : ST::S2_singlet, input.lr_init_xc_kernel);
+        this->pot[1] = std::make_shared<PotHxcLR>(xc_kernel, *this->pw_rho, *this->ucell_, chg_gs, Pgrid, openshell ? ST::S2_updown : ST::S2_triplet, input.lr_init_xc_kernel);
         break;
     default:
         throw std::invalid_argument("ESolver_LR: nspin must be 1 or 2");
@@ -717,7 +737,7 @@ void LR::ESolver_LR<T, TR>::read_ks_chg(Charge& chg_gs)
             GlobalV::ofs_running,
             ssc.str(),
             chg_gs.rho[is],
-            ucell.nat)) {
+            this->ucell_->nat)) {
             GlobalV::ofs_running << " Read in the charge density: " << ssc.str() << std::endl;
         } else {    // prenspin for nspin=4 is not supported currently
             ModuleBase::WARNING_QUIT(

--- a/source/source_lcao/module_lr/esolver_lrtd_lcao.h
+++ b/source/source_lcao/module_lr/esolver_lrtd_lcao.h
@@ -26,17 +26,14 @@ namespace LR
     class ESolver_LR : public ModuleESolver::ESolver_FP
     {
     public:
-        /// @brief  a move constructor from ESolver_KS_LCAO
-        ESolver_LR(ModuleESolver::ESolver_KS_LCAO<T, TR>&& ks_sol, const Input_para& inp, UnitCell& ucell);
-        /// @brief a from-scratch constructor
-        ESolver_LR(const Input_para& inp, UnitCell& ucell);
+        explicit ESolver_LR(const Input_para& inp);
         ~ESolver_LR() {
             delete this->psi_ks;
         }
 
         ///input: input, call, basis(LCAO), psi(ground state), elecstate
         // initialize sth. independent of the ground state
-        virtual void before_all_runners(UnitCell& ucell, const Input_para& inp) override {};
+        virtual void before_all_runners(UnitCell& ucell, const Input_para& inp) override;
         virtual void runner(UnitCell& ucell, int istep) override;
         virtual void after_all_runners(UnitCell& ucell) override;
 
@@ -46,7 +43,7 @@ namespace LR
 
       protected:
         const Input_para& input;
-        const UnitCell& ucell;
+        const UnitCell* ucell_ = nullptr;
         Grid_Driver gd;
         std::vector<double> orb_cutoff_;
 
@@ -86,6 +83,11 @@ namespace LR
         int nupdown = 0;
         bool openshell = false;
         std::string xc_kernel;
+
+        void initialize_from_unitcell_(UnitCell& ucell, const Input_para& inp);
+        void initialize_from_ks_(ModuleESolver::ESolver_KS_LCAO<T, TR>&& ks_sol,
+                                 UnitCell& ucell,
+                                 const Input_para& inp);
 
         std::unique_ptr<ModuleGint::GintInfo> gint_info_ = nullptr;
         void set_gint();

--- a/source/source_main/driver_run.cpp
+++ b/source/source_main/driver_run.cpp
@@ -64,7 +64,7 @@ void Driver::driver_run()
     //! 2: initialize the ESolver (depends on a set-up ucell after `setup_cell`)
     this->init_hardware();
 
-    ModuleESolver::ESolver* p_esolver = ModuleESolver::init_esolver(PARAM.inp, ucell);
+    ModuleESolver::ESolver* p_esolver = ModuleESolver::init_esolver(PARAM.inp);
 
     //! 3: initialize Esolver and fill json-structure
     p_esolver->before_all_runners(ucell, PARAM.inp);


### PR DESCRIPTION
### Reminder
  - [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
  - [x] I have linked an issue or explained why this PR does not need one.
  - [x] I have added adequate unit tests and/or case tests, or explained why not.
  - [x] I have listed the exact verification commands run and their results.
  - [x] I have described user-visible behavior changes, including INPUT parameter changes.
  - [x] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
  - [x] I have requested any needed governance exception below.

  ### Linked Issue
  No linked issue. This is a prerequisite internal refactor for the parallel-MD PR series. It removes the unnecessary `UnitCell` argument from the ESolver
  factory without changing user-facing input behavior.

  ### Unit Tests and/or Case Tests for my changes
  - Commands run:

    ```bash
    cmake -S . -B /tmp/abacus-pr0-build -DENABLE_MPI=ON -DBUILD_TESTING=ON
    cmake --build /tmp/abacus-pr0-build --target lr driver -j8
    cmake --build /tmp/abacus-pr0-build --target abacus_basic_para -j8
    git diff --check

  - Result summary:
      - Configuration completed successfully with MPI enabled.
      - lr, driver, and abacus_basic_para built successfully.
      - git diff --check passed.

  - Checks not run, with reason:
      - No new focused unit test was added because this PR changes factory construction timing only; it does not add a new algorithm or INPUT behavior.
      - A complete LR numerical case comparison was not run in this build environment because LibXC is unavailable. The existing ksdft_lr_lcao case was used
        to confirm that the deferred initialization enters the KS preparation path, but it cannot finish the LR kernel calculation without LibXC.

  ### What's changed?

  - Changed the ESolver factory interface from:

    ModuleESolver::init_esolver(const Input_para&, UnitCell&)

    to:

    ModuleESolver::init_esolver(const Input_para&)

  - init_esolver now only selects and constructs an ESolver. It no longer requires a pre-initialized UnitCell.
  - Moved LR-TDDFT initialization that requires UnitCell from factory construction into ESolver_LR::before_all_runners.
  - For ks-lr, the temporary ground-state ESolver_KS_LCAO is created, initialized, run once, and moved into ESolver_LR during before_all_runners, preserving
    the original KS-to-LR initialization sequence.

  - Updated the driver call site to use the new factory signature.
  - No INPUT parameter, output format, or user-facing calculation workflow is intentionally changed.

  ### Governance Notes

  - INPUT/docs changes:
      - None. No INPUT semantics or documented parameters changed.

  - Core module impact:
      - ESolver: factory construction is decoupled from UnitCell; the cell-dependent phase remains in before_all_runners.
      - ESolver_LR: replaces constructor-held UnitCell reference with a non-owning pointer assigned during before_all_runners, because the factory no longer
        receives a cell.

      - ESolver_KS_LCAO: its existing initialization and one-step ground-state execution are reused for ks-lr; no algorithmic change is intended.
      - HSolver, ElecState, Hamilt, Operator, and Psi: no interface or algorithm changes.

  - Exceptions requested:
      - None.
