### PR TITLE
Reject negative DeePKS output frequency

### DIFF
--- a/source/source_io/module_parameter/read_input_item_deepks.cpp
+++ b/source/source_io/module_parameter/read_input_item_deepks.cpp
@@ -37,13 +37,11 @@ void ReadInput::item_deepks()
         item.unit = "";
         item.availability = "Numerical atomic orbital basis";
         read_sync_int(input.deepks_out_freq_elec);
-        item.reset_value = [](const Input_Item& item, Parameter& para) {
+        item.check_value = [](const Input_Item& item, const Parameter& para) {
             if (para.input.deepks_out_freq_elec < 0)
             {
-                para.input.deepks_out_freq_elec = 0;
+                ModuleBase::WARNING_QUIT("ReadInput", "deepks_out_freq_elec must not be negative");
             }
-        };
-        item.check_value = [](const Input_Item& item, const Parameter& para) {
             if (para.input.deepks_out_freq_elec > 0 && para.input.deepks_out_base == "none")
             {
                 ModuleBase::WARNING_QUIT("ReadInput", "to use deepks_out_freq_elec, please set deepks_out_base ");

--- a/source/source_io/test_serial/read_input_test.cpp
+++ b/source/source_io/test_serial/read_input_test.cpp
@@ -283,6 +283,36 @@ TEST_F(InputTest, ValidateBandParallelization)
                          "bndpar can not exceed the number of MPI processes");
 }
 
+TEST_F(InputTest, ValidateDeepksOutputFrequency)
+{
+    Parameter default_param;
+    EXPECT_NO_THROW(read_parameters("deepks_freq_default_INPUT", "", default_param));
+    EXPECT_EQ(default_param.inp.deepks_out_freq_elec, 0);
+
+    Parameter disabled_param;
+    EXPECT_NO_THROW(read_parameters("deepks_freq_disabled_INPUT", "deepks_out_freq_elec 0\n", disabled_param));
+    EXPECT_EQ(disabled_param.inp.deepks_out_freq_elec, 0);
+
+    expect_invalid_input("deepks_freq_negative_INPUT",
+                         "deepks_out_freq_elec -1\n",
+                         "deepks_out_freq_elec must not be negative");
+    expect_invalid_input("deepks_freq_missing_base_INPUT",
+                         "deepks_out_freq_elec 2\n",
+                         "to use deepks_out_freq_elec, please set deepks_out_base");
+
+    Parameter enabled_param;
+    testing::internal::CaptureStdout();
+    EXPECT_THROW(read_parameters("deepks_freq_enabled_INPUT",
+                                 "deepks_out_freq_elec 2\n"
+                                 "deepks_out_base pbe\n"
+                                 "deepks_out_labels 1\n",
+                                 enabled_param),
+                 std::runtime_error);
+    const std::string output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(output, testing::HasSubstr("please compile with DeePKS"));
+    EXPECT_EQ(enabled_param.inp.deepks_out_freq_elec, 2);
+}
+
 TEST_F(InputTest, Check)
 {
     ModuleIO::ReadInput readinput(0);


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have linked the reset audit issue and the original feature PR.
- [x] I have added focused real-INPUT regression coverage.
- [x] I have listed the verification results below.
- [x] I have described the `deepks_out_freq_elec` behavior change.
- [x] Core-module impact is limited to `source_io` input validation and tests.
- [x] No governance exception is requested.

### Linked Issue
Related to #7719. Follow-up to the `deepks_out_freq_elec` feature introduced in #6325.

### Unit Tests and/or Case Tests for my changes
- Before the change, the regression test showed that `deepks_out_freq_elec -1` was accepted and silently rewritten to `0`.
- `MODULE_IO_read_input_serial` and `MODULE_IO_read_item_serial` pass.
- Real-INPUT coverage verifies omitted/default zero, explicit zero, negative rejection, the existing missing-`deepks_out_base` diagnostic, and preservation of a positive frequency through to the existing DeePKS build guard.
- `git diff --check` passes.
- No DeePKS runtime case was run. This PR does not change enabled-path output cadence; the focused input test verifies the existing feature guard without pretending DeePKS is enabled.

### What changed?
When an INPUT file specified a negative `deepks_out_freq_elec`, the reset callback silently changed it to `0`. Because zero disables per-electronic-step DeePKS output, an invalid or mistyped negative value looked like an intentional request to disable the feature.

This PR removes that silent reset and rejects negative values with a direct diagnostic. Omitted and explicit zero remain valid, and positive values retain the existing `deepks_out_base` and `deepks_out_labels` requirements. Other DeePKS resets and output cadence logic are unchanged.

### Governance Notes
- INPUT/docs changes: no generated documentation change is needed. Parameter type, default, description, and availability are unchanged; the existing metadata already describes operation only for positive frequencies.
- Core module impact: limited to `source_io` input validation and focused tests. DeePKS runtime calculations and output cadence are unchanged.
- Exceptions requested: none.