### PR TITLE
Fix(ci): publish governance warnings on pull requests from forks

### DIFF
--- a/.github/workflows/agent_governance.yml
+++ b/.github/workflows/agent_governance.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited, ready_for_review]
 
+# This workflow runs with the pull request head in scope, so it stays read-only.
+# Publishing the warning comment needs write access that forked pull requests
+# never get here; that half lives in agent_governance_comment.yml, which is
+# triggered by workflow_run and never checks out pull request code.
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   governance:
@@ -55,39 +57,29 @@ jobs:
         run: |
           cat agent_governance_summary.md >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Comment governance warnings
-        if: >-
-          always() &&
-          github.event.pull_request.head.repo.full_name == github.repository
+      - name: Collect comment payload
+        if: always()
         env:
-          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if ! grep -qi '^| warning |' agent_governance_summary.md; then
-            exit 0
-          fi
-
-          marker='<!-- agent-governance-warning -->'
-          body_file="$(mktemp)"
-          json_file="$(mktemp)"
-          {
-            echo "$marker"
-            echo
-            cat agent_governance_summary.md
-          } > "$body_file"
-          jq -Rs '{body: .}' < "$body_file" > "$json_file"
-
-          existing_comment_id="$(gh api --paginate \
-            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            --jq ".[] | select(.body | contains(\"${marker}\")) | .id" \
-            | head -n 1)"
-
-          if [ -n "$existing_comment_id" ]; then
-            gh api --method PATCH \
-              "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_comment_id}" \
-              --input "$json_file"
+          set -eu
+          mkdir -p agent_governance_payload
+          if [ -s agent_governance_summary.md ]; then
+            cp agent_governance_summary.md agent_governance_payload/
           else
-            gh api --method POST \
-              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-              --input "$json_file"
+            {
+              echo "## Agent Governance Check"
+              echo
+              echo "Checker did not run."
+            } > agent_governance_payload/agent_governance_summary.md
           fi
+          printf '%s\n' "$PR_NUMBER" > agent_governance_payload/pr_number.txt
+
+      - name: Upload comment payload
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: agent-governance-payload
+          path: agent_governance_payload/
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/agent_governance_comment.yml
+++ b/.github/workflows/agent_governance_comment.yml
@@ -1,0 +1,100 @@
+name: Agent Governance Comment
+
+# Privileged half of the governance check. `Agent Governance` runs on
+# `pull_request`, where forked pull requests only ever get a read-only token, so
+# it cannot comment on the very pull requests that need the feedback most. This
+# workflow is triggered by `workflow_run`, which always runs from the base
+# branch with the base repository's permissions.
+#
+# Safety contract for this file:
+# - It never checks out pull request code and never runs anything from the head.
+# - Its only inputs are the text artifact uploaded by the analysis run.
+# - Pull request supplied text reaches the API through files and `jq -Rs`, never
+#   through shell interpolation.
+on:
+  workflow_run:
+    workflows: ["Agent Governance"]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  comment:
+    name: Publish governance warnings
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download comment payload
+        id: payload
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -eu
+          mkdir -p agent_governance_payload
+          if ! gh run download "$RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name agent-governance-payload \
+            --dir agent_governance_payload; then
+            echo "No governance payload for run ${RUN_ID}; nothing to publish."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "found=true" >> "$GITHUB_OUTPUT"
+
+      - name: Comment governance warnings
+        if: steps.payload.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          summary_file=agent_governance_payload/agent_governance_summary.md
+          pr_file=agent_governance_payload/pr_number.txt
+          if [ ! -s "$summary_file" ] || [ ! -s "$pr_file" ]; then
+            echo "Incomplete governance payload; nothing to publish."
+            exit 0
+          fi
+
+          pr_number="$(tr -dc '0-9' < "$pr_file")"
+          if [ -z "$pr_number" ]; then
+            echo "Payload does not carry a pull request number; nothing to publish."
+            exit 0
+          fi
+
+          if ! grep -qi '^| warning |' "$summary_file"; then
+            exit 0
+          fi
+
+          # GitHub rejects comment bodies over 65536 characters.
+          body_limit=60000
+          marker='<!-- agent-governance-warning -->'
+          body_file="$(mktemp)"
+          json_file="$(mktemp)"
+          {
+            echo "$marker"
+            echo
+            head -c "$body_limit" "$summary_file"
+            if [ "$(wc -c < "$summary_file")" -gt "$body_limit" ]; then
+              echo
+              echo "_Summary truncated. See the \`Agent Governance\` run summary for the full report._"
+            fi
+          } > "$body_file"
+          jq -Rs '{body: .}' < "$body_file" > "$json_file"
+
+          existing_comment_id="$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" \
+            --jq ".[] | select(.body | contains(\"${marker}\")) | .id" \
+            | head -n 1)"
+
+          if [ -n "$existing_comment_id" ]; then
+            gh api --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_comment_id}" \
+              --input "$json_file"
+          else
+            gh api --method POST \
+              "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" \
+              --input "$json_file"
+          fi

--- a/docs/developers_guide/agent_governance.md
+++ b/docs/developers_guide/agent_governance.md
@@ -183,6 +183,15 @@ ABACUS uses a layered review model:
 - `Agent Governance` is the deterministic GitHub Actions check for low-noise
   diff rules. Repository maintainers may make this workflow a required check in
   branch protection.
+- `Agent Governance` is split across two workflow files. The `pull_request`
+  half runs the checker with a read-only token and uploads the summary as an
+  artifact. The `Agent Governance Comment` half is triggered by `workflow_run`,
+  so it runs from the base branch with the base repository's permissions and
+  can publish the warning comment on pull requests from forks, which the
+  `pull_request` half cannot do. The comment half never checks out pull request
+  code and reads only the uploaded text artifact. `workflow_run` workflows are
+  always taken from the default branch, so changes to the comment half take
+  effect only after they are merged.
 - CodeRabbit is a PR-triggered AI reviewer for semantic review hints. Its
   repository configuration lives in `.coderabbit.yaml` and uses this document
   plus `AGENTS.md` as review guidelines.


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have linked an issue or explained why this PR does not need one.
- [x] I have added adequate unit tests and/or case tests, or explained why not.
- [x] I have listed the exact verification commands run and their results.
- [x] I have described user-visible behavior changes, including INPUT parameter changes.
- [x] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [x] I have requested any needed governance exception below.

### Linked Issue
No issue. This is a self-contained CI defect found by reading
`.github/workflows/agent_governance.yml`; happy to open one first if maintainers
prefer that order.

### The problem

`Agent Governance` runs on `pull_request`. For a pull request opened from a
fork, GitHub caps `GITHUB_TOKEN` at read-only regardless of the `permissions:`
block, so the comment step cannot post. The workflow guards against the
resulting failure with:

```yaml
github.event.pull_request.head.repo.full_name == github.repository
```

The effect is that the warning comment is skipped for every fork pull request —
which is essentially all external contributions. Warnings land only in the run
summary, where contributors do not look. The check is quietly least useful
exactly where it was meant to help.

### What's changed?

Split the check into the standard two-workflow pattern.

| | Trigger | Token | Job |
|---|---|---|---|
| `Agent Governance` | `pull_request` | `contents: read` | runs the checker, uploads summary + PR number as an artifact |
| `Agent Governance Comment` (new) | `workflow_run` | `pull-requests: write` | downloads that artifact, posts/updates the comment |

`workflow_run` runs from the base branch with the base repository's
permissions, so the comment now lands on fork pull requests too. The
`head.repo.full_name` guard is gone.

Also caps the comment body under the 65536-character API limit, which the
previous version could exceed on a large diff, and appends a pointer to the run
summary when truncated.

### Why this is not a `pull_request_target` style hole

The privileged workflow deliberately does not become an arbitrary-code-execution
surface:

- It never checks out pull request code and never runs anything from the head.
- Its only input is the text artifact uploaded by the analysis run.
- Untrusted text reaches the API through files and `jq -Rs`, never through shell
  interpolation.
- The PR number is re-derived with `tr -dc '0-9'` before it is used in an API
  path.
- The analysis half is downgraded from `pull-requests: write` + `issues: write`
  to `contents: read`, so the half that does touch PR code now holds strictly
  fewer permissions than before.

### Unit Tests and/or Case Tests for my changes

There is no test harness for workflow files, so the shell logic was extracted
from the shipped YAML and exercised directly against stubbed `gh` and `jq`,
over real `agent_governance_check.py --format markdown` output.

- Commands run:
  - `python tools/03_code_analysis/agent_governance_check.py --staged --format markdown`
  - YAML parse of both workflow files
  - extracted `Collect comment payload`, `Download comment payload` and
    `Comment governance warnings` `run:` blocks, executed under `bash` with a
    `gh`/`jq` stub
- Result summary:
  - governance checker: `No findings.`, exit 0
  - both workflows parse
  - 25/25 shell assertions pass, covering: payload collection with and without a
    summary file, artifact present vs. absent, new comment (`POST`) vs. update of
    an existing comment (`PATCH`), clean summary posting nothing, incomplete
    payload, non-numeric PR number, and oversized-summary truncation staying
    under 65536 bytes
- Checks not run, with reason:
  - No live end-to-end run. `workflow_run` workflows are read from the default
    branch, so `Agent Governance Comment` cannot execute from a PR branch by
    design. It becomes active only once this is merged into `develop`, and the
    first fork PR afterwards is the real end-to-end test. This is inherent to
    the pattern, not something this PR can work around.

### Governance Notes
- INPUT/docs changes: no INPUT change. `docs/developers_guide/agent_governance.md`
  gains a paragraph describing the two-workflow split and the merge-before-active
  caveat.
- Core module impact: none. No `source/` file is touched.
- Exceptions requested: none.

### Follow-up, not in this PR

The comment condition is `grep -qi '^| warning |'`, so `error`-severity findings
still produce no comment even though they fail the job. That looks unintended,
but it is orthogonal to the fork permission bug and is left alone here to keep
this diff reviewable. Happy to send it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYWRHYxWwMgxoyWVYRHFn1
