### PR TITLE
CI: use LTS container packages in test workflows

### DIFF
--- a/.github/workflows/build_test_cmake.yml
+++ b/.github/workflows/build_test_cmake.yml
@@ -41,7 +41,7 @@ jobs:
             name: "Build without LCAO and MPI"
 
     name: ${{ matrix.name }}
-    container: ghcr.io/deepmodeling/abacus-${{ matrix.tag }}
+    container: ghcr.io/deepmodeling/abacus-${{ matrix.tag }}-lts
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build_test_makefile.yml
+++ b/.github/workflows/build_test_makefile.yml
@@ -13,7 +13,7 @@ jobs:
           build_args: "CXX=mpiicpc ELPA_LIB_DIR=/usr/local/lib ELPA_INCLUDE_DIR=/usr/local/include CEREAL_DIR=/usr/include/cereal OPENMP=ON"
           name: "Build with Makefile & Intel compilers"
     name: ${{ matrix.name }}
-    container: ghcr.io/deepmodeling/abacus-${{ matrix.tag }}
+    container: ghcr.io/deepmodeling/abacus-${{ matrix.tag }}-lts
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ jobs:
   test-coverage:
     name: Generate Coverage Report
     runs-on: X64
-    container: ghcr.io/deepmodeling/abacus-gnu
+    container: ghcr.io/deepmodeling/abacus-gnu-lts
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: nvidia
     if: github.repository_owner == 'deepmodeling'
     container:
-      image: ghcr.io/deepmodeling/abacus-cuda
+      image: ghcr.io/deepmodeling/abacus-cuda-lts
       volumes:
         - /tmp/ccache:/github/home/.ccache
       options: --gpus all

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -26,8 +26,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/deepmodeling/abacus-${{ matrix.dockerfile }}
-            dp-harbor-registry.us-east-1.cr.aliyuncs.com/deepmodeling/abacus-${{ matrix.dockerfile }}
+            ghcr.io/deepmodeling/abacus-${{ matrix.dockerfile }}-lts
+            dp-harbor-registry.us-east-1.cr.aliyuncs.com/deepmodeling/abacus-${{ matrix.dockerfile }}-lts
           tags: |
             type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' }}
             type=raw,value=latest
@@ -57,5 +57,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           file: Dockerfile.${{ matrix.dockerfile }}
           push: true
-          cache-from: type=registry,ref=ghcr.io/deepmodeling/abacus-${{ matrix.dockerfile }}:latest
+          cache-from: type=registry,ref=ghcr.io/deepmodeling/abacus-${{ matrix.dockerfile }}-lts:latest
           cache-to: type=inline

--- a/.github/workflows/dynamic.yml
+++ b/.github/workflows/dynamic.yml
@@ -10,7 +10,7 @@ jobs:
     name: Dynamic analysis
     runs-on: X64
     if: github.repository_owner == 'deepmodeling'
-    container: ghcr.io/deepmodeling/abacus-gnu
+    container: ghcr.io/deepmodeling/abacus-gnu-lts
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         tag: ["gnu", "intel"]
-    container: ghcr.io/deepmodeling/abacus-${{ matrix.tag }}
+    container: ghcr.io/deepmodeling/abacus-${{ matrix.tag }}-lts
     timeout-minutes: 2880
     steps:
       - name: Checkout

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,7 +8,7 @@ jobs:
     name: PyTest
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/deepmodeling/abacus-gnu
+      image: ghcr.io/deepmodeling/abacus-gnu-lts
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: X64
     if: github.repository_owner == 'deepmodeling'
     container:
-      image: ghcr.io/deepmodeling/abacus-gnu
+      image: ghcr.io/deepmodeling/abacus-gnu-lts
       volumes:
         - /tmp/ccache:/github/home/.ccache
     steps:

--- a/.github/workflows/toolchain_full.yaml
+++ b/.github/workflows/toolchain_full.yaml
@@ -13,7 +13,7 @@ jobs:
     if: contains(inputs.variants || 'gnu,intel,cuda', 'gnu')
     runs-on: X64
     container:
-      image: ghcr.io/deepmodeling/abacus-gnu
+      image: ghcr.io/deepmodeling/abacus-gnu-lts
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -52,7 +52,7 @@ jobs:
     if: contains(inputs.variants || 'gnu,intel,cuda', 'intel')
     runs-on: X64
     container:
-      image: ghcr.io/deepmodeling/abacus-intel
+      image: ghcr.io/deepmodeling/abacus-intel-lts
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/toolchain_smoke.yaml
+++ b/.github/workflows/toolchain_smoke.yaml
@@ -11,7 +11,7 @@ jobs:
   smoke-build-gnu:
     runs-on: X64
     container:
-      image: ghcr.io/deepmodeling/abacus-gnu
+      image: ghcr.io/deepmodeling/abacus-gnu-lts
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
> [!IMPORTANT]
> This PR depends on #7781 and must not be merged first.
>
> Merge order:
> 1. Merge #7781 into `LTS`.
> 2. Wait for its Container workflow to publish and verify that `abacus-gnu-lts:latest`, `abacus-intel-lts:latest`, and `abacus-cuda-lts:latest` are pullable.
> 3. Rebase/update this PR, mark it ready for review, and merge it into `LTS`.

### Reminder
- [x] Have you linked an issue with this pull request?
- [x] Have you added adequate unit tests and/or case tests for your pull request?
- [x] Have you noticed possible changes of behavior below or in the linked issue?
- [x] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (not applicable)

### Linked Issue
Follow-up to #7781. Related to #7780.

### Unit Tests and/or Case Tests for my changes
- Parsed all 10 changed workflow files with Ruby/Psych -- passed (`10/10`).
- Verified every ABACUS GHCR reference in the LTS workflows uses the `-lts` package namespace -- passed (`13/13`).
- `git diff --check upstream/LTS...HEAD` -- passed.
- Runtime Actions verification is intentionally blocked until #7781 publishes the three LTS images.

### What's changed?
- Switch GNU, Intel, and CUDA container references in all LTS test workflows from the develop-owned `abacus-*` packages to `abacus-*-lts`.
- Cover Build Test, Makefile Build Test, integration/unit tests, PyTest, coverage, CUDA, dynamic, performance, and full/smoke toolchain workflows.
- Keep the unsuffixed `abacus-*:latest` packages owned by develop for backward compatibility with existing consumers.

This branch is stacked on #7781, so the PR currently also contains its publisher-isolation commit. Once #7781 is merged into `LTS`, only the test-consumer migration remains as the effective diff.

### Any changes of core modules? (ignore if not applicable)
- None. This PR only changes LTS workflow container references.
