### PR TITLE
Fix: Initialize LCAO LDOS DMR independently

### DIFF
--- a/source/source_estate/module_dm/density_matrix_io.cpp
+++ b/source/source_estate/module_dm/density_matrix_io.cpp
@@ -7,6 +7,9 @@
 #include "source_base/tool_title.h"
 #include "source_cell/klist.h"
 
+#include <cstddef>
+#include <stdexcept>
+
 namespace elecstate
 {
 
@@ -185,9 +188,14 @@ void DensityMatrix<TK, TR>::init_DMR(const hamilt::HContainer<TRShift>& DMR_in)
 template <typename TK, typename TR>
 hamilt::HContainer<TR>* DensityMatrix<TK, TR>::get_DMR_pointer(const int ispin) const
 {
-#ifdef __DEBUG
-    assert(ispin > 0 && ispin <= this->_nspin);
-#endif
+    if (ispin <= 0 || ispin > this->_nspin)
+    {
+        throw std::out_of_range("DensityMatrix::get_DMR_pointer: DMR spin index is out of range");
+    }
+    if (this->_DMR.size() != static_cast<std::size_t>(this->_nspin))
+    {
+        throw std::logic_error("DensityMatrix::get_DMR_pointer: DMR has not been initialized");
+    }
     return this->_DMR[ispin - 1];
 }
 

--- a/source/source_io/module_ctrl/ctrl_runner_lcao.cpp
+++ b/source/source_io/module_ctrl/ctrl_runner_lcao.cpp
@@ -51,7 +51,7 @@ void ctrl_runner_lcao(UnitCell& ucell,      // unitcell
 	if (inp.out_ldos[0])
     {
         ModuleIO::Cal_ldos<TK>::cal_ldos_lcao(pelec->eferm, chr, dmat, kv, 
-          pelec->ekb, pelec->wg, psi[0], pgrid, ucell);
+          pelec->ekb, pelec->wg, psi[0], pgrid, gd, ucell);
     }
 
     // 3) print out exchange-correlation potential

--- a/source/source_io/module_dos/cal_ldos.cpp
+++ b/source/source_io/module_dos/cal_ldos.cpp
@@ -22,6 +22,7 @@ void Cal_ldos<T>::cal_ldos_lcao(
         const ModuleBase::matrix &wg, // mohan add 2025-11-02
 		const psi::Psi<T>& psi,
 		const Parallel_Grid& pgrid,
+		const Grid_Driver& grid_driver,
 		const UnitCell& ucell)
 {
     for (int ie = 0; ie < PARAM.inp.stm_bias[2]; ie++)
@@ -55,7 +56,7 @@ void Cal_ldos<T>::cal_ldos_lcao(
                                                     kv.get_nks() / nspin_dm);
 
         elecstate::cal_dm_psi(dmat.dm->get_paraV_pointer(), weight, psi, dm_ldos);
-        dm_ldos.init_DMR(*(dmat.dm->get_DMR_pointer(1)));
+        dm_ldos.init_DMR(&grid_driver, &ucell);
         dm_ldos.cal_DMR();
 
         // allocate ldos space

--- a/source/source_io/module_dos/cal_ldos.h
+++ b/source/source_io/module_dos/cal_ldos.h
@@ -8,6 +8,7 @@
 #include "source_estate/module_charge/charge.h" // chr
 #include "source_lcao/setup_dm.h" // Setup_DM
 #include "source_cell/klist.h" // K_Vectors
+#include "source_cell/module_neighbor/sltk_grid_driver.h" // Grid_Driver
 #include "source_base/matrix.h" // matrix
 
 namespace ModuleIO
@@ -28,6 +29,7 @@ class Cal_ldos
         const ModuleBase::matrix &wg, // mohan add 2025-11-02
 		const psi::Psi<T>& psi,
 		const Parallel_Grid& pgrid,
+		const Grid_Driver& grid_driver,
 		const UnitCell& ucell);
 
 }; // namespace Cal_ldos


### PR DESCRIPTION
## What's changed?

- Initialize the temporary LCAO LDOS DMR directly from `Grid_Driver` and `UnitCell`, removing its dependency on the main density matrix DMR lifecycle.
- Prevent crashes when LDOS is requested after `get_pchg` or `get_wf`, where the main DMR is not initialized.
- Add defensive `DensityMatrix::get_DMR_pointer()` checks that throw standard exceptions for invalid spin indices or uninitialized DMR storage. (Be aware of "dyzheng play"!!!)