### PR TITLE
Reject GEN-ELPA with GPU device

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -1161,7 +1161,7 @@
   For numerical atomic orbitals basis,
 
   - lapack: Use LAPACK to diagonalize the Hamiltonian, only used for serial version
-  - genelpa: Use GEN-ELPA to diagonalize the Hamiltonian.
+  - genelpa: Use the CPU-only GEN-ELPA interface to diagonalize the Hamiltonian.
   - scalapack_gvx: Use Scalapack to diagonalize the Hamiltonian.
   - cusolver: Use CUSOLVER to diagonalize the Hamiltonian, at least one GPU is needed.
   - cusolvermp: Use CUSOLVER to diagonalize the Hamiltonian, supporting multi-GPU devices. Note that you should set the number of MPI processes equal to the number of GPUs.

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -540,7 +540,7 @@ parameters:
       For numerical atomic orbitals basis,
 
       * lapack: Use LAPACK to diagonalize the Hamiltonian, only used for serial version
-      * genelpa: Use GEN-ELPA to diagonalize the Hamiltonian.
+      * genelpa: Use the CPU-only GEN-ELPA interface to diagonalize the Hamiltonian.
       * scalapack_gvx: Use Scalapack to diagonalize the Hamiltonian.
       * cusolver: Use CUSOLVER to diagonalize the Hamiltonian, at least one GPU is needed.
       * cusolvermp: Use CUSOLVER to diagonalize the Hamiltonian, supporting multi-GPU devices. Note that you should set the number of MPI processes equal to the number of GPUs.

--- a/source/source_io/module_parameter/read_input_item_elec_stru.cpp
+++ b/source/source_io/module_parameter/read_input_item_elec_stru.cpp
@@ -60,7 +60,7 @@ For plane-wave basis,
 For numerical atomic orbitals basis,
 
 * lapack: Use LAPACK to diagonalize the Hamiltonian, only used for serial version
-* genelpa: Use GEN-ELPA to diagonalize the Hamiltonian.
+* genelpa: Use the CPU-only GEN-ELPA interface to diagonalize the Hamiltonian.
 * scalapack_gvx: Use Scalapack to diagonalize the Hamiltonian.
 * cusolver: Use CUSOLVER to diagonalize the Hamiltonian, at least one GPU is needed.
 * cusolvermp: Use CUSOLVER to diagonalize the Hamiltonian, supporting multi-GPU devices. Note that you should set the number of MPI processes equal to the number of GPUs.
@@ -164,6 +164,13 @@ Then the user has to correct the input file and restart the calculation.)";
                 }
                 else if (ks_solver == "genelpa")
                 {
+                    if (para.input.device == "gpu")
+                    {
+                        ModuleBase::WARNING_QUIT(
+                            "ReadInput",
+                            "ks_solver = genelpa does not support GPU acceleration. "
+                            "Please use ks_solver = elpa with device = gpu.");
+                    }
 #ifndef __ELPA
                     ModuleBase::WARNING_QUIT("Input",
                                              "Can not use genelpa if abacus is not compiled with "

--- a/source/source_io/test_serial/read_input_item_test.cpp
+++ b/source/source_io/test_serial/read_input_item_test.cpp
@@ -649,6 +649,14 @@ TEST_F(InputTest, Item_test)
         param.input.device = "gpu";
         it->second.reset_value(it->second, param);
         EXPECT_EQ(param.input.ks_solver, "cusolver");
+
+        param.input.ks_solver = "genelpa";
+        param.input.basis_type = "lcao";
+        param.input.device = "gpu";
+        testing::internal::CaptureStdout();
+        EXPECT_EXIT(it->second.check_value(it->second, param), ::testing::ExitedWithCode(1), "");
+        output = testing::internal::GetCapturedStdout();
+        EXPECT_THAT(output, testing::HasSubstr("Please use ks_solver = elpa with device = gpu"));
 #ifdef __ELPA
         param.input.towannier90 = true;
         param.input.basis_type = "lcao_in_pw";


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have linked an issue or explained why this PR does not need one.
- [x] I have added adequate unit tests and/or case tests, or explained why not.
- [x] I have described user-visible behavior changes, including INPUT parameter changes.
- [x] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [x] I have requested any needed governance exception below.

### Related Issue
Related to #7719, which audits existing INPUT reset semantics and recommends rejecting unsupported explicit combinations during final validation rather than silently rewriting user intent. This focused PR does not close that broader issue.

### When does the problem occur?
The unsupported state occurs for an LCAO calculation when the user explicitly sets both `ks_solver = genelpa` and `device = gpu`. GEN-ELPA is a CPU-only interface, but the combination previously passed INPUT validation and could fail later inside ELPA.

The existing `ks_solver` reset behavior is unaffected: with `basis_type = lcao`, `device = gpu`, and the default `ks_solver`, ABACUS derives `ks_solver = cusolver`. CPU `genelpa` remains valid, and GPU ELPA acceleration remains available through `ks_solver = elpa`.

### Unit Tests and/or Case Tests for my changes
A focused INPUT validation test covers the explicit LCAO `genelpa`/GPU combination and checks that ABACUS exits with guidance to use `ks_solver = elpa`. Existing solver reset tests continue to cover the default GPU selection behavior.

### What changed?
- Reject explicit `ks_solver = genelpa` with `device = gpu` during final INPUT validation.
- Direct users to `ks_solver = elpa` for ELPA GPU acceleration.
- Describe GEN-ELPA as CPU-only in parameter metadata and generated user documentation.

### Governance Notes
- INPUT/docs changes: `ks_solver` validation and description changed; `docs/parameters.yaml` and `docs/advanced/input_files/input-main.md` are updated together.
- Core module impact: limited to final INPUT validation in `source_io`; no ESolver, HSolver, ELPA implementation, or numerical path is modified.
- Exceptions requested: none.