### PR TITLE
Refactor: inject solver config into HSolver/PEXSI instead of reading PARAM

### DIFF
--- a/source/source_esolver/esolver_ks_lcao.cpp
+++ b/source/source_esolver/esolver_ks_lcao.cpp
@@ -434,7 +434,11 @@ void ESolver_KS_LCAO<TK, TR>::hamilt2rho_single(UnitCell& ucell, int istep, int 
     // 3) run Hsolver
     if (!skip_solve)
     {
-        hsolver::HSolverLCAO<TK> hsolver_lcao_obj(&(this->pv), PARAM.inp.ks_solver);
+        hsolver::HSolverLCAO<TK> hsolver_lcao_obj(&(this->pv),
+                                                  PARAM.inp.ks_solver,
+                                                  PARAM.globalv.kpar_lcao,
+                                                  PARAM.globalv.nlocal,
+                                                  PARAM.inp.nelec);
         hsolver_lcao_obj.solve(static_cast<hamilt::Hamilt<TK>*>(this->p_hamilt), this->psi[0], this->pelec, *this->dmat.dm, 
           this->chr, PARAM.inp.nspin, skip_charge);
     }

--- a/source/source_esolver/esolver_ks_lcao_tddft.cpp
+++ b/source/source_esolver/esolver_ks_lcao_tddft.cpp
@@ -329,7 +329,11 @@ void ESolver_KS_LCAO_TDDFT<TR, Device>::hamilt2rho_single(UnitCell& ucell,
         if (this->psi != nullptr)
         {
             bool skip_charge = PARAM.inp.calculation == "nscf" ? true : false;
-            hsolver::HSolverLCAO<std::complex<double>> hsolver_lcao_obj(&this->pv, PARAM.inp.ks_solver);
+            hsolver::HSolverLCAO<std::complex<double>> hsolver_lcao_obj(&this->pv,
+                                                                        PARAM.inp.ks_solver,
+                                                                        PARAM.globalv.kpar_lcao,
+                                                                        PARAM.globalv.nlocal,
+                                                                        PARAM.inp.nelec);
             hsolver_lcao_obj.solve(static_cast<hamilt::Hamilt<std::complex<double>>*>(this->p_hamilt),
                                    this->psi[0],
                                    this->pelec,

--- a/source/source_esolver/esolver_ks_lcaopw.cpp
+++ b/source/source_esolver/esolver_ks_lcaopw.cpp
@@ -133,7 +133,7 @@ namespace ModuleESolver
         hsolver::DiagoIterAssist<T>::PW_DIAG_NMAX = PARAM.inp.pw_diag_nmax;
         bool skip_charge = PARAM.inp.calculation == "nscf" ? true : false;
 
-        hsolver::HSolverLIP<T> hsolver_lip_obj(this->pw_wfc);
+        hsolver::HSolverLIP<T> hsolver_lip_obj(this->pw_wfc, PARAM.globalv.use_uspp);
         hsolver_lip_obj.solve(static_cast<hamilt::Hamilt<T>*>(this->p_hamilt), *this->stp.template get_psi_t<T, base_device::DEVICE_CPU>(), this->pelec, 
           *this->psi_local, skip_charge,ucell.tpiba,ucell.nat);
 

--- a/source/source_esolver/esolver_ks_pw.cpp
+++ b/source/source_esolver/esolver_ks_pw.cpp
@@ -222,6 +222,11 @@ void ESolver_KS_PW<T, Device>::hamilt2rho_single(UnitCell& ucell, const int iste
                                                      hsolver::DiagoIterAssist<T, Device>::PW_DIAG_NMAX,
                                                      hsolver::DiagoIterAssist<T, Device>::PW_DIAG_THR,
                                                      hsolver::DiagoIterAssist<T, Device>::need_subspace,
+                                                     PARAM.inp.nbands,
+                                                     PARAM.inp.diago_smooth_ethr,
+                                                     PARAM.inp.pw_diag_ndim,
+                                                     PARAM.inp.diag_subspace,
+                                                     PARAM.inp.nb2d,
                                                      PARAM.inp.use_k_continuity);
 
         hsolver_pw_obj.solve(static_cast<hamilt::Hamilt<T, Device>*>(this->p_hamilt), *this->stp.template get_psi_t<T, Device>(), this->pelec, this->pelec->ekb.c,

--- a/source/source_esolver/esolver_sdft_pw.cpp
+++ b/source/source_esolver/esolver_sdft_pw.cpp
@@ -163,7 +163,15 @@ void ESolver_SDFT_PW<T, Device>::hamilt2rho_single(UnitCell& ucell, int istep, i
                                                            hsolver::DiagoIterAssist<T, Device>::SCF_ITER,
                                                            hsolver::DiagoIterAssist<T, Device>::PW_DIAG_NMAX,
                                                            hsolver::DiagoIterAssist<T, Device>::PW_DIAG_THR,
-                                                           hsolver::DiagoIterAssist<T, Device>::need_subspace);
+                                                           hsolver::DiagoIterAssist<T, Device>::need_subspace,
+                                                           PARAM.inp.nbands,
+                                                           PARAM.inp.diago_smooth_ethr,
+                                                           PARAM.inp.pw_diag_ndim,
+                                                           PARAM.inp.diag_subspace,
+                                                           PARAM.inp.nb2d,
+                                                           PARAM.globalv.ks_run,
+                                                           PARAM.globalv.all_ks_run,
+                                                           PARAM.inp.bndpar);
 
     hsolver_pw_sdft_obj.solve(ucell,
                               static_cast<hamilt::Hamilt<T, Device>*>(this->p_hamilt),

--- a/source/source_hsolver/diago_pexsi.cpp
+++ b/source/source_hsolver/diago_pexsi.cpp
@@ -1,6 +1,5 @@
 #include <mpi.h>
 #include <complex>
-#include "source_io/module_parameter/parameter.h"
 #include <memory>
 #ifdef __PEXSI
 #include "diago_pexsi.h"
@@ -19,25 +18,27 @@ template <typename T>
 std::vector<double> DiagoPexsi<T>::mu_buffer;
 
 template <typename T>
-DiagoPexsi<T>::DiagoPexsi(const Parallel_Orbitals* ParaV_in)
+DiagoPexsi<T>::DiagoPexsi(const Parallel_Orbitals* ParaV_in,
+                          const int nspin_in,
+                          const int nlocal_in,
+                          const double nelec_in)
 {
-    int nspin = PARAM.inp.nspin;
-    if (PARAM.inp.nspin == 4)
+    this->nspin_dm = (nspin_in == 4) ? 1 : nspin_in;
+    this->nlocal = nlocal_in;
+    this->nelec = nelec_in;
+
+    mu_buffer.resize(this->nspin_dm);
+    for (int i = 0; i < this->nspin_dm; i++)
     {
-        nspin = 1;
-    }
-    mu_buffer.resize(nspin);
-    for (int i = 0; i < nspin; i++)
-    {
-        mu_buffer[i] = this->ps->pexsi_mu;
+        mu_buffer[i] = pexsi::PEXSI_Solver::pexsi_mu;
     }
 
     this->ParaV = ParaV_in;
     this->ps = std::make_unique<pexsi::PEXSI_Solver>();
 
-    this->DM.resize(nspin);
-    this->EDM.resize(nspin);
-    for (int i = 0; i < nspin; i++)
+    this->DM.resize(this->nspin_dm);
+    this->EDM.resize(this->nspin_dm);
+    for (int i = 0; i < this->nspin_dm; i++)
     {
         this->DM[i] = new T[ParaV->nrow * ParaV->ncol];
         this->EDM[i] = new T[ParaV->nrow * ParaV->ncol];
@@ -48,12 +49,7 @@ DiagoPexsi<T>::DiagoPexsi(const Parallel_Orbitals* ParaV_in)
 template <typename T>
 DiagoPexsi<T>::~DiagoPexsi()
 {
-    int nspin = PARAM.inp.nspin;
-    if (PARAM.inp.nspin == 4)
-    {
-        nspin = 1;
-    }
-    for (int i = 0; i < nspin; i++)
+    for (int i = 0; i < this->nspin_dm; i++)
     {
         delete[] this->DM[i];
         delete[] this->EDM[i];
@@ -67,12 +63,13 @@ void DiagoPexsi<double>::diag(hamilt::Hamilt<double>* phm_in, psi::Psi<double>& 
     ModuleBase::TITLE("DiagoPEXSI", "diag");
     matd h_mat, s_mat;
     phm_in->matrix(h_mat, s_mat);
-    std::vector<double> eigen(PARAM.globalv.nlocal, 0.0);
     int ik = psi.get_current_k();
     this->ps->prepare(this->ParaV->blacs_ctxt,
                       this->ParaV->nb,
                       this->ParaV->nrow,
                       this->ParaV->ncol,
+                      this->nlocal,
+                      this->nelec,
                       h_mat.p,
                       s_mat.p,
                       DM[ik],

--- a/source/source_hsolver/diago_pexsi.h
+++ b/source/source_hsolver/diago_pexsi.h
@@ -19,7 +19,7 @@ class DiagoPexsi
     static std::vector<double> mu_buffer;
 
   public:
-    DiagoPexsi(const Parallel_Orbitals* ParaV_in);
+    DiagoPexsi(const Parallel_Orbitals* ParaV_in, const int nspin_in, const int nlocal_in, const double nelec_in);
     void diag(hamilt::Hamilt<T>* phm_in, psi::Psi<T>& psi, Real* eigenvalue_in);
     const Parallel_Orbitals* ParaV = nullptr;
     std::vector<T*> DM;
@@ -29,6 +29,14 @@ class DiagoPexsi
     double totalFreeEnergy;
     std::unique_ptr<pexsi::PEXSI_Solver> ps;
     ~DiagoPexsi();
+
+  private:
+    /// number of density matrices to keep: nspin, except that nspin == 4 is
+    /// treated as a single (spinor) density matrix
+    int nspin_dm = 1;
+    /// global dimension of the NAO Hamiltonian
+    int nlocal = 0;
+    double nelec = 0.0;
 };
 } // namespace hsolver
 

--- a/source/source_hsolver/hsolver_lcao.cpp
+++ b/source/source_hsolver/hsolver_lcao.cpp
@@ -33,7 +33,6 @@
 #include "source_estate/module_dm/cal_dm_psi.h"
 #include "source_estate/module_dm/density_matrix.h"
 #include "source_hsolver/parallel_k2d.h"
-#include "source_io/module_parameter/parameter.h"
 
 namespace hsolver
 {
@@ -59,13 +58,13 @@ void HSolverLCAO<TK, Device>::solve(hamilt::Hamilt<TK>* pHamilt,
             this->parakSolve_cusolver(pHamilt, psi, pes);
         }else 
     #endif
-        if (PARAM.globalv.kpar_lcao > 1
+        if (this->kpar_lcao > 1
             && (this->method == "genelpa" || this->method == "elpa" || this->method == "scalapack_gvx" || this->method == "lapack"))
         {
-            this->parakSolve(pHamilt, psi, pes, PARAM.globalv.kpar_lcao, nspin);
+            this->parakSolve(pHamilt, psi, pes, this->kpar_lcao, nspin);
         } else
     #endif
-        if (PARAM.globalv.kpar_lcao == 1)
+        if (this->kpar_lcao == 1)
         {
             /// Loop over k points for solve Hamiltonian to eigenpairs(eigenvalues and eigenvectors).
             for (int ik = 0; ik < psi.get_nk(); ++ik)
@@ -113,7 +112,7 @@ void HSolverLCAO<TK, Device>::solve(hamilt::Hamilt<TK>* pHamilt,
     else if (this->method == "pexsi")
     {
 #ifdef __PEXSI // other purification methods should follow this routine
-        DiagoPexsi<TK> pe(ParaV);
+        DiagoPexsi<TK> pe(ParaV, nspin, this->nlocal, this->nelec);
         for (int ik = 0; ik < psi.get_nk(); ++ik)
         {
             /// update H(k) for each k point

--- a/source/source_hsolver/hsolver_lcao.h
+++ b/source/source_hsolver/hsolver_lcao.h
@@ -15,7 +15,12 @@ template <typename TK, typename Device = base_device::DEVICE_CPU>
 class HSolverLCAO
 {
   public:
-    HSolverLCAO(const Parallel_Orbitals* ParaV_in, std::string method_in) : ParaV(ParaV_in), method(method_in) {};
+    HSolverLCAO(const Parallel_Orbitals* ParaV_in,
+                const std::string method_in,
+                const int kpar_lcao_in,
+                const int nlocal_in,
+                const double nelec_in)
+        : ParaV(ParaV_in), method(method_in), kpar_lcao(kpar_lcao_in), nlocal(nlocal_in), nelec(nelec_in) {};
 
     void solve(hamilt::Hamilt<TK>* pHamilt,
                psi::Psi<TK>& psi,
@@ -40,8 +45,12 @@ class HSolverLCAO
                              elecstate::ElecState* pes);
 
     const Parallel_Orbitals* ParaV = nullptr;
-    
+
     const std::string method;
+
+    const int kpar_lcao; // number of pools for LCAO diagonalization
+    const int nlocal;    // global dimension of the NAO Hamiltonian, only used by the pexsi branch
+    const double nelec;  // total number of electrons, only used by the pexsi branch
 };
 
 } // namespace hsolver

--- a/source/source_hsolver/hsolver_lcaopw.cpp
+++ b/source/source_hsolver/hsolver_lcaopw.cpp
@@ -7,7 +7,6 @@
 #include "source_estate/elecstate_pw.h"
 #include "source_pw/module_pwdft/hamilt_pw.h"
 #include "source_hsolver/diago_iter_assist.h"
-#include "source_io/module_parameter/parameter.h"
 #include "source_estate/elecstate_tools.h"
 #include "source_hamilt/module_xc/exx_info.h"
 
@@ -106,7 +105,7 @@ void HSolverLIP<T>::solve(hamilt::Hamilt<T>* pHamilt, // ESolver_KS_PW::p_hamilt
     elecstate::calEBand(pes->ekb,pes->wg,pes->f_en);
     if (skip_charge)
     {
-        if (PARAM.globalv.use_uspp)
+        if (this->use_uspp)
         {
             reinterpret_cast<elecstate::ElecStatePW<T>*>(pes)->cal_becsum(psi);
         }

--- a/source/source_hsolver/hsolver_lcaopw.h
+++ b/source/source_hsolver/hsolver_lcaopw.h
@@ -18,7 +18,8 @@ class HSolverLIP
     using Real = typename GetTypeReal<T>::type;
 
   public:
-    HSolverLIP(ModulePW::PW_Basis_K* wfc_basis_in) : wfc_basis(wfc_basis_in) {};
+    HSolverLIP(ModulePW::PW_Basis_K* wfc_basis_in, const bool use_uspp_in)
+        : wfc_basis(wfc_basis_in), use_uspp(use_uspp_in) {};
 
     /// @brief solve function for lcao_in_pw
     /// @param pHamilt interface to hamilt
@@ -36,6 +37,8 @@ class HSolverLIP
 
   private:
     ModulePW::PW_Basis_K* wfc_basis = nullptr;
+
+    const bool use_uspp; // true if ultrasoft pseudopotentials are in use
 };
 
 } // namespace hsolver

--- a/source/source_hsolver/hsolver_pw.cpp
+++ b/source/source_hsolver/hsolver_pw.cpp
@@ -12,7 +12,6 @@
 #include "source_hsolver/diago_dav_subspace.h"
 #include "source_hsolver/diago_david.h"
 #include "source_hsolver/diago_iter_assist.h"
-#include "source_io/module_parameter/parameter.h"
 #include "source_psi/psi.h"
 #include "source_estate/elecstate_tools.h"
 
@@ -124,7 +123,7 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
             update_precondition(precondition, ik, this->wfc_basis->npwk[ik], Real(pes->pot->get_vl_of_0()));
 
             // use smooth threshold for all iter methods
-            if (PARAM.inp.diago_smooth_ethr == true)
+            if (this->diago_smooth_ethr == true)
             {
                 this->cal_smooth_ethr(pes->klist->wk[ik],
                                     &pes->wg(ik, 0),
@@ -162,7 +161,7 @@ void HSolverPW<T, Device>::solve(hamilt::Hamilt<T, Device>* pHamilt,
             update_precondition(precondition, ik, this->wfc_basis->npwk[ik], Real(pes->pot->get_vl_of_0()));
 
             // use smooth threshold for all iter methods
-            if (PARAM.inp.diago_smooth_ethr == true)
+            if (this->diago_smooth_ethr == true)
             {
                 this->cal_smooth_ethr(pes->klist->wk[ik],
                                     &pes->wg(ik, 0),
@@ -320,7 +319,7 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm,
         const int nbasis = psi.get_nbasis();
         const int ndim = psi.get_current_ngk();
         DiagoBPCG<T, Device> bpcg(pre_condition.data());
-        bpcg.init_iter(PARAM.inp.nbands, nband_l, nbasis, ndim);
+        bpcg.init_iter(this->nbands, nband_l, nbasis, ndim);
         bpcg.diag(hpsi_func, psi.get_pointer(), eigenvalue, this->ethr_band);
     }
     else if (this->method == "dav_subspace")
@@ -331,12 +330,12 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm,
                                                   psi.get_nbands(),
                                                   psi.get_k_first() ? psi.get_current_ngk()
                                                                     : psi.get_nk() * psi.get_nbasis(),
-                                                  PARAM.inp.pw_diag_ndim,
+                                                  this->pw_diag_ndim,
                                                   this->diag_thr,
                                                   this->diag_iter_max,
                                                   comm_info,
-                                                  PARAM.inp.diag_subspace,
-                                                  PARAM.inp.nb2d);
+                                                  this->diag_subspace,
+                                                  this->nb2d);
 
         DiagoIterAssist<T, Device>::avg_iter += static_cast<double>(
             dav_subspace.diag(hpsi_func,
@@ -366,7 +365,7 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm,
         const int nband = psi.get_nbands();            /// number of eigenpairs sought
         const int ld_psi = psi.get_nbasis();           /// leading dimension of psi
 
-        DiagoDavid<T, Device> david(pre_condition.data(), nband, dim, PARAM.inp.pw_diag_ndim, comm_info);
+        DiagoDavid<T, Device> david(pre_condition.data(), nband, dim, this->pw_diag_ndim, comm_info);
         // do diag and add davidson iteration counts up to avg_iter
         DiagoIterAssist<T, Device>::avg_iter += static_cast<double>(
              david.diag(hpsi_func,

--- a/source/source_hsolver/hsolver_pw.h
+++ b/source/source_hsolver/hsolver_pw.h
@@ -33,10 +33,17 @@ class HSolverPW
               const int diag_iter_max_in,
               const double diag_thr_in,
               const bool need_subspace_in,
+              const int nbands_in,
+              const bool diago_smooth_ethr_in,
+              const int pw_diag_ndim_in,
+              const int diag_subspace_in,
+              const int nb2d_in,
               const bool use_k_continuity_in = false)
         : wfc_basis(wfc_basis_in), calculation_type(calculation_type_in), basis_type(basis_type_in), method(method_in),
           use_uspp(use_uspp_in), nspin(nspin_in), scf_iter(scf_iter_in),
           diag_iter_max(diag_iter_max_in), diag_thr(diag_thr_in), need_subspace(need_subspace_in),
+          nbands(nbands_in), diago_smooth_ethr(diago_smooth_ethr_in), pw_diag_ndim(pw_diag_ndim_in),
+          diag_subspace(diag_subspace_in), nb2d(nb2d_in),
           use_k_continuity(use_k_continuity_in) {};
 
     /// @brief solve function for pw
@@ -82,6 +89,12 @@ class HSolverPW
     const double diag_thr;   // threshold for diagonalization
 
     const bool need_subspace; // for cg or dav_subspace
+
+    const int nbands;              // global number of bands, may differ from psi.get_nbands() under band parallelism
+    const bool diago_smooth_ethr;  // use a band-wise smoothed threshold for all iter methods
+    const int pw_diag_ndim;        // dimension of the workspace for Davidson-type methods
+    const int diag_subspace;       // subspace eigensolver for dav_subspace: 0 Lapack, 1 elpa, 2 scalapack
+    const int nb2d;                // 2d block size used by the dav_subspace scalapack path
 
     const bool use_k_continuity;
 

--- a/source/source_hsolver/hsolver_pw_sdft.cpp
+++ b/source/source_hsolver/hsolver_pw_sdft.cpp
@@ -47,7 +47,7 @@ void HSolverPW_SDFT<T, Device>::solve(const UnitCell& ucell,
     {
         ModuleBase::timer::start("HSolverPW_SDFT", "solve_KS");
         pHamilt->updateHk(ik);
-        if (nbands > 0 && PARAM.globalv.ks_run)
+        if (nbands > 0 && this->ks_run)
         {
             /// update psi pointer for each k point
             psi.fix_k(ik);
@@ -59,7 +59,7 @@ void HSolverPW_SDFT<T, Device>::solve(const UnitCell& ucell,
         }
 
 #ifdef __MPI
-        if (nbands > 0 && !PARAM.globalv.all_ks_run)
+        if (nbands > 0 && !this->all_ks_run)
         {
             Parallel_Common::bcast_dev<T,Device>(&psi(ik, 0, 0), npwx * nbands, BP_WORLD, 0, &psi_cpu(ik, 0, 0));
             MPI_Bcast(&pes->ekb(ik, 0), nbands, MPI_DOUBLE, 0, BP_WORLD);
@@ -91,9 +91,9 @@ void HSolverPW_SDFT<T, Device>::solve(const UnitCell& ucell,
     // calculate eband = \sum_{ik,ib} w(ik)f(ik,ib)e_{ikib}, demet = -TS
     elecstate::ElecStatePW<T, Device>* pes_pw = static_cast<elecstate::ElecStatePW<T, Device>*>(pes);
     elecstate::calEBand(pes_pw->ekb,pes_pw->wg,pes_pw->f_en);
-    if(!PARAM.globalv.all_ks_run)
+    if(!this->all_ks_run)
     {
-        pes->f_en.eband /= PARAM.inp.bndpar;
+        pes->f_en.eband /= this->bndpar;
     }
     stoiter.sum_stoeband(stowf, pes_pw, pHamilt, wfc_basis);
     

--- a/source/source_hsolver/hsolver_pw_sdft.h
+++ b/source/source_hsolver/hsolver_pw_sdft.h
@@ -25,7 +25,15 @@ class HSolverPW_SDFT : public HSolverPW<T, Device>
                    const int scf_iter_in,
                    const int diag_iter_max_in,
                    const double diag_thr_in,
-                   const bool need_subspace_in)
+                   const bool need_subspace_in,
+                   const int nbands_in,
+                   const bool diago_smooth_ethr_in,
+                   const int pw_diag_ndim_in,
+                   const int diag_subspace_in,
+                   const int nb2d_in,
+                   const bool ks_run_in,
+                   const bool all_ks_run_in,
+                   const int bndpar_in)
         : HSolverPW<T, Device>(wfc_basis_in,
                                calculation_type_in,
                                basis_type_in,
@@ -35,7 +43,13 @@ class HSolverPW_SDFT : public HSolverPW<T, Device>
                                scf_iter_in,
                                diag_iter_max_in,
                                diag_thr_in,
-                               need_subspace_in)
+                               need_subspace_in,
+                               nbands_in,
+                               diago_smooth_ethr_in,
+                               pw_diag_ndim_in,
+                               diag_subspace_in,
+                               nb2d_in),
+          ks_run(ks_run_in), all_ks_run(all_ks_run_in), bndpar(bndpar_in)
     {
         stoiter.init(pkv, wfc_basis_in, stowf, stoche, p_hamilt_sto);
     }
@@ -54,6 +68,10 @@ class HSolverPW_SDFT : public HSolverPW<T, Device>
     Stochastic_Iter<T, Device> stoiter;
 
   protected:
+    const bool ks_run;     // true if the current process runs the KS part of the SDFT calculation
+    const bool all_ks_run; // true if every process runs the KS part
+    const int bndpar;      // number of band-parallel groups
+
     using setmem_complex_op = base_device::memory::set_memory_op<T, Device>;
     using setmem_var_op = base_device::memory::set_memory_op<Real, Device>;
     using syncmem_h2d_op = base_device::memory::synchronize_memory_op<T, Device, base_device::DEVICE_CPU>;

--- a/source/source_hsolver/module_pexsi/pexsi_solver.cpp
+++ b/source/source_hsolver/module_pexsi/pexsi_solver.cpp
@@ -1,6 +1,5 @@
 #include "source_base/parallel_global.h"
 #ifdef __PEXSI
-#include "source_io/module_parameter/parameter.h"
 #include "pexsi_solver.h"
 
 #include <mpi.h>
@@ -44,6 +43,8 @@ void PEXSI_Solver::prepare(const int blacs_text,
                            const int nb,
                            const int nrow,
                            const int ncol,
+                           const int nlocal,
+                           const double nelec,
                            const double* h,
                            const double* s,
                            double*& _DM,
@@ -53,6 +54,8 @@ void PEXSI_Solver::prepare(const int blacs_text,
     this->nb = nb;
     this->nrow = nrow;
     this->ncol = ncol;
+    this->nlocal = nlocal;
+    this->nelec = nelec;
     this->h = const_cast<double*>(h);
     this->s = const_cast<double*>(s);
     this->DM = _DM;
@@ -78,14 +81,14 @@ int PEXSI_Solver::solve(double mu0)
                 DIAG_WORLD,
                 grid_group,
                 this->blacs_text,
-                PARAM.globalv.nlocal,
+                this->nlocal,
                 this->nb,
                 this->nrow,
                 this->ncol,
                 'c',
                 this->h,
                 this->s,
-                PARAM.inp.nelec,
+                this->nelec,
                 "PEXSIOPTION",
                 this->DM,
                 this->EDM,

--- a/source/source_hsolver/module_pexsi/pexsi_solver.h
+++ b/source/source_hsolver/module_pexsi/pexsi_solver.h
@@ -12,6 +12,8 @@ class PEXSI_Solver
                  const int nb,
                  const int nrow,
                  const int ncol,
+                 const int nlocal,
+                 const double nelec,
                  const double* h,
                  const double* s,
                  double*& DM,
@@ -130,6 +132,8 @@ class PEXSI_Solver
     int nb;
     int nrow;
     int ncol;
+    int nlocal;   ///< global dimension of the NAO Hamiltonian
+    double nelec; ///< total number of electrons
     double* h = nullptr;
     double* s = nullptr;
     double* DM = nullptr;

--- a/source/source_hsolver/test/diago_pexsi_test.cpp
+++ b/source/source_hsolver/test/diago_pexsi_test.cpp
@@ -160,7 +160,7 @@ class PexsiPrepare
             std::cout << "nrow: " << hmtest.nrow << ", ncol: " << hmtest.ncol << ", nb: " << nb2d << std::endl;
         }
 
-        dh = std::make_unique<hsolver::DiagoPexsi<T>>(&po);
+        dh = std::make_unique<hsolver::DiagoPexsi<T>>(&po, PARAM.input.nspin, nlocal, PARAM.input.nelec);
     }
 
     void distribute_data()

--- a/source/source_hsolver/test/test_hsolver_pw.cpp
+++ b/source/source_hsolver/test/test_hsolver_pw.cpp
@@ -158,25 +158,33 @@ class TestHSolverPW : public ::testing::Test {
                                                                            "scf",
                                                                            "pw",
                                                                            "cg",
-                                                                           false,
                                                                            PARAM.sys.use_uspp,
                                                                            PARAM.input.nspin,
                      hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::SCF_ITER,
                      hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::PW_DIAG_NMAX,
                      hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::PW_DIAG_THR,
-                     hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::need_subspace);
+                     hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::need_subspace,
+                                                                           PARAM.input.nbands,
+                                                                           PARAM.input.diago_smooth_ethr,
+                                                                           PARAM.input.pw_diag_ndim,
+                                                                           PARAM.input.diag_subspace,
+                                                                           PARAM.input.nb2d);
     hsolver::HSolverPW<std::complex<double>, base_device::DEVICE_CPU> hs_d
         = hsolver::HSolverPW<std::complex<double>, base_device::DEVICE_CPU>(&pwbk,
                                                                             "scf",
                                                                             "pw",
                                                                             "cg",
-                                                                            false,
                                                                             PARAM.sys.use_uspp,
                                                                             PARAM.input.nspin,
                      hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::SCF_ITER,
                      hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::PW_DIAG_NMAX,
                      hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::PW_DIAG_THR,
-                     hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::need_subspace);
+                     hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_CPU>::need_subspace,
+                                                                            PARAM.input.nbands,
+                                                                            PARAM.input.diago_smooth_ethr,
+                                                                            PARAM.input.pw_diag_ndim,
+                                                                            PARAM.input.diag_subspace,
+                                                                            PARAM.input.nb2d);
 
     hamilt::Hamilt<std::complex<double>> hamilt_test_d;
     hamilt::Hamilt<std::complex<float>> hamilt_test_f;
@@ -367,9 +375,9 @@ TEST_F(TestHSolverPW, SolveLcaoInPW) {
     elecstate_test.ekb.c[1] = 2.0;
     
     hsolver::HSolverLIP<std::complex<float>> hs_f_lip
-        = hsolver::HSolverLIP<std::complex<float>>(&pwbk);
+        = hsolver::HSolverLIP<std::complex<float>>(&pwbk, PARAM.sys.use_uspp);
     hsolver::HSolverLIP<std::complex<double>> hs_d_lip
-        = hsolver::HSolverLIP<std::complex<double>>(&pwbk);
+        = hsolver::HSolverLIP<std::complex<double>>(&pwbk, PARAM.sys.use_uspp);
     hs_f_lip.solve(&hamilt_test_f, psi_test_cf, &elecstate_test,transform_test_cf, true,0.0,0);
     EXPECT_DOUBLE_EQ(hsolver::DiagoIterAssist<std::complex<float>>::avg_iter, 0.0);
     for (int i = 0; i < psi_test_cf.size(); i++)

--- a/source/source_hsolver/test/test_hsolver_sdft.cpp
+++ b/source/source_hsolver/test/test_hsolver_sdft.cpp
@@ -285,7 +285,15 @@ class TestHSolverPW_SDFT : public ::testing::Test
             hsolver::DiagoIterAssist<std::complex<double>>::SCF_ITER,
             hsolver::DiagoIterAssist<std::complex<double>>::PW_DIAG_NMAX,
             hsolver::DiagoIterAssist<std::complex<double>>::PW_DIAG_THR,
-            hsolver::DiagoIterAssist<std::complex<double>>::need_subspace);
+            hsolver::DiagoIterAssist<std::complex<double>>::need_subspace,
+            PARAM.input.nbands,
+            PARAM.input.diago_smooth_ethr,
+            PARAM.input.pw_diag_ndim,
+            PARAM.input.diag_subspace,
+            PARAM.input.nb2d,
+            PARAM.sys.ks_run,
+            PARAM.sys.all_ks_run,
+            PARAM.input.bndpar);
 
     hamilt::Hamilt<std::complex<double>> hamilt_test_d;
 

--- a/source/source_lcao/LCAO_set.cpp
+++ b/source/source_lcao/LCAO_set.cpp
@@ -230,7 +230,11 @@ void LCAO_domain::init_chg_hr(
     p_hamilt->refresh(false);
 
     // Step 3: Diagonalize to get wavefunctions and charge density
-    hsolver::HSolverLCAO<TK> hsolver_lcao_obj(pv, ks_solver);
+    hsolver::HSolverLCAO<TK> hsolver_lcao_obj(pv,
+                                              ks_solver,
+                                              PARAM.globalv.kpar_lcao,
+                                              PARAM.globalv.nlocal,
+                                              PARAM.inp.nelec);
     hsolver_lcao_obj.solve(p_hamilt, psi, pelec, dm, chr, nspin, 0);
 }
 

--- a/source/source_lcao/module_deltaspin/cal_mw_from_lambda.cpp
+++ b/source/source_lcao/module_deltaspin/cal_mw_from_lambda.cpp
@@ -344,6 +344,11 @@ void spinconstrain::SpinConstrain<std::complex<double>>::update_psi_charge_pw_cp
             hsolver::DiagoIterAssist<std::complex<double>>::PW_DIAG_NMAX,
             hsolver::DiagoIterAssist<std::complex<double>>::PW_DIAG_THR,
             hsolver::DiagoIterAssist<std::complex<double>>::need_subspace,
+            PARAM.inp.nbands,
+            PARAM.inp.diago_smooth_ethr,
+            PARAM.inp.pw_diag_ndim,
+            PARAM.inp.diag_subspace,
+            PARAM.inp.nb2d,
             PARAM.inp.use_k_continuity);
 
         hsolver_pw_obj.solve(hamilt_t, psi_t[0], this->pelec, this->pelec->ekb.c,
@@ -451,6 +456,11 @@ void spinconstrain::SpinConstrain<std::complex<double>>::update_psi_charge_pw_gp
             hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_GPU>::PW_DIAG_NMAX,
             hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_GPU>::PW_DIAG_THR,
             hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_GPU>::need_subspace,
+            PARAM.inp.nbands,
+            PARAM.inp.diago_smooth_ethr,
+            PARAM.inp.pw_diag_ndim,
+            PARAM.inp.diag_subspace,
+            PARAM.inp.nb2d,
             PARAM.inp.use_k_continuity);
 
         hsolver_pw_obj.solve(hamilt_t, psi_t[0], this->pelec, this->pelec->ekb.c,
@@ -511,7 +521,11 @@ void spinconstrain::SpinConstrain<std::complex<double>>::cal_mw_from_lambda(
         // =============================================================
         psi::Psi<std::complex<double>>* psi_t = static_cast<psi::Psi<std::complex<double>>*>(this->psi);
         hamilt::Hamilt<std::complex<double>>* hamilt_t = static_cast<hamilt::Hamilt<std::complex<double>>*>(this->p_hamilt);
-        hsolver::HSolverLCAO<std::complex<double>> hsolver_t(this->ParaV, PARAM.inp.ks_solver);
+        hsolver::HSolverLCAO<std::complex<double>> hsolver_t(this->ParaV,
+                                                            PARAM.inp.ks_solver,
+                                                            PARAM.globalv.kpar_lcao,
+                                                            PARAM.globalv.nlocal,
+                                                            PARAM.inp.nelec);
         if (this->nspin_ == 2)
         {
             dynamic_cast<hamilt::DeltaSpin<hamilt::OperatorLCAO<std::complex<double>, double>>*>(this->p_operator)


### PR DESCRIPTION
## Background

Follow-up to #7706, continuing the removal of `PARAM.*` reads from `source_hsolver` (coding rule 1 in `AGENTS.md`: do not increase cross-layer control through `GlobalV` / `GlobalC` / `PARAM`; pass dependencies explicitly).

This PR covers the parameters that were read from the `PARAM` global mid-algorithm and are now injected through constructors, following the existing explicit-scalar style of the `HSolverPW` / `HSolverLCAO` constructors.

Note on style: #7702 introduced `diago_params.h/cpp` in this module, which instead takes `const Input_para&` explicitly. Both approaches remove the global read; this PR stays with per-scalar constructor injection to match the constructors it is extending, but I am happy to switch these to `const Input_para&` if maintainers prefer to converge on that convention.

## Changes

| Class | Injected |
|---|---|
| `HSolverPW` | `nbands`, `diago_smooth_ethr`, `pw_diag_ndim`, `diag_subspace`, `nb2d` |
| `HSolverPW_SDFT` | `ks_run`, `all_ks_run`, `bndpar` (and forwards the five new base-class values) |
| `HSolverLIP` | `use_uspp` |
| `HSolverLCAO` | `kpar_lcao`, plus `nlocal` and `nelec` for the pexsi branch |

`PARAM.inp.nbands` in the bpcg path is deliberately kept distinct from `psi.get_nbands()`: the former is the global band count that `init_iter` wants, the latter is the local count under band parallelism.

### PEXSI chain

The two reads in `module_pexsi/pexsi_solver.cpp` could not simply be lifted one level, because `DiagoPexsi` did not have `nelec` either — moving them up would just relocate the global read. So the whole chain is threaded in one go:

- `PEXSI_Solver::prepare()` takes `nlocal` and `nelec` and stores them, alongside the `nb` / `nrow` / `ncol` it already received.
- `DiagoPexsi`'s constructor takes `nspin`, `nlocal` and `nelec`. The `nspin == 4` → single-density-matrix collapse was computed identically in the constructor and the destructor; it is now stored once as `nspin_dm`, which also removes the destructor's dependency on `PARAM` still holding the same `nspin` at teardown.
- `HSolverLCAO` passes its `solve()`-argument `nspin` plus the injected `nlocal` and `nelec` down to `DiagoPexsi`.

This also finishes `diago_pexsi.cpp`, which was originally scoped for a later batch.

### Two incidental fixes in code that had to be touched anyway

- `DiagoPexsi::diag()` declared `std::vector<double> eigen(nlocal)` and never used it. Removed — that was the only `nlocal` read in the function.
- The constructor read `pexsi_mu` through `this->ps` *before* `ps` was assigned. It is a `static` member so this happened to work, but it is UB on a null `unique_ptr`; it now reads `pexsi::PEXSI_Solver::pexsi_mu` directly.

### Pre-existing test bug surfaced by this change

The `HSolverPW` fixture in `test_hsolver_pw.cpp` passed an extra `false` after `method_in`, so every argument from `nspin_in` onwards was shifted by one:

| parameter | received |
|---|---|
| `nspin_in` | `use_uspp` |
| `scf_iter_in` | `nspin` |
| `diag_iter_max_in` | `SCF_ITER` |
| `diag_thr_in` | `PW_DIAG_NMAX` |
| `need_subspace_in` | `PW_DIAG_THR` |

It compiled only because of implicit bool/int/double conversions. Adding the new parameters made the call fail to compile, which is how it surfaced. Fixed. The affected tests only construct the object or exercise the early `npw_total < nbands` guard, so no assertion depended on the shifted values.

## Effect

`PARAM.*` occurrences in `source_hsolver` production code: **83 → 60**. Remaining are the six dense LCAO diagonalizers sharing `nlocal`/`nbands`, and `DiagoIterAssist`'s `basis_type` / `calculation` switches — both planned as separate PRs.

## Testing

Syntax-checked with `g++ -fsyntax-only` (with `-D__LCAO`): `hsolver_pw.cpp`, `hsolver_pw_sdft.cpp`, `hsolver_lcao.cpp`, `hsolver_lcaopw.cpp`, `esolver_ks_pw.cpp`, `esolver_sdft_pw.cpp`, `esolver_ks_lcao.cpp`, `esolver_ks_lcao_tddft.cpp`, `esolver_ks_lcaopw.cpp`, `LCAO_set.cpp`, `cal_mw_from_lambda.cpp`.

No gtest available locally, so the updated test fixtures were validated by compiling throwaway translation units that instantiate `HSolverPW`, `HSolverLIP`, `HSolverPW_SDFT`, `DiagoPexsi` and `PEXSI_Solver::prepare` with the exact argument lists the tests now use — this covers the real hazard of positional scalar constructors (arity and types). All passed.

Two paths were **not** covered by a compiler locally and rely on CI:

- the `__PEXSI` function bodies (no PEXSI library available here), and
- the `parakSolve` body and its call site, both inside `#ifdef __MPI` (no MPI headers available here).

Signatures and call sites for both were verified by inspection, and the declaration side of the PEXSI chain was checked by the throwaway TU.

Behaviour is intended to be unchanged throughout: every injected value is the same `PARAM` field that was previously read directly, sourced at the esolver layer.
