### PR TITLE
Fix(dftu): write dm_onsite.txt format matching read_occup_m parser

### DIFF
--- a/source/source_lcao/module_dftu/dftu_io.cpp
+++ b/source/source_lcao/module_dftu/dftu_io.cpp
@@ -125,9 +125,9 @@ void Plus_U::write_occup_m(const UnitCell& ucell,
                         continue;
                     }
 
-                    ofs << "\n Atom=" << iat+1;
-                    ofs << " L=" << l;
-                    ofs << " ORBITAL=" << n << std::endl;
+                    ofs << "\n Atom= " << iat+1;
+                    ofs << " L= " << l;
+                    ofs << " ORBITAL= " << n << std::endl;
 
                     if (nspin == 1 || nspin == 2)
                     {
@@ -156,7 +156,7 @@ void Plus_U::write_occup_m(const UnitCell& ucell,
                                 ofs << std::endl;
                                 ofs << " sum is " << std::setw(12) << sum0[is] << std::endl;
                             }
-                            ofs << " spin=" << is+1 << std::endl;
+                            ofs << " spin= " << is+1 << std::endl;
                             ofs << std::setprecision(8) << std::fixed;
                             for (int m0 = 0; m0 < 2 * l + 1; m0++)
                             {


### PR DESCRIPTION
write_occup_m emits tokens like "Atom=1" (no space after '='), but read_occup_m reads with >> and strcmp against "Atom=". The mismatch causes NSCF runs reading dm_onsite.txt to fail with "WRONG IN READING LOCAL OCCUPATION NUMBER MATRIX FROM Plus_U FILE".

Add a space after '=' for Atom, L, ORBITAL, and spin tokens so the written format matches what read_occup_m expects. Verified with the examples/19_dftu/01_lcao_NiO DFT+U case: SCF converges and the subsequent NSCF step completes successfully.

### Reminder
- [ ] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [ ] I have linked an issue or explained why this PR does not need one.
- [ ] I have added adequate unit tests and/or case tests, or explained why not.
- [ ] I have listed the exact verification commands run and their results.
- [ ] I have described user-visible behavior changes, including INPUT parameter changes.
- [ ] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [ ] I have requested any needed governance exception below.

### Linked Issue
Fix #

### Unit Tests and/or Case Tests for my changes
- Commands run:
- Result summary:
- Checks not run, with reason:

### What's changed?
- Example: brief summary of the user-visible or developer-facing change.

### Governance Notes
- INPUT/docs changes:
- Core module impact:
- Exceptions requested:
