### PR TITLE
Fix(device): dispatch memory operations by device pair

### DIFF
--- a/source/source_base/module_device/memory_op.cpp
+++ b/source/source_base/module_device/memory_op.cpp
@@ -549,16 +549,16 @@ void set_memory(FPTYPE* arr, const int var, const size_t size, base_device::Abac
 
 template <typename FPTYPE>
 void synchronize_memory(FPTYPE* arr_out, const FPTYPE* arr_in, const size_t size, base_device::AbacusDevice_t device_type_out, base_device::AbacusDevice_t device_type_in){
-    if (device_type_out == base_device::AbacusDevice_t::CpuDevice || device_type_in == base_device::AbacusDevice_t::CpuDevice){
+    if (device_type_out == base_device::AbacusDevice_t::CpuDevice && device_type_in == base_device::AbacusDevice_t::CpuDevice){
         synchronize_memory_op<FPTYPE, DEVICE_CPU, DEVICE_CPU>()(arr_out, arr_in, size);
     }
-    else if (device_type_out == base_device::AbacusDevice_t::CpuDevice || device_type_in == base_device::AbacusDevice_t::GpuDevice){
+    else if (device_type_out == base_device::AbacusDevice_t::CpuDevice && device_type_in == base_device::AbacusDevice_t::GpuDevice){
         synchronize_memory_op<FPTYPE, DEVICE_CPU, DEVICE_GPU>()(arr_out, arr_in, size);
     }
-    else if (device_type_out == base_device::AbacusDevice_t::GpuDevice || device_type_in == base_device::AbacusDevice_t::CpuDevice){
+    else if (device_type_out == base_device::AbacusDevice_t::GpuDevice && device_type_in == base_device::AbacusDevice_t::CpuDevice){
         synchronize_memory_op<FPTYPE, DEVICE_GPU, DEVICE_CPU>()(arr_out, arr_in, size);
     }
-    else if (device_type_out == base_device::AbacusDevice_t::GpuDevice || device_type_in == base_device::AbacusDevice_t::GpuDevice){
+    else if (device_type_out == base_device::AbacusDevice_t::GpuDevice && device_type_in == base_device::AbacusDevice_t::GpuDevice){
         synchronize_memory_op<FPTYPE, DEVICE_GPU, DEVICE_GPU>()(arr_out, arr_in, size);
     }
 }
@@ -566,16 +566,16 @@ void synchronize_memory(FPTYPE* arr_out, const FPTYPE* arr_in, const size_t size
 template <typename FPTYPE_out, typename FPTYPE_in>
 void cast_memory(FPTYPE_out* arr_out, const FPTYPE_in* arr_in, const size_t size, base_device::AbacusDevice_t device_type_out, base_device::AbacusDevice_t device_type_in)
 {
-    if (device_type_out == base_device::AbacusDevice_t::CpuDevice || device_type_in == base_device::AbacusDevice_t::CpuDevice){
+    if (device_type_out == base_device::AbacusDevice_t::CpuDevice && device_type_in == base_device::AbacusDevice_t::CpuDevice){
         cast_memory_op<FPTYPE_out, FPTYPE_in, DEVICE_CPU, DEVICE_CPU>()(arr_out, arr_in, size);
     }
-    else if (device_type_out == base_device::AbacusDevice_t::CpuDevice || device_type_in == base_device::AbacusDevice_t::GpuDevice){
+    else if (device_type_out == base_device::AbacusDevice_t::CpuDevice && device_type_in == base_device::AbacusDevice_t::GpuDevice){
         cast_memory_op<FPTYPE_out, FPTYPE_in, DEVICE_CPU, DEVICE_GPU>()(arr_out, arr_in, size);
     }
-    else if (device_type_out == base_device::AbacusDevice_t::GpuDevice || device_type_in == base_device::AbacusDevice_t::CpuDevice){
+    else if (device_type_out == base_device::AbacusDevice_t::GpuDevice && device_type_in == base_device::AbacusDevice_t::CpuDevice){
         cast_memory_op<FPTYPE_out, FPTYPE_in, DEVICE_GPU, DEVICE_CPU>()(arr_out, arr_in, size);
     }
-    else if (device_type_out == base_device::AbacusDevice_t::GpuDevice || device_type_in == base_device::AbacusDevice_t::GpuDevice){
+    else if (device_type_out == base_device::AbacusDevice_t::GpuDevice && device_type_in == base_device::AbacusDevice_t::GpuDevice){
         cast_memory_op<FPTYPE_out, FPTYPE_in, DEVICE_GPU, DEVICE_GPU>()(arr_out, arr_in, size);
     }
 }
@@ -590,6 +590,17 @@ void delete_memory(FPTYPE* arr, base_device::AbacusDevice_t device_type)
         delete_memory_op<FPTYPE, DEVICE_GPU>()(arr);
     }
 }
+
+template void synchronize_memory<double>(double*,
+                                         const double*,
+                                         const size_t,
+                                         base_device::AbacusDevice_t,
+                                         base_device::AbacusDevice_t);
+template void cast_memory<float, double>(float*,
+                                         const double*,
+                                         const size_t,
+                                         base_device::AbacusDevice_t,
+                                         base_device::AbacusDevice_t);
 
 } // namespace memory
 } // namespace base_device

--- a/source/source_base/module_device/test/memory_test.cpp
+++ b/source/source_base/module_device/test/memory_test.cpp
@@ -65,6 +65,7 @@ class TestModulePsiMemory : public ::testing::Test
 
 #if __UT_USE_CUDA || __UT_USE_ROCM
     using set_memory_double_gpu_op = base_device::memory::set_memory_op<double, base_device::DEVICE_GPU>;
+    using set_memory_float_gpu_op = base_device::memory::set_memory_op<float, base_device::DEVICE_GPU>;
     using set_memory_complex_double_gpu_op
         = base_device::memory::set_memory_op<std::complex<double>, base_device::DEVICE_GPU>;
     using resize_memory_double_gpu_op = base_device::memory::resize_memory_op<double, base_device::DEVICE_GPU>;
@@ -156,6 +157,81 @@ TEST_F(TestModulePsiMemory, synchronize_memory_op_complex_double_cpu_to_cpu)
     {
         EXPECT_EQ(hz_xx[ii], z_xx[ii]);
     }
+}
+
+TEST_F(TestModulePsiMemory, synchronize_memory_dispatch)
+{
+    const auto cpu = base_device::AbacusDevice_t::CpuDevice;
+    std::vector<double> output(xx.size(), 0.0);
+    base_device::memory::synchronize_memory(output.data(), xx.data(), xx.size(), cpu, cpu);
+    EXPECT_EQ(output, xx);
+
+#if __UT_USE_CUDA || __UT_USE_ROCM
+    const auto gpu = base_device::AbacusDevice_t::GpuDevice;
+    thrust::device_ptr<double> device_source = thrust::device_malloc<double>(xx.size());
+    thrust::device_ptr<double> device_output = thrust::device_malloc<double>(xx.size());
+
+    base_device::memory::synchronize_memory(
+        thrust::raw_pointer_cast(device_output), xx.data(), xx.size(), gpu, cpu);
+    thrust::copy(device_output, device_output + xx.size(), output.begin());
+    EXPECT_EQ(output, xx);
+
+    thrust::copy(xx.begin(), xx.end(), device_source);
+    std::fill(output.begin(), output.end(), 0.0);
+    base_device::memory::synchronize_memory(
+        output.data(), thrust::raw_pointer_cast(device_source), xx.size(), cpu, gpu);
+    EXPECT_EQ(output, xx);
+
+    set_memory_double_gpu_op()(thrust::raw_pointer_cast(device_output), 0, xx.size());
+    base_device::memory::synchronize_memory(thrust::raw_pointer_cast(device_output),
+                                            thrust::raw_pointer_cast(device_source),
+                                            xx.size(),
+                                            gpu,
+                                            gpu);
+    thrust::copy(device_output, device_output + xx.size(), output.begin());
+    EXPECT_EQ(output, xx);
+
+    thrust::device_free(device_source);
+    thrust::device_free(device_output);
+#endif
+}
+
+TEST_F(TestModulePsiMemory, cast_memory_dispatch)
+{
+    const auto cpu = base_device::AbacusDevice_t::CpuDevice;
+    std::vector<float> expected(xx.begin(), xx.end());
+    std::vector<float> output(xx.size(), 0.0F);
+    base_device::memory::cast_memory(output.data(), xx.data(), xx.size(), cpu, cpu);
+    EXPECT_EQ(output, expected);
+
+#if __UT_USE_CUDA || __UT_USE_ROCM
+    const auto gpu = base_device::AbacusDevice_t::GpuDevice;
+    thrust::device_ptr<double> device_source = thrust::device_malloc<double>(xx.size());
+    thrust::device_ptr<float> device_output = thrust::device_malloc<float>(xx.size());
+
+    base_device::memory::cast_memory(
+        thrust::raw_pointer_cast(device_output), xx.data(), xx.size(), gpu, cpu);
+    thrust::copy(device_output, device_output + xx.size(), output.begin());
+    EXPECT_EQ(output, expected);
+
+    thrust::copy(xx.begin(), xx.end(), device_source);
+    std::fill(output.begin(), output.end(), 0.0F);
+    base_device::memory::cast_memory(
+        output.data(), thrust::raw_pointer_cast(device_source), xx.size(), cpu, gpu);
+    EXPECT_EQ(output, expected);
+
+    set_memory_float_gpu_op()(thrust::raw_pointer_cast(device_output), 0, xx.size());
+    base_device::memory::cast_memory(thrust::raw_pointer_cast(device_output),
+                                     thrust::raw_pointer_cast(device_source),
+                                     xx.size(),
+                                     gpu,
+                                     gpu);
+    thrust::copy(device_output, device_output + xx.size(), output.begin());
+    EXPECT_EQ(output, expected);
+
+    thrust::device_free(device_source);
+    thrust::device_free(device_output);
+#endif
 }
 
 TEST_F(TestModulePsiMemory, delete_memory_op_double_cpu)


### PR DESCRIPTION
## Summary

- Dispatch the runtime `synchronize_memory()` and `cast_memory()` wrappers by the exact source/destination device pair.
- Add CPU/CUDA/ROCm-aware unit coverage for CPU-to-CPU, CPU-to-GPU, GPU-to-CPU, and GPU-to-GPU paths.

## Root cause

Each dispatch branch combined its destination and source checks with `||`. For example, the CPU-to-CPU branch also matched a GPU destination whenever the source was CPU. The wrapper then passed a device pointer to the host implementation; the new CUDA regression test reproduced this as a segmentation fault in the CPU-to-GPU synchronization case.

## Changes

- Replace the eight `||` operators in the two affected wrappers with `&&`, making the four device pairs mutually exclusive.
- Explicitly instantiate the scalar types used by the dispatch tests because these wrapper template definitions live in `memory_op.cpp`.
- Verify transferred/cast values for all four device pairs; no reference values or tolerances were changed.

## Verification

Environment: hmt03, NVIDIA GeForce RTX 4090, driver 590.48.01, CUDA 11.8.89, GCC 11.5.0, MPICH 4.1, `OMP_NUM_THREADS=1`.

- Unfixed CUDA baseline, Slurm job 214123: `MODULE_BASE_DEVICE_Unittests` segfaulted at `TestModulePsiMemory.synchronize_memory_dispatch`; CTest exit code 8.
- CPU RelWithDebInfo, Slurm job 214127:
  `ctest --test-dir build-cpu-test -R '^MODULE_BASE_DEVICE_Unittests$' --output-on-failure`
  passed 1/1; exit code 0.
- CUDA RelWithDebInfo, Slurm job 214127:
  `ctest --test-dir build-gpu-test -R '^MODULE_BASE_DEVICE_Unittests$' --output-on-failure`
  passed 1/1; exit code 0.
- CUDA memcheck, Slurm job 214126:
  `compute-sanitizer --tool memcheck --show-backtrace yes --error-exitcode 99 MODULE_BASE_DEVICE_Unittests --gtest_filter='TestModulePsiMemory.synchronize_memory_dispatch:TestModulePsiMemory.cast_memory_dispatch'`
  passed 2/2 with `ERROR SUMMARY: 0 errors`.
- `git diff --check` passed.
- ABACUS agent governance check passed with the expected documentation-review warning described below.

## Behavior change

Runtime memory wrappers now call the specialization corresponding to the requested source and destination devices. The low-level CPU, CUDA, and ROCm memory implementations are unchanged.

## INPUT/documentation impact

None. This fixes an internal dispatch bug and does not change INPUT parameters, public user-facing behavior, numerical tolerances, or output formats; no user documentation update is needed.

## Core-module impact

Limited to the runtime wrappers in `source_base/module_device` and their unit tests. No physics, solver, MPI, or scientific numerical logic is changed. CUDA was runtime-tested; the backend-neutral condition change and ROCm-guarded tests compile against the existing ROCm specialization, but ROCm hardware was not available for runtime verification.

Fixes #7553
