### PR TITLE
Fix GPU spinor density accumulation without magnetization

### DIFF
--- a/source/source_estate/kernels/cuda/elecstate_op.cu
+++ b/source/source_estate/kernels/cuda/elecstate_op.cu
@@ -52,7 +52,7 @@ __global__ void elecstate_pw(
     rho[3 * nrxx_dense + idx] += w1 * (norm(wfcr[idx]) - norm(wfcr_another_spin[idx]));
   }
   else {
-    rho[0 * nrxx_dense + idx] = 0;
+    // Keep the scalar charge accumulated above; only magnetization is disabled.
     rho[1 * nrxx_dense + idx] = 0;
     rho[2 * nrxx_dense + idx] = 0;
     rho[3 * nrxx_dense + idx] = 0;

--- a/source/source_estate/kernels/rocm/elecstate_op.hip.cu
+++ b/source/source_estate/kernels/rocm/elecstate_op.hip.cu
@@ -50,7 +50,7 @@ __global__ void elecstate_pw(
     rho[3 * nrxx + idx] += w1 * (norm(wfcr[idx]) - norm(wfcr_another_spin[idx]));
   }
   else {
-    rho[0 * nrxx + idx] = 0;
+    // Keep the scalar charge accumulated above; only magnetization is disabled.
     rho[1 * nrxx + idx] = 0;
     rho[2 * nrxx + idx] = 0;
     rho[3 * nrxx + idx] = 0;

--- a/source/source_estate/kernels/test/elecstate_op_test.cpp
+++ b/source/source_estate/kernels/test/elecstate_op_test.cpp
@@ -129,8 +129,8 @@ TEST_F(TestModuleElecstateMultiDevice, elecstate_pw_op_gpu)
         EXPECT_LT(fabs(rho_data[ii] - expected_rho[ii]), 6e-5);
     }
     delete [] rho;
-    delete_memory_var_op()(this->gpu_ctx, d_rho_data);
-    delete_memory_complex_op()(this->gpu_ctx, d_wfcr);
+    delete_memory_var_op()(d_rho_data);
+    delete_memory_complex_op()(d_wfcr);
 }
 
 TEST_F(TestModuleElecstateMultiDevice, elecstate_pw_spin_op_gpu)
@@ -168,9 +168,65 @@ TEST_F(TestModuleElecstateMultiDevice, elecstate_pw_spin_op_gpu)
         EXPECT_LT(fabs(rho_data_2[ii] - expected_rho_2[ii]), 5e-4);
     }
     delete [] rho;
-    delete_memory_var_op()(this->gpu_ctx, d_rho_data_2);
-    delete_memory_complex_op()(this->gpu_ctx, d_wfcr_2);
-    delete_memory_complex_op()(this->gpu_ctx, d_wfcr_another_spin_2);
+    delete_memory_var_op()(d_rho_data_2);
+    delete_memory_complex_op()(d_wfcr_2);
+    delete_memory_complex_op()(d_wfcr_another_spin_2);
+}
+
+TEST_F(TestModuleElecstateMultiDevice, nonmagnetic_spinor_preserves_charge_on_gpu)
+{
+    const int nrxx = 2;
+    const double weight = 0.5;
+    const bool domag = false;
+    const bool domag_z = false;
+    const std::vector<std::complex<double>> wfcr = {{1.0, 0.0}, {0.0, 2.0}};
+    const std::vector<std::complex<double>> wfcr_another_spin = {{0.0, 1.0}, {3.0, 0.0}};
+    std::vector<double> rho_cpu = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0};
+    std::vector<double> rho_gpu = rho_cpu;
+    double* rho_cpu_components[4]
+        = {rho_cpu.data(), rho_cpu.data() + nrxx, rho_cpu.data() + 2 * nrxx, rho_cpu.data() + 3 * nrxx};
+
+    elecstate_cpu_op()(this->cpu_ctx,
+                       domag,
+                       domag_z,
+                       nrxx,
+                       nrxx,
+                       weight,
+                       rho_cpu_components,
+                       wfcr.data(),
+                       wfcr_another_spin.data());
+
+    double* rho_device = nullptr;
+    std::complex<double>* wfcr_device = nullptr;
+    std::complex<double>* wfcr_another_spin_device = nullptr;
+    resize_memory_var_op()(rho_device, rho_gpu.size());
+    resize_memory_complex_op()(wfcr_device, wfcr.size());
+    resize_memory_complex_op()(wfcr_another_spin_device, wfcr_another_spin.size());
+    syncmem_var_h2d_op()(rho_device, rho_gpu.data(), rho_gpu.size());
+    syncmem_complex_h2d_op()(wfcr_device, wfcr.data(), wfcr.size());
+    syncmem_complex_h2d_op()(wfcr_another_spin_device, wfcr_another_spin.data(), wfcr_another_spin.size());
+    double* rho_gpu_components[4] = {rho_device, rho_device + nrxx, rho_device + 2 * nrxx, rho_device + 3 * nrxx};
+
+    elecstate_gpu_op()(this->gpu_ctx,
+                       domag,
+                       domag_z,
+                       nrxx,
+                       nrxx,
+                       weight,
+                       rho_gpu_components,
+                       wfcr_device,
+                       wfcr_another_spin_device);
+    syncmem_var_d2h_op()(rho_gpu.data(), rho_device, rho_gpu.size());
+
+    EXPECT_DOUBLE_EQ(rho_cpu[0], 2.0);
+    EXPECT_DOUBLE_EQ(rho_cpu[1], 8.5);
+    for (std::size_t ir = 0; ir < rho_cpu.size(); ++ir)
+    {
+        EXPECT_DOUBLE_EQ(rho_gpu[ir], rho_cpu[ir]);
+    }
+
+    delete_memory_var_op()(rho_device);
+    delete_memory_complex_op()(wfcr_device);
+    delete_memory_complex_op()(wfcr_another_spin_device);
 }
 #endif // __CUDA || __UT_USE_CUDA || __ROCM || __UT_USE_ROCM
-

--- a/source/source_estate/test/CMakeLists.txt
+++ b/source/source_estate/test/CMakeLists.txt
@@ -17,6 +17,12 @@ AddTest(
   SOURCES ../kernels/test/elecstate_op_test.cpp
 )
 
+if(USE_CUDA)
+  target_compile_definitions(MODULE_ESTATE_Elecstate_Op_UTs PRIVATE __UT_USE_CUDA)
+elseif(USE_ROCM)
+  target_compile_definitions(MODULE_ESTATE_Elecstate_Op_UTs PRIVATE __UT_USE_ROCM)
+endif()
+
 AddTest(
   TARGET MODULE_ESTATE_elecstate_occupy
   LIBS parameter  base device


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have linked an issue or explained why this PR does not need one.
- [x] I have added adequate unit tests and/or case tests, or explained why not.
- [x] I have listed the exact verification commands run and their results.
- [x] I have described user-visible behavior changes, including INPUT parameter changes.
- [x] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [x] I have requested any needed governance exception below.

### Linked Issue
Fix #7549

### Issue validation

The kernel-level problem is reproducible on the current `develop` commit `c2fa3ac19539bd10817d66e99ac5ff1cfd2156dd` with an NVIDIA A800 and CUDA 12.9.

A direct call to the GPU spinor-density kernel with `DOMAG=false` and `DOMAG_Z=false` produced:

```text
rho0 = 0 0; rho1-3 = 0 0 0 0 0 0
```

For the same initial density and wavefunctions, the CPU implementation preserves and accumulates scalar charge, giving `rho[0] = {2.0, 8.5}`. The regression test added by this PR failed before the production fix with those exact CPU/GPU differences and passes afterward.

The standard INPUT initialization currently makes this boolean combination unreachable for `nspin=4`: `noncolin=true` selects `(DOMAG, DOMAG_Z)=(true,false)`, while `noncolin=false` selects `(false,true)`. Therefore this PR fixes a verified backend contract inconsistency and protects future/internal callers; it does not claim that a normal current INPUT case already reaches the affected branch.

### Unit Tests and/or Case Tests for my changes
- Commands run:
  - `PATH=/usr/local/cuda-12.9/bin:$PATH cmake -S . -B build-cuda-issue7549 -G Ninja -DUSE_CUDA=ON -DBUILD_TESTING=ON -DENABLE_FLOAT_FFTW=ON -DCMAKE_CUDA_ARCHITECTURES=80 -DFETCHCONTENT_FULLY_DISCONNECTED=ON`
  - `PATH=/usr/local/cuda-12.9/bin:$PATH cmake --build build-cuda-issue7549 --target MODULE_ESTATE_Elecstate_Op_UTs -j2`
  - `OMP_NUM_THREADS=1 ctest --test-dir build-cuda-issue7549 -V -R '^MODULE_ESTATE_Elecstate_Op_UTs$'`
  - `PATH=/usr/local/cuda-12.9/bin:$PATH cmake --build build-cuda-issue7549 --target abacus_basic_gpu -j4`
  - `git diff --check`
  - `python3 tools/03_code_analysis/agent_governance_check.py --staged`
  - `python3 tools/03_code_analysis/code_quality_score.py --output /dev/stdout source/source_estate/kernels/test/elecstate_op_test.cpp`
- Result summary:
  - The focused CUDA regression failed before the production fix: GPU `rho[0]` was `{0, 0}` while CPU `rho[0]` was `{2.0, 8.5}`.
  - After the fix, all 5 tests in `MODULE_ESTATE_Elecstate_Op_UTs` passed on an NVIDIA A800.
  - The complete CUDA `abacus_basic_gpu` executable built successfully.
  - `git diff --check` passed.
  - The changed C++ test file received a code-quality score of 86/100, above the required score of 60.
  - The governance checker completed with only the expected documentation-sync warning addressed below.
- Checks not run, with reason:
  - ROCm runtime tests were not run because no ROCm compiler/device is available in the environment. The HIP change mirrors the verified CUDA one-line correction.
  - The full integration suite was not run because the affected behavior is isolated to the density-accumulation kernel and is directly covered by the focused CPU/GPU parity test.
  - `pre-commit` was not run because it is not installed in this environment.

### What's changed?
- Preserve scalar charge density `rho[0]` in the CUDA and ROCm spinor-density kernels when magnetization output is disabled.
- Continue clearing only `rho[1..3]`, matching the CPU implementation.
- Add a focused CPU/GPU parity regression test for the affected boolean combination.
- Enable the existing GPU portions of the elecstate operator unit-test target in CUDA/ROCm test builds and update their stale memory-release calls to the current API.

### Governance Notes
- INPUT/docs changes: none. No INPUT keyword, default, validation, file format, or documented user workflow changes.
- Core module impact: limited to the `source_estate` CUDA/ROCm density-accumulation kernel and its focused unit-test target. No interface, global dependency, header dependency, or MPI behavior changes.
- Exceptions requested: none.
