### PR TITLE
ci(cuda): build only for CI runner GPU arch and raise parallelism

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -46,13 +46,12 @@ jobs:
           nvidia-smi
           source toolchain/install/setup
           rm -rf build
-          # Build only for the GPU architecture of the CI runner instead of the
-          # default 7 architectures (60/70/75/80/86/89/90). The CI GPU pool is
-          # Tesla V100 (sm_70, see the nvidia-smi output above); update this if
-          # the runner GPU model changes (V100=70, A100=80, H100=90, T4=75).
-          # This cuts nvcc work by ~7x and allows safe -j.
-          cmake -B build -G Ninja -DUSE_CUDA=ON -DBUILD_TESTING=ON -DENABLE_FLOAT_FFTW=ON \
-            -DCMAKE_CUDA_ARCHITECTURES=70
+          # The GPU architecture is detected automatically by CMakeLists.txt at
+          # configure time (via `nvidia-smi --query-gpu=compute_cap`), so no
+          # explicit -DCMAKE_CUDA_ARCHITECTURES is needed here. Building for a
+          # single architecture instead of the default 7 (60/70/75/80/86/89/90)
+          # cuts nvcc work by ~7x and allows safe -j on the build host.
+          cmake -B build -G Ninja -DUSE_CUDA=ON -DBUILD_TESTING=ON -DENABLE_FLOAT_FFTW=ON
           cmake --build build -j "$(nproc)"
           cmake --install build
 

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -46,21 +46,6 @@ jobs:
           nvidia-smi
           source toolchain/install/setup
           rm -rf build
-          # Pin the CUDA architecture to sm_70 (Tesla V100) instead of building
-          # for the default 7 architectures (60/70/75/80/86/89/90). The CI GPU
-          # pool is a homogeneous set of V100 pods (verified by sampling 5+
-          # runner IDs, all on the gpu-runner-6qqd8-* K8s deployment with
-          # identical test step timings across runs). Building for a single
-          # arch cuts nvcc work to ~1/7 and keeps the ccache key uniform so
-          # cache_warmer (#7756) can populate every runner with the same
-          # entries.
-          #
-          # NOTE: this is an explicit pin rather than auto-detection. On a
-          # cluster, configuring on a login node whose GPU differs from the
-          # compute node would silently produce a binary that fails with
-          # "no kernel image is available" at run time; HPC convention is to
-          # build on the compute node, where the workflow's hardcoded -D
-          # matches the actual hardware.
           cmake -B build -G Ninja -DUSE_CUDA=ON -DBUILD_TESTING=ON -DENABLE_FLOAT_FFTW=ON \
             -DCMAKE_CUDA_ARCHITECTURES=70
           cmake --build build -j "$(nproc)"

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -46,12 +46,23 @@ jobs:
           nvidia-smi
           source toolchain/install/setup
           rm -rf build
-          # The GPU architecture is detected automatically by CMakeLists.txt at
-          # configure time (via `nvidia-smi --query-gpu=compute_cap`), so no
-          # explicit -DCMAKE_CUDA_ARCHITECTURES is needed here. Building for a
-          # single architecture instead of the default 7 (60/70/75/80/86/89/90)
-          # cuts nvcc work by ~7x and allows safe -j on the build host.
-          cmake -B build -G Ninja -DUSE_CUDA=ON -DBUILD_TESTING=ON -DENABLE_FLOAT_FFTW=ON
+          # Pin the CUDA architecture to sm_70 (Tesla V100) instead of building
+          # for the default 7 architectures (60/70/75/80/86/89/90). The CI GPU
+          # pool is a homogeneous set of V100 pods (verified by sampling 5+
+          # runner IDs, all on the gpu-runner-6qqd8-* K8s deployment with
+          # identical test step timings across runs). Building for a single
+          # arch cuts nvcc work to ~1/7 and keeps the ccache key uniform so
+          # cache_warmer (#7756) can populate every runner with the same
+          # entries.
+          #
+          # NOTE: this is an explicit pin rather than auto-detection. On a
+          # cluster, configuring on a login node whose GPU differs from the
+          # compute node would silently produce a binary that fails with
+          # "no kernel image is available" at run time; HPC convention is to
+          # build on the compute node, where the workflow's hardcoded -D
+          # matches the actual hardware.
+          cmake -B build -G Ninja -DUSE_CUDA=ON -DBUILD_TESTING=ON -DENABLE_FLOAT_FFTW=ON \
+            -DCMAKE_CUDA_ARCHITECTURES=70
           cmake --build build -j "$(nproc)"
           cmake --install build
 

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -46,8 +46,14 @@ jobs:
           nvidia-smi
           source toolchain/install/setup
           rm -rf build
-          cmake -B build -G Ninja -DUSE_CUDA=ON -DBUILD_TESTING=ON -DENABLE_FLOAT_FFTW=ON
-          cmake --build build -j4
+          # Build only for the GPU architecture of the CI runner instead of the
+          # default 7 architectures (60/70/75/80/86/89/90). The CI GPU pool is
+          # Tesla V100 (sm_70, see the nvidia-smi output above); update this if
+          # the runner GPU model changes (V100=70, A100=80, H100=90, T4=75).
+          # This cuts nvcc work by ~7x and allows safe -j.
+          cmake -B build -G Ninja -DUSE_CUDA=ON -DBUILD_TESTING=ON -DENABLE_FLOAT_FFTW=ON \
+            -DCMAKE_CUDA_ARCHITECTURES=70
+          cmake --build build -j "$(nproc)"
           cmake --install build
 
       - name: Module_LCAO CUDA Unittests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,7 +435,37 @@ if(USE_CUDA)
     # check
     # https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/Internal/CMakeCUDAArchitecturesAll.cmake
     # for available architectures in different CUDA versions
-    
+
+    # Auto-detect GPU compute capability at configure time when the user has
+    # not explicitly set CMAKE_CUDA_ARCHITECTURES and the build host has an
+    # NVIDIA GPU. This lets CI builds (and any other single-GPU host) compile
+    # for the GPU they actually have, instead of hardcoding an architecture.
+    # Falls back to the historical multi-arch default if nvidia-smi is not
+    # present (e.g., CPU-only build host) or returns an unrecognized value.
+    # User-provided CMAKE_CUDA_ARCHITECTURES still takes precedence.
+    if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES AND USE_CUDA AND COMMAND nvidia-smi)
+      execute_process(
+          COMMAND nvidia-smi --query-gpu=compute_cap --format=csv,noheader
+          OUTPUT_VARIABLE ABACUS_DETECTED_GPU_CAP
+          OUTPUT_STRIP_TRAILING_WHITESPACE
+          RESULT_VARIABLE ABACUS_DETECTED_GPU_CAP_RC)
+      if(ABACUS_DETECTED_GPU_CAP_RC EQUAL 0 AND NOT "${ABACUS_DETECTED_GPU_CAP}" STREQUAL "")
+        # Map "7.0" -> 70, "8.0" -> 80, "8.9" -> 89, "9.0" -> 90, etc.
+        string(REPLACE "." "" ABACUS_DETECTED_ARCH "${ABACUS_DETECTED_GPU_CAP}")
+        # Accept known CUDA architectures (50..99 covers all current generations).
+        if("${ABACUS_DETECTED_ARCH}" MATCHES "^[5-9][0-9]$")
+          set(CMAKE_CUDA_ARCHITECTURES "${ABACUS_DETECTED_ARCH}"
+              CACHE STRING "GPU architectures to compile for")
+          message(STATUS "ABACUS: detected GPU compute capability "
+                         "${ABACUS_DETECTED_GPU_CAP}; building for sm_${ABACUS_DETECTED_ARCH}")
+        else()
+          message(STATUS "ABACUS: detected GPU compute capability "
+                         "'${ABACUS_DETECTED_GPU_CAP}' looks unrecognized; "
+                         "falling back to default arch list")
+        endif()
+      endif()
+    endif()
+
     # CUDA 13.0+ dropped support for architectures below 75
     if(CUDAToolkit_VERSION VERSION_LESS "13.0")
       set(CMAKE_CUDA_ARCHITECTURES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,37 +435,7 @@ if(USE_CUDA)
     # check
     # https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/Internal/CMakeCUDAArchitecturesAll.cmake
     # for available architectures in different CUDA versions
-
-    # Auto-detect GPU compute capability at configure time when the user has
-    # not explicitly set CMAKE_CUDA_ARCHITECTURES and the build host has an
-    # NVIDIA GPU. This lets CI builds (and any other single-GPU host) compile
-    # for the GPU they actually have, instead of hardcoding an architecture.
-    # Falls back to the historical multi-arch default if nvidia-smi is not
-    # present (e.g., CPU-only build host) or returns an unrecognized value.
-    # User-provided CMAKE_CUDA_ARCHITECTURES still takes precedence.
-    if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES AND USE_CUDA AND COMMAND nvidia-smi)
-      execute_process(
-          COMMAND nvidia-smi --query-gpu=compute_cap --format=csv,noheader
-          OUTPUT_VARIABLE ABACUS_DETECTED_GPU_CAP
-          OUTPUT_STRIP_TRAILING_WHITESPACE
-          RESULT_VARIABLE ABACUS_DETECTED_GPU_CAP_RC)
-      if(ABACUS_DETECTED_GPU_CAP_RC EQUAL 0 AND NOT "${ABACUS_DETECTED_GPU_CAP}" STREQUAL "")
-        # Map "7.0" -> 70, "8.0" -> 80, "8.9" -> 89, "9.0" -> 90, etc.
-        string(REPLACE "." "" ABACUS_DETECTED_ARCH "${ABACUS_DETECTED_GPU_CAP}")
-        # Accept known CUDA architectures (50..99 covers all current generations).
-        if("${ABACUS_DETECTED_ARCH}" MATCHES "^[5-9][0-9]$")
-          set(CMAKE_CUDA_ARCHITECTURES "${ABACUS_DETECTED_ARCH}"
-              CACHE STRING "GPU architectures to compile for")
-          message(STATUS "ABACUS: detected GPU compute capability "
-                         "${ABACUS_DETECTED_GPU_CAP}; building for sm_${ABACUS_DETECTED_ARCH}")
-        else()
-          message(STATUS "ABACUS: detected GPU compute capability "
-                         "'${ABACUS_DETECTED_GPU_CAP}' looks unrecognized; "
-                         "falling back to default arch list")
-        endif()
-      endif()
-    endif()
-
+    
     # CUDA 13.0+ dropped support for architectures below 75
     if(CUDAToolkit_VERSION VERSION_LESS "13.0")
       set(CMAKE_CUDA_ARCHITECTURES


### PR DESCRIPTION
The CUDA CI built every .cu file for 7 GPU architectures (60/70/75/80/86/89/90) with a hardcoded -j4, so the Configure & Build step took ~33 min (baseline run 30695060432).

- Pin CMAKE_CUDA_ARCHITECTURES=70: the CI GPU pool is a homogeneous set of Tesla V100 (sm_70) pods — verified via nvidia-smi in the run logs (runs 30744983645 / 30732639957 / 30736458339) and the '16V100' Slurm partition in .ci/slurm/config.ini.
- Build with -j $(nproc) instead of -j4; the arch pin makes the higher parallelism memory-safe (7 archs × nproc nvcc processes would OOM) and keeps the ccache key uniform.

Measured on the current head (2f429be8d): Configure & Build 33m02s -> 17m44s (run 30744983645, cache-cold). The dominant lever is the higher parallelism; the arch pin contributes memory safety, a smaller fatbin and uniform ccache keys. A warm-cache steady-state measurement is still pending.


### Reminder
- [ ] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [ ] I have linked an issue or explained why this PR does not need one.
- [ ] I have added adequate unit tests and/or case tests, or explained why not.
- [ ] I have listed the exact verification commands run and their results.
- [ ] I have described user-visible behavior changes, including INPUT parameter changes.
- [ ] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [ ] I have requested any needed governance exception below.

### Linked Issue
Fix #

### Unit Tests and/or Case Tests for my changes
- Commands run:
- Result summary:
- Checks not run, with reason:

### What's changed?
- Example: brief summary of the user-visible or developer-facing change.

### Governance Notes
- INPUT/docs changes:
- Core module impact:
- Exceptions requested:
