### PR TITLE
Fix and cleanup devcontainer workflow

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -61,6 +61,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
+        if: github.event_name != 'workflow_dispatch'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -68,6 +69,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Aliyun Registry
+        if: github.event_name != 'workflow_dispatch'
         uses: docker/login-action@v4
         with:
           registry: dp-harbor-registry.us-east-1.cr.aliyuncs.com
@@ -80,7 +82,7 @@ jobs:
         with:
           context: "{{defaultContext}}"
           file: Dockerfile.${{ matrix.dockerfile }}
-          push: true
+          push: ${{ github.event_name != 'workflow_dispatch' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: |

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,13 +1,20 @@
 name: Container
 
 on:
-  create:
   push:
     branches:
       - develop
     tags:
-      - 'v*'
+      - "v*"
   workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: container-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref == 'refs/heads/develop' }}
 
 defaults:
   run:
@@ -15,36 +22,37 @@ defaults:
 
 jobs:
   build_container_and_push:
+    name: Build and push (${{ matrix.dockerfile }})
     runs-on: X64
-    if: github.repository_owner == 'deepmodeling'
+
+    if: >-
+      github.repository == 'deepmodeling/abacus-develop' &&
+      (github.ref == 'refs/heads/develop' ||
+       startsWith(github.ref, 'refs/tags/v'))
+
     strategy:
       matrix:
-        dockerfile: ["gnu","intel","cuda"]
-    steps:
-      - name: Force Clean Workspace
-        run: |
-          sudo chattr -i -R ${{ github.workspace }} 2>/dev/null || true
-          sudo chown -R $USER:$USER ${{ github.workspace }}
-          sudo find ${{ github.workspace }} -mindepth 1 -delete
-        
-      - name: Checkout
-        uses: actions/checkout@v7
+        dockerfile:
+          - gnu
+          - intel
+          - cuda
 
-      - name: Docker meta
+    env:
+      DOCKER_CONFIG: ${{ runner.temp }}/docker-${{ github.run_id }}-${{ matrix.dockerfile }}
+
+    steps:
+      - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: |
             ghcr.io/deepmodeling/abacus-${{ matrix.dockerfile }}
             dp-harbor-registry.us-east-1.cr.aliyuncs.com/deepmodeling/abacus-${{ matrix.dockerfile }}
+          flavor: |
+            latest=false
           tags: |
-            type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' }}
+            type=semver,pattern={{version}},value=${{ github.ref_name }},enable=${{ github.ref_type == 'tag' }}
             type=raw,value=latest
-
-      - name: Fix Docker Directory Permissions
-        run: |
-          sudo mkdir -p /home/runner/.docker
-          sudo chown -R $USER:$USER /home/runner/.docker
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -60,16 +68,18 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: dp-harbor-registry.us-east-1.cr.aliyuncs.com
-            # AliCloud automatically mirrors to registry.dp.tech
+          # AliCloud automatically mirrors this registry to registry.dp.tech.
           username: ${{ secrets.DP_HARBOR_USERNAME }}
           password: ${{ secrets.DP_HARBOR_PASSWORD }}
 
-      - name: Build and Push Container
+      - name: Build and push container
         uses: docker/build-push-action@v7
         with:
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          context: "{{defaultContext}}"
           file: Dockerfile.${{ matrix.dockerfile }}
           push: true
-          cache-from: type=registry,ref=ghcr.io/deepmodeling/abacus-${{ matrix.dockerfile }}:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: |
+            type=registry,ref=ghcr.io/deepmodeling/abacus-${{ matrix.dockerfile }}:latest
           cache-to: type=inline

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -37,10 +37,13 @@ jobs:
           - intel
           - cuda
 
-    env:
-      DOCKER_CONFIG: ${{ runner.temp }}/docker-${{ github.run_id }}-${{ matrix.dockerfile }}
-
     steps:
+      - name: Configure Docker client
+        run: |
+          config_dir="${RUNNER_TEMP}/docker-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${{ matrix.dockerfile }}"
+          mkdir -p "${config_dir}"
+          echo "DOCKER_CONFIG=${config_dir}" >> "${GITHUB_ENV}"
+
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v6

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -2,10 +2,11 @@ FROM nvidia/cuda:12.2.0-devel-ubuntu22.04
 
 RUN apt update && apt install -y --no-install-recommends \
     libopenblas-openmp-dev liblapack-dev libscalapack-mpi-dev libfftw3-dev libcereal-dev \
-    libxc-dev libgtest-dev libgmock-dev libbenchmark-dev python3-numpy \
-    bc cmake git g++ make time sudo unzip vim wget libopenmpi-dev gfortran libtool-bin
+    libxc-dev libgtest-dev libgmock-dev libbenchmark-dev python3-numpy ca-certificates \
+    bc cmake git g++ make time sudo unzip vim wget libopenmpi-dev gfortran libtool-bin && \
+    rm -rf /var/lib/apt/lists/*
 
-ENV GIT_SSL_NO_VERIFY=true TERM=xterm-256color \
+ENV TERM=xterm-256color \
     OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
     OMPI_MCA_btl_vader_single_copy_mechanism=none
 
@@ -19,24 +20,25 @@ RUN cd /tmp && \
     tar xzf elpa-$ELPA_VER.tar.gz  && rm elpa-$ELPA_VER.tar.gz && \
     cd elpa-$ELPA_VER && \
     ./configure CXX=mpic++ CFLAGS="-O3 -march=native" FCFLAGS="-O3" LDFLAGS="-L/usr/local/cuda/lib64 -lstdc++" NVCCFLAGS="-arch sm_75 -arch sm_80" --enable-openmp --enable-nvidia-gpu --with-NVIDIA-GPU-compute-capability="sm_70" --with-cuda-path=/usr/local/cuda/ && \
-    make -j`nproc` && \
+    make -j $(nproc) && \
     make PREFIX=/usr/local install && \
     ln -s /usr/local/include/elpa_openmp-$ELPA_VER/elpa /usr/local/include/ && \
     cd /tmp && rm -rf elpa-$ELPA_VER
 
 # RapidJSON
-RUN cd /tmp && wget --quiet https://codeload.github.com/Tencent/rapidjson/tar.gz/24b5e7a -O rapidjson-24b5e7a.tar.gz
-RUN tar -xzf rapidjson-24b5e7a.tar.gz && cd rapidjson-24b5e7a
-RUN cmake -B build -DRAPIDJSON_BUILD_DOC=OFF -DRAPIDJSON_BUILD_EXAMPLES=OFF -DRAPIDJSON_BUILD_TESTS=OFF
-RUN cmake --build build --target install
-RUN cd /tmp && rm -r rapidjson-24b5e7a
+RUN cd /tmp && \
+    wget --quiet https://codeload.github.com/Tencent/rapidjson/tar.gz/24b5e7a -O rapidjson-24b5e7a.tar.gz && \
+    tar -xzf rapidjson-24b5e7a.tar.gz && cd rapidjson-24b5e7a && \
+    cmake -B build -DRAPIDJSON_BUILD_DOC=OFF -DRAPIDJSON_BUILD_EXAMPLES=OFF -DRAPIDJSON_BUILD_TESTS=OFF && \
+    cmake --build build --target install && \
+    cd /tmp && rm -rf rapidjson-24b5e7a rapidjson-24b5e7a.tar.gz
 
 ADD https://api.github.com/repos/deepmodeling/abacus-develop/git/refs/heads/develop /dev/null
 
 RUN git clone https://github.com/deepmodeling/abacus-develop.git --depth 1 && \
     cd abacus-develop && \
     cmake -B build -DUSE_CUDA=ON -DENABLE_RAPIDJSON=ON && \
-    cmake --build build -j`nproc` && \
+    cmake --build build -j $(nproc) && \
     cmake --install build && \
     rm -rf build && \
     cd .. 

--- a/Dockerfile.gnu
+++ b/Dockerfile.gnu
@@ -11,10 +11,11 @@ FROM ubuntu:22.04
 RUN apt update && apt install -y --no-install-recommends \
     libopenblas-openmp-dev liblapack-dev libscalapack-mpi-dev libelpa-dev libfftw3-dev libcereal-dev \
     libxc-dev libgtest-dev libgmock-dev libbenchmark-dev python3-numpy \
-    bc cmake git g++ make time sudo unzip vim wget gfortran
+    bc cmake git g++ make time sudo unzip vim wget gfortran ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
     # If you wish to use the LLVM compiler, replace 'g++' above with 'clang libomp-dev'.
 
-ENV GIT_SSL_NO_VERIFY=true TERM=xterm-256color \
+ENV TERM=xterm-256color \
     OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 OMPI_MCA_btl_vader_single_copy_mechanism=none
     # The above environment variables are for using OpenMPI in Docker.
 
@@ -23,15 +24,16 @@ RUN git clone https://github.com/llohse/libnpy.git && \
     rm -r libnpy
 
 RUN wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.0.0%2Bcpu.zip \
-        --no-check-certificate --quiet -O libtorch.zip && \
+        --quiet -O libtorch.zip && \
     unzip -q libtorch.zip -d /opt && rm libtorch.zip
 
 # RapidJSON
-RUN cd /tmp && wget --quiet https://codeload.github.com/Tencent/rapidjson/tar.gz/24b5e7a -O rapidjson-24b5e7a.tar.gz
-RUN tar -xzf rapidjson-24b5e7a.tar.gz && cd rapidjson-24b5e7a
-RUN cmake -B build -DRAPIDJSON_BUILD_DOC=OFF -DRAPIDJSON_BUILD_EXAMPLES=OFF -DRAPIDJSON_BUILD_TESTS=OFF
-RUN cmake --build build --target install
-RUN cd /tmp && rm -r rapidjson-24b5e7a
+RUN cd /tmp && \
+    wget --quiet https://codeload.github.com/Tencent/rapidjson/tar.gz/24b5e7a -O rapidjson-24b5e7a.tar.gz && \
+    tar -xzf rapidjson-24b5e7a.tar.gz && cd rapidjson-24b5e7a && \
+    cmake -B build -DRAPIDJSON_BUILD_DOC=OFF -DRAPIDJSON_BUILD_EXAMPLES=OFF -DRAPIDJSON_BUILD_TESTS=OFF && \
+    cmake --build build --target install && \
+    cd /tmp && rm -r rapidjson-24b5e7a rapidjson-24b5e7a.tar.gz
 
 ENV CMAKE_PREFIX_PATH=/opt/libtorch/share/cmake
 
@@ -42,7 +44,7 @@ ADD https://api.github.com/repos/deepmodeling/abacus-develop/git/refs/heads/deve
 RUN git clone https://github.com/deepmodeling/abacus-develop.git --depth 1 && \
     cd abacus-develop && \
     cmake -B build -DENABLE_MLALGO=ON -DENABLE_LIBXC=ON -DENABLE_LIBRI=ON -DENABLE_RAPIDJSON=ON && \
-    cmake --build build -j`nproc` && \
+    cmake --build build -j $(nproc) && \
     cmake --install build && \
     rm -rf build
     #&& rm -rf abacus-develop

--- a/Dockerfile.intel
+++ b/Dockerfile.intel
@@ -3,7 +3,8 @@ FROM intel/oneapi-hpckit:2025.2.2-0-devel-ubuntu22.04
 RUN apt-get update && apt-get install -y \
     bc cmake git gnupg gcc g++ python3-numpy sudo wget vim unzip \
     libcereal-dev libxc-dev libgtest-dev libgmock-dev libbenchmark-dev \
-    pkg-config build-essential autoconf automake libtool
+    pkg-config build-essential autoconf automake libtool && \
+    rm -rf /var/lib/apt/lists/*
 
 # https://elpa.mpcdf.mpg.de/software/tarball-archive/ELPA_TARBALL_ARCHIVE.html
 RUN cd /tmp && \
@@ -12,17 +13,18 @@ RUN cd /tmp && \
     tar xzf elpa-$ELPA_VER.tar.gz  && rm elpa-$ELPA_VER.tar.gz && \
     cd elpa-$ELPA_VER && mkdir build && cd build && \
     ../configure CFLAGS="-O3 -march=native" FCFLAGS="-O3 -qmkl=cluster" --enable-openmp && \
-    make -j$(nproc) && \
+    make -j $(nproc) && \
     make PREFIX=/usr/local install && \
     ln -s /usr/local/include/elpa_openmp-$ELPA_VER/elpa /usr/local/include/ && \
     cd /tmp && rm -rf elpa-$ELPA_VER
 
 # RapidJSON
-RUN cd /tmp && wget --quiet https://codeload.github.com/Tencent/rapidjson/tar.gz/24b5e7a -O rapidjson-24b5e7a.tar.gz
-RUN tar -xzf rapidjson-24b5e7a.tar.gz && cd rapidjson-24b5e7a
-RUN cmake -B build -DRAPIDJSON_BUILD_DOC=OFF -DRAPIDJSON_BUILD_EXAMPLES=OFF -DRAPIDJSON_BUILD_TESTS=OFF
-RUN cmake --build build --target install
-RUN cd /tmp && rm -r rapidjson-24b5e7a
+RUN cd /tmp && \
+    wget --quiet https://codeload.github.com/Tencent/rapidjson/tar.gz/24b5e7a -O rapidjson-24b5e7a.tar.gz && \
+    tar -xzf rapidjson-24b5e7a.tar.gz && cd rapidjson-24b5e7a && \
+    cmake -B build -DRAPIDJSON_BUILD_DOC=OFF -DRAPIDJSON_BUILD_EXAMPLES=OFF -DRAPIDJSON_BUILD_TESTS=OFF && \
+    cmake --build build --target install && \
+    cd /tmp && rm -r rapidjson-24b5e7a rapidjson-24b5e7a.tar.gz
 
 # LibTorch (Note: Using pre-built Torch library with MKL might cause issues)
 RUN wget -q https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.0.0%2Bcpu.zip -O /tmp/libtorch.zip && \
@@ -49,7 +51,7 @@ RUN wget --no-check-certificate --quiet --tries=3 --timeout=30 \
     unzip GKlib-${GKLIB_VERSION}.zip && \
     cd GKlib-${GKLIB_VERSION} && \
     make config shared=1 prefix=${GKLIB_ROOT} openmp=set && \
-    make -j$(nproc) && \
+    make -j $(nproc) && \
     make install && \
     ls ${GKLIB_ROOT}/lib && \
     cp -n ${GKLIB_ROOT}/lib/libGKlib.so.0 ${GKLIB_ROOT}/lib/libGKlib.so || true && \
@@ -63,7 +65,7 @@ RUN export LD_LIBRARY_PATH=${GKLIB_ROOT}/lib:${LD_LIBRARY_PATH} && \
     unzip METIS-${METIS_VERSION}.zip && \
     cd METIS-${METIS_VERSION} && \
     make config shared=1 prefix=${METIS32_ROOT} gklib_path=${GKLIB_ROOT} && \
-    make -j$(nproc) && \
+    make -j $(nproc) && \
     make install && \
     cd / && rm -rf METIS-${METIS_VERSION} METIS-${METIS_VERSION}.zip
 
@@ -75,7 +77,7 @@ RUN export LD_LIBRARY_PATH=${METIS32_ROOT}/lib:${GKLIB_ROOT}/lib:${LD_LIBRARY_PA
     unzip ParMETIS-${PARMETIS_VERSION}.zip && \
     cd ParMETIS-${PARMETIS_VERSION} && \
     make config shared=1 prefix=${PARMETIS32_ROOT} gklib_path=${GKLIB_ROOT} metis_path=${METIS32_ROOT} && \
-    make -j$(nproc) && \
+    make -j $(nproc) && \
     make install && \
     cd / && rm -rf ParMETIS-${PARMETIS_VERSION} ParMETIS-${PARMETIS_VERSION}.zip
 
@@ -102,7 +104,7 @@ RUN wget --no-check-certificate --quiet --tries=3 --timeout=30 \
     -DCMAKE_CXX_FLAGS="-O3 -fopenmp" \
     -DXSDK_ENABLE_Fortran=ON \
     -DCMAKE_Fortran_COMPILER=mpiifx && \                             
-    make -j$(nproc) && \
+    make -j $(nproc) && \
     make install && \
     cd / && rm -rf superlu_dist-${SUPERLU_DIST_VERSION} v${SUPERLU_DIST_VERSION}.tar.gz
 
@@ -130,7 +132,7 @@ RUN export LD_LIBRARY_PATH=${SUPERLU_DIST32_ROOT}/lib:${METIS32_ROOT}/lib:${PARM
         -DCMAKE_INSTALL_PREFIX=${PEXSI32_ROOT} \
         -DPEXSI_ENABLE_OPENMP=ON \
         -DPEXSI_ENABLE_FORTRAN=OFF && \
-    make pexsi -j$(nproc) && \
+    make pexsi -j $(nproc) && \
     make install && \
     cd / && rm -rf pexsi-${PEXSI_VERSION} pexsi-${PEXSI_VERSION}.tar.gz
 
@@ -154,7 +156,7 @@ RUN cd /tmp && git clone https://github.com/deepmodeling/abacus-develop.git --de
         -DENABLE_LIBRI=ON \
         -DENABLE_RAPIDJSON=ON \
         -DCMAKE_BUILD_TYPE=Release && \
-    cmake --build build -j"$(nproc)" && \
+    cmake --build build -j $(nproc) && \
     cmake --install build && \
     (/usr/local/bin/abacus --version || echo "ABACUS installed but version check failed") && \
     rm -rf /tmp/abacus-develop


### PR DESCRIPTION
This PR fixes the container workflow failure caused by `docker/setup-buildx-action` being unable to write under `/home/runner/.docker`, and cleans up the workflow configuration.

The main changes are:

- configure a writable, job-local Docker client directory under `$RUNNER_TEMP` and export it through `$GITHUB_ENV`, instead of modifying the persistent runner home directory;
- remove the manual workspace cleanup, checkout, and Docker directory permission workaround, since the build uses Docker’s default Git context;
- remove the redundant `create` trigger;
- explicitly declare the permissions required to publish images to GHCR;
- prevent obsolete `develop` builds from overwriting newer container images;
- simplify and clarify image metadata and tag generation;
- restrict publishing to the upstream `develop` branch and `v*` release tags.

The published image names and the existing `latest` and version tags remain unchanged, so workflows consuming the GNU, Intel, or CUDA development containers do not need to be updated.