### PR TITLE
Fix Tensor::inner_most_ptr bounds checks

### DIFF
--- a/source/source_base/module_container/ATen/core/tensor.h
+++ b/source/source_base/module_container/ATen/core/tensor.h
@@ -390,24 +390,29 @@ class Tensor {
      *
      * @return The pointer to the specified row.
      *
-     * @note This function assumes the tensor is treated as a matrix, where each row
-     * is a contiguous block of memory.
-     * If the row index is out of bounds, the behavior is undefined.
+     * @note This function supports rank-1 and rank-2 tensors. For a rank-1 tensor,
+     * the index selects an element. For a rank-2 tensor, the index selects a row.
+     * An invalid rank or index throws std::invalid_argument.
      */
     template <typename T>
-    T* inner_most_ptr(const int &index) const {
-        if (shape_.ndim() > 2) {
-            throw std::invalid_argument("Invalid call, inner_most_ptr only support tensor rank <= 2!");
+    T* inner_most_ptr(const int& index) const
+    {
+        const unsigned int rank = shape_.ndim();
+        if (rank == 0 || rank > 2)
+        {
+            throw std::invalid_argument("Invalid call, inner_most_ptr only supports tensor ranks 1 and 2!");
         }
-        if (index > shape_.dim_size(static_cast<int>(shape_.ndim() - 2))) {
-            throw std::invalid_argument("Invalid index, index of the inner-most must less than the inner-most shape size!");
+        const int64_t outer_size = shape_.dim_size(0);
+        if (index < 0 || static_cast<int64_t>(index) >= outer_size)
+        {
+            throw std::invalid_argument("Invalid index, inner_most_ptr index is out of bounds!");
         }
-        if (shape_.ndim() == 1) {
+        if (rank == 1)
+        {
             return data<T>() + index;
         }
-        return data<T>() + index * shape_.dim_size(static_cast<int>(shape_.ndim()) - 1);
+        return data<T>() + index * shape_.dim_size(1);
     }
-
 
     /**
      * @brief Equality comparison operator for tensors.

--- a/source/source_base/module_container/test/tensor_test.cpp
+++ b/source/source_base/module_container/test/tensor_test.cpp
@@ -218,6 +218,27 @@ TEST(Tensor, GetValueAndInnerMostPtr) {
     EXPECT_EQ(row_ptr[3], 12);
 }
 
+TEST(Tensor, InnerMostPtrBounds)
+{
+    container::Tensor vector(container::DataType::DT_INT, container::DeviceType::CpuDevice, {4});
+    std::vector<int> values = {1, 2, 3, 4};
+    memcpy(vector.data<int>(), values.data(), sizeof(int) * values.size());
+
+    auto element_ptr = vector.inner_most_ptr<int>(2);
+    EXPECT_EQ(*element_ptr, 3);
+    EXPECT_THROW(vector.inner_most_ptr<int>(-1), std::invalid_argument);
+    EXPECT_THROW(vector.inner_most_ptr<int>(4), std::invalid_argument);
+
+    container::Tensor matrix(container::DataType::DT_INT, container::DeviceType::CpuDevice, {2, 2});
+    EXPECT_THROW(matrix.inner_most_ptr<int>(2), std::invalid_argument);
+
+    container::Tensor empty(container::DataType::DT_INT, container::DeviceType::CpuDevice, container::TensorShape());
+    EXPECT_THROW(empty.inner_most_ptr<int>(0), std::invalid_argument);
+
+    container::Tensor rank_three(container::DataType::DT_INT, container::DeviceType::CpuDevice, {1, 1, 1});
+    EXPECT_THROW(rank_three.inner_most_ptr<int>(0), std::invalid_argument);
+}
+
 TEST(Tensor, ReshapeDeathTest) {
     ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     container::Tensor t(container::DataType::DT_FLOAT, container::DeviceType::CpuDevice, {2, 3, 4});


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have linked an issue or explained why this PR does not need one.
- [x] I have added adequate unit tests and/or case tests, or explained why not.
- [x] I have listed the exact verification commands run and their results.
- [x] I have described user-visible behavior changes, including INPUT parameter changes.
- [x] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [x] I have requested any needed governance exception below.

### Linked Issue
Fix #7560

### Unit Tests and/or Case Tests for my changes
- Commands run:
  - `cmake --build /tmp/abacus-source-base-coverage --target MODULE_BASE_CONTAINER_Unittests -j2`
  - `OMP_NUM_THREADS=1 ctest --test-dir /tmp/abacus-source-base-coverage --output-on-failure -R ^MODULE_BASE_CONTAINER_Unittests$`
  - `git diff --check`
  - `python3 tools/03_code_analysis/code_quality_score.py source/source_base/module_container/ATen/core/tensor.h source/source_base/module_container/test/tensor_test.cpp`
  - `python3 tools/03_code_analysis/agent_governance_check.py --staged`
  - `python3 tools/03_code_analysis/agent_governance_check.py --base upstream/develop --head HEAD --format text`
- Result summary: the final focused build and all 38 container unit tests passed. Both changed files passed the code-quality score. Governance reported only the expected documentation-sync reminder addressed below.
- Earlier result: the first focused test run failed because the new rank-zero test used the default rank-one float Tensor while requesting an int pointer. The test was corrected to construct an explicit rank-zero int Tensor; the final rebuild and rerun passed.
- Checks not run, with reason: the full ABACUS suite was not run because the change is confined to bounds validation in the container Tensor helper and is covered by its owning unit-test target.

### What changed?
- Reject rank-zero and rank-greater-than-two tensors before accessing dimensions.
- Reject negative and one-past indices.
- Handle rank-one element pointers without unsigned dimension underflow.
- Add focused coverage for valid rank-one access and invalid rank/index cases.

### Governance Notes
- INPUT/docs changes: no INPUT or user-facing calculation behavior changed. The API Doxygen comment was updated; generated parameter documentation is not applicable.
- Core module impact: limited to `source_base/module_container`; valid rank-one and rank-two access behavior is unchanged.
- Global dependency budget: no `GlobalV`, `GlobalC`, or `PARAM` references added.
- Exceptions requested: none.