### PR TITLE
Temporarily remove DeePKS nspin test.

### DIFF
--- a/tests/09_DeePKS/CASES_CPU.txt
+++ b/tests/09_DeePKS/CASES_CPU.txt
@@ -26,6 +26,6 @@
 26_NO_KP_deepks_out_freq_elec
 27_NO_GO_deepks_out_2
 28_NO_KP_deepks_out_2
-29_NO_GO_deepks_scf_nspin2
-30_NO_KP_deepks_scf_nspin2
-31_NO_GO_deepks_bandgap_nspin2
+#29_NO_GO_deepks_scf_nspin2
+#30_NO_KP_deepks_scf_nspin2
+#31_NO_GO_deepks_bandgap_nspin2


### PR DESCRIPTION
### Unit Tests and/or Case Tests for my changes
- Comment out integration test for DeePKS nspin=2.

Note: Current DeePKS nspin model has not been trained yet, the whole workflow is not built and the test case here use a random model, which may lead to failure in scf process (a bad converged point) since it randomly correct the Hamiltonian. The test should be reopened only when the nspin model is available.

