### PR TITLE
ci(test): run module unittests and integration suites in parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,18 +130,75 @@ jobs:
           ctest --test-dir build -V --timeout 1700 -j "$(nproc)" \
             -R 'MODULE_' -E PERF_MODULE_HSOLVER_KERNELS
 
-      - name: Integration Test Suites
+      - name: 01_PW Test
         env:
           GTEST_COLOR: 'yes'
           OMP_NUM_THREADS: '2'
         run: |
-          # The 10 integration suites are independent ctest entries (each
-          # runs Autotest.sh in its own tests/<suite> directory). Run up to
-          # 4 concurrently instead of fully serial (measured ~14 min serial).
-          # -j4 (not nproc) avoids extreme oversubscription: each suite
-          # already spawns MPI ranks with OMP_NUM_THREADS=2.
-          ctest --test-dir build -V --timeout 1700 -j 4 \
-            -R '01_PW|02_NAO_Gamma|03_NAO_multik|04_FF|05_rtTDDFT|06_SDFT|07_OFDFT|08_EXX|09_DeePKS|10_others'
+          ctest --test-dir build -V --timeout 1700 -R 01_PW
+
+      - name: 02_NAO_Gamma Test
+        env:
+          GTEST_COLOR: 'yes'
+          OMP_NUM_THREADS: '2'
+        run: |
+          ctest --test-dir build -V --timeout 1700 -R 02_NAO_Gamma
+
+      - name: 03_NAO_multik Test
+        env:
+          GTEST_COLOR: 'yes'
+          OMP_NUM_THREADS: '2'
+        run: |
+          ctest --test-dir build -V --timeout 1700 -R 03_NAO_multik
+
+      - name: 04_FF Test
+        env:
+          GTEST_COLOR: 'yes'
+          OMP_NUM_THREADS: '2'
+        run: |
+          ctest --test-dir build -V --timeout 1700 -R 04_FF
+
+      - name: 05_rtTDDFT Test
+        env:
+          GTEST_COLOR: 'yes'
+          OMP_NUM_THREADS: '2'
+        run: |
+          ctest --test-dir build -V --timeout 1700 -R 05_rtTDDFT
+
+      - name: 06_SDFT Test
+        env:
+          GTEST_COLOR: 'yes'
+          OMP_NUM_THREADS: '2'
+        run: |
+          ctest --test-dir build -V --timeout 1700 -R 06_SDFT
+
+      - name: 07_OFDFT Test
+        env:
+          GTEST_COLOR: 'yes'
+          OMP_NUM_THREADS: '2'
+        run: |
+          ctest --test-dir build -V --timeout 1700 -R 07_OFDFT
+
+      - name: 08_EXX Test
+        env:
+          GTEST_COLOR: 'yes'
+          OMP_NUM_THREADS: '2'
+        run: |
+          ctest --test-dir build -V --timeout 1700 -R 08_EXX
+
+      - name: 09_DeePKS Test
+        env:
+          GTEST_COLOR: 'yes'
+          OMP_NUM_THREADS: '2'
+        run: |
+          ctest --test-dir build -V --timeout 1700 -R 09_DeePKS
+
+      - name: 10_others Test
+        env:
+          GTEST_COLOR: 'yes'
+          OMP_NUM_THREADS: '2'
+        run: |
+          ctest --test-dir build -V --timeout 1700 -R 10_others
 
 #      - name: 17_DS_DFTU Test
 #        env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,180 +120,28 @@ jobs:
         run: |
           ctest --test-dir build -V --timeout 1700 -R integrated_test
 
-      - name: Module_Base Unittests
+      - name: All Module Unittests
         env:
           GTEST_COLOR: 'yes'
           OMP_NUM_THREADS: '2'
         run: |
-          ctest --test-dir build -V --timeout 1700 -R MODULE_BASE
+          # Run all module unit tests in one parallel ctest invocation
+          # instead of 16 serial steps (measured ~4.5 min serial).
+          ctest --test-dir build -V --timeout 1700 -j "$(nproc)" \
+            -R 'MODULE_' -E PERF_MODULE_HSOLVER_KERNELS
 
-      - name: Module_IO Unittests
+      - name: Integration Test Suites
         env:
           GTEST_COLOR: 'yes'
           OMP_NUM_THREADS: '2'
         run: |
-          ctest --test-dir build -V --timeout 1700 -R MODULE_IO
-
-      - name: Module_HSolver Unittests
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R MODULE_HSOLVER -E PERF_MODULE_HSOLVER_KERNELS
-
-      - name: Module_Cell Unittests
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R MODULE_CELL
-
-      - name: Module_MD Unittests
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R MODULE_MD
-
-      - name: Module_Psi Unittests
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R MODULE_PSI
-
-      - name: Module_RI Unittests
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R MODULE_RI
-
-      - name: Module_Estate Unittests
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R MODULE_ESTATE
-
-      - name: Module_Hamilt Unittests
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R MODULE_HAMILT
-
-      - name: Module_PW Unittests
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R MODULE_PW
-
-      - name: Module_LCAO Unittests
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R MODULE_LCAO
-
-      - name: Module_AO Unittests
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R MODULE_AO
-
-      - name: Module_NAO Unittests
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R MODULE_NAO
-
-      - name: Module_RELAX Unittests
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R MODULE_RELAX
-
-      - name: Module_LR Unittests
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R MODULE_LR
-
-      - name: 01_PW Test
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R 01_PW
-
-      - name: 02_NAO_Gamma Test
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R 02_NAO_Gamma
-
-      - name: 03_NAO_multik Test
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R 03_NAO_multik
-
-      - name: 04_FF Test
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R 04_FF
-
-      - name: 05_rtTDDFT Test
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R 05_rtTDDFT
-
-      - name: 06_SDFT Test
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R 06_SDFT
-
-      - name: 07_OFDFT Test
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R 07_OFDFT
-
-      - name: 08_EXX Test
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R 08_EXX
-
-      - name: 09_DeePKS Test
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R 09_DeePKS
-
-      - name: 10_others Test
-        env:
-          GTEST_COLOR: 'yes'
-          OMP_NUM_THREADS: '2'
-        run: |
-          ctest --test-dir build -V --timeout 1700 -R 10_others
+          # The 10 integration suites are independent ctest entries (each
+          # runs Autotest.sh in its own tests/<suite> directory). Run up to
+          # 4 concurrently instead of fully serial (measured ~14 min serial).
+          # -j4 (not nproc) avoids extreme oversubscription: each suite
+          # already spawns MPI ranks with OMP_NUM_THREADS=2.
+          ctest --test-dir build -V --timeout 1700 -j 4 \
+            -R '01_PW|02_NAO_Gamma|03_NAO_multik|04_FF|05_rtTDDFT|06_SDFT|07_OFDFT|08_EXX|09_DeePKS|10_others'
 
 #      - name: 17_DS_DFTU Test
 #        env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           # Run all module unit tests in one parallel ctest invocation
           # instead of 16 serial steps (measured ~4.5 min serial).
-          ctest --test-dir build -V --timeout 1700 -j "$(nproc)" \
+          ctest --test-dir build --output-on-failure --timeout 1700 -j "$(nproc)" \
             -R 'MODULE_' -E PERF_MODULE_HSOLVER_KERNELS
 
       - name: 01_PW Test
@@ -212,4 +212,7 @@ jobs:
           GTEST_COLOR: 'yes'
           OMP_NUM_THREADS: '2'
         run: |
-          ctest --test-dir build -V --timeout 1700 -E 'integrate_test|01_PW|02_NAO_Gamma|03_NAO_multik|04_FF|05_rtTDDFT|06_SDFT|07_OFDFT|08_EXX|09_DeePKS|10_others|11_PW_GPU|12_NAO_Gamma_GPU|13_NAO_multik_GPU|15_rtTDDFT_GPU|16_SDFT_GPU|17_DS_DFTU|MODULE_BASE|MODULE_IO|MODULE_HSOLVER|MODULE_CELL|MODULE_MD|MODULE_PSI|MODULE_ESTATE|MODULE_RI|MODULE_HAMILT|MODULE_PW|MODULE_LCAO|MODULE_AO|MODULE_NAO|MODULE_RELAX|MODULE_LR'
+          # Exclude every MODULE_* test with a single regex: the old list of
+          # 15 MODULE_* prefixes missed MODULE_ESOLVER, which made it run
+          # twice (once here, once under "All Module Unittests").
+          ctest --test-dir build -V --timeout 1700 -E 'integrate_test|01_PW|02_NAO_Gamma|03_NAO_multik|04_FF|05_rtTDDFT|06_SDFT|07_OFDFT|08_EXX|09_DeePKS|10_others|11_PW_GPU|12_NAO_Gamma_GPU|13_NAO_multik_GPU|15_rtTDDFT_GPU|16_SDFT_GPU|17_DS_DFTU|MODULE_'


### PR DESCRIPTION
The test workflow executed 16 module-unittest steps fully serially - measured ~4.5 min of wall time even when the Build step only takes ~3 min with a warm ccache.

## Changes
- Merge the 16 MODULE_* steps into one `ctest -j $(nproc) -R 'MODULE_'` invocation (`PERF_MODULE_HSOLVER_KERNELS` still excluded), and use `--output-on-failure` so the merged step keeps a compact log.
- Fix the duplicate-run bug found in review: the trailing "Other Unittests" step enumerated 15 MODULE_* prefixes in `-E` and missed `MODULE_ESOLVER`, so it ran twice. The exclusion is now a single `MODULE_` regex, which also covers future module prefixes automatically.

The 10 integration suite steps stay serial in this PR (as decided after the earlier single-job `ctest -j 4` attempt oversubscribed the X64 runner and timed out).

## Verification
- Run 30736458334 (head 4d0a9e558): All Module Unittests = 1m49s vs ~4.5 min serial; integration suites still ~17 min serial.
- Known follow-ups (not in this PR): PROCESSORS metadata for MPI entries and RUN_SERIAL for serial/_para_N twins sharing a CWD; a few consecutive green runs before merging.

### Reminder
- [ ] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [ ] I have linked an issue or explained why this PR does not need one.
- [ ] I have added adequate unit tests and/or case tests, or explained why not.
- [ ] I have listed the exact verification commands run and their results.
- [ ] I have described user-visible behavior changes, including INPUT parameter changes.
- [ ] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [ ] I have requested any needed governance exception below.

### Linked Issue
Fix #

### Unit Tests and/or Case Tests for my changes
- Commands run:
- Result summary:
- Checks not run, with reason:

### What's changed?
- Example: brief summary of the user-visible or developer-facing change.

### Governance Notes
- INPUT/docs changes:
- Core module impact:
- Exceptions requested: