### PR TITLE
Fix(input): validate contradictory final parameters

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -651,7 +651,7 @@
 ### bndpar
 
 - **Type**: Integer
-- **Description**: Divide all processors into bndpar groups for SDFT or the BPCG solver. bndpar must be positive, no greater than the number of MPI processes, and divide it exactly.
+- **Description**: Divide all processors into bndpar groups for SDFT or the BPCG solver. bndpar must be positive, no greater than the number of MPI processes, and kpar * bndpar must divide the number of MPI processes exactly.
 - **Default**: 1
 
 ### latname

--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -651,7 +651,7 @@
 ### bndpar
 
 - **Type**: Integer
-- **Description**: Divide all processors into bndpar groups, and bands (only stochastic orbitals now) will be distributed among each group. It should be larger than 0.
+- **Description**: Divide all processors into bndpar groups for SDFT or the BPCG solver. bndpar must be positive, no greater than the number of MPI processes, and divide it exactly.
 - **Default**: 1
 
 ### latname
@@ -1263,7 +1263,7 @@
 - **Description**: The number of spin components of wave functions.
   - 1: Spin degeneracy
   - 2: Collinear spin polarized.
-  - 4: For the case of noncollinear polarized, nspin will be automatically set to 4 without being specified by the user.
+  - 4: Noncollinear or spin-orbit calculations. Set nspin to 4 explicitly when noncolin or lspinorb is enabled.
 - **Default**: 1
 
 ### smearing_method
@@ -1467,7 +1467,7 @@
 - **Type**: Boolean
 - **Description**: Whether to consider spin-orbit coupling (SOC) effect in the calculation.
   - True: Consider spin-orbit coupling effect. When enabled:
-  - nspin is automatically set to 4 (noncollinear spin representation)
+  - nspin must be explicitly set to 4 (noncollinear spin representation)
   - Symmetry is automatically disabled (SOC breaks inversion symmetry)
   - Requires full-relativistic pseudopotentials with has_so=true in the UPF header
   - False: Do not consider spin-orbit coupling effect.
@@ -1479,7 +1479,7 @@
 - **Type**: Boolean
 - **Description**: Whether to allow non-collinear magnetic moments, where magnetization can point in arbitrary directions (x, y, z components) rather than being constrained to the z-axis.
   - True: Allow non-collinear polarization. When enabled:
-  - nspin is automatically set to 4
+  - nspin must be explicitly set to 4
   - Wave function dimension is doubled (npol=2), and the number of occupied states is doubled
   - Charge density has 4 components (Pauli spin matrices)
   - Cannot be used with gamma_only=true
@@ -1534,7 +1534,7 @@
 - **Availability**: *esolver_type = sdft*
 - **Description**: The number of stochastic orbitals
   - &gt; 0: Perform stochastic DFT. Increasing the number of bands improves accuracy and reduces stochastic errors; To perform mixed stochastic-deterministic DFT, you should set nbands, which represents the number of KS orbitals.
-  - 0: Perform Kohn-Sham DFT.
+  - 0: Invalid with esolver_type=sdft. Use esolver_type=ksdft for Kohn-Sham DFT.
   - all: All complete basis sets are used to replace stochastic orbitals with the Chebyshev method (CT), resulting in the same results as KSDFT without stochastic errors.
 - **Default**: 256
 

--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -1533,7 +1533,7 @@
 - **Type**: Integer or string
 - **Availability**: *esolver_type = sdft*
 - **Description**: The number of stochastic orbitals
-  - 1-100000: Perform stochastic DFT. Increasing the number of bands improves accuracy and reduces stochastic errors; To perform mixed stochastic-deterministic DFT, you should set nbands, which represents the number of KS orbitals.
+  - 1-1000000: Perform stochastic DFT. Increasing the number of bands improves accuracy and reduces stochastic errors; To perform mixed stochastic-deterministic DFT, you should set nbands, which represents the number of KS orbitals.
   - 0: Invalid. Use all for the complete-basis SDFT mode.
   - all: All complete basis sets are used to replace stochastic orbitals with the Chebyshev method (CT), resulting in the same results as KSDFT without stochastic errors.
 - **Default**: 256

--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -1533,8 +1533,8 @@
 - **Type**: Integer or string
 - **Availability**: *esolver_type = sdft*
 - **Description**: The number of stochastic orbitals
-  - &gt; 0: Perform stochastic DFT. Increasing the number of bands improves accuracy and reduces stochastic errors; To perform mixed stochastic-deterministic DFT, you should set nbands, which represents the number of KS orbitals.
-  - 0: Invalid with esolver_type=sdft. Use esolver_type=ksdft for Kohn-Sham DFT.
+  - 1-100000: Perform stochastic DFT. Increasing the number of bands improves accuracy and reduces stochastic errors; To perform mixed stochastic-deterministic DFT, you should set nbands, which represents the number of KS orbitals.
+  - 0: Invalid. Use all for the complete-basis SDFT mode.
   - all: All complete basis sets are used to replace stochastic orbitals with the Chebyshev method (CT), resulting in the same results as KSDFT without stochastic errors.
 - **Default**: 256
 

--- a/docs/advanced/scf/spin.md
+++ b/docs/advanced/scf/spin.md
@@ -30,11 +30,11 @@ If **"nupdown"** is set to non-zero, number of spin-up and spin-down electrons w
 
 ## Noncollinear Spin Polarized Calculations
 The spin non-collinear polarization calculation corresponds to setting **"noncolin 1"**, in which case the coupling between spin up and spin down will be taken into account.
-In this case, nspin is automatically set to 4, which is usually not required to be specified manually.
+In this case, **"nspin 4"** must also be specified. ABACUS reports an input error instead of silently changing an incompatible or omitted nspin value.
 The weight of each band will not change, but the number of occupied states will be double.
 If the nbands parameter is set manually, it is generally set to twice what it would be when nspin<4.
 
-In general, non-collinear magnetic moment settings are often used in calculations considering [SOC effects](#soc-effects). When **"lspinorb 1"** in INPUT file, "nspin" is also automatically set to 4.
+In general, non-collinear magnetic moment settings are often used in calculations considering [SOC effects](#soc-effects). When **"lspinorb 1"** is set in INPUT, **"nspin 4"** is also required.
 
 Note: different settings for "noncolin" and "lspinorb" correspond to different calculations:
 
@@ -119,22 +119,22 @@ Example from a full-relativistic UPF file:
 - **PseudoDOJO**: Provides both scalar and full-relativistic versions
 - **ABACUS official**: [abacus.ustc.edu.cn](http://abacus.ustc.edu.cn/pseudo/list.htm)
 
-## Automatic Parameter Settings
+## Parameter Requirements and Automatic Settings
 
-When using SOC or non-collinear calculations, ABACUS automatically adjusts several parameters:
+When using SOC or non-collinear calculations, set the required spin representation explicitly. ABACUS still derives internal spin state and some related settings after validating the input:
 
 ### When `lspinorb=true`:
-1. **nspin**: Automatically set to 4 (noncollinear spin representation)
+1. **nspin**: Must be explicitly set to 4 (noncollinear spin representation)
 2. **Symmetry**: Automatically disabled (`symm_flag=-1`) because SOC breaks inversion symmetry
 3. **Magnetization**: NOT automatically set when `noncolin=0` (implies non-magnetic material with SOC)
 
 ### When `noncolin=true`:
-1. **nspin**: Automatically set to 4
+1. **nspin**: Must be explicitly set to 4
 2. **npol**: Set to 2 (wave function has two spinor components)
 3. **Magnetization**: Automatically set if user provides zero values (unless `lspinorb=1` and `noncolin=0`)
 
 ### Important Notes:
-- You do NOT need to manually set `nspin=4` when using `lspinorb=1` or `noncolin=1`
+- You must set `nspin=4` when using `lspinorb=1` or `noncolin=1`; missing or incompatible values are rejected during input validation
 - Symmetry operations are incompatible with SOC, so they are automatically turned off
 - For `lspinorb=1, noncolin=0`: This is a special case for non-magnetic materials with SOC, where magnetization is not initialized
 
@@ -172,7 +172,7 @@ basis_type          pw
 ecutwfc             50
 lspinorb            1        # Enable SOC
 noncolin            0        # No non-collinear magnetism
-# nspin will be automatically set to 4
+nspin               4        # Required spinor representation
 # symmetry will be automatically disabled
 ```
 
@@ -185,7 +185,7 @@ calculation         scf
 basis_type          lcao
 lspinorb            0        # No SOC
 noncolin            1        # Enable non-collinear magnetism
-# nspin will be automatically set to 4
+nspin               4        # Required spinor representation
 # Magnetization directions should be specified in STRU file
 ```
 
@@ -199,7 +199,7 @@ basis_type          pw
 ecutwfc             60
 lspinorb            1        # Enable SOC
 noncolin            1        # Enable non-collinear magnetism
-# nspin will be automatically set to 4
+nspin               4        # Required spinor representation
 # symmetry will be automatically disabled
 # Magnetization directions should be specified in STRU file
 ```
@@ -213,6 +213,7 @@ calculation         scf
 basis_type          pw
 ecutwfc             50
 lspinorb            1        # Enable SOC
+nspin               4        # Required spinor representation
 soc_lambda          0.5      # 50% SOC strength
 # Useful when full SOC overestimates or underestimates experimental results
 ```

--- a/docs/community/faq.md
+++ b/docs/community/faq.md
@@ -50,7 +50,7 @@ To perform SOC calculations in ABACUS, follow these steps:
 2. **Use full-relativistic pseudopotentials**: SOC calculations require pseudopotentials with `has_so=true` in the UPF header
    - Download full-relativistic versions of SG15_ONCV pseudopotentials from [quantum-simulation.org](http://quantum-simulation.org/potentials/sg15_oncv/upf/)
    - Check the UPF file header for `relativistic="full"` and `has_so="T"`
-3. **Verify automatic settings**: When `lspinorb=1` is set, `nspin` is automatically set to 4 and symmetry is automatically disabled
+3. **Set the spin representation**: When `lspinorb=1` is set, explicitly set `nspin=4`; symmetry is automatically disabled
 
 **Basis set support**: Both `basis_type=pw` (plane wave) and `basis_type=lcao` (numerical atomic orbitals) support SOC calculations for both SCF and NSCF.
 

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2198,7 +2198,7 @@ parameters:
     type: Integer or string
     description: |
       The number of stochastic orbitals
-      * 1-100000: Perform stochastic DFT. Increasing the number of bands improves accuracy and reduces stochastic errors; To perform mixed stochastic-deterministic DFT, you should set nbands, which represents the number of KS orbitals.
+      * 1-1000000: Perform stochastic DFT. Increasing the number of bands improves accuracy and reduces stochastic errors; To perform mixed stochastic-deterministic DFT, you should set nbands, which represents the number of KS orbitals.
       * 0: Invalid. Use all for the complete-basis SDFT mode.
       * all: All complete basis sets are used to replace stochastic orbitals with the Chebyshev method (CT), resulting in the same results as KSDFT without stochastic errors.
     default_value: "256"

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -108,7 +108,7 @@ parameters:
     category: System variables
     type: Integer
     description: |
-      Divide all processors into bndpar groups, and bands (only stochastic orbitals now) will be distributed among each group. It should be larger than 0.
+      Divide all processors into bndpar groups for SDFT or the BPCG solver. bndpar must be positive, no greater than the number of MPI processes, and divide it exactly.
     default_value: "1"
     unit: ""
     availability: ""
@@ -661,7 +661,7 @@ parameters:
       The number of spin components of wave functions.
       * 1: Spin degeneracy
       * 2: Collinear spin polarized.
-      * 4: For the case of noncollinear polarized, nspin will be automatically set to 4 without being specified by the user.
+      * 4: Noncollinear or spin-orbit calculations. Set nspin to 4 explicitly when noncolin or lspinorb is enabled.
     default_value: "1"
     unit: ""
     availability: ""
@@ -906,7 +906,7 @@ parameters:
     description: |
       Whether to consider spin-orbit coupling (SOC) effect in the calculation.
       * True: Consider spin-orbit coupling effect. When enabled:
-        * nspin is automatically set to 4 (noncollinear spin representation)
+        * nspin must be explicitly set to 4 (noncollinear spin representation)
         * Symmetry is automatically disabled (SOC breaks inversion symmetry)
         * Requires full-relativistic pseudopotentials with has_so=true in the UPF header
       * False: Do not consider spin-orbit coupling effect.
@@ -920,7 +920,7 @@ parameters:
     description: |
       Whether to allow non-collinear magnetic moments, where magnetization can point in arbitrary directions (x, y, z components) rather than being constrained to the z-axis.
       * True: Allow non-collinear polarization. When enabled:
-        * nspin is automatically set to 4
+        * nspin must be explicitly set to 4
         * Wave function dimension is doubled (npol=2), and the number of occupied states is doubled
         * Charge density has 4 components (Pauli spin matrices)
         * Cannot be used with gamma_only=true
@@ -2199,7 +2199,7 @@ parameters:
     description: |
       The number of stochastic orbitals
       * > 0: Perform stochastic DFT. Increasing the number of bands improves accuracy and reduces stochastic errors; To perform mixed stochastic-deterministic DFT, you should set nbands, which represents the number of KS orbitals.
-      * 0: Perform Kohn-Sham DFT.
+      * 0: Invalid with esolver_type=sdft. Use esolver_type=ksdft for Kohn-Sham DFT.
       * all: All complete basis sets are used to replace stochastic orbitals with the Chebyshev method (CT), resulting in the same results as KSDFT without stochastic errors.
     default_value: "256"
     unit: ""

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -108,7 +108,7 @@ parameters:
     category: System variables
     type: Integer
     description: |
-      Divide all processors into bndpar groups for SDFT or the BPCG solver. bndpar must be positive, no greater than the number of MPI processes, and divide it exactly.
+      Divide all processors into bndpar groups for SDFT or the BPCG solver. bndpar must be positive, no greater than the number of MPI processes, and kpar * bndpar must divide the number of MPI processes exactly.
     default_value: "1"
     unit: ""
     availability: ""

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2198,8 +2198,8 @@ parameters:
     type: Integer or string
     description: |
       The number of stochastic orbitals
-      * > 0: Perform stochastic DFT. Increasing the number of bands improves accuracy and reduces stochastic errors; To perform mixed stochastic-deterministic DFT, you should set nbands, which represents the number of KS orbitals.
-      * 0: Invalid with esolver_type=sdft. Use esolver_type=ksdft for Kohn-Sham DFT.
+      * 1-100000: Perform stochastic DFT. Increasing the number of bands improves accuracy and reduces stochastic errors; To perform mixed stochastic-deterministic DFT, you should set nbands, which represents the number of KS orbitals.
+      * 0: Invalid. Use all for the complete-basis SDFT mode.
       * all: All complete basis sets are used to replace stochastic orbitals with the Chebyshev method (CT), resulting in the same results as KSDFT without stochastic errors.
     default_value: "256"
     unit: ""

--- a/examples/21_deepks/03_lcao_CsPbI3/INPUT
+++ b/examples/21_deepks/03_lcao_CsPbI3/INPUT
@@ -29,6 +29,7 @@ deepks_model         model.ptg
 
 #Parameters (7.SOC)
 lspinorb             1
+nspin                4
 
 
 

--- a/source/source_io/module_parameter/read_input_item_elec_stru.cpp
+++ b/source/source_io/module_parameter/read_input_item_elec_stru.cpp
@@ -482,21 +482,19 @@ The other way is only available when compiling with LIBXC, and it allows for sup
         item.description = R"(The number of spin components of wave functions.
 * 1: Spin degeneracy
 * 2: Collinear spin polarized.
-* 4: For the case of noncollinear polarized, nspin will be automatically set to 4 without being specified by the user.)";
+* 4: Noncollinear or spin-orbit calculations. Set nspin to 4 explicitly when noncolin or lspinorb is enabled.)";
         item.default_value = "1";
         item.unit = "";
         item.availability = "";
         read_sync_int(input.nspin);
-        item.reset_value = [](const Input_Item& item, Parameter& para) {
-            if (para.input.noncolin || para.input.lspinorb)
-            {
-                para.input.nspin = 4;
-            }
-        };
         item.check_value = [](const Input_Item& item, const Parameter& para) {
             if (para.input.nspin != 1 && para.input.nspin != 2 && para.input.nspin != 4)
             {
                 ModuleBase::WARNING_QUIT("ReadInput", "nspin should be 1, 2 or 4.");
+            }
+            if ((para.input.noncolin || para.input.lspinorb) && para.input.nspin != 4)
+            {
+                ModuleBase::WARNING_QUIT("ReadInput", "nspin must be 4 when noncolin or lspinorb is enabled.");
             }
         };
         this->add_item(item);
@@ -986,7 +984,7 @@ Note: If gamma_only is set to 1, the KPT file will be overwritten. So make sure 
         item.type = "Boolean";
         item.description = R"(Whether to consider spin-orbit coupling (SOC) effect in the calculation.
 * True: Consider spin-orbit coupling effect. When enabled:
-  * nspin is automatically set to 4 (noncollinear spin representation)
+  * nspin must be explicitly set to 4 (noncollinear spin representation)
   * Symmetry is automatically disabled (SOC breaks inversion symmetry)
   * Requires full-relativistic pseudopotentials with has_so=true in the UPF header
 * False: Do not consider spin-orbit coupling effect.
@@ -1004,7 +1002,7 @@ Note: If gamma_only is set to 1, the KPT file will be overwritten. So make sure 
         item.type = "Boolean";
         item.description = R"(Whether to allow non-collinear magnetic moments, where magnetization can point in arbitrary directions (x, y, z components) rather than being constrained to the z-axis.
 * True: Allow non-collinear polarization. When enabled:
-  * nspin is automatically set to 4
+  * nspin must be explicitly set to 4
   * Wave function dimension is doubled (npol=2), and the number of occupied states is doubled
   * Charge density has 4 components (Pauli spin matrices)
   * Cannot be used with gamma_only=true

--- a/source/source_io/module_parameter/read_input_item_sdft.cpp
+++ b/source/source_io/module_parameter/read_input_item_sdft.cpp
@@ -1,4 +1,3 @@
-#include "source_base/global_function.h"
 #include "source_base/tool_quit.h"
 #include "read_input.h"
 #include "read_input_tool.h"
@@ -38,7 +37,7 @@ void ReadInput::item_sdft()
         item.type = "Integer or string";
         item.description = R"(The number of stochastic orbitals
 * > 0: Perform stochastic DFT. Increasing the number of bands improves accuracy and reduces stochastic errors; To perform mixed stochastic-deterministic DFT, you should set nbands, which represents the number of KS orbitals.
-* 0: Perform Kohn-Sham DFT.
+* 0: Invalid with esolver_type=sdft. Use esolver_type=ksdft for Kohn-Sham DFT.
 * all: All complete basis sets are used to replace stochastic orbitals with the Chebyshev method (CT), resulting in the same results as KSDFT without stochastic errors.)";
         item.default_value = "256";
         item.unit = "";
@@ -54,21 +53,17 @@ void ReadInput::item_sdft()
                 para.input.nbands_sto = 0;
             }
         };
-        item.reset_value = [](const Input_Item& item, Parameter& para) {
-            // only do it when nbands_sto is set in INPUT
-            if (item.is_read())
-            {
-                if (strvalue == "0" && para.input.esolver_type == "sdft")
-                {
-                    para.input.esolver_type = "ksdft";
-                    ModuleBase::GlobalFunc::AUTO_SET("esolver_type", para.input.esolver_type);
-                }
-            }
-        };
         item.check_value = [](const Input_Item& item, const Parameter& para) {
             if (para.input.nbands_sto < 0 || para.input.nbands_sto > 100000)
             {
                 ModuleBase::WARNING_QUIT("ReadInput", "nbands_sto should be in the range of 0 to 100000");
+            }
+            if (para.input.esolver_type == "sdft" && item.is_read() && para.input.nbands_sto == 0
+                && strvalue != "all")
+            {
+                ModuleBase::WARNING_QUIT("ReadInput",
+                                         "nbands_sto=0 is incompatible with esolver_type=sdft; use "
+                                         "esolver_type=ksdft instead.");
             }
         };
         item.get_final_value = [](Input_Item& item, const Parameter& para) {

--- a/source/source_io/module_parameter/read_input_item_sdft.cpp
+++ b/source/source_io/module_parameter/read_input_item_sdft.cpp
@@ -2,6 +2,8 @@
 #include "read_input.h"
 #include "read_input_tool.h"
 
+#include <exception>
+
 namespace ModuleIO
 {
 void ReadInput::item_sdft()
@@ -46,7 +48,21 @@ void ReadInput::item_sdft()
             std::string nbandsto_str = strvalue;
             if (nbandsto_str != "all")
             {
-                para.input.nbands_sto = std::stoi(nbandsto_str);
+                std::size_t parsed_chars = 0;
+                try
+                {
+                    para.input.nbands_sto = std::stoi(nbandsto_str, &parsed_chars);
+                }
+                catch (const std::exception&)
+                {
+                    ModuleBase::WARNING_QUIT("ReadInput",
+                                             "nbands_sto should be in the range of 1 to 100000 or be all");
+                }
+                if (parsed_chars != nbandsto_str.size())
+                {
+                    ModuleBase::WARNING_QUIT("ReadInput",
+                                             "nbands_sto should be in the range of 1 to 100000 or be all");
+                }
             }
             else
             {

--- a/source/source_io/module_parameter/read_input_item_sdft.cpp
+++ b/source/source_io/module_parameter/read_input_item_sdft.cpp
@@ -36,8 +36,8 @@ void ReadInput::item_sdft()
         item.category = "Electronic structure (SDFT)";
         item.type = "Integer or string";
         item.description = R"(The number of stochastic orbitals
-* > 0: Perform stochastic DFT. Increasing the number of bands improves accuracy and reduces stochastic errors; To perform mixed stochastic-deterministic DFT, you should set nbands, which represents the number of KS orbitals.
-* 0: Invalid with esolver_type=sdft. Use esolver_type=ksdft for Kohn-Sham DFT.
+* 1-100000: Perform stochastic DFT. Increasing the number of bands improves accuracy and reduces stochastic errors; To perform mixed stochastic-deterministic DFT, you should set nbands, which represents the number of KS orbitals.
+* 0: Invalid. Use all for the complete-basis SDFT mode.
 * all: All complete basis sets are used to replace stochastic orbitals with the Chebyshev method (CT), resulting in the same results as KSDFT without stochastic errors.)";
         item.default_value = "256";
         item.unit = "";
@@ -54,16 +54,10 @@ void ReadInput::item_sdft()
             }
         };
         item.check_value = [](const Input_Item& item, const Parameter& para) {
-            if (para.input.nbands_sto < 0 || para.input.nbands_sto > 100000)
+            const bool use_complete_basis = item.is_read() && strvalue == "all";
+            if ((!use_complete_basis && para.input.nbands_sto < 1) || para.input.nbands_sto > 100000)
             {
-                ModuleBase::WARNING_QUIT("ReadInput", "nbands_sto should be in the range of 0 to 100000");
-            }
-            if (para.input.esolver_type == "sdft" && item.is_read() && para.input.nbands_sto == 0
-                && strvalue != "all")
-            {
-                ModuleBase::WARNING_QUIT("ReadInput",
-                                         "nbands_sto=0 is incompatible with esolver_type=sdft; use "
-                                         "esolver_type=ksdft instead.");
+                ModuleBase::WARNING_QUIT("ReadInput", "nbands_sto should be in the range of 1 to 100000 or be all");
             }
         };
         item.get_final_value = [](Input_Item& item, const Parameter& para) {

--- a/source/source_io/module_parameter/read_input_item_sdft.cpp
+++ b/source/source_io/module_parameter/read_input_item_sdft.cpp
@@ -38,7 +38,7 @@ void ReadInput::item_sdft()
         item.category = "Electronic structure (SDFT)";
         item.type = "Integer or string";
         item.description = R"(The number of stochastic orbitals
-* 1-100000: Perform stochastic DFT. Increasing the number of bands improves accuracy and reduces stochastic errors; To perform mixed stochastic-deterministic DFT, you should set nbands, which represents the number of KS orbitals.
+* 1-1000000: Perform stochastic DFT. Increasing the number of bands improves accuracy and reduces stochastic errors; To perform mixed stochastic-deterministic DFT, you should set nbands, which represents the number of KS orbitals.
 * 0: Invalid. Use all for the complete-basis SDFT mode.
 * all: All complete basis sets are used to replace stochastic orbitals with the Chebyshev method (CT), resulting in the same results as KSDFT without stochastic errors.)";
         item.default_value = "256";
@@ -56,12 +56,12 @@ void ReadInput::item_sdft()
                 catch (const std::exception&)
                 {
                     ModuleBase::WARNING_QUIT("ReadInput",
-                                             "nbands_sto should be in the range of 1 to 100000 or be all");
+                                             "nbands_sto should be in the range of 1 to 1000000 or be all");
                 }
                 if (parsed_chars != nbandsto_str.size())
                 {
                     ModuleBase::WARNING_QUIT("ReadInput",
-                                             "nbands_sto should be in the range of 1 to 100000 or be all");
+                                             "nbands_sto should be in the range of 1 to 1000000 or be all");
                 }
             }
             else
@@ -71,9 +71,9 @@ void ReadInput::item_sdft()
         };
         item.check_value = [](const Input_Item& item, const Parameter& para) {
             const bool use_complete_basis = item.is_read() && strvalue == "all";
-            if ((!use_complete_basis && para.input.nbands_sto < 1) || para.input.nbands_sto > 100000)
+            if ((!use_complete_basis && para.input.nbands_sto < 1) || para.input.nbands_sto > 1000000)
             {
-                ModuleBase::WARNING_QUIT("ReadInput", "nbands_sto should be in the range of 1 to 100000 or be all");
+                ModuleBase::WARNING_QUIT("ReadInput", "nbands_sto should be in the range of 1 to 1000000 or be all");
             }
         };
         item.get_final_value = [](Input_Item& item, const Parameter& para) {

--- a/source/source_io/module_parameter/read_input_item_system.cpp
+++ b/source/source_io/module_parameter/read_input_item_system.cpp
@@ -313,7 +313,7 @@ void ReadInput::item_system()
             // GPU + PW: validate kpar against total processors
             // Moved from base_device::information::get_device_kpar()
 #if defined(__CUDA) || defined(__ROCM)
-            if (para.input.device == "gpu" && para.input.basis_type == "pw")
+            if (para.input.device == "gpu" && para.input.basis_type == "pw" && para.input.bndpar > 0)
             {
                 if (GlobalV::NPROC != para.input.kpar * para.input.bndpar)
                 {
@@ -339,21 +339,23 @@ void ReadInput::item_system()
                           "will be distributed among each group";
         item.category = "System variables";
         item.type = "Integer";
-        item.description = "Divide all processors into bndpar groups, and bands (only stochastic orbitals now) "
-                          "will be distributed among each group. It should be larger than 0.";
+        item.description = "Divide all processors into bndpar groups for SDFT or the BPCG solver. bndpar must be "
+                           "positive, no greater than the number of MPI processes, and divide it exactly.";
         item.default_value = "1";
         read_sync_int(input.bndpar);
-        item.reset_value = [](const Input_Item& item, Parameter& para) {
-            if (para.input.esolver_type != "sdft" && para.input.ks_solver != "bpcg")
+        item.check_value = [](const Input_Item& item, const Parameter& para) {
+            if (para.input.bndpar <= 0)
             {
-                para.input.bndpar = 1;
+                ModuleBase::WARNING_QUIT("ReadInput", "bndpar must be greater than 0");
             }
             if (para.input.bndpar > GlobalV::NPROC)
             {
-                para.input.bndpar = GlobalV::NPROC;
+                ModuleBase::WARNING_QUIT("ReadInput", "bndpar can not exceed the number of MPI processes");
             }
-        };
-        item.check_value = [](const Input_Item& item, const Parameter& para) {
+            if (para.input.bndpar > 1 && para.input.esolver_type != "sdft" && para.input.ks_solver != "bpcg")
+            {
+                ModuleBase::WARNING_QUIT("ReadInput", "bndpar > 1 requires esolver_type=sdft or ks_solver=bpcg");
+            }
             if (GlobalV::NPROC % para.input.bndpar != 0)
             {
                 ModuleBase::WARNING_QUIT("ReadInput", "The number of processors can not be divided by bndpar");

--- a/source/source_io/module_parameter/read_input_item_system.cpp
+++ b/source/source_io/module_parameter/read_input_item_system.cpp
@@ -340,7 +340,8 @@ void ReadInput::item_system()
         item.category = "System variables";
         item.type = "Integer";
         item.description = "Divide all processors into bndpar groups for SDFT or the BPCG solver. bndpar must be "
-                           "positive, no greater than the number of MPI processes, and divide it exactly.";
+                           "positive, no greater than the number of MPI processes, and kpar * bndpar must divide "
+                           "the number of MPI processes exactly.";
         item.default_value = "1";
         read_sync_int(input.bndpar);
         item.check_value = [](const Input_Item& item, const Parameter& para) {
@@ -359,6 +360,12 @@ void ReadInput::item_system()
             if (GlobalV::NPROC % para.input.bndpar != 0)
             {
                 ModuleBase::WARNING_QUIT("ReadInput", "The number of processors can not be divided by bndpar");
+            }
+            if (para.input.bndpar > 1
+                && (para.input.kpar <= 0 || (GlobalV::NPROC / para.input.bndpar) % para.input.kpar != 0))
+            {
+                ModuleBase::WARNING_QUIT("ReadInput",
+                                         "The number of processors can not be divided by kpar * bndpar");
             }
         };
         this->add_item(item);

--- a/source/source_io/test_serial/read_input_item_test.cpp
+++ b/source/source_io/test_serial/read_input_item_test.cpp
@@ -88,11 +88,7 @@ TEST_F(InputTest, Item_test)
     }
     { // nspin
         auto it = find_label("nspin", readinput.input_lists);
-        param.input.nspin = 0;
-        param.input.noncolin = true;
-        it->second.reset_value(it->second, param);
-        EXPECT_EQ(param.input.nspin, 4);
-
+        param.input.noncolin = false;
         param.input.nspin = 3;
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
@@ -188,15 +184,9 @@ TEST_F(InputTest, Item_test)
     }
     { // bndpar
         auto it = find_label("bndpar", readinput.input_lists);
-        param.input.esolver_type = "ksdft";
-        it->second.reset_value(it->second, param);
-        EXPECT_EQ(param.input.bndpar, 1);
-
         param.input.esolver_type = "sdft";
-        param.input.bndpar = 2;
-        GlobalV::NPROC = 1;
-        it->second.reset_value(it->second, param);
-        EXPECT_EQ(param.input.bndpar, 1);
+        param.input.bndpar = 1;
+        EXPECT_NO_THROW(it->second.check_value(it->second, param));
     }
     { // dft_plus_dmft
         auto it = find_label("dft_plus_dmft", readinput.input_lists);
@@ -871,22 +861,26 @@ TEST_F(InputTest, Item_test)
 
         it->second.str_values = {"all"};
         it->second.read_value(it->second, param);
-        it->second.reset_value(it->second, param);
+        EXPECT_NO_THROW(it->second.check_value(it->second, param));
         EXPECT_EQ(param.input.nbands_sto, 0);
         EXPECT_EQ(param.input.esolver_type, "sdft");
 
         it->second.str_values = {"8"};
         it->second.read_value(it->second, param);
-        it->second.reset_value(it->second, param);
+        EXPECT_NO_THROW(it->second.check_value(it->second, param));
         EXPECT_EQ(param.input.nbands_sto, 8);
         EXPECT_EQ(param.input.esolver_type, "sdft");
 
         it->second.str_values = {"0"};
         it->second.read_value(it->second, param);
-        it->second.reset_value(it->second, param);
+        testing::internal::CaptureStdout();
+        EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
+        output = testing::internal::GetCapturedStdout();
+        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
         EXPECT_EQ(param.input.nbands_sto, 0);
-        EXPECT_EQ(param.input.esolver_type, "ksdft");
+        EXPECT_EQ(param.input.esolver_type, "sdft");
 
+        it->second.str_values = {"-1"};
         param.input.nbands_sto = -1;
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");

--- a/source/source_io/test_serial/read_input_item_test.cpp
+++ b/source/source_io/test_serial/read_input_item_test.cpp
@@ -871,11 +871,11 @@ TEST_F(InputTest, Item_test)
         EXPECT_EQ(param.input.nbands_sto, 8);
         EXPECT_EQ(param.input.esolver_type, "sdft");
 
-        it->second.str_values = {"100000"};
+        it->second.str_values = {"1000000"};
         it->second.read_value(it->second, param);
         EXPECT_NO_THROW(it->second.check_value(it->second, param));
 
-        it->second.str_values = {"100001"};
+        it->second.str_values = {"1000001"};
         it->second.read_value(it->second, param);
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");

--- a/source/source_io/test_serial/read_input_item_test.cpp
+++ b/source/source_io/test_serial/read_input_item_test.cpp
@@ -871,6 +871,17 @@ TEST_F(InputTest, Item_test)
         EXPECT_EQ(param.input.nbands_sto, 8);
         EXPECT_EQ(param.input.esolver_type, "sdft");
 
+        it->second.str_values = {"100000"};
+        it->second.read_value(it->second, param);
+        EXPECT_NO_THROW(it->second.check_value(it->second, param));
+
+        it->second.str_values = {"100001"};
+        it->second.read_value(it->second, param);
+        testing::internal::CaptureStdout();
+        EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
+        output = testing::internal::GetCapturedStdout();
+        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
+
         it->second.str_values = {"0"};
         it->second.read_value(it->second, param);
         testing::internal::CaptureStdout();

--- a/source/source_io/test_serial/read_input_test.cpp
+++ b/source/source_io/test_serial/read_input_test.cpp
@@ -234,15 +234,21 @@ TEST_F(InputTest, ValidateSdftStochasticBands)
     EXPECT_NO_THROW(read_parameters("sdft_all_INPUT", "esolver_type sdft\nnbands_sto all\n", all_param));
     EXPECT_EQ(all_param.inp.esolver_type, "sdft");
 
+    Parameter relaxed_limit_param;
+    EXPECT_NO_THROW(read_parameters("sdft_relaxed_limit_INPUT",
+                                    "esolver_type sdft\nnbands_sto 100001\n",
+                                    relaxed_limit_param));
+    EXPECT_EQ(relaxed_limit_param.inp.nbands_sto, 100001);
+
     expect_invalid_input("sdft_zero_INPUT",
                          "esolver_type sdft\nnbands_sto 00\n",
-                         "nbands_sto should be in the range of 1 to 100000 or be all");
+                         "nbands_sto should be in the range of 1 to 1000000 or be all");
     expect_invalid_input("ksdft_zero_INPUT",
                          "esolver_type ksdft\nnbands_sto 0\n",
-                         "nbands_sto should be in the range of 1 to 100000 or be all");
+                         "nbands_sto should be in the range of 1 to 1000000 or be all");
     expect_invalid_input("sdft_fractional_INPUT",
                          "esolver_type sdft\nnbands_sto 1.5\n",
-                         "nbands_sto should be in the range of 1 to 100000 or be all");
+                         "nbands_sto should be in the range of 1 to 1000000 or be all");
 }
 
 TEST_F(InputTest, ValidateBandParallelization)

--- a/source/source_io/test_serial/read_input_test.cpp
+++ b/source/source_io/test_serial/read_input_test.cpp
@@ -240,6 +240,9 @@ TEST_F(InputTest, ValidateSdftStochasticBands)
     expect_invalid_input("ksdft_zero_INPUT",
                          "esolver_type ksdft\nnbands_sto 0\n",
                          "nbands_sto should be in the range of 1 to 100000 or be all");
+    expect_invalid_input("sdft_fractional_INPUT",
+                         "esolver_type sdft\nnbands_sto 1.5\n",
+                         "nbands_sto should be in the range of 1 to 100000 or be all");
 }
 
 TEST_F(InputTest, ValidateBandParallelization)
@@ -247,7 +250,7 @@ TEST_F(InputTest, ValidateBandParallelization)
     set_nproc(4);
     Parameter valid_param;
     EXPECT_NO_THROW(read_parameters("bndpar_valid_INPUT",
-                                    "esolver_type sdft\nnbands_sto all\nbndpar 2\n",
+                                    "esolver_type sdft\nnbands_sto all\nkpar 2\nbndpar 2\n",
                                     valid_param));
     EXPECT_EQ(valid_param.inp.bndpar, 2);
 
@@ -259,6 +262,9 @@ TEST_F(InputTest, ValidateBandParallelization)
     expect_invalid_input("bndpar_wrong_solver_INPUT",
                          "bndpar 2\n",
                          "bndpar > 1 requires esolver_type=sdft or ks_solver=bpcg");
+    expect_invalid_input("bndpar_kpar_not_divisible_INPUT",
+                         "esolver_type sdft\nnbands_sto all\nkpar 2\nbndpar 4\n",
+                         "The number of processors can not be divided by kpar * bndpar");
 
     set_nproc(3);
     expect_invalid_input("bndpar_not_divisible_INPUT",

--- a/source/source_io/test_serial/read_input_test.cpp
+++ b/source/source_io/test_serial/read_input_test.cpp
@@ -236,7 +236,10 @@ TEST_F(InputTest, ValidateSdftStochasticBands)
 
     expect_invalid_input("sdft_zero_INPUT",
                          "esolver_type sdft\nnbands_sto 00\n",
-                         "nbands_sto=0 is incompatible with esolver_type=sdft");
+                         "nbands_sto should be in the range of 1 to 100000 or be all");
+    expect_invalid_input("ksdft_zero_INPUT",
+                         "esolver_type ksdft\nnbands_sto 0\n",
+                         "nbands_sto should be in the range of 1 to 100000 or be all");
 }
 
 TEST_F(InputTest, ValidateBandParallelization)

--- a/source/source_io/test_serial/read_input_test.cpp
+++ b/source/source_io/test_serial/read_input_test.cpp
@@ -68,6 +68,50 @@ void make_dir_out(const std::string& suffix,
 class InputTest : public testing::Test
 {
   protected:
+    void TearDown() override
+    {
+        set_nproc(1);
+    }
+
+    void set_nproc(const int nproc)
+    {
+        GlobalV::NPROC = nproc;
+    }
+
+    void write_input(const std::string& filename, const std::string& parameters)
+    {
+        std::ofstream input(filename.c_str());
+        input << "INPUT_PARAMETERS\n" << parameters;
+    }
+
+    void read_parameters(const std::string& filename, const std::string& parameters, Parameter& param)
+    {
+        write_input(filename, parameters);
+        ModuleIO::ReadInput readinput(0);
+        readinput.check_ntype_flag = false;
+        try
+        {
+            readinput.read_parameters(param, filename);
+        }
+        catch (...)
+        {
+            std::remove(filename.c_str());
+            throw;
+        }
+        EXPECT_EQ(std::remove(filename.c_str()), 0);
+    }
+
+    void expect_invalid_input(const std::string& filename,
+                              const std::string& parameters,
+                              const std::string& reason)
+    {
+        Parameter param;
+        testing::internal::CaptureStdout();
+        EXPECT_THROW(read_parameters(filename, parameters, param), std::runtime_error);
+        const std::string output = testing::internal::GetCapturedStdout();
+        EXPECT_THAT(output, testing::HasSubstr(reason));
+    }
+
     bool compare_two_files(const std::string& filename1, const std::string& filename2)
     {
         std::ifstream file1(filename1.c_str());
@@ -166,6 +210,62 @@ TEST_F(InputTest, RejectAutoDevice)
     Parameter param;
     EXPECT_THROW(readinput.read_parameters(param, "./auto_device_INPUT"), std::runtime_error);
     EXPECT_TRUE(std::remove("./auto_device_INPUT") == 0);
+}
+
+TEST_F(InputTest, ValidateNoncollinearSpin)
+{
+    Parameter valid_param;
+    EXPECT_NO_THROW(read_parameters("noncolin_valid_INPUT", "noncolin 1\nnspin 4\n", valid_param));
+
+    expect_invalid_input("noncolin_missing_nspin_INPUT",
+                         "noncolin 1\n",
+                         "nspin must be 4 when noncolin or lspinorb is enabled");
+    expect_invalid_input("noncolin_invalid_nspin_INPUT",
+                         "noncolin 1\nnspin 2\n",
+                         "nspin must be 4 when noncolin or lspinorb is enabled");
+    expect_invalid_input("soc_missing_nspin_INPUT",
+                         "lspinorb 1\n",
+                         "nspin must be 4 when noncolin or lspinorb is enabled");
+}
+
+TEST_F(InputTest, ValidateSdftStochasticBands)
+{
+    Parameter all_param;
+    EXPECT_NO_THROW(read_parameters("sdft_all_INPUT", "esolver_type sdft\nnbands_sto all\n", all_param));
+    EXPECT_EQ(all_param.inp.esolver_type, "sdft");
+
+    expect_invalid_input("sdft_zero_INPUT",
+                         "esolver_type sdft\nnbands_sto 00\n",
+                         "nbands_sto=0 is incompatible with esolver_type=sdft");
+}
+
+TEST_F(InputTest, ValidateBandParallelization)
+{
+    set_nproc(4);
+    Parameter valid_param;
+    EXPECT_NO_THROW(read_parameters("bndpar_valid_INPUT",
+                                    "esolver_type sdft\nnbands_sto all\nbndpar 2\n",
+                                    valid_param));
+    EXPECT_EQ(valid_param.inp.bndpar, 2);
+
+    Parameter bpcg_param;
+    EXPECT_NO_THROW(read_parameters("bndpar_bpcg_INPUT", "ks_solver bpcg\nbndpar 2\n", bpcg_param));
+    EXPECT_EQ(bpcg_param.inp.bndpar, 2);
+
+    expect_invalid_input("bndpar_zero_INPUT", "bndpar 0\n", "bndpar must be greater than 0");
+    expect_invalid_input("bndpar_wrong_solver_INPUT",
+                         "bndpar 2\n",
+                         "bndpar > 1 requires esolver_type=sdft or ks_solver=bpcg");
+
+    set_nproc(3);
+    expect_invalid_input("bndpar_not_divisible_INPUT",
+                         "esolver_type sdft\nnbands_sto all\nbndpar 2\n",
+                         "The number of processors can not be divided by bndpar");
+
+    set_nproc(1);
+    expect_invalid_input("bndpar_too_large_INPUT",
+                         "esolver_type sdft\nnbands_sto all\nbndpar 2\n",
+                         "bndpar can not exceed the number of MPI processes");
 }
 
 TEST_F(InputTest, Check)

--- a/tests/01_PW/035_PW_15_SO/INPUT
+++ b/tests/01_PW/035_PW_15_SO/INPUT
@@ -31,6 +31,7 @@ cal_stress        1
 
 #noncolin        1
 lspinorb          1
+nspin             4
 
 basis_type        pw
 ks_solver         dav_subspace

--- a/tests/01_PW/038_PW_NC/INPUT
+++ b/tests/01_PW/038_PW_NC/INPUT
@@ -5,6 +5,7 @@ init_wfc          random
 basis_type        pw
 calculation       scf
 noncolin          1
+nspin             4
 symmetry          0
 cal_force         1
 cal_stress        1

--- a/tests/01_PW/057_PW_SO_IW/INPUT
+++ b/tests/01_PW/057_PW_SO_IW/INPUT
@@ -3,6 +3,7 @@ INPUT_PARAMETERS
 calculation       scf
 #noncolin           1
 lspinorb          1
+nspin             4
 gamma_only        0
 symmetry          0
 

--- a/tests/01_PW/099_PW_DJ_SO/INPUT
+++ b/tests/01_PW/099_PW_DJ_SO/INPUT
@@ -32,6 +32,7 @@ pw_diag_ndim      2
 basis_type        pw
 gamma_only        0
 noncolin          1
+nspin             4
 lspinorb          1
 cal_force         1
 cal_stress        1

--- a/tests/03_NAO_multik/scf_angle_spin4/INPUT
+++ b/tests/03_NAO_multik/scf_angle_spin4/INPUT
@@ -14,6 +14,7 @@ scf_thr           1e-7
 scf_nmax          50
 
 noncolin          1
+nspin             4
 #Parameters (3.Basis)
 basis_type        lcao
 

--- a/tests/03_NAO_multik/scf_out_dos_spin4/INPUT
+++ b/tests/03_NAO_multik/scf_out_dos_spin4/INPUT
@@ -17,6 +17,7 @@ scf_nmax          100
 
 #noncolin         1
 lspinorb          1
+nspin             4
 cal_force         1
 cal_stress        1
 

--- a/tests/03_NAO_multik/scf_out_mul_spin4/INPUT
+++ b/tests/03_NAO_multik/scf_out_mul_spin4/INPUT
@@ -3,6 +3,7 @@ INPUT_PARAMETERS
 # non-collinear LCAO calculations
 basis_type        lcao
 noncolin          1
+nspin             4
 symmetry          1
 
 calculation       scf

--- a/tests/03_NAO_multik/scf_out_mul_spin4/result.ref
+++ b/tests/03_NAO_multik/scf_out_mul_spin4/result.ref
@@ -4,4 +4,5 @@ Compare_mulliken_pass 0
 pointgroupref O_h
 spacegroupref O_h
 nksibzref 1
+magpointgroupref C_4h
 totaltimeref 4.42

--- a/tests/03_NAO_multik/scf_u_spin4/INPUT
+++ b/tests/03_NAO_multik/scf_u_spin4/INPUT
@@ -25,6 +25,7 @@ ks_solver         scalapack_gvx
 basis_type        lcao
 gamma_only        0
 noncolin          1
+nspin             4
 lspinorb          1
 cal_force         1
 cal_stress        1

--- a/tests/06_SDFT/16_PW_KG_100/INPUT
+++ b/tests/06_SDFT/16_PW_KG_100/INPUT
@@ -2,10 +2,9 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix            autotest
 calculation       scf
-esolver_type      sdft
+esolver_type      ksdft
 
 nbands            100
-nbands_sto        0 #execute KSDFT
 pseudo_dir        ../../PP_ORB
 symmetry          1
 kpar              2

--- a/tests/11_PW_GPU/BUG_nspin4_u/INPUT
+++ b/tests/11_PW_GPU/BUG_nspin4_u/INPUT
@@ -33,6 +33,7 @@ pw_diag_ndim      2
 basis_type        pw
 gamma_only        0
 noncolin          1
+nspin             4
 lspinorb          1
 cal_force         1
 cal_stress        1

--- a/tests/17_DS_DFTU/02_LCAO_SPIN_S4_XYZ/INPUT
+++ b/tests/17_DS_DFTU/02_LCAO_SPIN_S4_XYZ/INPUT
@@ -5,6 +5,7 @@ basis_type    lcao
 ecutwfc    20
 gamma_only    0
 noncolin    1
+nspin       4
 #nbands    40
 scf_thr    1.0e-6
 scf_nmax    50

--- a/tests/17_DS_DFTU/04_LCAO_DFTU_S4_XY/INPUT
+++ b/tests/17_DS_DFTU/04_LCAO_DFTU_S4_XY/INPUT
@@ -6,6 +6,7 @@ ecutwfc    20
 gamma_only    0
 
 noncolin    1
+nspin       4
 #nbands    28
 scf_thr    1.0e-6
 scf_nmax    50

--- a/tests/17_DS_DFTU/05_LCAO_DFTU_S4_XYZ/INPUT
+++ b/tests/17_DS_DFTU/05_LCAO_DFTU_S4_XYZ/INPUT
@@ -5,6 +5,7 @@ basis_type    lcao
 ecutwfc    20
 gamma_only    0
 noncolin    1
+nspin       4
 #nbands    40
 scf_thr    1.0e-6
 scf_nmax    50

--- a/tests/17_DS_DFTU/07_PW_SPIN_S4_XYZ/INPUT
+++ b/tests/17_DS_DFTU/07_PW_SPIN_S4_XYZ/INPUT
@@ -5,6 +5,7 @@ basis_type    pw
 ecutwfc    20
 gamma_only    0
 noncolin    1
+nspin       4
 #nbands    40
 scf_thr    1.0e-6
 scf_nmax    50

--- a/tests/17_DS_DFTU/09_PW_DFTU_S4_XY/INPUT
+++ b/tests/17_DS_DFTU/09_PW_DFTU_S4_XY/INPUT
@@ -7,6 +7,7 @@ gamma_only    0
 device    cpu
 
 noncolin    1
+nspin       4
 scf_thr    1.0e-6
 scf_nmax    50
 out_chg    0

--- a/tests/17_DS_DFTU/14_PW_DS_S4_XYZ/INPUT
+++ b/tests/17_DS_DFTU/14_PW_DS_S4_XYZ/INPUT
@@ -5,6 +5,7 @@ basis_type    pw
 ecutwfc    20
 gamma_only    0
 noncolin    1
+nspin       4
 #nbands    28
 scf_thr    1.0e-6
 scf_nmax    50

--- a/tests/17_DS_DFTU/15_PW_DS_S4_Z/INPUT
+++ b/tests/17_DS_DFTU/15_PW_DS_S4_Z/INPUT
@@ -5,6 +5,7 @@ basis_type    pw
 ecutwfc    20
 gamma_only    0
 noncolin    1
+nspin       4
 #nbands    40
 scf_thr    1.0e-6
 scf_nmax    50

--- a/tests/17_DS_DFTU/16_PW_DS_S4_XY/INPUT
+++ b/tests/17_DS_DFTU/16_PW_DS_S4_XY/INPUT
@@ -5,6 +5,7 @@ basis_type    pw
 ecutwfc    20
 gamma_only    0
 noncolin    1
+nspin       4
 #nbands    40
 scf_thr    1.0e-6
 scf_nmax    50

--- a/tests/17_DS_DFTU/19_PW_DFTU_DS_S4_XY/INPUT
+++ b/tests/17_DS_DFTU/19_PW_DFTU_DS_S4_XY/INPUT
@@ -7,6 +7,7 @@ gamma_only    0
 device    cpu
 
 noncolin    1
+nspin       4
 scf_thr    1.0e-6
 scf_nmax    50
 out_chg    0

--- a/tests/17_DS_DFTU/21_PW_DFTU_DS_S4_Z/INPUT
+++ b/tests/17_DS_DFTU/21_PW_DFTU_DS_S4_Z/INPUT
@@ -5,6 +5,7 @@ basis_type    pw
 ecutwfc    20
 gamma_only    0
 noncolin    1
+nspin       4
 #nbands    40
 scf_thr    1.0e-6
 scf_nmax    50

--- a/tests/17_DS_DFTU/26_LCAO_DS_S4_XYZ/INPUT
+++ b/tests/17_DS_DFTU/26_LCAO_DS_S4_XYZ/INPUT
@@ -6,6 +6,7 @@ ecutwfc    20
 gamma_only    0
 
 noncolin    1
+nspin       4
 #nbands    28
 scf_thr    1.0e-6
 scf_nmax    100

--- a/tests/17_DS_DFTU/27_LCAO_DS_S4_Z/INPUT
+++ b/tests/17_DS_DFTU/27_LCAO_DS_S4_Z/INPUT
@@ -5,6 +5,7 @@ basis_type    lcao
 ecutwfc    20
 gamma_only    0
 noncolin    1
+nspin       4
 #nbands    40
 scf_thr    1.0e-6
 scf_nmax    100

--- a/tests/17_DS_DFTU/28_LCAO_DS_S4_XY/INPUT
+++ b/tests/17_DS_DFTU/28_LCAO_DS_S4_XY/INPUT
@@ -5,6 +5,7 @@ basis_type    lcao
 ecutwfc    20
 gamma_only    0
 noncolin    1
+nspin       4
 #nbands    40
 scf_thr    1.0e-6
 scf_nmax    100

--- a/tests/17_DS_DFTU/31_LCAO_DFTU_DS_S4_XY/INPUT
+++ b/tests/17_DS_DFTU/31_LCAO_DFTU_DS_S4_XY/INPUT
@@ -6,6 +6,7 @@ ecutwfc    20
 gamma_only    0
 
 noncolin    1
+nspin       4
 #nbands    28
 scf_thr    1.0e-6
 scf_nmax    50

--- a/tests/17_DS_DFTU/32_LCAO_DFTU_DS_S4_XYZ/INPUT
+++ b/tests/17_DS_DFTU/32_LCAO_DFTU_DS_S4_XYZ/INPUT
@@ -6,6 +6,7 @@ ecutwfc    20
 gamma_only    0
 
 noncolin    1
+nspin       4
 #nbands    28
 scf_thr    1.0e-6
 scf_nmax    100

--- a/tests/17_DS_DFTU/33_LCAO_DFTU_DS_S4_Z/INPUT
+++ b/tests/17_DS_DFTU/33_LCAO_DFTU_DS_S4_Z/INPUT
@@ -5,6 +5,7 @@ basis_type    lcao
 ecutwfc    20
 gamma_only    0
 noncolin    1
+nspin       4
 #nbands    40
 scf_thr    1.0e-6
 scf_nmax    50

--- a/tests/17_DS_DFTU/37_PW_DS_S4_ReadLam_XY/INPUT
+++ b/tests/17_DS_DFTU/37_PW_DS_S4_ReadLam_XY/INPUT
@@ -6,6 +6,7 @@ ecutwfc    20
 gamma_only    0
 
 noncolin    1
+nspin       4
 scf_thr    1.0e-6
 scf_nmax    50
 out_chg    0

--- a/tests/17_DS_DFTU/39_PW_DS_S4_Thr1e10_XY/INPUT
+++ b/tests/17_DS_DFTU/39_PW_DS_S4_Thr1e10_XY/INPUT
@@ -6,6 +6,7 @@ ecutwfc    20
 gamma_only    0
 
 noncolin    1
+nspin       4
 scf_thr    1.0e-6
 scf_nmax    100
 out_chg    0

--- a/tests/17_DS_DFTU/41_PW_DS_S4_Thr10_XY/INPUT
+++ b/tests/17_DS_DFTU/41_PW_DS_S4_Thr10_XY/INPUT
@@ -6,6 +6,7 @@ ecutwfc    20
 gamma_only    0
 
 noncolin    1
+nspin       4
 scf_thr    1.0e-6
 scf_nmax    50
 out_chg    0

--- a/tests/17_DS_DFTU/43_PW_DFTU_DS_S4_Thr1e10_XY/INPUT
+++ b/tests/17_DS_DFTU/43_PW_DFTU_DS_S4_Thr1e10_XY/INPUT
@@ -6,6 +6,7 @@ ecutwfc    20
 gamma_only    0
 
 noncolin    1
+nspin       4
 scf_thr    1.0e-6
 scf_nmax    100
 out_chg    0

--- a/tests/17_DS_DFTU/45_PW_DFTU_DS_S4_Thr10_XY/INPUT
+++ b/tests/17_DS_DFTU/45_PW_DFTU_DS_S4_Thr10_XY/INPUT
@@ -6,6 +6,7 @@ ecutwfc    20
 gamma_only    0
 
 noncolin    1
+nspin       4
 scf_thr    1.0e-6
 scf_nmax    50
 out_chg    0

--- a/tests/17_DS_DFTU/55_PW_DS_NSCF_S4_XY/INPUT
+++ b/tests/17_DS_DFTU/55_PW_DS_NSCF_S4_XY/INPUT
@@ -7,6 +7,7 @@ gamma_only    0
 init_chg    file
 read_file_dir    ./
 noncolin    1
+nspin       4
 #nbands    28
 scf_thr    1.0e-6
 scf_nmax    1

--- a/tests/17_DS_DFTU/55_PW_DS_NSCF_S4_XY/scf/INPUT
+++ b/tests/17_DS_DFTU/55_PW_DS_NSCF_S4_XY/scf/INPUT
@@ -6,6 +6,7 @@ ecutwfc    20
 gamma_only    0
 init_chg    atomic
 noncolin    1
+nspin       4
 #nbands    28
 scf_thr    1.0e-6
 scf_nmax    50

--- a/tests/17_DS_DFTU/56_PW_DS_S4_DirectionOnly_XY/INPUT
+++ b/tests/17_DS_DFTU/56_PW_DS_S4_DirectionOnly_XY/INPUT
@@ -5,6 +5,7 @@ basis_type    pw
 ecutwfc    20
 gamma_only    0
 noncolin    1
+nspin       4
 #nbands    28
 scf_thr    1.0e-8
 scf_nmax    50

--- a/tests/17_DS_DFTU/57_PW_DFTU_DS_S4_DirectionOnly_XY/INPUT
+++ b/tests/17_DS_DFTU/57_PW_DFTU_DS_S4_DirectionOnly_XY/INPUT
@@ -6,6 +6,7 @@ ecutwfc    20
 gamma_only    0
 
 noncolin    1
+nspin       4
 scf_thr    1.0e-8
 scf_nmax    50
 out_chg    0

--- a/tests/17_DS_DFTU/58_LCAO_DS_S4_DirectionOnly_XY/INPUT
+++ b/tests/17_DS_DFTU/58_LCAO_DS_S4_DirectionOnly_XY/INPUT
@@ -6,6 +6,7 @@ ecutwfc    20
 gamma_only    0
 
 noncolin    1
+nspin       4
 #nbands    28
 scf_thr    1.0e-6
 scf_nmax    100

--- a/tests/17_DS_DFTU/59_LCAO_DFTU_DS_S4_DirectionOnly_XY/INPUT
+++ b/tests/17_DS_DFTU/59_LCAO_DFTU_DS_S4_DirectionOnly_XY/INPUT
@@ -6,6 +6,7 @@ ecutwfc    20
 gamma_only    0
 
 noncolin    1
+nspin       4
 #nbands    28
 scf_thr    1.0e-6
 scf_nmax    50

--- a/tests/17_DS_DFTU/60_PW_DFTU_DS_NSCF_Band_XY/INPUT
+++ b/tests/17_DS_DFTU/60_PW_DFTU_DS_NSCF_Band_XY/INPUT
@@ -7,6 +7,7 @@ gamma_only    0
 init_chg    file
 read_file_dir    ./
 noncolin    1
+nspin       4
 nbands    40
 scf_thr    1.0e-6
 scf_nmax    1

--- a/tests/17_DS_DFTU/60_PW_DFTU_DS_NSCF_Band_XY/scf/INPUT
+++ b/tests/17_DS_DFTU/60_PW_DFTU_DS_NSCF_Band_XY/scf/INPUT
@@ -6,6 +6,7 @@ ecutwfc    10
 gamma_only    0
 init_chg    atomic
 noncolin    1
+nspin       4
 nbands    40
 scf_thr    1.0e-6
 scf_nmax    50

--- a/tests/17_DS_DFTU/61_LCAO_DS_NSCF_S4_XY/INPUT
+++ b/tests/17_DS_DFTU/61_LCAO_DS_NSCF_S4_XY/INPUT
@@ -7,6 +7,7 @@ gamma_only    0
 init_chg    file
 read_file_dir    ./
 noncolin    1
+nspin       4
 #nbands    28
 scf_thr    1.0e-6
 scf_nmax    1

--- a/tests/17_DS_DFTU/61_LCAO_DS_NSCF_S4_XY/scf/INPUT
+++ b/tests/17_DS_DFTU/61_LCAO_DS_NSCF_S4_XY/scf/INPUT
@@ -6,6 +6,7 @@ ecutwfc    5
 gamma_only    0
 init_chg    atomic
 noncolin    1
+nspin       4
 #nbands    28
 scf_thr    1.0e-6
 scf_nmax    50

--- a/tests/17_DS_DFTU/62_LCAO_DFTU_NSCF_Band_XY/INPUT
+++ b/tests/17_DS_DFTU/62_LCAO_DFTU_NSCF_Band_XY/INPUT
@@ -7,6 +7,7 @@ gamma_only    0
 init_chg    file
 read_file_dir    ./
 noncolin    1
+nspin       4
 #nbands    28
 scf_thr    1.0e-6
 scf_nmax    1

--- a/tests/17_DS_DFTU/62_LCAO_DFTU_NSCF_Band_XY/scf/INPUT
+++ b/tests/17_DS_DFTU/62_LCAO_DFTU_NSCF_Band_XY/scf/INPUT
@@ -6,6 +6,7 @@ ecutwfc    5
 gamma_only    0
 init_chg    atomic
 noncolin    1
+nspin       4
 #nbands    28
 scf_thr    1.0e-6
 scf_nmax    50

--- a/tests/17_DS_DFTU/63_LCAO_DFTU_DS_NSCF_Band_XY/INPUT
+++ b/tests/17_DS_DFTU/63_LCAO_DFTU_DS_NSCF_Band_XY/INPUT
@@ -7,6 +7,7 @@ gamma_only    0
 init_chg    file
 read_file_dir    ./
 noncolin    1
+nspin       4
 #nbands    28
 scf_thr    1.0e-6
 scf_nmax    1

--- a/tests/17_DS_DFTU/63_LCAO_DFTU_DS_NSCF_Band_XY/scf/INPUT
+++ b/tests/17_DS_DFTU/63_LCAO_DFTU_DS_NSCF_Band_XY/scf/INPUT
@@ -6,6 +6,7 @@ ecutwfc    5
 gamma_only    0
 init_chg    atomic
 noncolin    1
+nspin       4
 #nbands    28
 scf_thr    1.0e-6
 scf_nmax    50

--- a/tests/17_DS_DFTU/64_PW_DFTU_NSCF_Band_XY/INPUT
+++ b/tests/17_DS_DFTU/64_PW_DFTU_NSCF_Band_XY/INPUT
@@ -7,6 +7,7 @@ gamma_only    0
 init_chg    file
 read_file_dir    ./
 noncolin    1
+nspin       4
 #nbands    40
 scf_thr    1.0e-6
 scf_nmax    1

--- a/tests/17_DS_DFTU/64_PW_DFTU_NSCF_Band_XY/scf/INPUT
+++ b/tests/17_DS_DFTU/64_PW_DFTU_NSCF_Band_XY/scf/INPUT
@@ -6,6 +6,7 @@ ecutwfc    10
 gamma_only    0
 init_chg    atomic
 noncolin    1
+nspin       4
 #nbands    40
 scf_thr    1.0e-6
 scf_nmax    50


### PR DESCRIPTION
## Summary

- require explicit `nspin=4` for noncollinear and spin-orbit calculations instead of silently resetting it
- accept `nbands_sto` only as an integer from 1 to 100000 or `all`, without changing `esolver_type`
- validate the final `kpar`/`bndpar`/solver configuration instead of resetting or clamping `bndpar`
- update affected examples, regression inputs, and generated parameter documentation

These checks use the existing final `check_value` phase, after parameter finalization, without adding reset ordering or dependency machinery.

Refs #7719.

## Tests

- four focused CTest targets passed
- behavior tests cover `nbands_sto` syntax and boundaries, `all`, valid and invalid spin, solver compatibility, process limits, and `kpar * bndpar` divisibility
- the migrated noncollinear integration reference records the reproduced `C_4h` magnetic point group
- generated metadata contains 519 parameters and matches the checked-in Markdown
- repository governance check passed