### PR TITLE
Feature: Generalize element-wise vector operators for complex operands

### DIFF
--- a/source/source_base/kernels/cuda/math_kernel_op_vec.cu
+++ b/source/source_base/kernels/cuda/math_kernel_op_vec.cu
@@ -32,11 +32,11 @@ __global__ void vector_mul_real_kernel(const int size,
     }
 }
 
-template <typename T>
+template <typename T, typename Operand>
 __global__ void vector_mul_vector_kernel(const int size,
                                          T* result,
                                          const T* vector1,
-                                         const typename GetTypeReal<T>::type* vector2,
+                                         const Operand* vector2,
                                          const bool add)
 {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -66,11 +66,11 @@ __global__ void vector_div_constant_kernel(const int size,
     }
 }
 
-template <typename T>
+template <typename T, typename Operand>
 __global__ void vector_div_vector_kernel(const int size,
                                          T* result,
                                          const T* vector1,
-                                         const typename GetTypeReal<T>::type* vector2)
+                                         const Operand* vector2)
 {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i < size)
@@ -79,13 +79,13 @@ __global__ void vector_div_vector_kernel(const int size,
     }
 }
 
-template <typename T, typename Real>
-__global__ void constantvector_addORsub_constantVector_kernel(const int size,
-                                                              T* result,
-                                                              const T* vector1,
-                                                              const Real constant1,
-                                                              const T* vector2,
-                                                              const Real constant2)
+template <typename T, typename Scalar>
+__global__ void vector_add_vector_kernel(const int size,
+                                         T* result,
+                                         const T* vector1,
+                                         const Scalar constant1,
+                                         const T* vector2,
+                                         const Scalar constant2)
 {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i < size)
@@ -190,123 +190,89 @@ void vector_div_constant_op<std::complex<double>, base_device::DEVICE_GPU>::oper
     vector_div_constant_wrapper(dim, result, vector, constant);
 }
 
-// vector operator: result[i] = vector1[i](not complex) * vector2[i](not complex)
-template <>
-void vector_mul_vector_op<double, base_device::DEVICE_GPU>::operator()(const int& dim,
-                                                                       double* result,
-                                                                       const double* vector1,
-                                                                       const double* vector2,
-                                                                       const bool& add)
-{
-    int thread = thread_per_block;
-    int block = (dim + thread - 1) / thread;
-    vector_mul_vector_kernel<double><<<block, thread>>>(dim, result, vector1, vector2, add);
-
-    CHECK_CUDA_SYNC();
-}
-// vector operator: result[i] = vector1[i](complex) * vector2[i](not complex)
-template <typename FPTYPE>
-inline void vector_mul_vector_complex_wrapper(const int& dim,
-                                              std::complex<FPTYPE>* result,
-                                              const std::complex<FPTYPE>* vector1,
-                                              const FPTYPE* vector2,
-                                              const bool& add)
-{
-    thrust::complex<FPTYPE>* result_tmp = reinterpret_cast<thrust::complex<FPTYPE>*>(result);
-    const thrust::complex<FPTYPE>* vector1_tmp = reinterpret_cast<const thrust::complex<FPTYPE>*>(vector1);
-    int thread = thread_per_block;
-    int block = (dim + thread - 1) / thread;
-    vector_mul_vector_kernel<thrust::complex<FPTYPE>><<<block, thread>>>(dim, result_tmp, vector1_tmp, vector2, add);
-
-    CHECK_CUDA_SYNC();
-}
-template <>
-void vector_mul_vector_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const int& dim,
-                                                                                    std::complex<float>* result,
-                                                                                    const std::complex<float>* vector1,
-                                                                                    const float* vector2,
-                                                                                    const bool& add)
-{
-    vector_mul_vector_complex_wrapper(dim, result, vector1, vector2, add);
-}
-template <>
-void vector_mul_vector_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(
-    const int& dim,
-    std::complex<double>* result,
-    const std::complex<double>* vector1,
-    const double* vector2,
-    const bool& add)
-{
-    vector_mul_vector_complex_wrapper(dim, result, vector1, vector2, add);
-}
-
-// vector operator: result[i] = vector1[i](not complex) / vector2[i](not complex)
-template <>
-void vector_div_vector_op<double, base_device::DEVICE_GPU>::operator()(const int& dim,
-                                                                       double* result,
-                                                                       const double* vector1,
-                                                                       const double* vector2)
-{
-    int thread = thread_per_block;
-    int block = (dim + thread - 1) / thread;
-    vector_div_vector_kernel<double><<<block, thread>>>(dim, result, vector1, vector2);
-
-    CHECK_CUDA_SYNC();
-}
-// vector operator: result[i] = vector1[i](complex) / vector2[i](not complex)
-template <typename FPTYPE>
-inline void vector_div_vector_complex_wrapper(const int& dim,
-                                              std::complex<FPTYPE>* result,
-                                              const std::complex<FPTYPE>* vector1,
-                                              const FPTYPE* vector2)
-{
-    thrust::complex<FPTYPE>* result_tmp = reinterpret_cast<thrust::complex<FPTYPE>*>(result);
-    const thrust::complex<FPTYPE>* vector1_tmp = reinterpret_cast<const thrust::complex<FPTYPE>*>(vector1);
-    int thread = thread_per_block;
-    int block = (dim + thread - 1) / thread;
-    vector_div_vector_kernel<thrust::complex<FPTYPE>><<<block, thread>>>(dim, result_tmp, vector1_tmp, vector2);
-
-    CHECK_CUDA_SYNC();
-}
-template <>
-void vector_div_vector_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const int& dim,
-                                                                                    std::complex<float>* result,
-                                                                                    const std::complex<float>* vector1,
-                                                                                    const float* vector2)
-{
-    vector_div_vector_complex_wrapper(dim, result, vector1, vector2);
-}
-template <>
-void vector_div_vector_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(
-    const int& dim,
-    std::complex<double>* result,
-    const std::complex<double>* vector1,
-    const double* vector2)
-{
-    vector_div_vector_complex_wrapper(dim, result, vector1, vector2);
-}
-
-// vector operator: result[i] = vector1[i] * constant1 + vector2[i] * constant2
 template <typename T>
-void vector_add_vector_op<T, base_device::DEVICE_GPU>::operator()(const int& dim,
-                                                                                       T* result,
-                                                                                       const T* vector1,
-                                                                                       const Real constant1,
-                                                                                       const T* vector2,
-                                                                                       const Real constant2)
+inline T to_device_value(const T value)
 {
-    using Type = typename GetTypeThrust<T>::type;
-    using Real = typename GetTypeReal<T>::type;
+    return value;
+}
 
-    auto result_tmp = reinterpret_cast<Type*>(result);
-    auto vector1_tmp = reinterpret_cast<const Type*>(vector1);
-    auto vector2_tmp = reinterpret_cast<const Type*>(vector2);
+template <typename FPTYPE>
+inline thrust::complex<FPTYPE> to_device_value(const std::complex<FPTYPE> value)
+{
+    return thrust::complex<FPTYPE>(value.real(), value.imag());
+}
 
-    int thread = thread_per_block;
-    int block = (dim + thread - 1) / thread;
-    constantvector_addORsub_constantVector_kernel<Type, Real>
-        <<<block, thread>>>(dim, result_tmp, vector1_tmp, constant1, vector2_tmp, constant2);
+template <typename T, typename Operand>
+void vector_mul_vector_op<T, base_device::DEVICE_GPU, Operand>::operator()(const int& dim,
+                                                                           T* result,
+                                                                           const T* vector1,
+                                                                           const Operand* vector2,
+                                                                           const bool& add)
+{
+    if (dim <= 0)
+    {
+        return;
+    }
 
+    using DeviceT = typename GetTypeThrust<T>::type;
+    using DeviceOperand = typename GetTypeThrust<Operand>::type;
+    auto result_tmp = reinterpret_cast<DeviceT*>(result);
+    auto vector1_tmp = reinterpret_cast<const DeviceT*>(vector1);
+    auto vector2_tmp = reinterpret_cast<const DeviceOperand*>(vector2);
+    const int thread = thread_per_block;
+    const int block = (dim + thread - 1) / thread;
+    vector_mul_vector_kernel<DeviceT, DeviceOperand>
+        <<<block, thread>>>(dim, result_tmp, vector1_tmp, vector2_tmp, add);
+    CHECK_CUDA_SYNC();
+}
+
+template <typename T, typename Operand>
+void vector_div_vector_op<T, base_device::DEVICE_GPU, Operand>::operator()(const int& dim,
+                                                                           T* result,
+                                                                           const T* vector1,
+                                                                           const Operand* vector2)
+{
+    if (dim <= 0)
+    {
+        return;
+    }
+
+    using DeviceT = typename GetTypeThrust<T>::type;
+    using DeviceOperand = typename GetTypeThrust<Operand>::type;
+    auto result_tmp = reinterpret_cast<DeviceT*>(result);
+    auto vector1_tmp = reinterpret_cast<const DeviceT*>(vector1);
+    auto vector2_tmp = reinterpret_cast<const DeviceOperand*>(vector2);
+    const int thread = thread_per_block;
+    const int block = (dim + thread - 1) / thread;
+    vector_div_vector_kernel<DeviceT, DeviceOperand>
+        <<<block, thread>>>(dim, result_tmp, vector1_tmp, vector2_tmp);
+    CHECK_CUDA_SYNC();
+}
+
+template <typename T, typename Scalar>
+void vector_add_vector_op<T, base_device::DEVICE_GPU, Scalar>::operator()(const int& dim,
+                                                                          T* result,
+                                                                          const T* vector1,
+                                                                          const Scalar constant1,
+                                                                          const T* vector2,
+                                                                          const Scalar constant2)
+{
+    if (dim <= 0)
+    {
+        return;
+    }
+
+    using DeviceT = typename GetTypeThrust<T>::type;
+    using DeviceScalar = typename GetTypeThrust<Scalar>::type;
+    auto result_tmp = reinterpret_cast<DeviceT*>(result);
+    auto vector1_tmp = reinterpret_cast<const DeviceT*>(vector1);
+    auto vector2_tmp = reinterpret_cast<const DeviceT*>(vector2);
+    const DeviceScalar device_constant1 = to_device_value(constant1);
+    const DeviceScalar device_constant2 = to_device_value(constant2);
+    const int thread = thread_per_block;
+    const int block = (dim + thread - 1) / thread;
+    vector_add_vector_kernel<DeviceT, DeviceScalar>
+        <<<block, thread>>>(dim, result_tmp, vector1_tmp, device_constant1, vector2_tmp, device_constant2);
     CHECK_CUDA_SYNC();
 }
 
@@ -373,18 +339,26 @@ template struct vector_div_constant_op<std::complex<float>, base_device::DEVICE_
 template struct vector_div_constant_op<double, base_device::DEVICE_GPU>;
 template struct vector_div_constant_op<std::complex<double>, base_device::DEVICE_GPU>;
 
-template struct vector_mul_vector_op<float, base_device::DEVICE_GPU>;
-template struct vector_mul_vector_op<std::complex<float>, base_device::DEVICE_GPU>;
-template struct vector_mul_vector_op<double, base_device::DEVICE_GPU>;
-template struct vector_mul_vector_op<std::complex<double>, base_device::DEVICE_GPU>;
-template struct vector_div_vector_op<std::complex<float>, base_device::DEVICE_GPU>;
-template struct vector_div_vector_op<double, base_device::DEVICE_GPU>;
-template struct vector_div_vector_op<std::complex<double>, base_device::DEVICE_GPU>;
+template struct vector_mul_vector_op<float, base_device::DEVICE_GPU, float>;
+template struct vector_mul_vector_op<double, base_device::DEVICE_GPU, double>;
+template struct vector_mul_vector_op<std::complex<float>, base_device::DEVICE_GPU, float>;
+template struct vector_mul_vector_op<std::complex<double>, base_device::DEVICE_GPU, double>;
+template struct vector_mul_vector_op<std::complex<float>, base_device::DEVICE_GPU, std::complex<float>>;
+template struct vector_mul_vector_op<std::complex<double>, base_device::DEVICE_GPU, std::complex<double>>;
 
-template struct vector_add_vector_op<float, base_device::DEVICE_GPU>;
-template struct vector_add_vector_op<std::complex<float>, base_device::DEVICE_GPU>;
-template struct vector_add_vector_op<double, base_device::DEVICE_GPU>;
-template struct vector_add_vector_op<std::complex<double>, base_device::DEVICE_GPU>;
+template struct vector_div_vector_op<float, base_device::DEVICE_GPU, float>;
+template struct vector_div_vector_op<double, base_device::DEVICE_GPU, double>;
+template struct vector_div_vector_op<std::complex<float>, base_device::DEVICE_GPU, float>;
+template struct vector_div_vector_op<std::complex<double>, base_device::DEVICE_GPU, double>;
+template struct vector_div_vector_op<std::complex<float>, base_device::DEVICE_GPU, std::complex<float>>;
+template struct vector_div_vector_op<std::complex<double>, base_device::DEVICE_GPU, std::complex<double>>;
+
+template struct vector_add_vector_op<float, base_device::DEVICE_GPU, float>;
+template struct vector_add_vector_op<double, base_device::DEVICE_GPU, double>;
+template struct vector_add_vector_op<std::complex<float>, base_device::DEVICE_GPU, float>;
+template struct vector_add_vector_op<std::complex<double>, base_device::DEVICE_GPU, double>;
+template struct vector_add_vector_op<std::complex<float>, base_device::DEVICE_GPU, std::complex<float>>;
+template struct vector_add_vector_op<std::complex<double>, base_device::DEVICE_GPU, std::complex<double>>;
 
 template struct dot_real_op<std::complex<float>, base_device::DEVICE_GPU>;
 template struct dot_real_op<double, base_device::DEVICE_GPU>;

--- a/source/source_base/kernels/math_kernel_op.h
+++ b/source/source_base/kernels/math_kernel_op.h
@@ -80,10 +80,9 @@ template <typename T, typename Device> struct vector_mul_real_op {
   void operator()(const int dim, T* result, const T* vector, const Real constant);
 };
 
-// vector operator: result[i] = vector1[i](complex) * vector2[i](not complex)
-template <typename T, typename Device> struct vector_mul_vector_op {
-  using Real = typename GetTypeReal<T>::type;
-  /// @brief result[i] = vector1[i](complex) * vector2[i](not complex)
+// vector operator: result[i] = vector1[i] * vector2[i]
+template <typename T, typename Device, typename Operand> struct vector_mul_vector_op {
+  /// @brief result[i] = vector1[i] * vector2[i]
   ///
   /// Input Parameters
   /// \param dim : array size
@@ -93,7 +92,32 @@ template <typename T, typename Device> struct vector_mul_vector_op {
   ///
   /// Output Parameters
   /// \param result : output array
-  void operator()(const int& dim, T* result, const T* vector1, const Real* vector2, const bool& add = false);
+  void operator()(const int& dim, T* result, const T* vector1, const Operand* vector2, const bool& add);
+};
+
+template <typename T, typename Operand>
+struct vector_mul_vector_op<T, base_device::DEVICE_CPU, Operand> {
+  void operator()(const int &dim, T *result, const T *vector1,
+                  const Operand *vector2, const bool &add) {
+    if (dim <= 0) {
+      return;
+    }
+    if (add) {
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+      for (int i = 0; i < dim; i++) {
+        result[i] += vector1[i] * vector2[i];
+      }
+    } else {
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+      for (int i = 0; i < dim; i++) {
+        result[i] = vector1[i] * vector2[i];
+      }
+    }
+  }
 };
 
 // vector operator: result[i] = vector[i] / constant
@@ -111,10 +135,9 @@ template <typename T, typename Device> struct vector_div_constant_op {
   void operator()(const int& dim, T* result, const T* vector, const Real constant);
 };
 
-// vector operator: result[i] = vector1[i](complex) / vector2[i](not complex)
-template <typename T, typename Device> struct vector_div_vector_op {
-  using Real = typename GetTypeReal<T>::type;
-  /// @brief result[i] = vector1[i](complex) / vector2[i](not complex)
+// vector operator: result[i] = vector1[i] / vector2[i]
+template <typename T, typename Device, typename Operand> struct vector_div_vector_op {
+  /// @brief result[i] = vector1[i] / vector2[i]
   ///
   /// Input Parameters
   /// \param dim : array size
@@ -124,7 +147,23 @@ template <typename T, typename Device> struct vector_div_vector_op {
   /// Output Parameters
   /// \param result : output array
   void operator()(const int &dim, T *result, const T *vector1,
-                  const Real *vector2);
+                  const Operand *vector2);
+};
+
+template <typename T, typename Operand>
+struct vector_div_vector_op<T, base_device::DEVICE_CPU, Operand> {
+  void operator()(const int &dim, T *result, const T *vector1,
+                  const Operand *vector2) {
+    if (dim <= 0) {
+      return;
+    }
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (int i = 0; i < dim; i++) {
+      result[i] = vector1[i] / vector2[i];
+    }
+  }
 };
 
 //  compute Y = alpha * X + Y
@@ -146,9 +185,8 @@ template <typename T, typename Device> struct axpy_op {
 };
 
 // vector operator: result[i] = vector1[i] * constant1 + vector2[i] * constant2
-template <typename T, typename Device>
+template <typename T, typename Device, typename Scalar>
 struct vector_add_vector_op {
-  using Real = typename GetTypeReal<T>::type;
   /// @brief result[i] = vector1[i] * constant1 + vector2[i] * constant2
   ///
   /// Input Parameters
@@ -161,7 +199,24 @@ struct vector_add_vector_op {
   /// Output Parameters
   /// \param result : output array
   void operator()(const int &dim, T *result, const T *vector1,
-                  const Real constant1, const T *vector2, const Real constant2);
+                  const Scalar constant1, const T *vector2, const Scalar constant2);
+};
+
+template <typename T, typename Scalar>
+struct vector_add_vector_op<T, base_device::DEVICE_CPU, Scalar> {
+  void operator()(const int &dim, T *result, const T *vector1,
+                  const Scalar constant1, const T *vector2,
+                  const Scalar constant2) {
+    if (dim <= 0) {
+      return;
+    }
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (int i = 0; i < dim; i++) {
+      result[i] = vector1[i] * constant1 + vector2[i] * constant2;
+    }
+  }
 };
 
 template <typename T, typename Device> struct dot_real_op {
@@ -405,10 +460,10 @@ struct vector_mul_real_op<T, base_device::DEVICE_GPU>
   void operator()(const int dim, T* result, const T* vector, const Real constant);
 };
 
-// vector operator: result[i] = vector1[i](complex) * vector2[i](not complex)
-template <typename T> struct vector_mul_vector_op<T, base_device::DEVICE_GPU> {
-  using Real = typename GetTypeReal<T>::type;
-  void operator()(const int& dim, T* result, const T* vector1, const Real* vector2, const bool& add = false);
+// vector operator: result[i] = vector1[i] * vector2[i]
+template <typename T, typename Operand>
+struct vector_mul_vector_op<T, base_device::DEVICE_GPU, Operand> {
+  void operator()(const int& dim, T* result, const T* vector1, const Operand* vector2, const bool& add);
 };
 
 // vector operator: result[i] = vector[i] / constant
@@ -417,20 +472,19 @@ template <typename T> struct vector_div_constant_op<T, base_device::DEVICE_GPU> 
   void operator()(const int& dim, T* result, const T* vector, const Real constant);
 };
 
-// vector operator: result[i] = vector1[i](complex) / vector2[i](not complex)
-template <typename T> struct vector_div_vector_op<T, base_device::DEVICE_GPU> {
-  using Real = typename GetTypeReal<T>::type;
+// vector operator: result[i] = vector1[i] / vector2[i]
+template <typename T, typename Operand>
+struct vector_div_vector_op<T, base_device::DEVICE_GPU, Operand> {
   void operator()(const int &dim, T *result,
-                  const T *vector1, const Real *vector2);
+                  const T *vector1, const Operand *vector2);
 };
 
 // vector operator: result[i] = vector1[i] * constant1 + vector2[i] * constant2
-template <typename T>
-struct vector_add_vector_op<T, base_device::DEVICE_GPU> {
-  using Real = typename GetTypeReal<T>::type;
+template <typename T, typename Scalar>
+struct vector_add_vector_op<T, base_device::DEVICE_GPU, Scalar> {
   void operator()(const int &dim, T *result,
-                  const T *vector1, const Real constant1, const T *vector2,
-                  const Real constant2);
+                  const T *vector1, const Scalar constant1, const T *vector2,
+                  const Scalar constant2);
 };
 
 template <typename T> struct matrixCopy<T, base_device::DEVICE_GPU> {

--- a/source/source_base/kernels/math_kernel_op_vec.cpp
+++ b/source/source_base/kernels/math_kernel_op_vec.cpp
@@ -35,35 +35,6 @@ struct vector_mul_real_op<T, base_device::DEVICE_CPU>
 };
 
 template <typename T>
-struct vector_mul_vector_op<T, base_device::DEVICE_CPU>
-{
-    using Real = typename GetTypeReal<T>::type;
-    void operator()(const int& dim, T* result, const T* vector1, const Real* vector2, const bool& add)
-    {
-        if (add)
-        {
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static)
-#endif
-            for (int i = 0; i < dim; i++)
-            {
-                result[i] += vector1[i] * vector2[i];
-            }
-        }
-        else
-        {
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static)
-#endif
-            for (int i = 0; i < dim; i++)
-            {
-                result[i] = vector1[i] * vector2[i];
-            }
-        }
-    }
-};
-
-template <typename T>
 struct vector_div_constant_op<T, base_device::DEVICE_CPU>
 {
     using Real = typename GetTypeReal<T>::type;
@@ -75,22 +46,6 @@ struct vector_div_constant_op<T, base_device::DEVICE_CPU>
         for (int i = 0; i < dim; i++)
         {
             result[i] = vector[i] / constant;
-        }
-    }
-};
-
-template <typename T>
-struct vector_div_vector_op<T, base_device::DEVICE_CPU>
-{
-    using Real = typename GetTypeReal<T>::type;
-    void operator()(const int& dim, T* result, const T* vector1, const Real* vector2)
-    {
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static)
-#endif
-        for (int i = 0; i < dim; i++)
-        {
-            result[i] = vector1[i] / vector2[i];
         }
     }
 };
@@ -108,29 +63,6 @@ struct axpy_op<T, base_device::DEVICE_CPU>
         BlasConnector::axpy(dim, *alpha, X, incX, Y, incY);
     }
 };
-
-
-template <typename T>
-struct vector_add_vector_op<T, base_device::DEVICE_CPU>
-{
-    using Real = typename GetTypeReal<T>::type;
-    void operator()(const int& dim,
-                    T* result,
-                    const T* vector1,
-                    const Real constant1,
-                    const T* vector2,
-                    const Real constant2)
-    {
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static)
-#endif
-        for (int i = 0; i < dim; i++)
-        {
-            result[i] = vector1[i] * constant1 + vector2[i] * constant2;
-        }
-    }
-};
-
 
 
 template <typename FPTYPE>
@@ -174,25 +106,34 @@ template struct vector_mul_real_op<std::complex<float>, base_device::DEVICE_CPU>
 template struct vector_mul_real_op<double, base_device::DEVICE_CPU>;
 template struct vector_mul_real_op<std::complex<double>, base_device::DEVICE_CPU>;
 
-template struct vector_mul_vector_op<std::complex<float>, base_device::DEVICE_CPU>;
-template struct vector_mul_vector_op<double, base_device::DEVICE_CPU>;
-template struct vector_mul_vector_op<std::complex<double>, base_device::DEVICE_CPU>;
+template struct vector_mul_vector_op<float, base_device::DEVICE_CPU, float>;
+template struct vector_mul_vector_op<double, base_device::DEVICE_CPU, double>;
+template struct vector_mul_vector_op<std::complex<float>, base_device::DEVICE_CPU, float>;
+template struct vector_mul_vector_op<std::complex<double>, base_device::DEVICE_CPU, double>;
+template struct vector_mul_vector_op<std::complex<float>, base_device::DEVICE_CPU, std::complex<float>>;
+template struct vector_mul_vector_op<std::complex<double>, base_device::DEVICE_CPU, std::complex<double>>;
 
 template struct vector_div_constant_op<std::complex<float>, base_device::DEVICE_CPU>;
 template struct vector_div_constant_op<double, base_device::DEVICE_CPU>;
 template struct vector_div_constant_op<std::complex<double>, base_device::DEVICE_CPU>;
 
-template struct vector_div_vector_op<std::complex<float>, base_device::DEVICE_CPU>;
-template struct vector_div_vector_op<double, base_device::DEVICE_CPU>;
-template struct vector_div_vector_op<std::complex<double>, base_device::DEVICE_CPU>;
+template struct vector_div_vector_op<float, base_device::DEVICE_CPU, float>;
+template struct vector_div_vector_op<double, base_device::DEVICE_CPU, double>;
+template struct vector_div_vector_op<std::complex<float>, base_device::DEVICE_CPU, float>;
+template struct vector_div_vector_op<std::complex<double>, base_device::DEVICE_CPU, double>;
+template struct vector_div_vector_op<std::complex<float>, base_device::DEVICE_CPU, std::complex<float>>;
+template struct vector_div_vector_op<std::complex<double>, base_device::DEVICE_CPU, std::complex<double>>;
 
 template struct axpy_op<std::complex<float>, base_device::DEVICE_CPU>;
 template struct axpy_op<std::complex<double>, base_device::DEVICE_CPU>;
 template struct axpy_op<double, base_device::DEVICE_CPU>;
 
-template struct vector_add_vector_op<std::complex<float>, base_device::DEVICE_CPU>;
-template struct vector_add_vector_op<double, base_device::DEVICE_CPU>;
-template struct vector_add_vector_op<std::complex<double>, base_device::DEVICE_CPU>;
+template struct vector_add_vector_op<float, base_device::DEVICE_CPU, float>;
+template struct vector_add_vector_op<double, base_device::DEVICE_CPU, double>;
+template struct vector_add_vector_op<std::complex<float>, base_device::DEVICE_CPU, float>;
+template struct vector_add_vector_op<std::complex<double>, base_device::DEVICE_CPU, double>;
+template struct vector_add_vector_op<std::complex<float>, base_device::DEVICE_CPU, std::complex<float>>;
+template struct vector_add_vector_op<std::complex<double>, base_device::DEVICE_CPU, std::complex<double>>;
 
 template struct dot_real_op<std::complex<float>, base_device::DEVICE_CPU>;
 template struct dot_real_op<std::complex<double>, base_device::DEVICE_CPU>;

--- a/source/source_base/kernels/rocm/math_kernel_op_vec.hip.cu
+++ b/source/source_base/kernels/rocm/math_kernel_op_vec.hip.cu
@@ -29,11 +29,11 @@ __launch_bounds__(1024) __global__ void vector_mul_real_kernel(const int size,
     }
 }
 
-template <typename T>
+template <typename T, typename Operand>
 __launch_bounds__(1024) __global__ void vector_mul_vector_kernel(const int size,
                                                                  T* result,
                                                                  const T* vector1,
-                                                                 const typename GetTypeReal<T>::type* vector2,
+                                                                 const Operand* vector2,
                                                                  const bool add)
 {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -63,11 +63,11 @@ __launch_bounds__(1024) __global__ void vector_div_constant_kernel(const int siz
     }
 }
 
-template <typename T>
+template <typename T, typename Operand>
 __launch_bounds__(1024) __global__ void vector_div_vector_kernel(const int size,
                                                                  T* result,
                                                                  const T* vector1,
-                                                                 const typename GetTypeReal<T>::type* vector2)
+                                                                 const Operand* vector2)
 {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i < size)
@@ -76,13 +76,13 @@ __launch_bounds__(1024) __global__ void vector_div_vector_kernel(const int size,
     }
 }
 
-template <typename T, typename Real>
-__launch_bounds__(1024) __global__ void constantvector_addORsub_constantVector_kernel(const int size,
-                                                                                      T* result,
-                                                                                      const T* vector1,
-                                                                                      const Real constant1,
-                                                                                      const T* vector2,
-                                                                                      const Real constant2)
+template <typename T, typename Scalar>
+__launch_bounds__(1024) __global__ void vector_add_vector_kernel(const int size,
+                                                                 T* result,
+                                                                 const T* vector1,
+                                                                 const Scalar constant1,
+                                                                 const T* vector2,
+                                                                 const Scalar constant2)
 {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i < size)
@@ -218,158 +218,113 @@ void vector_div_constant_op<std::complex<double>, base_device::DEVICE_GPU>::oper
     vector_div_constant_wrapper(dim, result, vector, constant);
 }
 
-// vector operator: result[i] = vector1[i](not complex) * vector2[i](not complex)
-template <>
-void vector_mul_vector_op<double, base_device::DEVICE_GPU>::operator()(const int& dim,
-                                                                       double* result,
-                                                                       const double* vector1,
-                                                                       const double* vector2,
-                                                                       const bool& add)
-{
-    int thread = 1024;
-    int block = (dim + thread - 1) / thread;
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(vector_mul_vector_kernel<double>),
-                       dim3(block),
-                       dim3(thread),
-                       0,
-                       0,
-                       dim,
-                       result,
-                       vector1,
-                       vector2,
-                       add);
-
-    hipCheckOnDebug();
-}
-
-// vector operator: result[i] = vector1[i](complex) * vector2[i](not complex)
-template <typename FPTYPE>
-inline void vector_mul_vector_complex_wrapper(const int& dim,
-                                              std::complex<FPTYPE>* result,
-                                              const std::complex<FPTYPE>* vector1,
-                                              const FPTYPE* vector2,
-                                              const bool& add)
-{
-    thrust::complex<FPTYPE>* result_tmp = reinterpret_cast<thrust::complex<FPTYPE>*>(result);
-    const thrust::complex<FPTYPE>* vector1_tmp = reinterpret_cast<const thrust::complex<FPTYPE>*>(vector1);
-    int thread = 1024;
-    int block = (dim + thread - 1) / thread;
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(vector_mul_vector_kernel<thrust::complex<FPTYPE>>),
-                       dim3(block),
-                       dim3(thread),
-                       0,
-                       0,
-                       dim,
-                       result_tmp,
-                       vector1_tmp,
-                       vector2,
-                       add);
-
-    hipCheckOnDebug();
-}
-template <>
-void vector_mul_vector_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const int& dim,
-                                                                                    std::complex<float>* result,
-                                                                                    const std::complex<float>* vector1,
-                                                                                    const float* vector2,
-                                                                                    const bool& add)
-{
-    vector_mul_vector_complex_wrapper(dim, result, vector1, vector2, add);
-}
-template <>
-void vector_mul_vector_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(
-    const int& dim,
-    std::complex<double>* result,
-    const std::complex<double>* vector1,
-    const double* vector2,
-    const bool& add)
-{
-    vector_mul_vector_complex_wrapper(dim, result, vector1, vector2, add);
-}
-
-// vector operator: result[i] = vector1[i](complex) / vector2[i](not complex)
-template <>
-void vector_div_vector_op<double, base_device::DEVICE_GPU>::operator()(const int& dim,
-                                                                       double* result,
-                                                                       const double* vector1,
-                                                                       const double* vector2)
-{
-    int thread = 1024;
-    int block = (dim + thread - 1) / thread;
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(vector_div_vector_kernel<double>),
-                       dim3(block),
-                       dim3(thread),
-                       0,
-                       0,
-                       dim,
-                       result,
-                       vector1,
-                       vector2);
-
-    hipCheckOnDebug();
-}
-// vector operator: result[i] = vector1[i](complex) / vector2[i](not complex)
-template <typename FPTYPE>
-inline void vector_div_vector_op_complex_wrapper(const int& dim,
-                                                 std::complex<FPTYPE>* result,
-                                                 const std::complex<FPTYPE>* vector1,
-                                                 const FPTYPE* vector2)
-{
-    thrust::complex<FPTYPE>* result_tmp = reinterpret_cast<thrust::complex<FPTYPE>*>(result);
-    const thrust::complex<FPTYPE>* vector1_tmp = reinterpret_cast<const thrust::complex<FPTYPE>*>(vector1);
-    int thread = 1024;
-    int block = (dim + thread - 1) / thread;
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(vector_div_vector_kernel<thrust::complex<FPTYPE>>),
-                       dim3(block),
-                       dim3(thread),
-                       0,
-                       0,
-                       dim,
-                       result_tmp,
-                       vector1_tmp,
-                       vector2);
-
-    hipCheckOnDebug();
-}
-template <>
-void vector_div_vector_op<std::complex<float>, base_device::DEVICE_GPU>::operator()(const int& dim,
-                                                                                    std::complex<float>* result,
-                                                                                    const std::complex<float>* vector1,
-                                                                                    const float* vector2)
-{
-    vector_div_vector_op_complex_wrapper(dim, result, vector1, vector2);
-}
-template <>
-void vector_div_vector_op<std::complex<double>, base_device::DEVICE_GPU>::operator()(
-    const int& dim,
-    std::complex<double>* result,
-    const std::complex<double>* vector1,
-    const double* vector2)
-{
-    vector_div_vector_op_complex_wrapper(dim, result, vector1, vector2);
-}
-
-// vector operator: result[i] = vector1[i] * constant1 + vector2[i] * constant2
 template <typename T>
-void vector_add_vector_op<T, base_device::DEVICE_GPU>::operator()(const int& dim,
-                                                                                       T* result,
-                                                                                       const T* vector1,
-                                                                                       const Real constant1,
-                                                                                       const T* vector2,
-                                                                                       const Real constant2)
+inline T to_device_value(const T value)
 {
-    using Type = typename GetTypeThrust<T>::type;
-    using Real = typename GetTypeReal<T>::type;
+    return value;
+}
 
-    auto result_tmp = reinterpret_cast<Type*>(result);
-    auto vector1_tmp = reinterpret_cast<const Type*>(vector1);
-    auto vector2_tmp = reinterpret_cast<const Type*>(vector2);
+template <typename FPTYPE>
+inline thrust::complex<FPTYPE> to_device_value(const std::complex<FPTYPE> value)
+{
+    return thrust::complex<FPTYPE>(value.real(), value.imag());
+}
 
-    int thread = 1024;
-    int block = (dim + thread - 1) / thread;
-    constantvector_addORsub_constantVector_kernel<Type, Real>
-        <<<block, thread>>>(dim, result_tmp, vector1_tmp, constant1, vector2_tmp, constant2);
+template <typename T, typename Operand>
+void vector_mul_vector_op<T, base_device::DEVICE_GPU, Operand>::operator()(const int& dim,
+                                                                           T* result,
+                                                                           const T* vector1,
+                                                                           const Operand* vector2,
+                                                                           const bool& add)
+{
+    if (dim <= 0)
+    {
+        return;
+    }
 
+    using DeviceT = typename GetTypeThrust<T>::type;
+    using DeviceOperand = typename GetTypeThrust<Operand>::type;
+    auto result_tmp = reinterpret_cast<DeviceT*>(result);
+    auto vector1_tmp = reinterpret_cast<const DeviceT*>(vector1);
+    auto vector2_tmp = reinterpret_cast<const DeviceOperand*>(vector2);
+    const int thread = 1024;
+    const int block = (dim + thread - 1) / thread;
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(vector_mul_vector_kernel<DeviceT, DeviceOperand>),
+                       dim3(block),
+                       dim3(thread),
+                       0,
+                       0,
+                       dim,
+                       result_tmp,
+                       vector1_tmp,
+                       vector2_tmp,
+                       add);
+    hipCheckOnDebug();
+}
+
+template <typename T, typename Operand>
+void vector_div_vector_op<T, base_device::DEVICE_GPU, Operand>::operator()(const int& dim,
+                                                                           T* result,
+                                                                           const T* vector1,
+                                                                           const Operand* vector2)
+{
+    if (dim <= 0)
+    {
+        return;
+    }
+
+    using DeviceT = typename GetTypeThrust<T>::type;
+    using DeviceOperand = typename GetTypeThrust<Operand>::type;
+    auto result_tmp = reinterpret_cast<DeviceT*>(result);
+    auto vector1_tmp = reinterpret_cast<const DeviceT*>(vector1);
+    auto vector2_tmp = reinterpret_cast<const DeviceOperand*>(vector2);
+    const int thread = 1024;
+    const int block = (dim + thread - 1) / thread;
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(vector_div_vector_kernel<DeviceT, DeviceOperand>),
+                       dim3(block),
+                       dim3(thread),
+                       0,
+                       0,
+                       dim,
+                       result_tmp,
+                       vector1_tmp,
+                       vector2_tmp);
+    hipCheckOnDebug();
+}
+
+template <typename T, typename Scalar>
+void vector_add_vector_op<T, base_device::DEVICE_GPU, Scalar>::operator()(const int& dim,
+                                                                          T* result,
+                                                                          const T* vector1,
+                                                                          const Scalar constant1,
+                                                                          const T* vector2,
+                                                                          const Scalar constant2)
+{
+    if (dim <= 0)
+    {
+        return;
+    }
+
+    using DeviceT = typename GetTypeThrust<T>::type;
+    using DeviceScalar = typename GetTypeThrust<Scalar>::type;
+    auto result_tmp = reinterpret_cast<DeviceT*>(result);
+    auto vector1_tmp = reinterpret_cast<const DeviceT*>(vector1);
+    auto vector2_tmp = reinterpret_cast<const DeviceT*>(vector2);
+    const DeviceScalar device_constant1 = to_device_value(constant1);
+    const DeviceScalar device_constant2 = to_device_value(constant2);
+    const int thread = 1024;
+    const int block = (dim + thread - 1) / thread;
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(vector_add_vector_kernel<DeviceT, DeviceScalar>),
+                       dim3(block),
+                       dim3(thread),
+                       0,
+                       0,
+                       dim,
+                       result_tmp,
+                       vector1_tmp,
+                       device_constant1,
+                       vector2_tmp,
+                       device_constant2);
     hipCheckOnDebug();
 }
 
@@ -437,18 +392,26 @@ template struct vector_div_constant_op<std::complex<float>, base_device::DEVICE_
 template struct vector_div_constant_op<double, base_device::DEVICE_GPU>;
 template struct vector_div_constant_op<std::complex<double>, base_device::DEVICE_GPU>;
 
-template struct vector_mul_vector_op<float, base_device::DEVICE_GPU>;
-template struct vector_mul_vector_op<std::complex<float>, base_device::DEVICE_GPU>;
-template struct vector_mul_vector_op<double, base_device::DEVICE_GPU>;
-template struct vector_mul_vector_op<std::complex<double>, base_device::DEVICE_GPU>;
-template struct vector_div_vector_op<std::complex<float>, base_device::DEVICE_GPU>;
-template struct vector_div_vector_op<double, base_device::DEVICE_GPU>;
-template struct vector_div_vector_op<std::complex<double>, base_device::DEVICE_GPU>;
+template struct vector_mul_vector_op<float, base_device::DEVICE_GPU, float>;
+template struct vector_mul_vector_op<double, base_device::DEVICE_GPU, double>;
+template struct vector_mul_vector_op<std::complex<float>, base_device::DEVICE_GPU, float>;
+template struct vector_mul_vector_op<std::complex<double>, base_device::DEVICE_GPU, double>;
+template struct vector_mul_vector_op<std::complex<float>, base_device::DEVICE_GPU, std::complex<float>>;
+template struct vector_mul_vector_op<std::complex<double>, base_device::DEVICE_GPU, std::complex<double>>;
 
-template struct vector_add_vector_op<float, base_device::DEVICE_GPU>;
-template struct vector_add_vector_op<std::complex<float>, base_device::DEVICE_GPU>;
-template struct vector_add_vector_op<double, base_device::DEVICE_GPU>;
-template struct vector_add_vector_op<std::complex<double>, base_device::DEVICE_GPU>;
+template struct vector_div_vector_op<float, base_device::DEVICE_GPU, float>;
+template struct vector_div_vector_op<double, base_device::DEVICE_GPU, double>;
+template struct vector_div_vector_op<std::complex<float>, base_device::DEVICE_GPU, float>;
+template struct vector_div_vector_op<std::complex<double>, base_device::DEVICE_GPU, double>;
+template struct vector_div_vector_op<std::complex<float>, base_device::DEVICE_GPU, std::complex<float>>;
+template struct vector_div_vector_op<std::complex<double>, base_device::DEVICE_GPU, std::complex<double>>;
+
+template struct vector_add_vector_op<float, base_device::DEVICE_GPU, float>;
+template struct vector_add_vector_op<double, base_device::DEVICE_GPU, double>;
+template struct vector_add_vector_op<std::complex<float>, base_device::DEVICE_GPU, float>;
+template struct vector_add_vector_op<std::complex<double>, base_device::DEVICE_GPU, double>;
+template struct vector_add_vector_op<std::complex<float>, base_device::DEVICE_GPU, std::complex<float>>;
+template struct vector_add_vector_op<std::complex<double>, base_device::DEVICE_GPU, std::complex<double>>;
 
 template struct dot_real_op<std::complex<float>, base_device::DEVICE_GPU>;
 template struct dot_real_op<double, base_device::DEVICE_GPU>;

--- a/source/source_base/kernels/test/math_kernel_test.cpp
+++ b/source/source_base/kernels/test/math_kernel_test.cpp
@@ -69,23 +69,29 @@ class TestModuleHsolverMathKernel : public ::testing::Test
     using delete_memory_op_double = base_device::memory::delete_memory_op<double, base_device::DEVICE_GPU>;
     using synchronize_memory_op_double
         = base_device::memory::synchronize_memory_op<double, base_device::DEVICE_GPU, base_device::DEVICE_CPU>;
+    using synchronize_memory_op_double_gpu
+        = base_device::memory::synchronize_memory_op<double, base_device::DEVICE_CPU, base_device::DEVICE_GPU>;
 
     // haozhihan add
     // cpu operator
     using vector_mul_real_op_cpu = ModuleBase::vector_mul_real_op<std::complex<double>, base_device::DEVICE_CPU>;
-    using vector_mul_vector_op_cpu = ModuleBase::vector_mul_vector_op<std::complex<double>, base_device::DEVICE_CPU>;
-    using vector_div_vector_op_cpu = ModuleBase::vector_div_vector_op<std::complex<double>, base_device::DEVICE_CPU>;
+    using vector_mul_vector_op_cpu
+        = ModuleBase::vector_mul_vector_op<std::complex<double>, base_device::DEVICE_CPU, double>;
+    using vector_div_vector_op_cpu
+        = ModuleBase::vector_div_vector_op<std::complex<double>, base_device::DEVICE_CPU, double>;
     using vector_add_vector_op_cpu
-        = ModuleBase::vector_add_vector_op<std::complex<double>, base_device::DEVICE_CPU>;
+        = ModuleBase::vector_add_vector_op<std::complex<double>, base_device::DEVICE_CPU, double>;
     using axpy_op_cpu = ModuleBase::axpy_op<std::complex<double>, base_device::DEVICE_CPU>;
     using scal_op_cpu = ModuleBase::scal_op<double, base_device::DEVICE_CPU>;
     using gemv_op_cpu = ModuleBase::gemv_op<std::complex<double>, base_device::DEVICE_CPU>;
     // gpu operator
     using vector_mul_real_op_gpu = ModuleBase::vector_mul_real_op<std::complex<double>, base_device::DEVICE_GPU>;
-    using vector_mul_vector_op_gpu = ModuleBase::vector_mul_vector_op<std::complex<double>, base_device::DEVICE_GPU>;
-    using vector_div_vector_op_gpu = ModuleBase::vector_div_vector_op<std::complex<double>, base_device::DEVICE_GPU>;
+    using vector_mul_vector_op_gpu
+        = ModuleBase::vector_mul_vector_op<std::complex<double>, base_device::DEVICE_GPU, double>;
+    using vector_div_vector_op_gpu
+        = ModuleBase::vector_div_vector_op<std::complex<double>, base_device::DEVICE_GPU, double>;
     using vector_add_vector_op_gpu
-        = ModuleBase::vector_add_vector_op<std::complex<double>, base_device::DEVICE_GPU>;
+        = ModuleBase::vector_add_vector_op<std::complex<double>, base_device::DEVICE_GPU, double>;
     using axpy_op_gpu = ModuleBase::axpy_op<std::complex<double>, base_device::DEVICE_GPU>;
     using scal_op_gpu = ModuleBase::scal_op<double, base_device::DEVICE_GPU>;
     using gemv_op_gpu = ModuleBase::gemv_op<std::complex<double>, base_device::DEVICE_GPU>;
@@ -274,39 +280,129 @@ TEST_F(TestModuleHsolverMathKernel, vector_mul_real_op_cpu)
 
 TEST_F(TestModuleHsolverMathKernel, vector_mul_vector_op_cpu)
 {
-    std::vector<std::complex<double>> output(input.size());
-    vector_mul_vector_op_cpu()(dim, output.data(), input.data(), input_double.data());
-    for (int i = 0; i < input.size(); i++)
+    const std::vector<double> real1 = {1.5, -2.0, 4.0};
+    const std::vector<double> real2 = {-3.0, 0.5, 2.0};
+    std::vector<double> real_result(real1.size());
+    ModuleBase::vector_mul_vector_op<double, base_device::DEVICE_CPU, double>()(
+        real1.size(), real_result.data(), real1.data(), real2.data(), false);
+    for (std::size_t i = 0; i < real1.size(); ++i)
     {
-        EXPECT_LT(fabs(output[i].imag() - output_vector_mul_vector_op[i].imag()), 1e-8);
-        EXPECT_LT(fabs(output[i].real() - output_vector_mul_vector_op[i].real()), 1e-8);
+        EXPECT_DOUBLE_EQ(real_result[i], real1[i] * real2[i]);
+    }
+
+    const std::vector<std::complex<double>> complex1 = {{1.0, 2.0}, {-3.0, 0.5}, {2.0, -4.0}};
+    const std::vector<double> real_operand = {2.0, -0.5, 1.5};
+    std::vector<std::complex<double>> complex_result(complex1.size(), {0.25, -0.75});
+    vector_mul_vector_op_cpu()(
+        complex1.size(), complex_result.data(), complex1.data(), real_operand.data(), false);
+    for (std::size_t i = 0; i < complex1.size(); ++i)
+    {
+        EXPECT_LT(std::abs(complex_result[i] - complex1[i] * real_operand[i]), 1e-12);
+    }
+
+    const std::vector<std::complex<double>> initial(complex1.size(), {0.25, -0.75});
+    complex_result = initial;
+    vector_mul_vector_op_cpu()(
+        complex1.size(), complex_result.data(), complex1.data(), real_operand.data(), true);
+    for (std::size_t i = 0; i < complex1.size(); ++i)
+    {
+        EXPECT_LT(std::abs(complex_result[i] - (initial[i] + complex1[i] * real_operand[i])), 1e-12);
+    }
+
+    const std::vector<std::complex<double>> complex2 = {{0.5, -1.0}, {2.0, 3.0}, {-0.25, 0.75}};
+    BlasConnector::vector_mul_vector(complex1.size(),
+                                     complex_result.data(),
+                                     complex1.data(),
+                                     complex2.data(),
+                                     base_device::AbacusDevice_t::CpuDevice);
+    for (std::size_t i = 0; i < complex1.size(); ++i)
+    {
+        EXPECT_LT(std::abs(complex_result[i] - complex1[i] * complex2[i]), 1e-12);
     }
 }
 
 TEST_F(TestModuleHsolverMathKernel, vector_div_vector_op_cpu)
 {
-    std::vector<std::complex<double>> output(input.size());
-    vector_div_vector_op_cpu()(dim, output.data(), input.data(), input_double.data());
-    for (int i = 0; i < input.size(); i++)
+    const std::vector<double> real1 = {1.5, -2.0, 4.0};
+    const std::vector<double> real2 = {-3.0, 0.5, 2.0};
+    std::vector<double> real_result(real1.size());
+    ModuleBase::vector_div_vector_op<double, base_device::DEVICE_CPU, double>()(
+        real1.size(), real_result.data(), real1.data(), real2.data());
+    for (std::size_t i = 0; i < real1.size(); ++i)
     {
-        EXPECT_LT(fabs(output[i].imag() - output_vector_div_vector_op[i].imag()), 1e-8);
-        EXPECT_LT(fabs(output[i].real() - output_vector_div_vector_op[i].real()), 1e-8);
+        EXPECT_DOUBLE_EQ(real_result[i], real1[i] / real2[i]);
+    }
+
+    const std::vector<std::complex<double>> complex1 = {{1.0, 2.0}, {-3.0, 0.5}, {2.0, -4.0}};
+    const std::vector<double> real_operand = {2.0, -0.5, 1.5};
+    std::vector<std::complex<double>> complex_result(complex1.size());
+    vector_div_vector_op_cpu()(complex1.size(), complex_result.data(), complex1.data(), real_operand.data());
+    for (std::size_t i = 0; i < complex1.size(); ++i)
+    {
+        EXPECT_LT(std::abs(complex_result[i] - complex1[i] / real_operand[i]), 1e-12);
+    }
+
+    const std::vector<std::complex<double>> complex2 = {{0.5, -1.0}, {2.0, 3.0}, {-0.25, 0.75}};
+    BlasConnector::vector_div_vector(complex1.size(),
+                                     complex_result.data(),
+                                     complex1.data(),
+                                     complex2.data(),
+                                     base_device::AbacusDevice_t::CpuDevice);
+    for (std::size_t i = 0; i < complex1.size(); ++i)
+    {
+        EXPECT_LT(std::abs(complex_result[i] - complex1[i] / complex2[i]), 1e-12);
     }
 }
 
 TEST_F(TestModuleHsolverMathKernel, vector_add_vector_op_cpu)
 {
-    std::vector<std::complex<double>> output(input.size());
-    vector_add_vector_op_cpu()(dim,
-                                                    output.data(),
-                                                    input1.data(),
-                                                    constant1,
-                                                    input2.data(),
-                                                    constant2);
-    for (int i = 0; i < input.size(); i++)
+    const std::vector<double> real1 = {1.5, -2.0, 4.0};
+    const std::vector<double> real2 = {-3.0, 0.5, 2.0};
+    std::vector<double> real_result(real1.size());
+    ModuleBase::vector_add_vector_op<double, base_device::DEVICE_CPU, double>()(
+        real1.size(), real_result.data(), real1.data(), 2.0, real2.data(), -0.5);
+    for (std::size_t i = 0; i < real1.size(); ++i)
     {
-        EXPECT_LT(fabs(output[i].imag() - output_vector_add_vector_op[i].imag()), 1e-8);
-        EXPECT_LT(fabs(output[i].real() - output_vector_add_vector_op[i].real()), 1e-8);
+        EXPECT_DOUBLE_EQ(real_result[i], real1[i] * 2.0 + real2[i] * -0.5);
+    }
+
+    const std::vector<std::complex<double>> complex1 = {{1.0, 2.0}, {-3.0, 0.5}, {2.0, -4.0}};
+    const std::vector<std::complex<double>> complex2 = {{0.5, -1.0}, {2.0, 3.0}, {-0.25, 0.75}};
+    std::vector<std::complex<double>> alias_vector1 = complex1;
+    vector_add_vector_op_cpu()(alias_vector1.size(),
+                               alias_vector1.data(),
+                               alias_vector1.data(),
+                               1.5,
+                               complex2.data(),
+                               -0.25);
+    for (std::size_t i = 0; i < complex1.size(); ++i)
+    {
+        EXPECT_LT(std::abs(alias_vector1[i] - (complex1[i] * 1.5 + complex2[i] * -0.25)), 1e-12);
+    }
+
+    const std::complex<double> scalar1(1.25, -0.5);
+    const std::complex<double> scalar2(-0.75, 2.0);
+    std::vector<std::complex<double>> alias_vector2 = complex2;
+    ModuleBase::vector_add_vector_op<std::complex<double>,
+                                     base_device::DEVICE_CPU,
+                                     std::complex<double>>()(
+        alias_vector2.size(), alias_vector2.data(), complex1.data(), scalar1, alias_vector2.data(), scalar2);
+    for (std::size_t i = 0; i < complex1.size(); ++i)
+    {
+        EXPECT_LT(std::abs(alias_vector2[i] - (complex1[i] * scalar1 + complex2[i] * scalar2)), 1e-12);
+    }
+
+    std::vector<std::complex<double>> connector_result(complex1.size());
+    BlasConnector::vector_add_vector(complex1.size(),
+                                     connector_result.data(),
+                                     complex1.data(),
+                                     scalar1,
+                                     complex2.data(),
+                                     scalar2,
+                                     base_device::AbacusDevice_t::CpuDevice);
+    for (std::size_t i = 0; i < complex1.size(); ++i)
+    {
+        EXPECT_LT(std::abs(connector_result[i] - (complex1[i] * scalar1 + complex2[i] * scalar2)), 1e-12);
     }
 }
 
@@ -408,115 +504,222 @@ TEST_F(TestModuleHsolverMathKernel, vector_mul_real_op_gpu)
 
 TEST_F(TestModuleHsolverMathKernel, vector_mul_vector_op_gpu)
 {
-    // in CPU
-    std::vector<std::complex<double>> output(input.size());
-
-    // in GPU
-    std::complex<double>* input_dev = NULL;
-    double* input_double_dev = NULL;
-    std::complex<double>* output_dev = NULL;
-
-    // resize memory for values
-    resize_memory_op()(input_dev, input.size());
-    resize_memory_op_double()(input_double_dev, input.size());
-    resize_memory_op()(output_dev, input.size());
-
-    // syn the input data in CPU to GPU
-    synchronize_memory_op()(input_dev, input.data(), input.size());
-    synchronize_memory_op_double()(input_double_dev, input_double.data(), input.size());
-
-    // run
-    vector_mul_vector_op_gpu()(dim, output_dev, input_dev, input_double_dev);
-
-    // syn the output data in GPU to CPU
-    synchronize_memory_op_gpu()(output.data(), output_dev, output.size());
-
-    for (int i = 0; i < input.size(); i++)
+    const int size = 1025;
+    std::vector<double> real1(size);
+    std::vector<double> real2(size);
+    std::vector<double> real_result(size);
+    std::vector<std::complex<double>> complex1(size);
+    std::vector<std::complex<double>> complex2(size);
+    std::vector<std::complex<double>> complex_result(size);
+    for (int i = 0; i < size; ++i)
     {
-        EXPECT_LT(fabs(output[i].imag() - output_vector_mul_vector_op[i].imag()), 1e-8);
-        EXPECT_LT(fabs(output[i].real() - output_vector_mul_vector_op[i].real()), 1e-8);
+        real1[i] = 0.25 * i - 3.0;
+        real2[i] = 1.0 + 0.01 * i;
+        complex1[i] = {real1[i], 0.5 - 0.02 * i};
+        complex2[i] = {0.75 + 0.01 * i, -0.25 + 0.005 * i};
     }
 
-    delete_memory_op()(input_dev);
-    delete_memory_op_double()(input_double_dev);
-    delete_memory_op()(output_dev);
+    double* real1_dev = nullptr;
+    double* real2_dev = nullptr;
+    double* real_result_dev = nullptr;
+    std::complex<double>* complex1_dev = nullptr;
+    std::complex<double>* complex2_dev = nullptr;
+    std::complex<double>* complex_result_dev = nullptr;
+    resize_memory_op_double()(real1_dev, size);
+    resize_memory_op_double()(real2_dev, size);
+    resize_memory_op_double()(real_result_dev, size);
+    resize_memory_op()(complex1_dev, size);
+    resize_memory_op()(complex2_dev, size);
+    resize_memory_op()(complex_result_dev, size);
+    synchronize_memory_op_double()(real1_dev, real1.data(), size);
+    synchronize_memory_op_double()(real2_dev, real2.data(), size);
+    synchronize_memory_op()(complex1_dev, complex1.data(), size);
+    synchronize_memory_op()(complex2_dev, complex2.data(), size);
+
+    ModuleBase::vector_mul_vector_op<double, base_device::DEVICE_GPU, double>()(
+        0, nullptr, nullptr, nullptr, false);
+    ModuleBase::vector_mul_vector_op<double, base_device::DEVICE_GPU, double>()(
+        size, real_result_dev, real1_dev, real2_dev, false);
+    synchronize_memory_op_double_gpu()(real_result.data(), real_result_dev, size);
+    for (int i = 0; i < size; ++i)
+    {
+        EXPECT_LT(std::abs(real_result[i] - real1[i] * real2[i]), 1e-12);
+    }
+
+    vector_mul_vector_op_gpu()(size, complex_result_dev, complex1_dev, real2_dev, false);
+    synchronize_memory_op_gpu()(complex_result.data(), complex_result_dev, size);
+    for (int i = 0; i < size; ++i)
+    {
+        EXPECT_LT(std::abs(complex_result[i] - complex1[i] * real2[i]), 1e-12);
+    }
+
+    synchronize_memory_op()(complex_result_dev, complex2.data(), size);
+    vector_mul_vector_op_gpu()(size, complex_result_dev, complex1_dev, real2_dev, true);
+    synchronize_memory_op_gpu()(complex_result.data(), complex_result_dev, size);
+    for (int i = 0; i < size; ++i)
+    {
+        EXPECT_LT(std::abs(complex_result[i] - (complex2[i] + complex1[i] * real2[i])), 1e-12);
+    }
+
+    BlasConnector::vector_mul_vector(size,
+                                     complex_result_dev,
+                                     complex1_dev,
+                                     complex2_dev,
+                                     base_device::AbacusDevice_t::GpuDevice);
+    synchronize_memory_op_gpu()(complex_result.data(), complex_result_dev, size);
+    for (int i = 0; i < size; ++i)
+    {
+        EXPECT_LT(std::abs(complex_result[i] - complex1[i] * complex2[i]), 1e-12);
+    }
+
+    delete_memory_op_double()(real1_dev);
+    delete_memory_op_double()(real2_dev);
+    delete_memory_op_double()(real_result_dev);
+    delete_memory_op()(complex1_dev);
+    delete_memory_op()(complex2_dev);
+    delete_memory_op()(complex_result_dev);
 }
 
 TEST_F(TestModuleHsolverMathKernel, vector_div_vector_op_gpu)
 {
-    // in CPU
-    std::vector<std::complex<double>> output(input.size());
-
-    // in GPU
-    std::complex<double>* input_dev = NULL;
-    double* input_double_dev = NULL;
-    std::complex<double>* output_dev = NULL;
-
-    // resize memory for values in GPU
-    resize_memory_op()(input_dev, input.size());
-    resize_memory_op_double()(input_double_dev, input.size());
-    resize_memory_op()(output_dev, input.size());
-
-    // syn the input data in CPU to GPU
-    synchronize_memory_op()(input_dev, input.data(), input.size());
-    synchronize_memory_op_double()(input_double_dev, input_double.data(), input.size());
-
-    // run
-    vector_div_vector_op_gpu()(dim, output_dev, input_dev, input_double_dev);
-
-    // syn the output data in GPU to CPU
-    synchronize_memory_op_gpu()(output.data(), output_dev, output.size());
-
-    for (int i = 0; i < input.size(); i++)
+    const int size = 1025;
+    std::vector<double> real1(size);
+    std::vector<double> real2(size);
+    std::vector<double> real_result(size);
+    std::vector<std::complex<double>> complex1(size);
+    std::vector<std::complex<double>> complex2(size);
+    std::vector<std::complex<double>> complex_result(size);
+    for (int i = 0; i < size; ++i)
     {
-        EXPECT_LT(fabs(output[i].imag() - output_vector_div_vector_op[i].imag()), 1e-8);
-        EXPECT_LT(fabs(output[i].real() - output_vector_div_vector_op[i].real()), 1e-8);
+        real1[i] = 0.25 * i - 3.0;
+        real2[i] = 1.0 + 0.01 * i;
+        complex1[i] = {real1[i], 0.5 - 0.02 * i};
+        complex2[i] = {0.75 + 0.01 * i, -0.25 + 0.005 * i};
     }
 
-    delete_memory_op()(input_dev);
-    delete_memory_op_double()(input_double_dev);
-    delete_memory_op()(output_dev);
+    double* real1_dev = nullptr;
+    double* real2_dev = nullptr;
+    double* real_result_dev = nullptr;
+    std::complex<double>* complex1_dev = nullptr;
+    std::complex<double>* complex2_dev = nullptr;
+    std::complex<double>* complex_result_dev = nullptr;
+    resize_memory_op_double()(real1_dev, size);
+    resize_memory_op_double()(real2_dev, size);
+    resize_memory_op_double()(real_result_dev, size);
+    resize_memory_op()(complex1_dev, size);
+    resize_memory_op()(complex2_dev, size);
+    resize_memory_op()(complex_result_dev, size);
+    synchronize_memory_op_double()(real1_dev, real1.data(), size);
+    synchronize_memory_op_double()(real2_dev, real2.data(), size);
+    synchronize_memory_op()(complex1_dev, complex1.data(), size);
+    synchronize_memory_op()(complex2_dev, complex2.data(), size);
+
+    ModuleBase::vector_div_vector_op<double, base_device::DEVICE_GPU, double>()(0, nullptr, nullptr, nullptr);
+    ModuleBase::vector_div_vector_op<double, base_device::DEVICE_GPU, double>()(
+        size, real_result_dev, real1_dev, real2_dev);
+    synchronize_memory_op_double_gpu()(real_result.data(), real_result_dev, size);
+    for (int i = 0; i < size; ++i)
+    {
+        EXPECT_LT(std::abs(real_result[i] - real1[i] / real2[i]), 1e-12);
+    }
+
+    vector_div_vector_op_gpu()(size, complex_result_dev, complex1_dev, real2_dev);
+    synchronize_memory_op_gpu()(complex_result.data(), complex_result_dev, size);
+    for (int i = 0; i < size; ++i)
+    {
+        EXPECT_LT(std::abs(complex_result[i] - complex1[i] / real2[i]), 1e-12);
+    }
+
+    BlasConnector::vector_div_vector(size,
+                                     complex_result_dev,
+                                     complex1_dev,
+                                     complex2_dev,
+                                     base_device::AbacusDevice_t::GpuDevice);
+    synchronize_memory_op_gpu()(complex_result.data(), complex_result_dev, size);
+    for (int i = 0; i < size; ++i)
+    {
+        EXPECT_LT(std::abs(complex_result[i] - complex1[i] / complex2[i]), 1e-12);
+    }
+
+    delete_memory_op_double()(real1_dev);
+    delete_memory_op_double()(real2_dev);
+    delete_memory_op_double()(real_result_dev);
+    delete_memory_op()(complex1_dev);
+    delete_memory_op()(complex2_dev);
+    delete_memory_op()(complex_result_dev);
 }
 
 TEST_F(TestModuleHsolverMathKernel, vector_add_vector_op_gpu)
 {
-    // in CPU
-    std::vector<std::complex<double>> output(input.size());
-
-    // in GPU
-    std::complex<double>* input1_dev = NULL;
-    std::complex<double>* input2_dev = NULL;
-    std::complex<double>* output_dev = NULL;
-
-    // resize memory for values in GPU
-    resize_memory_op()(input1_dev, input.size());
-    resize_memory_op()(input2_dev, input.size());
-    resize_memory_op()(output_dev, input.size());
-
-    // syn the input data in CPU to GPU
-    synchronize_memory_op()(input1_dev, input1.data(), input.size());
-    synchronize_memory_op()(input2_dev, input2.data(), input.size());
-
-    // run
-    vector_add_vector_op_gpu()(dim,
-                                                    output_dev,
-                                                    input1_dev,
-                                                    constant1,
-                                                    input2_dev,
-                                                    constant2);
-
-    // syn the output data in GPU to CPU
-    synchronize_memory_op_gpu()(output.data(), output_dev, output.size());
-
-    for (int i = 0; i < input.size(); i++)
+    const int size = 1025;
+    std::vector<double> real1(size);
+    std::vector<double> real2(size);
+    std::vector<double> real_result(size);
+    std::vector<std::complex<double>> complex1(size);
+    std::vector<std::complex<double>> complex2(size);
+    std::vector<std::complex<double>> complex_result(size);
+    for (int i = 0; i < size; ++i)
     {
-        EXPECT_LT(fabs(output[i].imag() - output_vector_add_vector_op[i].imag()), 1e-8);
-        EXPECT_LT(fabs(output[i].real() - output_vector_add_vector_op[i].real()), 1e-8);
+        real1[i] = 0.25 * i - 3.0;
+        real2[i] = 1.0 + 0.01 * i;
+        complex1[i] = {real1[i], 0.5 - 0.02 * i};
+        complex2[i] = {0.75 + 0.01 * i, -0.25 + 0.005 * i};
     }
 
-    delete_memory_op()(input1_dev);
-    delete_memory_op()(input2_dev);
-    delete_memory_op()(output_dev);
+    double* real1_dev = nullptr;
+    double* real2_dev = nullptr;
+    double* real_result_dev = nullptr;
+    std::complex<double>* complex1_dev = nullptr;
+    std::complex<double>* complex2_dev = nullptr;
+    resize_memory_op_double()(real1_dev, size);
+    resize_memory_op_double()(real2_dev, size);
+    resize_memory_op_double()(real_result_dev, size);
+    resize_memory_op()(complex1_dev, size);
+    resize_memory_op()(complex2_dev, size);
+    synchronize_memory_op_double()(real1_dev, real1.data(), size);
+    synchronize_memory_op_double()(real2_dev, real2.data(), size);
+    synchronize_memory_op()(complex1_dev, complex1.data(), size);
+    synchronize_memory_op()(complex2_dev, complex2.data(), size);
+
+    ModuleBase::vector_add_vector_op<double, base_device::DEVICE_GPU, double>()(
+        0, nullptr, nullptr, 1.0, nullptr, 1.0);
+    ModuleBase::vector_add_vector_op<double, base_device::DEVICE_GPU, double>()(
+        size, real_result_dev, real1_dev, 2.0, real2_dev, -0.5);
+    synchronize_memory_op_double_gpu()(real_result.data(), real_result_dev, size);
+    for (int i = 0; i < size; ++i)
+    {
+        EXPECT_LT(std::abs(real_result[i] - (real1[i] * 2.0 + real2[i] * -0.5)), 1e-12);
+    }
+
+    vector_add_vector_op_gpu()(size, complex1_dev, complex1_dev, 1.5, complex2_dev, -0.25);
+    synchronize_memory_op_gpu()(complex_result.data(), complex1_dev, size);
+    for (int i = 0; i < size; ++i)
+    {
+        EXPECT_LT(std::abs(complex_result[i] - (complex1[i] * 1.5 + complex2[i] * -0.25)), 1e-12);
+    }
+
+    synchronize_memory_op()(complex1_dev, complex1.data(), size);
+    synchronize_memory_op()(complex2_dev, complex2.data(), size);
+    const std::complex<double> scalar1(1.25, -0.5);
+    const std::complex<double> scalar2(-0.75, 2.0);
+    BlasConnector::vector_add_vector(size,
+                                     complex2_dev,
+                                     complex1_dev,
+                                     scalar1,
+                                     complex2_dev,
+                                     scalar2,
+                                     base_device::AbacusDevice_t::GpuDevice);
+    synchronize_memory_op_gpu()(complex_result.data(), complex2_dev, size);
+    for (int i = 0; i < size; ++i)
+    {
+        EXPECT_LT(std::abs(complex_result[i] - (complex1[i] * scalar1 + complex2[i] * scalar2)), 1e-12);
+    }
+
+    delete_memory_op_double()(real1_dev);
+    delete_memory_op_double()(real2_dev);
+    delete_memory_op_double()(real_result_dev);
+    delete_memory_op()(complex1_dev);
+    delete_memory_op()(complex2_dev);
 }
 
 TEST_F(TestModuleHsolverMathKernel, axpy_op_gpu)

--- a/source/source_base/module_external/blas_connector.h
+++ b/source/source_base/module_external/blas_connector.h
@@ -406,26 +406,32 @@ public:
 	void copy(const int n, const std::complex<double> *a, const int incx, std::complex<double> *b, const int incy, base_device::AbacusDevice_t device_type = base_device::AbacusDevice_t::CpuDevice);
 
 	// There is some other operators needed, so implemented manually here
-	template <typename T>
+	template <typename T, typename Operand>
 	static
-	void vector_mul_vector(const int& dim, T* result, const T* vector1, const T* vector2, base_device::AbacusDevice_t device_type = base_device::AbacusDevice_t::CpuDevice);
+	void vector_mul_vector(const int& dim,
+	                       T* result,
+	                       const T* vector1,
+	                       const Operand* vector2,
+	                       base_device::AbacusDevice_t device_type);
 
-	template <typename T>
+	template <typename T, typename Operand>
 	static
-	void vector_div_vector(const int& dim, T* result, const T* vector1, const T* vector2, base_device::AbacusDevice_t device_type = base_device::AbacusDevice_t::CpuDevice);
+	void vector_div_vector(const int& dim,
+	                       T* result,
+	                       const T* vector1,
+	                       const Operand* vector2,
+	                       base_device::AbacusDevice_t device_type);
 
-	// y = alpha * x + beta * y
+	// result = constant1 * vector1 + constant2 * vector2
+	template <typename T, typename Scalar>
 	static
-	void vector_add_vector(const int& dim, float *result, const float *vector1, const float constant1, const float *vector2, const float constant2, base_device::AbacusDevice_t device_type = base_device::AbacusDevice_t::CpuDevice);
-
-	static
-	void vector_add_vector(const int& dim, double *result, const double *vector1, const double constant1, const double *vector2, const double constant2, base_device::AbacusDevice_t device_type = base_device::AbacusDevice_t::CpuDevice);
-
-	static
-	void vector_add_vector(const int& dim, std::complex<float> *result, const std::complex<float> *vector1, const float constant1, const std::complex<float> *vector2, const float constant2, base_device::AbacusDevice_t device_type = base_device::AbacusDevice_t::CpuDevice);
-
-	static
-	void vector_add_vector(const int& dim, std::complex<double> *result, const std::complex<double> *vector1, const double constant1, const std::complex<double> *vector2, const double constant2, base_device::AbacusDevice_t device_type = base_device::AbacusDevice_t::CpuDevice);
+	void vector_add_vector(const int& dim,
+	                       T* result,
+	                       const T* vector1,
+	                       const Scalar constant1,
+	                       const T* vector2,
+	                       const Scalar constant2,
+	                       base_device::AbacusDevice_t device_type);
 
 #ifdef __DSP
 	/// @brief Inject the DSP cluster id used by mt-allocator BLAS kernels.

--- a/source/source_base/module_external/blas_connector_vector.cpp
+++ b/source/source_base/module_external/blas_connector_vector.cpp
@@ -1,5 +1,6 @@
 #include "blas_connector.h"
 #include "../macros.h"
+#include "source_base/kernels/math_kernel_op.h"
 
 #ifdef __DSP
 #include "source_base/kernels/dsp/dsp_connector.h"
@@ -10,7 +11,6 @@
 #include <base/macros/macros.h>
 #include <cuda_runtime.h>
 #include "cublas_v2.h"
-#include "source_base/kernels/math_kernel_op.h"
 #include "source_base/module_device/memory_op.h"
 #endif
 
@@ -363,131 +363,157 @@ void BlasConnector::copy(const int n, const std::complex<double> *a, const int i
 }
 
 
-template <typename T>
-void vector_mul_vector(const int& dim, T* result, const T* vector1, const T* vector2, base_device::AbacusDevice_t device_type){
-	using Real = typename GetTypeReal<T>::type;
-	if (device_type == base_device::AbacusDevice_t::CpuDevice) {
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static)
-#endif
-        for (int i = 0; i < dim; i++)
-        {
-            result[i] = vector1[i] * vector2[i];
-        }
-	}
-#ifdef __CUDA
-	else if (device_type == base_device::AbacusDevice_t::GpuDevice) {
-		ModuleBase::vector_mul_vector_op<T, base_device::DEVICE_GPU>()(dim, result, vector1, vector2);
-	}
-#endif
-	else {
-		throw std::invalid_argument("device_type = " + std::to_string(device_type) + " in " + std::string(__FILE__) + " line " + std::to_string(__LINE__));
-	}
-}
-
-
-template <typename T>
-void vector_div_vector(const int& dim, T* result, const T* vector1, const T* vector2, base_device::AbacusDevice_t device_type){
-	using Real = typename GetTypeReal<T>::type;
-	if (device_type == base_device::AbacusDevice_t::CpuDevice) {
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static)
-#endif
-		for (int i = 0; i < dim; i++)
-        {
-            result[i] = vector1[i] / vector2[i];
-        }
-	}
-#ifdef __CUDA
-	else if (device_type == base_device::AbacusDevice_t::GpuDevice) {
-		ModuleBase::vector_div_vector_op<T, base_device::DEVICE_GPU>()(dim, result, vector1, vector2);
-	}
-#endif
-	else {
-		throw std::invalid_argument("device_type = " + std::to_string(device_type) + " in " + std::string(__FILE__) + " line " + std::to_string(__LINE__));
-	}
-}
-
-void vector_add_vector(const int& dim, float *result, const float *vector1, const float constant1, const float *vector2, const float constant2, base_device::AbacusDevice_t device_type)
+template <typename T, typename Operand>
+void BlasConnector::vector_mul_vector(const int& dim,
+                                      T* result,
+                                      const T* vector1,
+                                      const Operand* vector2,
+                                      base_device::AbacusDevice_t device_type)
 {
-	if (device_type == base_device::CpuDevice){
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static)
+    if (device_type == base_device::AbacusDevice_t::CpuDevice)
+    {
+        ModuleBase::vector_mul_vector_op<T, base_device::DEVICE_CPU, Operand>()(
+            dim, result, vector1, vector2, false);
+    }
+#if defined(__CUDA) || defined(__ROCM)
+    else if (device_type == base_device::AbacusDevice_t::GpuDevice)
+    {
+        ModuleBase::vector_mul_vector_op<T, base_device::DEVICE_GPU, Operand>()(
+            dim, result, vector1, vector2, false);
+    }
 #endif
-        for (int i = 0; i < dim; i++)
-        {
-            result[i] = vector1[i] * constant1 + vector2[i] * constant2;
-        }
-	}
-#ifdef __CUDA
-	else if (device_type == base_device::GpuDevice) {
-		ModuleBase::vector_add_vector_op<float, base_device::DEVICE_GPU>()(dim, result, vector1, constant1, vector2, constant2);
-	}
-#endif
-	else {
-		throw std::invalid_argument("device_type = " + std::to_string(device_type) + " in " + std::string(__FILE__) + " line " + std::to_string(__LINE__));
-	}
+    else
+    {
+        throw std::invalid_argument("device_type = " + std::to_string(device_type) + " in " + std::string(__FILE__)
+                                    + " line " + std::to_string(__LINE__));
+    }
 }
 
-void vector_add_vector(const int& dim, double *result, const double *vector1, const double constant1, const double *vector2, const double constant2, base_device::AbacusDevice_t device_type)
+template <typename T, typename Operand>
+void BlasConnector::vector_div_vector(const int& dim,
+                                      T* result,
+                                      const T* vector1,
+                                      const Operand* vector2,
+                                      base_device::AbacusDevice_t device_type)
 {
-	if (device_type == base_device::CpuDevice){
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static)
+    if (device_type == base_device::AbacusDevice_t::CpuDevice)
+    {
+        ModuleBase::vector_div_vector_op<T, base_device::DEVICE_CPU, Operand>()(dim, result, vector1, vector2);
+    }
+#if defined(__CUDA) || defined(__ROCM)
+    else if (device_type == base_device::AbacusDevice_t::GpuDevice)
+    {
+        ModuleBase::vector_div_vector_op<T, base_device::DEVICE_GPU, Operand>()(dim, result, vector1, vector2);
+    }
 #endif
-        for (int i = 0; i < dim; i++)
-        {
-            result[i] = vector1[i] * constant1 + vector2[i] * constant2;
-        }
-	}
-#ifdef __CUDA
-	else if (device_type == base_device::GpuDevice) {
-		ModuleBase::vector_add_vector_op<double, base_device::DEVICE_GPU>()(dim, result, vector1, constant1, vector2, constant2);
-	}
-#endif
-	else {
-		throw std::invalid_argument("device_type = " + std::to_string(device_type) + " in " + std::string(__FILE__) + " line " + std::to_string(__LINE__));
-	}
+    else
+    {
+        throw std::invalid_argument("device_type = " + std::to_string(device_type) + " in " + std::string(__FILE__)
+                                    + " line " + std::to_string(__LINE__));
+    }
 }
 
-void vector_add_vector(const int& dim, std::complex<float> *result, const std::complex<float> *vector1, const float constant1, const std::complex<float> *vector2, const float constant2, base_device::AbacusDevice_t device_type)
+template <typename T, typename Scalar>
+void BlasConnector::vector_add_vector(const int& dim,
+                                      T* result,
+                                      const T* vector1,
+                                      const Scalar constant1,
+                                      const T* vector2,
+                                      const Scalar constant2,
+                                      base_device::AbacusDevice_t device_type)
 {
-	if (device_type == base_device::CpuDevice){
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static)
+    if (device_type == base_device::AbacusDevice_t::CpuDevice)
+    {
+        ModuleBase::vector_add_vector_op<T, base_device::DEVICE_CPU, Scalar>()(
+            dim, result, vector1, constant1, vector2, constant2);
+    }
+#if defined(__CUDA) || defined(__ROCM)
+    else if (device_type == base_device::AbacusDevice_t::GpuDevice)
+    {
+        ModuleBase::vector_add_vector_op<T, base_device::DEVICE_GPU, Scalar>()(
+            dim, result, vector1, constant1, vector2, constant2);
+    }
 #endif
-        for (int i = 0; i < dim; i++)
-        {
-            result[i] = vector1[i] * constant1 + vector2[i] * constant2;
-        }
-	}
-#ifdef __CUDA
-	else if (device_type == base_device::GpuDevice) {
-		ModuleBase::vector_add_vector_op<std::complex<float>, base_device::DEVICE_GPU>()(dim, result, vector1, constant1, vector2, constant2);
-	}
-#endif
-	else {
-		throw std::invalid_argument("device_type = " + std::to_string(device_type) + " in " + std::string(__FILE__) + " line " + std::to_string(__LINE__));
-	}
+    else
+    {
+        throw std::invalid_argument("device_type = " + std::to_string(device_type) + " in " + std::string(__FILE__)
+                                    + " line " + std::to_string(__LINE__));
+    }
 }
 
-void vector_add_vector(const int& dim, std::complex<double> *result, const std::complex<double> *vector1, const double constant1, const std::complex<double> *vector2, const double constant2, base_device::AbacusDevice_t device_type)
-{
-	if (device_type == base_device::CpuDevice){
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static)
-#endif
-        for (int i = 0; i < dim; i++)
-        {
-            result[i] = vector1[i] * constant1 + vector2[i] * constant2;
-        }
-	}
-#ifdef __CUDA
-	else if (device_type == base_device::GpuDevice) {
-		ModuleBase::vector_add_vector_op<std::complex<double>, base_device::DEVICE_GPU>()(dim, result, vector1, constant1, vector2, constant2);
-	}
-#endif
-	else {
-		throw std::invalid_argument("device_type = " + std::to_string(device_type) + " in " + std::string(__FILE__) + " line " + std::to_string(__LINE__));
-	}
-}
+template void BlasConnector::vector_mul_vector<float, float>(
+    const int&, float*, const float*, const float*, base_device::AbacusDevice_t);
+template void BlasConnector::vector_mul_vector<double, double>(
+    const int&, double*, const double*, const double*, base_device::AbacusDevice_t);
+template void BlasConnector::vector_mul_vector<std::complex<float>, float>(
+    const int&, std::complex<float>*, const std::complex<float>*, const float*, base_device::AbacusDevice_t);
+template void BlasConnector::vector_mul_vector<std::complex<double>, double>(
+    const int&, std::complex<double>*, const std::complex<double>*, const double*, base_device::AbacusDevice_t);
+template void BlasConnector::vector_mul_vector<std::complex<float>, std::complex<float>>(
+    const int&,
+    std::complex<float>*,
+    const std::complex<float>*,
+    const std::complex<float>*,
+    base_device::AbacusDevice_t);
+template void BlasConnector::vector_mul_vector<std::complex<double>, std::complex<double>>(
+    const int&,
+    std::complex<double>*,
+    const std::complex<double>*,
+    const std::complex<double>*,
+    base_device::AbacusDevice_t);
+
+template void BlasConnector::vector_div_vector<float, float>(
+    const int&, float*, const float*, const float*, base_device::AbacusDevice_t);
+template void BlasConnector::vector_div_vector<double, double>(
+    const int&, double*, const double*, const double*, base_device::AbacusDevice_t);
+template void BlasConnector::vector_div_vector<std::complex<float>, float>(
+    const int&, std::complex<float>*, const std::complex<float>*, const float*, base_device::AbacusDevice_t);
+template void BlasConnector::vector_div_vector<std::complex<double>, double>(
+    const int&, std::complex<double>*, const std::complex<double>*, const double*, base_device::AbacusDevice_t);
+template void BlasConnector::vector_div_vector<std::complex<float>, std::complex<float>>(
+    const int&,
+    std::complex<float>*,
+    const std::complex<float>*,
+    const std::complex<float>*,
+    base_device::AbacusDevice_t);
+template void BlasConnector::vector_div_vector<std::complex<double>, std::complex<double>>(
+    const int&,
+    std::complex<double>*,
+    const std::complex<double>*,
+    const std::complex<double>*,
+    base_device::AbacusDevice_t);
+
+template void BlasConnector::vector_add_vector<float, float>(
+    const int&, float*, const float*, const float, const float*, const float, base_device::AbacusDevice_t);
+template void BlasConnector::vector_add_vector<double, double>(
+    const int&, double*, const double*, const double, const double*, const double, base_device::AbacusDevice_t);
+template void BlasConnector::vector_add_vector<std::complex<float>, float>(const int&,
+                                                                           std::complex<float>*,
+                                                                           const std::complex<float>*,
+                                                                           const float,
+                                                                           const std::complex<float>*,
+                                                                           const float,
+                                                                           base_device::AbacusDevice_t);
+template void BlasConnector::vector_add_vector<std::complex<double>, double>(const int&,
+                                                                             std::complex<double>*,
+                                                                             const std::complex<double>*,
+                                                                             const double,
+                                                                             const std::complex<double>*,
+                                                                             const double,
+                                                                             base_device::AbacusDevice_t);
+template void BlasConnector::vector_add_vector<std::complex<float>, std::complex<float>>(
+    const int&,
+    std::complex<float>*,
+    const std::complex<float>*,
+    const std::complex<float>,
+    const std::complex<float>*,
+    const std::complex<float>,
+    base_device::AbacusDevice_t);
+template void BlasConnector::vector_add_vector<std::complex<double>, std::complex<double>>(
+    const int&,
+    std::complex<double>*,
+    const std::complex<double>*,
+    const std::complex<double>,
+    const std::complex<double>*,
+    const std::complex<double>,
+    base_device::AbacusDevice_t);

--- a/source/source_hsolver/diago_cg.cpp
+++ b/source/source_hsolver/diago_cg.cpp
@@ -228,8 +228,8 @@ void DiagoCG<T, Device>::calc_grad(const ct::Tensor& prec,
     // }
     // denghui replace this at 20221106
     // TODO: use GPU precondition to initialize CG class
-    ModuleBase::vector_div_vector_op<T, Device>()(this->n_basis_, grad.data<T>(), hphi.data<T>(), prec.data<Real>());
-    ModuleBase::vector_div_vector_op<T, Device>()(this->n_basis_, pphi.data<T>(), sphi.data<T>(), prec.data<Real>());
+    ModuleBase::vector_div_vector_op<T, Device, Real>()(this->n_basis_, grad.data<T>(), hphi.data<T>(), prec.data<Real>());
+    ModuleBase::vector_div_vector_op<T, Device, Real>()(this->n_basis_, pphi.data<T>(), sphi.data<T>(), prec.data<Real>());
 
     // Update lambda !
     // (4) <psi|SPH|psi >
@@ -249,12 +249,12 @@ void DiagoCG<T, Device>::calc_grad(const ct::Tensor& prec,
     //     grad.data<T>()[i] -= lambda * this->pphi[i];
     // }
     // haozhihan replace this 2022-10-6
-    ModuleBase::vector_add_vector_op<T, Device>()(this->n_basis_,
-                                                  grad.data<T>(),
-                                                  grad.data<T>(),
-                                                  1.0,
-                                                  pphi.data<T>(),
-                                                  (-lambda));
+    ModuleBase::vector_add_vector_op<T, Device, Real>()(this->n_basis_,
+                                                        grad.data<T>(),
+                                                        grad.data<T>(),
+                                                        1.0,
+                                                        pphi.data<T>(),
+                                                        (-lambda));
 }
 
 template <typename T, typename Device>
@@ -340,7 +340,7 @@ void DiagoCG<T, Device>::calc_gamma_cg(const int& iter,
     // }
     // denghui replace this 20221106
     // TODO: use GPU precondition instead
-    ModuleBase::vector_mul_vector_op<T, Device>()(this->n_basis_, g0.data<T>(), scg.data<T>(), prec.data<Real>());
+    ModuleBase::vector_mul_vector_op<T, Device, Real>()(this->n_basis_, g0.data<T>(), scg.data<T>(), prec.data<Real>(), false);
 
     // (3) Update gg_now!
     // gg_now = < g|P|scg > = < g|g0 >
@@ -368,12 +368,12 @@ void DiagoCG<T, Device>::calc_gamma_cg(const int& iter,
         //     pcg[i] = gamma * pcg[i] + grad.data<T>()[i];
         // }
         // haozhihan replace this 2022-10-6
-        ModuleBase::vector_add_vector_op<T, Device>()(this->n_basis_,
-                                                      cg.data<T>(),
-                                                      cg.data<T>(),
-                                                      gamma,
-                                                      grad.data<T>(),
-                                                      1.0);
+        ModuleBase::vector_add_vector_op<T, Device, Real>()(this->n_basis_,
+                                                            cg.data<T>(),
+                                                            cg.data<T>(),
+                                                            gamma,
+                                                            grad.data<T>(),
+                                                            1.0);
 
         const Real norma = gamma * cg_norm * sin(theta);
         T znorma = static_cast<T>(norma * -1);
@@ -436,12 +436,12 @@ bool DiagoCG<T, Device>::update_psi(const ct::Tensor& pphi,
     // }
 
     // haozhihan replace this 2022-10-6
-    ModuleBase::vector_add_vector_op<T, Device>()(this->n_basis_,
-                                                  phi_m.data<T>(),
-                                                  phi_m.data<T>(),
-                                                  cost,
-                                                  cg.data<T>(),
-                                                  sint_norm);
+    ModuleBase::vector_add_vector_op<T, Device, Real>()(this->n_basis_,
+                                                        phi_m.data<T>(),
+                                                        phi_m.data<T>(),
+                                                        cost,
+                                                        cg.data<T>(),
+                                                        sint_norm);
 
     if (std::abs(eigen - e0) < ethreshold)
     {
@@ -457,18 +457,18 @@ bool DiagoCG<T, Device>::update_psi(const ct::Tensor& pphi,
         // }
 
         // haozhihan replace this 2022-10-6
-        ModuleBase::vector_add_vector_op<T, Device>()(this->n_basis_,
-                                                      sphi.data<T>(),
-                                                      sphi.data<T>(),
-                                                      cost,
-                                                      scg.data<T>(),
-                                                      sint_norm);
-        ModuleBase::vector_add_vector_op<T, Device>()(this->n_basis_,
-                                                      hphi.data<T>(),
-                                                      hphi.data<T>(),
-                                                      cost,
-                                                      pphi.data<T>(),
-                                                      sint_norm);
+        ModuleBase::vector_add_vector_op<T, Device, Real>()(this->n_basis_,
+                                                            sphi.data<T>(),
+                                                            sphi.data<T>(),
+                                                            cost,
+                                                            scg.data<T>(),
+                                                            sint_norm);
+        ModuleBase::vector_add_vector_op<T, Device, Real>()(this->n_basis_,
+                                                            hphi.data<T>(),
+                                                            hphi.data<T>(),
+                                                            cost,
+                                                            pphi.data<T>(),
+                                                            sint_norm);
         return false;
     }
 }

--- a/source/source_hsolver/diago_david.cpp
+++ b/source/source_hsolver/diago_david.cpp
@@ -407,19 +407,21 @@ void DiagoDavid<T, Device>::cal_grad(const HPsiFunc& hpsi_func,
             Real* e_temp_gpu = nullptr;
             resmem_var_op()(e_temp_gpu, nbase);
             syncmem_var_h2d_op()(e_temp_gpu, e_temp_cpu.data(), nbase);
-            ModuleBase::vector_mul_vector_op<T, Device>()(nbase,
-                                                          vc_ev_vector + m * nbase,
-                                                          vc_ev_vector + m * nbase,
-                                                          e_temp_gpu);
+            ModuleBase::vector_mul_vector_op<T, Device, Real>()(nbase,
+                                                                vc_ev_vector + m * nbase,
+                                                                vc_ev_vector + m * nbase,
+                                                                e_temp_gpu,
+                                                                false);
             delmem_var_op()(e_temp_gpu);
 #endif
         }
         else
         {
-            ModuleBase::vector_mul_vector_op<T, Device>()(nbase,
-                                                          vc_ev_vector + m * nbase,
-                                                          vc_ev_vector + m * nbase,
-                                                          e_temp_cpu.data());
+            ModuleBase::vector_mul_vector_op<T, Device, Real>()(nbase,
+                                                                vc_ev_vector + m * nbase,
+                                                                vc_ev_vector + m * nbase,
+                                                                e_temp_cpu.data(),
+                                                                false);
         }
     }
     //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -473,18 +475,18 @@ void DiagoDavid<T, Device>::cal_grad(const HPsiFunc& hpsi_func,
         if (this->device == base_device::GpuDevice)
         {
 #if defined(__CUDA) || defined(__ROCM)
-            ModuleBase::vector_div_vector_op<T, Device>()(dim,
-                                                          basis + dim * (nbase + m),
-                                                          basis + dim * (nbase + m),
-                                                          this->d_precondition);
+            ModuleBase::vector_div_vector_op<T, Device, Real>()(dim,
+                                                                basis + dim * (nbase + m),
+                                                                basis + dim * (nbase + m),
+                                                                this->d_precondition);
 #endif
         }
         else
         {
-            ModuleBase::vector_div_vector_op<T, Device>()(dim,
-                                                          basis + dim * (nbase + m),
-                                                          basis + dim * (nbase + m),
-                                                          this->precondition);
+            ModuleBase::vector_div_vector_op<T, Device, Real>()(dim,
+                                                                basis + dim * (nbase + m),
+                                                                basis + dim * (nbase + m),
+                                                                this->precondition);
         }
         //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
         // for (int ig = 0; ig < dim; ig++)

--- a/source/source_hsolver/kernels/bpcg_kernel_op.cpp
+++ b/source/source_hsolver/kernels/bpcg_kernel_op.cpp
@@ -141,7 +141,7 @@ struct precondition_op<T, base_device::DEVICE_CPU> {
                 Real x = std::abs(precondition[i] - eigenvalues[m]);
                 pre[i] = 0.5 * (1.0 + x + sqrt(1 + (x - 1.0) * (x - 1.0)));
             }
-            ModuleBase::vector_div_vector_op<T, base_device::DEVICE_CPU>()(
+            ModuleBase::vector_div_vector_op<T, base_device::DEVICE_CPU, Real>()(
                                                              dim,
                                                              psi_iter + (nbase + m) * dim,
                                                              psi_iter + (nbase + m) * dim,

--- a/source/source_hsolver/kernels/test/perf_math_kernel.cpp
+++ b/source/source_hsolver/kernels/test/perf_math_kernel.cpp
@@ -134,10 +134,12 @@ class PerfModuleHsolverMathKernel : public benchmark::Fixture {
     using zdot_real_cpu_op = ModuleBase::dot_real_op<std::complex<double>, base_device::DEVICE_CPU>;
     
     using vector_mul_real_op_cpu = ModuleBase::vector_mul_real_op<std::complex<double>, base_device::DEVICE_CPU>;
-    using vector_mul_vector_op_cpu = ModuleBase::vector_mul_vector_op<std::complex<double>, base_device::DEVICE_CPU>;
-    using vector_div_vector_op_cpu = ModuleBase::vector_div_vector_op<std::complex<double>, base_device::DEVICE_CPU>;
+    using vector_mul_vector_op_cpu
+        = ModuleBase::vector_mul_vector_op<std::complex<double>, base_device::DEVICE_CPU, double>;
+    using vector_div_vector_op_cpu
+        = ModuleBase::vector_div_vector_op<std::complex<double>, base_device::DEVICE_CPU, double>;
     using vector_add_vector_op_cpu
-        = ModuleBase::vector_add_vector_op<std::complex<double>, base_device::DEVICE_CPU>;
+        = ModuleBase::vector_add_vector_op<std::complex<double>, base_device::DEVICE_CPU, double>;
     using axpy_op_cpu = ModuleBase::axpy_op<std::complex<double>, base_device::DEVICE_CPU>;
     using scal_op_cpu = ModuleBase::scal_op<double, base_device::DEVICE_CPU>;
     using gemv_op_cpu = ModuleBase::gemv_op<std::complex<double>, base_device::DEVICE_CPU>;
@@ -148,10 +150,12 @@ class PerfModuleHsolverMathKernel : public benchmark::Fixture {
     using zdot_real_gpu_op = ModuleBase::dot_real_op<std::complex<double>, base_device::DEVICE_GPU>;
 
     using vector_mul_real_op_gpu = ModuleBase::vector_mul_real_op<std::complex<double>, base_device::DEVICE_GPU>;
-    using vector_mul_vector_op_gpu = ModuleBase::vector_mul_vector_op<std::complex<double>, base_device::DEVICE_GPU>;
-    using vector_div_vector_op_gpu = ModuleBase::vector_div_vector_op<std::complex<double>, base_device::DEVICE_GPU>;
+    using vector_mul_vector_op_gpu
+        = ModuleBase::vector_mul_vector_op<std::complex<double>, base_device::DEVICE_GPU, double>;
+    using vector_div_vector_op_gpu
+        = ModuleBase::vector_div_vector_op<std::complex<double>, base_device::DEVICE_GPU, double>;
     using vector_add_vector_op_gpu
-        = ModuleBase::vector_add_vector_op<std::complex<double>, base_device::DEVICE_GPU>;
+        = ModuleBase::vector_add_vector_op<std::complex<double>, base_device::DEVICE_GPU, double>;
     using axpy_op_gpu = ModuleBase::axpy_op<std::complex<double>, base_device::DEVICE_GPU>;
     using scal_op_gpu = ModuleBase::scal_op<double, base_device::DEVICE_GPU>;
 
@@ -174,7 +178,7 @@ BENCHMARK_DEFINE_F(PerfModuleHsolverMathKernel, BM_vector_mul_real_op_cpu)(bench
 
 BENCHMARK_DEFINE_F(PerfModuleHsolverMathKernel, BM_vector_mul_vector_op_cpu)(benchmark::State& state) {
     for (auto _ : state) {
-        vector_mul_vector_op_cpu()(dim_vector, result_zvector, test_zvector_a, test_dvector_a);
+        vector_mul_vector_op_cpu()(dim_vector, result_zvector, test_zvector_a, test_dvector_a, false);
     }
 }
 
@@ -243,7 +247,7 @@ BENCHMARK_DEFINE_F(PerfModuleHsolverMathKernel, BM_vector_mul_real_op_gpu)(bench
 
 BENCHMARK_DEFINE_F(PerfModuleHsolverMathKernel, BM_vector_mul_vector_op_gpu)(benchmark::State& state) {
     for (auto _ : state) {
-        vector_mul_vector_op_gpu()(dim_vector, result_zvector_gpu, test_zvector_a_gpu, test_dvector_a_gpu);
+        vector_mul_vector_op_gpu()(dim_vector, result_zvector_gpu, test_zvector_a_gpu, test_dvector_a_gpu, false);
     }
 }
 
@@ -285,4 +289,4 @@ BENCHMARK_REGISTER_F(PerfModuleHsolverMathKernel, BM_scal_op_gpu)->RangeMultipli
 #endif // __CUDA || __UT_USE_CUDA || __ROCM || __UT_USE_ROCM
 
 
-BENCHMARK_MAIN(); 
+BENCHMARK_MAIN();

--- a/source/source_lcao/module_lr/operator_casida/operator_lr_diag.h
+++ b/source/source_lcao/module_lr/operator_casida/operator_lr_diag.h
@@ -44,10 +44,11 @@ namespace LR
             const bool is_first_node = false)const override
         {
             ModuleBase::TITLE("OperatorLRDiag", "act");
-            ModuleBase::vector_mul_vector_op<T, Device>()(nk * pX.get_local_size(),   // local size of particle-hole basis
+            ModuleBase::vector_mul_vector_op<T, Device, double>()(nk * pX.get_local_size(),   // local size of particle-hole basis
                 hpsi,
                 psi_in,
-                this->eig_ks_diff.c);
+                this->eig_ks_diff.c,
+                false);
         }
     private:
         const Parallel_2D& pX;

--- a/source/source_pw/module_pwdft/op_pw_exx.h
+++ b/source/source_pw/module_pwdft/op_pw_exx.h
@@ -162,7 +162,7 @@ class OperatorEXXPW : public OperatorPW<T, Device>
     using delmem_real_op = base_device::memory::delete_memory_op<Real, Device>;
     using gemm_complex_op = ModuleBase::gemm_op<T, Device>;
     using axpy_complex_op = ModuleBase::axpy_op<T, Device>;
-    using vec_add_vec_complex_op = ModuleBase::vector_add_vector_op<T, Device>;
+    using vec_add_vec_complex_op = ModuleBase::vector_add_vector_op<T, Device, Real>;
     using dot_op = ModuleBase::dot_real_op<T, Device>;
     using syncmem_complex_c2d_op = base_device::memory::synchronize_memory_op<T, Device, base_device::DEVICE_CPU>;
     using syncmem_complex_d2c_op = base_device::memory::synchronize_memory_op<T, base_device::DEVICE_CPU, Device>;

--- a/source/source_pw/module_pwdft/op_pw_meta.cpp
+++ b/source/source_pw/module_pwdft/op_pw_meta.cpp
@@ -69,7 +69,7 @@ void Meta<OperatorPW<T, Device>>::act(
             wfcpw->recip_to_real(this->ctx, this->porter, this->porter, this->ik);
 
             if(this->vk_col != 0) {
-                vector_mul_vector_op()(this->vk_col, this->porter, this->porter, this->vk + current_spin * this->vk_col);
+                vector_mul_vector_op()(this->vk_col, this->porter, this->porter, this->vk + current_spin * this->vk_col, false);
             }
 
             wfcpw->real_to_recip(this->ctx, this->porter, this->porter, this->ik);

--- a/source/source_pw/module_pwdft/op_pw_meta.h
+++ b/source/source_pw/module_pwdft/op_pw_meta.h
@@ -81,7 +81,7 @@ class Meta<OperatorPW<T, Device>> : public OperatorPW<T, Device>
     base_device::DEVICE_CPU* cpu_ctx = {};
     T *porter = nullptr;
     using meta_op = meta_pw_op<Real, Device>;
-    using vector_mul_vector_op = ModuleBase::vector_mul_vector_op<T, Device>;
+    using vector_mul_vector_op = ModuleBase::vector_mul_vector_op<T, Device, Real>;
     using resmem_complex_op = base_device::memory::resize_memory_op<T, Device>;
     using delmem_complex_op = base_device::memory::delete_memory_op<T, Device>;
     using setmem_complex_op = base_device::memory::set_memory_op<T, Device>;

--- a/source/source_pw/module_pwdft/op_pw_vel.cpp
+++ b/source/source_pw/module_pwdft/op_pw_vel.cpp
@@ -115,7 +115,7 @@ void Velocity<FPTYPE, Device>::act(const psi::Psi<std::complex<FPTYPE>, Device>*
         Complex* tmpvpsi = vpsi + id * n_npwx * max_npw;
         for (int ib = 0; ib < n_npwx; ++ib)
         {
-            ModuleBase::vector_mul_vector_op<Complex, Device>()(npw, tmpvpsi, tmpsi_in, gtmp_ptr[id], add);
+            ModuleBase::vector_mul_vector_op<Complex, Device, FPTYPE>()(npw, tmpvpsi, tmpsi_in, gtmp_ptr[id], add);
             tmpvpsi += max_npw;
             tmpsi_in += max_npw;
         }
@@ -156,10 +156,11 @@ void Velocity<FPTYPE, Device>::act(const psi::Psi<std::complex<FPTYPE>, Device>*
         {
             const Complex* bandpsi = psi0 + ib * max_npw;
             this->wfcpw->recip_to_real(this->ctx, bandpsi, this->porter1_, this->ik);
-            ModuleBase::vector_mul_vector_op<Complex, Device>()(this->vtau_col_,
-                                                                this->porter1_,
-                                                                this->porter1_,
-                                                                vtau_spin);
+            ModuleBase::vector_mul_vector_op<Complex, Device, FPTYPE>()(this->vtau_col_,
+                                                                        this->porter1_,
+                                                                        this->porter1_,
+                                                                        vtau_spin,
+                                                                        false);
             this->wfcpw->real_to_recip(this->ctx, this->porter1_, this->porter1_, this->ik);
             for (int id = 0; id < 3; ++id)
             {
@@ -193,10 +194,11 @@ void Velocity<FPTYPE, Device>::act(const psi::Psi<std::complex<FPTYPE>, Device>*
                                            this->porter2_,
                                            false);
                 this->wfcpw->recip_to_real(this->ctx, this->porter2_, this->porter2_, this->ik);
-                ModuleBase::vector_mul_vector_op<Complex, Device>()(this->vtau_col_,
-                                                                    this->porter2_,
-                                                                    this->porter2_,
-                                                                    vtau_spin);
+                ModuleBase::vector_mul_vector_op<Complex, Device, FPTYPE>()(this->vtau_col_,
+                                                                            this->porter2_,
+                                                                            this->porter2_,
+                                                                            vtau_spin,
+                                                                            false);
                 this->wfcpw->real_to_recip(this->ctx, this->porter2_, this->porter2_, this->ik);
                 ModuleBase::scal_op<Real, Device>()(npw, &minus_half_i, this->porter2_, 1);
                 ModuleBase::axpy_op<Complex, Device>()(npw, &one, this->porter2_, 1, vpsi_slice, 1);

--- a/source/source_pw/module_stodft/sto_elecond.cpp
+++ b/source/source_pw/module_stodft/sto_elecond.cpp
@@ -406,7 +406,7 @@ void Sto_EleCond<FPTYPE, Device>::cal_jmatrix(hamilt::HamiltSdftPW<std::complex<
                 // {
                 //     j2mat[j] = 0.5f * j2mat[j] + (0.5f * ei - mu) * j1mat[j];
                 // }
-                ModuleBase::vector_add_vector_op<lcomplex, Device>()(allbands_sto, j2mat, j2mat, half, j1mat, half * ei - mu);
+                ModuleBase::vector_add_vector_op<lcomplex, Device, lowTYPE>()(allbands_sto, j2mat, j2mat, half, j1mat, half * ei - mu);
             }
             else
             {
@@ -416,7 +416,7 @@ void Sto_EleCond<FPTYPE, Device>::cal_jmatrix(hamilt::HamiltSdftPW<std::complex<
                 //     j2mat[j] = jfac * (0.5f * j2mat[j] + (0.5f * ei - mu) * j1mat[j]);
                 //     j1mat[j] *= jfac;
                 // }
-                ModuleBase::vector_add_vector_op<lcomplex, Device>()(allbands_sto, j2mat, j2mat, half, j1mat, half * ei - mu);
+                ModuleBase::vector_add_vector_op<lcomplex, Device, lowTYPE>()(allbands_sto, j2mat, j2mat, half, j1mat, half * ei - mu);
                 ModuleBase::scal_op<lowTYPE, Device>()(allbands_sto, &jfac, j2mat, 1);
                 ModuleBase::scal_op<lowTYPE, Device>()(allbands_sto, &jfac, j1mat, 1);
             }
@@ -434,7 +434,8 @@ void Sto_EleCond<FPTYPE, Device>::cal_jmatrix(hamilt::HamiltSdftPW<std::complex<
                 // {
                 //     j2mat[j] = 0.5f * j2mat[j] + (0.5f * ei - mu) * j1mat[j];
                 // }
-                ModuleBase::vector_add_vector_op<lcomplex, Device>()(perbands_sto, j2mat, j2mat, half, j1mat, half * ei - mu);
+                ModuleBase::vector_add_vector_op<lcomplex, Device, lowTYPE>()(
+                    perbands_sto, j2mat, j2mat, half, j1mat, half * ei - mu);
             }
             else
             {
@@ -444,7 +445,7 @@ void Sto_EleCond<FPTYPE, Device>::cal_jmatrix(hamilt::HamiltSdftPW<std::complex<
                 //     j2mat[j] = jfac * (0.5f * j2mat[j] + (0.5f * ei - mu) * j1mat[j]);
                 //     j1mat[j] *= jfac;
                 // }
-                ModuleBase::vector_add_vector_op<lcomplex, Device>()(perbands_sto, j2mat, j2mat, half, j1mat, half * ei - mu);
+                ModuleBase::vector_add_vector_op<lcomplex, Device, lowTYPE>()(perbands_sto, j2mat, j2mat, half, j1mat, half * ei - mu);
                 ModuleBase::scal_op<lowTYPE, Device>()(perbands_sto, &jfac, j2mat, 1);
                 ModuleBase::scal_op<lowTYPE, Device>()(perbands_sto, &jfac, j1mat, 1);
             }
@@ -460,8 +461,8 @@ void Sto_EleCond<FPTYPE, Device>::cal_jmatrix(hamilt::HamiltSdftPW<std::complex<
         // {
         //     j2mat[j] = 0.5f * (j2mat[j] + tmpjmat[j]) - mu * j1mat[j];
         // }
-        ModuleBase::vector_add_vector_op<lcomplex, Device>()(ed, j2mat, j2mat, one, tmpjmat, one);
-        ModuleBase::vector_add_vector_op<lcomplex, Device>()(ed, j2mat, j2mat, half, j1mat, -mu);
+        ModuleBase::vector_add_vector_op<lcomplex, Device, lowTYPE>()(ed, j2mat, j2mat, one, tmpjmat, one);
+        ModuleBase::vector_add_vector_op<lcomplex, Device, lowTYPE>()(ed, j2mat, j2mat, half, j1mat, -mu);
     }
 
 #ifdef __MPI


### PR DESCRIPTION
## Summary

This is a prerequisite PR for the plane-wave RT-TDDFT implementation.

This PR generalizes the existing low-level element-wise vector add, multiply, and divide operators. In `develop`, their coefficient or second-operand type is fixed to the real type associated with the vector element type. This change makes that type an explicit, independent template parameter, enabling complex vectors to use either real or complex coefficients and operands on CPU, CUDA, and ROCm.

## Changes

- Replace the previous two-parameter vector operator templates with explicit three-parameter interfaces:
  - `vector_add_vector_op<T, Device, Scalar>`
  - `vector_mul_vector_op<T, Device, Operand>`
  - `vector_div_vector_op<T, Device, Operand>`
- Require all template arguments and the `add` argument of `vector_mul_vector_op` to be specified explicitly at every call site.
- Generalize the existing CPU, CUDA, and HIP implementations to handle the supported scalar and operand types, including complex-complex add, multiply, and divide operations.
- Add the missing CPU instantiations for the float-vector paths and explicit instantiations for all supported type combinations.
- Use the same type-generic kernel path for each operation within the CUDA and HIP backends, with explicit conversion between `std::complex` and the backend complex representation.
- Make `dim <= 0` a no-op before computing GPU launch dimensions.
- Generalize the three `BlasConnector` interfaces to two-type function templates and route their CPU, CUDA, and ROCm paths through the corresponding `ModuleBase` operators.
- Update existing call sites and the performance benchmark to use the new explicit interfaces without changing their numerical behavior.
- Extend the existing math kernel tests to cover the key real, complex-real, complex-complex, aliasing, accumulation, zero-length, and cross-block paths.

## Supported type combinations

- `float` / `float`
- `double` / `double`
- `std::complex<float>` / `float`
- `std::complex<double>` / `double`
- `std::complex<float>` / `std::complex<float>`
- `std::complex<double>` / `std::complex<double>`

Mixed precision and real-valued results with complex operands are not part of the supported interface.

The element-wise formulas are unchanged. Complete aliasing of `result` with a same-type input vector remains supported; partial overlap is outside the interface contract.

## Notes

- The HIP implementation mirrors the CPU/CUDA type dispatch and formulas, but ROCm was not configured, compiled, linked, or executed in this validation.
- This PR does not change INPUT behavior, so no parameter documentation update is required.