### PR TITLE
fix: `get_pchg_lcao.cpp` with c^* c^T

### DIFF
--- a/source/source_estate/module_dm/cal_dm_psi.cpp
+++ b/source/source_estate/module_dm/cal_dm_psi.cpp
@@ -192,7 +192,7 @@ void psiMulPsiMpi(const psi::Psi<std::complex<double>>& psi1,
                          const int* desc_psi,
                          const int* desc_dm)
 {
-    ModuleBase::timer::start("psiMulPsiMpi", "pdgemm");
+    ModuleBase::timer::start("psiMulPsiMpi", "pzgemm");
     const std::complex<double> one_complex = {1.0, 0.0}, zero_complex = {0.0, 0.0};
     const int one_int = 1;
     const char N_char = 'N', T_char = 'T';
@@ -217,7 +217,7 @@ void psiMulPsiMpi(const psi::Psi<std::complex<double>>& psi1,
             one_int,
             one_int,
             desc_dm);
-    ModuleBase::timer::end("psiMulPsiMpi", "pdgemm");
+    ModuleBase::timer::end("psiMulPsiMpi", "pzgemm");
 }
 
 #endif

--- a/source/source_io/module_chgpot/get_pchg_lcao.cpp
+++ b/source/source_io/module_chgpot/get_pchg_lcao.cpp
@@ -436,6 +436,11 @@ void Get_pchg_lcao::idmatrix(const int& ib,
                                               this->psi_k->get_nbasis(),
                                               true);
         wg_wfc.set_all_psi(this->psi_k->get_pointer(), wg_wfc.size());
+        std::complex<double>* wg_wfc_ptr = wg_wfc.get_pointer();
+        for (int i = 0; i < wg_wfc.size(); ++i)
+        {
+            wg_wfc_ptr[i] = std::conj(wg_wfc_ptr[i]);
+        }
 
         for (int ir = 0; ir < wg_wfc.get_nbands(); ++ir)
         {

--- a/tests/03_NAO_multik/get_pchg/result.ref
+++ b/tests/03_NAO_multik/get_pchg/result.ref
@@ -1,3 +1,3 @@
-pchgi1s1.cube 0.9999969968
-pchgi1s2.cube 0.9999969968
+pchgi1s1.cube 0.999999265
+pchgi1s2.cube 0.999999265
 totaltimeref 0.13

--- a/tests/03_NAO_multik/get_pchg_k/result.ref
+++ b/tests/03_NAO_multik/get_pchg_k/result.ref
@@ -1,7 +1,7 @@
-pchgi1s1k1.cube 0.9999996697
-pchgi1s1k2.cube 0.9999956604
-pchgi1s1k3.cube 0.9999956604
-pchgi1s2k1.cube 0.9999996697
-pchgi1s2k2.cube 0.9999956604
-pchgi1s2k3.cube 0.9999956604
+pchgi1s1k1.cube 0.9999996473
+pchgi1s1k2.cube 0.9999991015
+pchgi1s1k3.cube 0.9999991015
+pchgi1s2k1.cube 0.9999996473
+pchgi1s2k2.cube 0.9999991015
+pchgi1s2k3.cube 0.9999991015
 totaltimeref 0.25


### PR DESCRIPTION
Fix a bug in `get_pchg_lcao.cpp`

Since `psiMulPsiMpi` uses a plain transpose, the conjugate must be handled explicitly to form C^* C^T.

Same treatment can be seen `source/elecstate/module_dm/cal_dm_psi.cpp:107-110`. I think current code in  `get_pchg_lcao.cpp` is missed.