### PR TITLE
Fix(hsolver): sync d_eigenvalue before GPU refresh in Diago_DavSubspace

### DIFF
--- a/source/source_hsolver/diago_dav_subspace.cpp
+++ b/source/source_hsolver/diago_dav_subspace.cpp
@@ -795,6 +795,9 @@ void Diago_DavSubspace<T, Device>::refresh(const int& dim,
 
     if (this->device == base_device::GpuDevice)
     {
+#if defined(__CUDA) || defined(__ROCM)
+        syncmem_var_h2d_op()(this->d_eigenvalue, eigenvalue_in_hsolver, nbase);
+#endif
         refresh_hcc_scc_vcc_op<T, Device>()(nbase, hcc, scc, vcc, this->nbase_x, this->d_eigenvalue, this->one_);
     }
     else


### PR DESCRIPTION
The GPU path of Diago_DavSubspace::refresh() reads this->d_eigenvalue which was last synchronized in cal_grad() — before diag_zhegvx() computed the latest eigenvalues. This caused the restarted subspace Hamiltonian to receive stale diagonal entries on GPU, leading to:
- Davidson eigenvalue oscillation and divergence
- Non-positive-definite overlap matrix
- zhegvx failure and zeroed wavefunctions

The CPU path already used the up-to-date eigenvalue_in_hsolver argument. Fix the GPU path to re-sync d_eigenvalue from eigenvalue_in_hsolver.

Bug introduced by 8f7d319c1 (PR #6493).

### Reminder
- [ ] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [ ] I have linked an issue or explained why this PR does not need one.
- [ ] I have added adequate unit tests and/or case tests, or explained why not.
- [ ] I have listed the exact verification commands run and their results.
- [ ] I have described user-visible behavior changes, including INPUT parameter changes.
- [ ] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [ ] I have requested any needed governance exception below.

### Linked Issue
Fix #

### Unit Tests and/or Case Tests for my changes
- Commands run:
- Result summary:
- Checks not run, with reason:

### What's changed?
- Example: brief summary of the user-visible or developer-facing change.

### Governance Notes
- INPUT/docs changes:
- Core module impact:
- Exceptions requested:
