### PR TITLE
Refactor: start removing PARAM from source_hsolver (hsolver.cpp + redundant reads)

### DIFF
--- a/source/source_esolver/esolver_ks.cpp
+++ b/source/source_esolver/esolver_ks.cpp
@@ -184,13 +184,14 @@ void ESolver_KS::iter_init(UnitCell& ucell, const int istep, const int iter)
     {
         diag_ethr = hsolver::set_diagethr_ks(PARAM.inp.basis_type, PARAM.inp.esolver_type,
           PARAM.inp.calculation, PARAM.inp.init_chg, PARAM.inp.precision, istep, iter,
-          drho, PARAM.inp.pw_diag_thr, diag_ethr, PARAM.inp.nelec);
+          drho, PARAM.inp.pw_diag_thr, diag_ethr, PARAM.inp.nelec, PARAM.inp.scf_thr);
     }
     else if (PARAM.inp.esolver_type == "sdft")
     {
         diag_ethr = hsolver::set_diagethr_sdft(PARAM.inp.basis_type, PARAM.inp.esolver_type,
           PARAM.inp.calculation, PARAM.inp.init_chg, istep, iter, drho,
-          PARAM.inp.pw_diag_thr, diag_ethr, PARAM.inp.nbands, esolver_KS_ne);
+          PARAM.inp.pw_diag_thr, diag_ethr, PARAM.inp.nbands, esolver_KS_ne,
+          PARAM.inp.nelec, PARAM.inp.scf_thr);
     }
 
     // save input charge density (rho)

--- a/source/source_hsolver/hsolver.cpp
+++ b/source/source_hsolver/hsolver.cpp
@@ -1,7 +1,9 @@
 #include "hsolver.h"
 
 #include "source_base/global_function.h"
-#include "source_io/module_parameter/parameter.h"
+
+#include <algorithm>
+#include <cmath>
 
 namespace hsolver
 {
@@ -16,7 +18,8 @@ double set_diagethr_ks(const std::string basis_type,
                        const double drho,
                        const double pw_diag_thr_init,
                        const double diag_ethr_in,
-                       const double nelec_in)
+                       const double nelec_in,
+                       const double scf_thr_in)
 {
     double res_diag_ethr = diag_ethr_in;
 
@@ -27,7 +30,7 @@ double set_diagethr_ks(const std::string basis_type,
         {
             if (res_diag_ethr - 1e-2 > -1e-5)
             {
-                res_diag_ethr = std::max(1e-13, 0.1 * std::min(1e-2, PARAM.inp.scf_thr / PARAM.inp.nelec));
+                res_diag_ethr = std::max(1e-13, 0.1 * std::min(1e-2, scf_thr_in / nelec_in));
             }
         }
         else if (iter == 1)
@@ -97,7 +100,9 @@ double set_diagethr_sdft(const std::string basis_type,
                          const double pw_diag_thr_init,
                          const double diag_ethr_in,
                          const int nband_in,
-                         const double stoiter_ks_ne_in)
+                         const double stoiter_ks_ne_in,
+                         const double nelec_in,
+                         const double scf_thr_in)
 {
     double res_diag_ethr = diag_ethr_in;
 
@@ -105,7 +110,7 @@ double set_diagethr_sdft(const std::string basis_type,
     {
         if (calculation_in == "nscf")
         {
-            res_diag_ethr = std::max(std::min(1e-5, 0.1 * PARAM.inp.scf_thr / std::max(1.0, PARAM.inp.nelec)), 1e-12);
+            res_diag_ethr = std::max(std::min(1e-5, 0.1 * scf_thr_in / std::max(1.0, nelec_in)), 1e-12);
         }
         else if (iter == 1)
         {
@@ -124,7 +129,7 @@ double set_diagethr_sdft(const std::string basis_type,
         }
         else
         {
-            if (nband_in > 0 && stoiter_ks_ne_in > 1e-6) //PARAM.inp.nbands > 0 && this->stoiter.KS_ne > 1e-6
+            if (nband_in > 0 && stoiter_ks_ne_in > 1e-6)
             {
                 res_diag_ethr = std::min(res_diag_ethr, 0.1 * drho / std::max(1.0, stoiter_ks_ne_in));
             }

--- a/source/source_hsolver/hsolver.h
+++ b/source/source_hsolver/hsolver.h
@@ -17,7 +17,8 @@ double set_diagethr_ks(const std::string basis_type,
                        const double drho,
                        const double pw_diag_thr_init,
                        const double diag_ethr_in,
-                       const double nelec_in);
+                       const double nelec_in,
+                       const double scf_thr_in);
 
 double set_diagethr_sdft(const std::string basis_type,
                          const std::string esolver_type,
@@ -29,7 +30,9 @@ double set_diagethr_sdft(const std::string basis_type,
                          const double pw_diag_thr_init,
                          const double diag_ethr_in,
                          const int nband_in,
-                         const double stoiter_ks_ne_in);
+                         const double stoiter_ks_ne_in,
+                         const double nelec_in,
+                         const double scf_thr_in);
 
 
 // reset diagethr according to drho and hsolver_error

--- a/source/source_hsolver/hsolver_lcao.cpp
+++ b/source/source_hsolver/hsolver_lcao.cpp
@@ -62,7 +62,7 @@ void HSolverLCAO<TK, Device>::solve(hamilt::Hamilt<TK>* pHamilt,
         if (PARAM.globalv.kpar_lcao > 1
             && (this->method == "genelpa" || this->method == "elpa" || this->method == "scalapack_gvx" || this->method == "lapack"))
         {
-            this->parakSolve(pHamilt, psi, pes, PARAM.globalv.kpar_lcao);
+            this->parakSolve(pHamilt, psi, pes, PARAM.globalv.kpar_lcao, nspin);
         } else
     #endif
         if (PARAM.globalv.kpar_lcao == 1)
@@ -192,7 +192,8 @@ template <typename T, typename Device>
 void HSolverLCAO<T, Device>::parakSolve(hamilt::Hamilt<T>* pHamilt,
                                         psi::Psi<T>& psi,
                                         elecstate::ElecState* pes,
-                                        int kpar)
+                                        const int kpar,
+                                        const int nspin)
 {
 #ifdef __MPI
     ModuleBase::timer::start("HSolverLCAO", "parakSolve");
@@ -202,7 +203,7 @@ void HSolverLCAO<T, Device>::parakSolve(hamilt::Hamilt<T>* pHamilt,
     int nks = psi.get_nk();
     int nrow = this->ParaV->get_global_row_size();
     int nb2d = this->ParaV->get_block_size();
-    k2d.set_para_env(psi.get_nk(), nrow, nb2d, GlobalV::NPROC, GlobalV::MY_RANK, PARAM.inp.nspin);
+    k2d.set_para_env(psi.get_nk(), nrow, nb2d, GlobalV::NPROC, GlobalV::MY_RANK, nspin);
     /// set psi_pool
     const int zero = 0;
     int coord_col = k2d.get_p2D_pool()->get_coord_col();

--- a/source/source_hsolver/hsolver_lcao.h
+++ b/source/source_hsolver/hsolver_lcao.h
@@ -28,7 +28,11 @@ class HSolverLCAO
   private:
     void hamiltSolvePsiK(hamilt::Hamilt<TK>* hm, psi::Psi<TK>& psi, double* eigenvalue); // for kpar_lcao == 1
 
-    void parakSolve(hamilt::Hamilt<TK>* pHamilt, psi::Psi<TK>& psi, elecstate::ElecState* pes, int kpar); // for kpar_lcao > 1
+    void parakSolve(hamilt::Hamilt<TK>* pHamilt,
+                    psi::Psi<TK>& psi,
+                    elecstate::ElecState* pes,
+                    const int kpar,
+                    const int nspin); // for kpar_lcao > 1
 
     // The solving algorithm using cusolver is different from others, so a separate function is needed
     void parakSolve_cusolver(hamilt::Hamilt<TK>* pHamilt,

--- a/source/source_hsolver/hsolver_pw.cpp
+++ b/source/source_hsolver/hsolver_pw.cpp
@@ -212,7 +212,7 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
     elecstate::calEBand(_pes_pw->ekb,_pes_pw->wg,_pes_pw->f_en);
     if (skip_charge)
     {
-        if (PARAM.globalv.use_uspp)
+        if (this->use_uspp)
         {
             reinterpret_cast<elecstate::ElecStatePW<T, Device>*>(pes)->cal_becsum(psi);
         }


### PR DESCRIPTION
## Background

`source_hsolver` currently reads `PARAM.*` in ~88 places across 15 production files, which conflicts with coding rule 1 in `AGENTS.md` (do not increase cross-layer control through `GlobalV` / `GlobalC` / `PARAM`; pass dependencies explicitly).

A full survey grouped these into five clusters by difficulty. This PR is the **first and smallest batch**: the cases where the dependency was already available locally and no design decision is needed. Follow-up PRs will handle constructor injection for the `HSolverPW` / `HSolverLCAO` / `PEXSI_Solver` config parameters, the `DiagoIterAssist` `basis_type` / `calculation` switches, and the large `nlocal` / `nbands` cluster shared by the seven LCAO dense diagonalizers.

## Changes

### Group A — redundant reads

Both of these re-read a value the surrounding object already had:

- **`hsolver_pw.cpp`**: `PARAM.globalv.use_uspp` → `this->use_uspp`. `HSolverPW` already receives `use_uspp` through its constructor (injected from `PARAM.globalv.use_uspp` at the esolver level), so the direct read was duplicating an existing member.
- **`hsolver_lcao.cpp`**: `PARAM.inp.nspin` → `nspin`. `HSolverLCAO::solve()` already takes `nspin` as an argument; it is now threaded into `parakSolve()` instead of being re-read from `PARAM`. All three external callers pass either `PARAM.inp.nspin` or an equivalent local `nspin`.

### Group B — `hsolver.cpp` is now completely PARAM-free

`set_diagethr_ks()` and `set_diagethr_sdft()` were already pure parameter-based functions except for two leaked reads of `PARAM.inp.scf_thr` / `PARAM.inp.nelec` in their `nscf` branches.

- `set_diagethr_ks()`: added `scf_thr_in`. The `nscf` branch was reading `PARAM.inp.nelec` even though the function already had a `nelec_in` parameter — both now use `nelec_in`. This is behaviour-preserving: the only call site passes `PARAM.inp.nelec` for that argument.
- `set_diagethr_sdft()`: added `nelec_in` and `scf_thr_in`.
- Dropped the now-unused `parameter.h` include, and added the `<algorithm>` / `<cmath>` includes the file had been getting transitively.

Both new parameters are appended at the end of the parameter lists rather than inserted mid-list, so that same-typed (`double`) arguments cannot silently shift at call sites.

Call sites in `source_esolver/esolver_ks.cpp` updated accordingly — these are the only external callers of the two functions.

## Effect

`PARAM.*` occurrences in `source_hsolver` production code: **88 → 83**, with `hsolver.cpp` fully cleaned. No unit tests touch these two functions, so no test changes are needed.

## Testing

Syntax-checked `hsolver.cpp`, `hsolver_pw.cpp`, `hsolver_lcao.cpp` and `esolver_ks.cpp` locally with `g++ -fsyntax-only`.

One caveat worth flagging for review: no MPI headers were available locally, and both the body of `parakSolve()` and its call site sit inside `#ifdef __MPI`, so that path was not covered by the local check. The signature and the five call arguments were verified by inspection, but it relies on CI for the MPI build.

Behaviour is intended to be unchanged throughout — every value now passed in is the same `PARAM` field that was previously read directly
