### PR TITLE
Fix: compiling error in exciton_plotter.cpp

### DIFF
--- a/source/source_lcao/module_lr/utils/exciton_plotter.cpp
+++ b/source/source_lcao/module_lr/utils/exciton_plotter.cpp
@@ -624,7 +624,7 @@ std::vector<std::vector<std::complex<double>>> ExcitonPlotter<T>::build_conditio
             {
                 const Complex fixed_wfc = std::conj(
                     this->orb_eval_
-                        .eval_wfc_bloch<T>(r_fix, ik, io, this->psi_ks_vec[0], this->ucell, this->kv.kvec_d[ik]));
+                        .template eval_wfc_bloch<T>(r_fix, ik, io, this->psi_ks_vec[0], this->ucell, this->kv.kvec_d[ik]));
                 for (int iv = 0; iv < nvirt; ++iv)
                 {
                     mixing[ik][iv] += this->X[offset_b + x_start + iv + io * nvirt] * fixed_wfc;
@@ -635,12 +635,12 @@ std::vector<std::vector<std::complex<double>>> ExcitonPlotter<T>::build_conditio
         {
             for (int iv = 0; iv < nvirt; ++iv)
             {
-                const Complex fixed_wfc = this->orb_eval_.eval_wfc_bloch<T>(r_fix,
-                                                                            ik,
-                                                                            nocc + iv,
-                                                                            this->psi_ks_vec[0],
-                                                                            this->ucell,
-                                                                            this->kv.kvec_d[ik]);
+                const Complex fixed_wfc = this->orb_eval_.template eval_wfc_bloch<T>(r_fix,
+                                                                                      ik,
+                                                                                      nocc + iv,
+                                                                                      this->psi_ks_vec[0],
+                                                                                      this->ucell,
+                                                                                      this->kv.kvec_d[ik]);
                 for (int io = 0; io < nocc; ++io)
                 {
                     mixing[ik][io] += this->X[offset_b + x_start + iv + io * nvirt] * fixed_wfc;


### PR DESCRIPTION
adding 'template' keyword for dependent eval_wfc_bloch call exciton_plotter.cpp calls orb_eval_.eval_wfc_bloch<T>() where orb_eval_ is a dependent type, requiring the 'template' keyword under C++11 parsing rules.

### Reminder
- [ ] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [ ] I have linked an issue or explained why this PR does not need one.
- [ ] I have added adequate unit tests and/or case tests, or explained why not.
- [ ] I have listed the exact verification commands run and their results.
- [ ] I have described user-visible behavior changes, including INPUT parameter changes.
- [ ] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [ ] I have requested any needed governance exception below.

### Linked Issue
Fix #

### Unit Tests and/or Case Tests for my changes
- Commands run:
- Result summary:
- Checks not run, with reason:

### What's changed?
- Example: brief summary of the user-visible or developer-facing change.

### Governance Notes
- INPUT/docs changes:
- Core module impact:
- Exceptions requested:
