### PR TITLE
Build: keep CI Docker images dependency-only

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -33,13 +33,10 @@ RUN cd /tmp && \
     cmake --build build --target install && \
     cd /tmp && rm -rf rapidjson-24b5e7a rapidjson-24b5e7a.tar.gz
 
-ADD https://api.github.com/repos/deepmodeling/abacus-develop/git/refs/heads/develop /dev/null
-
-RUN git clone https://github.com/deepmodeling/abacus-develop.git --depth 1 && \
-    cd abacus-develop && \
-    cmake -B build -DUSE_CUDA=ON -DENABLE_RAPIDJSON=ON && \
-    cmake --build build -j $(nproc) && \
-    cmake --install build && \
-    rm -rf build && \
-    cd .. 
-    #&& rm -rf abacus-develop
+# NOTE: This image intentionally does NOT build ABACUS itself. The CI
+# workflows always check out the PR code and rebuild from source, so baking
+# a binary into the image was pure churn: the cache-busting ADD below plus an
+# in-image build made the published image change after EVERY merge to
+# develop, forcing every self-hosted runner to re-download gigabytes of
+# layers ("Initialize containers" took 8-78 min in CI). Keep this image
+# dependency-only so runners can cache it for weeks.

--- a/Dockerfile.gnu
+++ b/Dockerfile.gnu
@@ -4,8 +4,14 @@
 # Also available at `docker pull registry.dp.tech/deepmodeling/abacus-intel:latest`.
 # Available image names: abacus-gnu, abacus-intel, abacus-cuda
 
-# Docker images are aimed for evaluating ABACUS.
-# For production use, please compile ABACUS from source code and run in bare-metal for a better performace.
+# Docker images provide the build/runtime dependencies of ABACUS (used by CI
+# and for compiling ABACUS from source). They intentionally do NOT contain a
+# built ABACUS binary: the CI always checks out the PR code and rebuilds, and
+# baking a build into the image (plus a cache-busting ADD of the develop ref)
+# made the image change after EVERY merge, forcing every self-hosted runner
+# to re-download gigabytes of layers ("Initialize containers" took 8-78 min).
+# For production use, compile ABACUS from source code and run in bare-metal
+# for a better performace.
 
 FROM ubuntu:22.04
 RUN apt update && apt install -y --no-install-recommends \
@@ -36,15 +42,3 @@ RUN cd /tmp && \
     cd /tmp && rm -r rapidjson-24b5e7a rapidjson-24b5e7a.tar.gz
 
 ENV CMAKE_PREFIX_PATH=/opt/libtorch/share/cmake
-
-ADD https://api.github.com/repos/deepmodeling/abacus-develop/git/refs/heads/develop /dev/null
-    # This will fetch the latest commit info, and store in docker building cache.
-    # If there are newer commits, docker build will ignore the cache and build latest codes.
-
-RUN git clone https://github.com/deepmodeling/abacus-develop.git --depth 1 && \
-    cd abacus-develop && \
-    cmake -B build -DENABLE_MLALGO=ON -DENABLE_LIBXC=ON -DENABLE_LIBRI=ON -DENABLE_RAPIDJSON=ON && \
-    cmake --build build -j $(nproc) && \
-    cmake --install build && \
-    rm -rf build
-    #&& rm -rf abacus-develop


### PR DESCRIPTION
The devcontainer workflow rebuilds and pushes abacus-{gnu,cuda}:latest on every push to develop, and the Dockerfiles contained a cache-busting ADD of the develop ref plus a full in-image ABACUS build. The published image therefore changed after EVERY merge, so self-hosted runners had to re-download gigabytes of image layers at job start - the 'Initialize containers' step took 8-78 min in CI (measured via the GitHub API).

The CI never uses the baked-in binary: every workflow checks out the PR code and rebuilds from source. Removing the cache-bust and the in-image build makes the image content change only when dependencies themselves change, so runners can keep it cached for weeks.

Note: users who ran 'docker run' to get a prebuilt ABACUS from these images should instead build from source (docs/quick_start) or use a release binary.

### Reminder
- [ ] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [ ] I have linked an issue or explained why this PR does not need one.
- [ ] I have added adequate unit tests and/or case tests, or explained why not.
- [ ] I have listed the exact verification commands run and their results.
- [ ] I have described user-visible behavior changes, including INPUT parameter changes.
- [ ] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [ ] I have requested any needed governance exception below.

### Linked Issue
Fix #

### Unit Tests and/or Case Tests for my changes
- Commands run:
- Result summary:
- Checks not run, with reason:

### What's changed?
- Example: brief summary of the user-visible or developer-facing change.

### Governance Notes
- INPUT/docs changes:
- Core module impact:
- Exceptions requested:
