### PR TITLE
Prevent dependency building failure in Intel Dockerfile

### DIFF
--- a/.github/workflows/build_test_cmake.yml
+++ b/.github/workflows/build_test_cmake.yml
@@ -11,6 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - tag: gnu

--- a/.github/workflows/build_test_makefile.yml
+++ b/.github/workflows/build_test_makefile.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         include:
         - tag: intel
-          build_args: "CXX=mpiicpc ELPA_LIB_DIR=/usr/local/lib ELPA_INCLUDE_DIR=/usr/local/include CEREAL_DIR=/usr/include/cereal OPENMP=ON"
+          build_args: "CXX=mpiicpx ELPA_LIB_DIR=/usr/local/lib ELPA_INCLUDE_DIR=/usr/local/include CEREAL_DIR=/usr/include/cereal OPENMP=ON"
           name: "Build with Makefile & Intel compilers"
     name: ${{ matrix.name }}
     container: ghcr.io/deepmodeling/abacus-${{ matrix.tag }}

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -31,6 +31,7 @@ jobs:
        startsWith(github.ref, 'refs/tags/v'))
 
     strategy:
+      fail-fast: false
       matrix:
         dockerfile:
           - gnu

--- a/Dockerfile.intel
+++ b/Dockerfile.intel
@@ -3,8 +3,12 @@ FROM intel/oneapi-hpckit:2025.2.2-0-devel-ubuntu22.04
 RUN apt-get update && apt-get install -y \
     bc cmake git gnupg gcc g++ python3-numpy sudo wget vim unzip \
     libcereal-dev libxc-dev libgtest-dev libgmock-dev libbenchmark-dev \
-    pkg-config build-essential autoconf automake libtool && \
+    pkg-config build-essential autoconf automake libtool ca-certificates && \
     rm -rf /var/lib/apt/lists/*
+
+ENV CC="mpiicx"
+ENV CXX="mpiicpx"
+ENV FC="mpiifx"
 
 # https://elpa.mpcdf.mpg.de/software/tarball-archive/ELPA_TARBALL_ARCHIVE.html
 RUN cd /tmp && \


### PR DESCRIPTION
Currently Intel Dockerfiles fails because Intel oneAPI toolkit lefts an invalid `mpiifort` wrapper that generates `ifort` command which doesn't exist in Intel oneAPI 2025.2; same as `mpiicc` and `mpiicpc`. This PR explicity set compilers to `mpiicx`, `mpiicpx`, and `mpiifx` through Docker's `ENV`.

Also, adds `fail-fast: false` to the workflow files with several jobs so that the jobs that should be successful are not interrupted by a single failing job.