### PR TITLE
Make agent verification requirements tiered, and fix the ./build/abacus CLI recipe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,12 +41,10 @@ rules. Read the complete governance document before making or reviewing changes:
 - INPUT parameter behavior changes must update `docs/parameters.yaml` and
   `docs/advanced/input_files/input-main.md`, or the PR must state why no update
   is required.
-- Report the exact verification performed. Do not claim completion without
-  fresh test or check output.
-- For multi-step refactors (e.g., splitting a large `.cpp` into several
-  files), build and commit after each step rather than batching all changes
-  before verification. This keeps the blast radius small when a step
-  surfaces a missing include or instantiation error.
+- Report the exact verification performed, and match the depth of verification
+  to the risk of the change. `Verification Tiers` below states which evidence
+  each kind of change owes. Never present an unrun command as if it had passed,
+  and never silently claim a lower tier than the change belongs to.
 - Prefer `std::vector` over raw `new`/`delete` for dynamic arrays; before
   converting class members, confirm no external code consumes them as raw
   pointers (e.g., `std::vector<bool>` has no `.data()`), and use
@@ -71,14 +69,69 @@ rules. Read the complete governance document before making or reviewing changes:
 - Prefer the repository CMake/CTest flow already used by CI. For focused local
   checks, use commands such as `ctest --test-dir build -V -R MODULE_MD` after a
   usable build exists.
+- The executable is not named `abacus`. CMake names it
+  `abacus_<level>_<para-or-device>` (`ABACUS_BIN_NAME` in the top-level
+  `CMakeLists.txt`), where level is `pw`, `basic`, `ml`, `std`, or `max`, and
+  `install` keeps that name. Locate it the way `.github/workflows/test.yml`
+  does, and use the resolved path in recorded commands:
+
+  ```bash
+  ABACUS_BIN=$(find build -name "abacus_*" -type f -executable | head -1)
+  ```
+
 - For INPUT-related changes, verify both documentation and CLI behavior when an
-  executable is available: `./build/abacus -h <parameter>` and
-  `./build/abacus --check-input` from a valid case directory.
-- For executable identity, record `./build/abacus --version` or the equivalent
-  installed `abacus --version` command used during verification.
+  executable is available: `"$ABACUS_BIN" -h <parameter>` and
+  `"$ABACUS_BIN" --check-input` from a valid case directory.
+- For executable identity, record `"$ABACUS_BIN" --version` together with the
+  binary name it resolved to.
 - Reuse existing Docker and toolchain assets. Do not add a new container,
   compiler setup, or calculation-task skill unless the PR explicitly requires
   and justifies it.
+
+## Verification Tiers
+
+The verification a change owes depends on what the change can break, not on how
+large the diff is. Pick the highest tier that applies, produce its evidence, and
+record the exact commands in the PR.
+
+- **Tier 1, static checks only.** Text no compiler reads: documentation,
+  comments, PR templates, governance files, whitespace or line-ending
+  normalization. Evidence: the governance check from `Local Commands` below,
+  plus regenerated `docs/parameters.yaml` and
+  `docs/advanced/input_files/input-main.md` when those artifacts are in scope.
+  A local build is not expected, and configuring one to satisfy this tier is
+  wasted effort.
+- **Tier 2, must compile.** Changes that can break the build without changing
+  any number: include and header-dependency edits, moving code between
+  translation units, splitting or merging files, renames, mechanical call-site
+  updates, interface signature changes, `new`/`delete` to `std::vector`
+  conversions, and `CMakeLists.txt` linkage. Evidence: a build of the affected
+  targets plus the unit tests of the touched modules, such as
+  `ctest --test-dir build -R MODULE_MD`. Header-dependency trimming belongs
+  here even when it only deletes lines, because a removed include can break an
+  unrelated translation unit that relied on it transitively.
+- **Tier 3, must reproduce behavior.** Changes that can move numbers or alter
+  control flow: algorithms, operators, heterogeneous kernels, eigensolvers,
+  mixing, occupations, symmetry, INPUT semantics or defaults. Evidence: Tier 2,
+  plus at least one relevant case from `tests/`, plus the CLI checks above for
+  INPUT and command-line changes. Say which reference values were compared, not
+  only that the case ran.
+
+For a multi-step Tier 2 or Tier 3 refactor, such as splitting a large `.cpp`
+into several files, build and commit after each step rather than batching every
+change before the first build. This keeps the blast radius small when a step
+surfaces a missing include or instantiation error.
+
+When the evidence a tier requires cannot be produced locally, say so
+specifically: name the tier, name the command that could not be run, and give
+the reason, such as no Linux toolchain in the checkout, no configured build
+tree, a sandbox restriction, or a missing optional dependency. ABACUS builds on
+Linux in practice, so a Windows or otherwise unsupported checkout is a
+legitimate reason to stop at static checks and leave compile and runtime
+evidence to CI. A disclosed gap is acceptable and reviewable. An undisclosed gap
+is not, and neither is provisioning a new toolchain or container to reach a tier
+the change never required; reuse the existing Docker and toolchain assets or
+defer to CI.
 
 ## Local Runtime Testing
 
@@ -111,7 +164,7 @@ rules. Read the complete governance document before making or reviewing changes:
 
 - Member -> free function: inventory `this->` reads; pass as params (const
   for config, ref for mutable state); move only when body is `this`-free;
-  keep thin wrapper; compile each step.
+  keep thin wrapper; compile each step when a usable build exists (Tier 2).
 - Extract a base-class nested-vector member in three steps (hold + forward,
   switch writers, delete legacy) so no commit mixes old-storage writes with
   new-storage reads.
@@ -132,8 +185,9 @@ full mixed-line-ending hook only for intentional repository-wide normalization.
 
 ## PR Self-Check
 
-- Confirm the PR body states exact commands run, whether they passed or failed,
-  and why any expected check could not be run.
+- Confirm the PR body names the verification tier reached, states the exact
+  commands run and whether they passed or failed, and explains why any check
+  expected at that tier could not be run.
 - Keep warning rationales concrete. For example, a header include warning can be
   acceptable when the header owns a value member that requires the complete type.
 - Keep historical-debt notes separate from new deterministic errors introduced

--- a/docs/developers_guide/agent_governance.md
+++ b/docs/developers_guide/agent_governance.md
@@ -55,7 +55,9 @@ AI agents have additional workflow obligations:
 
 - Inspect existing interfaces before using them.
 - State uncertainty instead of inventing business rules or APIs.
-- Report exact verification results and any checks that could not be run.
+- Report exact verification results and any checks that could not be run. Match
+  verification depth to the risk of the change using the tiers in `AGENTS.md`,
+  and name the tier reached rather than implying an unrun command passed.
 
 ## Rule Grading Matrix
 
@@ -165,16 +167,23 @@ changed and the PR explains why the new reference is correct.
 ## CLI Verification
 
 When a usable ABACUS executable is present, INPUT and command-line changes
-should include the relevant CLI checks in the PR verification record:
+should include the relevant CLI checks in the PR verification record.
+
+The executable is not named `abacus`. CMake names it
+`abacus_<level>_<para-or-device>` through `ABACUS_BIN_NAME`, and `install`
+preserves that name, so resolve the path first the way
+`.github/workflows/test.yml` does:
 
 ```bash
-./build/abacus --version
-./build/abacus -h <parameter>
-./build/abacus --check-input
+ABACUS_BIN=$(find build -name "abacus_*" -type f -executable | head -1)
+"$ABACUS_BIN" --version
+"$ABACUS_BIN" -h <parameter>
+"$ABACUS_BIN" --check-input
 ```
 
 Run `--check-input` from a directory containing a valid `INPUT` case. If no
-local executable or valid case is available, state that explicitly in the PR.
+local executable or valid case is available, state that explicitly in the PR
+rather than configuring a new build solely to produce the output.
 
 ## AI PR Review Integration
 


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have linked an issue or explained why this PR does not need one.
- [x] I have added adequate unit tests and/or case tests, or explained why not.
- [x] I have listed the exact verification commands run and their results.
- [x] I have described user-visible behavior changes, including INPUT parameter changes.
- [x] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [x] I have requested any needed governance exception below.

### Linked Issue

No issue. This is a governance-documentation correction found while following
`AGENTS.md` on an unrelated refactor; there is no code defect to track.

### Unit Tests and/or Case Tests for my changes

- Commands run:
  ```
  python tools/03_code_analysis/agent_governance_check.py --staged
  ```
- Result summary: `Agent governance check: no findings.`
- Checks not run, with reason: no build, unit tests, integration cases, or CLI
  checks. This PR touches only `AGENTS.md` and
  `docs/developers_guide/agent_governance.md`; no source file, `CMakeLists.txt`,
  or INPUT registration is modified, so nothing here can affect compilation or
  numerical results. Under the tiers this PR introduces, this is Tier 1.

### What's changed?

**1. Verification requirements are now tiered instead of flat.**

`AGENTS.md` previously said, without qualification:

> Report the exact verification performed. Do not claim completion without fresh
> test or check output.

and

> For multi-step refactors ... build and commit after each step rather than
> batching all changes before verification.

Read literally, a comment fix or a docs edit owed the same evidence as an
eigensolver change. The observed effect on AI agents is that they configure a
local build for changes that cannot possibly need one. That is unusually
expensive in this repository: ABACUS builds on Linux in practice, so a
contributor on Windows or in a bare container spends real time provisioning a
toolchain, and the reward is a compile of files the diff never touched.

The replacement is a new `## Verification Tiers` section keyed to what a change
can break rather than how large its diff is:

- **Tier 1, static checks only** - documentation, comments, governance files,
  whitespace/line-ending normalization. Governance check only; a local build is
  explicitly not expected.
- **Tier 2, must compile** - include and header-dependency edits, moving code
  between translation units, file splits, renames, mechanical call-site updates,
  signature changes, `new`/`delete` to `std::vector`, `CMakeLists.txt` linkage.
  Build the affected targets plus the touched modules' unit tests.
- **Tier 3, must reproduce behavior** - algorithms, operators, heterogeneous
  kernels, eigensolvers, mixing, occupations, symmetry, INPUT semantics or
  defaults. Tier 2 plus a relevant case from `tests/` plus the CLI checks, and
  say which reference values were compared.

Header-dependency trimming is placed in Tier 2 explicitly, because it is the one
case that looks like pure deletion but can still break an unrelated translation
unit that relied on an include transitively.

The per-step build rule is kept verbatim, only scoped to Tier 2 and Tier 3 where
it pays for itself.

**2. The escape hatch is stated once, precisely.**

The old text had the exemption scattered across three conditional phrases
("after a usable build exists", "when an executable is available", "If no local
executable or valid case is available") while the headline rule was
unconditional, so the exemption did not read as one. It is now a single
paragraph: name the tier, name the command that could not be run, and give the
reason. A disclosed gap is reviewable; an undisclosed gap is not, and neither is
provisioning a new toolchain or container to reach a tier the change never
required.

The intent is unchanged for real code changes. Tier 2 and Tier 3 ask for the
same build and test evidence the old text asked for. What changes is that Tier 1
work stops paying for it, and that an agent which genuinely cannot build has a
sanctioned, auditable way to say so instead of either guessing or burning an
hour on a toolchain.

**3. `./build/abacus` does not exist; fixed in both files.**

`AGENTS.md` and the governance doc both told contributors to run:

```bash
./build/abacus --version
./build/abacus -h <parameter>
./build/abacus --check-input
```

CMake names the executable `abacus_${_abacus_bin_level}_${_abacus_bin_device}`
or `abacus_${_abacus_bin_level}_${_abacus_bin_para}` (`ABACUS_BIN_NAME`,
`CMakeLists.txt:225-228`), and `install(PROGRAMS ${ABACUS_BIN_PATH} TYPE BIN)`
(`source/CMakeLists.txt:760`) preserves that name, so the installed binary is
not `abacus` either. Every one of those three commands fails with "No such file
or directory" as written. Both files now use the same discovery idiom as
`.github/workflows/test.yml:91`:

```bash
ABACUS_BIN=$(find build -name "abacus_*" -type f -executable | head -1)
```

This matters beyond tidiness: an agent following the documented command hits a
missing path and then starts probing the build directory or reconfiguring CMake
to find out why, which is the same wasted-effort loop item 1 is trying to close.

**4. Two consistency follow-ups.**

- `## PR Self-Check` now asks the PR body to name the tier reached.
- The `Member -> free function` refactoring pattern's "compile each step" is
  scoped to "when a usable build exists (Tier 2)".
- `docs/developers_guide/agent_governance.md` gets the matching pointer in its
  AI-workflow obligations, so the short and complete rule sources do not
  disagree.

### Governance Notes

- INPUT/docs changes: no INPUT parameter is touched, so `docs/parameters.yaml`
  and `docs/advanced/input_files/input-main.md` need no regeneration. The two
  files changed are agent-governance documentation.
- Core module impact: none. No file under `source/` is modified.
- Exceptions requested: none. Both files are ASCII with LF endings and the
  staged governance check is clean.
