### PR TITLE
Fix: Fix LibXC 7.x build after the XC gradient split

### DIFF
--- a/source/source_hamilt/module_xc/xc_grad.cpp
+++ b/source/source_hamilt/module_xc/xc_grad.cpp
@@ -17,6 +17,10 @@
 #include "xc_grad_internal.h"
 #include "source_base/timer.h"
 
+#ifdef __LIBXC
+#include <xc_funcs.h>
+#endif
+
 void XC_Functional::gradcorr(
     double &etxc,
     double &vtxc,


### PR DESCRIPTION
## Summary

PR #7873, `Split some large files (fs_nonlocal_tools.cpp, onsite_proj.cpp, to_wannier90_lcao.cpp, etc.) into smaller ones`, removed the indirect `libxc_abacus.h` include from `xc_grad.cpp` while splitting the XC gradient implementation. However, `XC_Functional::gradcorr()` still uses the LibXC functional ID `XC_GGA_C_LYP`.

With LibXC 7.1.2, `xc.h` does not define functional IDs; they are provided by `xc_funcs.h`. Consequently, builds with `ENABLE_LIBXC=ON` fail because `XC_GGA_C_LYP` is undefined.

This PR conditionally includes `xc_funcs.h` when `__LIBXC` is enabled. The change restores the missing direct dependency without altering runtime or numerical behavior.
