### PR TITLE
CMake: Fix RapidJSON target for non-MPI builds

### DIFF
--- a/source/source_io/CMakeLists.txt
+++ b/source/source_io/CMakeLists.txt
@@ -152,7 +152,5 @@ if(BUILD_TESTING)
 endif()
 
 if(ENABLE_RAPIDJSON)
-  if(ENABLE_MPI)
-    add_subdirectory(module_json)
-  endif()
+  add_subdirectory(module_json)
 endif()


### PR DESCRIPTION
The target `json_output` was created only when both RapidJSON and MPI were enabled, while the executable links against `json_output` whenever `ENABLE_RAPIDJSON=ON`. As a result, non-MPI builds could treat `json_output` as a plain library name and fail at link time with:

```text
/usr/bin/ld: cannot find -ljson_output
```

However, the MPI requirement is only relevant to the tests under `module_json`; the `json_output` target itself already handles non-MPI builds correctly.

Therefore, this PR removes the redundant MPI guard from the parent CMake logic.
