### PR TITLE
Fix Dockerfiles

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -24,6 +24,13 @@ RUN cd /tmp && \
     ln -s /usr/local/include/elpa_openmp-$ELPA_VER/elpa /usr/local/include/ && \
     cd /tmp && rm -rf elpa-$ELPA_VER
 
+# RapidJSON
+RUN cd /tmp && wget --quiet https://codeload.github.com/Tencent/rapidjson/tar.gz/24b5e7a -O rapidjson-24b5e7a.tar.gz
+RUN tar -xzf rapidjson-24b5e7a.tar.gz && cd rapidjson-24b5e7a
+RUN cmake -B build -DRAPIDJSON_BUILD_DOC=OFF -DRAPIDJSON_BUILD_EXAMPLES=OFF -DRAPIDJSON_BUILD_TESTS=OFF
+RUN cmake --build build --target install
+RUN cd /tmp && rm -r rapidjson-24b5e7a
+
 ADD https://api.github.com/repos/deepmodeling/abacus-develop/git/refs/heads/develop /dev/null
 
 RUN git clone https://github.com/deepmodeling/abacus-develop.git --depth 1 && \

--- a/Dockerfile.gnu
+++ b/Dockerfile.gnu
@@ -26,6 +26,13 @@ RUN wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-wit
         --no-check-certificate --quiet -O libtorch.zip && \
     unzip -q libtorch.zip -d /opt && rm libtorch.zip
 
+# RapidJSON
+RUN cd /tmp && wget --quiet https://codeload.github.com/Tencent/rapidjson/tar.gz/24b5e7a -O rapidjson-24b5e7a.tar.gz
+RUN tar -xzf rapidjson-24b5e7a.tar.gz && cd rapidjson-24b5e7a
+RUN cmake -B build -DRAPIDJSON_BUILD_DOC=OFF -DRAPIDJSON_BUILD_EXAMPLES=OFF -DRAPIDJSON_BUILD_TESTS=OFF
+RUN cmake --build build --target install
+RUN cd /tmp && rm -r rapidjson-24b5e7a
+
 ENV CMAKE_PREFIX_PATH=/opt/libtorch/share/cmake
 
 ADD https://api.github.com/repos/deepmodeling/abacus-develop/git/refs/heads/develop /dev/null

--- a/Dockerfile.intel
+++ b/Dockerfile.intel
@@ -1,63 +1,12 @@
-FROM ubuntu:22.04
+FROM intel/oneapi-hpckit:2025.2.2-0-devel-ubuntu22.04
 
 RUN apt-get update && apt-get install -y \
     bc cmake git gnupg gcc g++ python3-numpy sudo wget vim unzip \
     libcereal-dev libxc-dev libgtest-dev libgmock-dev libbenchmark-dev \
     pkg-config build-essential autoconf automake libtool
 
-# Following steps by https://software.intel.com/content/www/us/en/develop/documentation/installation-guide-for-intel-oneapi-toolkits-linux/top/installation/install-using-package-managers/apt.html .
-RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
-    | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null && \
-    echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
-    | sudo tee /etc/apt/sources.list.d/oneAPI.list
-
-# To save disk space, only install the essential components, but not the whole toolkit.
-RUN apt-get update && \
-    apt-get install -y \
-        intel-oneapi-compiler-dpcpp-cpp \
-        intel-oneapi-compiler-fortran \
-        intel-oneapi-mkl-devel \
-        intel-oneapi-mkl-sycl-devel \
-        intel-oneapi-mkl-sycl-distributed-dft-devel \
-        intel-oneapi-mpi-devel \
-        intel-oneapi-vtune && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN ls -la /opt/intel/oneapi/mkl/latest/lib/intel64/*sycl*dft*
-RUN ls -la /opt/intel/oneapi/mkl/latest/lib/intel64/*dis*
-
-# Set oneAPI environment variables
-ENV ONEAPI_ROOT=/opt/intel/oneapi
-ENV I_MPI_ROOT=${ONEAPI_ROOT}/mpi/latest
-ENV MKLROOT=${ONEAPI_ROOT}/mkl/latest
-ENV CMPLR_ROOT=${ONEAPI_ROOT}/compiler/latest
-
-# Set library paths and include paths
-ENV LIBRARY_PATH=${ONEAPI_ROOT}/tbb/latest/lib/intel64/gcc4.8:${ONEAPI_ROOT}/mpi/latest/lib:${MKLROOT}/lib/intel64:${ONEAPI_ROOT}/compiler/latest/lib/:${LIBRARY_PATH}
-ENV LD_LIBRARY_PATH=${ONEAPI_ROOT}/tbb/latest/lib/intel64/gcc4.8:${ONEAPI_ROOT}/mpi/latest/lib:${MKLROOT}/lib/intel64:${ONEAPI_ROOT}/compiler/latest/lib/:${LD_LIBRARY_PATH}
-ENV PATH=${ONEAPI_ROOT}/vtune/latest/bin64:${ONEAPI_ROOT}/mpi/latest/bin:${MKLROOT}/bin/intel64:${ONEAPI_ROOT}/compiler/latest/bin:${PATH}
-ENV CPATH=${MKLROOT}/include:${ONEAPI_ROOT}/mpi/latest/include:${CPATH}
-ENV PKG_CONFIG_PATH=${MKLROOT}/lib/pkgconfig:${ONEAPI_ROOT}/mpi/latest/lib/pkgconfig:${PKG_CONFIG_PATH}
-
-# Set CMAKE related paths
-ENV CMAKE_PREFIX_PATH=${ONEAPI_ROOT}/tbb/latest:${MKLROOT}/lib/cmake:${ONEAPI_ROOT}/dpl/latest/lib/cmake:${ONEAPI_ROOT}/dnnl/latest/lib/cmake:${ONEAPI_ROOT}/dal/latest:${ONEAPI_ROOT}/compiler/latest:${CMAKE_PREFIX_PATH}
-
-SHELL ["/bin/bash", "-c"]
-ENV CC=mpiicx CXX=mpiicpx FC=mpiifx
-
-# Verify oneAPI installation
-RUN source ${ONEAPI_ROOT}/setvars.sh && \
-    echo "=== Verify compiler ===" && \
-    which mpiicx && mpiicx --version && \
-    echo "=== Verify MKL ===" && \
-    ls ${MKLROOT}/lib/intel64/ && \
-    echo "=== Verify MPI ===" && \
-    which mpirun && mpirun --version
-
 # https://elpa.mpcdf.mpg.de/software/tarball-archive/ELPA_TARBALL_ARCHIVE.html
-RUN source /opt/intel/oneapi/setvars.sh && \
-    cd /tmp && \
+RUN cd /tmp && \
     ELPA_VER=2022.11.001 && \
     wget -q https://elpa.mpcdf.mpg.de/software/tarball-archive/Releases/$ELPA_VER/elpa-$ELPA_VER.tar.gz && \
     tar xzf elpa-$ELPA_VER.tar.gz  && rm elpa-$ELPA_VER.tar.gz && \
@@ -68,8 +17,14 @@ RUN source /opt/intel/oneapi/setvars.sh && \
     ln -s /usr/local/include/elpa_openmp-$ELPA_VER/elpa /usr/local/include/ && \
     cd /tmp && rm -rf elpa-$ELPA_VER
 
-# rapidjson and libtorch
-RUN cd /tmp && git clone --depth 1 https://github.com/Tencent/rapidjson.git && cp -r rapidjson/include/rapidjson /usr/include/ && rm -rf rapidjson
+# RapidJSON
+RUN cd /tmp && wget --quiet https://codeload.github.com/Tencent/rapidjson/tar.gz/24b5e7a -O rapidjson-24b5e7a.tar.gz
+RUN tar -xzf rapidjson-24b5e7a.tar.gz && cd rapidjson-24b5e7a
+RUN cmake -B build -DRAPIDJSON_BUILD_DOC=OFF -DRAPIDJSON_BUILD_EXAMPLES=OFF -DRAPIDJSON_BUILD_TESTS=OFF
+RUN cmake --build build --target install
+RUN cd /tmp && rm -r rapidjson-24b5e7a
+
+# LibTorch (Note: Using pre-built Torch library with MKL might cause issues)
 RUN wget -q https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.0.0%2Bcpu.zip -O /tmp/libtorch.zip && \
     unzip -q /tmp/libtorch.zip -d /opt && rm -f /tmp/libtorch.zip
 ENV CMAKE_PREFIX_PATH=/opt/libtorch/share/cmake:${CMAKE_PREFIX_PATH}


### PR DESCRIPTION
- I removed `FetchContent` for RapidJSON before, so the Dockerfile is failing. Build RapidJSON in the Dockerfile so the failure hopefully goes away
- Use the official docker image provided by Intel in `Dockerfile.intel`, rather than install Intel oneAPI toolkits and set env variables ourselves.