### PR TITLE
Fix: refresh v_eff again after updating XC type

### DIFF
--- a/source/source_esolver/esolver_ks_lcaopw.cpp
+++ b/source/source_esolver/esolver_ks_lcaopw.cpp
@@ -168,6 +168,8 @@ namespace ModuleESolver
 #ifdef __EXX
         if (GlobalC::exx_info.info_global.cal_exx && conv_esolver)
         {
+            const int two_level_step_before = this->two_level_step;
+
             // no separate_loop case
             if (!GlobalC::exx_info.info_global.separate_loop)
             {
@@ -217,6 +219,20 @@ namespace ModuleESolver
                                  + (double)(t_end.tv_usec - t_start.tv_usec) / 1000000.0
                           << std::defaultfloat << " (s)" << std::endl;
                 conv_esolver = false;
+            }
+
+            // On the 0->1 transition, exx_after_converge switches the XC functional (PBE->hybrid), 
+            // but v_eff was already set for this (converged) iteration under the OLD functional. 
+            // Without this refresh, the 1st iteration of the EXX loop builds H from the stale GGA v_eff 
+            // and then adds Hexx on top of it, double-counting exchange. 
+            // Usually only that one iteration is affected and the loop washes it out; 
+            // but when the 2nd loop converges immediately (density already exact, e.g. a minimal basis fixed by symmetry) 
+            // the polluted H is the final one -- it gets diagonalized and written out by out_mat_hs.
+            // cal_converged() is used rather than a bare update_from_charge() so that vnew (used
+            // by force_scc) and descf stay consistent with the refreshed v_eff.
+            if (!conv_esolver && two_level_step_before == 0 && this->two_level_step == 1)
+            {
+                this->pelec->cal_converged();
             }
         }
 #endif

--- a/source/source_lcao/module_ri/exx_lri_interface.hpp
+++ b/source/source_lcao/module_ri/exx_lri_interface.hpp
@@ -326,6 +326,7 @@ void Exx_LRI_Interface<T, Tdata>::exx_iter_finish(const K_Vectors& kv,
         }
         // mohan update 2025-11-04
         this->dm_last_step = dm;
+        const int two_level_step_before = this->two_level_step;
         conv_esolver = this->exx_after_converge(
             ucell,
             hamilt,
@@ -336,6 +337,20 @@ void Exx_LRI_Interface<T, Tdata>::exx_iter_finish(const K_Vectors& kv,
             istep,
             elec.f_en.etot,
             scf_ene_thr);
+
+        // On the 0->1 transition, exx_after_converge switches the XC functional (PBE->hybrid), 
+        // but v_eff was already set for this (converged) iteration under the OLD functional. 
+        // Without this refresh, the 1st iteration of the EXX loop builds H from the stale GGA v_eff 
+        // and then adds Hexx on top of it, double-counting exchange. 
+        // Usually only that one iteration is affected and the loop washes it out; 
+        // but when the 2nd loop converges immediately (density already exact, e.g. a minimal basis fixed by symmetry) 
+        // the polluted H is the final one -- it gets diagonalized and written out by out_mat_hs.
+        // cal_converged() is used rather than a bare update_from_charge() so that vnew (used
+        // by force_scc) and descf stay consistent with the refreshed v_eff.
+        if (!conv_esolver && two_level_step_before == 0 && this->two_level_step == 1)
+        {
+            elec.cal_converged();
+        }
     }
     //else if ( PARAM.inp.rdmft && two_level_step ) { conv_esolver = true; }    // for RDMFT in the future to quit after the first iter of the exx-loop
 }

--- a/tests/08_EXX/01_GO_S1_HSE/result.ref
+++ b/tests/08_EXX/01_GO_S1_HSE/result.ref
@@ -1,5 +1,5 @@
-etotref -428.9942827110014605
-etotperatomref -142.9980942370
+etotref -428.9942827105964511
+etotperatomref -142.9980942369
 totalforceref 30.937113
-totalstressref 256.779922
+totalstressref 256.779921
 totaltimeref 2.76

--- a/tests/08_EXX/02_GO_S2_HSE/result.ref
+++ b/tests/08_EXX/02_GO_S2_HSE/result.ref
@@ -1,5 +1,5 @@
-etotref -448.7146661013188691
-etotperatomref -149.5715553671
-totalforceref 33.612992
-totalstressref 825.537129
+etotref -448.7146661094475348
+etotperatomref -149.5715553698
+totalforceref 33.613002
+totalstressref 825.537122
 totaltimeref 2.91

--- a/tests/08_EXX/03_KP_S4_HSE/result.ref
+++ b/tests/08_EXX/03_KP_S4_HSE/result.ref
@@ -1,5 +1,5 @@
-etotref -448.3614595740453979
-etotperatomref -149.4538198580
-totalforceref 33.668064
-totalstressref 813.488523
+etotref -448.3614595745778502
+etotperatomref -149.4538198582
+totalforceref 33.668068
+totalstressref 813.488522
 totaltimeref 3.18

--- a/tests/08_EXX/04_GO_S1_HSE_loop0/result.ref
+++ b/tests/08_EXX/04_GO_S1_HSE_loop0/result.ref
@@ -1,3 +1,3 @@
-etotref -428.9946798906369
-etotperatomref -142.9982266302
+etotref -428.9946799664623
+etotperatomref -142.9982266555
 totaltimeref 2.02

--- a/tests/08_EXX/05_GO_RE_HSE/result.ref
+++ b/tests/08_EXX/05_GO_RE_HSE/result.ref
@@ -1,3 +1,3 @@
-etotref -461.2147367084566
-etotperatomref -153.7382455695
+etotref -461.2147366408772
+etotperatomref -153.7382455470
 totaltimeref 3.20

--- a/tests/08_EXX/06_KP_MD_HSE/result.ref
+++ b/tests/08_EXX/06_KP_MD_HSE/result.ref
@@ -1,3 +1,3 @@
-etotref -467.2676785054572
-etotperatomref -155.7558928352
+etotref -467.2676788578187
+etotperatomref -155.7558929526
 totaltimeref 3.40

--- a/tests/08_EXX/07_KP_CR_HSE/result.ref
+++ b/tests/08_EXX/07_KP_CR_HSE/result.ref
@@ -1,3 +1,3 @@
-etotref -463.4113534766316889
-etotperatomref -154.4704511589
+etotref -463.4113534713501963
+etotperatomref -154.4704511571
 totaltimeref 5.46

--- a/tests/08_EXX/08_KP_HSE_symm/result.ref
+++ b/tests/08_EXX/08_KP_HSE_symm/result.ref
@@ -1,5 +1,5 @@
-etotref -189.4277005989405893
-etotperatomref -94.7138502995
+etotref -189.4277005988057567
+etotperatomref -94.7138502994
 totalforceref 0.000000
 totalstressref 2155.899405
 pointgroupref D_3d

--- a/tests/08_EXX/09_KP_HSE_comp/result.ref
+++ b/tests/08_EXX/09_KP_HSE_comp/result.ref
@@ -1,3 +1,3 @@
-etotref -193.395458223484
-etotperatomref -96.6977291117
+etotref -193.395458237598
+etotperatomref -96.6977291188
 totaltimeref 2.28

--- a/tests/08_EXX/10_KP_HF/result.ref
+++ b/tests/08_EXX/10_KP_HF/result.ref
@@ -1,3 +1,3 @@
-etotref -175.9018485378363
+etotref -175.901848537778
 etotperatomref -87.9509242689
 totaltimeref 2.81

--- a/tests/08_EXX/11_KP_PBE0/result.ref
+++ b/tests/08_EXX/11_KP_PBE0/result.ref
@@ -1,3 +1,3 @@
-etotref -190.0780619156031
+etotref -190.0780619156075
 etotperatomref -95.0390309578
 totaltimeref 2.80

--- a/tests/08_EXX/12_KP_OXC/result.ref
+++ b/tests/08_EXX/12_KP_OXC/result.ref
@@ -1,5 +1,5 @@
-etotref -192.4587810561693
-etotperatomref -96.2293905281
+etotref -192.4587810559611
+etotperatomref -96.2293905280
 CompareVXC_pass 0
 CompareOrbXC_pass 0
 CompareOrbKinetic_pass 0

--- a/tests/08_EXX/13_NO_KP_CAMPBEH/result.ref
+++ b/tests/08_EXX/13_NO_KP_CAMPBEH/result.ref
@@ -1,3 +1,3 @@
-etotref -184.2691047017444
-etotperatomref -92.1345523508722
+etotref -184.269104701654
+etotperatomref -92.1345523508
 totaltimeref 2.81

--- a/tests/08_EXX/14_NO_TDDFT_PBE0/result.ref
+++ b/tests/08_EXX/14_NO_TDDFT_PBE0/result.ref
@@ -1,4 +1,4 @@
-etotref -203.77109235
-etotperatomref -101.88554617
+etotref -203.7710923478310
+etotperatomref -101.8855461739
 CompareCurrent_pass 0
 totaltimeref 16.38

--- a/tests/08_EXX/15_KP_HSE_SOC_symm/result.ref
+++ b/tests/08_EXX/15_KP_HSE_SOC_symm/result.ref
@@ -1,9 +1,9 @@
-etotref -3419.2070243000000000
-etotperatomref -3419.2070243000
+etotref -3419.2371787940001013
+etotperatomref -3419.2371787940
 totalforceref 0.000000
-totalstressref 20903.561458
+totalstressref 20962.912099
 pointgroupref O_h
 spacegroupref O_h
 nksibzref 3
 magpointgroupref C_4h
-totaltimeref 210.49
+totaltimeref 99.07

--- a/tests/08_EXX/57_KP_RPA_SHRINK/result.ref
+++ b/tests/08_EXX/57_KP_RPA_SHRINK/result.ref
@@ -1,6 +1,6 @@
-etotref -34.21719023086459
-etotperatomref -17.1085951154
-Etot_without_rpa  -1.228213816470492
+etotref -34.21719023095734
+etotperatomref -17.1085951155
+Etot_without_rpa  -1.228213816386491
 CompareRPA_Cs_data_0_txt_pass 0
 CompareRPA_Cs_data_1_txt_pass 0
 CompareRPA_Cs_data_2_txt_pass 0


### PR DESCRIPTION
to prevent adding an extra PBE potential onto the hybrid Hamiltonian in the 1st iter of the EXX loop 

Fix #7839 