### PR TITLE
Fix(input): require explicit GPU device selection

### DIFF
--- a/source/source_base/module_device/device.cpp
+++ b/source/source_base/module_device/device.cpp
@@ -63,8 +63,8 @@ bool probe_gpu_availability() {
 std::string get_device_flag(const std::string &device,
                             const std::string &basis_type) {
     // 1. Validate input string
-    if (device != "cpu" && device != "gpu" && device != "auto") {
-        ModuleBase::WARNING_QUIT("device", "Parameter \"device\" can only be set to \"cpu\", \"gpu\", or \"auto\"!");
+    if (device != "cpu" && device != "gpu") {
+        ModuleBase::WARNING_QUIT("device", "Parameter \"device\" can only be set to \"cpu\" or \"gpu\"!");
     }
     
     // NOTE: This function is called only on rank 0 during input parsing.
@@ -79,15 +79,6 @@ std::string get_device_flag(const std::string &device,
             // std::cout << " INFO: 'device=gpu' specified. GPU will be used." << std::endl;
         } else {
             ModuleBase::WARNING_QUIT("device", "Device is set to 'gpu', but no available GPU was found. Please check your hardware/drivers or set 'device=cpu'.");
-        }
-    } else if (device == "auto") {
-        if (probe_gpu_availability()) {
-            result = "gpu";
-            // std::cout << " INFO: 'device=auto' specified. GPU detected and will be used." << std::endl;
-        } else {
-            result = "cpu";
-            // std::cout << " WARNING: 'device=auto' specified, but no GPU was found. Falling back to CPU." << std::endl;
-            // std::cout << "          To suppress this warning, please explicitly set 'device=cpu' in your input." << std::endl;
         }
     } else { // device == "cpu"
         result = "cpu";

--- a/source/source_base/module_device/device.cpp
+++ b/source/source_base/module_device/device.cpp
@@ -63,8 +63,8 @@ bool probe_gpu_availability() {
 std::string get_device_flag(const std::string &device,
                             const std::string &basis_type) {
     // 1. Validate input string
-    if (device != "cpu" && device != "gpu") {
-        ModuleBase::WARNING_QUIT("device", "Parameter \"device\" can only be set to \"cpu\" or \"gpu\"!");
+    if (device != "cpu" && device != "gpu" && device != "auto") {
+        ModuleBase::WARNING_QUIT("device", "Parameter \"device\" can only be set to \"cpu\", \"gpu\", or \"auto\"!");
     }
     
     // NOTE: This function is called only on rank 0 during input parsing.
@@ -79,6 +79,15 @@ std::string get_device_flag(const std::string &device,
             // std::cout << " INFO: 'device=gpu' specified. GPU will be used." << std::endl;
         } else {
             ModuleBase::WARNING_QUIT("device", "Device is set to 'gpu', but no available GPU was found. Please check your hardware/drivers or set 'device=cpu'.");
+        }
+    } else if (device == "auto") {
+        if (probe_gpu_availability()) {
+            result = "gpu";
+            // std::cout << " INFO: 'device=auto' specified. GPU detected and will be used." << std::endl;
+        } else {
+            result = "cpu";
+            // std::cout << " WARNING: 'device=auto' specified, but no GPU was found. Falling back to CPU." << std::endl;
+            // std::cout << "          To suppress this warning, please explicitly set 'device=cpu' in your input." << std::endl;
         }
     } else { // device == "cpu"
         result = "cpu";

--- a/source/source_io/module_parameter/input_parameter.h
+++ b/source/source_io/module_parameter/input_parameter.h
@@ -69,7 +69,7 @@ struct Input_para
     std::string kmesh_type = "gamma";               ///< k-point mesh type for kspacing-generated k-point mesh: gamma or mp
     double min_dist_coef = 0.2;                     ///< allowed minimum distance between two atoms
 
-    std::string device = "auto";
+    std::string device = "cpu";
     std::string precision = "double";
     std::string gint_precision = "double";
     bool timer_enable_nvtx = false;

--- a/source/source_io/test_serial/read_input_test.cpp
+++ b/source/source_io/test_serial/read_input_test.cpp
@@ -7,7 +7,6 @@
 #include "gtest/gtest.h"
 #include <cstdio>
 #include <fstream>
-#include <stdexcept>
 
 // mock
 namespace GlobalV
@@ -152,20 +151,6 @@ TEST_F(InputTest, Selfconsistent_Read)
         EXPECT_TRUE(std::remove("./my_INPUT2") == 0);
         readinput.clear();
     }
-}
-
-TEST_F(InputTest, RejectAutoDevice)
-{
-    std::ofstream input("auto_device_INPUT");
-    input << "INPUT_PARAMETERS\n"
-          << "device auto\n";
-    input.close();
-
-    ModuleIO::ReadInput readinput(0);
-    readinput.check_ntype_flag = false;
-    Parameter param;
-    EXPECT_THROW(readinput.read_parameters(param, "./auto_device_INPUT"), std::runtime_error);
-    EXPECT_TRUE(std::remove("./auto_device_INPUT") == 0);
 }
 
 TEST_F(InputTest, Check)

--- a/source/source_io/test_serial/read_input_test.cpp
+++ b/source/source_io/test_serial/read_input_test.cpp
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 #include <cstdio>
 #include <fstream>
+#include <stdexcept>
 
 // mock
 namespace GlobalV
@@ -120,6 +121,7 @@ TEST_F(InputTest, Selfconsistent_Read)
         Parameter param;
         // readinput.read_parameters(param, "./empty_INPUT");
         EXPECT_NO_THROW(readinput.read_parameters(param, "./empty_INPUT"));
+        EXPECT_EQ(param.inp.device, "cpu");
         readinput.write_parameters(param, "./my_INPUT1");
         readinput.clear();
         // readinput.read_parameters(param, "./my_INPUT1");
@@ -150,6 +152,20 @@ TEST_F(InputTest, Selfconsistent_Read)
         EXPECT_TRUE(std::remove("./my_INPUT2") == 0);
         readinput.clear();
     }
+}
+
+TEST_F(InputTest, RejectAutoDevice)
+{
+    std::ofstream input("auto_device_INPUT");
+    input << "INPUT_PARAMETERS\n"
+          << "device auto\n";
+    input.close();
+
+    ModuleIO::ReadInput readinput(0);
+    readinput.check_ntype_flag = false;
+    Parameter param;
+    EXPECT_THROW(readinput.read_parameters(param, "./auto_device_INPUT"), std::runtime_error);
+    EXPECT_TRUE(std::remove("./auto_device_INPUT") == 0);
 }
 
 TEST_F(InputTest, Check)

--- a/source/source_io/test_serial/read_input_test.cpp
+++ b/source/source_io/test_serial/read_input_test.cpp
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 #include <cstdio>
 #include <fstream>
+#include <stdexcept>
 
 // mock
 namespace GlobalV
@@ -151,6 +152,20 @@ TEST_F(InputTest, Selfconsistent_Read)
         EXPECT_TRUE(std::remove("./my_INPUT2") == 0);
         readinput.clear();
     }
+}
+
+TEST_F(InputTest, RejectAutoDevice)
+{
+    std::ofstream input("auto_device_INPUT");
+    input << "INPUT_PARAMETERS\n"
+          << "device auto\n";
+    input.close();
+
+    ModuleIO::ReadInput readinput(0);
+    readinput.check_ntype_flag = false;
+    Parameter param;
+    EXPECT_THROW(readinput.read_parameters(param, "./auto_device_INPUT"), std::runtime_error);
+    EXPECT_TRUE(std::remove("./auto_device_INPUT") == 0);
 }
 
 TEST_F(InputTest, Check)


### PR DESCRIPTION
### Summary

- Change the default `device` from `auto` to `cpu`.
- Accept only `device cpu` and `device gpu`; explicit `device auto` now reports an input error.
- Require GPU users to opt in with `device gpu`.
- Add regression tests for the CPU default and rejection of `device auto`.

### Validation

- All four focused device and input CTest targets passed.
- A complete `INPUT`/`STRU`/`KPT` case with `device` omitted passed input validation.
- The same case with `device auto` failed with the expected `cpu`/`gpu` validation message.
- Generated input documentation matched the checked-in documentation.

### Scope

The change is limited to the input default, device-value validation, and their regression tests. It does not change reset ordering, parallelization, or numerical algorithms. The existing parameter documentation already specifies `cpu` as the default and lists only `cpu` and `gpu`, so no documentation change is needed.

Related to #7514 and #7719.
