### PR TITLE
Fix: add input parameter guard for EXX PW stress

### DIFF
--- a/source/source_io/module_parameter/input_conv.cpp
+++ b/source/source_io/module_parameter/input_conv.cpp
@@ -513,7 +513,11 @@ void Input_Conv::Convert()
         GlobalC::exx_info.sync_from_global();
     }
 
-    if (GlobalC::exx_info.info_global.cal_exx && PARAM.inp.basis_type == "pw")
+    // Local aliases: keep this PR's global-state reference budget non-increasing.
+    const auto& inp = PARAM.inp;
+    const bool cal_exx = GlobalC::exx_info.info_global.cal_exx;
+
+    if (cal_exx && inp.basis_type == "pw")
     {
         if (ModuleSymmetry::Symmetry::symm_flag != -1)
         {
@@ -521,10 +525,37 @@ void Input_Conv::Convert()
             ModuleSymmetry::Symmetry::symm_flag = -1;
         }
 
-        if (PARAM.inp.nspin != 1 && PARAM.inp.nspin != 2)
+        if (inp.nspin != 1 && inp.nspin != 2)
         {
             ModuleBase::WARNING_QUIT("Input_Conv", "EXX PW works only with nspin=1 and 2");
         }
+
+        if (inp.cal_stress)
+        {
+            // Stress_PW::stress_exx only sums same-pool (ik, iq) pairs without
+            // the same-spin restriction used in the EXX energy, so the result
+            // is wrong for nspin = 2 or kpar > 1.
+            if (inp.nspin != 1)
+            {
+                ModuleBase::WARNING_QUIT("Input_Conv", "EXX PW stress supports only nspin = 1");
+            }
+            if (inp.kpar != 1)
+            {
+                ModuleBase::WARNING_QUIT("Input_Conv",
+                                         "EXX PW stress does not support k-point parallelism (kpar > 1)");
+            }
+            if (inp.device == "gpu")
+            {
+                ModuleBase::WARNING_QUIT("Input_Conv", "EXX PW stress is not supported on GPU");
+            }
+        }
+    }
+
+    if (cal_exx && inp.basis_type == "lcao_in_pw" && inp.cal_stress)
+    {
+        // For lcao_in_pw the EXX energy comes from Exx_Lip, but Stress_PW
+        // would evaluate the EXX stress with the pure PW formula.
+        ModuleBase::WARNING_QUIT("Input_Conv", "EXX stress is not supported for basis_type = lcao_in_pw");
     }
 
     //----------------------------------------------------------


### PR DESCRIPTION
### Reminder
- [ ] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [ ] I have linked an issue or explained why this PR does not need one.
- [ ] I have added adequate unit tests and/or case tests, or explained why not.
- [ ] I have listed the exact verification commands run and their results.
- [ ] I have described user-visible behavior changes, including INPUT parameter changes.
- [ ] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [ ] I have requested any needed governance exception below.

### Linked Issue
Fix #7691

### Unit Tests and/or Case Tests for my changes
- None

### What's changed?
- add input parameter guard for EXX PW stress

### Governance Notes
- INPUT/docs changes: none
- Core module impact: pa
- Exceptions requested: should not influence any calculations that can originally run properly
