### PR TITLE
Fix static PyABACUS base wrapper calls

### DIFF
--- a/python/pyabacus/CONTRIBUTING.md
+++ b/python/pyabacus/CONTRIBUTING.md
@@ -375,7 +375,7 @@ To contribute to the `pyabacus` project, follow these steps:
            
        @staticmethod
        def sphbes_zeros(l: int, n: int, zeros: NDArray[np.float64]) -> None: 
-           super().sphbes_zeros(l, n, zeros)
+           _Sphbes.sphbes_zeros(l, n, zeros)
    ```
 
 ## Conclusion

--- a/python/pyabacus/src/pyabacus/ModuleBase/_module_base.py
+++ b/python/pyabacus/src/pyabacus/ModuleBase/_module_base.py
@@ -48,7 +48,7 @@ class Sphbes(_Sphbes):
         
     @staticmethod
     def sphbes_zeros(l: int, n: int, zeros: NDArray[np.float64]) -> None: 
-        super().sphbes_zeros(l, n, zeros)
+        _Sphbes.sphbes_zeros(l, n, zeros)
 
 class Integral(_Integral):
     def __init__(self) -> None: 
@@ -81,7 +81,7 @@ class Integral(_Integral):
         rab: NDArray[np.float64], 
         asum: NDArray[np.float64]
     ) -> None: 
-        super().Simpson_Integral_0toall(mesh, func, rab, asum)
+        _Integral.Simpson_Integral_0toall(mesh, func, rab, asum)
         
     @staticmethod
     def Simpson_Integral_alltoinf(
@@ -90,7 +90,7 @@ class Integral(_Integral):
         rab: NDArray[np.float64], 
         asum: NDArray[np.float64]
     ) -> None: 
-        super().Simpson_Integral_alltoinf(mesh, func, rab, asum)
+        _Integral.Simpson_Integral_alltoinf(mesh, func, rab, asum)
         
     @overload
     @staticmethod

--- a/python/pyabacus/tests/test_base_math.py
+++ b/python/pyabacus/tests/test_base_math.py
@@ -13,6 +13,23 @@ def test_sphbes():
     assert s.sphbesj(0, 0.0) == 1.0
     assert s.sphbesj(1, np.array([0.0]), 1, 1, np.zeros(1)) == None
 
+def test_static_array_wrappers():
+    zeros = np.zeros(2)
+    base.Sphbes.sphbes_zeros(0, 2, zeros)
+    np.testing.assert_allclose(zeros, [np.pi, 2 * np.pi])
+
+    mesh = 3
+    func = np.ones(mesh)
+    rab = np.ones(mesh)
+    integral_from_zero = np.zeros(mesh)
+    integral_to_infinity = np.zeros(mesh)
+
+    base.Integral.Simpson_Integral_0toall(mesh, func, rab, integral_from_zero)
+    base.Integral.Simpson_Integral_alltoinf(mesh, func, rab, integral_to_infinity)
+
+    np.testing.assert_allclose(integral_from_zero, [0.0, 1.0, 2.0])
+    np.testing.assert_allclose(integral_to_infinity, [2.0, 1.0, 0.0])
+
 def test_sbt():
     sbt = base.SphericalBesselTransformer()
 


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have linked an issue or explained why this PR does not need one.
- [x] I have added adequate unit tests and/or case tests, or explained why not.
- [x] I have listed the exact verification commands run and their results.
- [x] I have described user-visible behavior changes, including INPUT parameter changes.
- [x] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [x] I have requested any needed governance exception below.

### Linked Issue
Fix #7557

### Unit Tests and/or Case Tests for my changes
- Commands run:
  - `python3 -m compileall -q python/pyabacus/src/pyabacus python/pyabacus/tests/test_base_math.py`
  - isolated `/tmp` build: `PYTHONPATH=/tmp/abacus-pydeps-7557 python3 -m pip install --no-build-isolation --target /tmp/abacus-pyinstall-7557 python/pyabacus`
  - `PYTHONPATH=/tmp/abacus-pyinstall-7557:/tmp/abacus-pydeps-7557 python3 -m pytest python/pyabacus/tests/test_base_math.py -v`
  - `git diff --check`
  - `python3 tools/03_code_analysis/agent_governance_check.py --staged`
  - `python3 tools/03_code_analysis/agent_governance_check.py --base upstream/develop --head HEAD --format text`
- Result summary: PyABACUS built successfully; all 4 focused base-math tests passed; compileall, diff, and governance checks passed.
- Checks not run, with reason: the full PyABACUS test suite collected 59 tests but stopped because the environment lacks the optional `scipy` dependency used by `test_hsolver.py`. The focused owning test file completed successfully.
- Environment note: an initial attempt to create a venv failed because system Python lacks `ensurepip`; dependencies and the built package were instead isolated under `/tmp` with `pip --target`.

### What changed?
- Call the pybind11 base classes explicitly from static Python wrapper methods instead of using zero-argument `super()`.
- Add regression coverage for `sphbes_zeros`, `Simpson_Integral_0toall`, and `Simpson_Integral_alltoinf`.
- Correct the corresponding wrapper example in the PyABACUS contributing guide.

### Governance Notes
- INPUT/docs changes: no ABACUS INPUT behavior changed; the relevant PyABACUS contributor example was synchronized.
- Core module impact: none; only Python wrapper dispatch changes.
- Exceptions requested: none.