### PR TITLE
CI: isolate LTS container packages

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -26,8 +26,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/deepmodeling/abacus-${{ matrix.dockerfile }}
-            dp-harbor-registry.us-east-1.cr.aliyuncs.com/deepmodeling/abacus-${{ matrix.dockerfile }}
+            ghcr.io/deepmodeling/abacus-${{ matrix.dockerfile }}-lts
+            dp-harbor-registry.us-east-1.cr.aliyuncs.com/deepmodeling/abacus-${{ matrix.dockerfile }}-lts
           tags: |
             type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' }}
             type=raw,value=latest
@@ -57,5 +57,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           file: Dockerfile.${{ matrix.dockerfile }}
           push: true
-          cache-from: type=registry,ref=ghcr.io/deepmodeling/abacus-${{ matrix.dockerfile }}:latest
+          cache-from: type=registry,ref=ghcr.io/deepmodeling/abacus-${{ matrix.dockerfile }}-lts:latest
           cache-to: type=inline


### PR DESCRIPTION
### Reminder
- [x] Have you linked an issue with this pull request?
- [x] Have you added adequate unit tests and/or case tests for your pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [x] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (not applicable)

### Linked Issue
Fix #7780

### Unit Tests and/or Case Tests for my changes
- `ruby -e 'require "yaml"; YAML.parse_file(".github/workflows/devcontainer.yml")'` -- passed.
- A focused assertion verified that all three registry publish/cache references use the `-lts` suffix -- passed (`3/3 isolated`).
- `git diff --check` -- passed.
- A live container publication was not run locally because it requires the upstream `X64` runner and registry credentials.

### What's changed?
- Publish LTS images as `abacus-{gnu,intel,cuda}-lts` in both GHCR and the AliCloud registry.
- Read the BuildKit cache from the corresponding `abacus-*-lts:latest` package.
- Preserve the existing unsuffixed `abacus-*:latest` names for develop and existing consumers, avoiding a breaking migration of legacy workflows and user scripts.
- Keep LTS CI consumers on their current image references for now; the new packages do not exist until this PR is merged and the LTS Container workflow runs.

This prevents future LTS pushes from overwriting the develop images. The first LTS build may be a cold build because the suffixed cache packages do not exist yet. After this PR is merged, the develop Container workflow still needs to be rerun once to restore the currently overwritten unsuffixed `latest` images.

### Any changes of core modules? (ignore if not applicable)
- None. This PR only changes the LTS container publication destinations.
