### PR TITLE
Fix redundant density symmetrization in OFDFT

### DIFF
--- a/source/source_esolver/esolver_of.cpp
+++ b/source/source_esolver/esolver_of.cpp
@@ -236,21 +236,11 @@ void ESolver_OF::before_opt(const int istep, UnitCell& ucell)
 
     elecstate::init_scf(ucell, Pgrid, sf.strucFac, locpp.numeric, istep, PARAM.globalv.global_out_dir, PARAM.inp, this->pelec);
 
-    Symmetry_rho::symmetrize_rho(PARAM.inp.nspin, this->chr, this->pw_rho, ucell.symm);
-
-    for (int is = 0; is < PARAM.inp.nspin; ++is)
+    const int nspin = PARAM.inp.nspin;
+    if (PARAM.inp.init_chg == "file")
     {
-        if (PARAM.inp.init_chg != "file")
-        {
-            for (int ibs = 0; ibs < this->pw_rho->nrxx; ++ibs)
-            {
-                // Here we initialize rho to be uniform,
-                // because the rho got by pot.init_pot -> Charge::atomic_rho may contain minus elements.
-                this->chr.rho[is][ibs] = this->nelec_[is] / ucell.omega;
-                this->pphi_[is][ibs] = sqrt(this->chr.rho[is][ibs]);
-            }
-        }
-        else
+        Symmetry_rho::symmetrize_rho(nspin, this->chr, this->pw_rho, ucell.symm);
+        for (int is = 0; is < nspin; ++is)
         {
             for (int ibs = 0; ibs < this->pw_rho->nrxx; ++ibs)
             {
@@ -258,8 +248,22 @@ void ESolver_OF::before_opt(const int istep, UnitCell& ucell)
             }
         }
     }
+    else
+    {
+        // Non-file densities are replaced with a uniform density, so
+        // symmetrizing them would only add an unnecessary FFT round trip.
+        for (int is = 0; is < nspin; ++is)
+        {
+            for (int ibs = 0; ibs < this->pw_rho->nrxx; ++ibs)
+            {
+                // The density from pot.init_pot -> Charge::atomic_rho may contain negative elements.
+                this->chr.rho[is][ibs] = this->nelec_[is] / ucell.omega;
+                this->pphi_[is][ibs] = sqrt(this->chr.rho[is][ibs]);
+            }
+        }
+    }
 
-    for (int is = 0; is < PARAM.inp.nspin; ++is)
+    for (int is = 0; is < nspin; ++is)
     {
         this->pelec->eferm.set_efval(is, 0);
         this->theta_[is] = 0.;
@@ -267,7 +271,7 @@ void ESolver_OF::before_opt(const int istep, UnitCell& ucell)
         ModuleBase::GlobalFunc::ZEROS(this->pdEdphi_[is], this->pw_rho->nrxx);
         ModuleBase::GlobalFunc::ZEROS(this->pdirect_[is], this->pw_rho->nrxx);
     }
-    if (PARAM.inp.nspin == 1)
+    if (nspin == 1)
     {
         this->theta_[0] = 0.2;
     }


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have linked an issue or explained why this PR does not need one.
- [x] I have added adequate unit tests and/or case tests, or explained why not.
- [x] I have listed the exact verification commands run and their results.
- [x] I have described user-visible behavior changes, including INPUT parameter changes.
- [x] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [x] I have requested any needed governance exception below.

### Linked Issue
Fix #7724 

### Unit Tests and/or Case Tests for my changes
- No tests added.

### What's changed?
- Remove redundant `rho_symmetrize` operation whose results will soon be overwritten in `esolver_of.cpp`.
- Now no unnecessary symmetrization is performed for `ofdft` with `init_chg!=file`, saving up to 95% of total time.

### Governance Notes
- INPUT/docs changes: No changes.