### PR TITLE
Refactor input relaxation method variants

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -133,7 +133,6 @@
     - [npart\_sto](#npart_sto)
   - [Geometry relaxation](#geometry-relaxation)
     - [relax\_method](#relax_method)
-    - [relax\_new](#relax_new)
     - [relax\_scale\_force](#relax_scale_force)
     - [relax\_nmax](#relax_nmax)
     - [relax\_cg\_thr](#relax_cg_thr)
@@ -1605,51 +1604,32 @@
 ### relax_method
 
 - **Type**: Vector of string
-- **Description**: The methods to do geometry optimization. The available algorithms depend on the relax_new setting.
+- **Description**: The method used for geometry optimization.
 
   First element (algorithm selection):
 
-  - cg: Conjugate gradient (CG) algorithm. Available for both relax_new = True (default, simultaneous optimization) and relax_new = False (nested optimization). See relax_new for implementation details.
-  - bfgs: Broyden–Fletcher–Goldfarb–Shanno (BFGS) quasi-Newton algorithm. Only available when relax_new = False.
-  - lbfgs: Limited-memory BFGS algorithm, suitable for large systems. Only available when relax_new = False.
-  - cg_bfgs: Mixed method starting with CG and switching to BFGS when force convergence reaches relax_cg_thr. Only available when relax_new = False.
-  - sd: Steepest descent algorithm. Only available when relax_new = False. Not recommended for production use.
-  - fire: Fast Inertial Relaxation Engine method, a molecular-dynamics-based relaxation algorithm. Use by setting calculation to md and md_type to fire. Ionic velocities must be set in STRU file. See fire for details.
+  - cg: Conjugate gradient (CG) algorithm.
+  - bfgs: Broyden–Fletcher–Goldfarb–Shanno (BFGS) quasi-Newton algorithm.
+  - lbfgs: Limited-memory BFGS algorithm, suitable for large systems.
+  - cg_bfgs: Mixed method starting with CG and switching to BFGS when force convergence reaches relax_cg_thr.
+  - sd: Steepest descent algorithm. Not recommended for production use.
 
-  Second element (BFGS variant, only when first element is bfgs):
+  Optional second element:
 
-  - 1: Traditional BFGS that updates the Hessian matrix B and then inverts it.
-  - 2 or omitted: Default BFGS that directly updates the inverse Hessian (recommended).
+  - cg 1: First optimize ionic positions at fixed cell, then update the cell, and repeat.
+  - cg 2 or omitted: Simultaneously optimize ionic positions and cell parameters with line search (recommended).
+  - bfgs 1: Traditional BFGS that updates the Hessian matrix B and then inverts it.
+  - bfgs 2 or omitted: Default BFGS that directly updates the inverse Hessian (recommended).
+
+  The second element is not accepted by other methods.
 
   > Note: In the 3.10-LTS version, the type of this parameter is std::string. It can be set to "cg", "bfgs", "cg_bfgs", "bfgs_trad", "lbfgs", "sd", "fire".
-- **Default**: cg 1
-
-### relax_new
-
-- **Type**: Boolean
-- **Description**: Controls which implementation of geometry relaxation to use. At the end of 2022, a new implementation of the Conjugate Gradient (CG) method was introduced for relax and cell-relax calculations, while the old implementation was kept for backward compatibility.
-
-
-  - True (default): Use the new CG implementation with the following features:
-   - Simultaneous optimization of ionic positions and cell parameters (for cell-relax)
-   - Line search algorithm for step size determination
-   - Only CG algorithm is available (relax_method must be cg)
-   - Supports advanced cell constraints: fixed_axes = "shape", "volume", "a", "b", "c", etc.
-   - Supports fixed_ibrav to maintain lattice type
-   - More efficient for variable-cell relaxation
-   - Step size controlled by relax_scale_force
-
-  - False: Use the old implementation with the following features:
-   - Nested optimization procedure: ionic positions optimized first, then cell parameters (for cell-relax)
-   - Multiple algorithms available: cg, bfgs, lbfgs, sd, cg_bfgs
-   - Limited cell constraints: only fixed_axes = "volume" is supported
-   - Traditional approach with separate ionic and cell optimization steps
-- **Default**: True
+- **Default**: cg 2
 
 ### relax_scale_force
 
 - **Type**: Real
-- **Availability**: *Only used when relax_new set to True*
+- **Availability**: *Only used when relax_method is cg 2*
 - **Description**: The paramether controls the size of the first conjugate gradient step. A smaller value means the first step along a new CG direction is smaller. This might be helpful for large systems, where it is safer to take a smaller initial step to prevent the collapse of the whole configuration.
 - **Default**: 0.5
 
@@ -1662,7 +1642,7 @@
 ### relax_cg_thr
 
 - **Type**: Real
-- **Availability**: *Only used when relax_new = False and relax_method = cg_bfgs*
+- **Availability**: *Only used when relax_method is cg_bfgs*
 - **Description**: When relax_method is set to cg_bfgs, a mixed algorithm of conjugate gradient (CG) and Broyden–Fletcher–Goldfarb–Shanno (BFGS) is used. The ions first move according to the CG method, then switch to the BFGS method when the maximum force on atoms is reduced below this threshold.
 - **Default**: 0.5
 - **Unit**: eV/Angstrom
@@ -1691,21 +1671,21 @@
 ### relax_bfgs_w1
 
 - **Type**: Real
-- **Availability**: *Only used when relax_new = False and relax_method is bfgs or cg_bfgs*
+- **Availability**: *Only used when relax_method is bfgs or cg_bfgs*
 - **Description**: Controls the Wolfe condition for the Broyden–Fletcher–Goldfarb–Shanno (BFGS) algorithm used in geometry relaxation. This parameter sets the sufficient decrease condition (c1 in Wolfe conditions). For more information, see Phys. Chem. Chem. Phys., 2000, 2, 2177.
 - **Default**: 0.01
 
 ### relax_bfgs_w2
 
 - **Type**: Real
-- **Availability**: *Only used when relax_new = False and relax_method is bfgs or cg_bfgs*
+- **Availability**: *Only used when relax_method is bfgs or cg_bfgs*
 - **Description**: Controls the Wolfe condition for the Broyden–Fletcher–Goldfarb–Shanno (BFGS) algorithm used in geometry relaxation. This parameter sets the curvature condition (c2 in Wolfe conditions). For more information, see Phys. Chem. Chem. Phys., 2000, 2, 2177.
 - **Default**: 0.5
 
 ### relax_bfgs_rmax
 
 - **Type**: Real
-- **Availability**: *Only used when relax_new = False and relax_method is bfgs or cg_bfgs*
+- **Availability**: *Only used when relax_method is bfgs or cg_bfgs*
 - **Description**: Maximum allowed total displacement of all atoms during geometry optimization. The sum of atomic displacements can increase during optimization steps but cannot exceed this value.
 - **Default**: 0.8
 - **Unit**: Bohr
@@ -1713,7 +1693,7 @@
 ### relax_bfgs_rmin
 
 - **Type**: Real
-- **Availability**: *Only used when relax_new = False and relax_method = bfgs 1 (traditional BFGS)*
+- **Availability**: *Only used when relax_method is bfgs 1 (traditional BFGS)*
 - **Description**: Minimum allowed total displacement of all atoms. When the total atomic displacement falls below this value and force convergence is not achieved, the calculation will terminate. Note: This parameter is not used in the default BFGS algorithm (relax_method = bfgs 2 or bfgs).
 - **Default**: 1e-5
 - **Unit**: Bohr
@@ -1721,7 +1701,7 @@
 ### relax_bfgs_init
 
 - **Type**: Real
-- **Availability**: *Only used when relax_new = False and relax_method is bfgs or cg_bfgs*
+- **Availability**: *Only used when relax_method is bfgs or cg_bfgs*
 - **Description**: Initial total displacement of all atoms in the first BFGS step. This sets the scale for the initial movement.
 - **Default**: 0.5
 - **Unit**: Bohr
@@ -1758,9 +1738,9 @@
 
 - **Type**: String
 - **Availability**: *Only used when calculation is set to cell-relax*
-- **Description**: Specifies which cell degrees of freedom are fixed during variable-cell relaxation. The available options depend on the relax_new setting:
+- **Description**: Specifies which cell degrees of freedom are fixed during variable-cell relaxation. The available options depend on relax_method:
 
-  When relax_new = True (default), all options are available:
+  With relax_method = cg 2 (default), all options are available:
 
   - None: Default; all cell parameters can relax freely
   - volume: Relaxation with fixed volume (allows shape changes)
@@ -1771,21 +1751,17 @@
   - ab: Fix both a and b axes during relaxation
   - ac: Fix both a and c axes during relaxation
   - bc: Fix both b and c axes during relaxation
+  - abc: Fix all three lattice vectors during relaxation
 
-  When relax_new = False, all options are now available:
+  With relax_method set to cg 1, bfgs, lbfgs, sd, or cg_bfgs, None and a, b, c, ab, ac, bc, abc are available. The shape and volume options require cg 2.
 
-  - None: Default; all cell parameters can relax freely
-  - volume: Relaxation with fixed volume (allows shape changes). Volume is preserved by rescaling the lattice after each update.
-  - shape: Fix shape but allow volume changes (hydrostatic pressure only). Stress tensor is replaced with isotropic pressure.
-  - a, b, c, ab, ac, bc: Fix specific lattice vectors. Gradients for fixed vectors are set to zero.
-
-  > Note: For VASP users, see the ISIF correspondence table in the geometry optimization documentation. Both implementations now support all constraint types.
+  > Note: For VASP users, see the ISIF correspondence table in the geometry optimization documentation.
 - **Default**: None
 
 ### fixed_ibrav
 
 - **Type**: Boolean
-- **Availability**: *Can be used with both relax_new = True and relax_new = False. A specific latname must be provided.*
+- **Availability**: *Only used with relax_method = cg 2. A specific latname must be provided.*
 - **Description**: - True: the lattice type will be preserved during relaxation. The lattice vectors are reconstructed to match the specified Bravais lattice type after each update.
   - False: No restrictions are exerted during relaxation in terms of lattice type
 

--- a/docs/advanced/opt.md
+++ b/docs/advanced/opt.md
@@ -2,13 +2,13 @@
 
 By setting `calculation` to be `relax` or `cell-relax`, ABACUS supports structural relaxation and variable-cell relaxation.
 
-ABACUS provides two implementations for variable-cell relaxation, controlled by the [relax_new](./input_files/input-main.md#relax_new) parameter:
+ABACUS provides two CG implementations for variable-cell relaxation, selected by the [relax_method](./input_files/input-main.md#relax_method) parameter:
 
-- **New implementation** (`relax_new = True`, default since v3.8): Uses a simultaneous conjugate gradient (CG) optimization for both ionic positions and cell parameters. Both degrees of freedom are optimized together in each step.
+- **CG variant 2** (`relax_method = cg 2` or `relax_method = cg`, default since v3.8): Uses simultaneous conjugate gradient (CG) optimization for both ionic positions and cell parameters. Both degrees of freedom are optimized together in each step.
 
-- **Old implementation** (`relax_new = False`): Follows a nested procedure where fixed-cell structural relaxation is performed first, followed by an update of the cell parameters, and the process is repeated until convergence is achieved.
+- **CG variant 1** (`relax_method = cg 1`): Follows a nested procedure where fixed-cell structural relaxation is performed first, followed by an update of the cell parameters, and the process is repeated until convergence is achieved.
 
-An example of the variable cell relaxation can be found in our [repository](https://github.com/deepmodeling/abacus-develop/tree/develop/examples/relax/pw_al), which is provided with the reference output file log.ref. When using the old implementation (`relax_new = False`), each ionic step is labelled in the following manner:
+An example of the variable cell relaxation can be found in our [repository](https://github.com/deepmodeling/abacus-develop/tree/develop/examples/relax/pw_al), which is provided with the reference output file log.ref. When using CG variant 1, each ionic step is labelled in the following manner:
 ```
  -------------------------------------------
  RELAX CELL : 3
@@ -21,27 +21,21 @@ indicating that this is the first ionic step of the 3rd cell configuration, and 
 
 ## Optimization Algorithms
 
-ABACUS offers multiple optimization algorithms for structural relaxation, which can be selected using the [relax_method](./input_files/input-main.md#relax_method) keyword. The available algorithms and their behavior depend on the [relax_new](./input_files/input-main.md#relax_new) setting:
+ABACUS offers multiple optimization algorithms for structural relaxation, which can be selected using the [relax_method](./input_files/input-main.md#relax_method) keyword. The optional second value selects an implementation variant for CG or BFGS. For both methods, variant 1 is the traditional implementation and variant 2 is the recommended default.
 
-### Algorithm Availability
+### Available Algorithms
 
-**New implementation** (`relax_new = True`, default):
-- **CG (Conjugate Gradient)**: Simultaneous optimization of both ionic positions and cell parameters using CG with line search. This is the only algorithm available for the new implementation.
-
-**Old implementation** (`relax_new = False`):
-- **CG (Conjugate Gradient)**: For ionic relaxation; CG is also used for cell parameter optimization in the nested procedure
-- **BFGS**: Quasi-Newton method for ionic relaxation
-- **LBFGS**: Limited-memory BFGS for ionic relaxation
-- **SD (Steepest Descent)**: Simple gradient descent for ionic relaxation
-- **CG-BFGS**: Mixed method that starts with CG and switches to BFGS when force convergence reaches the threshold set by [relax_cg_thr](./input_files/input-main.md#relax_cg_thr)
+- **CG (Conjugate Gradient)**: Variant 1 optimizes ionic positions and cell parameters in separate stages; variant 2 optimizes them simultaneously with line search.
+- **BFGS**: Quasi-Newton method for ionic relaxation.
+- **LBFGS**: Limited-memory BFGS for ionic relaxation.
+- **SD (Steepest Descent)**: Simple gradient descent for ionic relaxation.
+- **CG-BFGS**: Mixed method that starts with CG and switches to BFGS when force convergence reaches the threshold set by [relax_cg_thr](./input_files/input-main.md#relax_cg_thr).
 
 We also provide a [list of keywords](./input_files/input-main.md#geometry-relaxation) for controlling the relaxation process.
 
 ### BFGS method
 
 The [BFGS method](https://en.wikipedia.org/wiki/Broyden%E2%80%93Fletcher%E2%80%93Goldfarb%E2%80%93Shanno_algorithm) is a quasi-Newton method for solving nonlinear optimization problems. It belongs to the class of quasi-Newton methods where the Hessian matrix is approximated during the optimization process. If the initial point is not far from the extrema, BFGS tends to work better than gradient-based methods.
-
-**Note**: BFGS is only available with the old implementation (`relax_new = False`).
 
 ABACUS provides two BFGS implementations, controlled by the second element of [relax_method](./input_files/input-main.md#relax_method):
 
@@ -53,13 +47,11 @@ ABACUS provides two BFGS implementations, controlled by the second element of [r
 
 The [L-BFGS (Limited-memory BFGS)](https://en.wikipedia.org/wiki/Limited-memory_BFGS) method is a memory-efficient variant of BFGS that stores only a few vectors representing the Hessian approximation instead of the full matrix. This makes it particularly suitable for large systems with many atoms.
 
-**Note**: LBFGS is only available with the old implementation (`relax_new = False`). Set `relax_method = lbfgs` to use this method.
+Set `relax_method = lbfgs` to use this method.
 
 ### SD method
 
 The [SD (steepest descent) method](https://en.wikipedia.org/wiki/Gradient_descent) is one of the simplest first-order optimization methods, where in each step the motion is along the direction of the gradient, where the function descends the fastest.
-
-**Note**: SD is only available with the old implementation (`relax_new = False`).
 
 In practice, the SD method may take many iterations to converge, and is generally not recommended for production calculations.
 
@@ -69,9 +61,11 @@ The [CG (conjugate gradient) method](https://en.wikipedia.org/wiki/Conjugate_gra
 
 ABACUS provides two implementations of the CG method:
 
-- **New CG implementation** (`relax_new = True`, default): Performs simultaneous optimization of both ionic positions and cell parameters using a line search algorithm. This implementation is more efficient for `cell-relax` calculations as it optimizes all degrees of freedom together. The step size can be controlled by [relax_scale_force](./input_files/input-main.md#relax_scale_force).
+- **CG variant 2** (`relax_method = cg 2` or `relax_method = cg`, default): Performs simultaneous optimization of both ionic positions and cell parameters using a line search algorithm. This implementation is more efficient for `cell-relax` calculations as it optimizes all degrees of freedom together. The step size can be controlled by [relax_scale_force](./input_files/input-main.md#relax_scale_force).
 
-- **Old CG implementation** (`relax_new = False`): Uses a nested procedure where ionic positions are optimized first using CG, followed by cell parameter optimization (also using CG) in `cell-relax` calculations. This is the traditional approach where the two optimization steps are separated.
+- **CG variant 1** (`relax_method = cg 1`): Uses a nested procedure where ionic positions are optimized first using CG, followed by cell parameter optimization (also using CG) in `cell-relax` calculations. This is the traditional approach where the two optimization steps are separated.
+
+The former `relax_new` parameter has been removed. Replace `relax_new = True` with `relax_method = cg 2`, and replace `relax_new = False` with `relax_method = cg 1` when using CG. The `bfgs`, `lbfgs`, `sd`, and `cg_bfgs` methods do not require a separate switch.
 
 ## Constrained Optimization
 
@@ -111,17 +105,15 @@ Sometimes we want to do variable-cell relaxation with some of the cell degrees o
 
 **Available constraints by implementation:**
 
-- **New implementation** (`relax_new = True`):
+- **CG variant 2** (`relax_method = cg 2` or `relax_method = cg`):
   - `fixed_axes = "shape"`: Only allows volume changes (hydrostatic pressure), cell shape is fixed
   - `fixed_axes = "volume"`: Allows shape changes but keeps volume constant
-  - `fixed_axes = "a"`, `"b"`, `"c"`, etc.: Fix specific lattice vectors or combinations
+  - `fixed_axes = "a"`, `"b"`, `"c"`, `"ab"`, `"ac"`, `"bc"`, or `"abc"`: Fix specific lattice vectors or combinations
   - `fixed_ibrav = True`: Maintain the Bravais lattice type during relaxation
 
-- **Old implementation** (`relax_new = False`):
-  - **All `fixed_axes` options now supported**: "shape", "volume", "a", "b", "c", "ab", "ac", "bc", "abc"
-  - **`fixed_ibrav` now supported**: Maintains Bravais lattice type during relaxation
-  - Can combine `fixed_axes` with `fixed_ibrav` for constrained relaxation
-  - **Implementation approach**: Uses post-update constraint enforcement (volume rescaling and lattice reconstruction after each CG step)
+- **`relax_method = cg 1`, `bfgs`, `lbfgs`, `sd`, or `cg_bfgs`**:
+  - `fixed_axes = "a"`, `"b"`, `"c"`, `"ab"`, `"ac"`, `"bc"`, or `"abc"`: Fix specific lattice vectors or combinations
+  - `fixed_axes = "shape"`, `"volume"` and `fixed_ibrav = True` are not available
 
 **VASP ISIF correspondence:**
 

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1148,46 +1148,25 @@ parameters:
     category: Geometry relaxation
     type: Vector of string
     description: |
-      The methods to do geometry optimization. The available algorithms depend on the relax_new setting.
+      The method used for geometry optimization.
 
       First element (algorithm selection):
-      * cg: Conjugate gradient (CG) algorithm. Available for both relax_new = True (default, simultaneous optimization) and relax_new = False (nested optimization). See relax_new for implementation details.
-      * bfgs: Broyden–Fletcher–Goldfarb–Shanno (BFGS) quasi-Newton algorithm. Only available when relax_new = False.
-      * lbfgs: Limited-memory BFGS algorithm, suitable for large systems. Only available when relax_new = False.
-      * cg_bfgs: Mixed method starting with CG and switching to BFGS when force convergence reaches relax_cg_thr. Only available when relax_new = False.
-      * sd: Steepest descent algorithm. Only available when relax_new = False. Not recommended for production use.
-      * fire: Fast Inertial Relaxation Engine method, a molecular-dynamics-based relaxation algorithm. Use by setting calculation to md and md_type to fire. Ionic velocities must be set in STRU file. See fire for details.
+      * cg: Conjugate gradient (CG) algorithm.
+      * bfgs: Broyden–Fletcher–Goldfarb–Shanno (BFGS) quasi-Newton algorithm.
+      * lbfgs: Limited-memory BFGS algorithm, suitable for large systems.
+      * cg_bfgs: Mixed method starting with CG and switching to BFGS when force convergence reaches relax_cg_thr.
+      * sd: Steepest descent algorithm. Not recommended for production use.
 
-      Second element (BFGS variant, only when first element is bfgs):
-      * 1: Traditional BFGS that updates the Hessian matrix B and then inverts it.
-      * 2 or omitted: Default BFGS that directly updates the inverse Hessian (recommended).
+      Optional second element:
+      * cg 1: First optimize ionic positions at fixed cell, then update the cell, and repeat.
+      * cg 2 or omitted: Simultaneously optimize ionic positions and cell parameters with line search (recommended).
+      * bfgs 1: Traditional BFGS that updates the Hessian matrix B and then inverts it.
+      * bfgs 2 or omitted: Default BFGS that directly updates the inverse Hessian (recommended).
+
+      The second element is not accepted by other methods.
 
       [NOTE] In the 3.10-LTS version, the type of this parameter is std::string. It can be set to "cg", "bfgs", "cg_bfgs", "bfgs_trad", "lbfgs", "sd", "fire".
-    default_value: cg 1
-    unit: ""
-    availability: ""
-  - name: relax_new
-    category: Geometry relaxation
-    type: Boolean
-    description: |
-      Controls which implementation of geometry relaxation to use. At the end of 2022, a new implementation of the Conjugate Gradient (CG) method was introduced for relax and cell-relax calculations, while the old implementation was kept for backward compatibility.
-
-
-      * True (default): Use the new CG implementation with the following features:
-       * Simultaneous optimization of ionic positions and cell parameters (for cell-relax)
-       * Line search algorithm for step size determination
-       * Only CG algorithm is available (relax_method must be cg)
-       * Supports advanced cell constraints: fixed_axes = "shape", "volume", "a", "b", "c", etc.
-       * Supports fixed_ibrav to maintain lattice type
-       * More efficient for variable-cell relaxation
-       * Step size controlled by relax_scale_force
-
-      - False: Use the old implementation with the following features:
-       * Nested optimization procedure: ionic positions optimized first, then cell parameters (for cell-relax)
-       * Multiple algorithms available: cg, bfgs, lbfgs, sd, cg_bfgs
-       * Limited cell constraints: only fixed_axes = "volume" is supported
-       * Traditional approach with separate ionic and cell optimization steps
-    default_value: "True"
+    default_value: cg 2
     unit: ""
     availability: ""
   - name: relax_scale_force
@@ -1197,7 +1176,7 @@ parameters:
       The paramether controls the size of the first conjugate gradient step. A smaller value means the first step along a new CG direction is smaller. This might be helpful for large systems, where it is safer to take a smaller initial step to prevent the collapse of the whole configuration.
     default_value: "0.5"
     unit: ""
-    availability: Only used when relax_new set to True
+    availability: Only used when relax_method is cg 2
   - name: relax_nmax
     category: Geometry relaxation
     type: Integer
@@ -1213,7 +1192,7 @@ parameters:
       When relax_method is set to cg_bfgs, a mixed algorithm of conjugate gradient (CG) and Broyden–Fletcher–Goldfarb–Shanno (BFGS) is used. The ions first move according to the CG method, then switch to the BFGS method when the maximum force on atoms is reduced below this threshold.
     default_value: "0.5"
     unit: eV/Angstrom
-    availability: Only used when relax_new = False and relax_method = cg_bfgs
+    availability: Only used when relax_method is cg_bfgs
   - name: force_thr
     category: Geometry relaxation
     type: Real
@@ -1245,7 +1224,7 @@ parameters:
       Controls the Wolfe condition for the Broyden–Fletcher–Goldfarb–Shanno (BFGS) algorithm used in geometry relaxation. This parameter sets the sufficient decrease condition (c1 in Wolfe conditions). For more information, see Phys. Chem. Chem. Phys., 2000, 2, 2177.
     default_value: "0.01"
     unit: ""
-    availability: Only used when relax_new = False and relax_method is bfgs or cg_bfgs
+    availability: Only used when relax_method is bfgs or cg_bfgs
   - name: relax_bfgs_w2
     category: Geometry relaxation
     type: Real
@@ -1253,7 +1232,7 @@ parameters:
       Controls the Wolfe condition for the Broyden–Fletcher–Goldfarb–Shanno (BFGS) algorithm used in geometry relaxation. This parameter sets the curvature condition (c2 in Wolfe conditions). For more information, see Phys. Chem. Chem. Phys., 2000, 2, 2177.
     default_value: "0.5"
     unit: ""
-    availability: Only used when relax_new = False and relax_method is bfgs or cg_bfgs
+    availability: Only used when relax_method is bfgs or cg_bfgs
   - name: relax_bfgs_rmax
     category: Geometry relaxation
     type: Real
@@ -1261,7 +1240,7 @@ parameters:
       Maximum allowed total displacement of all atoms during geometry optimization. The sum of atomic displacements can increase during optimization steps but cannot exceed this value.
     default_value: "0.8"
     unit: Bohr
-    availability: Only used when relax_new = False and relax_method is bfgs or cg_bfgs
+    availability: Only used when relax_method is bfgs or cg_bfgs
   - name: relax_bfgs_rmin
     category: Geometry relaxation
     type: Real
@@ -1269,7 +1248,7 @@ parameters:
       Minimum allowed total displacement of all atoms. When the total atomic displacement falls below this value and force convergence is not achieved, the calculation will terminate. Note: This parameter is not used in the default BFGS algorithm (relax_method = bfgs 2 or bfgs).
     default_value: "1e-5"
     unit: Bohr
-    availability: Only used when relax_new = False and relax_method = bfgs 1 (traditional BFGS)
+    availability: Only used when relax_method is bfgs 1 (traditional BFGS)
   - name: relax_bfgs_init
     category: Geometry relaxation
     type: Real
@@ -1277,7 +1256,7 @@ parameters:
       Initial total displacement of all atoms in the first BFGS step. This sets the scale for the initial movement.
     default_value: "0.5"
     unit: Bohr
-    availability: Only used when relax_new = False and relax_method is bfgs or cg_bfgs
+    availability: Only used when relax_method is bfgs or cg_bfgs
   - name: stress_thr
     category: Geometry relaxation
     type: Real
@@ -1314,9 +1293,9 @@ parameters:
     category: Geometry relaxation
     type: String
     description: |
-      Specifies which cell degrees of freedom are fixed during variable-cell relaxation. The available options depend on the relax_new setting:
+      Specifies which cell degrees of freedom are fixed during variable-cell relaxation. The available options depend on relax_method:
 
-      When relax_new = True (default), all options are available:
+      With relax_method = cg 2 (default), all options are available:
       * None: Default; all cell parameters can relax freely
       * volume: Relaxation with fixed volume (allows shape changes)
       * shape: Fix shape but allow volume changes (hydrostatic pressure only)
@@ -1326,14 +1305,11 @@ parameters:
       * ab: Fix both a and b axes during relaxation
       * ac: Fix both a and c axes during relaxation
       * bc: Fix both b and c axes during relaxation
+      * abc: Fix all three lattice vectors during relaxation
 
-      When relax_new = False, all options are now available:
-      * None: Default; all cell parameters can relax freely
-      * volume: Relaxation with fixed volume (allows shape changes). Volume is preserved by rescaling the lattice after each update.
-      * shape: Fix shape but allow volume changes (hydrostatic pressure only). Stress tensor is replaced with isotropic pressure.
-      * a, b, c, ab, ac, bc: Fix specific lattice vectors. Gradients for fixed vectors are set to zero.
+      With relax_method set to cg 1, bfgs, lbfgs, sd, or cg_bfgs, None and a, b, c, ab, ac, bc, abc are available. The shape and volume options require cg 2.
 
-      [NOTE] For VASP users, see the ISIF correspondence table in the geometry optimization documentation. Both implementations now support all constraint types.
+      [NOTE] For VASP users, see the ISIF correspondence table in the geometry optimization documentation.
     default_value: None
     unit: ""
     availability: Only used when calculation is set to cell-relax
@@ -1347,7 +1323,7 @@ parameters:
       [NOTE] Note: it is possible to use fixed_ibrav with fixed_axes, but please make sure you know what you are doing. For example, if we are doing relaxation of a simple cubic lattice (latname = "sc"), and we use fixed_ibrav along with fixed_axes = "volume", then the cell is never allowed to move and as a result, the relaxation never converges. When both are used, fixed_ibrav is applied first, then fixed_axes = "volume" rescaling is applied.
     default_value: "False"
     unit: ""
-    availability: Can be used with both relax_new = True and relax_new = False. A specific latname must be provided.
+    availability: Only used with relax_method = cg 2. A specific latname must be provided.
   - name: fixed_atoms
     category: Geometry relaxation
     type: Boolean

--- a/examples/17_relax/03_relax_with_output_pw/INPUT
+++ b/examples/17_relax/03_relax_with_output_pw/INPUT
@@ -19,7 +19,7 @@ ks_solver            cg
 mixing_type          broyden
 mixing_beta          0.7
 
-relax_new            0
+relax_method         cg 1
 
 pseudo_dir           ../../../tests/PP_ORB    
 orbital_dir          ../../../tests/PP_ORB
@@ -35,5 +35,3 @@ out_stru             1
 out_app_flag         0
 
 out_interval         1
-
-

--- a/examples/17_relax/04_relax_with_output_lcao/INPUT
+++ b/examples/17_relax/04_relax_with_output_lcao/INPUT
@@ -19,7 +19,7 @@ ks_solver            scalapack_gvx
 mixing_type          broyden
 mixing_beta          0.7
 
-relax_new            0
+relax_method         cg 1
 
 pseudo_dir           ../../../tests/PP_ORB    
 orbital_dir          ../../../tests/PP_ORB
@@ -37,5 +37,3 @@ out_stru             1
 out_app_flag         0
 
 out_interval         1
-
-

--- a/source/source_cell/test/unitcell_test.cpp
+++ b/source/source_cell/test/unitcell_test.cpp
@@ -38,11 +38,6 @@ Magnetism::~Magnetism()
  *   - Setup:
  *     - setup(): to set latname, ntype, lmaxmax, init_vel, and lc
  *     - if_cell_can_change(): judge if any lattice vector can change
- *   - SetupWarningQuit1:
- *     - setup(): deliver warning: "there are bugs in the old implementation;
- *         set relax_new to be 1 for fixed_volume relaxation"
- *   - SetupWarningQuit2:
- *     - setup(): deliver warning: "set relax_new to be 1 for fixed_shape relaxation"
  *   - RemakeCell
  *     - remake_cell(): rebuild cell according to its latName
  *   - RemakeCellWarnings
@@ -235,10 +230,6 @@ TEST_F(UcellTest, Setup)
         }
     }
 }
-
-// These tests are removed because fixed_axes="volume" and fixed_axes="shape"
-// are now supported with relax_new=false (see commit cdc3457f5a8546cda869655c3faabd8b29687aff)
-// The old implementation now properly handles these constraints via post-update enforcement
 
 TEST_F(UcellDeathTest, CompareAatomLabel)
 {

--- a/source/source_io/input_help.cpp
+++ b/source/source_io/input_help.cpp
@@ -603,7 +603,7 @@ std::vector<std::string> ParameterHelp::find_similar_parameters(const std::strin
 
         int effective_distance;
 
-        // Priority 1: Exact prefix match (e.g., "relax" matches "relax_new")
+        // Priority 1: Exact prefix match (e.g., "relax" matches "relax_method")
         // Give these the lowest effective distance (0)
         if (name_lower.size() > query_lower.size() &&
             name_lower.compare(0, query_lower.size(), query_lower) == 0 &&

--- a/source/source_io/input_help.h
+++ b/source/source_io/input_help.h
@@ -100,7 +100,7 @@ public:
      * @brief Find similar parameter names for fuzzy matching
      *
      * Uses a multi-tier matching strategy to find relevant parameters:
-     * 1. Prefix matches (e.g., "relax" matches "relax_new") - highest priority
+     * 1. Prefix matches (e.g., "relax" matches "relax_method") - highest priority
      * 2. Substring matches (e.g., "cut" matches "ecutwfc") - medium priority
      * 3. Levenshtein distance for typos - lowest priority
      *

--- a/source/source_io/module_parameter/input_parameter.h
+++ b/source/source_io/module_parameter/input_parameter.h
@@ -155,8 +155,12 @@ struct Input_para
     //  int		bessel_nao_lmax;		///< lmax used in descriptor
 
     // ==============   #Parameters (4.Relaxation) ===========================
-    std::vector<std::string> relax_method = {"cg", "1"}; ///< methods to move_ion: sd, bfgs, cg...
-    bool relax_new = true;
+    std::vector<std::string> relax_method = {"cg", "2"}; ///< relaxation algorithm and optional variant
+
+    bool uses_simultaneous_relaxation() const
+    {
+        return relax_method.size() == 2 && relax_method[0] == "cg" && relax_method[1] == "2";
+    }
     bool relax = false; ///< allow relaxation along the specific direction
     double relax_scale_force = 0.5;
     int relax_nmax = -1;       ///< number of max ionic iter

--- a/source/source_io/module_parameter/read_input_item_relax.cpp
+++ b/source/source_io/module_parameter/read_input_item_relax.cpp
@@ -6,6 +6,41 @@
 namespace ModuleIO
 {
 
+namespace
+{
+std::vector<std::string> parse_relax_method(const std::vector<std::string>& values)
+{
+    if (values.empty() || values.size() > 2)
+    {
+        ModuleBase::WARNING_QUIT("ReadInput", "relax_method accepts one or two values");
+    }
+
+    const std::string& method = values[0];
+    const std::vector<std::string> valid_methods = {"cg", "sd", "cg_bfgs", "lbfgs", "bfgs"};
+    if (std::find(valid_methods.begin(), valid_methods.end(), method) == valid_methods.end())
+    {
+        ModuleBase::WARNING_QUIT("ReadInput", nofound_str(valid_methods, "relax_method"));
+    }
+
+    if (method == "cg" || method == "bfgs")
+    {
+        const std::string variant = values.size() == 1 ? "2" : values[1];
+        if (variant != "1" && variant != "2")
+        {
+            const std::string algorithm = method == "cg" ? "CG" : "BFGS";
+            ModuleBase::WARNING_QUIT("ReadInput", "the " + algorithm + " variant must be 1 or 2");
+        }
+        return {method, variant};
+    }
+
+    if (values.size() == 2)
+    {
+        ModuleBase::WARNING_QUIT("ReadInput", "relax_method " + method + " does not accept a second value");
+    }
+    return {method, ""};
+}
+} // namespace
+
 
 void ReadInput::item_relax()
 {
@@ -14,106 +49,45 @@ void ReadInput::item_relax()
     // Please preserve this ordering when adding new parameters.
     {
         Input_Item item("relax_method");
-        item.annotation = "cg; bfgs; sd; cg; cg_bfgs;";
+        item.annotation = "cg; bfgs; sd; cg_bfgs; lbfgs";
         item.category = "Geometry relaxation";
         item.type = "Vector of string";
-        item.description = R"(The methods to do geometry optimization. The available algorithms depend on the relax_new setting.
+        item.description = R"(The method used for geometry optimization.
 
 First element (algorithm selection):
-* cg: Conjugate gradient (CG) algorithm. Available for both relax_new = True (default, simultaneous optimization) and relax_new = False (nested optimization). See relax_new for implementation details.
-* bfgs: Broyden–Fletcher–Goldfarb–Shanno (BFGS) quasi-Newton algorithm. Only available when relax_new = False.
-* lbfgs: Limited-memory BFGS algorithm, suitable for large systems. Only available when relax_new = False.
-* cg_bfgs: Mixed method starting with CG and switching to BFGS when force convergence reaches relax_cg_thr. Only available when relax_new = False.
-* sd: Steepest descent algorithm. Only available when relax_new = False. Not recommended for production use.
-* fire: Fast Inertial Relaxation Engine method, a molecular-dynamics-based relaxation algorithm. Use by setting calculation to md and md_type to fire. Ionic velocities must be set in STRU file. See fire for details.
+* cg: Conjugate gradient (CG) algorithm.
+* bfgs: Broyden–Fletcher–Goldfarb–Shanno (BFGS) quasi-Newton algorithm.
+* lbfgs: Limited-memory BFGS algorithm, suitable for large systems.
+* cg_bfgs: Mixed method starting with CG and switching to BFGS when force convergence reaches relax_cg_thr.
+* sd: Steepest descent algorithm. Not recommended for production use.
 
-Second element (BFGS variant, only when first element is bfgs):
-* 1: Traditional BFGS that updates the Hessian matrix B and then inverts it.
-* 2 or omitted: Default BFGS that directly updates the inverse Hessian (recommended).
+Optional second element:
+* cg 1: First optimize ionic positions at fixed cell, then update the cell, and repeat.
+* cg 2 or omitted: Simultaneously optimize ionic positions and cell parameters with line search (recommended).
+* bfgs 1: Traditional BFGS that updates the Hessian matrix B and then inverts it.
+* bfgs 2 or omitted: Default BFGS that directly updates the inverse Hessian (recommended).
+
+The second element is not accepted by other methods.
 
 [NOTE] In the 3.10-LTS version, the type of this parameter is std::string. It can be set to "cg", "bfgs", "cg_bfgs", "bfgs_trad", "lbfgs", "sd", "fire".)";
-        item.default_value = "cg 1";
+        item.default_value = "cg 2";
         item.unit = "";
         item.availability = "";
         item.read_value = [](const Input_Item& item, Parameter& para) {
-        if(item.get_size()==1)
-        {
-            para.input.relax_method[0] = item.str_values[0];
-            para.input.relax_method[1] = "1"; 
-        }
-        else if(item.get_size()>=2)
-        {
-            para.input.relax_method[0] = item.str_values[0];
-            para.input.relax_method[1] = item.str_values[1];
-        }
-        };
-        item.check_value = [](const Input_Item& item, const Parameter& para) {          
-        const std::vector<std::string> relax_methods = {"cg", "sd", "cg_bfgs","lbfgs","bfgs"};
-        if (std::find(relax_methods.begin(), relax_methods.end(), para.input.relax_method[0]) == relax_methods.end()) {
-            const std::string warningstr = nofound_str(relax_methods, "relax_method");
-            ModuleBase::WARNING_QUIT("ReadInput", warningstr);
-        }
+            para.input.relax_method = parse_relax_method(item.str_values);
         };
         sync_stringvec(input.relax_method, para.input.relax_method.size(), "");
-        this->add_item(item);
-        
-        
-        // Input_Item item("relax_method");
-        // item.annotation = "cg; bfgs; sd; cg; cg_bfgs;";
-        // read_sync_string(input.relax_method);
-        // item.check_value = [](const Input_Item& item, const Parameter& para) {
-        //     const std::vector<std::string> relax_methods = {"cg", "bfgs_old", "sd", "cg_bfgs","bfgs","lbfgs"};
-        //     if (std::find(relax_methods.begin(),relax_methods.end(), para.input.relax_method)==relax_methods.end())
-        //     {
-        //         const std::string warningstr = nofound_str(relax_methods, "relax_method");
-        //         ModuleBase::WARNING_QUIT("ReadInput", warningstr);
-        //     }
-        // };
-        // this->add_item(item);
-    }
-    {
-        Input_Item item("relax_new");
-        item.annotation = "whether to use the new relaxation method";
-        item.category = "Geometry relaxation";
-        item.type = "Boolean";
-        item.description = R"(Controls which implementation of geometry relaxation to use. At the end of 2022, a new implementation of the Conjugate Gradient (CG) method was introduced for relax and cell-relax calculations, while the old implementation was kept for backward compatibility.
-
-
-* True (default): Use the new CG implementation with the following features:
- * Simultaneous optimization of ionic positions and cell parameters (for cell-relax)
- * Line search algorithm for step size determination
- * Only CG algorithm is available (relax_method must be cg)
- * Supports advanced cell constraints: fixed_axes = "shape", "volume", "a", "b", "c", etc.
- * Supports fixed_ibrav to maintain lattice type
- * More efficient for variable-cell relaxation
- * Step size controlled by relax_scale_force
-
-- False: Use the old implementation with the following features:
- * Nested optimization procedure: ionic positions optimized first, then cell parameters (for cell-relax)
- * Multiple algorithms available: cg, bfgs, lbfgs, sd, cg_bfgs
- * Limited cell constraints: only fixed_axes = "volume" is supported
- * Traditional approach with separate ionic and cell optimization steps)";
-        item.default_value = "True";
-        item.unit = "";
-        item.availability = "";
-        read_sync_bool(input.relax_new);
-        item.reset_value = [](const Input_Item& item, Parameter& para) {
-            if (para.input.relax_new && para.input.relax_method[0] != "cg")
-            {
-                para.input.relax_new = false;
-            }
-        };
         this->add_item(item);
     }
     {
         Input_Item item("relax_scale_force");
-        item.annotation = "controls the size of the first CG step if relax_new is true";
+        item.annotation = "controls the size of the first CG 2 step";
         item.category = "Geometry relaxation";
         item.type = "Real";
         item.description = "The paramether controls the size of the first conjugate gradient step. A smaller value means the first step along a new CG direction is smaller. This might be helpful for large systems, where it is safer to take a smaller initial step to prevent the collapse of the whole configuration.";
         item.default_value = "0.5";
         item.unit = "";
-        item.availability = "Only used when relax_new set to True";
+        item.availability = "Only used when relax_method is cg 2";
         read_sync_double(input.relax_scale_force);
         this->add_item(item);
     }
@@ -156,7 +130,7 @@ Second element (BFGS variant, only when first element is bfgs):
         item.description = "When relax_method is set to cg_bfgs, a mixed algorithm of conjugate gradient (CG) and Broyden–Fletcher–Goldfarb–Shanno (BFGS) is used. The ions first move according to the CG method, then switch to the BFGS method when the maximum force on atoms is reduced below this threshold.";
         item.default_value = "0.5";
         item.unit = "eV/Angstrom";
-        item.availability = "Only used when relax_new = False and relax_method = cg_bfgs";
+        item.availability = "Only used when relax_method is cg_bfgs";
         read_sync_double(input.relax_cg_thr);
         this->add_item(item);
     }
@@ -224,7 +198,7 @@ Second element (BFGS variant, only when first element is bfgs):
         item.description = "Controls the Wolfe condition for the Broyden–Fletcher–Goldfarb–Shanno (BFGS) algorithm used in geometry relaxation. This parameter sets the sufficient decrease condition (c1 in Wolfe conditions). For more information, see Phys. Chem. Chem. Phys., 2000, 2, 2177.";
         item.default_value = "0.01";
         item.unit = "";
-        item.availability = "Only used when relax_new = False and relax_method is bfgs or cg_bfgs";
+        item.availability = "Only used when relax_method is bfgs or cg_bfgs";
         read_sync_double(input.relax_bfgs_w1);
         this->add_item(item);
     }
@@ -236,7 +210,7 @@ Second element (BFGS variant, only when first element is bfgs):
         item.description = "Controls the Wolfe condition for the Broyden–Fletcher–Goldfarb–Shanno (BFGS) algorithm used in geometry relaxation. This parameter sets the curvature condition (c2 in Wolfe conditions). For more information, see Phys. Chem. Chem. Phys., 2000, 2, 2177.";
         item.default_value = "0.5";
         item.unit = "";
-        item.availability = "Only used when relax_new = False and relax_method is bfgs or cg_bfgs";
+        item.availability = "Only used when relax_method is bfgs or cg_bfgs";
         read_sync_double(input.relax_bfgs_w2);
         this->add_item(item);
     }
@@ -248,7 +222,7 @@ Second element (BFGS variant, only when first element is bfgs):
         item.description = "Maximum allowed total displacement of all atoms during geometry optimization. The sum of atomic displacements can increase during optimization steps but cannot exceed this value.";
         item.default_value = "0.8";
         item.unit = "Bohr";
-        item.availability = "Only used when relax_new = False and relax_method is bfgs or cg_bfgs";
+        item.availability = "Only used when relax_method is bfgs or cg_bfgs";
         read_sync_double(input.relax_bfgs_rmax);
         this->add_item(item);
     }
@@ -260,7 +234,7 @@ Second element (BFGS variant, only when first element is bfgs):
         item.description = "Minimum allowed total displacement of all atoms. When the total atomic displacement falls below this value and force convergence is not achieved, the calculation will terminate. Note: This parameter is not used in the default BFGS algorithm (relax_method = bfgs 2 or bfgs).";
         item.default_value = "1e-5";
         item.unit = "Bohr";
-        item.availability = "Only used when relax_new = False and relax_method = bfgs 1 (traditional BFGS)";
+        item.availability = "Only used when relax_method is bfgs 1 (traditional BFGS)";
         read_sync_double(input.relax_bfgs_rmin);
         this->add_item(item);
     }
@@ -272,7 +246,7 @@ Second element (BFGS variant, only when first element is bfgs):
         item.description = "Initial total displacement of all atoms in the first BFGS step. This sets the scale for the initial movement.";
         item.default_value = "0.5";
         item.unit = "Bohr";
-        item.availability = "Only used when relax_new = False and relax_method is bfgs or cg_bfgs";
+        item.availability = "Only used when relax_method is bfgs or cg_bfgs";
         read_sync_double(input.relax_bfgs_init);
         this->add_item(item);
     }
@@ -329,9 +303,9 @@ Second element (BFGS variant, only when first element is bfgs):
         item.annotation = "which axes are fixed";
         item.category = "Geometry relaxation";
         item.type = "String";
-        item.description = R"(Specifies which cell degrees of freedom are fixed during variable-cell relaxation. The available options depend on the relax_new setting:
+        item.description = R"(Specifies which cell degrees of freedom are fixed during variable-cell relaxation. The available options depend on relax_method:
 
-When relax_new = True (default), all options are available:
+With relax_method = cg 2 (default), all options are available:
 * None: Default; all cell parameters can relax freely
 * volume: Relaxation with fixed volume (allows shape changes)
 * shape: Fix shape but allow volume changes (hydrostatic pressure only)
@@ -341,22 +315,20 @@ When relax_new = True (default), all options are available:
 * ab: Fix both a and b axes during relaxation
 * ac: Fix both a and c axes during relaxation
 * bc: Fix both b and c axes during relaxation
+* abc: Fix all three lattice vectors during relaxation
 
-When relax_new = False, all options are now available:
-* None: Default; all cell parameters can relax freely
-* volume: Relaxation with fixed volume (allows shape changes). Volume is preserved by rescaling the lattice after each update.
-* shape: Fix shape but allow volume changes (hydrostatic pressure only). Stress tensor is replaced with isotropic pressure.
-* a, b, c, ab, ac, bc: Fix specific lattice vectors. Gradients for fixed vectors are set to zero.
+With relax_method set to cg 1, bfgs, lbfgs, sd, or cg_bfgs, None and a, b, c, ab, ac, bc, abc are available. The shape and volume options require cg 2.
 
-[NOTE] For VASP users, see the ISIF correspondence table in the geometry optimization documentation. Both implementations now support all constraint types.)";
+[NOTE] For VASP users, see the ISIF correspondence table in the geometry optimization documentation.)";
         item.default_value = "None";
         item.unit = "";
         item.availability = "Only used when calculation is set to cell-relax";
         read_sync_string(input.fixed_axes);
         item.check_value = [](const Input_Item& item, const Parameter& para) {
-            if ((para.input.fixed_axes == "shape" || para.input.fixed_axes == "volume") && !para.input.relax_new)
+            if ((para.input.fixed_axes == "shape" || para.input.fixed_axes == "volume")
+                && !para.input.uses_simultaneous_relaxation())
             {
-                ModuleBase::WARNING_QUIT("ReadInput", "fixed shape and fixed volume only supported for relax_new = 1");
+                ModuleBase::WARNING_QUIT("ReadInput", "fixed shape and fixed volume require relax_method = cg 2");
             }
         };
         this->add_item(item);
@@ -372,12 +344,12 @@ When relax_new = False, all options are now available:
 [NOTE] Note: it is possible to use fixed_ibrav with fixed_axes, but please make sure you know what you are doing. For example, if we are doing relaxation of a simple cubic lattice (latname = "sc"), and we use fixed_ibrav along with fixed_axes = "volume", then the cell is never allowed to move and as a result, the relaxation never converges. When both are used, fixed_ibrav is applied first, then fixed_axes = "volume" rescaling is applied.)";
         item.default_value = "False";
         item.unit = "";
-        item.availability = "Can be used with both relax_new = True and relax_new = False. A specific latname must be provided.";
+        item.availability = "Only used with relax_method = cg 2. A specific latname must be provided.";
         read_sync_bool(input.fixed_ibrav);
         item.check_value = [](const Input_Item& item, const Parameter& para) {
-            if (para.input.fixed_ibrav && !para.input.relax_new)
+            if (para.input.fixed_ibrav && !para.input.uses_simultaneous_relaxation())
             {
-                ModuleBase::WARNING_QUIT("ReadInput", "fixed_ibrav only available for relax_new = 1");
+                ModuleBase::WARNING_QUIT("ReadInput", "fixed_ibrav requires relax_method = cg 2");
             }
             if (para.input.latname == "none" && para.input.fixed_ibrav)
             {

--- a/source/source_io/test/for_testing_input_conv.h
+++ b/source/source_io/test/for_testing_input_conv.h
@@ -169,11 +169,7 @@ void UnitCell::setup(const std::string& latname_in,
         this->lat_axis_free[0] = 1;
         this->lat_axis_free[1] = 1;
         this->lat_axis_free[2] = 1;
-        // Note: fixed_axes="volume" is now supported with relax_new=false
-        // (see commit cdc3457f5a8546cda869655c3faabd8b29687aff)
     } else if (fixed_axes_in == "shape") {
-        // Note: fixed_axes="shape" is now supported with relax_new=false
-        // (see commit cdc3457f5a8546cda869655c3faabd8b29687aff)
         this->lat_axis_free[0] = 1;
         this->lat_axis_free[1] = 1;
         this->lat_axis_free[2] = 1;

--- a/source/source_io/test/input_help_test.cpp
+++ b/source/source_io/test/input_help_test.cpp
@@ -226,7 +226,6 @@ TEST_F(ParameterHelpTest, FuzzyMatchingMultipleSuggestions) {
     auto results = ModuleIO::ParameterHelp::find_similar_parameters("relax_met", 5, 3);
     EXPECT_GT(results.size(), 1); // Should find multiple matches
     // Results should be sorted by distance (closest first)
-    // "relax_met" to "relax_new": distance 2 (m->n, t->w)
     // "relax_met" to "relax_method": distance 3 (insert h, o, d)
     // Note: Actual results depend on which parameters exist in the parameter database
 }

--- a/source/source_io/test/print_info_test.cpp
+++ b/source/source_io/test/print_info_test.cpp
@@ -172,7 +172,6 @@ TEST_F(PrintInfoTest, PrintScreen)
 		}
 		else
 		{
-			PARAM.input.relax_new = false;
 			if(PARAM.input.calculation=="relax")
 			{
 				testing::internal::CaptureStdout();

--- a/source/source_io/test/read_input_ptest.cpp
+++ b/source/source_io/test/read_input_ptest.cpp
@@ -120,7 +120,6 @@ TEST_F(InputParaTest, ParaRead)
     EXPECT_DOUBLE_EQ(param.inp.relax_cg_thr, 0.5);
     EXPECT_EQ(param.inp.out_level, "ie");
     EXPECT_TRUE(param.globalv.out_md_control);
-    EXPECT_TRUE(param.inp.relax_new);
     EXPECT_DOUBLE_EQ(param.inp.relax_bfgs_w1, 0.01);
     EXPECT_DOUBLE_EQ(param.inp.relax_bfgs_w2, 0.5);
     EXPECT_DOUBLE_EQ(param.inp.relax_bfgs_rmax, 0.8);

--- a/source/source_io/test/support/INPUT
+++ b/source/source_io/test/support/INPUT
@@ -116,8 +116,7 @@ fixed_axes                     None #which axes are fixed
 fixed_ibrav                    0 #whether to preseve lattice type during relaxation
 fixed_atoms                    0 #whether to preseve direct coordinates of atoms during relaxation
 relax_method                   cg #bfgs; sd; cg; cg_bfgs;
-relax_new                      TRUE #whether to use the new relaxation method
-relax_scale_force              0.5 #controls the size of the first CG step if relax_new is true
+relax_scale_force              0.5 #controls the size of the first CG 2 step
 out_level                      ie #ie(for electrons); i(for ions);
 out_dmk                        0 #>0 output density matrix DM(k)
 deepks_out_labels              0 #>0 compute descriptor for deepks

--- a/source/source_io/test_serial/read_input_item_test.cpp
+++ b/source/source_io/test_serial/read_input_item_test.cpp
@@ -35,6 +35,55 @@ class InputTest : public testing::Test
     }
 };
 
+TEST_F(InputTest, RelaxMethod)
+{
+    ModuleIO::ReadInput readinput(0);
+    readinput.check_ntype_flag = false;
+    Parameter param;
+    auto it = find_label("relax_method", readinput.input_lists);
+
+    it->second.str_values = {"cg"};
+    it->second.read_value(it->second, param);
+    EXPECT_EQ(param.input.relax_method, (std::vector<std::string>{"cg", "2"}));
+    EXPECT_TRUE(param.input.uses_simultaneous_relaxation());
+
+    it->second.str_values = {"cg", "1"};
+    it->second.read_value(it->second, param);
+    EXPECT_EQ(param.input.relax_method, (std::vector<std::string>{"cg", "1"}));
+    EXPECT_FALSE(param.input.uses_simultaneous_relaxation());
+
+    it->second.str_values = {"cg", "2"};
+    it->second.read_value(it->second, param);
+    EXPECT_EQ(param.input.relax_method, (std::vector<std::string>{"cg", "2"}));
+    EXPECT_TRUE(param.input.uses_simultaneous_relaxation());
+
+    it->second.str_values = {"bfgs"};
+    it->second.read_value(it->second, param);
+    EXPECT_EQ(param.input.relax_method, (std::vector<std::string>{"bfgs", "2"}));
+    EXPECT_FALSE(param.input.uses_simultaneous_relaxation());
+
+    it->second.str_values = {"bfgs", "1"};
+    it->second.read_value(it->second, param);
+    EXPECT_EQ(param.input.relax_method, (std::vector<std::string>{"bfgs", "1"}));
+
+    it->second.str_values = {"bfgs", "2"};
+    it->second.read_value(it->second, param);
+    EXPECT_EQ(param.input.relax_method, (std::vector<std::string>{"bfgs", "2"}));
+
+    for (const std::vector<std::string>& invalid : {
+             std::vector<std::string>{"cg", "3"},
+             std::vector<std::string>{"bfgs", "3"},
+             std::vector<std::string>{"sd", "1"},
+             std::vector<std::string>{"none"},
+             std::vector<std::string>{"cg", "2", "extra"}})
+    {
+        it->second.str_values = invalid;
+        EXPECT_EXIT(it->second.read_value(it->second, param), ::testing::ExitedWithCode(1), "");
+    }
+
+    EXPECT_EQ(find_label("relax_new", readinput.input_lists), readinput.input_lists.end());
+}
+
 TEST_F(InputTest, Item_test)
 {
     ModuleIO::ReadInput readinput(0);
@@ -738,14 +787,14 @@ TEST_F(InputTest, Item_test)
     { // fixed_axes
         auto it = find_label("fixed_axes", readinput.input_lists);
         param.input.fixed_axes = "shape";
-        param.input.relax_new = false;
+        param.input.relax_method = {"cg", "1"};
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
         EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
 
         param.input.fixed_axes = "volume";
-        param.input.relax_new = false;
+        param.input.relax_method = {"cg", "1"};
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
@@ -754,7 +803,7 @@ TEST_F(InputTest, Item_test)
     { // fixed_ibrav
         auto it = find_label("fixed_ibrav", readinput.input_lists);
         param.input.fixed_ibrav = true;
-        param.input.relax_new = false;
+        param.input.relax_method = {"cg", "1"};
         testing::internal::CaptureStdout();
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
@@ -775,26 +824,6 @@ TEST_F(InputTest, Item_test)
         EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
         output = testing::internal::GetCapturedStdout();
         EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
-    }
-    { // relax_method
-        auto it = find_label("relax_method", readinput.input_lists);
-        param.input.relax_method[0] = "none";
-        testing::internal::CaptureStdout();
-        EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
-        output = testing::internal::GetCapturedStdout();
-        EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
-    }
-    { //relax_new
-        auto it = find_label("relax_new", readinput.input_lists);
-        param.input.relax_new = true;
-        param.input.relax_method[0] = "cg";
-        it->second.reset_value(it->second, param);
-        EXPECT_EQ(param.input.relax_new, true);
-
-        param.input.relax_new = true;
-        param.input.relax_method[0] = "none";
-        it->second.reset_value(it->second, param);
-        EXPECT_EQ(param.input.relax_new, false);
     }
     { // force_thr
         auto it = find_label("force_thr", readinput.input_lists);

--- a/source/source_io/test_serial/read_input_test.cpp
+++ b/source/source_io/test_serial/read_input_test.cpp
@@ -212,6 +212,29 @@ TEST_F(InputTest, RejectAutoDevice)
     EXPECT_TRUE(std::remove("./auto_device_INPUT") == 0);
 }
 
+TEST_F(InputTest, ValidateRelaxMethodVariants)
+{
+    Parameter cg_param;
+    EXPECT_NO_THROW(read_parameters("relax_cg_INPUT", "relax_method cg\n", cg_param));
+    EXPECT_EQ(cg_param.inp.relax_method, (std::vector<std::string>{"cg", "2"}));
+    EXPECT_TRUE(cg_param.inp.uses_simultaneous_relaxation());
+
+    Parameter bfgs_default_param;
+    EXPECT_NO_THROW(read_parameters("relax_bfgs_default_INPUT", "relax_method bfgs\n", bfgs_default_param));
+    EXPECT_EQ(bfgs_default_param.inp.relax_method, (std::vector<std::string>{"bfgs", "2"}));
+    EXPECT_FALSE(bfgs_default_param.inp.uses_simultaneous_relaxation());
+
+    Parameter bfgs_one_param;
+    EXPECT_NO_THROW(read_parameters("relax_bfgs_one_INPUT", "relax_method bfgs 1\n", bfgs_one_param));
+    EXPECT_EQ(bfgs_one_param.inp.relax_method, (std::vector<std::string>{"bfgs", "1"}));
+
+    expect_invalid_input("relax_bad_variant_INPUT", "relax_method cg 3\n", "the CG variant must be 1 or 2");
+    expect_invalid_input("relax_irrelevant_variant_INPUT",
+                         "relax_method sd 1\n",
+                         "relax_method sd does not accept a second value");
+    expect_invalid_input("relax_new_removed_INPUT", "relax_new 1\n", "THE PARAMETER NAME 'relax_new' IS INCORRECT");
+}
+
 TEST_F(InputTest, ValidateNoncollinearSpin)
 {
     Parameter valid_param;

--- a/source/source_relax/relax_driver.cpp
+++ b/source/source_relax/relax_driver.cpp
@@ -63,7 +63,7 @@ void Relax_Driver::init_relax(const int nat, const Input_para& inp)
 {
     if (inp.calculation == "relax" || inp.calculation == "cell-relax")
     {
-        if (!inp.relax_new)
+        if (!inp.uses_simultaneous_relaxation())
         {
             this->rl_old.init_relax(nat);
         }
@@ -133,7 +133,7 @@ bool Relax_Driver::relax_step(std::vector<int>& steps,
 
     bool converged = false;
 
-    if (inp.relax_new)
+    if (inp.uses_simultaneous_relaxation())
     {
         converged = this->rl.relax_step(ucell, force, stress, etot, ofs_running);
 	// stress step +1

--- a/tests/01_PW/058_PW_RE_MB/INPUT
+++ b/tests/01_PW/058_PW_RE_MB/INPUT
@@ -10,7 +10,6 @@ relax_nmax        2
 cal_force         1
 force_thr_ev      0.01
 relax_method      bfgs 2
-relax_new         0
 
 # Self-Consistent Field
 basis_type        pw

--- a/tests/01_PW/059_PW_RE_MB_traj/INPUT
+++ b/tests/01_PW/059_PW_RE_MB_traj/INPUT
@@ -17,7 +17,7 @@ scf_nmax          100
 relax_nmax        2
 cal_force         1
 force_thr_ev      0.01
-relax_method      bfgs
+relax_method      bfgs 1
 
 #Parameters (4.Basis)
 basis_type        pw
@@ -29,5 +29,3 @@ smearing_sigma    0.002
 #Parameters (6.Mixing)
 mixing_type       broyden
 mixing_beta       0.5
-
-relax_new         0

--- a/tests/01_PW/060_PW_RE_MG/INPUT
+++ b/tests/01_PW/060_PW_RE_MG/INPUT
@@ -17,7 +17,7 @@ cal_force         1
 #Parameters (3.Relaxation)
 relax_nmax        2
 force_thr_ev      0.01
-relax_method      cg
+relax_method      cg 1
 
 #Parameters (4.Basis)
 basis_type        pw
@@ -29,5 +29,3 @@ smearing_sigma    0.002
 #Parameters (6.Mixing)
 mixing_type       broyden
 mixing_beta       0.5
-
-relax_new         0

--- a/tests/01_PW/063_PW_CR/INPUT
+++ b/tests/01_PW/063_PW_CR/INPUT
@@ -13,9 +13,8 @@ ecutwfc           20
 scf_nmax          20
 kpar              2
 
-relax_method      cg
+relax_method      cg 1
 relax_nmax        2
-relax_new         0
 
 cal_stress        1
 stress_thr        0.1

--- a/tests/01_PW/064_PW_CR_fix_a/INPUT
+++ b/tests/01_PW/064_PW_CR_fix_a/INPUT
@@ -15,7 +15,7 @@ scf_nmax          20
 
 basis_type        pw
 relax_nmax        2
-relax_new         0
+relax_method      cg 1
 
 cal_stress        1
 stress_thr        1e-6

--- a/tests/01_PW/065_PW_CR_fix_ab/INPUT
+++ b/tests/01_PW/065_PW_CR_fix_ab/INPUT
@@ -15,7 +15,7 @@ scf_nmax          20
 
 basis_type        pw
 relax_nmax        2
-relax_new         0
+relax_method      cg 1
 
 cal_stress        1
 stress_thr        1e-6

--- a/tests/01_PW/066_PW_CR_fix_abc/INPUT
+++ b/tests/01_PW/066_PW_CR_fix_abc/INPUT
@@ -14,7 +14,7 @@ scf_nmax          20
 
 basis_type        pw
 relax_nmax        2
-relax_new         0
+relax_method      cg 1
 
 cal_stress        1
 stress_thr        1e-6

--- a/tests/01_PW/067_PW_CR_fix_ac/INPUT
+++ b/tests/01_PW/067_PW_CR_fix_ac/INPUT
@@ -15,7 +15,7 @@ scf_nmax          20
 
 basis_type        pw
 relax_nmax        2
-relax_new         0
+relax_method      cg 1
 
 cal_stress        1
 stress_thr        1e-6

--- a/tests/01_PW/068_PW_CR_fix_b/INPUT
+++ b/tests/01_PW/068_PW_CR_fix_b/INPUT
@@ -15,7 +15,7 @@ scf_nmax          20
 
 basis_type        pw
 relax_nmax        2
-relax_new         0
+relax_method      cg 1
 
 cal_stress        1
 stress_thr        1e-6

--- a/tests/01_PW/069_PW_CR_fix_bc/INPUT
+++ b/tests/01_PW/069_PW_CR_fix_bc/INPUT
@@ -15,7 +15,7 @@ scf_nmax          20
 
 basis_type        pw
 relax_nmax        2
-relax_new         0
+relax_method      cg 1
 
 cal_stress        1
 stress_thr        1e-6

--- a/tests/01_PW/070_PW_CR_fix_c/INPUT
+++ b/tests/01_PW/070_PW_CR_fix_c/INPUT
@@ -15,7 +15,7 @@ scf_nmax          20
 
 basis_type        pw
 relax_nmax        2
-relax_new         0
+relax_method      cg 1
 
 cal_stress        1
 stress_thr        1e-6

--- a/tests/01_PW/071_PW_CR_move/INPUT
+++ b/tests/01_PW/071_PW_CR_move/INPUT
@@ -12,7 +12,7 @@ scf_nmax          20
 
 basis_type        pw
 relax_nmax        2
-relax_new         0
+relax_method      cg 1
 
 cal_stress        1
 stress_thr        1e-6

--- a/tests/02_NAO_Gamma/relax_bfgs2/INPUT
+++ b/tests/02_NAO_Gamma/relax_bfgs2/INPUT
@@ -31,5 +31,3 @@ mixing_type       broyden
 mixing_beta       0.5
 
 gamma_only        1
-
-relax_new         0

--- a/tests/02_NAO_Gamma/relax_cell/INPUT
+++ b/tests/02_NAO_Gamma/relax_cell/INPUT
@@ -24,6 +24,5 @@ mixing_beta       0.7
 gamma_only        1
 
 relax_method      cg
-relax_new         1
 relax_nmax        2
 relax_scale_force  0.4

--- a/tests/02_NAO_Gamma/relax_old_cg/INPUT
+++ b/tests/02_NAO_Gamma/relax_old_cg/INPUT
@@ -17,7 +17,7 @@ scf_nmax          100
 relax_nmax        2
 cal_force         1
 force_thr_ev      0.01
-relax_method      cg
+relax_method      cg 1
 cal_stress        1
 
 #Parameters (4.Basis)
@@ -32,5 +32,3 @@ mixing_type       broyden
 mixing_beta       0.5
 
 gamma_only        1
-
-relax_new         0

--- a/tests/03_NAO_multik/relax_bfgs2/INPUT
+++ b/tests/03_NAO_multik/relax_bfgs2/INPUT
@@ -29,5 +29,3 @@ smearing_sigma    0.002
 #Parameters (6.Mixing)
 mixing_type       broyden
 mixing_beta       0.5
-
-relax_new         0

--- a/tests/03_NAO_multik/relax_cell/INPUT
+++ b/tests/03_NAO_multik/relax_cell/INPUT
@@ -22,4 +22,4 @@ ks_solver         scalapack_gvx
 mixing_type       broyden
 mixing_beta       0.7
 
-relax_new         0
+relax_method      cg 1

--- a/tests/03_NAO_multik/relax_old_cg/INPUT
+++ b/tests/03_NAO_multik/relax_old_cg/INPUT
@@ -22,4 +22,4 @@ ks_solver         scalapack_gvx
 mixing_type       broyden
 mixing_beta       0.7
 
-relax_new         0
+relax_method      cg 1

--- a/tests/04_FF/16_LJ_RE_rule1/INPUT
+++ b/tests/04_FF/16_LJ_RE_rule1/INPUT
@@ -12,7 +12,6 @@ lj_epsilon        0.01 0.02
 lj_sigma          3.4 3.5
 
 #Parameters (relax)
-relax_new         1
 relax_nmax        5
 force_thr_ev      0.01
 cal_force         1

--- a/tests/04_FF/17_LJ_CR_multi_ele/INPUT
+++ b/tests/04_FF/17_LJ_CR_multi_ele/INPUT
@@ -11,7 +11,6 @@ lj_epsilon        0.01 0.02 0.03
 lj_sigma          3.4 3.5 3.6
 
 #Parameters (relax)
-relax_new         1
 relax_nmax        5
 force_thr_ev      0.01
 stress_thr        0.1

--- a/tests/04_FF/19_LJ_RE_stop/INPUT
+++ b/tests/04_FF/19_LJ_RE_stop/INPUT
@@ -12,7 +12,6 @@ lj_epsilon        0.01 0.02
 lj_sigma          3.4 3.5
 
 #Parameters (relax)
-relax_new         1
 relax_nmax        5
 force_thr_ev      0.01
 cal_force         1

--- a/tests/04_FF/20_LJ_dry_run/INPUT
+++ b/tests/04_FF/20_LJ_dry_run/INPUT
@@ -11,5 +11,4 @@ lj_epsilon        0.01 0.02
 lj_sigma          3.4 3.5
 
 #Parameters (relax)
-relax_new         1
 relax_nmax        0


### PR DESCRIPTION
## Summary

- Remove the top-level `relax_new` switch and select CG implementations through `relax_method`.
- Normalize omitted CG and BFGS variants to the recommended variant 2, and strictly reject invalid or irrelevant second values.
- Migrate repository INPUT files, update constraint checks, and regenerate the parameter documentation.

This continues the reset-behavior cleanup discussed in #7719 and extends the `algorithm + variant number` interface introduced for BFGS in #6517 to CG.

## Rationale

The previous `relax_method` reader validated only the algorithm name. It accepted any second token for BFGS, while the consuming code treated exactly `1` as the traditional implementation and every other value as implementation 2. Inputs such as `bfgs 3` or `bfgs anything` therefore ran without reporting the typo. This PR makes the public interface match the two implementations that actually exist: the optional variant is restricted to `1` or `2`, and omission selects the recommended variant 2.

`relax_new` was also not a general new-versus-old optimizer framework. `relax_new=true` selected the simultaneous CG implementation, whose line search, combined ionic/cell gradient, constraint handling, and state are closely tied to CG. The other path is the existing staged relaxation driver, which supports CG, BFGS, LBFGS, SD, and CG-BFGS. When a non-CG method was combined with the default `relax_new=true`, an input reset silently changed `relax_new` to false. Extending that simultaneous CG implementation to another algorithm would require implementing how that algorithm handles the combined ionic/cell search space, line search or trust update, constraints, and optimizer state; it is not enabled by making the boolean accept more methods.

Representing the two CG implementations as `cg 1` and `cg 2` removes that hidden reset and describes the current algorithms directly. Non-CG methods continue to use the staged driver, while BFGS keeps the variant interface introduced in #6517.

## Input migration

```text
relax_new 0 + relax_method cg  -> relax_method cg 1
relax_new 1 + relax_method cg  -> relax_method cg 2
relax_method cg                -> relax_method cg 2
relax_method bfgs              -> relax_method bfgs 2
```

Only `cg` and `bfgs` accept a second value, and the value must be `1` or `2`. The former `relax_new` keyword is now rejected as unknown.

## Verification

- Six affected unit-test targets passed, including full input-reader, input-item, help, relaxation-dispatch, output, and UnitCell tests.
- Four PW regression cases passed with 4 MPI ranks: BFGS 2, BFGS 1 trajectory, CG 1, and CG 1 cell relaxation.
- Two LJ regression cases passed with 4 MPI ranks, covering default CG 2 ionic and cell relaxation.
- `abacus -h relax_method` and `abacus --check-input` passed with the updated interface.
- Generated YAML and Markdown documentation match the executable metadata; governance and diff checks reported no findings.