### PR TITLE
Balance the EXX q-pack timer when output is disabled

### DIFF
--- a/source/source_lcao/module_ri/exx_lip.hpp
+++ b/source/source_lcao/module_ri/exx_lip.hpp
@@ -473,10 +473,12 @@ void Exx_Lip<T, Device>::exx_energy_cal()
 template <typename T, typename Device>
 void Exx_Lip<T, Device>::write_q_pack() const
 {
-    ModuleBase::timer::start("Exx_Lip", "write_q_pack");
-
     if (PARAM.inp.out_chg[0] == 0)
-        { return; }
+    {
+        return;
+    }
+
+    ModuleBase::timer::start("Exx_Lip", "write_q_pack");
 
     if (!GlobalV::RANK_IN_POOL)
     {


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have linked an issue or explained why this PR does not need one.
- [x] I have added adequate unit tests and/or case tests, or explained why not.
- [x] I have listed the exact verification commands run and their results.
- [x] I have described user-visible behavior changes, including INPUT parameter changes.
- [x] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [x] I have requested any needed governance exception below.

### Linked Issue
Fix #7545

### Unit Tests and/or Case Tests for my changes
- Commands run:
  - `cmake -S . -B /tmp/abacus-build-mpi-openblas`
  - `cmake --build /tmp/abacus-build-mpi-openblas --target abacus_basic_para -j2`
  - `cmake --build /tmp/abacus-build-mpi-openblas --target MODULE_BASE_timer -j2`
  - `OMP_NUM_THREADS=1 ctest --test-dir /tmp/abacus-build-mpi-openblas --output-on-failure -R ^MODULE_BASE_timer$`
  - `git diff --check`
  - `python3 tools/03_code_analysis/agent_governance_check.py --staged`
  - `python3 tools/03_code_analysis/agent_governance_check.py --base upstream/develop --head HEAD --format text`
- Result summary: the LCAO-enabled `abacus_basic_para` target completed all 555 build steps; `MODULE_BASE_timer` passed; diff checks passed. Governance emitted test-evidence and documentation reminders addressed below.
- Environment note: MPI-linked compilation printed the documented sandbox artifact `opal_ifinit: socket() failed errno=1`, but every compile and link step completed successfully.
- Earlier command correction: the first build command used the nonexistent generic target `abacus`; the configured executable target is `abacus_basic_para`, which subsequently built successfully.
- Checks not run, with reason: no dedicated `Exx_Lip::write_q_pack` runtime test was added because the template has no lightweight independently constructible fixture and its constructor requires the full LCAO/PW electronic-state stack. The full owning executable build instantiates the changed template, and the timer component test covers timer start/end invariants.

### What changed?
- Return before starting the `write_q_pack` timer when charge output is disabled.
- Preserve the existing paired timer start/end calls on the enabled-output path.

### Governance Notes
- INPUT/docs changes: no INPUT semantics or output contents changed; only internal timing statistics are corrected, so user documentation is not required.
- Core module impact: limited to the legacy EXX LIP output helper; numerical EXX calculations and q-pack output are unchanged.
- Global dependency budget: the existing `PARAM` check was moved before the timer start; no global references were added.
- Existing `.hpp` rationale: this PR modifies an existing template implementation header and does not add or propagate a new `.hpp` include.
- Exceptions requested: none.