### PR TITLE
Fix `eig_occ.txt` lifecycle

### DIFF
--- a/interfaces/ASE_interface/abacuslite/io/latestio.py
+++ b/interfaces/ASE_interface/abacuslite/io/latestio.py
@@ -443,9 +443,6 @@ def read_abacus_out(fileobj,
 
     # read the eigenvalues (nframe, nk, nbnd)
     elecstate = read_band_from_eig_occ(fileobj.parent / 'eig_occ.txt')
-    # FIXME: remove thw following line till the eig_occ.txt is not written 
-    #        in the append mode
-    (fileobj.parent / 'eig_occ.txt').unlink()
 
     # read the atomic forces (nframe, nat, 3)
     forces = read_forces_from_running_log(abacus_lines)
@@ -682,14 +679,16 @@ class TestLatestIO(unittest.TestCase):
         # make files ready
         shutil.copy(self.testfiles / 'pw-symm0-nspin4-gamma-md', 
                     self.testfiles / 'running_md.log')
+        eig_occ_file = self.testfiles / 'eig_occ.txt'
         shutil.copy(self.testfiles / 'nspin4-gamma-eigocc',
-                    self.testfiles / 'eig_occ.txt')
+                    eig_occ_file)
         shutil.copy(self.testfiles / 'nspin4-gamma-mddump',
                     self.testfiles / 'MD_dump')
 
         res = read_abacus_out(self.testfiles / 'running_md.log')
         self.assertIsNotNone(res)
         self.assertEqual(len(res), 2) # two frames
+        self.assertTrue(eig_occ_file.is_file())
 
         for atoms in res:
             self.assertIsInstance(atoms, Atoms)
@@ -701,7 +700,7 @@ class TestLatestIO(unittest.TestCase):
 
         # remove the files
         (self.testfiles / 'running_md.log').unlink()
-        # (self.testfiles / 'eig_occ.txt').unlink()
+        eig_occ_file.unlink()
         (self.testfiles / 'MD_dump').unlink()
 
     def test_read_iter_header_from_running_log(self):

--- a/interfaces/ASE_interface/abacuslite/io/latestio.py
+++ b/interfaces/ASE_interface/abacuslite/io/latestio.py
@@ -679,16 +679,14 @@ class TestLatestIO(unittest.TestCase):
         # make files ready
         shutil.copy(self.testfiles / 'pw-symm0-nspin4-gamma-md', 
                     self.testfiles / 'running_md.log')
-        eig_occ_file = self.testfiles / 'eig_occ.txt'
         shutil.copy(self.testfiles / 'nspin4-gamma-eigocc',
-                    eig_occ_file)
+                    self.testfiles / 'eig_occ.txt')
         shutil.copy(self.testfiles / 'nspin4-gamma-mddump',
                     self.testfiles / 'MD_dump')
 
         res = read_abacus_out(self.testfiles / 'running_md.log')
         self.assertIsNotNone(res)
         self.assertEqual(len(res), 2) # two frames
-        self.assertTrue(eig_occ_file.is_file())
 
         for atoms in res:
             self.assertIsInstance(atoms, Atoms)
@@ -700,7 +698,7 @@ class TestLatestIO(unittest.TestCase):
 
         # remove the files
         (self.testfiles / 'running_md.log').unlink()
-        eig_occ_file.unlink()
+        (self.testfiles / 'eig_occ.txt').unlink()
         (self.testfiles / 'MD_dump').unlink()
 
     def test_read_iter_header_from_running_log(self):

--- a/source/source_io/module_energy/write_eig_occ.cpp
+++ b/source/source_io/module_energy/write_eig_occ.cpp
@@ -212,8 +212,10 @@ void ModuleIO::write_eig_file(const ModuleBase::matrix &ekb,
     if (GlobalV::MY_RANK == 0)
     {
         std::ofstream ofs_eig0;
+        const bool append = istep > 0
+                            || (PARAM.inp.calculation == "md" && PARAM.inp.mdp.md_restart);
 
-		if(PARAM.inp.out_app_flag==true)
+		if (append)
 		{
 			ofs_eig0.open(filename.c_str(), std::ios::app);
 		}

--- a/source/source_io/module_energy/write_eig_occ.cpp
+++ b/source/source_io/module_energy/write_eig_occ.cpp
@@ -212,8 +212,9 @@ void ModuleIO::write_eig_file(const ModuleBase::matrix &ekb,
     if (GlobalV::MY_RANK == 0)
     {
         std::ofstream ofs_eig0;
+        const auto& inp = PARAM.inp;
         const bool append = istep > 0
-                            || (PARAM.inp.calculation == "md" && PARAM.inp.mdp.md_restart);
+                            || (inp.calculation == "md" && inp.mdp.md_restart);
 
 		if (append)
 		{

--- a/source/source_io/test/write_eig_occ_test.cpp
+++ b/source/source_io/test/write_eig_occ_test.cpp
@@ -97,9 +97,14 @@ TEST_F(IstateInfoTest, OutIstateInfoS1)
         ++i;
     }
    
-    // write eigenvalues and occupations
-    const int istep_in = -1;
-    ModuleIO::write_eig_file(ekb, wg, *kv, istep_in);
+    {
+        std::ofstream stale_file("eig_occ.txt");
+        stale_file << "stale calculation" << std::endl;
+    }
+
+    // A new calculation truncates stale output, then later ionic steps append.
+    ModuleIO::write_eig_file(ekb, wg, *kv, 0);
+    ModuleIO::write_eig_file(ekb, wg, *kv, 1);
 
     // check the output files
     std::ifstream ifs;
@@ -108,7 +113,11 @@ TEST_F(IstateInfoTest, OutIstateInfoS1)
     EXPECT_THAT(str, testing::HasSubstr("Electronic state energy (eV) and occupations"));
     EXPECT_THAT(str, testing::HasSubstr("spin=1 k-point=1/10 Cartesian=0.0000000 0.0000000 0.0000000 (299 plane wave)"));
     EXPECT_THAT(str, testing::HasSubstr("1 2.040854700000000 0.000000000000000"));
+    EXPECT_THAT(str, testing::Not(testing::HasSubstr("stale calculation")));
+    EXPECT_THAT(str, testing::HasSubstr("1     # ionic step"));
+    EXPECT_THAT(str, testing::HasSubstr("2     # ionic step"));
     ifs.close();
+
     remove("eig_occ.txt");
 }
 


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have linked an issue or explained why this PR does not need one.
- [ ] I have added adequate unit tests and/or case tests, or explained why not.
- [ ] I have listed the exact verification commands run and their results.
- [ ] I have described user-visible behavior changes, including INPUT parameter changes.
- [ ] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [ ] I have requested any needed governance exception below.

### Linked Issue
Fix #7751

### Unit Tests and/or Case Tests for my changes
  - PASS: `OMP_NUM_THREADS=1 ctest --test-dir build -V -R '^MODULE_IO_write_eig_occ_test$'`
  - PASS: `python3 -m unittest abacuslite.io.latestio.TestLatestIO` (10 tests)
  - NOTE: An ad hoc 2-rank run hits the existing fixed `299 plane wave` assertion; MPI reduction produces `598`. This is unrelated to this change.

### What's changed?
  - Reset `eig_occ.txt` for new calculations and append later ionic steps or MD restarts, independently of `out_app_flag`.
  - Prevent `abacuslite.read_abacus_out()` from deleting `eig_occ.txt`.
  - Extend focused C++ and Python tests.
  -  No documentation update required: this change does not modify INPUT definitions or the output file format.

### Governance Notes
- INPUT/docs changes:
- Core module impact:
- Exceptions requested:
