### PR TITLE
Feature: Enable correct Laplacian-dependent meta-GGA calculations

### DIFF
--- a/source/source_hamilt/module_xc/libxc_pot.cpp
+++ b/source/source_hamilt/module_xc/libxc_pot.cpp
@@ -462,32 +462,35 @@ std::tuple<double,double,ModuleBase::matrix,ModuleBase::matrix> XC_Functional_Li
                 voflapl(is,ir) += vlapl[ir*nspin+is] * sgn[ir*nspin+is];
             }
         }
-}
+    }
 
     // v_xc += nabla^2(vlapl) where vlapl = d(rho*eps_xc)/d(nabla^2 rho)
     if (need_laplacian)
     {
         const int ng = chr->rhopw->npw;
         const double tpiba2 = tpiba * tpiba;
-        std::vector<std::complex<double>> lapl_tmp(chr->rhopw->nmaxgr);
-        for(int is = 0; is < voflapl.nr; is++)
+        std::vector<double> lapl_r(nrxx);
+        std::vector<std::complex<double>> lapl_g(ng);
+        for (int is = 0; is < voflapl.nr; is++)
         {
-            for(int ir = 0; ir < nrxx; ir++)
-                lapl_tmp[ir] = std::complex<double>(voflapl(is, ir), 0.0);
-            for(int ig = ng; ig < chr->rhopw->nmaxgr; ig++)
-                lapl_tmp[ig] = std::complex<double>(0.0, 0.0);
-            chr->rhopw->real2recip(lapl_tmp.data(), lapl_tmp.data());
-            for(int ig = 0; ig < ng; ig++)
+            for (int ir = 0; ir < nrxx; ir++)
+            {
+                lapl_r[ir] = voflapl(is, ir);
+            }
+            chr->rhopw->real2recip(lapl_r.data(), lapl_g.data());
+            for (int ig = 0; ig < ng; ig++)
             {
                 double g2 = 0.0;
-                for(int i = 0; i < 3; i++)
+                for (int i = 0; i < 3; i++)
+                {
                     g2 += chr->rhopw->gcar[ig][i] * chr->rhopw->gcar[ig][i];
-                lapl_tmp[ig] *= -g2 * tpiba2;
+                }
+                lapl_g[ig] *= -g2 * tpiba2;
             }
-            chr->rhopw->recip2real(lapl_tmp.data(), lapl_tmp.data());
-            for(int ir = 0; ir < nrxx; ir++)
+            chr->rhopw->recip2real(lapl_g.data(), lapl_r.data());
+            for (int ir = 0; ir < nrxx; ir++)
             {
-                double vlapl_corr = ModuleBase::e2 * lapl_tmp[ir].real();
+                double vlapl_corr = ModuleBase::e2 * lapl_r[ir];
                 v(is, ir) += vlapl_corr;
                 vtxc += vlapl_corr * chr->rho[is][ir];
             }

--- a/source/source_hamilt/module_xc/test/xc3_mock.h
+++ b/source/source_hamilt/module_xc/test/xc3_mock.h
@@ -53,6 +53,22 @@ namespace ModulePW
                                        const double factor) const;
 
     template <typename FPTYPE>
+    void PW_Basis::recip2real(const std::complex<FPTYPE>* in,
+                              FPTYPE* out,
+                              const bool add,
+                              const FPTYPE factor) const
+    {
+        for (int i = 0; i < nrxx; i++)
+        {
+            out[i] = (-ModuleBase::IMAG_UNIT * in[i]).real();
+        }
+    }
+    template void PW_Basis::recip2real(const std::complex<double>* in,
+                                       double* out,
+                                       const bool add,
+                                       const double factor) const;
+
+    template <typename FPTYPE>
     void PW_Basis_K::recip2real(const std::complex<FPTYPE>* in,
                                 std::complex<FPTYPE>* out,
                                 const int ik,

--- a/source/source_hamilt/module_xc/test/xc3_mock.h
+++ b/source/source_hamilt/module_xc/test/xc3_mock.h
@@ -4,250 +4,279 @@
 
 namespace ModulePW
 {
-    PW_Basis::PW_Basis(){};
-    PW_Basis::~PW_Basis(){};
-
-    template <typename FPTYPE>
-    void PW_Basis::real2recip(const FPTYPE* in, std::complex<FPTYPE>* out, const bool add, const FPTYPE factor) const
+namespace
+{
+// Preserve the shared prefix and use zero for mock outputs without a
+// one-to-one counterpart between real- and reciprocal-space buffers.
+template <typename FPTYPE, typename InputType>
+void mock_real2recip(const InputType* in, std::complex<FPTYPE>* out, const int nrxx, const int nrecip, const bool add, const FPTYPE factor)
+{
+    for (int i = 0; i < nrecip; ++i)
     {
-        for (int i=0;i<nrxx;i++)
+        const std::complex<FPTYPE> value = (i < nrxx) ? std::complex<FPTYPE>(in[i]) : std::complex<FPTYPE>(0.0, 0.0);
+        if (add)
         {
-            out[i] = in[i];
+            out[i] += factor * value;
+        }
+        else
+        {
+            out[i] = value;
         }
     }
-    template void PW_Basis::real2recip<double>(const double* in,
-                                               std::complex<double>* out,
-                                               bool add,
-                                               double factor) const;
+}
 
-    template <typename FPTYPE>
-    void PW_Basis::real2recip(const std::complex<FPTYPE>* in,
-                              std::complex<FPTYPE>* out,
-                              const bool add,
-                              const FPTYPE factor) const
+template <typename FPTYPE>
+void mock_recip2real(const std::complex<FPTYPE>* in,
+                     std::complex<FPTYPE>* out,
+                     const int nrecip,
+                     const int nrxx,
+                     const bool add,
+                     const FPTYPE factor)
+{
+    for (int i = 0; i < nrxx; ++i)
     {
-        for (int i=0;i<nrxx;i++)
+        const std::complex<FPTYPE> value = (i < nrecip) ? -ModuleBase::IMAG_UNIT * in[i] : std::complex<FPTYPE>(0.0, 0.0);
+        if (add)
         {
-            out[i] = in[i];
+            out[i] += factor * value;
+        }
+        else
+        {
+            out[i] = value;
         }
     }
-    template void PW_Basis::real2recip<double>(const std::complex<double>* in,
-                                               std::complex<double>* out,
-                                               const bool add,
-                                               const double factor) const;
+}
 
-    template <typename FPTYPE>
-    void PW_Basis::recip2real(const std::complex<FPTYPE>* in,
-                              std::complex<FPTYPE>* out,
-                              const bool add,
-                              const FPTYPE factor) const // in:(nz, ns)  ; out(nplane,nx*ny)
+template <typename FPTYPE>
+void mock_recip2real(const std::complex<FPTYPE>* in, FPTYPE* out, const int nrecip, const int nrxx, const bool add, const FPTYPE factor)
+{
+    for (int i = 0; i < nrxx; ++i)
     {
-        for (int i=0;i<nrxx;i++)
+        const FPTYPE value = (i < nrecip) ? (-ModuleBase::IMAG_UNIT * in[i]).real() : FPTYPE(0.0);
+        if (add)
         {
-            out[i] = - ModuleBase::IMAG_UNIT*in[i];
+            out[i] += factor * value;
+        }
+        else
+        {
+            out[i] = value;
         }
     }
-    template void PW_Basis::recip2real(const std::complex<double>* in,
-                                       std::complex<double>* out,
-                                       const bool add,
-                                       const double factor) const;
+}
+} // namespace
 
-    template <typename FPTYPE>
-    void PW_Basis::recip2real(const std::complex<FPTYPE>* in,
-                              FPTYPE* out,
-                              const bool add,
-                              const FPTYPE factor) const
-    {
-        for (int i = 0; i < nrxx; i++)
-        {
-            out[i] = (-ModuleBase::IMAG_UNIT * in[i]).real();
-        }
-    }
-    template void PW_Basis::recip2real(const std::complex<double>* in,
-                                       double* out,
-                                       const bool add,
-                                       const double factor) const;
+PW_Basis::PW_Basis() {};
+PW_Basis::~PW_Basis() {};
 
-    template <typename FPTYPE>
-    void PW_Basis_K::recip2real(const std::complex<FPTYPE>* in,
-                                std::complex<FPTYPE>* out,
-                                const int ik,
-                                const bool add,
-                                const FPTYPE factor) const // in:(nz, ns)  ; out(nplane,nx*ny)
-    {
-        for (int i = 0; i < nrxx; i++)
-        {
-            out[i] = -ModuleBase::IMAG_UNIT * in[i];
-        }
-    }
-    template void PW_Basis_K::recip2real(const std::complex<double>* in,
-                                         std::complex<double>* out,
-                                         const int ik,
-                                         const bool add,
-                                         const double factor) const;
+template <typename FPTYPE>
+void PW_Basis::real2recip(const FPTYPE* in, std::complex<FPTYPE>* out, const bool add, const FPTYPE factor) const
+{
+    mock_real2recip(in, out, nrxx, npw, add, factor);
+}
+template void PW_Basis::real2recip<double>(const double* in, std::complex<double>* out, bool add, double factor) const;
 
-    ModuleBase::Vector3<double> PW_Basis_K::getgpluskcar(int, int) const
-    {
-        ModuleBase::Vector3<double> x = {1,2,3};
-        return x;
-    }
+template <typename FPTYPE>
+void PW_Basis::real2recip(const std::complex<FPTYPE>* in, std::complex<FPTYPE>* out, const bool add, const FPTYPE factor) const
+{
+    mock_real2recip(in, out, nrxx, npw, add, factor);
+}
+template void PW_Basis::real2recip<double>(const std::complex<double>* in,
+                                           std::complex<double>* out,
+                                           const bool add,
+                                           const double factor) const;
 
+template <typename FPTYPE>
+void PW_Basis::recip2real(const std::complex<FPTYPE>* in,
+                          std::complex<FPTYPE>* out,
+                          const bool add,
+                          const FPTYPE factor) const // in:(nz, ns)  ; out(nplane,nx*ny)
+{
+    mock_recip2real(in, out, npw, nrxx, add, factor);
+}
+template void PW_Basis::recip2real(const std::complex<double>* in, std::complex<double>* out, const bool add, const double factor) const;
 
-    template <typename FPTYPE, typename Device>
-    void PW_Basis_K::real_to_recip(const Device* ctx,
-                       const std::complex<FPTYPE>* in,
-                       std::complex<FPTYPE>* out,
-                       const int ik,
-                       const bool add,
-                       const FPTYPE factor) const // in:(nplane,nx*ny)  ; out(nz, ns)
-    {
-        for (int i=0;i<nrxx;i++)
-        {
-            out[i] = in[i];
-        }
-    }
-    template <typename FPTYPE, typename Device>
-    void PW_Basis_K::recip_to_real(const Device* ctx,
-                       const std::complex<FPTYPE>* in,
-                       std::complex<FPTYPE>* out,
-                       const int ik,
-                       const bool add,
-                       const FPTYPE factor) const
-    {
-        for (int i = 0; i < nrxx; i++)
-        {
-            out[i] = -ModuleBase::IMAG_UNIT * in[i];
-        }
-    }
+template <typename FPTYPE>
+void PW_Basis::recip2real(const std::complex<FPTYPE>* in, FPTYPE* out, const bool add, const FPTYPE factor) const
+{
+    mock_recip2real(in, out, npw, nrxx, add, factor);
+}
+template void PW_Basis::recip2real(const std::complex<double>* in, double* out, const bool add, const double factor) const;
 
-    template void PW_Basis_K::real_to_recip<double, base_device::DEVICE_CPU>(const base_device::DEVICE_CPU* ctx,
-                                                                             const std::complex<double>* in,
-                                                                             std::complex<double>* out,
-                                                                             const int ik,
-                                                                             const bool add,
-                                                                             const double factor) const;
-    template void PW_Basis_K::recip_to_real<double, base_device::DEVICE_CPU>(const base_device::DEVICE_CPU* ctx,
-                                                                             const std::complex<double>* in,
-                                                                             std::complex<double>* out,
-                                                                             const int ik,
-                                                                             const bool add,
-                                                                             const double factor) const;
+template <typename FPTYPE>
+void PW_Basis_K::recip2real(const std::complex<FPTYPE>* in,
+                            std::complex<FPTYPE>* out,
+                            const int ik,
+                            const bool add,
+                            const FPTYPE factor) const // in:(nz, ns)  ; out(nplane,nx*ny)
+{
+    mock_recip2real(in, out, npwk[ik], nrxx, add, factor);
+}
+template void PW_Basis_K::recip2real(const std::complex<double>* in,
+                                     std::complex<double>* out,
+                                     const int ik,
+                                     const bool add,
+                                     const double factor) const;
+
+ModuleBase::Vector3<double> PW_Basis_K::getgpluskcar(int, int) const
+{
+    ModuleBase::Vector3<double> x = {1, 2, 3};
+    return x;
+}
+
+template <typename FPTYPE, typename Device>
+void PW_Basis_K::real_to_recip(const Device* ctx,
+                               const std::complex<FPTYPE>* in,
+                               std::complex<FPTYPE>* out,
+                               const int ik,
+                               const bool add,
+                               const FPTYPE factor) const // in:(nplane,nx*ny)  ; out(nz, ns)
+{
+    mock_real2recip(in, out, nrxx, npwk[ik], add, factor);
+}
+template <typename FPTYPE, typename Device>
+void PW_Basis_K::recip_to_real(const Device* ctx,
+                               const std::complex<FPTYPE>* in,
+                               std::complex<FPTYPE>* out,
+                               const int ik,
+                               const bool add,
+                               const FPTYPE factor) const
+{
+    mock_recip2real(in, out, npwk[ik], nrxx, add, factor);
+}
+
+template void PW_Basis_K::real_to_recip<double, base_device::DEVICE_CPU>(const base_device::DEVICE_CPU* ctx,
+                                                                         const std::complex<double>* in,
+                                                                         std::complex<double>* out,
+                                                                         const int ik,
+                                                                         const bool add,
+                                                                         const double factor) const;
+template void PW_Basis_K::recip_to_real<double, base_device::DEVICE_CPU>(const base_device::DEVICE_CPU* ctx,
+                                                                         const std::complex<double>* in,
+                                                                         std::complex<double>* out,
+                                                                         const int ik,
+                                                                         const bool add,
+                                                                         const double factor) const;
 #if __CUDA || __ROCM
-    template void PW_Basis_K::real_to_recip<double, base_device::DEVICE_GPU>(const base_device::DEVICE_GPU* ctx,
-                                                                             const std::complex<double>* in,
-                                                                             std::complex<double>* out,
-                                                                             const int ik,
-                                                                             const bool add,
-                                                                             const double factor) const;
+template void PW_Basis_K::real_to_recip<double, base_device::DEVICE_GPU>(const base_device::DEVICE_GPU* ctx,
+                                                                         const std::complex<double>* in,
+                                                                         std::complex<double>* out,
+                                                                         const int ik,
+                                                                         const bool add,
+                                                                         const double factor) const;
 
-    template void PW_Basis_K::recip_to_real<double, base_device::DEVICE_GPU>(const base_device::DEVICE_GPU* ctx,
-                                                                             const std::complex<double>* in,
-                                                                             std::complex<double>* out,
-                                                                             const int ik,
-                                                                             const bool add,
-                                                                             const double factor) const;
+template void PW_Basis_K::recip_to_real<double, base_device::DEVICE_GPU>(const base_device::DEVICE_GPU* ctx,
+                                                                         const std::complex<double>* in,
+                                                                         std::complex<double>* out,
+                                                                         const int ik,
+                                                                         const bool add,
+                                                                         const double factor) const;
 #endif
 
+void PW_Basis::initgrids(double, ModuleBase::Matrix3, double) {};
+void PW_Basis::distribute_r() {};
+void PW_Basis::initgrids(double, ModuleBase::Matrix3, int, int, int) {};
 
-    void PW_Basis::initgrids(double, ModuleBase::Matrix3, double){};
-    void PW_Basis::distribute_r(){};
-    void PW_Basis::initgrids(double, ModuleBase::Matrix3, int, int, int){};
-
-    PW_Basis_K::PW_Basis_K(){};
-    PW_Basis_K::~PW_Basis_K(){};
-}
+PW_Basis_K::PW_Basis_K() {};
+PW_Basis_K::~PW_Basis_K() {};
+} // namespace ModulePW
 
 namespace ModuleBase
 {
-    void WARNING_QUIT(const std::string &file,const std::string &description)
-    {
-        std::cout << " " << file <<"  warning : "<< description<<std::endl;
-        exit(1);
-    }
-    void WARNING(const std::string &file,const std::string &description) {};
-
-    void Matrix3::Identity(){};
-
-    IntArray::IntArray(int,int){};
-    IntArray::~IntArray(){};
-
-    void TITLE(const std::string &class_function_name,bool disable){};
-    void TITLE(const std::string &class_name,const std::string &function_name,bool disable){};
-
+void WARNING_QUIT(const std::string& file, const std::string& description)
+{
+    std::cout << " " << file << "  warning : " << description << std::endl;
+    exit(1);
 }
+void WARNING(const std::string& file, const std::string& description) {};
+
+void Matrix3::Identity() {};
+
+IntArray::IntArray(int, int) {};
+IntArray::~IntArray() {};
+
+void TITLE(const std::string& class_function_name, bool disable) {};
+void TITLE(const std::string& class_name, const std::string& function_name, bool disable) {};
+
+} // namespace ModuleBase
 
 namespace GlobalV
 {
-    std::string BASIS_TYPE = "";
-    bool CAL_STRESS = false;
-    int CAL_FORCE = 0;
-    int NSPIN;
-    int NPOL;
-    bool DOMAG;
-    bool DOMAG_Z;
-    std::ofstream ofs_device;
-    std::ofstream ofs_running;
-}
+std::string BASIS_TYPE = "";
+bool CAL_STRESS = false;
+int CAL_FORCE = 0;
+int NSPIN;
+int NPOL;
+bool DOMAG;
+bool DOMAG_Z;
+std::ofstream ofs_device;
+std::ofstream ofs_running;
+} // namespace GlobalV
 
 namespace GlobalC
 {
-	Exx_Info exx_info;
+Exx_Info exx_info;
 }
 
-UnitCell::UnitCell(){};
-UnitCell::~UnitCell(){};
+UnitCell::UnitCell() {};
+UnitCell::~UnitCell() {};
 
-Charge::Charge(){};
-Charge::~Charge(){};
+Charge::Charge() {};
+Charge::~Charge() {};
 
-Magnetism::Magnetism(){};
-Magnetism::~Magnetism(){};
+Magnetism::Magnetism() {};
+Magnetism::~Magnetism() {};
 
-SepPot::SepPot(){}
-SepPot::~SepPot(){}
-Sep_Cell::Sep_Cell() noexcept {}
-Sep_Cell::~Sep_Cell() noexcept {}
+SepPot::SepPot()
+{
+}
+SepPot::~SepPot()
+{
+}
+Sep_Cell::Sep_Cell() noexcept
+{
+}
+Sep_Cell::~Sep_Cell() noexcept
+{
+}
 
 namespace unitcell
 {
-    void cal_ux(UnitCell& ucell, const int nspin)
-    {
-        ucell.magnet.lsign_ = false;
+void cal_ux(UnitCell& ucell, const int nspin)
+{
+    ucell.magnet.lsign_ = false;
 
-        ucell.magnet.ux_[0] = 0;
-        ucell.magnet.ux_[1] = 1;
-        ucell.magnet.ux_[2] = 2;
+    ucell.magnet.ux_[0] = 0;
+    ucell.magnet.ux_[1] = 1;
+    ucell.magnet.ux_[2] = 2;
 
-        ucell.magnet.lsign_ = true;
-    };
-}
-
-
+    ucell.magnet.lsign_ = true;
+};
+} // namespace unitcell
 
 namespace Parallel_Reduce
 {
-    /// reduce in all process
-    template<typename T>
-    void reduce_all(T& object){};
-    template<typename T>
-    void reduce_all(T* object, const int n){};
-    template<typename T>
-    void reduce_pool(T& object){};
-    template<typename T>
-    void reduce_pool(T* object, const int n){};
+/// reduce in all process
+template <typename T>
+void reduce_all(T& object) {};
+template <typename T>
+void reduce_all(T* object, const int n) {};
+template <typename T>
+void reduce_pool(T& object) {};
+template <typename T>
+void reduce_pool(T* object, const int n) {};
 
-    template<>
-    void Parallel_Reduce::reduce_pool<double>(double& object)
-    {
-    #ifdef __MPI
-    	double swap = object;
-    	MPI_Allreduce(&swap , &object , 1, MPI_DOUBLE , MPI_SUM , MPI_COMM_WORLD);
-    #endif
-        return;
-    }
-    template void reduce_all<double>(double& object);
-    template void reduce_all<double>(double* object, const int n);
-    template void reduce_pool<float>(float& object);
-    template void reduce_pool<float>(float* object, const int n);
-    template void reduce_pool<double>(double* object, const int n);
+template <>
+void Parallel_Reduce::reduce_pool<double>(double& object)
+{
+#ifdef __MPI
+    double swap = object;
+    MPI_Allreduce(&swap, &object, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+#endif
+    return;
 }
+template void reduce_all<double>(double& object);
+template void reduce_all<double>(double* object, const int n);
+template void reduce_pool<float>(float& object);
+template void reduce_pool<float>(float* object, const int n);
+template void reduce_pool<double>(double* object, const int n);
+} // namespace Parallel_Reduce

--- a/tests/01_PW/207_PW_SCANL/result.ref
+++ b/tests/01_PW/207_PW_SCANL/result.ref
@@ -1,5 +1,5 @@
-etotref -205.28423347
-etotperatomref -102.64211673
-totalforceref 16.23426800
-totalstressref 1297.505181
+etotref -205.4194741913589439
+etotperatomref -102.7097370957
+totalforceref 16.622862
+totalstressref 1344.868111
 totaltimeref 246.99

--- a/tests/01_PW/207_PW_SCANL/threshold
+++ b/tests/01_PW/207_PW_SCANL/threshold
@@ -1,5 +1,5 @@
-# SCAN-L Laplacian is sensitive to the plane-wave cutoff, requiring
-# relaxed thresholds compared to the default (1e-7/1e-4/1e-3)
-threshold 0.0000003
-force_threshold 0.0005
-stress_threshold 0.02
+# Libxc 5.1.7 and 7.1.x use different numerical implementations of SCAN-L.
+# These thresholds cover both supported versions.
+threshold 0.000002
+force_threshold 0.005
+stress_threshold 0.05


### PR DESCRIPTION
## Linked Issue

This PR is a follow-up to #7457, which introduced the energy, potential, and stress paths required by Laplacian-dependent meta-GGA functionals.

Fixes #7813.

## What's changed?

### Summary

This PR fixes the remaining corruption in the Laplacian-potential FFT path. With this correction, SCAN-L and other Libxc meta-GGA functionals marked with `XC_FLAGS_NEEDS_LAPLACIAN` can use the shared Laplacian-dependent implementation correctly.

### Root cause

The code added in #7457 reused one complex array for both the real-space and reciprocal-space representations of the Laplacian potential. It first filled `nrxx` real-space values, but then cleared the range from `npw` to `nmaxgr` as if the same array already contained reciprocal-space coefficients. Since `npw` is normally smaller than `nrxx`, this erased valid real-space data before the forward FFT. The resulting `∇²v_lapl` contribution to the self-consistent XC potential was therefore corrupted.

## Finite-difference validation at 50 Ry

The correction was validated by comparing analytic stress with central finite differences of the total energy for all six independent stress components: `xx`, `yy`, `zz`, `xy`, `xz`, and `yz`.

- System: Si-2
- Basis types: PW and LCAO
- Functionals: PBE, r²SCAN, and SCAN-L before and after this fix
- Wave-function cutoff: 50 Ry
- Strain magnitude: ±0.005

<img width="2400" height="1800" alt="image" src="https://github.com/user-attachments/assets/cb15f3b4-5622-45cb-a14c-f3ae6bf749bb" />
