### PR TITLE
Fix: loose the threshold of the exx-nspin4-sym test case

### DIFF
--- a/tests/08_EXX/15_KP_HSE_SOC_symm/threshold
+++ b/tests/08_EXX/15_KP_HSE_SOC_symm/threshold
@@ -9,5 +9,5 @@
 # case 07_KP_CR_HSE. See also: np=1 is bit-identical, confirming the MPI seed.
 threshold 0.005
 force_threshold 0.01
-stress_threshold 5
-fatal_threshold 10
+stress_threshold 10
+fatal_threshold 20


### PR DESCRIPTION
The case added in #7692 has randomness due to MPI + LibRI + Pathologically small parameter for testing efficiency (ecutwfc 5, etc. ). Other EXX cases unrelated to #7692 also suffer from this randomness. We now have no idea but to enlarge the error threshold.

Here's a detailed document to explain the randomness (generated by Claude):
[EXX随机性：MPI 归约不可复现——机制拆解.md](https://github.com/user-attachments/files/30550605/EXX.MPI.md)
