### PR TITLE
Docs: add dav_subspace to the PW GPU solver list

### DIFF
--- a/docs/advanced/acceleration/cuda.md
+++ b/docs/advanced/acceleration/cuda.md
@@ -44,7 +44,7 @@ The ABACUS program will automatically determine whether the current ELPA support
 ## Run with the GPU support by editing the INPUT script:
 
 In `INPUT` file we need to set the input parameter [device](../input_files/input-main.md#device) to `gpu`. If this parameter is not set, ABACUS will try to determine if there are available GPUs.
-- Set `ks_solver`: For the PW basis, CG, BPCG and Davidson methods are supported on GPU; set the input parameter [ks_solver](../input_files/input-main.md#ks_solver) to `cg`, `bpcg` or `dav`. For the LCAO basis, `cusolver`, `cusolvermp` and `elpa` is supported on GPU.
+- Set `ks_solver`: For the PW basis, CG, BPCG, Davidson, and Davidson subspace methods are supported on GPU; set the input parameter [ks_solver](../input_files/input-main.md#ks_solver) to `cg`, `bpcg`, `dav`, or `dav_subspace`. For the LCAO basis, `cusolver`, `cusolvermp`, and `elpa` are supported on GPU.
 - **single-card**: ABACUS allows for single-GPU acceleration. You can run ABACUS without any MPI process by command `abacus`, and `ks_solver cusolver` is recommended for the LCAO basis. *note: avoid using `mpirun -n 1 abacus`*.
 - **multi-cards**: ABACUS allows for multi-GPU acceleration. If you have multiple GPU cards, you can run ABACUS with several MPI processes, and each process will utilize one GPU card. For example, the command `mpirun -n 2 abacus` will by default launch two GPUs for computation. If you only have one card, this command will only start one GPU. *note: the number of MPI processes SHOULD be equal to the number of GPU cards, unless you are using MPS in your computer.*
 


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have linked an issue or explained why this PR does not need one.
- [x] I have added adequate unit tests and/or case tests, or explained why not.
- [x] I have listed the exact verification commands run and their results.
- [x] I have described user-visible behavior changes, including INPUT parameter changes.
- [x] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [x] I have requested any needed governance exception below.

### Linked Issue
Fix #7775

### Unit Tests and/or Case Tests for my changes
- Commands run:
  - `test -d tests/11_PW_GPU/scf_dav_sub`
  - `rg -n dav_subspace docs/advanced/acceleration/cuda.md tests/11_PW_GPU/scf_dav_sub/INPUT`
  - `git diff --check`
  - `python3 tools/03_code_analysis/agent_governance_check.py --staged`
  - `python3 tools/03_code_analysis/agent_governance_check.py --base upstream/develop --head HEAD --format text`
- Result summary: all commands passed; both governance checks reported no findings.
- Checks not run, with reason: no ABACUS build or GPU runtime test was run because this PR changes only hand-written documentation and the existing GPU integration case already records `ks_solver dav_subspace`.

### What changed?
- Document `dav_subspace` as a supported PW GPU eigensolver.
- Correct the grammar and punctuation of the same solver-list sentence.

### Governance Notes
- INPUT/docs changes: documentation-only clarification; no INPUT behavior or generated parameter documentation changes.
- Core module impact: none.
- Exceptions requested: none.