### PR TITLE
Refactor: Remove obsolete `cg_in_lcao` code

### DIFF
--- a/source/source_base/glob_fn_each2.h
+++ b/source/source_base/glob_fn_each2.h
@@ -4,6 +4,7 @@
 #ifndef GLOB_FN_EACH2_H
 #define GLOB_FN_EACH2_H
 
+#include <cstddef>
 #include <functional>
 #include <map>
 #include <vector>
@@ -12,45 +13,37 @@ namespace ModuleBase
 {
 namespace GlobalFunc
 {
-	
-template<typename Ti, typename... T_tail>
-void FUNC_EACH_2( 
-	Ti & tA, 
-	const Ti & tB, 
-	std::function< void( Ti&, const Ti&, T_tail... ) > func, 
-	const T_tail&... t_tail )
+
+template <typename Ti, typename... T_tail>
+void FUNC_EACH_2(Ti& tA, const Ti& tB, std::function<void(Ti&, const Ti&, T_tail...)> func, const T_tail&... t_tail)
 {
-	func( tA, tB, t_tail... );
+    func(tA, tB, t_tail...);
 }
 
-
-template<typename Tv, typename Ti, typename... T_tail>
-void FUNC_EACH_2( 
-	std::vector<Tv> & tA, 
-	const std::vector<Tv> & tB, 
-	std::function< void( Ti&, const Ti&, T_tail... ) > func,
-	const T_tail&... t_tail )
+template <typename Tv, typename Ti, typename... T_tail>
+void FUNC_EACH_2(std::vector<Tv>& tA,
+                 const std::vector<Tv>& tB,
+                 std::function<void(Ti&, const Ti&, T_tail...)> func,
+                 const T_tail&... t_tail)
 {
-	for( size_t i=0; i!=tA.size(); ++i )
-	{
-		FUNC_EACH_2( tA[i], tB[i], func, t_tail... );
-	}
+    for (std::size_t i = 0; i != tA.size(); ++i)
+    {
+        FUNC_EACH_2(tA[i], tB[i], func, t_tail...);
+    }
 }
 
-
-template<typename T1, typename T2, typename Ti, typename... T_tail>
-void FUNC_EACH_2( 
-	std::map<T1,T2> & tA, 
-	const std::map<T1,T2> & tB, 
-	std::function< void( Ti&, const Ti&, T_tail... ) > func,
-	const T_tail&... t_tail ) 
+template <typename T1, typename T2, typename Ti, typename... T_tail>
+void FUNC_EACH_2(std::map<T1, T2>& tA,
+                 const std::map<T1, T2>& tB,
+                 std::function<void(Ti&, const Ti&, T_tail...)> func,
+                 const T_tail&... t_tail)
 {
-	for( auto & ta : tA )
-	{
-		FUNC_EACH_2( ta.second, tB.at(ta.first), func, t_tail... );
-	}
+    for (auto& ta: tA)
+    {
+        FUNC_EACH_2(ta.second, tB.at(ta.first), func, t_tail...);
+    }
 }
 
-}
-}
+} // namespace GlobalFunc
+} // namespace ModuleBase
 #endif // GLOB_FN_EACH2_H

--- a/source/source_base/global_function.h
+++ b/source/source_base/global_function.h
@@ -1,9 +1,9 @@
 #ifndef GLOBAL_FUNCTION_H
 #define GLOBAL_FUNCTION_H
 
-#include "module_external/blas_connector.h"
 #include "glob_fn_each2.h" // Peize Lin add 2016-09-07
 #include "global_variable.h"
+#include "module_external/blas_connector.h"
 #include "tool_check.h" // mohan add 2021-05-08
 #include "tool_quit.h"  // mohan add 2021-05-07
 #include "tool_title.h" // mohan add 2021-05-05
@@ -146,37 +146,34 @@ static void READ_VALUE(std::ifstream& ifs, T& v)
 }
 
 //-------------------------------------------------------------
-//! The `SCAN_BEGIN` function efficiently searches 
-//! text files for specified keywords 
+//! The `SCAN_BEGIN` function efficiently searches
+//! text files for specified keywords
 //-------------------------------------------------------------
-bool SCAN_BEGIN(std::ifstream& ifs, 
-                const std::string& TargetName, 
-                const bool restart = true, 
-                const bool ifwarn = true);
+bool SCAN_BEGIN(std::ifstream& ifs, const std::string& TargetName, const bool restart = true, const bool ifwarn = true);
 
 //-------------------------------------------------------------
-// The `SCAN_LINE_BEGIN` function efficiently searches 
+// The `SCAN_LINE_BEGIN` function efficiently searches
 // text files for specified keywords while ignoring comment
-// lines and whitespace. It skips any line starting with '#' 
+// lines and whitespace. It skips any line starting with '#'
 //-------------------------------------------------------------
-bool SCAN_LINE_BEGIN(std::ifstream& ifs, 
-                const std::string& TargetName, 
-                const bool restart = true, 
-                const bool ifwarn = true);
+bool SCAN_LINE_BEGIN(std::ifstream& ifs, const std::string& TargetName, const bool restart = true, const bool ifwarn = true);
 
 void SCAN_END(std::ifstream& ifs, const std::string& TargetName, const bool ifwarn = true);
 
 template <class T>
 static inline void DCOPY(const T& a, T& b, const int& dim)
 {
-    for (int i = 0; i < dim; ++i) {
+    for (int i = 0; i < dim; ++i)
+    {
         b[i] = a[i];
     }
 }
 
 template <typename T>
-inline void DCOPY(const T* a, T* b, const int& dim) {
-    for (int i = 0; i < dim; ++i) {
+inline void DCOPY(const T* a, T* b, const int& dim)
+{
+    for (int i = 0; i < dim; ++i)
+    {
         b[i] = a[i];
     }
 }
@@ -236,7 +233,7 @@ static inline const T* VECTOR_TO_PTR(const std::valarray<T>& v)
 // Peize Lin add 2016-07-18
 //==========================================================
 template <typename T>
-std::string TO_STRING(const T& t, const int n=20)		// n=20 since LDBL_EPSILON is 1E-16 or 1E-19
+std::string TO_STRING(const T& t, const int n = 20) // n=20 since LDBL_EPSILON is 1E-16 or 1E-19
 {
     std::stringstream newstr;
     newstr << std::setprecision(n) << t;
@@ -255,7 +252,8 @@ template <typename T_map, typename T_key1>
 inline void* MAP_EXIST(T_map& ms, const T_key1& key1)
 {
     auto ms1 = ms.find(key1);
-    if (ms1 == ms.end()) {
+    if (ms1 == ms.end())
+    {
         return nullptr;
     }
     return static_cast<void*>(&ms1->second);
@@ -265,7 +263,8 @@ template <typename T_map, typename T_key1, typename... T_key_tail>
 inline void* MAP_EXIST(T_map& ms, const T_key1& key1, const T_key_tail&... key_tail)
 {
     auto ms1 = ms.find(key1);
-    if (ms1 == ms.end()) {
+    if (ms1 == ms.end())
+    {
         return nullptr;
     }
     return MAP_EXIST(ms1->second, key_tail...);
@@ -275,7 +274,8 @@ template <typename T_map, typename T_key1>
 inline const void* MAP_EXIST(const T_map& ms, const T_key1& key1)
 {
     auto ms1 = ms.find(key1);
-    if (ms1 == ms.end()) {
+    if (ms1 == ms.end())
+    {
         return nullptr;
     }
     return static_cast<const void*>(&ms1->second);
@@ -285,7 +285,8 @@ template <typename T_map, typename T_key1, typename... T_key_tail>
 inline const void* MAP_EXIST(const T_map& ms, const T_key1& key1, const T_key_tail&... key_tail)
 {
     auto ms1 = ms.find(key1);
-    if (ms1 == ms.end()) {
+    if (ms1 == ms.end())
+    {
         return nullptr;
     }
     return MAP_EXIST(ms1->second, key_tail...);
@@ -323,7 +324,8 @@ static inline void DELETE_MUL_PTR(T_element* v)
 template <typename T_element, typename T_N_first, typename... T_N_tail>
 static inline void DELETE_MUL_PTR(T_element* v, const T_N_first N_first, const T_N_tail... N_tail)
 {
-    for (T_N_first i = 0; i < N_first; ++i) {
+    for (T_N_first i = 0; i < N_first; ++i)
+    {
         DELETE_MUL_PTR(v[i], N_tail...);
     }
     delete[] v;
@@ -353,7 +355,8 @@ static inline void FREE_MUL_PTR(T_element* v)
 template <typename T_element, typename T_N_first, typename... T_N_tail>
 static inline void FREE_MUL_PTR(T_element* v, const T_N_first N_first, const T_N_tail... N_tail)
 {
-    for (T_N_first i = 0; i < N_first; ++i) {
+    for (T_N_first i = 0; i < N_first; ++i)
+    {
         FREE_MUL_PTR(v[i], N_tail...);
     }
     free(v);
@@ -371,7 +374,7 @@ T ddot_real(const int& dim, const std::complex<T>* psi_L, const std::complex<T>*
 static inline bool IS_COLUMN_MAJOR_KS_SOLVER(std::string ks_solver)
 {
     return ks_solver == "genelpa" || ks_solver == "elpa" || ks_solver == "scalapack_gvx" || ks_solver == "cusolver"
-           || ks_solver == "cusolvermp" || ks_solver == "cg_in_lcao" || ks_solver == "pexsi" || ks_solver == "lapack";
+           || ks_solver == "cusolvermp" || ks_solver == "pexsi" || ks_solver == "lapack";
 }
 
 } // namespace GlobalFunc

--- a/source/source_estate/elecstate_print.cpp
+++ b/source/source_estate/elecstate_print.cpp
@@ -1,13 +1,13 @@
 #include "elecstate.h"
+#include "occupy.h"
 #include "source_base/formatter.h"
 #include "source_base/global_variable.h"
 #include "source_base/parallel_common.h"
-#include "source_estate/module_pot/h_hartree_pw.h"
 #include "source_estate/module_pot/efield.h"
 #include "source_estate/module_pot/gatefield.h"
+#include "source_estate/module_pot/h_hartree_pw.h"
 #include "source_hamilt/module_xc/xc_functional.h"
 #include "source_io/module_parameter/parameter.h"
-#include "occupy.h"
 namespace elecstate
 {
 /**
@@ -49,7 +49,6 @@ void print_scf_iterinfo(const std::string& ks_solver,
 {
     std::map<std::string, std::string> iter_header_dict
         = {{"cg", "CG"},
-           {"cg_in_lcao", "CG"},
            {"lapack", "LA"},
            {"genelpa", "GE"},
            {"elpa", "EL"},
@@ -127,10 +126,7 @@ void print_scf_iterinfo(const std::string& ks_solver,
         values = {double(istep), mag[0], mag[1], mag[2], mag[3], etot, ediff, drho[0]};
         break;
     default:
-        titles = {"ITER",
-                  FmtCore::center("ETOT/eV", wener),
-                  FmtCore::center("EDIFF/eV", wener),
-                  FmtCore::center("DRHO", wrho)};
+        titles = {"ITER", FmtCore::center("ETOT/eV", wener), FmtCore::center("EDIFF/eV", wener), FmtCore::center("DRHO", wrho)};
         values = {double(istep), etot, ediff, drho[0]};
         break;
     }
@@ -162,7 +158,6 @@ void print_scf_iterinfo(const std::string& ks_solver,
     }
     std::cout << buf << std::flush;
 }
-
 
 /// @brief print total free energy and other energies
 /// @param ucell: unit cell
@@ -204,10 +199,10 @@ void print_etot(const Magnetism& magnet,
     std::vector<double> energies_Ry;
     std::vector<double> energies_eV;
 
-	if( (iter % PARAM.inp.out_freq_elec == 0) || converged || iter == PARAM.inp.scf_nmax )
-	{
+    if ((iter % PARAM.inp.out_freq_elec == 0) || converged || iter == PARAM.inp.scf_nmax)
+    {
         int n_order = std::max(0, Occupy::gaussian_type);
-      
+
         //! Kohn-Sham functional energy
         titles.push_back("E_KohnSham");
         energies_Ry.push_back(elec.f_en.etot);
@@ -271,11 +266,11 @@ void print_etot(const Magnetism& magnet,
         }
 
         // mohan add 20251108
-		if (PARAM.inp.dft_plus_u)
-		{
+        if (PARAM.inp.dft_plus_u)
+        {
             titles.push_back("E_plusU");
             energies_Ry.push_back(elec.f_en.edftu);
-		}
+        }
 
         //! hybrid functional energy
         titles.push_back("E_exx");
@@ -296,7 +291,7 @@ void print_etot(const Magnetism& magnet,
             titles.push_back("E_efield");
             energies_Ry.push_back(elecstate::Efield::etotefield);
         }
- 
+
         //! gate energy
         if (PARAM.inp.gate_flag)
         {
@@ -354,23 +349,19 @@ void print_etot(const Magnetism& magnet,
         energies_Ry.push_back(elec.bandgap_dw);
     }
     energies_eV.resize(energies_Ry.size());
-    std::transform(energies_Ry.begin(), energies_Ry.end(), energies_eV.begin(), [](double ener) {
-        return ener * ModuleBase::Ry_to_eV;
-    });
+    std::transform(energies_Ry.begin(), energies_Ry.end(), energies_eV.begin(), [](double ener) { return ener * ModuleBase::Ry_to_eV; });
 
     // for each SCF step, we print out energy
     FmtTable table(/*titles=*/{"Energy", "Rydberg", "eV"},
                    /*nrows=*/titles.size(),
-                   /*formats=*/{"%-14s", "%20.10f", "%20.10f"}, 
+                   /*formats=*/{"%-14s", "%20.10f", "%20.10f"},
                    /*indents=*/1,
-                   /*align=*/{/*value*/FmtTable::Align::LEFT, /*title*/FmtTable::Align::CENTER});
+                   /*align=*/{/*value*/ FmtTable::Align::LEFT, /*title*/ FmtTable::Align::CENTER});
     // print out the titles
     table << titles << energies_Ry << energies_eV;
 
     GlobalV::ofs_running << table.str() << std::endl;
 
-
-    
     if (PARAM.inp.out_level == "ie" || PARAM.inp.out_level == "m")
     {
         std::vector<double> mag;
@@ -380,10 +371,7 @@ void print_etot(const Magnetism& magnet,
             mag = {magnet.tot_mag, magnet.abs_mag};
             break;
         case 4:
-            mag = {magnet.tot_mag_nc[0],
-                   magnet.tot_mag_nc[1],
-                   magnet.tot_mag_nc[2],
-                   magnet.abs_mag};
+            mag = {magnet.tot_mag_nc[0], magnet.tot_mag_nc[1], magnet.tot_mag_nc[2], magnet.abs_mag};
             break;
         default:
             mag = {};
@@ -396,9 +384,7 @@ void print_etot(const Magnetism& magnet,
         }
         // Pure SDFT (nbands=0) uses Chebyshev trace (CT) since no H diagonalization is performed.
         // Mixed SDFT (nbands>0) still diagonalizes KS orbitals, so use the actual ks_solver label.
-        const std::string iter_label = (PARAM.inp.esolver_type == "sdft" && PARAM.inp.nbands == 0)
-                                           ? "sdft"
-                                           : PARAM.inp.ks_solver;
+        const std::string iter_label = (PARAM.inp.esolver_type == "sdft" && PARAM.inp.nbands == 0) ? "sdft" : PARAM.inp.ks_solver;
         elecstate::print_scf_iterinfo(iter_label,
                                       iter,
                                       4,
@@ -422,8 +408,7 @@ void print_etot(const Magnetism& magnet,
 void print_format(const std::string& name, const double& value)
 {
     GlobalV::ofs_running << std::setiosflags(std::ios::showpos);
-    GlobalV::ofs_running << " " << std::setw(16) << name << std::setw(30) << value << std::setw(30)
-                         << value * ModuleBase::Ry_to_eV << std::endl;
+    GlobalV::ofs_running << " " << std::setw(16) << name << std::setw(30) << value << std::setw(30) << value * ModuleBase::Ry_to_eV << std::endl;
     GlobalV::ofs_running << std::resetiosflags(std::ios::showpos);
     return;
 }

--- a/source/source_estate/module_dm/cal_dm_psi.cpp
+++ b/source/source_estate/module_dm/cal_dm_psi.cpp
@@ -1,6 +1,5 @@
 #include "cal_dm_psi.h"
 
-#include "source_io/module_parameter/parameter.h"
 #include "source_base/module_external/blas_connector.h"
 #include "source_base/module_external/scalapack_connector.h"
 #include "source_base/timer.h"
@@ -11,9 +10,9 @@ namespace elecstate
 
 // for Gamma-Only case where DMK is double
 void cal_dm_psi(const Parallel_Orbitals* ParaV,
-                       const ModuleBase::matrix& wg,
-                       const psi::Psi<double>& wfc,
-                       elecstate::DensityMatrix<double, double>& DM)
+                const ModuleBase::matrix& wg,
+                const psi::Psi<double>& wfc,
+                elecstate::DensityMatrix<double, double>& DM)
 {
     ModuleBase::TITLE("elecstate", "cal_dm_psi");
     ModuleBase::timer::start("elecstate", "cal_dm_psi");
@@ -33,8 +32,7 @@ void cal_dm_psi(const Parallel_Orbitals* ParaV,
         // dm[ik].create(ParaV->ncol, ParaV->nrow);
         //  wg_wfc(ib,iw) = wg[ib] * wfc(ib,iw);
 
-        psi::Psi<double> wg_wfc(1, wfc.get_nbands(), 
-          wfc.get_nbasis(), wfc.get_nbasis(), true);
+        psi::Psi<double> wg_wfc(1, wfc.get_nbands(), wfc.get_nbasis(), wfc.get_nbasis(), true);
 
         wg_wfc.set_all_psi(wfc.get_pointer(), wg_wfc.size());
 
@@ -49,10 +47,10 @@ void cal_dm_psi(const Parallel_Orbitals* ParaV,
                     break;
                 }
             }
-			if (ib_global >= wg.nc)
-			{
-				continue;
-			}
+            if (ib_global >= wg.nc)
+            {
+                continue;
+            }
             const double wg_local = wg(ik, ib_global);
 
             double* wg_wfc_pointer = &(wg_wfc(0, ib_local, 0));
@@ -72,9 +70,9 @@ void cal_dm_psi(const Parallel_Orbitals* ParaV,
 }
 template <typename TR>
 void cal_dm_psi(const Parallel_Orbitals* ParaV,
-                       const ModuleBase::matrix& wg,
-                       const psi::Psi<std::complex<double>>& wfc,
-                       elecstate::DensityMatrix<std::complex<double>, TR>& DM)
+                const ModuleBase::matrix& wg,
+                const psi::Psi<std::complex<double>>& wfc,
+                elecstate::DensityMatrix<std::complex<double>, TR>& DM)
 {
     ModuleBase::TITLE("elecstate", "cal_dm_psi");
     ModuleBase::timer::start("elecstate", "cal_dm_psi");
@@ -90,14 +88,10 @@ void cal_dm_psi(const Parallel_Orbitals* ParaV,
         wfc.fix_k(ik);
         std::complex<double>* dmk_pointer = DM.get_DMK_pointer(ik);
         // dm.fix_k(ik);
-        //dm[ik].create(ParaV->ncol, ParaV->nrow);
+        // dm[ik].create(ParaV->ncol, ParaV->nrow);
         // wg_wfc(ib,iw) = wg[ib] * wfc(ib,iw);
-        psi::Psi<std::complex<double>> wg_wfc(1, 
-                                              wfc.get_nbands(), 
-                                              wfc.get_nbasis(),
-                                              wfc.get_nbasis(),
-                                              true);
-        
+        psi::Psi<std::complex<double>> wg_wfc(1, wfc.get_nbands(), wfc.get_nbasis(), wfc.get_nbasis(), true);
+
         const std::complex<double>* pwfc = wfc.get_pointer();
         std::complex<double>* pwg_wfc = wg_wfc.get_pointer();
 
@@ -121,26 +115,18 @@ void cal_dm_psi(const Parallel_Orbitals* ParaV,
                     ModuleBase::WARNING_QUIT("ElecStateLCAO::cal_dm", "please check global2local_col!");
                 }
             }
-			if (ib_global >= wg.nc)
-			{
-				continue;
-			}
-			const double wg_local = wg(ik, ib_global);
+            if (ib_global >= wg.nc)
+            {
+                continue;
+            }
+            const double wg_local = wg(ik, ib_global);
             std::complex<double>* wg_wfc_pointer = &(wg_wfc(0, ib_local, 0));
             BlasConnector::scal(nbasis_local, wg_local, wg_wfc_pointer, 1);
         }
 
         // C++: dm(iw1,iw2) = wfc(ib,iw1).T * wg_wfc(ib,iw2)
 #ifdef __MPI
-
-        if (PARAM.inp.ks_solver == "cg_in_lcao")
-        {
-            psiMulPsi(wg_wfc, wfc, dmk_pointer);
-		} 
-		else 
-		{
-            psiMulPsiMpi(wg_wfc, wfc, dmk_pointer, ParaV->desc_wfc, ParaV->desc);
-        }
+        psiMulPsiMpi(wg_wfc, wfc, dmk_pointer, ParaV->desc_wfc, ParaV->desc);
 #else
         psiMulPsi(wg_wfc, wfc, dmk_pointer);
 #endif
@@ -151,11 +137,7 @@ void cal_dm_psi(const Parallel_Orbitals* ParaV,
 }
 
 #ifdef __MPI
-void psiMulPsiMpi(const psi::Psi<double>& psi1,
-                         const psi::Psi<double>& psi2,
-                         double* dm_out,
-                         const int* desc_psi,
-                         const int* desc_dm)
+void psiMulPsiMpi(const psi::Psi<double>& psi1, const psi::Psi<double>& psi2, double* dm_out, const int* desc_psi, const int* desc_dm)
 {
     ModuleBase::timer::start("psiMulPsiMpi", "pdgemm");
     const double one_float = 1.0, zero_float = 0.0;
@@ -165,32 +147,32 @@ void psiMulPsiMpi(const psi::Psi<double>& psi1,
     const int nbands = desc_psi[3];
 
     ScalapackConnector::gemm(N_char,
-            T_char,
-            nlocal,
-            nlocal,
-            nbands,
-            one_float,
-            psi1.get_pointer(),
-            one_int,
-            one_int,
-            desc_psi,
-            psi2.get_pointer(),
-            one_int,
-            one_int,
-            desc_psi,
-            zero_float,
-            dm_out,
-            one_int,
-            one_int,
-            desc_dm);
+                             T_char,
+                             nlocal,
+                             nlocal,
+                             nbands,
+                             one_float,
+                             psi1.get_pointer(),
+                             one_int,
+                             one_int,
+                             desc_psi,
+                             psi2.get_pointer(),
+                             one_int,
+                             one_int,
+                             desc_psi,
+                             zero_float,
+                             dm_out,
+                             one_int,
+                             one_int,
+                             desc_dm);
     ModuleBase::timer::end("psiMulPsiMpi", "pdgemm");
 }
 
 void psiMulPsiMpi(const psi::Psi<std::complex<double>>& psi1,
-                         const psi::Psi<std::complex<double>>& psi2,
-                         std::complex<double>* dm_out,
-                         const int* desc_psi,
-                         const int* desc_dm)
+                  const psi::Psi<std::complex<double>>& psi2,
+                  std::complex<double>* dm_out,
+                  const int* desc_psi,
+                  const int* desc_dm)
 {
     ModuleBase::timer::start("psiMulPsiMpi", "pzgemm");
     const std::complex<double> one_complex = {1.0, 0.0}, zero_complex = {0.0, 0.0};
@@ -199,28 +181,28 @@ void psiMulPsiMpi(const psi::Psi<std::complex<double>>& psi1,
     const int nlocal = desc_dm[2];
     const int nbands = desc_psi[3];
     ScalapackConnector::gemm(N_char,
-            T_char,
-            nlocal,
-            nlocal,
-            nbands,
-            one_complex,
-            psi1.get_pointer(),
-            one_int,
-            one_int,
-            desc_psi,
-            psi2.get_pointer(),
-            one_int,
-            one_int,
-            desc_psi,
-            zero_complex,
-            dm_out,
-            one_int,
-            one_int,
-            desc_dm);
+                             T_char,
+                             nlocal,
+                             nlocal,
+                             nbands,
+                             one_complex,
+                             psi1.get_pointer(),
+                             one_int,
+                             one_int,
+                             desc_psi,
+                             psi2.get_pointer(),
+                             one_int,
+                             one_int,
+                             desc_psi,
+                             zero_complex,
+                             dm_out,
+                             one_int,
+                             one_int,
+                             desc_dm);
     ModuleBase::timer::end("psiMulPsiMpi", "pzgemm");
 }
 
-#endif
+#else
 
 void psiMulPsi(const psi::Psi<double>& psi1, const psi::Psi<double>& psi2, double* dm_out)
 {
@@ -230,23 +212,21 @@ void psiMulPsi(const psi::Psi<double>& psi1, const psi::Psi<double>& psi2, doubl
     const int nlocal = psi1.get_nbasis();
     const int nbands = psi1.get_nbands();
     BlasConnector::gemm_cm(N_char,
-           T_char,
-           nlocal,
-           nlocal,
-           nbands,
-           one_float,
-           psi1.get_pointer(),
-           nlocal,
-           psi2.get_pointer(),
-           nlocal,
-           zero_float,
-           dm_out,
-           nlocal);
+                           T_char,
+                           nlocal,
+                           nlocal,
+                           nbands,
+                           one_float,
+                           psi1.get_pointer(),
+                           nlocal,
+                           psi2.get_pointer(),
+                           nlocal,
+                           zero_float,
+                           dm_out,
+                           nlocal);
 }
 
-void psiMulPsi(const psi::Psi<std::complex<double>>& psi1,
-                      const psi::Psi<std::complex<double>>& psi2,
-                      std::complex<double>* dm_out)
+void psiMulPsi(const psi::Psi<std::complex<double>>& psi1, const psi::Psi<std::complex<double>>& psi2, std::complex<double>* dm_out)
 {
     const int one_int = 1;
     const char N_char = 'N', T_char = 'T';
@@ -255,27 +235,27 @@ void psiMulPsi(const psi::Psi<std::complex<double>>& psi1,
     const std::complex<double> one_complex = {1.0, 0.0};
     const std::complex<double> zero_complex = {0.0, 0.0};
     BlasConnector::gemm_cm(N_char,
-           T_char,
-           nlocal,
-           nlocal,
-           nbands,
-           one_complex,
-           psi1.get_pointer(),
-           nlocal,
-           psi2.get_pointer(),
-           nlocal,
-           zero_complex,
-           dm_out,
-           nlocal);
+                           T_char,
+                           nlocal,
+                           nlocal,
+                           nbands,
+                           one_complex,
+                           psi1.get_pointer(),
+                           nlocal,
+                           psi2.get_pointer(),
+                           nlocal,
+                           zero_complex,
+                           dm_out,
+                           nlocal);
 }
-template
-void cal_dm_psi(const Parallel_Orbitals* ParaV,
-                const ModuleBase::matrix& wg,
-                const psi::Psi<std::complex<double>>& wfc,
-                elecstate::DensityMatrix<std::complex<double>, std::complex<double>>& DM);
-template
-void cal_dm_psi(const Parallel_Orbitals* ParaV,
-                const ModuleBase::matrix& wg,
-                const psi::Psi<std::complex<double>>& wfc,
-                elecstate::DensityMatrix<std::complex<double>, double>& DM);
+#endif
+
+template void cal_dm_psi(const Parallel_Orbitals* ParaV,
+                         const ModuleBase::matrix& wg,
+                         const psi::Psi<std::complex<double>>& wfc,
+                         elecstate::DensityMatrix<std::complex<double>, std::complex<double>>& DM);
+template void cal_dm_psi(const Parallel_Orbitals* ParaV,
+                         const ModuleBase::matrix& wg,
+                         const psi::Psi<std::complex<double>>& wfc,
+                         elecstate::DensityMatrix<std::complex<double>, double>& DM);
 } // namespace elecstate

--- a/source/source_estate/module_dm/cal_dm_psi.h
+++ b/source/source_estate/module_dm/cal_dm_psi.h
@@ -1,39 +1,42 @@
 #ifndef CAL_DM_PSI_H
 #define CAL_DM_PSI_H
 
+#include "density_matrix.h"
 #include "source_base/matrix.h"
 #include "source_psi/psi.h"
-#include "density_matrix.h"
 
 namespace elecstate
 {
-    // for Gamma-Only case where DMK is double
-    void cal_dm_psi(const Parallel_Orbitals* ParaV, const ModuleBase::matrix& wg, const psi::Psi<double>& wfc, elecstate::DensityMatrix<double, double>& DM);
+// for Gamma-Only case where DMK is double
+void cal_dm_psi(const Parallel_Orbitals* ParaV,
+                const ModuleBase::matrix& wg,
+                const psi::Psi<double>& wfc,
+                elecstate::DensityMatrix<double, double>& DM);
 
-    // for Multi-k case where DMK is std::complex<double>
-    template <typename TR>
-    void cal_dm_psi(const Parallel_Orbitals* ParaV, const ModuleBase::matrix& wg, const psi::Psi<std::complex<double>>& wfc, elecstate::DensityMatrix<std::complex<double>, TR>& DM);
+// for Multi-k case where DMK is std::complex<double>
+template <typename TR>
+void cal_dm_psi(const Parallel_Orbitals* ParaV,
+                const ModuleBase::matrix& wg,
+                const psi::Psi<std::complex<double>>& wfc,
+                elecstate::DensityMatrix<std::complex<double>, TR>& DM);
 
-    // for Gamma-Only case with MPI
-    void psiMulPsiMpi(const psi::Psi<double>& psi1,
-                            const psi::Psi<double>& psi2,
-                            double* dm_out,
-                            const int* desc_psi,
-                            const int* desc_dm);
-    
-    // for multi-k case with MPI
-    void psiMulPsiMpi(const psi::Psi<std::complex<double>>& psi1,
-                            const psi::Psi<std::complex<double>>& psi2,
-                            std::complex<double>* dm_out,
-                            const int* desc_psi,
-                            const int* desc_dm);
+#ifdef __MPI
+// for Gamma-Only case with MPI
+void psiMulPsiMpi(const psi::Psi<double>& psi1, const psi::Psi<double>& psi2, double* dm_out, const int* desc_psi, const int* desc_dm);
 
-    // for Gamma-Only case without MPI
-    void psiMulPsi(const psi::Psi<double>& psi1, const psi::Psi<double>& psi2, double* dm_out);
+// for multi-k case with MPI
+void psiMulPsiMpi(const psi::Psi<std::complex<double>>& psi1,
+                  const psi::Psi<std::complex<double>>& psi2,
+                  std::complex<double>* dm_out,
+                  const int* desc_psi,
+                  const int* desc_dm);
 
-    // for multi-k case without MPI
-    void psiMulPsi(const psi::Psi<std::complex<double>>& psi1,
-                        const psi::Psi<std::complex<double>>& psi2,
-                        std::complex<double>* dm_out);
-};
+#else
+// for Gamma-Only case without MPI
+void psiMulPsi(const psi::Psi<double>& psi1, const psi::Psi<double>& psi2, double* dm_out);
+
+// for multi-k case without MPI
+void psiMulPsi(const psi::Psi<std::complex<double>>& psi1, const psi::Psi<std::complex<double>>& psi2, std::complex<double>* dm_out);
+#endif
+}; // namespace elecstate
 #endif

--- a/source/source_hsolver/diago_cg.cpp
+++ b/source/source_hsolver/diago_cg.cpp
@@ -684,7 +684,6 @@ namespace hsolver
 {
 template class DiagoCG<std::complex<float>, base_device::DEVICE_CPU>;
 template class DiagoCG<std::complex<double>, base_device::DEVICE_CPU>;
-// template class DiagoCG<double, base_device::DEVICE_CPU>;
 #if ((defined __CUDA) || (defined __ROCM))
 template class DiagoCG<std::complex<float>, base_device::DEVICE_GPU>;
 template class DiagoCG<std::complex<double>, base_device::DEVICE_GPU>;

--- a/source/source_hsolver/diago_iter_assist.h
+++ b/source/source_hsolver/diago_iter_assist.h
@@ -22,9 +22,6 @@ class DiagoIterAssist
     static Real PW_DIAG_THR;
     static int PW_DIAG_NMAX;
 
-    static Real LCAO_DIAG_THR;
-    static int LCAO_DIAG_NMAX;
-
     /// average steps of last cg diagonalization for each band.
     static Real avg_iter;
     static bool need_subspace;
@@ -159,12 +156,6 @@ int DiagoIterAssist<T, Device>::PW_DIAG_NMAX = 30;
 
 template <typename T, typename Device>
 typename DiagoIterAssist<T, Device>::Real DiagoIterAssist<T, Device>::PW_DIAG_THR = 1.0e-2;
-
-template <typename T, typename Device>
-int DiagoIterAssist<T, Device>::LCAO_DIAG_NMAX = 50;
-
-template <typename T, typename Device>
-typename DiagoIterAssist<T, Device>::Real DiagoIterAssist<T, Device>::LCAO_DIAG_THR = 1.0e-12;
 
 template <typename T, typename Device>
 bool DiagoIterAssist<T, Device>::need_subspace = false;

--- a/source/source_hsolver/hsolver_lcao.cpp
+++ b/source/source_hsolver/hsolver_lcao.cpp
@@ -37,8 +37,8 @@
 namespace hsolver
 {
 
-template <typename TK, typename Device>
-void HSolverLCAO<TK, Device>::solve(hamilt::Hamilt<TK>* pHamilt,
+template <typename TK>
+void HSolverLCAO<TK>::solve(hamilt::Hamilt<TK>* pHamilt,
                                    psi::Psi<TK>& psi,
 								   elecstate::ElecState* pes,
 								   elecstate::DensityMatrix<TK, double>& dm, // mohan add 2025-11-03
@@ -133,8 +133,8 @@ void HSolverLCAO<TK, Device>::solve(hamilt::Hamilt<TK>* pHamilt,
     return;
 }
 
-template <typename T, typename Device>
-void HSolverLCAO<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T>* hm, psi::Psi<T>& psi, double* eigenvalue)
+template <typename T>
+void HSolverLCAO<T>::hamiltSolvePsiK(hamilt::Hamilt<T>* hm, psi::Psi<T>& psi, double* eigenvalue)
 {
     ModuleBase::TITLE("HSolverLCAO", "hamiltSolvePsiK");
     ModuleBase::timer::start("HSolverLCAO", "hamiltSolvePsiK");
@@ -188,8 +188,8 @@ void HSolverLCAO<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T>* hm, psi::Psi<T>&
     ModuleBase::timer::end("HSolverLCAO", "hamiltSolvePsiK");
 }
 
-template <typename T, typename Device>
-void HSolverLCAO<T, Device>::parakSolve(hamilt::Hamilt<T>* pHamilt,
+template <typename T>
+void HSolverLCAO<T>::parakSolve(hamilt::Hamilt<T>* pHamilt,
                                         psi::Psi<T>& psi,
                                         elecstate::ElecState* pes,
                                         const int kpar,
@@ -314,8 +314,8 @@ void HSolverLCAO<T, Device>::parakSolve(hamilt::Hamilt<T>* pHamilt,
 }
 
 #if defined (__MPI) && defined (__CUDA)
-template <typename T, typename Device>
-void HSolverLCAO<T, Device>::parakSolve_cusolver(hamilt::Hamilt<T>* pHamilt,
+template <typename T>
+void HSolverLCAO<T>::parakSolve_cusolver(hamilt::Hamilt<T>* pHamilt,
                                             psi::Psi<T>& psi,
                                             elecstate::ElecState* pes)
 {

--- a/source/source_hsolver/hsolver_lcao.h
+++ b/source/source_hsolver/hsolver_lcao.h
@@ -11,7 +11,7 @@
 namespace hsolver
 {
 
-template <typename TK, typename Device = base_device::DEVICE_CPU>
+template <typename TK>
 class HSolverLCAO
 {
   public:

--- a/source/source_io/module_parameter/read_inp_estruc.cpp
+++ b/source/source_io/module_parameter/read_inp_estruc.cpp
@@ -138,7 +138,6 @@ Then the user has to correct the input file and restart the calculation.)";
                 "cusolver",
                 "cusolvermp",
                 "pexsi",
-                "cg_in_lcao",
             };
 
             if (para.input.basis_type == "pw")
@@ -156,11 +155,7 @@ Then the user has to correct the input file and restart the calculation.)";
                     const std::string warningstr = "For LCAO basis: " + nofound_str(lcao_solvers, "ks_solver");
                     ModuleBase::WARNING_QUIT("ReadInput", warningstr);
                 }
-                if (ks_solver == "cg_in_lcao")
-                {
-                    GlobalV::ofs_warning << "cg_in_lcao is under testing" << std::endl;
-                }
-                else if (ks_solver == "genelpa")
+                if (ks_solver == "genelpa")
                 {
                     if (para.input.device == "gpu")
                     {


### PR DESCRIPTION
## What's changed?

`ks_solver=cg_in_lcao` was introduced in #3473 but was later removed in #5257. There are still some dead code, which is rather misleading. This PR aims to remove these obsolete `cg_in_lcao` code.

- Reject the unsupported `ks_solver=cg_in_lcao` value during INPUT validation.
- Remove its stale matrix-layout, SCF-label, density-matrix, and iterative-diagonalization branches.
- Remove the unused LCAO CG thresholds and `HSolverLCAO` device template parameter left by the old implementation.
- Restore the MPI/serial separation of density-matrix multiplication helpers.

## User-visible behavior

LCAO inputs using `cg_in_lcao` now fail during input validation instead of reaching unsupported or unsafe downstream paths. Supported LCAO solvers are unaffected. The generated parameter documentation is unchanged because this value was never documented as supported.
