### PR TITLE
Docs: clarify Kerker bypass conditions

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -1351,8 +1351,8 @@
 ### mixing_gg0
 
 - **Type**: Real
-- **Description**: Whether to perfom Kerker scaling for charge density.
-  - &gt;0: The high frequency wave vectors will be suppressed by multiplying a scaling factor. Setting mixing_gg0 = 1.0 is normally a good starting point. Kerker preconditioner will be automatically turned off if mixing_beta &lt;= 0.1.
+- **Description**: Controls the Kerker preconditioner for charge-density mixing.
+  - &gt;0: Enables Kerker scaling to suppress long-wavelength (small-G) charge-density fluctuations. Setting mixing_gg0 = 1.0 is normally a good starting point. This setting has no effect when mixing_beta &lt;= 0.1 because the charge-density Kerker preconditioner is bypassed.
   - 0: No Kerker scaling is performed.
 
   For systems that are difficult to converge, particularly metallic systems, enabling Kerker scaling may aid in achieving convergence.
@@ -1361,13 +1361,17 @@
 ### mixing_gg0_mag
 
 - **Type**: Real
-- **Description**: Whether to perfom Kerker preconditioner of magnetic density. Note: we do not recommand to open Kerker preconditioner of magnetic density unless the system is too hard to converge.
+- **Description**: Controls the Kerker preconditioner for magnetic-density mixing. It is disabled by default and is generally only recommended for systems whose magnetic density is difficult to converge.
+
+  The magnetic-density Kerker preconditioner is bypassed when mixing_beta_mag &lt;= 0.1, so mixing_gg0_mag has no effect in that regime. It is also unavailable when the charge-density Kerker preconditioner itself is bypassed.
 - **Default**: 0.0
 
 ### mixing_gg0_min
 
 - **Type**: Real
-- **Description**: The minimum kerker coefficient.
+- **Description**: Sets the lower bound used by the Kerker filter. The lower bound is evaluated as mixing_gg0_min / mixing_beta for charge-density mixing and mixing_gg0_min / mixing_beta_mag for magnetic-density mixing.
+
+  In the current implementation, the automatic bypass thresholds are fixed independently of mixing_gg0_min: charge-density Kerker is bypassed when mixing_beta &lt;= 0.1, and magnetic-density Kerker is bypassed when mixing_beta_mag &lt;= 0.1. Changing mixing_gg0_min does not change these thresholds or re-enable Kerker.
 - **Default**: 0.1
 
 ### mixing_angle

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -765,8 +765,8 @@ parameters:
     category: Electronic structure
     type: Real
     description: |
-      Whether to perfom Kerker scaling for charge density.
-      * >0: The high frequency wave vectors will be suppressed by multiplying a scaling factor. Setting mixing_gg0 = 1.0 is normally a good starting point. Kerker preconditioner will be automatically turned off if mixing_beta <= 0.1.
+      Controls the Kerker preconditioner for charge-density mixing.
+      * >0: Enables Kerker scaling to suppress long-wavelength (small-G) charge-density fluctuations. Setting mixing_gg0 = 1.0 is normally a good starting point. This setting has no effect when mixing_beta <= 0.1 because the charge-density Kerker preconditioner is bypassed.
       * 0: No Kerker scaling is performed.
 
       For systems that are difficult to converge, particularly metallic systems, enabling Kerker scaling may aid in achieving convergence.
@@ -777,7 +777,9 @@ parameters:
     category: Electronic structure
     type: Real
     description: |
-      Whether to perfom Kerker preconditioner of magnetic density. Note: we do not recommand to open Kerker preconditioner of magnetic density unless the system is too hard to converge.
+      Controls the Kerker preconditioner for magnetic-density mixing. It is disabled by default and is generally only recommended for systems whose magnetic density is difficult to converge.
+
+      The magnetic-density Kerker preconditioner is bypassed when mixing_beta_mag <= 0.1, so mixing_gg0_mag has no effect in that regime. It is also unavailable when the charge-density Kerker preconditioner itself is bypassed.
     default_value: "0.0"
     unit: ""
     availability: ""
@@ -785,7 +787,9 @@ parameters:
     category: Electronic structure
     type: Real
     description: |
-      The minimum kerker coefficient.
+      Sets the lower bound used by the Kerker filter. The lower bound is evaluated as mixing_gg0_min / mixing_beta for charge-density mixing and mixing_gg0_min / mixing_beta_mag for magnetic-density mixing.
+
+      In the current implementation, the automatic bypass thresholds are fixed independently of mixing_gg0_min: charge-density Kerker is bypassed when mixing_beta <= 0.1, and magnetic-density Kerker is bypassed when mixing_beta_mag <= 0.1. Changing mixing_gg0_min does not change these thresholds or re-enable Kerker.
     default_value: "0.1"
     unit: ""
     availability: ""

--- a/source/source_io/module_parameter/read_input_item_elec_stru.cpp
+++ b/source/source_io/module_parameter/read_input_item_elec_stru.cpp
@@ -711,8 +711,8 @@ For systems that are difficult to converge, one could try increasing the value o
         item.annotation = "mixing parameter in kerker";
         item.category = "Electronic structure";
         item.type = "Real";
-        item.description = R"(Whether to perfom Kerker scaling for charge density.
-* >0: The high frequency wave vectors will be suppressed by multiplying a scaling factor. Setting mixing_gg0 = 1.0 is normally a good starting point. Kerker preconditioner will be automatically turned off if mixing_beta <= 0.1.
+        item.description = R"(Controls the Kerker preconditioner for charge-density mixing.
+* >0: Enables Kerker scaling to suppress long-wavelength (small-G) charge-density fluctuations. Setting mixing_gg0 = 1.0 is normally a good starting point. This setting has no effect when mixing_beta <= 0.1 because the charge-density Kerker preconditioner is bypassed.
 * 0: No Kerker scaling is performed.
 
 For systems that are difficult to converge, particularly metallic systems, enabling Kerker scaling may aid in achieving convergence.)";
@@ -727,7 +727,9 @@ For systems that are difficult to converge, particularly metallic systems, enabl
         item.annotation = "mixing parameter in kerker";
         item.category = "Electronic structure";
         item.type = "Real";
-        item.description = "Whether to perfom Kerker preconditioner of magnetic density. Note: we do not recommand to open Kerker preconditioner of magnetic density unless the system is too hard to converge.";
+        item.description = R"(Controls the Kerker preconditioner for magnetic-density mixing. It is disabled by default and is generally only recommended for systems whose magnetic density is difficult to converge.
+
+The magnetic-density Kerker preconditioner is bypassed when mixing_beta_mag <= 0.1, so mixing_gg0_mag has no effect in that regime. It is also unavailable when the charge-density Kerker preconditioner itself is bypassed.)";
         item.default_value = "0.0";
         item.unit = "";
         item.availability = "";
@@ -739,7 +741,9 @@ For systems that are difficult to converge, particularly metallic systems, enabl
         item.annotation = "the minimum kerker coefficient";
         item.category = "Electronic structure";
         item.type = "Real";
-        item.description = "The minimum kerker coefficient.";
+        item.description = R"(Sets the lower bound used by the Kerker filter. The lower bound is evaluated as mixing_gg0_min / mixing_beta for charge-density mixing and mixing_gg0_min / mixing_beta_mag for magnetic-density mixing.
+
+In the current implementation, the automatic bypass thresholds are fixed independently of mixing_gg0_min: charge-density Kerker is bypassed when mixing_beta <= 0.1, and magnetic-density Kerker is bypassed when mixing_beta_mag <= 0.1. Changing mixing_gg0_min does not change these thresholds or re-enable Kerker.)";
         item.default_value = "0.1";
         item.unit = "";
         item.availability = "";


### PR DESCRIPTION
## Linked Issue

Fixes #7766

## Summary

This PR clarifies the documentation of the Kerker-related INPUT parameters:

- `mixing_gg0`
- `mixing_gg0_mag`
- `mixing_gg0_min`

It documents when Kerker preconditioning is bypassed and clarifies that changing `mixing_gg0_min` does not alter the fixed `mixing_beta <= 0.1` or `mixing_beta_mag <= 0.1` bypass conditions.

No numerical behavior, default value, INPUT parsing logic, or Kerker implementation is changed.

## Background

Kerker preconditioning is used to suppress long-wavelength (small-wave-vector) charge-density fluctuations, commonly known as charge sloshing, during SCF iterations.

For the charge-density channel, the Kerker filter contains a lower bound of the form

```math
f(G) =
\max\left(
\frac{G^2}{G^2 + G_0^2},
\frac{\mathrm{mixing\_gg0\_min}}
     {\mathrm{mixing\_beta}}
\right).
```

The magnetic-density channel uses the analogous ratio

```math
\frac{\mathrm{mixing\_gg0\_min}}
     {\mathrm{mixing\_beta\_mag}}.
```

With the default `mixing_gg0_min = 0.1`, the lower bound reaches or exceeds 1 when the corresponding mixing parameter is less than or equal to 0.1. Such a factor would no longer provide suppression and could become amplifying. The current implementation therefore bypasses Kerker preconditioning in this regime.

The bypass thresholds are fixed in the current implementation:

- Charge-density Kerker is bypassed when `mixing_beta <= 0.1`.
- Magnetic-density Kerker is bypassed when `mixing_beta_mag <= 0.1`.
- The magnetic-density Kerker path is also unavailable when the charge-density Kerker preconditioner itself is bypassed.

These conditions are independent of the user-provided value of `mixing_gg0_min`. Changing `mixing_gg0_min` affects the filter lower bound when Kerker is active, but it does not change the fixed bypass thresholds or re-enable Kerker.

## What's changed?

- Clarified that `mixing_gg0` controls suppression of long-wavelength, small-\(G\) charge-density fluctuations.
- Documented that `mixing_gg0` has no effect when `mixing_beta <= 0.1`.
- Documented the corresponding `mixing_beta_mag <= 0.1` condition for `mixing_gg0_mag`.
- Clarified that magnetic-density Kerker is unavailable when the charge-density Kerker path is bypassed.
- Expanded the `mixing_gg0_min` description to explain how it enters the charge and magnetic filter lower bounds.
- Explicitly documented that changing `mixing_gg0_min` does not change either fixed bypass threshold.
- Synchronized the built-in CLI help, `docs/parameters.yaml`, and the generated `input-main.md`.

Although a C++ file appears in the diff, only the `Input_Item` documentation strings are changed. No calculation code is modified.
