### PR TITLE
Ci/cuda test matrix smoke

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -13,11 +13,14 @@ defaults:
     shell: bash
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.suite || 'build' }}
+  # The matrix context is not available at workflow scope; referencing
+  # matrix.suite here made the workflow fail to run entirely. Keep the
+  # same per-ref cancellation semantics as before.
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # ── Job 1: build once, publish the binary as an artifact ─────────────
+  # 鈹€鈹€ Job 1: build once, publish the binary as an artifact 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
   build:
     name: Build CUDA
     runs-on: gpu
@@ -86,7 +89,7 @@ jobs:
           path: install/
           retention-days: 1
 
-  # ── Job 2: matrix instances run their test suites in parallel ────────
+  # 鈹€鈹€ Job 2: matrix instances run their test suites in parallel 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
   gpu-test:
     name: Test ${{ matrix.suite }}
     needs: build
@@ -144,7 +147,9 @@ jobs:
                     echo "device    gpu" >> "$f"
                 fi
             done
-            bash ../integrate/Autotest.sh -n 2 -f "$CASE_FILE"
+            # CI pods are single-GPU: keep the intentional -n 1 from #7690.
+            # The speed win comes from the smoke subset, not MPI processes.
+            bash ../integrate/Autotest.sh -n 1 -f "$CASE_FILE"
           else
             bash ../integrate/Autotest.sh -n 2 -f CASES_GPU.txt
           fi

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -3,18 +3,23 @@ name: CUDA Test
 on:
   workflow_dispatch:
   pull_request:
+  schedule:
+    # Nightly at 18:00 UTC: run the full 01_PW GPU case list. Pull requests
+    # run the smaller CASES_GPU_SMOKE.txt subset instead.
+    - cron: '0 18 * * *'
 
 defaults:
   run:
     shell: bash
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.suite || 'build' }}
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test on CUDA Build
+  # ── Job 1: build once, publish the binary as an artifact ─────────────
+  build:
+    name: Build CUDA
     runs-on: gpu
     if: github.repository_owner == 'deepmodeling'
     container:
@@ -22,7 +27,7 @@ jobs:
       volumes:
         - /tmp/ccache:/github/home/.ccache
       options: --gpus all
-      
+
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -33,6 +38,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ccache xz-utils ninja-build pkg-config
+
+      - name: Setup ccache
+        run: |
+          ccache --max-size=30G
+          ccache --zero-stats
+          ccache -s
 
       - name: Install external tools from toolchain
         run: |
@@ -46,15 +57,20 @@ jobs:
           nvidia-smi
           source toolchain/install/setup
           rm -rf build
-          # Build only for the GPU architecture of the CI runner instead of the
-          # default 7 architectures (60/70/75/80/86/89/90). The CI GPU pool is
-          # Tesla V100 (sm_70, see the nvidia-smi output above); update this if
-          # the runner GPU model changes (V100=70, A100=80, H100=90, T4=75).
-          # This cuts nvcc work by ~7x and allows safe -j.
+          # Build only for the GPU architecture of the CI runner instead of
+          # the default 7 architectures (60/70/75/80/86/89/90). The CI GPU
+          # pool is Tesla V100 (sm_70, see the nvidia-smi output above);
+          # update this if the runner GPU model changes (V100=70, A100=80,
+          # H100=90, T4=75). This cuts nvcc work by ~7x and allows safe -j.
           cmake -B build -G Ninja -DUSE_CUDA=ON -DBUILD_TESTING=ON -DENABLE_FLOAT_FFTW=ON \
-            -DCMAKE_CUDA_ARCHITECTURES=70
+            -DCMAKE_CUDA_ARCHITECTURES=70 \
+            -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/install"
           cmake --build build -j "$(nproc)"
           cmake --install build
+
+      - name: ccache statistics
+        if: always()
+        run: ccache -s
 
       - name: Module_LCAO CUDA Unittests
         env:
@@ -63,39 +79,72 @@ jobs:
         run: |
           ctest --test-dir build -V --timeout 1700 -R '^(MODULE_LCAO_tddft_radial_interpolation_cuda_test|MODULE_LCAO_tddft_snap_psibeta_half_test)$'
 
-      - name: Test 11_PW_GPU
-        run: |
-          cd tests/11_PW_GPU
-          bash ../integrate/Autotest.sh -n 2 -f CASES_GPU.txt
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: abacus-cuda-bin
+          path: install/
+          retention-days: 1
 
-      - name: Test 12_NAO_Gamma_GPU
-        run: |
-          cd tests/12_NAO_Gamma_GPU
-          bash ../integrate/Autotest.sh -n 2 -f CASES_GPU.txt
+  # ── Job 2: matrix instances run their test suites in parallel ────────
+  gpu-test:
+    name: Test ${{ matrix.suite }}
+    needs: build
+    runs-on: gpu
+    if: github.repository_owner == 'deepmodeling'
+    container:
+      image: ghcr.io/deepmodeling/abacus-cuda
+      options: --gpus all
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - 11_PW_GPU
+          - 12_NAO_Gamma_GPU
+          - 13_NAO_multik_GPU
+          - 15_rtTDDFT_GPU
+          - 16_SDFT_GPU
+          - 01_PW
 
-      - name: Test 13_NAO_multik_GPU
-        run: |
-          cd tests/13_NAO_multik_GPU
-          bash ../integrate/Autotest.sh -n 2 -f CASES_GPU.txt
+    steps:
+      - name: Checkout test scripts
+        uses: actions/checkout@v7
 
-      - name: Test 15_rtTDDFT_GPU
-        run: |
-          cd tests/15_rtTDDFT_GPU
-          bash ../integrate/Autotest.sh -n 2 -f CASES_GPU.txt
+      - name: Download binary artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: abacus-cuda-bin
+          path: install/
 
-      - name: Test 16_SDFT_GPU
-        run: |
-          cd tests/16_SDFT_GPU
-          bash ../integrate/Autotest.sh -n 2 -f CASES_GPU.txt
+      - name: Make binary executable
+        run: find install/bin -type f -exec chmod +x {} \;
 
-      - name: Test 01_PW on GPU
+      - name: Select 01_PW case list
+        if: matrix.suite == '01_PW'
         run: |
-          cd tests/01_PW
-          find . -name INPUT | while read f; do
-              if grep -q "^device" "$f"; then
-                  sed -i 's/^device.*/device    gpu/' "$f"
-              else
-                  echo "device    gpu" >> "$f"
-              fi
-          done
-          bash ../integrate/Autotest.sh -n 1 -a abacus -f CASES_GPU.txt
+          # PRs run the smoke subset; schedule/dispatch runs the full list.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "CASE_FILE=CASES_GPU_SMOKE.txt" >> "$GITHUB_ENV"
+          else
+            echo "CASE_FILE=CASES_GPU.txt" >> "$GITHUB_ENV"
+          fi
+
+      - name: Test ${{ matrix.suite }}
+        env:
+          GTEST_COLOR: 'yes'
+          OMP_NUM_THREADS: '2'
+        run: |
+          export PATH="${GITHUB_WORKSPACE}/install/bin:${PATH}"
+          cd "tests/${{ matrix.suite }}"
+          if [ "${{ matrix.suite }}" = "01_PW" ]; then
+            find . -name INPUT | while read f; do
+                if grep -q "^device" "$f"; then
+                    sed -i 's/^device.*/device    gpu/' "$f"
+                else
+                    echo "device    gpu" >> "$f"
+                fi
+            done
+            bash ../integrate/Autotest.sh -n 2 -f "$CASE_FILE"
+          else
+            bash ../integrate/Autotest.sh -n 2 -f CASES_GPU.txt
+          fi

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -46,8 +46,14 @@ jobs:
           nvidia-smi
           source toolchain/install/setup
           rm -rf build
-          cmake -B build -G Ninja -DUSE_CUDA=ON -DBUILD_TESTING=ON -DENABLE_FLOAT_FFTW=ON
-          cmake --build build -j4
+          # Build only for the GPU architecture of the CI runner instead of the
+          # default 7 architectures (60/70/75/80/86/89/90). The CI GPU pool is
+          # Tesla V100 (sm_70, see the nvidia-smi output above); update this if
+          # the runner GPU model changes (V100=70, A100=80, H100=90, T4=75).
+          # This cuts nvcc work by ~7x and allows safe -j.
+          cmake -B build -G Ninja -DUSE_CUDA=ON -DBUILD_TESTING=ON -DENABLE_FLOAT_FFTW=ON \
+            -DCMAKE_CUDA_ARCHITECTURES=70
+          cmake --build build -j "$(nproc)"
           cmake --install build
 
       - name: Module_LCAO CUDA Unittests

--- a/tests/01_PW/CASES_GPU_SMOKE.txt
+++ b/tests/01_PW/CASES_GPU_SMOKE.txt
@@ -1,0 +1,29 @@
+# Smoke subset of CASES_GPU.txt for pull_request runs (~1/3 of the cases,
+# chosen to cover: basic SCF with different pseudopotentials, diagonalization
+# solvers CG/David/DS_sca, spin variants nspin=1/2/4, smearing, charge
+# mixing, force/stress, relax/cell-relax, symmetry, vdW, MD, DFT+half and
+# output options). The full CASES_GPU.txt list still runs on schedule
+# (nightly) and workflow_dispatch triggers.
+nscf_out_pot
+scf_out_elf
+001_PW_UPF100_Al
+004_PW_UPF201_Si
+006_PW_UPF201_Eu
+020_PW_kspace
+022_PW_CG
+023_PW_DA
+025_PW_DS_sca
+029_PW_15_CF_CS_S1_smallg
+035_PW_15_SO
+036_PW_AF
+037_PW_FM
+041_PW_GA_smear
+045_PW_BD_chgmix
+051_PW_OBOD_MemSaver
+058_PW_RE_MB
+066_PW_CR_fix_abc
+073_PW_SY
+083_PW_sol_H2
+090_PW_VWR
+101_PW_MD_1O
+209_PW_DFTHALF


### PR DESCRIPTION
Split the CUDA Test workflow into a build job (builds once and uploads the binary as an artifact) plus a matrix of GPU test jobs, so the six test suites run in parallel on PRs instead of serially.

- `pull_request` runs the 01_PW smoke subset (new CASES_GPU_SMOKE.txt, 23 representative cases covering solvers, nspin=1/2/4, relax, symmetry, vdW, MD, DFT+half, output options); `schedule` (nightly) and `workflow_dispatch` run the full CASES_GPU.txt.
- Fix (review): the workflow-level `concurrency.group` referenced `matrix.suite`, which is unavailable at workflow scope and made the workflow fail to run. The group is now `workflow`+`ref` only.
- Fix (review): 01_PW GPU tests stay at `-n 1` (#7690 intentionally used single-process on the single-GPU CI pods); the win comes from the smoke subset, not from MPI process count.
- ccache statistics are printed in every run (30G limit, zero-stats, before/after).

## Verification
- Prior serial CUDA Test: 6 suites ~9 min of tests (01_PW 73 cases alone ~4.8 min) behind one build.
- This PR: 01_PW PR runs drop from 73 to 23 cases; suites run in parallel. Re-measure end-to-end after the concurrency fix (container init ~8-10 min each is the cost to watch; if the parallel matrix costs more than it saves, group the short suites 12/13/15/16 into one job).

### Reminder
- [ ] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [ ] I have linked an issue or explained why this PR does not need one.
- [ ] I have added adequate unit tests and/or case tests, or explained why not.
- [ ] I have listed the exact verification commands run and their results.
- [ ] I have described user-visible behavior changes, including INPUT parameter changes.
- [ ] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [ ] I have requested any needed governance exception below.

### Linked Issue
Fix #

### Unit Tests and/or Case Tests for my changes
- Commands run:
- Result summary:
- Checks not run, with reason:

### What's changed?
- Example: brief summary of the user-visible or developer-facing change.

### Governance Notes
- INPUT/docs changes:
- Core module impact:
- Exceptions requested: