### PR TITLE
perf: parallelize neighbor-list construction with OpenMP

### DIFF
--- a/source/source_cell/module_neighlist/bin_manager.cpp
+++ b/source/source_cell/module_neighlist/bin_manager.cpp
@@ -5,6 +5,15 @@
 #include <stdexcept>
 #include "bin_manager.h"
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace
+{
+constexpr int neighbor_build_openmp_threshold = 256;
+}
+
 // ========== Bin class implementation ==========
 
 const std::vector<ModuleNeighList::LocalAtomIndex>& Bin::get_atom_indices() const {
@@ -176,6 +185,63 @@ int BinManager::bin_index(int ix, int iy, int iz) const {
     return ix * nbiny_ * nbinz_ + iy * nbinz_ + iz;
 }
 
+template <typename Emit>
+void BinManager::visit_neighbors(const NeighborAtom& atom,
+                                 const std::vector<NeighborAtom>& binned_atoms,
+                                 double sradius2,
+                                 const Emit& emit) const
+{
+    const int ix = std::min(
+        std::max(int((atom.position_x - x_min_) / bin_sizex_), 0),
+        nbinx_ - 1
+    );
+
+    const int iy = std::min(
+        std::max(int((atom.position_y - y_min_) / bin_sizey_), 0),
+        nbiny_ - 1
+    );
+
+    const int iz = std::min(
+        std::max(int((atom.position_z - z_min_) / bin_sizez_), 0),
+        nbinz_ - 1
+    );
+
+    for (int dx = -1; dx <= 1; dx++)
+    {
+        for (int dy = -1; dy <= 1; dy++)
+        {
+            for (int dz = -1; dz <= 1; dz++)
+            {
+                const int jx = ix + dx;
+                const int jy = iy + dy;
+                const int jz = iz + dz;
+
+                if (jx < 0 || jx >= nbinx_ ||
+                    jy < 0 || jy >= nbiny_ ||
+                    jz < 0 || jz >= nbinz_)
+                {
+                    continue;
+                }
+
+                const int nidx = bin_index(jx, jy, jz);
+                for (const ModuleNeighList::LocalAtomIndex binned_atom_index : bins_[nidx].get_atom_indices())
+                {
+                    const NeighborAtom& natom = binned_atoms[static_cast<std::size_t>(binned_atom_index)];
+                    const double delta_x = atom.position_x - natom.position_x;
+                    const double delta_y = atom.position_y - natom.position_y;
+                    const double delta_z = atom.position_z - natom.position_z;
+                    const double dist2 = delta_x * delta_x + delta_y * delta_y + delta_z * delta_z;
+
+                    if (natom.atom_id != atom.atom_id && dist2 <= sradius2)
+                    {
+                        emit(natom.atom_id);
+                    }
+                }
+            }
+        }
+    }
+}
+
 void BinManager::build_atom_neighbors(
     NeighborList& neighbor_list,
     const std::vector<NeighborAtom>& atoms,
@@ -184,71 +250,63 @@ void BinManager::build_atom_neighbors(
 {
     assert(atoms.size() == static_cast<size_t>(neighbor_list.get_nlocal()));
 
-    double sradius2 = sradius_ * sradius_;
+    const double sradius2 = sradius_ * sradius_;
 
     neighbor_list.reset();
 
-    std::vector<int> neigh_tmp;
-
     const int nlocal = neighbor_list.get_nlocal();
+
+#ifdef _OPENMP
+    const bool use_parallel = nlocal >= neighbor_build_openmp_threshold && omp_get_max_threads() > 1;
+    if (use_parallel)
+    {
+        std::vector<std::size_t> neighbor_counts(static_cast<std::size_t>(nlocal), 0);
+
+#pragma omp parallel for schedule(static)
+        for (int i = 0; i < nlocal; i++)
+        {
+            std::size_t count = 0;
+            visit_neighbors(atoms[i], binned_atoms, sradius2,
+                            [&count](ModuleNeighList::LocalAtomIndex) { ++count; });
+            neighbor_counts[static_cast<std::size_t>(i)] = count;
+        }
+
+        for (int i = 0; i < nlocal; i++)
+        {
+            const int n = ModuleNeighList::checked_int_size(
+                neighbor_counts[static_cast<std::size_t>(i)],
+                "BinManager neighbor count"
+            );
+            neighbor_list.firstneigh_[i] = neighbor_list.allocator_.allocate(n);
+            neighbor_list.numneigh_[i] = n;
+        }
+
+#pragma omp parallel for schedule(static)
+        for (int i = 0; i < nlocal; i++)
+        {
+            int* ptr = neighbor_list.firstneigh_[i];
+            int k = 0;
+            visit_neighbors(atoms[i], binned_atoms, sradius2,
+                            [&](ModuleNeighList::LocalAtomIndex atom_id)
+                            {
+                                assert(ptr != nullptr);
+                                ptr[k++] = atom_id;
+                            });
+            assert(k == neighbor_list.numneigh_[i]);
+        }
+        return;
+    }
+#endif
+
+    std::vector<int> neigh_tmp;
     for (int i = 0; i < nlocal; i++)
     {
         neigh_tmp.clear();
-        const NeighborAtom& atom = atoms[i];
-
-        int ix = std::min(
-            std::max(int((atom.position_x - x_min_) / bin_sizex_), 0),
-            nbinx_ - 1
-        );
-
-        int iy = std::min(
-            std::max(int((atom.position_y - y_min_) / bin_sizey_), 0),
-            nbiny_ - 1
-        );
-
-        int iz = std::min(
-            std::max(int((atom.position_z - z_min_) / bin_sizez_), 0),
-            nbinz_ - 1
-        );
-
-        for (int dx = -1; dx <= 1; dx++)
-        {
-            for (int dy = -1; dy <= 1; dy++)
-            {
-                for (int dz = -1; dz <= 1; dz++)
-                {
-                    int jx = ix + dx;
-                    int jy = iy + dy;
-                    int jz = iz + dz;
-
-                    if (jx < 0 || jx >= nbinx_ ||
-                        jy < 0 || jy >= nbiny_ ||
-                        jz < 0 || jz >= nbinz_)
-                        continue;
-
-                    int nidx = bin_index(jx, jy, jz);
-
-                    for (const ModuleNeighList::LocalAtomIndex binned_atom_index : bins_[nidx].get_atom_indices())
-                    {
-                        const NeighborAtom& natom = binned_atoms[static_cast<std::size_t>(binned_atom_index)];
-                        double dx = atom.position_x - natom.position_x;
-                        double dy = atom.position_y - natom.position_y;
-                        double dz = atom.position_z - natom.position_z;
-
-                        double dist2 = dx * dx + dy * dy + dz * dz;
-
-                        if (natom.atom_id == atom.atom_id)
+        visit_neighbors(atoms[i], binned_atoms, sradius2,
+                        [&neigh_tmp](ModuleNeighList::LocalAtomIndex atom_id)
                         {
-                            continue;
-                        }
-                        if (dist2 <= sradius2)
-                        {
-                            neigh_tmp.push_back(natom.atom_id);
-                        }
-                    }
-                }
-            }
-        }
+                            neigh_tmp.push_back(atom_id);
+                        });
 
         const int n = ModuleNeighList::checked_int_size(neigh_tmp.size(), "BinManager neighbor count");
 

--- a/source/source_cell/module_neighlist/bin_manager.h
+++ b/source/source_cell/module_neighlist/bin_manager.h
@@ -198,6 +198,21 @@ private:
      * @return Flat index in the bins_ array.
      */
     int bin_index(int ix, int iy, int iz) const;
+
+    /**
+     * @brief Visit neighbors of one atom in the existing deterministic bin order.
+     *
+     * @tparam Emit Callable accepting a rank-local neighbor atom ID.
+     * @param atom Atom used as the neighbor-list center.
+     * @param binned_atoms All atoms assigned to bins by do_binning().
+     * @param sradius2 Squared search radius.
+     * @param emit Callback invoked once for every accepted neighbor.
+     */
+    template <typename Emit>
+    void visit_neighbors(const NeighborAtom& atom,
+                         const std::vector<NeighborAtom>& binned_atoms,
+                         double sradius2,
+                         const Emit& emit) const;
 };
 
 #endif // BIN_MANAGER_H

--- a/source/source_cell/module_neighlist/test/bin_manager_test.cpp
+++ b/source/source_cell/module_neighlist/test/bin_manager_test.cpp
@@ -2,6 +2,30 @@
 #include "source_cell/module_neighlist/bin_manager.h"
 #include "source_cell/module_neighlist/neighbor_list.h"
 
+#include <algorithm>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace
+{
+std::vector<std::vector<int>> snapshot_neighbors(const NeighborList& list)
+{
+    std::vector<std::vector<int>> result(static_cast<std::size_t>(list.get_nlocal()));
+    for (int i = 0; i < list.get_nlocal(); ++i)
+    {
+        const int count = list.get_numneigh(i);
+        const int* first = list.get_firstneigh(i);
+        if (count > 0)
+        {
+            result[static_cast<std::size_t>(i)].assign(first, first + count);
+        }
+    }
+    return result;
+}
+} // namespace
+
 TEST(BinManagerUnit, InitAndBinning)
 {
     std::vector<NeighborAtom> inside;
@@ -221,3 +245,93 @@ TEST(BinManagerUnit, MultipleBinsNeighborSearch)
     int center_index = 13;
     EXPECT_EQ(nl.get_numneigh(center_index), 6);
 }
+
+#ifdef _OPENMP
+TEST(BinManagerUnit, ParallelBuildPreservesSerialNeighborOrder)
+{
+    std::vector<NeighborAtom> centers;
+    std::vector<NeighborAtom> binned_atoms;
+    centers.reserve(300);
+    binned_atoms.reserve(600);
+    for (int i = 0; i < 300; ++i)
+    {
+        const double x = 0.2 * static_cast<double>(i % 10);
+        const double y = 0.2 * static_cast<double>((i / 10) % 10);
+        const double z = 0.2 * static_cast<double>(i / 100);
+        centers.emplace_back(x, y, z, 0, i, i);
+        binned_atoms.push_back(centers.back());
+    }
+    for (int i = 0; i < 300; ++i)
+    {
+        const NeighborAtom& center = centers[static_cast<std::size_t>(i)];
+        binned_atoms.emplace_back(center.position_x + 0.05,
+                                  center.position_y,
+                                  center.position_z,
+                                  0,
+                                  i,
+                                  300 + i,
+                                  1000 + i,
+                                  1);
+    }
+
+    BinManager bm;
+    bm.init_bins(0.31, binned_atoms);
+    bm.do_binning(binned_atoms);
+
+    const int previous_dynamic = omp_get_dynamic();
+    const int previous_threads = omp_get_max_threads();
+    omp_set_dynamic(0);
+
+    NeighborList serial_list;
+    serial_list.initialize(centers.size(), centers.size() * 128);
+    omp_set_num_threads(1);
+    bm.build_atom_neighbors(serial_list, centers, binned_atoms);
+    const std::vector<std::vector<int>> serial = snapshot_neighbors(serial_list);
+
+    NeighborList parallel_list;
+    parallel_list.initialize(centers.size(), centers.size() * 128);
+    omp_set_num_threads(4);
+    bm.build_atom_neighbors(parallel_list, centers, binned_atoms);
+    const std::vector<std::vector<int>> parallel = snapshot_neighbors(parallel_list);
+
+    omp_set_num_threads(previous_threads);
+    omp_set_dynamic(previous_dynamic);
+
+    EXPECT_EQ(parallel, serial);
+    EXPECT_NE(std::find_if(serial[0].begin(), serial[0].end(),
+                           [](int atom_id) { return atom_id >= 300; }),
+              serial[0].end());
+}
+
+TEST(BinManagerUnit, ParallelBuildKeepsZeroNeighborPointersNull)
+{
+    std::vector<NeighborAtom> atoms;
+    atoms.reserve(256);
+    for (int i = 0; i < 256; ++i)
+    {
+        atoms.emplace_back(static_cast<double>(i), 0.0, 0.0, 0, i, i);
+    }
+
+    BinManager bm;
+    bm.init_bins(0.4, atoms);
+    bm.do_binning(atoms);
+
+    const int previous_dynamic = omp_get_dynamic();
+    const int previous_threads = omp_get_max_threads();
+    omp_set_dynamic(0);
+    omp_set_num_threads(4);
+
+    NeighborList list;
+    list.initialize(atoms.size(), 1024);
+    bm.build_atom_neighbors(list, atoms, atoms);
+
+    omp_set_num_threads(previous_threads);
+    omp_set_dynamic(previous_dynamic);
+
+    for (int i = 0; i < list.get_nlocal(); ++i)
+    {
+        EXPECT_EQ(list.get_numneigh(i), 0);
+        EXPECT_EQ(list.get_firstneigh(i), nullptr);
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

This is the current-`develop` replacement for #7527. The old PR can no longer be reopened because GitHub has detached it from its fork branch.

For sufficiently large local atom sets, `BinManager::build_atom_neighbors()` now uses a deterministic count / allocate / fill flow:

- count each center atom's neighbors in parallel;
- allocate segments through the existing `PageAllocator` serially;
- fill disjoint per-center segments in parallel;
- preserve the existing bin traversal and per-atom neighbor order.

Small systems, single-thread runs, and OpenMP-disabled builds retain the serial path.

## Current-upstream compatibility

- Based directly on current `deepmodeling:develop` (`640e7f52`).
- Supports separate center and binned-atom vectors used by the distributed MPI path.
- Uses rank-local atom IDs and checked count conversions.
- No merge conflicts with current `develop`.

## Correctness and tests

Focused tests cross the OpenMP threshold and cover:

- exact serial-vs-parallel neighbor IDs and ordering for 300 local centers plus MPI-style ghost atoms;
- zero-neighbor entries retain `firstneigh == nullptr` in the parallel path.

Local verification:

- OpenMP ON: 12/12 focused tests passed with 4 threads;
- OpenMP OFF: 10/10 focused tests passed;
- production source compiles as C++11 with OpenMP ON and OFF;
- `git diff --check` passed;
- ABACUS agent-governance check has no blocking findings.

## Documentation

No documentation change is needed: this is an internal performance optimization with no input, public API, output, or user-visible behavior change.

The performance measurements in #7527 remain historical context; this replacement focuses on correctness and compatibility with the current MPI-aware implementation.