### PR TITLE
Fix(PW): avoid GPU crash in Wannier90 output

### DIFF
--- a/source/source_io/module_ctrl/ctrl_output_pw.cpp
+++ b/source/source_io/module_ctrl/ctrl_output_pw.cpp
@@ -1,18 +1,19 @@
 #include "ctrl_output_pw.h"
 
-#include "../module_wf/write_wfc_pw.h" // use write_wfc_pw
-#include "../module_dos/write_dos_pw.h" // use write_dos_pw
-#include "../module_wannier/to_wannier90_pw.h" // wannier90 interface
-#include "source_pw/module_pwdft/onsite_proj.h" // use projector
 #include "../module_bessel/numerical_basis.h"
 #include "../module_bessel/numerical_descriptor.h"
-#include "../module_dos/cal_ldos.h"
-#include "../module_unk/berryphase.h"
-#include "source_lcao/module_deltaspin/spin_constrain.h"
-#include "source_base/formatter.h"
 #include "../module_chgpot/get_pchg_pw.h"
+#include "../module_dos/cal_ldos.h"
+#include "../module_dos/write_dos_pw.h" // use write_dos_pw
+#include "../module_unk/berryphase.h"
+#include "../module_wannier/to_wannier90_pw.h" // wannier90 interface
 #include "../module_wf/get_wf_pw.h"
+#include "../module_wf/write_wfc_pw.h" // use write_wfc_pw
+#include "source_base/formatter.h"
+#include "source_base/module_device/device_helpers.h"
+#include "source_lcao/module_deltaspin/spin_constrain.h"
 #include "source_pw/module_pwdft/elecond.h"
+#include "source_pw/module_pwdft/onsite_proj.h" // use projector
 
 #ifdef __MLALGO
 #include "../module_ml/write_mlkedf_descriptors.h"
@@ -201,7 +202,8 @@ void ModuleIO::ctrl_scf_pw(const int istep,
                            inp.out_wannier_eig,
                            inp.out_wannier_wvfn_formatted,
                            inp.nnkpfile,
-                           inp.wannier_spin);
+                           inp.wannier_spin,
+                           base_device::get_device_type(ctx) == base_device::GpuDevice);
         wan.set_tpiba_omega(ucell.tpiba, ucell.omega);
         wan.calculate(ucell, pelec->ekb, pw_wfc, pw_big, kv, stp.psi_cpu);
         std::cout << FmtCore::format(" >> Finish %s.\n * * * * * *\n", "Wannier functions calculation");

--- a/source/source_io/module_wannier/to_wannier90_lcao_in_pw.cpp
+++ b/source/source_io/module_wannier/to_wannier90_lcao_in_pw.cpp
@@ -10,15 +10,21 @@
 
 #include "source_psi/psi_init_nao.h"
 #ifdef __LCAO
-toWannier90_LCAO_IN_PW::toWannier90_LCAO_IN_PW(
-    const bool &out_wannier_mmn, 
-    const bool &out_wannier_amn, 
-    const bool &out_wannier_unk, 
-    const bool &out_wannier_eig,
-    const bool &out_wannier_wvfn_formatted, 
-    const std::string &nnkpfile,
-    const std::string &wannier_spin
-):toWannier90_PW(out_wannier_mmn, out_wannier_amn, out_wannier_unk, out_wannier_eig, out_wannier_wvfn_formatted, nnkpfile, wannier_spin)
+toWannier90_LCAO_IN_PW::toWannier90_LCAO_IN_PW(const bool& out_wannier_mmn,
+                                               const bool& out_wannier_amn,
+                                               const bool& out_wannier_unk,
+                                               const bool& out_wannier_eig,
+                                               const bool& out_wannier_wvfn_formatted,
+                                               const std::string& nnkpfile,
+                                               const std::string& wannier_spin)
+    : toWannier90_PW(out_wannier_mmn,
+                     out_wannier_amn,
+                     out_wannier_unk,
+                     out_wannier_eig,
+                     out_wannier_wvfn_formatted,
+                     nnkpfile,
+                     wannier_spin,
+                     false)
 {
 }
 

--- a/source/source_io/module_wannier/to_wannier90_pw.cpp
+++ b/source/source_io/module_wannier/to_wannier90_pw.cpp
@@ -1,23 +1,106 @@
 #include "to_wannier90_pw.h"
-#include "source_base/parallel_comm.h" // use POOL_WORLD
 
-#include "source_io/module_parameter/parameter.h"
+#include "../module_output/binstream.h"
 #include "source_base/math_integral.h"
 #include "source_base/math_polyint.h"
 #include "source_base/math_sphbes.h"
 #include "source_base/math_ylmreal.h"
+#include "source_base/module_device/memory_op.h"
+#include "source_base/parallel_comm.h" // use POOL_WORLD
 #include "source_base/parallel_reduce.h"
-#include "../module_output/binstream.h"
+#include "source_io/module_parameter/parameter.h"
 
-toWannier90_PW::toWannier90_PW(
-    const bool &out_wannier_mmn, 
-    const bool &out_wannier_amn, 
-    const bool &out_wannier_unk, 
-    const bool &out_wannier_eig,
-    const bool &out_wannier_wvfn_formatted, 
-    const std::string &nnkpfile,
-    const std::string &wannier_spin
-):toWannier90(out_wannier_mmn, out_wannier_amn, out_wannier_unk, out_wannier_eig, out_wannier_wvfn_formatted, nnkpfile, wannier_spin)
+#include <memory>
+
+class toWannier90_PW::Wannier90PWFFT
+{
+  public:
+    Wannier90PWFFT(const ModulePW::PW_Basis_K* wfcpw, const bool use_gpu_fft) : wfcpw_(wfcpw)
+    {
+#if defined(__CUDA) || defined(__ROCM)
+        if (use_gpu_fft)
+        {
+            reciprocal_.reset(new psi::Psi<std::complex<double>, base_device::DEVICE_GPU>(1,
+                                                                                          1,
+                                                                                          wfcpw_->npwk_max,
+                                                                                          wfcpw_->npwk_max,
+                                                                                          true));
+            realspace_.reset(
+                new psi::Psi<std::complex<double>, base_device::DEVICE_GPU>(1, 1, wfcpw_->nrxx, wfcpw_->nrxx, true));
+        }
+#endif
+    }
+
+    void recip_to_real(const std::complex<double>* in, std::complex<double>* out, const int ik) const
+    {
+#if defined(__CUDA) || defined(__ROCM)
+        if (reciprocal_)
+        {
+            base_device::memory::synchronize_memory_op<std::complex<double>,
+                                                       base_device::DEVICE_GPU,
+                                                       base_device::DEVICE_CPU>()(reciprocal_->get_pointer(),
+                                                                                  in,
+                                                                                  wfcpw_->npwk[ik]);
+            const base_device::DEVICE_GPU* ctx = nullptr;
+            wfcpw_->recip_to_real(ctx, reciprocal_->get_pointer(), realspace_->get_pointer(), ik);
+            base_device::memory::synchronize_memory_op<std::complex<double>,
+                                                       base_device::DEVICE_CPU,
+                                                       base_device::DEVICE_GPU>()(out,
+                                                                                  realspace_->get_pointer(),
+                                                                                  wfcpw_->nrxx);
+            return;
+        }
+#endif
+        wfcpw_->recip2real(in, out, ik);
+    }
+
+    void real_to_recip(const std::complex<double>* in, std::complex<double>* out, const int ik) const
+    {
+#if defined(__CUDA) || defined(__ROCM)
+        if (realspace_)
+        {
+            base_device::memory::synchronize_memory_op<std::complex<double>,
+                                                       base_device::DEVICE_GPU,
+                                                       base_device::DEVICE_CPU>()(realspace_->get_pointer(),
+                                                                                  in,
+                                                                                  wfcpw_->nrxx);
+            const base_device::DEVICE_GPU* ctx = nullptr;
+            wfcpw_->real_to_recip(ctx, realspace_->get_pointer(), reciprocal_->get_pointer(), ik);
+            base_device::memory::synchronize_memory_op<std::complex<double>,
+                                                       base_device::DEVICE_CPU,
+                                                       base_device::DEVICE_GPU>()(out,
+                                                                                  reciprocal_->get_pointer(),
+                                                                                  wfcpw_->npwk[ik]);
+            return;
+        }
+#endif
+        wfcpw_->real2recip(in, out, ik);
+    }
+
+  private:
+    const ModulePW::PW_Basis_K* wfcpw_;
+#if defined(__CUDA) || defined(__ROCM)
+    std::unique_ptr<psi::Psi<std::complex<double>, base_device::DEVICE_GPU>> reciprocal_;
+    std::unique_ptr<psi::Psi<std::complex<double>, base_device::DEVICE_GPU>> realspace_;
+#endif
+};
+
+toWannier90_PW::toWannier90_PW(const bool& out_wannier_mmn,
+                               const bool& out_wannier_amn,
+                               const bool& out_wannier_unk,
+                               const bool& out_wannier_eig,
+                               const bool& out_wannier_wvfn_formatted,
+                               const std::string& nnkpfile,
+                               const std::string& wannier_spin,
+                               const bool use_gpu_fft)
+    : toWannier90(out_wannier_mmn,
+                  out_wannier_amn,
+                  out_wannier_unk,
+                  out_wannier_eig,
+                  out_wannier_wvfn_formatted,
+                  nnkpfile,
+                  wannier_spin),
+      use_gpu_fft_(use_gpu_fft)
 {
 
 }
@@ -88,6 +171,7 @@ void toWannier90_PW::cal_Mmn(
 )
 {
     std::ofstream mmn_file;
+    Wannier90PWFFT fft(wfcpw, this->use_gpu_fft_);
 
     if (GlobalV::MY_RANK == 0)
     {
@@ -109,7 +193,7 @@ void toWannier90_PW::cal_Mmn(
 
             int cal_ik = ik + start_k_index;
             int cal_ikb = ikb + start_k_index;
-            unkdotkb(psi_pw, wfcpw, cal_ik, cal_ikb, phase_G, Mmn);
+            unkdotkb(psi_pw, wfcpw, cal_ik, cal_ikb, phase_G, Mmn, fft);
 
             if (GlobalV::MY_RANK == 0)
             {
@@ -353,15 +437,13 @@ void toWannier90_PW::out_unk(
 
 }
 
-
-void toWannier90_PW::unkdotkb(
-    const psi::Psi<std::complex<double>>& psi_pw, 
-    const ModulePW::PW_Basis_K* wfcpw,
-    const int& cal_ik,
-    const int& cal_ikb,
-    const ModuleBase::Vector3<double> G,
-    ModuleBase::ComplexMatrix &Mmn
-)
+void toWannier90_PW::unkdotkb(const psi::Psi<std::complex<double>>& psi_pw,
+                              const ModulePW::PW_Basis_K* wfcpw,
+                              const int& cal_ik,
+                              const int& cal_ikb,
+                              const ModuleBase::Vector3<double> G,
+                              ModuleBase::ComplexMatrix& Mmn,
+                              Wannier90PWFFT& fft)
 {
     Mmn.create(num_bands, num_bands);
 
@@ -383,7 +465,7 @@ void toWannier90_PW::unkdotkb(
             }
         }
 
-        wfcpw->recip2real(phase, phase, cal_ik);
+        fft.recip_to_real(phase, phase, cal_ik);
 
         if (PARAM.inp.nspin == 4)
         {
@@ -396,17 +478,17 @@ void toWannier90_PW::unkdotkb(
             // (2) fft and get value
             // int npw_ik = wfcpw->npwk[cal_ik];
             int npwx = wfcpw->npwk_max;
-            wfcpw->recip2real(&psi_pw(cal_ik, im, 0), psir_up, cal_ik);
+            fft.recip_to_real(&psi_pw(cal_ik, im, 0), psir_up, cal_ik);
             // wfcpw->recip2real(&psi_pw(cal_ik, im, npw_ik), psir_dn, cal_ik);
-            wfcpw->recip2real(&psi_pw(cal_ik, im, npwx), psir_dn, cal_ik);
+            fft.recip_to_real(&psi_pw(cal_ik, im, npwx), psir_dn, cal_ik);
             for (int ir = 0; ir < wfcpw->nrxx; ir++)
             {
                 psir_up[ir] *= phase[ir];
                 psir_dn[ir] *= phase[ir];
             }
 
-            wfcpw->real2recip(psir_up, psir_up, cal_ikb);
-            wfcpw->real2recip(psir_dn, psir_dn, cal_ikb);
+            fft.real_to_recip(psir_up, psir_up, cal_ikb);
+            fft.real_to_recip(psir_dn, psir_dn, cal_ikb);
 
             for (int n = 0; n < num_bands; n++)
             {
@@ -447,13 +529,13 @@ void toWannier90_PW::unkdotkb(
             ModuleBase::GlobalFunc::ZEROS(psir, wfcpw->nmaxgr);
 
             // (2) fft and get value
-            wfcpw->recip2real(&psi_pw(cal_ik, im, 0), psir, cal_ik);
+            fft.recip_to_real(&psi_pw(cal_ik, im, 0), psir, cal_ik);
             for (int ir = 0; ir < wfcpw->nrxx; ir++)
             {
                 psir[ir] *= phase[ir];
             }
 
-            wfcpw->real2recip(psir, psir, cal_ikb);
+            fft.real_to_recip(psir, psir, cal_ikb);
 
             for (int n = 0; n < num_bands; n++)
             {

--- a/source/source_io/module_wannier/to_wannier90_pw.h
+++ b/source/source_io/module_wannier/to_wannier90_pw.h
@@ -20,15 +20,14 @@
 class toWannier90_PW : public toWannier90
 {
   public:
-    toWannier90_PW(
-      const bool &out_wannier_mmn, 
-      const bool &out_wannier_amn, 
-      const bool &out_wannier_unk, 
-      const bool &out_wannier_eig,
-      const bool &out_wannier_wvfn_formatted, 
-      const std::string &nnkpfile,
-      const std::string &wannier_spin
-    );
+    toWannier90_PW(const bool& out_wannier_mmn,
+                   const bool& out_wannier_amn,
+                   const bool& out_wannier_unk,
+                   const bool& out_wannier_eig,
+                   const bool& out_wannier_wvfn_formatted,
+                   const std::string& nnkpfile,
+                   const std::string& wannier_spin,
+                   const bool use_gpu_fft);
     ~toWannier90_PW();
 
     void calculate(
@@ -61,21 +60,23 @@ class toWannier90_PW : public toWannier90
     );
     void set_tpiba_omega(const double& tpiba, const double& omega);
   protected:
+    class Wannier90PWFFT;
+
     // Radial section of trial orbitals
     const int mesh_r = 333;
     const double dx = 0.025;
     const double x_min = -6.0;
     double const *tpiba;
     double const *omega;
+    const bool use_gpu_fft_;
 
-    void unkdotkb(
-      const psi::Psi<std::complex<double>>& psi_pw, 
-      const ModulePW::PW_Basis_K* wfcpw, 
-      const int& ik, 
-      const int& ikb, 
-      const ModuleBase::Vector3<double> G, 
-      ModuleBase::ComplexMatrix &Mmn
-    );
+    void unkdotkb(const psi::Psi<std::complex<double>>& psi_pw,
+                  const ModulePW::PW_Basis_K* wfcpw,
+                  const int& ik,
+                  const int& ikb,
+                  const ModuleBase::Vector3<double> G,
+                  ModuleBase::ComplexMatrix& Mmn,
+                  Wannier90PWFFT& fft);
 
     void gen_radial_function_in_q(std::vector<ModuleBase::matrix> &radial_in_q);
 

--- a/tests/01_PW/CASES_GPU.txt
+++ b/tests/01_PW/CASES_GPU.txt
@@ -100,7 +100,7 @@ scf_out_elf
 #096_PW_PBE0_FM
 098_PW_15_SO_avg
 #099_PW_DJ_SO
-#100_PW_W90
+100_PW_W90
 101_PW_MD_1O
 102_PW_MD_2O
 #103_PW_Gene_Descriptors


### PR DESCRIPTION
## Summary

- Fix the PW-GPU crash in the post-NSCF Wannier90 MMN calculation.
- Keep the existing CPU behavior and Wannier90 formulas unchanged.
- Enable `100_PW_W90` in the existing 01_PW GPU regression list.

## Root cause

`toWannier90_PW::unkdotkb()` operated on valid host-side wave functions, but called the CPU-style `PW_Basis_K::recip2real()` interface. In a CUDA build, the basis owns an `FFT_CUDA` backend, which implements the device-aware 3D FFT interface but not the CPU auxiliary-buffer interface. The first CPU-style auxiliary-buffer dispatch therefore reached an unresolved weak virtual slot and jumped to address `0x0`. This occurs only after the NSCF calculation has completed, when Wannier90 starts constructing the MMN matrix.

## Changes

- Pass the selected FFT backend into the PW Wannier90 object.
- Add a small RAII staging helper for the MMN calculation:
  - CPU builds continue to call the existing CPU FFT functions directly.
  - GPU builds reuse two device buffers and ABACUS memory synchronization operators around the existing device-aware `recip_to_real()` and `real_to_recip()` interfaces.
- Keep the LCAO-in-PW caller on its previous CPU FFT path.
- Uncomment the existing `100_PW_W90` GPU case; no new input or reference data is added.

## Verification

- Baseline, Slurm job `213795` on RTX 4090:
  - CPU `100_PW_W90`: passed all 5 checks.
  - GPU run 1: exit 139.
  - GPU run 2: exit 139.
  - GDB: null indirect call from `PW_Basis_K::recip2real<double>()`, called by `toWannier90_PW::unkdotkb()`.
- Final CPU/GPU integration run, Slurm job `213879`, `OMP_NUM_THREADS=1`, one MPI rank:
  - CPU `100_PW_W90`: passed all 5 existing checks.
  - CUDA `100_PW_W90`: passed all 5 existing checks.
  - Existing AMN/MMN/EIG references and comparison settings were not changed.
  - GPU NSCF control with `towannier90=0`: exit 0.
- CUDA Compute Sanitizer, Slurm job `213880`:
  - exit 0;
  - `ERROR SUMMARY: 0 errors`.
- LCAO-enabled `io_advanced` compile target, Slurm job `213874`: passed.
- `git diff --check`: passed.
- ABACUS agent-governance check: passed with only the expected no-documentation warning.

## Behavior change

PW-GPU Wannier90 MMN output now uses the FFT interface matching the CUDA backend instead of crashing. The synchronization and two temporary device buffers exist only during post-NSCF Wannier90 MMN output; the SCF/NSCF iteration path is unchanged.

## INPUT/documentation impact

None. No INPUT keyword, meaning, default, reference result, or tolerance is changed.

## Core-module impact

None. No wave-function, FFT, device-memory, solver, or physics implementation is modified; the fix is confined to the Wannier90 I/O boundary and its call site.

Fixes part of #7770
