### PR TITLE
CI: Add "fail-fast: false" for multi-job workflows

### DIFF
--- a/.github/workflows/build_test_cmake.yml
+++ b/.github/workflows/build_test_cmake.yml
@@ -7,6 +7,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - tag: gnu

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: X64
     if: github.repository_owner == 'deepmodeling'
     strategy:
+      fail-fast: false
       matrix:
         dockerfile: ["gnu","intel","cuda"]
     steps:


### PR DESCRIPTION
See https://github.com/deepmodeling/abacus-develop/pull/7781#issuecomment-5386436782:

> Looks like the [push workflow](https://github.com/deepmodeling/abacus-develop/actions/runs/32639371855/job/97193974036) failed:
> ```
> ERROR: failed to build: failed to solve: failed to push dp-harbor-registry.us-east-1.cr.aliyuncs.com/deepmodeling/abacus-gnu-lts:latest: push access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
> ```
>
> So it seems Aliyun does not recognize "abacus-gnu-lts" as authorized container. Since our goal is to avoid overwrite the containers in development branch, personally I would not treat this as a real issue; but it currently prevents other two workflows to be pushed.
>
> Therefore, my grand recommendation is to add `fail-fast: false` under `jobs/strategy` so all three containers can be pushed to at least `ghcr.io`, which is exactly where GitHub CI pull the containers.