### PR TITLE
Fix INPUT availability for diag_subspace

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -1006,6 +1006,7 @@
 ### diag_subspace
 
 - **Type**: Integer
+- **Availability**: *[`basis_type`](#basis_type)==pw and [`ks_solver`](#ks_solver)==dav_subspace*
 - **Description**: The method to diagonalize subspace in dav_subspace method.
   - 0: by LAPACK
   - 1: by GenELPA

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -428,7 +428,7 @@ parameters:
       * 2: by ScaLAPACK
     default_value: "0"
     unit: ""
-    availability: ""
+    availability: basis_type==pw and ks_solver==dav_subspace
   - name: erf_ecut
     category: Plane wave related variables
     type: Real

--- a/source/source_io/module_parameter/read_inp_sys.cpp
+++ b/source/source_io/module_parameter/read_inp_sys.cpp
@@ -1178,6 +1178,7 @@ Available options are:
 * 1: by GenELPA
 * 2: by ScaLAPACK)";
         item.default_value = "0";
+        item.set_availability("basis_type==pw and ks_solver==dav_subspace");
         read_sync_int(input.diag_subspace);
         this->add_item(item);
     }

--- a/source/source_io/test_serial/read_input_item_test.cpp
+++ b/source/source_io/test_serial/read_input_item_test.cpp
@@ -1990,6 +1990,10 @@ TEST_F(InputTest, Item_test2)
         output = testing::internal::GetCapturedStdout();
         EXPECT_THAT(output, testing::HasSubstr("NOTICE"));
     }
+    { // diag_subspace
+        auto it = find_label("diag_subspace", readinput.input_lists);
+        EXPECT_EQ(it->second.get_availability(), "basis_type==pw and ks_solver==dav_subspace");
+    }
     { // md_nstep
         auto it = find_label("md_nstep", readinput.input_lists);
         param.input.mdp.md_nstep = 0;


### PR DESCRIPTION
### Linked Issue
Ref #7719 — normalize INPUT `availability` into a machine-readable form and align it with parameter validation.

### Unit Tests and/or Case Tests for my changes
- Commands run: `cmake --build build -j2 --target abacus_pw_ser`; `ctest --test-dir build -V -R MODULE_IO_availability`; regenerated `docs/parameters.yaml` and `docs/advanced/input_files/input-main.md`; `git diff --check`; repository governance check.
- Result summary: The affected target and 20 focused availability tests passed, generated documentation is consistent, and repository checks passed.
- Checks not run, with reason: None.

### What's changed?
- Restrict `diag_subspace` availability to plane-wave calculations with `ks_solver=dav_subspace`.
- Add a focused registration test for the availability expression.
- Regenerate the INPUT parameter metadata and advanced input documentation.

### Governance Notes
- INPUT/docs changes: The availability metadata and generated INPUT documentation are updated.
- Core module impact: Limited to INPUT availability registration and its focused test; solver implementation is unchanged.
- Exceptions requested: None.