### PR TITLE
Fix relax_new test linkage for Relax_Data

### DIFF
--- a/source/source_relax/test/CMakeLists.txt
+++ b/source/source_relax/test/CMakeLists.txt
@@ -14,7 +14,7 @@ AddTest(
 
 AddTest(
   TARGET MODULE_RELAX_relax_new_relax
-  SOURCES  relax_test.cpp ../relax_sync.cpp ../line_search.cpp ../../source_base/tool_quit.cpp ../../source_base/global_variable.cpp ../../source_base/global_file.cpp ../../source_base/memory_recorder.cpp ../../source_base/timer.cpp
+  SOURCES  relax_test.cpp ../relax_sync.cpp ../line_search.cpp ../relax_data.cpp ../../source_base/tool_quit.cpp ../../source_base/global_variable.cpp ../../source_base/global_file.cpp ../../source_base/memory_recorder.cpp ../../source_base/timer.cpp
     ../../source_base/matrix3.cpp ../../source_base/intarray.cpp ../../source_base/tool_title.cpp
     ../../source_base/global_function.cpp ../../source_base/complexmatrix.cpp ../../source_base/matrix.cpp
     ../../source_base/complexarray.cpp ../../source_base/tool_quit.cpp ../../source_base/realarray.cpp


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have explained why this PR does not need an upstream issue link.
- [x] I have run focused unit-test verification and listed the results below.
- [x] There are no user-visible or INPUT behavior changes.
- [x] Core-module impact is limited to test-target linkage.
- [x] No governance exception is requested.

### Linked Issue
No upstream issue linked; this is a follow-up to the test-linkage regression introduced by PR #7456.

### Unit Tests and/or Case Tests for my changes
- Before the change, building `MODULE_RELAX_relax_new_relax` failed with undefined references to `Relax_Data::dim` and `Relax_Data::largest_grad`.
- After the change, `cmake --build build-debug --target MODULE_RELAX_relax_new_relax -j2` succeeds.
- The same target also links in a Release reduced-feature build.
- `MODULE_RELAX_relax_new_relax --gtest_filter=Test_SETGRAD.relax_new` passes.
- The neighboring `MODULE_RELAX_relax_new_line_search` target builds and its CTest passes.
- `git diff --check` and the agent governance check pass.
- The full `MODULE_RELAX_relax_new_relax` CTest now runs, but the existing `Test_RELAX.relax_new` numerical assertions fail on current `develop`. This PR does not change relaxation behavior or numerical references.

### What's changed?
PR #7456 moved shared relaxation state to static members of `Relax_Data`. As a result, `relax_sync.cpp`, through `ions_move_basic.h`, now references `Relax_Data::dim` and `Relax_Data::largest_grad`, whose definitions live in `relax_data.cpp`.

The production relaxation module already compiles `relax_data.cpp`. The failure occurs only with `BUILD_TESTING=ON` when CMake builds the standalone `MODULE_RELAX_relax_new_relax` unit-test executable from its explicit source list. That list included `relax_sync.cpp` but omitted `relax_data.cpp`, so the test executable failed at link time. The reduced non-LCAO configuration exposed the omission, but LCAO itself is not the cause.

This PR adds `../relax_data.cpp` to that test target's source list. No production source, runtime behavior, or public interface changes.

### Governance Notes
- INPUT/docs changes: none; no INPUT or user-facing behavior changed.
- Core module impact: test-target source linkage only.
- Exceptions requested: none.
