### PR TITLE
Fix: use real radial grids in RT projector interpolation (Useful Information for radial interpolation in the RT-TDDFT projector integration path for DeePKS alpha projectors, nonlocal beta projectors, and LCAO orbitals)

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -50,6 +50,13 @@ jobs:
           cmake --build build -j4
           cmake --install build
 
+      - name: Module_LCAO CUDA Unittests
+        env:
+          GTEST_COLOR: 'yes'
+          OMP_NUM_THREADS: '2'
+        run: |
+          ctest --test-dir build -V --timeout 1700 -R '^(MODULE_LCAO_tddft_radial_interpolation_cuda_test|MODULE_LCAO_tddft_snap_psibeta_half_test)$'
+
       - name: Test 11_PW_GPU
         run: |
           cd tests/11_PW_GPU

--- a/source/Makefile.Objects
+++ b/source/Makefile.Objects
@@ -636,8 +636,10 @@ OBJS_LCAO=evolve_elec.o\
       td_folding.o\
       td_info.o\
       velocity_op.o\
+      radial_interpolation.o\
       snap_projector_half_tddft.o\
       snap_psibeta_half_tddft.o\
+      snap_phialpha_half_tddft.o\
       solve_propagation.o\
       boundary_fix.o\
       upsi.o\

--- a/source/source_lcao/module_deepks/test/CMakeLists.txt
+++ b/source/source_lcao/module_deepks/test/CMakeLists.txt
@@ -62,6 +62,9 @@ set(DEEPKS_UNIT_COMMON_SOURCES
     ../../../source_io/module_hs/cal_r_overlap_R.cpp
     ../../../source_io/module_hs/single_R_io.cpp
     ../../../source_io/module_hs/rr_sparse_writer.cpp
+    ../../module_rt/radial_interpolation.cpp
+    ../../module_rt/snap_projector_half_tddft.cpp
+    ../../module_rt/snap_phialpha_half_tddft.cpp
     ../../module_rt/td_folding.cpp
     mock_berryphase.cpp
     mock_tdinfo.cpp
@@ -93,6 +96,9 @@ set(DEEPKS_UNIT_LIBS
 
 set(DEEPKS_UNIT_PHIALPHA_SOURCES
     deepks_test_phialpha.cpp
+)
+set(DEEPKS_UNIT_PHIALPHA_GRID_SOURCES
+    deepks_test_phialpha_grid.cpp
 )
 set(DEEPKS_UNIT_PDM_SOURCES
     ${DEEPKS_UNIT_PHIALPHA_SOURCES}
@@ -157,6 +163,9 @@ function(configure_deepks_unit_target TARGET_NAME CHECK_NAME CASE_DIR)
       DEEPKS_UT_CASE_DIR="${CASE_DIR}"
       DEEPKS_UT_RUNNER=run_deepks_unit_${CHECK_NAME}
   )
+  if("${CHECK_NAME}" STREQUAL "phialpha_grid_zero_field")
+    target_compile_definitions(${TARGET_NAME} PRIVATE DEEPKS_UT_MODERN_ORBITAL_READER=1)
+  endif()
 endfunction()
 
 AddTest(
@@ -165,6 +174,13 @@ AddTest(
     SOURCES main_deepks.cpp ${DEEPKS_UNIT_PHIALPHA_SOURCES}
 )
 configure_deepks_unit_target(MODULE_LCAO_DEEPKS_phialpha_gamma phialpha NO_GO_deepks_UT)
+
+AddTest(
+    TARGET MODULE_LCAO_DEEPKS_phialpha_grid_gamma
+    LIBS ${DEEPKS_UNIT_LIBS}
+    SOURCES main_deepks.cpp ${DEEPKS_UNIT_PHIALPHA_GRID_SOURCES}
+)
+configure_deepks_unit_target(MODULE_LCAO_DEEPKS_phialpha_grid_gamma phialpha_grid_zero_field NO_GO_deepks_UT)
 
 AddTest(
     TARGET MODULE_LCAO_DEEPKS_pdm_gamma
@@ -263,6 +279,13 @@ AddTest(
     SOURCES main_deepks.cpp ${DEEPKS_UNIT_PHIALPHA_SOURCES}
 )
 configure_deepks_unit_target(MODULE_LCAO_DEEPKS_phialpha_multik phialpha NO_KP_deepks_UT)
+
+AddTest(
+    TARGET MODULE_LCAO_DEEPKS_phialpha_grid_multik
+    LIBS ${DEEPKS_UNIT_LIBS}
+    SOURCES main_deepks.cpp ${DEEPKS_UNIT_PHIALPHA_GRID_SOURCES}
+)
+configure_deepks_unit_target(MODULE_LCAO_DEEPKS_phialpha_grid_multik phialpha_grid_zero_field NO_KP_deepks_UT)
 
 AddTest(
     TARGET MODULE_LCAO_DEEPKS_pdm_multik

--- a/source/source_lcao/module_deepks/test/deepks_test.h
+++ b/source/source_lcao/module_deepks/test/deepks_test.h
@@ -71,7 +71,7 @@ class test_deepks
     elecstate::DensityMatrix<T, double>* p_elec_DM = nullptr;
 
     // preparation
-    void preparation();
+    void preparation(bool use_modern_orbital_reader);
     void set_parameters(); // set some global variables
     void setup_cell();
 
@@ -80,7 +80,7 @@ class test_deepks
 
     void prep_neighbour();
     void setup_kpt();
-    void set_orbs();
+    void set_orbs(bool use_modern_orbital_reader);
 
     // tranfer Matrix into vector<T>
     void set_dm_new();
@@ -91,6 +91,7 @@ class test_deepks
     // checking
     void check_dstable();
     void check_phialpha();
+    void check_phialpha_grid_zero_field();
 
     void read_dm(const int nks);
 

--- a/source/source_lcao/module_deepks/test/deepks_test_phialpha_grid.cpp
+++ b/source/source_lcao/module_deepks/test/deepks_test_phialpha_grid.cpp
@@ -1,0 +1,158 @@
+#include "deepks_test_runner.h"
+
+#include "source_lcao/module_deepks/deepks_iterate.h"
+#include "source_lcao/module_rt/snap_phialpha_half_tddft.h"
+#include "source_lcao/module_rt/snap_projector_half_tddft.h"
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <gtest/gtest.h>
+#include <iomanip>
+#include <iostream>
+#include <type_traits>
+
+template <typename T>
+void test_deepks<T>::check_phialpha_grid_zero_field()
+{
+    struct ComparisonStats
+    {
+        double max_real_diff = 0.0;
+        double max_imag_abs = 0.0;
+        double max_reference_abs = 0.0;
+        double max_relative_diff = 0.0;
+        double reference_at_max_diff = 0.0;
+        int compared = 0;
+        bool shape_mismatch = false;
+    };
+
+    const ModuleBase::Vector3<double> zero_A(0.0, 0.0, 0.0);
+    const auto compare_grid = [&](const int radial_grid_num, const int lebedev_grid_points) {
+        ComparisonStats stats;
+        module_rt::SnapIntegrationOptions options;
+        options.radial_grid_num = radial_grid_num;
+        options.lebedev_grid_points = lebedev_grid_points;
+
+        DeePKS_domain::iterate_ad1(
+            ucell,
+            Test_Deepks::GridD,
+            ORB,
+            false,
+            [&](const int iat,
+                const ModuleBase::Vector3<double>& tau0,
+                const int ibt,
+                const ModuleBase::Vector3<double>& tau1,
+                const int start,
+                const int nw_tot,
+                ModuleBase::Vector3<int> dR) {
+                const int T1 = ucell.iat2it[ibt];
+                const Atom* atom1 = &ucell.atoms[T1];
+
+                auto all_indexes = ParaO.get_indexes_row(ibt);
+                auto col_indexes = ParaO.get_indexes_col(ibt);
+                all_indexes.insert(all_indexes.end(), col_indexes.begin(), col_indexes.end());
+                std::sort(all_indexes.begin(), all_indexes.end());
+                all_indexes.erase(std::unique(all_indexes.begin(), all_indexes.end()), all_indexes.end());
+
+                for (size_t iw1l = 0; iw1l < all_indexes.size(); iw1l += this->npol)
+                {
+                    const int iw1 = all_indexes[iw1l] / this->npol;
+                    const int L1 = atom1->iw2l[iw1];
+                    const int N1 = atom1->iw2n[iw1];
+                    const int m1 = atom1->iw2m[iw1];
+                    const int M1 = (m1 % 2 == 0) ? -m1 / 2 : (m1 + 1) / 2;
+
+                    std::vector<std::vector<std::complex<double>>> grid_nlm;
+                    module_rt::snap_phialpha_half_tddft(ORB,
+                                                        grid_nlm,
+                                                        tau1 * ucell.lat0,
+                                                        T1,
+                                                        L1,
+                                                        m1,
+                                                        N1,
+                                                        tau0 * ucell.lat0,
+                                                        zero_A,
+                                                        false,
+                                                        options);
+
+                    std::vector<std::vector<double>> tci_nlm;
+                    const int T0_fixed = 0;
+                    overlap_orb_alpha_.snap(T1,
+                                            L1,
+                                            N1,
+                                            M1,
+                                            T0_fixed,
+                                            (tau0 - tau1) * ucell.lat0,
+                                            false,
+                                            tci_nlm);
+
+                    if (grid_nlm.empty() || tci_nlm.empty() || grid_nlm[0].size() != tci_nlm[0].size())
+                    {
+                        stats.shape_mismatch = true;
+                        return;
+                    }
+
+                    for (size_t i = 0; i < grid_nlm[0].size(); ++i)
+                    {
+                        const double reference_abs = std::abs(tci_nlm[0][i]);
+                        const double real_diff = std::abs(grid_nlm[0][i].real() - tci_nlm[0][i]);
+                        if (real_diff > stats.max_real_diff)
+                        {
+                            stats.max_real_diff = real_diff;
+                            stats.reference_at_max_diff = tci_nlm[0][i];
+                        }
+                        stats.max_imag_abs = std::max(stats.max_imag_abs, std::abs(grid_nlm[0][i].imag()));
+                        stats.max_reference_abs = std::max(stats.max_reference_abs, reference_abs);
+                        if (reference_abs > 1.0e-8)
+                        {
+                            stats.max_relative_diff = std::max(stats.max_relative_diff, real_diff / reference_abs);
+                        }
+                        ++stats.compared;
+                    }
+                }
+            });
+
+        const char* instance = std::is_same<T, double>::value ? "gamma" : "multik";
+        std::cout << std::scientific << std::setprecision(12) << "phialpha " << instance << " grid "
+                  << radial_grid_num << "x" << lebedev_grid_points
+                  << ": max abs error = " << stats.max_real_diff
+                  << " (reference = " << stats.reference_at_max_diff << ")"
+                  << ", max reference = " << stats.max_reference_abs
+                  << ", max imaginary magnitude = " << stats.max_imag_abs
+                  << ", max relative error (|reference| > 1e-8) = " << stats.max_relative_diff
+                  << std::defaultfloat << std::endl;
+
+        EXPECT_FALSE(stats.shape_mismatch) << "phialpha grid and two-center integration output shapes differ";
+        EXPECT_GT(stats.compared, 0) << "No phialpha grid entries were compared";
+        EXPECT_LE(stats.max_imag_abs, 1.0e-14) << "max reference abs = " << stats.max_reference_abs;
+        return stats;
+    };
+
+    const ComparisonStats default_grid = compare_grid(140, 110);
+    const ComparisonStats dense_radial_grid = compare_grid(280, 110);
+    const ComparisonStats dense_angular_grid = compare_grid(140, 590);
+
+    const bool is_gamma = std::is_same<T, double>::value;
+    const double default_grid_tolerance = is_gamma ? 6.0e-5 : 1.0e-5;
+    const double dense_angular_grid_tolerance = is_gamma ? 5.0e-6 : 4.0e-6;
+
+    // The 110-point angular rule limits both radial-grid cases. The 590-point
+    // rule exposes the lower error reached by the corrected interpolation.
+    EXPECT_LE(default_grid.max_real_diff, default_grid_tolerance);
+    EXPECT_LE(dense_radial_grid.max_real_diff, default_grid_tolerance);
+    EXPECT_NEAR(dense_radial_grid.max_real_diff, default_grid.max_real_diff, 2.0e-10);
+    EXPECT_LE(dense_angular_grid.max_real_diff, dense_angular_grid_tolerance);
+    EXPECT_LE(dense_angular_grid.max_real_diff, 0.5 * default_grid.max_real_diff);
+}
+
+template void test_deepks<double>::check_phialpha_grid_zero_field();
+template void test_deepks<std::complex<double>>::check_phialpha_grid_zero_field();
+
+template <typename T>
+void run_deepks_unit_phialpha_grid_zero_field(test_deepks<T>& test)
+{
+    test.check_phialpha_grid_zero_field();
+}
+
+template void run_deepks_unit_phialpha_grid_zero_field<double>(test_deepks<double>& test);
+template void run_deepks_unit_phialpha_grid_zero_field<std::complex<double>>(test_deepks<std::complex<double>>& test);

--- a/source/source_lcao/module_deepks/test/deepks_test_prep.cpp
+++ b/source/source_lcao/module_deepks/test/deepks_test_prep.cpp
@@ -1,5 +1,6 @@
 #include "deepks_test.h"
 #include "source_base/global_variable.h"
+#include "source_basis/module_nao/two_center_bundle.h"
 #include "source_cell/read_pseudo.h"
 #include "source_hamilt/module_xc/exx_info.h"
 #include "../../LCAO_nonlocal_info.h"
@@ -38,7 +39,7 @@ public:
 };
 
 template <typename T>
-void test_deepks<T>::preparation()
+void test_deepks<T>::preparation(const bool use_modern_orbital_reader)
 {
     this->count_ntype();
     this->set_parameters();
@@ -52,7 +53,7 @@ void test_deepks<T>::preparation()
     this->setup_kpt();
 
     this->set_ekcut();
-    this->set_orbs();
+    this->set_orbs(use_modern_orbital_reader);
     this->prep_neighbour();
 
     this->ParaO.set_serial(this->nlocal, this->nlocal);
@@ -238,23 +239,41 @@ void test_deepks<T>::prep_neighbour()
 }
 
 template <typename T>
-void test_deepks<T>::set_orbs()
+void test_deepks<T>::set_orbs(const bool use_modern_orbital_reader)
 {
-    ORB.init(GlobalV::ofs_running,
-             ucell.ntype,
-             this->orbital_dir,
-             ucell.orbital_fn.data(),
-             ucell.descriptor_file,
-             ucell.lmax,
-             lcao_ecut,
-             lcao_dk,
-             lcao_dr,
-             lcao_rmax,
-             this->deepks_setorb,
-             out_mat_r,
-             this->out_element_info,
-             this->cal_force,
-             my_rank);
+    std::string file_alpha = this->orbital_dir + ucell.descriptor_file;
+    if (use_modern_orbital_reader)
+    {
+        TwoCenterBundle two_center_bundle;
+        two_center_bundle.build_orb(ucell.ntype, ucell.orbital_fn.data(), this->orbital_dir);
+        two_center_bundle.build_alpha(this->deepks_setorb, &file_alpha);
+        two_center_bundle.to_LCAO_Orbitals(ORB, lcao_ecut, lcao_dk, lcao_dr, lcao_rmax, this->out_element_info, this->cal_force);
+
+        // Feed both integration paths with data from the same modern read.
+        orb_ = *two_center_bundle.orb_;
+        alpha_ = *two_center_bundle.alpha_;
+    }
+    else
+    {
+        ORB.init(GlobalV::ofs_running,
+                 ucell.ntype,
+                 this->orbital_dir,
+                 ucell.orbital_fn.data(),
+                 ucell.descriptor_file,
+                 ucell.lmax,
+                 lcao_ecut,
+                 lcao_dk,
+                 lcao_dr,
+                 lcao_rmax,
+                 this->deepks_setorb,
+                 out_mat_r,
+                 this->out_element_info,
+                 this->cal_force,
+                 my_rank);
+
+        orb_.build(ntype, ucell.orbital_fn.data());
+        alpha_.build(1, &file_alpha);
+    }
 
     const std::string basis_type = "lcao";
     const bool out_element_info = this->out_element_info;
@@ -266,14 +285,12 @@ void test_deepks<T>::set_orbs()
                            basis_type, out_element_info, lspinorb, nspin);
     ucell.infoNL.reset(lcao_nl);
 
-    orb_.build(ntype, ucell.orbital_fn.data());
-
-    std::string file_alpha = this->orbital_dir + ucell.descriptor_file;
-    alpha_.build(1, &file_alpha);
-
     double rmax = std::max(orb_.rcut_max(), alpha_.rcut_max());
     double cutoff = 2.0 * rmax;
-    int nr = static_cast<int>(rmax / lcao_dr) + 1;
+    // The focused grid-integration comparison needs the requested lcao_dr
+    // spacing across the complete two-center tabulation range.
+    const double tabulation_spacing = use_modern_orbital_reader ? 0.5 * lcao_dr : lcao_dr;
+    int nr = static_cast<int>((use_modern_orbital_reader ? cutoff : rmax) / tabulation_spacing) + 1;
 
     orb_.set_uniform_grid(true, nr, cutoff, 'i', true);
     alpha_.set_uniform_grid(true, nr, cutoff, 'i', true);

--- a/source/source_lcao/module_deepks/test/main_deepks.cpp
+++ b/source/source_lcao/module_deepks/test/main_deepks.cpp
@@ -27,6 +27,10 @@
 #error "DEEPKS_UT_RUNNER must be defined by CMake."
 #endif
 
+#ifndef DEEPKS_UT_MODERN_ORBITAL_READER
+#define DEEPKS_UT_MODERN_ORBITAL_READER 0
+#endif
+
 template <typename T>
 void DEEPKS_UT_RUNNER(test_deepks<T>& test);
 
@@ -71,7 +75,7 @@ template <typename T>
 void run_typed_check()
 {
     test_deepks<T> test;
-    test.preparation();
+    test.preparation(DEEPKS_UT_MODERN_ORBITAL_READER != 0);
     if (testing::Test::HasFatalFailure())
     {
         return;

--- a/source/source_lcao/module_rt/CMakeLists.txt
+++ b/source/source_lcao/module_rt/CMakeLists.txt
@@ -12,8 +12,10 @@ if(ENABLE_LCAO)
         upsi.cpp
         td_info.cpp
         velocity_op.cpp
+        radial_interpolation.cpp
         snap_projector_half_tddft.cpp
         snap_psibeta_half_tddft.cpp
+        snap_phialpha_half_tddft.cpp
         td_folding.cpp
         solve_propagation.cpp
         boundary_fix.cpp

--- a/source/source_lcao/module_rt/kernels/cuda/snap_psibeta_gpu.cu
+++ b/source/source_lcao/module_rt/kernels/cuda/snap_psibeta_gpu.cu
@@ -18,7 +18,9 @@
 
 #include <cstdio>
 #include <cuda_runtime.h>
+#include <map>
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace module_rt
@@ -65,6 +67,15 @@ struct OrbitalMapping
 {
     int neighbor_idx; ///< Index of neighbor atom in adjacency list
     int iw_index;     ///< Global orbital index for output mapping
+};
+
+struct OrbitalRadialMapping
+{
+    int value_offset = 0;
+    int grid_offset = 0;
+    int mesh = 0;
+    double rcut = 0.0;
+    RadialGridInfo grid_info;
 };
 
 //=============================================================================
@@ -149,7 +160,9 @@ void snap_psibeta_atom_batch_gpu(
 
     std::vector<NeighborOrbitalData> neighbor_orbitals_h;
     std::vector<double> psi_radial_h;
+    std::vector<double> psi_radial_grid_h;
     std::vector<OrbitalMapping> orbital_mappings;
+    std::map<std::tuple<int, int, int>, OrbitalRadialMapping> orbital_radial_mappings;
 
     for (int ad = 0; ad < adjs.adj_num + 1; ++ad)
     {
@@ -180,15 +193,28 @@ void snap_psibeta_atom_batch_gpu(
                 continue;
             }
 
-            // Get orbital radial function (use getPsi(), not getPsi_r())
-            const double* phi_psi = orb.Phi[T1].PhiLN(L1, N1).getPsi();
-            int mesh = orb.Phi[T1].PhiLN(L1, N1).getNr();
-            double dk = orb.Phi[T1].PhiLN(L1, N1).getDk();
-            double rcut = orb.Phi[T1].getRcut();
+            const std::tuple<int, int, int> radial_key(T1, L1, N1);
+            auto radial_mapping = orbital_radial_mappings.find(radial_key);
+            if (radial_mapping == orbital_radial_mappings.end())
+            {
+                const auto& phi_ln = orb.Phi[T1].PhiLN(L1, N1);
+                const double* phi_psi = phi_ln.getPsi();
+                const double* phi_radial = phi_ln.getRadial();
 
-            // Append to flattened psi array
-            size_t psi_offset = psi_radial_h.size();
-            psi_radial_h.insert(psi_radial_h.end(), phi_psi, phi_psi + mesh);
+                OrbitalRadialMapping mapping;
+                mapping.value_offset = static_cast<int>(psi_radial_h.size());
+                mapping.grid_offset = static_cast<int>(psi_radial_grid_h.size());
+                mapping.mesh = phi_ln.getNr();
+                mapping.rcut = orb.Phi[T1].getRcut();
+                mapping.grid_info = validate_radial_grid(phi_radial,
+                                                         phi_psi,
+                                                         mapping.mesh,
+                                                         "snap_psibeta_gpu",
+                                                         "LCAO orbital");
+                psi_radial_h.insert(psi_radial_h.end(), phi_psi, phi_psi + mapping.mesh);
+                psi_radial_grid_h.insert(psi_radial_grid_h.end(), phi_radial, phi_radial + mapping.mesh);
+                radial_mapping = orbital_radial_mappings.insert(std::make_pair(radial_key, mapping)).first;
+            }
 
             // Create neighbor-orbital data
             NeighborOrbitalData norb;
@@ -198,10 +224,11 @@ void snap_psibeta_atom_batch_gpu(
             norb.m1 = m1;
             norb.N1 = N1;
             norb.iw_index = all_indexes[iw1l];
-            norb.psi_offset = static_cast<int>(psi_offset);
-            norb.psi_mesh = mesh;
-            norb.psi_dk = dk;
-            norb.psi_rcut = rcut;
+            norb.psi_offset = radial_mapping->second.value_offset;
+            norb.psi_grid_offset = radial_mapping->second.grid_offset;
+            norb.psi_mesh = radial_mapping->second.mesh;
+            norb.psi_rcut = radial_mapping->second.rcut;
+            norb.grid_info = radial_mapping->second.grid_info;
 
             neighbor_orbitals_h.push_back(norb);
 
@@ -226,26 +253,28 @@ void snap_psibeta_atom_batch_gpu(
 
     std::vector<ProjectorData> projectors_h(nproj);
     std::vector<double> beta_radial_h;
+    std::vector<double> beta_radial_grid_h;
 
     for (int ip = 0; ip < nproj; ip++)
     {
         const auto& proj = infoNL_.Beta[T0].Proj[ip];
-        int L0 = proj.getL();
-        int mesh = proj.getNr();
-        double dk = proj.getDk();
-        double rcut = proj.getRcut();
+        const int L0 = proj.getL();
+        const int mesh = proj.getNr();
+        const double rcut = proj.getRcut();
         const double* beta_r = proj.getBeta_r();
         const double* radial = proj.getRadial();
+        const RadialGridInfo grid_info
+            = validate_radial_grid(radial, beta_r, mesh, "snap_psibeta_gpu", "nonlocal beta projector");
 
         projectors_h[ip].L0 = L0;
         projectors_h[ip].beta_offset = static_cast<int>(beta_radial_h.size());
+        projectors_h[ip].beta_grid_offset = static_cast<int>(beta_radial_grid_h.size());
         projectors_h[ip].beta_mesh = mesh;
-        projectors_h[ip].beta_dk = dk;
         projectors_h[ip].beta_rcut = rcut;
-        projectors_h[ip].r_min = radial[0];
-        projectors_h[ip].r_max = radial[mesh - 1];
+        projectors_h[ip].grid_info = grid_info;
 
         beta_radial_h.insert(beta_radial_h.end(), beta_r, beta_r + mesh);
+        beta_radial_grid_h.insert(beta_radial_grid_h.end(), radial, radial + mesh);
     }
 
     //=========================================================================
@@ -255,16 +284,31 @@ void snap_psibeta_atom_batch_gpu(
     NeighborOrbitalData* neighbor_orbitals_d = nullptr;
     ProjectorData* projectors_d = nullptr;
     double* psi_radial_d = nullptr;
+    double* psi_radial_grid_d = nullptr;
     double* beta_radial_d = nullptr;
+    double* beta_radial_grid_d = nullptr;
     int* proj_m0_offset_d = nullptr;
     cuDoubleComplex* nlm_out_d = nullptr;
+
+    const auto release_device_data = [&]() {
+        cudaFree(neighbor_orbitals_d);
+        cudaFree(projectors_d);
+        cudaFree(psi_radial_d);
+        cudaFree(psi_radial_grid_d);
+        cudaFree(beta_radial_d);
+        cudaFree(beta_radial_grid_d);
+        cudaFree(proj_m0_offset_d);
+        cudaFree(nlm_out_d);
+    };
 
     size_t output_size = total_neighbor_orbitals * nlm_dim * natomwfc;
 
     CHECK_CUDA(cudaMalloc(&neighbor_orbitals_d, total_neighbor_orbitals * sizeof(NeighborOrbitalData)));
     CHECK_CUDA(cudaMalloc(&projectors_d, nproj * sizeof(ProjectorData)));
     CHECK_CUDA(cudaMalloc(&psi_radial_d, psi_radial_h.size() * sizeof(double)));
+    CHECK_CUDA(cudaMalloc(&psi_radial_grid_d, psi_radial_grid_h.size() * sizeof(double)));
     CHECK_CUDA(cudaMalloc(&beta_radial_d, beta_radial_h.size() * sizeof(double)));
+    CHECK_CUDA(cudaMalloc(&beta_radial_grid_d, beta_radial_grid_h.size() * sizeof(double)));
     CHECK_CUDA(cudaMalloc(&proj_m0_offset_d, nproj * sizeof(int)));
     CHECK_CUDA(cudaMalloc(&nlm_out_d, output_size * sizeof(cuDoubleComplex)));
 
@@ -280,7 +324,16 @@ void snap_psibeta_atom_batch_gpu(
     CHECK_CUDA(
         cudaMemcpy(psi_radial_d, psi_radial_h.data(), psi_radial_h.size() * sizeof(double), cudaMemcpyHostToDevice));
     CHECK_CUDA(
+        cudaMemcpy(psi_radial_grid_d,
+                   psi_radial_grid_h.data(),
+                   psi_radial_grid_h.size() * sizeof(double),
+                   cudaMemcpyHostToDevice));
+    CHECK_CUDA(
         cudaMemcpy(beta_radial_d, beta_radial_h.data(), beta_radial_h.size() * sizeof(double), cudaMemcpyHostToDevice));
+    CHECK_CUDA(cudaMemcpy(beta_radial_grid_d,
+                          beta_radial_grid_h.data(),
+                          beta_radial_grid_h.size() * sizeof(double),
+                          cudaMemcpyHostToDevice));
     CHECK_CUDA(cudaMemcpy(proj_m0_offset_d, proj_m0_offset_h.data(), nproj * sizeof(int), cudaMemcpyHostToDevice));
     CHECK_CUDA(cudaMemset(nlm_out_d, 0, output_size * sizeof(cuDoubleComplex)));
 
@@ -299,7 +352,9 @@ void snap_psibeta_atom_batch_gpu(
                                                     neighbor_orbitals_d,
                                                     projectors_d,
                                                     psi_radial_d,
+                                                    psi_radial_grid_d,
                                                     beta_radial_d,
+                                                    beta_radial_grid_d,
                                                     proj_m0_offset_d,
                                                     total_neighbor_orbitals,
                                                     nproj,
@@ -311,17 +366,18 @@ void snap_psibeta_atom_batch_gpu(
     cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess)
     {
-        cudaFree(neighbor_orbitals_d);
-        cudaFree(projectors_d);
-        cudaFree(psi_radial_d);
-        cudaFree(beta_radial_d);
-        cudaFree(proj_m0_offset_d);
-        cudaFree(nlm_out_d);
+        release_device_data();
         ModuleBase::WARNING_QUIT("snap_psibeta_gpu",
                                  std::string("Atom batch kernel launch error: ") + cudaGetErrorString(err));
     }
 
-    CHECK_CUDA(cudaDeviceSynchronize());
+    err = cudaDeviceSynchronize();
+    if (err != cudaSuccess)
+    {
+        release_device_data();
+        ModuleBase::WARNING_QUIT("snap_psibeta_gpu",
+                                 std::string("Atom batch kernel execution error: ") + cudaGetErrorString(err));
+    }
 
     //=========================================================================
     // Retrieve results
@@ -361,12 +417,7 @@ void snap_psibeta_atom_batch_gpu(
     // Cleanup GPU memory
     //=========================================================================
 
-    cudaFree(neighbor_orbitals_d);
-    cudaFree(projectors_d);
-    cudaFree(psi_radial_d);
-    cudaFree(beta_radial_d);
-    cudaFree(proj_m0_offset_d);
-    cudaFree(nlm_out_d);
+    release_device_data();
 
     ModuleBase::timer::end("module_rt", "snap_psibeta_gpu");
 }

--- a/source/source_lcao/module_rt/kernels/cuda/snap_psibeta_kernel.cu
+++ b/source/source_lcao/module_rt/kernels/cuda/snap_psibeta_kernel.cu
@@ -79,7 +79,9 @@ __global__ void snap_psibeta_atom_batch_kernel(double3 R0,
                                                const NeighborOrbitalData* __restrict__ neighbor_orbitals,
                                                const ProjectorData* __restrict__ projectors,
                                                const double* __restrict__ psi_radial,
+                                               const double* __restrict__ psi_radial_grid,
                                                const double* __restrict__ beta_radial,
+                                               const double* __restrict__ beta_radial_grid,
                                                const int* __restrict__ proj_m0_offset,
                                                int total_neighbor_orbitals,
                                                int nproj,
@@ -127,8 +129,8 @@ __global__ void snap_psibeta_atom_batch_kernel(double3 R0,
     const double r1_max = norb.psi_rcut;
 
     // Integration range from projector radial grid
-    const double r_min = proj.r_min;
-    const double r_max = proj.r_max;
+    const double r_min = proj.grid_info.r_min;
+    const double r_max = proj.grid_info.r_max;
     const double xl = 0.5 * (r_max - r_min);    // Half-range for Gauss-Legendre
     const double xmean = 0.5 * (r_max + r_min); // Midpoint
 
@@ -228,12 +230,18 @@ __global__ void snap_psibeta_atom_batch_kernel(double3 R0,
                 }
 
                 // Interpolate orbital radial function
-                const double psi_val
-                    = interpolate_radial_gpu(psi_radial + norb.psi_offset, norb.psi_mesh, 1.0 / norb.psi_dk, tnorm);
+                const double psi_val = interpolate_radial(psi_radial_grid + norb.psi_grid_offset,
+                                                          psi_radial + norb.psi_offset,
+                                                          norb.psi_mesh,
+                                                          norb.grid_info,
+                                                          tnorm);
 
                 // Interpolate projector radial function
-                const double beta_val
-                    = interpolate_radial_gpu(beta_radial + proj.beta_offset, proj.beta_mesh, 1.0 / proj.beta_dk, r_val);
+                const double beta_val = interpolate_radial(beta_radial_grid + proj.beta_grid_offset,
+                                                           beta_radial + proj.beta_offset,
+                                                           proj.beta_mesh,
+                                                           proj.grid_info,
+                                                           r_val);
 
                 // Phase factor exp(i * A · r)
                 const double phase = r_val * A_dot_leb;

--- a/source/source_lcao/module_rt/kernels/cuda/snap_psibeta_kernel.cuh
+++ b/source/source_lcao/module_rt/kernels/cuda/snap_psibeta_kernel.cuh
@@ -17,9 +17,10 @@
 #ifndef SNAP_PSIBETA_KERNEL_CUH
 #define SNAP_PSIBETA_KERNEL_CUH
 
-#include "source_base/tool_quit.h"
+#include "source_lcao/module_rt/radial_interpolation.h"
 #include "source_base/kernels/cuda/sph_harm_gpu.cuh"
 #include "source_base/module_device/device_check.h"
+#include "source_base/tool_quit.h"
 
 #include <cstdio>
 #include <cuComplex.h>
@@ -102,46 +103,6 @@ __device__ __forceinline__ cuDoubleComplex cu_mul_real(cuDoubleComplex a, double
 }
 
 //=============================================================================
-// Device Helper Functions - Radial Interpolation
-//=============================================================================
-
-/**
- * @brief Cubic spline interpolation for radial functions
- *
- * Implements cubic polynomial interpolation using 4 consecutive grid points.
- * This is the GPU equivalent of CPU-side PolyInt::Polynomial_Interpolation.
- *
- * @param psi     Radial function values on uniform grid
- * @param mesh    Number of grid points
- * @param inv_dk  Inverse of grid spacing (1/dk)
- * @param distance Radial distance r at which to interpolate
- * @return Interpolated function value
- */
-__device__ __forceinline__ double interpolate_radial_gpu(const double* __restrict__ psi,
-                                                         int mesh,
-                                                         double inv_dk,
-                                                         double distance)
-{
-    double position = distance * inv_dk;
-    int iq = __double2int_rd(position); // floor(position)
-
-    // Boundary checks
-    if (iq > mesh - 4 || iq < 0)
-    {
-        return 0.0;
-    }
-
-    // Lagrange interpolation weights
-    double x0 = position - static_cast<double>(iq);
-    double x1 = 1.0 - x0;
-    double x2 = 2.0 - x0;
-    double x3 = 3.0 - x0;
-
-    // 4-point Lagrange interpolation formula
-    return x1 * x2 * (psi[iq] * x3 + psi[iq + 3] * x0) / 6.0 + x0 * x3 * (psi[iq + 1] * x2 - psi[iq + 2] * x1) / 2.0;
-}
-
-//=============================================================================
 // Device Helper Functions - Spherical Harmonics
 //=============================================================================
 
@@ -157,13 +118,12 @@ __device__ __forceinline__ double interpolate_radial_gpu(const double* __restric
  */
 struct ProjectorData
 {
-    int L0;           ///< Angular momentum quantum number
-    int beta_offset;  ///< Offset into flattened beta radial array
-    int beta_mesh;    ///< Number of radial mesh points
-    double beta_dk;   ///< Radial grid spacing
-    double beta_rcut; ///< Cutoff radius for projector
-    double r_min;     ///< Minimum radial grid value (integration start)
-    double r_max;     ///< Maximum radial grid value (integration end)
+    int L0;                    ///< Angular momentum quantum number
+    int beta_offset;           ///< Offset into flattened beta value array
+    int beta_grid_offset;      ///< Offset into flattened beta coordinate array
+    int beta_mesh;             ///< Number of radial mesh points
+    double beta_rcut;          ///< Cutoff radius for projector
+    RadialGridInfo grid_info;  ///< Validated radial grid metadata
 };
 
 /**
@@ -183,10 +143,11 @@ struct NeighborOrbitalData
     int m1;          ///< Magnetic quantum number of orbital
     int N1;          ///< Radial quantum number of orbital
     int iw_index;    ///< Global orbital index for output mapping
-    int psi_offset;  ///< Offset into flattened psi radial array
-    int psi_mesh;    ///< Number of radial mesh points for orbital
-    double psi_dk;   ///< Radial grid spacing for orbital
-    double psi_rcut; ///< Cutoff radius for orbital
+    int psi_offset;           ///< Offset into flattened psi value array
+    int psi_grid_offset;      ///< Offset into flattened psi coordinate array
+    int psi_mesh;             ///< Number of radial mesh points for orbital
+    double psi_rcut;          ///< Cutoff radius for orbital
+    RadialGridInfo grid_info; ///< Validated radial grid metadata
 };
 
 //=============================================================================
@@ -217,7 +178,9 @@ struct NeighborOrbitalData
  * @param neighbor_orbitals     Array of neighbor-orbital data [total_neighbor_orbitals]
  * @param projectors            Array of projector data [nproj]
  * @param psi_radial            Flattened array of orbital radial functions
+ * @param psi_radial_grid       Flattened array of orbital radial coordinates
  * @param beta_radial           Flattened array of projector radial functions
+ * @param beta_radial_grid      Flattened array of projector radial coordinates
  * @param proj_m0_offset        Starting index of each projector's m=0 component in output
  * @param total_neighbor_orbitals Total number of (neighbor, orbital) pairs
  * @param nproj                 Number of projectors on center atom
@@ -230,7 +193,9 @@ __global__ void snap_psibeta_atom_batch_kernel(double3 R0,
                                                const NeighborOrbitalData* __restrict__ neighbor_orbitals,
                                                const ProjectorData* __restrict__ projectors,
                                                const double* __restrict__ psi_radial,
+                                               const double* __restrict__ psi_radial_grid,
                                                const double* __restrict__ beta_radial,
+                                               const double* __restrict__ beta_radial_grid,
                                                const int* __restrict__ proj_m0_offset,
                                                int total_neighbor_orbitals,
                                                int nproj,

--- a/source/source_lcao/module_rt/radial_interpolation.cpp
+++ b/source/source_lcao/module_rt/radial_interpolation.cpp
@@ -1,0 +1,79 @@
+#include "radial_interpolation.h"
+
+#include "source_base/tool_quit.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <string>
+
+namespace module_rt
+{
+
+bool analyze_radial_grid(const double* radial_grid,
+                         const double* radial_values,
+                         const int mesh,
+                         RadialGridInfo& grid_info)
+{
+    grid_info = RadialGridInfo();
+    if (radial_grid == nullptr || radial_values == nullptr || mesh <= 0)
+    {
+        return false;
+    }
+
+    for (int i = 0; i < mesh; ++i)
+    {
+        if (!std::isfinite(radial_grid[i]) || !std::isfinite(radial_values[i]))
+        {
+            return false;
+        }
+        if (i > 0 && radial_grid[i] <= radial_grid[i - 1])
+        {
+            return false;
+        }
+    }
+
+    grid_info.r_min = radial_grid[0];
+    grid_info.r_max = radial_grid[mesh - 1];
+    if (mesh == 1)
+    {
+        return true;
+    }
+
+    const double spacing = (grid_info.r_max - grid_info.r_min) / static_cast<double>(mesh - 1);
+    grid_info.inv_spacing = 1.0 / spacing;
+    grid_info.is_uniform = true;
+
+    const double scale = std::max(1.0, std::max(std::abs(grid_info.r_min), std::abs(grid_info.r_max)));
+    const double tolerance = 64.0 * std::numeric_limits<double>::epsilon() * scale;
+    for (int i = 1; i < mesh - 1; ++i)
+    {
+        const double expected = grid_info.r_min + static_cast<double>(i) * spacing;
+        if (std::abs(radial_grid[i] - expected) > tolerance)
+        {
+            grid_info.is_uniform = false;
+            grid_info.inv_spacing = 0.0;
+            break;
+        }
+    }
+    return true;
+}
+
+RadialGridInfo validate_radial_grid(const double* radial_grid,
+                                    const double* radial_values,
+                                    const int mesh,
+                                    const char* caller,
+                                    const char* data_name)
+{
+    RadialGridInfo grid_info;
+    if (!analyze_radial_grid(radial_grid, radial_values, mesh, grid_info))
+    {
+        ModuleBase::WARNING_QUIT(caller,
+                                 std::string("Invalid radial data for ") + data_name
+                                     + ": pointers must be non-null, mesh must be positive, values must be finite, "
+                                       "and coordinates must be strictly increasing.");
+    }
+    return grid_info;
+}
+
+} // namespace module_rt

--- a/source/source_lcao/module_rt/radial_interpolation.h
+++ b/source/source_lcao/module_rt/radial_interpolation.h
@@ -1,0 +1,185 @@
+#ifndef MODULE_RT_RADIAL_INTERPOLATION_H
+#define MODULE_RT_RADIAL_INTERPOLATION_H
+
+#include <cmath>
+
+namespace module_rt
+{
+
+/**
+ * @brief Metadata used to accelerate interpolation on uniform radial grids.
+ */
+struct RadialGridInfo
+{
+    double r_min = 0.0;
+    double r_max = 0.0;
+    double inv_spacing = 0.0;
+    bool is_uniform = false;
+};
+
+/**
+ * @brief Validate and analyze one radial function on the host.
+ *
+ * A valid grid has at least one point, finite coordinates and values, and
+ * strictly increasing coordinates when it contains multiple points.
+ */
+bool analyze_radial_grid(const double* radial_grid,
+                         const double* radial_values,
+                         int mesh,
+                         RadialGridInfo& grid_info);
+
+/**
+ * @brief Validate radial data and terminate with a diagnostic if it is invalid.
+ */
+RadialGridInfo validate_radial_grid(const double* radial_grid,
+                                    const double* radial_values,
+                                    int mesh,
+                                    const char* caller,
+                                    const char* data_name);
+
+#if defined(__CUDACC__)
+#define MODULE_RT_HOST_DEVICE __host__ __device__ __forceinline__
+#else
+#define MODULE_RT_HOST_DEVICE inline
+#endif
+
+namespace detail
+{
+
+MODULE_RT_HOST_DEVICE bool radial_is_finite(const double value)
+{
+#if defined(__CUDA_ARCH__)
+    return isfinite(value);
+#else
+    return std::isfinite(value);
+#endif
+}
+
+MODULE_RT_HOST_DEVICE int clamp_index(const int value, const int lower, const int upper)
+{
+    return value < lower ? lower : (value > upper ? upper : value);
+}
+
+MODULE_RT_HOST_DEVICE int find_radial_interval(const double* radial_grid,
+                                               const int mesh,
+                                               const RadialGridInfo& grid_info,
+                                               const double radius)
+{
+    if (grid_info.is_uniform)
+    {
+        int interval = static_cast<int>((radius - grid_info.r_min) * grid_info.inv_spacing);
+        interval = clamp_index(interval, 0, mesh - 2);
+
+        // Correct the arithmetic estimate with the actual stored coordinates.
+        while (interval > 0 && radius < radial_grid[interval])
+        {
+            --interval;
+        }
+        while (interval < mesh - 2 && radius > radial_grid[interval + 1])
+        {
+            ++interval;
+        }
+        return interval;
+    }
+
+    int lower = 0;
+    int upper = mesh - 1;
+    while (upper - lower > 1)
+    {
+        const int middle = lower + (upper - lower) / 2;
+        if (radius < radial_grid[middle])
+        {
+            upper = middle;
+        }
+        else
+        {
+            lower = middle;
+        }
+    }
+    return lower;
+}
+
+MODULE_RT_HOST_DEVICE double lagrange_interpolate(const double* radial_grid,
+                                                  const double* radial_values,
+                                                  const int start,
+                                                  const int point_count,
+                                                  const double radius)
+{
+    double result = 0.0;
+    for (int i = 0; i < point_count; ++i)
+    {
+        const int ii = start + i;
+        double weight = 1.0;
+        for (int j = 0; j < point_count; ++j)
+        {
+            if (i == j)
+            {
+                continue;
+            }
+            const int jj = start + j;
+            weight *= (radius - radial_grid[jj]) / (radial_grid[ii] - radial_grid[jj]);
+        }
+        result += weight * radial_values[ii];
+    }
+    return result;
+}
+
+} // namespace detail
+
+/**
+ * @brief Interpolate a radial function without extrapolating beyond its grid.
+ *
+ * Four or more points use a local four-point cubic Lagrange interpolant. The
+ * final intervals use the final four grid points instead of returning zero.
+ * Grids with one, two, or three points use constant, linear, or quadratic
+ * interpolation, respectively.
+ */
+MODULE_RT_HOST_DEVICE double interpolate_radial(const double* radial_grid,
+                                                const double* radial_values,
+                                                const int mesh,
+                                                const RadialGridInfo& grid_info,
+                                                const double radius)
+{
+    if (radial_grid == nullptr || radial_values == nullptr || mesh <= 0 || !detail::radial_is_finite(radius)
+        || radius < grid_info.r_min || radius > grid_info.r_max)
+    {
+        return 0.0;
+    }
+
+    if (radius == radial_grid[0])
+    {
+        return radial_values[0];
+    }
+    if (mesh == 1)
+    {
+        return 0.0;
+    }
+    if (radius == radial_grid[mesh - 1])
+    {
+        return radial_values[mesh - 1];
+    }
+
+    const int interval = detail::find_radial_interval(radial_grid, mesh, grid_info, radius);
+    if (radius == radial_grid[interval])
+    {
+        return radial_values[interval];
+    }
+    if (radius == radial_grid[interval + 1])
+    {
+        return radial_values[interval + 1];
+    }
+
+    if (mesh < 4)
+    {
+        return detail::lagrange_interpolate(radial_grid, radial_values, 0, mesh, radius);
+    }
+
+    const int start = detail::clamp_index(interval - 1, 0, mesh - 4);
+    return detail::lagrange_interpolate(radial_grid, radial_values, start, 4, radius);
+}
+
+#undef MODULE_RT_HOST_DEVICE
+
+} // namespace module_rt
+
+#endif

--- a/source/source_lcao/module_rt/snap_phialpha_half_tddft.cpp
+++ b/source/source_lcao/module_rt/snap_phialpha_half_tddft.cpp
@@ -1,0 +1,61 @@
+#include "snap_phialpha_half_tddft.h"
+
+#include "source_base/vector3.h"
+#include "source_basis/module_ao/ORB_read.h"
+#include "source_lcao/module_rt/snap_projector_half_tddft.h"
+
+#include <complex>
+#include <vector>
+
+namespace module_rt
+{
+
+void snap_phialpha_half_tddft(const LCAO_Orbitals& orb,
+                              std::vector<std::vector<std::complex<double>>>& nlm,
+                              const ModuleBase::Vector3<double>& R1,
+                              const int& T1,
+                              const int& L1,
+                              const int& m1,
+                              const int& N1,
+                              const ModuleBase::Vector3<double>& R0,
+                              const ModuleBase::Vector3<double>& A,
+                              const bool& calc_r)
+{
+    SnapIntegrationOptions options;
+    snap_phialpha_half_tddft(orb, nlm, R1, T1, L1, m1, N1, R0, A, calc_r, options);
+}
+
+void snap_phialpha_half_tddft(const LCAO_Orbitals& orb,
+                              std::vector<std::vector<std::complex<double>>>& nlm,
+                              const ModuleBase::Vector3<double>& R1,
+                              const int& T1,
+                              const int& L1,
+                              const int& m1,
+                              const int& N1,
+                              const ModuleBase::Vector3<double>& R0,
+                              const ModuleBase::Vector3<double>& A,
+                              const bool& calc_r,
+                              const SnapIntegrationOptions& options)
+{
+    std::vector<ProjectorChannel> channels;
+    const int lmax_alpha = orb.Alpha[0].getLmax();
+    for (int L = 0; L <= lmax_alpha; ++L)
+    {
+        const int nchi_L = orb.Alpha[0].getNchi(L);
+        for (int N = 0; N < nchi_L; ++N)
+        {
+            const auto& alpha_ln = orb.Alpha[0].PhiLN(L, N);
+            ProjectorChannel channel;
+            channel.l = L;
+            channel.mesh = alpha_ln.getNr();
+            channel.rcut = alpha_ln.getRcut();
+            channel.radial_times_r = alpha_ln.getPsi_r();
+            channel.radial_grid = alpha_ln.getRadial();
+            channels.push_back(channel);
+        }
+    }
+
+    snap_projector_half_tddft(orb, channels, nlm, R1, T1, L1, m1, N1, R0, A, calc_r, options, "snap_phialpha_half_tddft");
+}
+
+} // namespace module_rt

--- a/source/source_lcao/module_rt/snap_phialpha_half_tddft.h
+++ b/source/source_lcao/module_rt/snap_phialpha_half_tddft.h
@@ -1,0 +1,55 @@
+#ifndef SNAP_PHIALPHA_HALF_TDDFT_H
+#define SNAP_PHIALPHA_HALF_TDDFT_H
+
+#include <complex>
+#include <vector>
+
+class LCAO_Orbitals;
+
+namespace ModuleBase
+{
+template <class T> class Vector3;
+}
+
+namespace module_rt
+{
+
+struct SnapIntegrationOptions;
+
+/**
+ * @brief Compute RT-TDDFT velocity-gauge DeePKS alpha-projector overlaps.
+ *
+ * DeePKS alpha projectors currently use the global descriptor basis
+ * orb.Alpha[0]. Each radial channel is passed to the shared projector
+ * integrator through getPsi_r(), following the required r * alpha(r)
+ * convention.
+ */
+void snap_phialpha_half_tddft(const LCAO_Orbitals& orb,
+                              std::vector<std::vector<std::complex<double>>>& nlm,
+                              const ModuleBase::Vector3<double>& R1,
+                              const int& T1,
+                              const int& L1,
+                              const int& m1,
+                              const int& N1,
+                              const ModuleBase::Vector3<double>& R0,
+                              const ModuleBase::Vector3<double>& A,
+                              const bool& calc_r);
+
+/**
+ * @brief Compute DeePKS alpha-projector overlaps with explicit quadrature.
+ */
+void snap_phialpha_half_tddft(const LCAO_Orbitals& orb,
+                              std::vector<std::vector<std::complex<double>>>& nlm,
+                              const ModuleBase::Vector3<double>& R1,
+                              const int& T1,
+                              const int& L1,
+                              const int& m1,
+                              const int& N1,
+                              const ModuleBase::Vector3<double>& R0,
+                              const ModuleBase::Vector3<double>& A,
+                              const bool& calc_r,
+                              const SnapIntegrationOptions& options);
+
+} // namespace module_rt
+
+#endif

--- a/source/source_lcao/module_rt/snap_projector_half_tddft.cpp
+++ b/source/source_lcao/module_rt/snap_projector_half_tddft.cpp
@@ -1,10 +1,10 @@
 #include "snap_projector_half_tddft.h"
 
+#include "radial_interpolation.h"
 #include "source_base/constants.h"
 #include "source_base/global_function.h"
 #include "source_base/math_integral.h"
 #include "source_base/math_lebedev_laikov.h"
-#include "source_base/math_polyint.h"
 #include "source_base/timer.h"
 #include "source_base/ylm.h"
 
@@ -104,7 +104,8 @@ AngularGridView angular_grid(const int ngrid)
 {
     if (!is_supported_lebedev_grid(ngrid))
     {
-        ModuleBase::WARNING_QUIT("snap_projector_half_tddft", "Unsupported Lebedev-Laikov grid size: " + std::to_string(ngrid));
+        ModuleBase::WARNING_QUIT("snap_projector_half_tddft",
+                                 "Unsupported Lebedev-Laikov grid size: " + std::to_string(ngrid));
     }
 
     if (ngrid == default_lebedev_grid_points)
@@ -139,9 +140,13 @@ AngularGridView angular_grid(const int ngrid)
     return view;
 }
 
-double radial_factor(const ProjectorChannel& channel, const double r, const double w_radial)
+double radial_factor(const ProjectorChannel& channel,
+                     const RadialGridInfo& grid_info,
+                     const double r,
+                     const double w_radial)
 {
-    const double projector_val = ModuleBase::PolyInt::Polynomial_Interpolation(channel.radial_times_r, channel.mesh, channel.dk, r);
+    const double projector_val
+        = interpolate_radial(channel.radial_grid, channel.radial_times_r, channel.mesh, grid_info, r);
     return projector_val * r * w_radial;
 }
 } // namespace
@@ -196,6 +201,7 @@ void snap_projector_half_tddft(const LCAO_Orbitals& orb,
 
     int natomwfc = 0;
     std::vector<bool> active(projector_channels.size(), false);
+    std::vector<RadialGridInfo> projector_grid_info(projector_channels.size());
 
     const double Rcut1 = orb.Phi[T1].getRcut();
     const ModuleBase::Vector3<double> dRa = R0 - R1;
@@ -205,6 +211,11 @@ void snap_projector_half_tddft(const LCAO_Orbitals& orb,
     for (int ich = 0; ich < static_cast<int>(projector_channels.size()); ++ich)
     {
         const ProjectorChannel& channel = projector_channels[ich];
+        projector_grid_info[ich] = validate_radial_grid(channel.radial_grid,
+                                                        channel.radial_times_r,
+                                                        channel.mesh,
+                                                        "snap_projector_half_tddft",
+                                                        "projector");
         natomwfc += 2 * channel.l + 1;
         if (distance10 <= Rcut1 + channel.rcut)
         {
@@ -228,7 +239,9 @@ void snap_projector_half_tddft(const LCAO_Orbitals& orb,
     const auto& phi_ln = orb.Phi[T1].PhiLN(L1, N1);
     const int mesh_r1 = phi_ln.getNr();
     const double* psi_1 = phi_ln.getPsi();
-    const double dk_1 = phi_ln.getDk();
+    const double* radial_1 = phi_ln.getRadial();
+    const RadialGridInfo orbital_grid_info
+        = validate_radial_grid(radial_1, psi_1, mesh_r1, "snap_projector_half_tddft", "LCAO orbital");
 
     const GaussLegendreGrid& gl = gauss_legendre_grid(radial_grid_num);
     std::vector<double> r_radial(radial_grid_num);
@@ -260,12 +273,8 @@ void snap_projector_half_tddft(const LCAO_Orbitals& orb,
             continue;
         }
 
-        assert(channel.mesh > 0);
-        assert(channel.radial_times_r != nullptr);
-        assert(channel.radial_grid != nullptr);
-
-        const double r_min = channel.radial_grid[0];
-        const double r_max = channel.radial_grid[channel.mesh - 1];
+        const double r_min = projector_grid_info[ich].r_min;
+        const double r_max = projector_grid_info[ich].r_max;
         const double xl = (r_max - r_min) * 0.5;
         const double xmean = (r_max + r_min) * 0.5;
 
@@ -340,7 +349,8 @@ void snap_projector_half_tddft(const LCAO_Orbitals& orb,
 
                 const double phase = r_val * A_dot_lebedev[ian];
                 const std::complex<double> exp_iAr = std::exp(ModuleBase::IMAG_UNIT * phase);
-                const double interp_psi = ModuleBase::PolyInt::Polynomial_Interpolation(psi_1, mesh_r1, dk_1, tnorm);
+                const double interp_psi
+                    = interpolate_radial(radial_1, psi_1, mesh_r1, orbital_grid_info, tnorm);
                 const double ylm_L1_val = rly1[L1 * L1 + m1];
                 const std::complex<double> common_factor = exp_iAr * ylm_L1_val * interp_psi * w_ang;
 
@@ -361,7 +371,7 @@ void snap_projector_half_tddft(const LCAO_Orbitals& orb,
                 }
             }
 
-            const double factor = radial_factor(channel, r_val, w_radial[ir]);
+            const double factor = radial_factor(channel, projector_grid_info[ich], r_val, w_radial[ir]);
             int current_idx = index_offset;
             for (int m0 = 0; m0 < num_m0; ++m0)
             {

--- a/source/source_lcao/module_rt/snap_projector_half_tddft.h
+++ b/source/source_lcao/module_rt/snap_projector_half_tddft.h
@@ -32,7 +32,6 @@ struct ProjectorChannel
 {
     int l = 0;
     int mesh = 0;
-    double dk = 0.0;
     double rcut = 0.0;
     const double* radial_times_r = nullptr;
     const double* radial_grid = nullptr;

--- a/source/source_lcao/module_rt/snap_psibeta_half_tddft.cpp
+++ b/source/source_lcao/module_rt/snap_psibeta_half_tddft.cpp
@@ -44,7 +44,6 @@ void snap_psibeta_half_tddft(const LCAO_Orbitals& orb,
         ProjectorChannel channel;
         channel.l = proj.getL();
         channel.mesh = proj.getNr();
-        channel.dk = proj.getDk();
         channel.rcut = proj.getRcut();
         channel.radial_times_r = proj.getBeta_r();
         channel.radial_grid = proj.getRadial();

--- a/source/source_lcao/module_rt/test/CMakeLists.txt
+++ b/source/source_lcao/module_rt/test/CMakeLists.txt
@@ -1,3 +1,10 @@
+set(SNAP_PSIBETA_CUDA_TEST_SOURCES)
+if(USE_CUDA)
+  list(APPEND SNAP_PSIBETA_CUDA_TEST_SOURCES
+       ../kernels/cuda/snap_psibeta_kernel.cu
+       ../kernels/cuda/snap_psibeta_gpu.cu)
+endif()
+
 add_library(tddft_test_lib tddft_test.cpp)
 target_link_libraries(tddft_test_lib PRIVATE Threads::Threads GTest::gtest_main GTest::gmock_main)
 #target_include_directories(tddft_test_lib PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${GTEST_INCLUDE_DIRS}>)
@@ -35,7 +42,7 @@ AddTest(
 AddTest(
   TARGET MODULE_LCAO_tddft_snap_psibeta_half_test
   LIBS parameter base device orb numerical_atomic_orbitals tddft_test_lib
-  SOURCES snap_psibeta_half_tddft_test.cpp ../snap_projector_half_tddft.cpp ../snap_psibeta_half_tddft.cpp
+  SOURCES snap_psibeta_half_tddft_test.cpp ../radial_interpolation.cpp ../snap_projector_half_tddft.cpp ../snap_psibeta_half_tddft.cpp
           ../../center2_orb.cpp
           ../../center2_orb-orb11.cpp
           ../../center2_orb-orb21.cpp
@@ -53,4 +60,19 @@ AddTest(
           ../../../source_io/module_hs/single_R_io.cpp
           ../../../source_io/module_hs/rr_sparse_writer.cpp
           ../../../source_pw/module_pwdft/soc.cpp
+          ${SNAP_PSIBETA_CUDA_TEST_SOURCES}
 )
+
+AddTest(
+  TARGET MODULE_LCAO_tddft_radial_interpolation_test
+  LIBS base device
+  SOURCES radial_interpolation_test.cpp ../radial_interpolation.cpp
+)
+
+if(USE_CUDA)
+  AddTest(
+    TARGET MODULE_LCAO_tddft_radial_interpolation_cuda_test
+    LIBS base device
+    SOURCES radial_interpolation_cuda_test.cu ../radial_interpolation.cpp
+  )
+endif()

--- a/source/source_lcao/module_rt/test/radial_interpolation_cuda_test.cu
+++ b/source/source_lcao/module_rt/test/radial_interpolation_cuda_test.cu
@@ -1,0 +1,143 @@
+#include "source_lcao/module_rt/radial_interpolation.h"
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+namespace
+{
+
+__global__ void interpolate_queries(const double* radial_grid,
+                                    const double* radial_values,
+                                    const int mesh,
+                                    const module_rt::RadialGridInfo grid_info,
+                                    const double* queries,
+                                    const int query_count,
+                                    double* results)
+{
+    const int index = blockIdx.x * blockDim.x + threadIdx.x;
+    if (index < query_count)
+    {
+        results[index]
+            = module_rt::interpolate_radial(radial_grid, radial_values, mesh, grid_info, queries[index]);
+    }
+}
+
+void compare_cpu_and_gpu(const std::vector<double>& grid,
+                         const std::vector<double>& values,
+                         const std::vector<double>& queries)
+{
+    module_rt::RadialGridInfo grid_info;
+    ASSERT_TRUE(module_rt::analyze_radial_grid(grid.data(),
+                                               values.data(),
+                                               static_cast<int>(grid.size()),
+                                               grid_info));
+
+    double* grid_device = nullptr;
+    double* values_device = nullptr;
+    double* queries_device = nullptr;
+    double* results_device = nullptr;
+    ASSERT_EQ(cudaMalloc(&grid_device, grid.size() * sizeof(double)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&values_device, values.size() * sizeof(double)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&queries_device, queries.size() * sizeof(double)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&results_device, queries.size() * sizeof(double)), cudaSuccess);
+
+    ASSERT_EQ(cudaMemcpy(grid_device, grid.data(), grid.size() * sizeof(double), cudaMemcpyHostToDevice), cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(values_device,
+                         values.data(),
+                         values.size() * sizeof(double),
+                         cudaMemcpyHostToDevice),
+              cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(queries_device,
+                         queries.data(),
+                         queries.size() * sizeof(double),
+                         cudaMemcpyHostToDevice),
+              cudaSuccess);
+
+    constexpr int block_size = 128;
+    const int block_count = (static_cast<int>(queries.size()) + block_size - 1) / block_size;
+    interpolate_queries<<<block_count, block_size>>>(grid_device,
+                                                     values_device,
+                                                     static_cast<int>(grid.size()),
+                                                     grid_info,
+                                                     queries_device,
+                                                     static_cast<int>(queries.size()),
+                                                     results_device);
+    ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    std::vector<double> gpu_results(queries.size());
+    ASSERT_EQ(cudaMemcpy(gpu_results.data(),
+                         results_device,
+                         gpu_results.size() * sizeof(double),
+                         cudaMemcpyDeviceToHost),
+              cudaSuccess);
+
+    double max_difference = 0.0;
+    for (size_t i = 0; i < queries.size(); ++i)
+    {
+        const double cpu_result = module_rt::interpolate_radial(grid.data(),
+                                                                values.data(),
+                                                                static_cast<int>(grid.size()),
+                                                                grid_info,
+                                                                queries[i]);
+        const double difference = std::abs(gpu_results[i] - cpu_result);
+        max_difference = std::max(max_difference, difference);
+        EXPECT_LE(difference, 5.0e-15) << "query = " << queries[i];
+    }
+    std::cout << std::scientific << std::setprecision(12) << "radial interpolation CPU/GPU mesh=" << grid.size()
+              << ": max difference = " << max_difference << std::defaultfloat << std::endl;
+
+    EXPECT_EQ(cudaFree(grid_device), cudaSuccess);
+    EXPECT_EQ(cudaFree(values_device), cudaSuccess);
+    EXPECT_EQ(cudaFree(queries_device), cudaSuccess);
+    EXPECT_EQ(cudaFree(results_device), cudaSuccess);
+}
+
+} // namespace
+
+TEST(RadialInterpolationCuda, MatchesCpuOnUniformAndNonuniformGrids)
+{
+    int device_count = 0;
+    const cudaError_t device_status = cudaGetDeviceCount(&device_count);
+    if (device_status != cudaSuccess)
+    {
+        GTEST_SKIP() << "cudaGetDeviceCount failed: " << cudaGetErrorString(device_status);
+    }
+    if (device_count == 0)
+    {
+        GTEST_SKIP() << "cudaGetDeviceCount reported zero CUDA devices";
+    }
+
+    const std::vector<double> uniform_grid = {0.25, 0.75, 1.25, 1.75, 2.25, 2.75, 3.25};
+    std::vector<double> uniform_values;
+    for (const double radius: uniform_grid)
+    {
+        uniform_values.push_back(std::sin(radius) + radius * radius);
+    }
+    compare_cpu_and_gpu(uniform_grid,
+                        uniform_values,
+                        {0.25,
+                         0.5,
+                         2.1,
+                         2.6,
+                         3.1,
+                         3.25,
+                         3.5,
+                         std::numeric_limits<double>::quiet_NaN(),
+                         std::numeric_limits<double>::infinity()});
+
+    const std::vector<double> nonuniform_grid = {0.2, 0.201, 0.35, 1.4, 1.45, 4.0, 9.0};
+    std::vector<double> nonuniform_values;
+    for (const double radius: nonuniform_grid)
+    {
+        nonuniform_values.push_back(std::cos(radius) - 0.25 * radius);
+    }
+    compare_cpu_and_gpu(nonuniform_grid, nonuniform_values, {0.2, 0.2005, 1.43, 3.2, 8.5, 9.0, 9.1});
+}

--- a/source/source_lcao/module_rt/test/radial_interpolation_test.cpp
+++ b/source/source_lcao/module_rt/test/radial_interpolation_test.cpp
@@ -1,0 +1,200 @@
+#include "source_lcao/module_rt/radial_interpolation.h"
+
+#include <algorithm>
+#include <cmath>
+#include <gtest/gtest.h>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+namespace
+{
+
+constexpr double interpolation_tolerance = 5.0e-15;
+
+double cubic(const double radius)
+{
+    return ((0.75 * radius - 1.25) * radius + 0.5) * radius + 2.0;
+}
+
+void expect_cubic_interpolation(const std::vector<double>& grid, const std::vector<double>& queries)
+{
+    std::vector<double> values(grid.size());
+    for (size_t i = 0; i < grid.size(); ++i)
+    {
+        values[i] = cubic(grid[i]);
+    }
+
+    module_rt::RadialGridInfo grid_info;
+    ASSERT_TRUE(module_rt::analyze_radial_grid(grid.data(),
+                                               values.data(),
+                                               static_cast<int>(grid.size()),
+                                               grid_info));
+    double max_error = 0.0;
+    for (const double query: queries)
+    {
+        const double interpolated = module_rt::interpolate_radial(grid.data(),
+                                                                  values.data(),
+                                                                  static_cast<int>(grid.size()),
+                                                                  grid_info,
+                                                                  query);
+        const double error = std::abs(interpolated - cubic(query));
+        max_error = std::max(max_error, error);
+        EXPECT_LE(error, interpolation_tolerance) << "query = " << query;
+    }
+    std::cout << std::scientific << std::setprecision(12) << "radial interpolation mesh=" << grid.size()
+              << ", r=[" << grid.front() << ", " << grid.back() << "]: max cubic error = " << max_error
+              << std::defaultfloat << std::endl;
+}
+
+} // namespace
+
+TEST(RadialInterpolation, UniformGridCoversTailIntervalsAndEndpoint)
+{
+    const std::vector<double> grid = {0.25, 0.75, 1.25, 1.75, 2.25, 2.75, 3.25};
+    const std::vector<double> queries = {2.1, 2.6, 3.1, 3.25};
+    expect_cubic_interpolation(grid, queries);
+
+    std::vector<double> values(grid.size());
+    module_rt::RadialGridInfo grid_info;
+    EXPECT_TRUE(module_rt::analyze_radial_grid(grid.data(),
+                                               values.data(),
+                                               static_cast<int>(grid.size()),
+                                               grid_info));
+    EXPECT_TRUE(grid_info.is_uniform);
+}
+
+TEST(RadialInterpolation, NonuniformGridsReproduceCubic)
+{
+    std::vector<double> logarithmic_grid;
+    std::vector<double> shifted_logarithmic_grid;
+    for (int i = 0; i < 9; ++i)
+    {
+        logarithmic_grid.push_back(std::exp(-2.0 + 0.35 * i));
+        shifted_logarithmic_grid.push_back(0.4 + std::exp(-3.0 + 0.5 * i));
+    }
+    const std::vector<double> strongly_nonuniform_grid = {0.2, 0.201, 0.35, 1.4, 1.45, 4.0, 9.0};
+
+    expect_cubic_interpolation(logarithmic_grid,
+                               {logarithmic_grid[1] * 1.1,
+                                0.5 * (logarithmic_grid[5] + logarithmic_grid[6]),
+                                0.5 * (logarithmic_grid[7] + logarithmic_grid[8])});
+    expect_cubic_interpolation(shifted_logarithmic_grid,
+                               {0.5 * (shifted_logarithmic_grid[0] + shifted_logarithmic_grid[1]),
+                                0.5 * (shifted_logarithmic_grid[6] + shifted_logarithmic_grid[7]),
+                                shifted_logarithmic_grid.back()});
+    expect_cubic_interpolation(strongly_nonuniform_grid, {0.2005, 1.43, 3.2, 8.5});
+
+    std::vector<double> values(strongly_nonuniform_grid.size());
+    module_rt::RadialGridInfo grid_info;
+    ASSERT_TRUE(module_rt::analyze_radial_grid(strongly_nonuniform_grid.data(),
+                                               values.data(),
+                                               static_cast<int>(strongly_nonuniform_grid.size()),
+                                               grid_info));
+    EXPECT_FALSE(grid_info.is_uniform);
+}
+
+TEST(RadialInterpolation, PreservesGridValuesAndRejectsExtrapolation)
+{
+    const std::vector<double> grid = {0.3, 0.5, 1.1, 2.0, 3.7};
+    const std::vector<double> values = {9.0, -1.0, 4.5, 8.0, -3.0};
+    module_rt::RadialGridInfo grid_info;
+    ASSERT_TRUE(module_rt::analyze_radial_grid(grid.data(),
+                                               values.data(),
+                                               static_cast<int>(grid.size()),
+                                               grid_info));
+
+    for (size_t i = 0; i < grid.size(); ++i)
+    {
+        EXPECT_DOUBLE_EQ(module_rt::interpolate_radial(grid.data(),
+                                                      values.data(),
+                                                      static_cast<int>(grid.size()),
+                                                      grid_info,
+                                                      grid[i]),
+                         values[i]);
+    }
+
+    EXPECT_DOUBLE_EQ(module_rt::interpolate_radial(grid.data(), values.data(), 5, grid_info, 0.2), 0.0);
+    EXPECT_DOUBLE_EQ(module_rt::interpolate_radial(grid.data(), values.data(), 5, grid_info, 4.0), 0.0);
+    EXPECT_DOUBLE_EQ(module_rt::interpolate_radial(grid.data(),
+                                                  values.data(),
+                                                  5,
+                                                  grid_info,
+                                                  std::numeric_limits<double>::quiet_NaN()),
+                     0.0);
+    EXPECT_DOUBLE_EQ(module_rt::interpolate_radial(grid.data(),
+                                                  values.data(),
+                                                  5,
+                                                  grid_info,
+                                                  std::numeric_limits<double>::infinity()),
+                     0.0);
+}
+
+TEST(RadialInterpolation, HandlesSmallMeshes)
+{
+    double max_small_mesh_error = 0.0;
+    {
+        const std::vector<double> grid = {0.4};
+        const std::vector<double> values = {3.0};
+        module_rt::RadialGridInfo grid_info;
+        ASSERT_TRUE(module_rt::analyze_radial_grid(grid.data(), values.data(), 1, grid_info));
+        EXPECT_DOUBLE_EQ(module_rt::interpolate_radial(grid.data(), values.data(), 1, grid_info, 0.4), 3.0);
+        EXPECT_DOUBLE_EQ(module_rt::interpolate_radial(grid.data(), values.data(), 1, grid_info, 0.5), 0.0);
+    }
+
+    {
+        const std::vector<double> grid = {0.4, 1.2};
+        const std::vector<double> values = {-0.2, 1.4};
+        module_rt::RadialGridInfo grid_info;
+        ASSERT_TRUE(module_rt::analyze_radial_grid(grid.data(), values.data(), 2, grid_info));
+        const double error
+            = std::abs(module_rt::interpolate_radial(grid.data(), values.data(), 2, grid_info, 0.8) - 0.6);
+        max_small_mesh_error = std::max(max_small_mesh_error, error);
+        EXPECT_LE(error, interpolation_tolerance);
+    }
+
+    {
+        const std::vector<double> grid = {0.4, 0.7, 1.2};
+        std::vector<double> values;
+        for (const double radius: grid)
+        {
+            values.push_back(radius * radius - 0.5 * radius + 1.0);
+        }
+        module_rt::RadialGridInfo grid_info;
+        ASSERT_TRUE(module_rt::analyze_radial_grid(grid.data(), values.data(), 3, grid_info));
+        for (const double query: {0.4, 0.55, 0.9, 1.2})
+        {
+            const double expected = query * query - 0.5 * query + 1.0;
+            const double error
+                = std::abs(module_rt::interpolate_radial(grid.data(), values.data(), 3, grid_info, query) - expected);
+            max_small_mesh_error = std::max(max_small_mesh_error, error);
+            EXPECT_LE(error, interpolation_tolerance) << "query = " << query;
+        }
+    }
+
+    expect_cubic_interpolation({0.4, 0.7, 1.2, 2.0}, {0.4, 0.55, 0.9, 1.6, 2.0});
+    std::cout << std::scientific << std::setprecision(12)
+              << "radial interpolation mesh=1/2/3: max polynomial error = " << max_small_mesh_error
+              << std::defaultfloat << std::endl;
+}
+
+TEST(RadialInterpolation, RejectsInvalidRadialData)
+{
+    const double values[] = {1.0, 2.0, 3.0};
+    module_rt::RadialGridInfo grid_info;
+
+    EXPECT_FALSE(module_rt::analyze_radial_grid(nullptr, values, 3, grid_info));
+    EXPECT_FALSE(module_rt::analyze_radial_grid(values, nullptr, 3, grid_info));
+    EXPECT_FALSE(module_rt::analyze_radial_grid(values, values, 0, grid_info));
+
+    const double duplicate_grid[] = {0.0, 0.5, 0.5};
+    const double reversed_grid[] = {0.0, 0.5, 0.4};
+    const double nonfinite_grid[] = {0.0, std::numeric_limits<double>::infinity(), 1.0};
+    const double nonfinite_values[] = {1.0, std::numeric_limits<double>::quiet_NaN(), 3.0};
+
+    EXPECT_FALSE(module_rt::analyze_radial_grid(duplicate_grid, values, 3, grid_info));
+    EXPECT_FALSE(module_rt::analyze_radial_grid(reversed_grid, values, 3, grid_info));
+    EXPECT_FALSE(module_rt::analyze_radial_grid(nonfinite_grid, values, 3, grid_info));
+    EXPECT_FALSE(module_rt::analyze_radial_grid(values, nonfinite_values, 3, grid_info));
+}

--- a/source/source_lcao/module_rt/test/snap_psibeta_half_tddft_test.cpp
+++ b/source/source_lcao/module_rt/test/snap_psibeta_half_tddft_test.cpp
@@ -6,11 +6,18 @@
 #include "source_io/module_hs/cal_r_overlap_R.h"
 #include "../../LCAO_nonlocal_info.h"
 
+#ifdef __CUDA
+#include "source_lcao/module_rt/kernels/snap_psibeta_gpu.h"
+#include <cuda_runtime.h>
+#endif
+
 #include <algorithm>
 #include <cmath>
 #include <complex>
 #include <fstream>
 #include <gtest/gtest.h>
+#include <iomanip>
+#include <iostream>
 #include <vector>
 
 SepPot::SepPot() = default;
@@ -50,6 +57,12 @@ UnitCell::~UnitCell()
     }
 }
 
+void UnitCell::set_iat2iwt(const int& npol_in)
+{
+    npol = npol_in;
+    iat2iwt.assign(nat, 0);
+}
+
 namespace
 {
 struct ComparisonStats
@@ -59,6 +72,197 @@ struct ComparisonStats
     double max_imag_abs = 0.0;
     double max_reference_abs = 0.0;
 };
+
+void print_comparison_stats(const char* label, const ComparisonStats& stats)
+{
+    std::cout << std::scientific << std::setprecision(12) << "psibeta " << label
+              << ": max overlap error = " << stats.max_overlap_diff
+              << ", max position error = " << stats.max_position_diff
+              << ", max imaginary magnitude = " << stats.max_imag_abs
+              << ", max reference magnitude = " << stats.max_reference_abs << std::defaultfloat << std::endl;
+}
+
+ComparisonStats compare_zero_vector_potential(const LCAO_Orbitals& orb,
+                                              const UnitCell& ucell,
+                                              cal_r_overlap_R& r_calculator,
+                                              const int radial_grid_num,
+                                              const int lebedev_grid_points)
+{
+    const ModuleBase::Vector3<double> R0(0.1, -0.2, 0.3);
+    const ModuleBase::Vector3<double> R1(0.4, 0.2, -0.1);
+    const ModuleBase::Vector3<double> zero_A(0.0, 0.0, 0.0);
+    module_rt::SnapIntegrationOptions options;
+    options.radial_grid_num = radial_grid_num;
+    options.lebedev_grid_points = lebedev_grid_points;
+
+    ComparisonStats stats;
+    const auto* lcao_nl = dynamic_cast<const LCAONonlocalInfo*>(ucell.infoNL.get());
+    EXPECT_NE(lcao_nl, nullptr);
+    if (lcao_nl == nullptr)
+    {
+        return stats;
+    }
+
+    for (int L1 = 0; L1 <= orb.Phi[0].getLmax(); ++L1)
+    {
+        for (int N1 = 0; N1 < orb.Phi[0].getNchi(L1); ++N1)
+        {
+            for (int m1 = 0; m1 < 2 * L1 + 1; ++m1)
+            {
+                std::vector<std::vector<std::complex<double>>> grid_nlm;
+                module_rt::snap_psibeta_half_tddft(orb,
+                                                   lcao_nl->get_nonlocal(),
+                                                   grid_nlm,
+                                                   R1,
+                                                   0,
+                                                   L1,
+                                                   m1,
+                                                   N1,
+                                                   R0,
+                                                   0,
+                                                   zero_A,
+                                                   true,
+                                                   options);
+
+                std::vector<std::vector<double>> reference_nlm;
+                r_calculator.get_psi_r_beta(ucell, reference_nlm, R1, 0, L1, m1, N1, R0, 0);
+
+                EXPECT_EQ(grid_nlm.size(), 4);
+                EXPECT_EQ(reference_nlm.size(), 4);
+                if (grid_nlm.size() != 4 || reference_nlm.size() != 4)
+                {
+                    continue;
+                }
+
+                bool sizes_match = true;
+                for (size_t dim = 0; dim < grid_nlm.size(); ++dim)
+                {
+                    EXPECT_EQ(grid_nlm[dim].size(), reference_nlm[dim].size());
+                    sizes_match = sizes_match && (grid_nlm[dim].size() == reference_nlm[dim].size());
+                }
+                if (!sizes_match)
+                {
+                    continue;
+                }
+
+                for (size_t dim = 0; dim < grid_nlm.size(); ++dim)
+                {
+                    for (size_t i = 0; i < grid_nlm[dim].size(); ++i)
+                    {
+                        const double real_diff = std::abs(grid_nlm[dim][i].real() - reference_nlm[dim][i]);
+                        if (dim == 0)
+                        {
+                            stats.max_overlap_diff = std::max(stats.max_overlap_diff, real_diff);
+                        }
+                        else
+                        {
+                            stats.max_position_diff = std::max(stats.max_position_diff, real_diff);
+                        }
+                        stats.max_imag_abs = std::max(stats.max_imag_abs, std::abs(grid_nlm[dim][i].imag()));
+                        stats.max_reference_abs = std::max(stats.max_reference_abs, std::abs(reference_nlm[dim][i]));
+                    }
+                }
+            }
+        }
+    }
+
+    return stats;
+}
+
+#ifdef __CUDA
+void compare_cpu_and_gpu_overlap(const LCAO_Orbitals& orb,
+                                 const UnitCell& ucell,
+                                 const Parallel_Orbitals& pv,
+                                 const ModuleBase::Vector3<double>& vector_potential,
+                                 const bool calc_r)
+{
+    int device_count = 0;
+    const cudaError_t device_status = cudaGetDeviceCount(&device_count);
+    if (device_status != cudaSuccess)
+    {
+        GTEST_SKIP() << "cudaGetDeviceCount failed: " << cudaGetErrorString(device_status);
+    }
+    if (device_count == 0)
+    {
+        GTEST_SKIP() << "cudaGetDeviceCount reported zero CUDA devices";
+    }
+
+    const ModuleBase::Vector3<double> R0(0.1, -0.2, 0.3);
+    const ModuleBase::Vector3<double> R1(0.4, 0.2, -0.1);
+    // The GPU production interface converts adjacent_tau from lattice units
+    // to Cartesian coordinates, while the scalar CPU interface accepts R1
+    // directly in Cartesian coordinates.
+    const ModuleBase::Vector3<double> tau1(R1.x / ucell.lat0, R1.y / ucell.lat0, R1.z / ucell.lat0);
+    const int nlm_dim = calc_r ? 4 : 1;
+
+    AdjacentAtomInfo adjs;
+    adjs.adj_num = 0;
+    adjs.ntype.push_back(0);
+    adjs.natom.push_back(0);
+    adjs.adjacent_tau.push_back(tau1);
+    adjs.box.push_back(ModuleBase::Vector3<int>(0, 0, 0));
+
+    std::vector<std::vector<std::unordered_map<int, std::vector<std::complex<double>>>>> gpu_nlm(
+        1,
+        std::vector<std::unordered_map<int, std::vector<std::complex<double>>>>(nlm_dim));
+
+    const auto* lcao_nl = dynamic_cast<const LCAONonlocalInfo*>(ucell.infoNL.get());
+    ASSERT_NE(lcao_nl, nullptr);
+    module_rt::gpu::init_snap_psibeta_gpu();
+    module_rt::gpu::snap_psibeta_atom_batch_gpu(orb,
+                                                lcao_nl->get_nonlocal(),
+                                                0,
+                                                R0,
+                                                vector_potential,
+                                                adjs,
+                                                &ucell,
+                                                &pv,
+                                                1,
+                                                nlm_dim,
+                                                gpu_nlm);
+
+    const Atom& atom = ucell.atoms[0];
+    double max_difference = 0.0;
+    double max_cpu_abs = 0.0;
+    for (int iw = 0; iw < atom.nw; ++iw)
+    {
+        std::vector<std::vector<std::complex<double>>> cpu_nlm;
+        module_rt::snap_psibeta_half_tddft(orb,
+                                           lcao_nl->get_nonlocal(),
+                                           cpu_nlm,
+                                           R1,
+                                           0,
+                                           atom.iw2l[iw],
+                                           atom.iw2m[iw],
+                                           atom.iw2n[iw],
+                                           R0,
+                                           0,
+                                           vector_potential,
+                                           calc_r);
+
+        ASSERT_EQ(cpu_nlm.size(), static_cast<size_t>(nlm_dim));
+        for (int dim = 0; dim < nlm_dim; ++dim)
+        {
+            const auto gpu_entry = gpu_nlm[0][dim].find(iw);
+            ASSERT_NE(gpu_entry, gpu_nlm[0][dim].end());
+            ASSERT_EQ(gpu_entry->second.size(), cpu_nlm[dim].size());
+            for (size_t i = 0; i < cpu_nlm[dim].size(); ++i)
+            {
+                const double tolerance = 3.0e-14;
+                const double difference = std::abs(gpu_entry->second[i] - cpu_nlm[dim][i]);
+                max_difference = std::max(max_difference, difference);
+                max_cpu_abs = std::max(max_cpu_abs, std::abs(cpu_nlm[dim][i]));
+                EXPECT_LE(difference, tolerance)
+                    << "iw = " << iw << ", dim = " << dim << ", projector component = " << i;
+            }
+        }
+    }
+    std::cout << std::scientific << std::setprecision(12)
+              << "psibeta CPU/GPU calc_r=" << calc_r << ", A=(" << vector_potential.x << ", " << vector_potential.y
+              << ", " << vector_potential.z << "): max difference = " << max_difference
+              << ", max CPU magnitude = " << max_cpu_abs << std::defaultfloat << std::endl;
+}
+#endif
 
 class SnapPsibetaHalfTddftTest : public ::testing::Test
 {
@@ -72,7 +276,9 @@ class SnapPsibetaHalfTddftTest : public ::testing::Test
         const std::string orbital_files[1] = {orb_file};
 
         std::ofstream ofs("snap_psibeta_half_tddft_test.log");
-        orb.init(ofs, 1, root, orbital_files, "", 3, 100.0, 0.01, 0.01, 30.0, false, 0, false, false, 0);
+        // Keep the reciprocal transform spacing intentionally different from
+        // the 0.01 Bohr real-space orbital grid.
+        orb.init(ofs, 1, root, orbital_files, "", 3, 100.0, 0.013, 0.01, 30.0, false, 0, false, false, 0);
 
         ASSERT_EQ(orb.Phi[0].getLmax(), 3);
         ASSERT_EQ(orb.Phi[0].getNchi(0), 4);
@@ -88,6 +294,7 @@ class SnapPsibetaHalfTddftTest : public ::testing::Test
     {
         ucell.ntype = 1;
         ucell.nat = 1;
+        ucell.lat0 = 2.0;
         ucell.atoms = new Atom[1];
         ucell.set_atom_flag = true;
 
@@ -105,10 +312,16 @@ class SnapPsibetaHalfTddftTest : public ::testing::Test
         }
         atom.tau.resize(1);
         atom.tau[0] = ModuleBase::Vector3<double>(0.0, 0.0, 0.0);
+        atom.set_index();
+        ucell.itia2iat(0, 0) = 0;
+        ucell.set_iat2iwt(1);
+        pv.set_serial(atom.nw, atom.nw);
+        pv.set_atomic_trace(ucell.get_iat2iwt(), ucell.nat, atom.nw);
 
         Pseudopot_upf pseudo_reader;
         std::string pseudo_type = "auto";
-        const int pseudo_error = pseudo_reader.init_pseudo_reader(root + "tests/PP_ORB/Ti_ONCV_PBE-1.0.upf", pseudo_type, atom.ncpp);
+        const int pseudo_error
+            = pseudo_reader.init_pseudo_reader(root + "tests/PP_ORB/Ti_ONCV_PBE-1.0.upf", pseudo_type, atom.ncpp);
         ASSERT_EQ(pseudo_error, 0);
         ASSERT_EQ(pseudo_type, "upf201");
         ASSERT_EQ(atom.ncpp.psd, "Ti");
@@ -123,8 +336,16 @@ class SnapPsibetaHalfTddftTest : public ::testing::Test
         auto* lcao_nl = new LCAONonlocalInfo();
         lcao_nl->get_nonlocal().nproj = new int[1];
         std::ofstream log("snap_psibeta_half_tddft_nonlocal.log");
-        lcao_nl->get_nonlocal().Set_NonLocal(0, &atom, lcao_nl->get_nonlocal().nproj[0], orb.get_kmesh(), orb.get_dk(), orb.get_dr_uniform(), log,
-                                               false, false, 1);
+        lcao_nl->get_nonlocal().Set_NonLocal(0,
+                                            &atom,
+                                            lcao_nl->get_nonlocal().nproj[0],
+                                            orb.get_kmesh(),
+                                            orb.get_dk(),
+                                            orb.get_dr_uniform(),
+                                            log,
+                                            false,
+                                            false,
+                                            1);
 
         ASSERT_EQ(lcao_nl->get_nonlocal().nproj[0], 6);
         lcao_nl->get_nonlocal().nprojmax = lcao_nl->get_nonlocal().nproj[0];
@@ -139,67 +360,82 @@ class SnapPsibetaHalfTddftTest : public ::testing::Test
 
     ComparisonStats compare_zero_vector_potential(const int radial_grid_num, const int lebedev_grid_points)
     {
-        const ModuleBase::Vector3<double> R0(0.1, -0.2, 0.3);
-        const ModuleBase::Vector3<double> R1(0.4, 0.2, -0.1);
-        const ModuleBase::Vector3<double> zero_A(0.0, 0.0, 0.0);
-        module_rt::SnapIntegrationOptions options;
-        options.radial_grid_num = radial_grid_num;
-        options.lebedev_grid_points = lebedev_grid_points;
+        return ::compare_zero_vector_potential(orb, ucell, r_calculator, radial_grid_num, lebedev_grid_points);
+    }
 
-        ComparisonStats stats;
+    LCAO_Orbitals orb;
+    UnitCell ucell;
+    Parallel_Orbitals pv;
+    cal_r_overlap_R r_calculator;
+};
 
-        for (int L1 = 0; L1 <= orb.Phi[0].getLmax(); ++L1)
+class SnapPsibetaNonuniformHalfTddftTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        ModuleBase::Ylm::set_coefficients();
+
+        const std::string root = "../../../../../";
+        const std::string orbital_files[1] = {"tests/PP_ORB/Al_gga_10au_100Ry_3s3p2d.orb"};
+        std::ofstream ofs("snap_psibeta_half_tddft_al_test.log");
+        orb.init(ofs, 1, root, orbital_files, "", 2, 100.0, 0.017, 0.01, 30.0, false, 0, false, false, 0);
+
+        ucell.ntype = 1;
+        ucell.nat = 1;
+        ucell.lat0 = 2.0;
+        ucell.atoms = new Atom[1];
+        ucell.set_atom_flag = true;
+
+        Atom& atom = ucell.atoms[0];
+        atom.label = "Al";
+        atom.type = 0;
+        atom.na = 1;
+        atom.nwl = orb.Phi[0].getLmax();
+        atom.l_nchi.resize(atom.nwl + 1);
+        atom.nw = 0;
+        for (int L = 0; L <= atom.nwl; ++L)
         {
-            for (int N1 = 0; N1 < orb.Phi[0].getNchi(L1); ++N1)
-            {
-                for (int m1 = 0; m1 < 2 * L1 + 1; ++m1)
-                {
-                    std::vector<std::vector<std::complex<double>>> grid_nlm;
-                    module_rt::snap_psibeta_half_tddft(orb, dynamic_cast<LCAONonlocalInfo*>(ucell.infoNL.get())->get_nonlocal(), grid_nlm, R1, 0, L1, m1, N1, R0, 0, zero_A, true, options);
-
-                    std::vector<std::vector<double>> reference_nlm;
-                    r_calculator.get_psi_r_beta(ucell, reference_nlm, R1, 0, L1, m1, N1, R0, 0);
-
-                    EXPECT_EQ(grid_nlm.size(), 4);
-                    EXPECT_EQ(reference_nlm.size(), 4);
-                    if (grid_nlm.size() != 4 || reference_nlm.size() != 4)
-                    {
-                        continue;
-                    }
-
-                    bool sizes_match = true;
-                    for (size_t dim = 0; dim < grid_nlm.size(); ++dim)
-                    {
-                        EXPECT_EQ(grid_nlm[dim].size(), reference_nlm[dim].size());
-                        sizes_match = sizes_match && (grid_nlm[dim].size() == reference_nlm[dim].size());
-                    }
-                    if (!sizes_match)
-                    {
-                        continue;
-                    }
-
-                    for (size_t dim = 0; dim < grid_nlm.size(); ++dim)
-                    {
-                        for (size_t i = 0; i < grid_nlm[dim].size(); ++i)
-                        {
-                            const double real_diff = std::abs(grid_nlm[dim][i].real() - reference_nlm[dim][i]);
-                            if (dim == 0)
-                            {
-                                stats.max_overlap_diff = std::max(stats.max_overlap_diff, real_diff);
-                            }
-                            else
-                            {
-                                stats.max_position_diff = std::max(stats.max_position_diff, real_diff);
-                            }
-                            stats.max_imag_abs = std::max(stats.max_imag_abs, std::abs(grid_nlm[dim][i].imag()));
-                            stats.max_reference_abs = std::max(stats.max_reference_abs, std::abs(reference_nlm[dim][i]));
-                        }
-                    }
-                }
-            }
+            atom.l_nchi[L] = orb.Phi[0].getNchi(L);
+            atom.nw += (2 * L + 1) * atom.l_nchi[L];
         }
+        atom.tau.resize(1);
+        atom.tau[0] = ModuleBase::Vector3<double>(0.0, 0.0, 0.0);
+        atom.set_index();
+        ucell.itia2iat(0, 0) = 0;
+        ucell.set_iat2iwt(1);
+        pv.set_serial(atom.nw, atom.nw);
+        pv.set_atomic_trace(ucell.get_iat2iwt(), ucell.nat, atom.nw);
 
-        return stats;
+        Pseudopot_upf pseudo_reader;
+        std::string pseudo_type = "auto";
+        const int pseudo_error
+            = pseudo_reader.init_pseudo_reader(root + "tests/PP_ORB/Al.pbe-rrkj.UPF", pseudo_type, atom.ncpp);
+        ASSERT_EQ(pseudo_error, 0);
+        ASSERT_EQ(atom.ncpp.psd, "Al");
+        ASSERT_EQ(atom.ncpp.pp_type, "NC");
+        ASSERT_EQ(atom.ncpp.nbeta, 4);
+        pseudo_reader.complete_default(atom.ncpp, 15.0);
+
+        auto* lcao_nl = new LCAONonlocalInfo();
+        lcao_nl->get_nonlocal().nproj = new int[1];
+        std::ofstream log("snap_psibeta_half_tddft_al_nonlocal.log");
+        lcao_nl->get_nonlocal().Set_NonLocal(0,
+                                            &atom,
+                                            lcao_nl->get_nonlocal().nproj[0],
+                                            orb.get_kmesh(),
+                                            orb.get_dk(),
+                                            orb.get_dr_uniform(),
+                                            log,
+                                            false,
+                                            false,
+                                            1);
+        ASSERT_EQ(lcao_nl->get_nonlocal().nproj[0], 4);
+        lcao_nl->get_nonlocal().nprojmax = lcao_nl->get_nonlocal().nproj[0];
+        lcao_nl->get_nonlocal().rcutmax_Beta = lcao_nl->get_nonlocal().Beta[0].get_rcut_max();
+        ucell.infoNL.reset(lcao_nl);
+
+        r_calculator.init_nonlocal(ucell, pv, orb);
     }
 
     LCAO_Orbitals orb;
@@ -211,10 +447,11 @@ class SnapPsibetaHalfTddftTest : public ::testing::Test
 
 TEST_F(SnapPsibetaHalfTddftTest, ZeroVectorPotentialMatchesTwoCenterIntegral)
 {
-    const double overlap_tolerance = 4.0e-7;
-    const double position_tolerance = 6.0e-7;
-    const double imag_tolerance = 1.0e-12;
+    const double overlap_tolerance = 5.0e-8;
+    const double position_tolerance = 5.0e-8;
+    const double imag_tolerance = 1.0e-14;
     const ComparisonStats stats = compare_zero_vector_potential(140, 110);
+    print_comparison_stats("Ti 140x110", stats);
 
     EXPECT_LT(stats.max_overlap_diff, overlap_tolerance) << "max reference abs = " << stats.max_reference_abs;
     EXPECT_LT(stats.max_position_diff, position_tolerance) << "max reference abs = " << stats.max_reference_abs;
@@ -223,10 +460,11 @@ TEST_F(SnapPsibetaHalfTddftTest, ZeroVectorPotentialMatchesTwoCenterIntegral)
 
 TEST_F(SnapPsibetaHalfTddftTest, ZeroVectorPotentialDenseRadialGridMatchesTwoCenterIntegral)
 {
-    const double overlap_tolerance = 3.0e-7;
-    const double position_tolerance = 5.0e-7;
-    const double imag_tolerance = 1.0e-12;
+    const double overlap_tolerance = 5.0e-8;
+    const double position_tolerance = 6.0e-8;
+    const double imag_tolerance = 1.0e-14;
     const ComparisonStats stats = compare_zero_vector_potential(280, 110);
+    print_comparison_stats("Ti 280x110", stats);
 
     EXPECT_LT(stats.max_overlap_diff, overlap_tolerance) << "max reference abs = " << stats.max_reference_abs;
     EXPECT_LT(stats.max_position_diff, position_tolerance) << "max reference abs = " << stats.max_reference_abs;
@@ -235,12 +473,84 @@ TEST_F(SnapPsibetaHalfTddftTest, ZeroVectorPotentialDenseRadialGridMatchesTwoCen
 
 TEST_F(SnapPsibetaHalfTddftTest, ZeroVectorPotentialHighOrderGridMatchesTwoCenterIntegral)
 {
-    const double overlap_tolerance = 4.0e-7;
-    const double position_tolerance = 6.0e-7;
-    const double imag_tolerance = 1.0e-12;
+    const double overlap_tolerance = 5.0e-8;
+    const double position_tolerance = 5.0e-8;
+    const double imag_tolerance = 1.0e-14;
     const ComparisonStats stats = compare_zero_vector_potential(140, 590);
+    print_comparison_stats("Ti 140x590", stats);
 
     EXPECT_LT(stats.max_overlap_diff, overlap_tolerance) << "max reference abs = " << stats.max_reference_abs;
     EXPECT_LT(stats.max_position_diff, position_tolerance) << "max reference abs = " << stats.max_reference_abs;
     EXPECT_LT(stats.max_imag_abs, imag_tolerance) << "max reference abs = " << stats.max_reference_abs;
 }
+
+TEST_F(SnapPsibetaNonuniformHalfTddftTest, NonuniformAlProjectorMatchesTwoCenterIntegral)
+{
+    const auto* lcao_nl = dynamic_cast<const LCAONonlocalInfo*>(ucell.infoNL.get());
+    ASSERT_NE(lcao_nl, nullptr);
+
+    bool found_nonuniform_spacing = false;
+    for (int ip = 0; ip < lcao_nl->get_nonlocal().nproj[0]; ++ip)
+    {
+        const auto& projector = lcao_nl->get_nonlocal().Beta[0].Proj[ip];
+        ASSERT_GT(projector.getNr(), 2);
+        const double first_spacing = projector.getRadial(1) - projector.getRadial(0);
+        for (int ir = 2; ir < projector.getNr(); ++ir)
+        {
+            const double spacing = projector.getRadial(ir) - projector.getRadial(ir - 1);
+            if (std::abs(spacing - first_spacing) > 1.0e-12)
+            {
+                found_nonuniform_spacing = true;
+                break;
+            }
+        }
+    }
+    EXPECT_TRUE(found_nonuniform_spacing);
+
+    const ComparisonStats default_grid = compare_zero_vector_potential(orb, ucell, r_calculator, 140, 110);
+    const ComparisonStats dense_radial_grid = compare_zero_vector_potential(orb, ucell, r_calculator, 280, 110);
+    const ComparisonStats dense_angular_grid = compare_zero_vector_potential(orb, ucell, r_calculator, 140, 590);
+    print_comparison_stats("Al 140x110", default_grid);
+    print_comparison_stats("Al 280x110", dense_radial_grid);
+    print_comparison_stats("Al 140x590", dense_angular_grid);
+    EXPECT_LT(default_grid.max_overlap_diff, 2.0e-3)
+        << "max reference abs = " << default_grid.max_reference_abs;
+    EXPECT_LT(default_grid.max_position_diff, 3.0e-3)
+        << "max reference abs = " << default_grid.max_reference_abs;
+    EXPECT_LT(dense_radial_grid.max_overlap_diff, 2.0e-5)
+        << "max reference abs = " << dense_radial_grid.max_reference_abs;
+    EXPECT_LT(dense_radial_grid.max_position_diff, 4.0e-5)
+        << "max reference abs = " << dense_radial_grid.max_reference_abs;
+    EXPECT_LT(dense_radial_grid.max_overlap_diff, 0.02 * default_grid.max_overlap_diff);
+    EXPECT_LT(dense_radial_grid.max_position_diff, 0.02 * default_grid.max_position_diff);
+    EXPECT_NEAR(dense_angular_grid.max_overlap_diff, default_grid.max_overlap_diff, 3.0e-9);
+    EXPECT_NEAR(dense_angular_grid.max_position_diff, default_grid.max_position_diff, 1.0e-9);
+    EXPECT_LT(default_grid.max_imag_abs, 1.0e-14)
+        << "max reference abs = " << default_grid.max_reference_abs;
+    EXPECT_LT(dense_radial_grid.max_imag_abs, 1.0e-14)
+        << "max reference abs = " << dense_radial_grid.max_reference_abs;
+    EXPECT_LT(dense_angular_grid.max_imag_abs, 1.0e-14)
+        << "max reference abs = " << dense_angular_grid.max_reference_abs;
+}
+
+#ifdef __CUDA
+TEST_F(SnapPsibetaHalfTddftTest, UniformTiCpuGpuOverlapWithoutPositionOperator)
+{
+    compare_cpu_and_gpu_overlap(orb, ucell, pv, ModuleBase::Vector3<double>(0.0, 0.0, 0.0), false);
+}
+
+TEST_F(SnapPsibetaHalfTddftTest, UniformTiCpuGpuOverlapWithPositionOperator)
+{
+    compare_cpu_and_gpu_overlap(orb, ucell, pv, ModuleBase::Vector3<double>(0.03, -0.02, 0.01), true);
+}
+
+TEST_F(SnapPsibetaNonuniformHalfTddftTest, NonuniformAlCpuGpuOverlapWithoutPositionOperator)
+{
+    compare_cpu_and_gpu_overlap(orb, ucell, pv, ModuleBase::Vector3<double>(0.0, 0.0, 0.0), false);
+}
+
+TEST_F(SnapPsibetaNonuniformHalfTddftTest, NonuniformAlCpuGpuOverlapWithPositionOperator)
+{
+    compare_cpu_and_gpu_overlap(orb, ucell, pv, ModuleBase::Vector3<double>(0.03, -0.02, 0.01), true);
+}
+#endif

--- a/source/source_lcao/module_rt/test/tddft_test.cpp
+++ b/source/source_lcao/module_rt/test/tddft_test.cpp
@@ -47,5 +47,5 @@ int main(int argc, char** argv)
     Cblacs_exit(ictxt);
 
     // MPI_Finalize();
-    return 0;
+    return result;
 }

--- a/tests/05_rtTDDFT/16_NO_vel_TDDFT/result.ref
+++ b/tests/05_rtTDDFT/16_NO_vel_TDDFT/result.ref
@@ -1,6 +1,6 @@
-etotref -30.91272578807966
-etotperatomref -15.4563628940
-totalforceref 0.479236
-totalstressref 0.980314
+etotref -30.91256513934784
+etotperatomref -15.4562825697
+totalforceref 0.479296
+totalstressref 0.980419
 CompareCurrent_pass 0
 totaltimeref 1.10

--- a/tests/05_rtTDDFT/17_NO_vel_TDDFT/result.ref
+++ b/tests/05_rtTDDFT/17_NO_vel_TDDFT/result.ref
@@ -1,4 +1,4 @@
-etotref -194.7715239600903
-etotperatomref -97.3857619800
+etotref -194.7715696037895
+etotperatomref -97.3857848019
 CompareCurrent_pass 0
 totaltimeref 3.65

--- a/tests/15_rtTDDFT_GPU/16_NO_vel_TDDFT_GPU/result.ref
+++ b/tests/15_rtTDDFT_GPU/16_NO_vel_TDDFT_GPU/result.ref
@@ -1,6 +1,6 @@
-etotref -30.91272578807960
-etotperatomref -15.4563628940
-totalforceref 0.479236
-totalstressref 0.980314
+etotref -30.91256513934784
+etotperatomref -15.4562825697
+totalforceref 0.479296
+totalstressref 0.980419
 CompareCurrent_pass 0
 totaltimeref 1.81

--- a/tests/15_rtTDDFT_GPU/17_NO_vel_TDDFT_GPU/result.ref
+++ b/tests/15_rtTDDFT_GPU/17_NO_vel_TDDFT_GPU/result.ref
@@ -1,4 +1,4 @@
-etotref -194.7715239600903
-etotperatomref -97.3857619800
+etotref -194.7715696037895
+etotperatomref -97.3857848019
 CompareCurrent_pass 0
 totaltimeref 6.74


### PR DESCRIPTION
## Summary

This PR fixes radial interpolation in the RT-TDDFT projector integration path for DeePKS alpha projectors, nonlocal beta projectors, and LCAO orbitals. The implementation now uses the stored real-space radial coordinates instead of treating the reciprocal-space transform spacing `dk` as a real-space grid interval.

The fix also removes the premature zeroing of the final two valid radial intervals. DeePKS alpha and the CPU beta path use a shared projector integrator, while the existing CUDA beta-projector integration performs the same interpolation algorithm and boundary checks on the GPU.

## Problem

The previous CPU and CUDA implementations estimated a radial-array index from `r / dk`. This assumes a uniform real-space grid starting at zero and incorrectly assigns real-space meaning to the reciprocal-space transform parameter `dk`.

The historical four-point interpolation also returned zero when its forward-looking interpolation window no longer fit inside the array. As a result, queries in the final two intervals, including the final stored grid point, could return zero even though they were still inside the projector cutoff.

These assumptions fail for nonuniform UPF radial grids and can also produce incorrect results when an orbital or DeePKS descriptor's stored real-space spacing differs from `lcao_dk`.

## Changes

- Add a lightweight C++11 CPU/CUDA radial interpolation core that accepts explicit radial coordinates and values.
- Validate radial grids on the host before integration or CUDA allocation: pointers must be non-null, values must be finite, and multi-point coordinates must be strictly increasing.
- Return zero only for non-finite or out-of-range queries; return the stored value directly at exact grid nodes.
- Use constant, linear, quadratic, or local four-point cubic Lagrange interpolation for meshes of size 1, 2, 3, or at least 4, respectively.
- Clamp the cubic interpolation window to the final four nodes in the last two intervals instead of returning zero.
- Use a coordinate-derived uniform-grid fast path and binary search for nonuniform grids.
- Remove `dk` from the internal projector channel and use `getRadial()` with `getBeta_r()`, `getPsi_r()`, or `getPsi()` for beta projectors, DeePKS alpha projectors, and LCAO orbitals, respectively.
- Add a DeePKS alpha-projector wrapper over the shared CPU projector integrator so alpha and beta channels use the same radial interpolation and cutoff semantics.
- Copy flattened orbital and beta radial-coordinate arrays to the GPU and perform interpolation inside the CUDA kernel.
- Release the additional CUDA allocations on normal completion and kernel-error paths.
- Add focused gamma-only and multik DeePKS alpha regressions using real descriptor and orbital data loaded through the modern radial-data reader.
- Make the shared RT GoogleTest entry point return the actual `RUN_ALL_TESTS()` status so CTest cannot report a false pass.

## Tests

<img width="2904" height="2904" alt="image" src="https://github.com/user-attachments/assets/c57409de-f0b5-4532-b724-0d8cda632a2e" />
