### PR TITLE
Fix non-LCAO elecstate energy test mock

### DIFF
--- a/source/source_estate/test/elecstate_energy_test.cpp
+++ b/source/source_estate/test/elecstate_energy_test.cpp
@@ -37,12 +37,10 @@ double ElecState::get_solvent_model_Acav()
 {
     return 0.5;
 }
-#ifdef __LCAO
 double ElecState::get_dftu_energy()
 {
     return 0.6;
 }
-#endif
 double ElecState::get_local_pp_energy()
 {
     return 0.7;
@@ -128,11 +126,7 @@ TEST_F(ElecStateEnergyTest, CalEnergiesHarrisDFTU)
     PARAM.input.dft_plus_u = 1;
     elecstate->cal_energies(1);
     // deband_harris + hatree + efiled + gatefield + edftu + escon
-#ifdef __LCAO
     EXPECT_DOUBLE_EQ(elecstate->f_en.etot_harris, 1.3);
-#else
-    EXPECT_DOUBLE_EQ(elecstate->f_en.etot_harris, 0.7);
-#endif
 }
 
 TEST_F(ElecStateEnergyTest, CalEnergiesEtot)
@@ -158,11 +152,7 @@ TEST_F(ElecStateEnergyTest, CalEnergiesEtotDFTU)
     PARAM.input.dft_plus_u = 1;
     elecstate->cal_energies(2);
     // deband + hatree + efiled + gatefield + edftu + escon
-#ifdef __LCAO
     EXPECT_DOUBLE_EQ(elecstate->f_en.etot, 1.3);
-#else
-    EXPECT_DOUBLE_EQ(elecstate->f_en.etot, 0.7);
-#endif
 }
 
 TEST_F(ElecStateEnergyTest, CalConverged)


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] This PR is a follow-up to PR #5703; the historical test context is PR #2486.
- [x] I have run focused unit-test verification and listed the results below.
- [x] There are no user-visible or INPUT behavior changes.
- [x] Core-module impact is limited to a test-only replacement and assertions.
- [x] No governance exception is requested.

### Linked Issue
No upstream issue linked; this is a follow-up to the non-LCAO test regression introduced by PR #5703.

### Unit Tests and/or Case Tests for my changes
- Before the change, building `MODULE_ESTATE_elecstate_energy` with LCAO disabled failed with an undefined reference to `elecstate::ElecState::get_dftu_energy()`.
- After the change, the same reduced-feature target builds successfully; its CTest entry passes and the test binary reports 13/13 GoogleTest cases passing.
- The LCAO-enabled target also builds; its CTest entry and all 13 GoogleTest cases pass, confirming that the unconditional test replacement does not introduce a duplicate symbol.
- `git diff --check` passes.
- No full-repository test suite was run; the change is limited to one focused unit-test source.

### What's changed?
PR #5703 extended DFT+U to the PW basis and removed the production `__LCAO` guard around `ElecState::get_dftu_energy()` and its call from `cal_energies()`. The unit test added by PR #2486 still defined its lightweight `get_dftu_energy()` replacement only under `__LCAO`.

The failure occurs with `BUILD_TESTING=ON`, `ENABLE_MPI=ON`, and `ENABLE_LCAO=OFF` when CMake builds the standalone `MODULE_ESTATE_elecstate_energy` test executable. That target compiles `elecstate_energy.cpp` but intentionally does not link the production `elecstate_energy_terms.cpp` and its DFT+U dependencies. With LCAO disabled, the stale guard removed the test replacement as well, leaving the production call unresolved at link time.

The production ABACUS target is unaffected because the `source_estate` module compiles both `elecstate_energy.cpp` and `elecstate_energy_terms.cpp`.

This PR makes the test replacement available in both LCAO and non-LCAO builds. It also makes both DFT+U assertions expect the replacement's `0.6` contribution, matching the PW DFT+U behavior introduced by #5703. No production source or runtime behavior changes.

### Governance Notes
- INPUT/docs changes: none; no INPUT or user-facing behavior changed.
- Core module impact: test-only linkage and expectation maintenance.
- Exceptions requested: none.
