### PR TITLE
Validate explicit diago_proc bounds

### DIFF
--- a/source/source_io/module_parameter/read_input_item_system.cpp
+++ b/source/source_io/module_parameter/read_input_item_system.cpp
@@ -594,9 +594,19 @@ Available options are:
         item.availability = "Used only for plane wave basis set.";
         read_sync_int(input.diago_proc);
         item.reset_value = [](const Input_Item& item, Parameter& para) {
-            if (para.input.diago_proc > GlobalV::NPROC || para.input.diago_proc <= 0)
+            if (para.input.diago_proc == 0)
             {
                 para.input.diago_proc = GlobalV::NPROC;
+            }
+        };
+        item.check_value = [](const Input_Item& item, const Parameter& para) {
+            if (para.input.diago_proc < 0)
+            {
+                ModuleBase::WARNING_QUIT("ReadInput", "diago_proc must not be negative");
+            }
+            if (para.input.diago_proc > GlobalV::NPROC)
+            {
+                ModuleBase::WARNING_QUIT("ReadInput", "diago_proc cannot exceed the number of MPI processes");
             }
         };
         this->add_item(item);

--- a/source/source_io/test/read_input_ptest.cpp
+++ b/source/source_io/test/read_input_ptest.cpp
@@ -147,7 +147,7 @@ TEST_F(InputParaTest, ParaRead)
     EXPECT_EQ(param.inp.ndx, 0);
     EXPECT_EQ(param.inp.ndy, 0);
     EXPECT_EQ(param.inp.ndz, 0);
-    EXPECT_EQ(param.inp.diago_proc, std::min(GlobalV::NPROC, 4));
+    EXPECT_EQ(param.inp.diago_proc, GlobalV::NPROC);
     EXPECT_EQ(param.inp.pw_diag_nmax, 50);
     EXPECT_EQ(param.inp.diago_cg_prec, 1);
     EXPECT_EQ(param.inp.pw_diag_ndim, 4);
@@ -454,6 +454,29 @@ TEST_F(InputParaTest, ParaRead)
     EXPECT_EQ(param.inp.abs_gauge, "length");
     EXPECT_EQ(param.inp.rdmft, 0);
     EXPECT_DOUBLE_EQ(param.inp.rdmft_power_alpha, 0.656);
+}
+
+TEST_F(InputParaTest, DiagoProc)
+{
+    int rank = 0;
+    int nproc = 0;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+
+    ModuleIO::ReadInput readinput(rank);
+    readinput.check_ntype_flag = false;
+    Parameter full_param;
+    readinput.read_parameters(full_param, "./support/INPUT.diago_proc_full");
+    EXPECT_EQ(full_param.inp.diago_proc, nproc);
+
+    if (nproc == 4)
+    {
+        ModuleIO::ReadInput subset_readinput(rank);
+        subset_readinput.check_ntype_flag = false;
+        Parameter subset_param;
+        subset_readinput.read_parameters(subset_param, "./support/INPUT.diago_proc_subset");
+        EXPECT_EQ(subset_param.inp.diago_proc, 2);
+    }
 }
 
 // comment out this part of tests, since Parameter is in another directory now, mohan 2025-05-18

--- a/source/source_io/test/support/INPUT
+++ b/source/source_io/test/support/INPUT
@@ -33,7 +33,7 @@ out_freq_elec                  0 #the frequency ( >= 0) of electronic iter to ou
 dft_plus_dmft                  0 #true:DFT+DMFT; false: standard DFT calcullation(default)
 rpa                            0 #true:generate output files used in rpa calculation; false:(default)
 mem_saver                      0 #Only for nscf calculations. if set to 1, then a memory saving technique will be used for many k point calculations.
-diago_proc                     4 #the number of procs used to do diagonalization
+diago_proc                     0 #the number of procs used to do diagonalization
 nbspline                       -1 #the order of B-spline basis
 soc_lambda                     1 #The fraction of averaged SOC pseudopotential is given by (1-soc_lambda)
 cal_force                      0 #if calculate the force at the end of the electronic iteration

--- a/source/source_io/test/support/INPUT.diago_proc_full
+++ b/source/source_io/test/support/INPUT.diago_proc_full
@@ -1,0 +1,2 @@
+INPUT_PARAMETERS
+diago_proc 0

--- a/source/source_io/test/support/INPUT.diago_proc_subset
+++ b/source/source_io/test/support/INPUT.diago_proc_subset
@@ -1,0 +1,2 @@
+INPUT_PARAMETERS
+diago_proc 2

--- a/source/source_io/test_serial/read_input_test.cpp
+++ b/source/source_io/test_serial/read_input_test.cpp
@@ -336,6 +336,24 @@ TEST_F(InputTest, ValidateDeepksOutputFrequency)
     EXPECT_EQ(enabled_param.inp.deepks_out_freq_elec, 2);
 }
 
+TEST_F(InputTest, ValidateDiagoProc)
+{
+    set_nproc(4);
+
+    Parameter full_param;
+    EXPECT_NO_THROW(read_parameters("diago_proc_full_INPUT", "diago_proc 0\n", full_param));
+    EXPECT_EQ(full_param.inp.diago_proc, 4);
+
+    Parameter subset_param;
+    EXPECT_NO_THROW(read_parameters("diago_proc_subset_INPUT", "diago_proc 2\n", subset_param));
+    EXPECT_EQ(subset_param.inp.diago_proc, 2);
+
+    expect_invalid_input("diago_proc_negative_INPUT", "diago_proc -1\n", "diago_proc must not be negative");
+    expect_invalid_input("diago_proc_oversized_INPUT",
+                         "diago_proc 5\n",
+                         "diago_proc cannot exceed the number of MPI processes");
+}
+
 TEST_F(InputTest, Check)
 {
     ModuleIO::ReadInput readinput(0);


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have linked the reset audit issue.
- [x] I have added focused serial and MPI input tests.
- [x] I have listed the verification results below.
- [x] I have described the `diago_proc` behavior change.
- [x] Core-module impact is limited to `source_io` input validation and tests.
- [x] The migration-neutral global dependency is explained below.

### Linked Issue
Related to #7719.

### Unit Tests and/or Case Tests for my changes
- Before the change, the regression test showed that `diago_proc -1` and an explicit value above the available process count were accepted and rewritten to the full process count.
- `MODULE_IO_read_input_serial` and `MODULE_IO_read_item_serial` pass.
- The focused MPI input test passes through both the one-rank and four-rank entry points. It verifies that `0` resolves to the full process count and that `2` remains unchanged with four ranks.
- `git diff --check` passes.
- No full-repository test suite was run; verification is focused on input parsing and the affected MPI process-count paths.

### What changed?
An explicit negative `diago_proc`, or an explicit value larger than the available MPI process count, was silently replaced with `GlobalV::NPROC`. This hid invalid INPUT values and made them indistinguishable from the documented `diago_proc=0` sentinel.

The reset now handles only the documented zero sentinel. Negative and oversized explicit values fail with direct diagnostics, while legal positive subsets remain unchanged. The MPI input fixture now uses the sentinel explicitly, and focused tests cover the sentinel, a valid subset, a negative value, and an oversized value.

The original silent behavior predates the reset audit; this PR addresses the `diago_proc` finding recorded in #7719.

### Governance Notes
- INPUT/docs changes: no generated documentation change is needed. The parameter metadata already documents `0` as the full-process sentinel and positive values as bounded by the total MPI process count.
- Core module impact: limited to `source_io` input validation and tests. Diagonalization algorithms and communicator construction are unchanged.
- Exceptions requested: the `GlobalV::NPROC` references are a migration-neutral reorganization of the existing dependency; the governance check reports a net delta of zero.