### PR TITLE
Optimize DeltaSpin gradient decay and band updates

### DIFF
--- a/source/source_lcao/module_deltaspin/cal_mw_from_lambda.cpp
+++ b/source/source_lcao/module_deltaspin/cal_mw_from_lambda.cpp
@@ -128,16 +128,6 @@ void spinconstrain::SpinConstrain<std::complex<double>>::cal_mw_from_lambda(
         }
         // Diagonalization without updating charge density (last param = true means skip charge update)
         hsolver_t.solve(hamilt_t, psi_t[0], this->pelec, *this->dm_, *this->pelec->charge, this->state_.nspin_, true);
-        elecstate::calculate_weights(this->pelec->ekb,
-                                     this->pelec->wg,
-                                     this->pelec->klist,
-                                     this->pelec->eferm,
-                                     this->pelec->f_en,
-                                     this->pelec->nelec_spin,
-                                     PARAM.inp.nbands,
-                                     this->pelec->skip_weights);
-        elecstate::calEBand(this->pelec->ekb,this->pelec->wg,this->pelec->f_en);
-
         // Note: although update_lambda() modifies lambda in-place above,
         // solve() unconditionally recomputes DM and DMR (via cal_dm_psi +
         // cal_DMR) from the psi obtained by diagonalizing with the new

--- a/source/source_lcao/module_deltaspin/lambda_loop_helper.cpp
+++ b/source/source_lcao/module_deltaspin/lambda_loop_helper.cpp
@@ -219,10 +219,9 @@ double cal_alpha_opt(const SpinConstrain<TK>& sc,
  * @par Algorithm
  * 1. Compute spin_change = new_spin - spin (change in magnetic moments)
  * 2. Compute nu_change = delta_lambda - dnu_last_step (change in lambda)
- * 3. Compute full gradient matrix: dM[ia][ic]/dlambda[ja][jc] = spin_change[ia][ic] / nu_change[ja][jc]
- * 4. Extract diagonal: dM[ia][ic]/dlambda[ia][ic] (self-susceptibility)
- * 5. Find max diagonal gradient per atom type
- * 6. If max_gradient[itype] < decay_grad[itype], return true (early termination)
+ * 3. Compute the diagonal self-response dM[ia][ic]/dlambda[ia][ic]
+ * 4. Find the maximum diagonal response per atom type
+ * 5. If max_gradient[itype] < decay_grad[itype], return true (early termination)
  *
  * @par Physical meaning
  * The diagonal gradient dM/dlambda represents how sensitive the magnetic moment
@@ -235,10 +234,10 @@ double cal_alpha_opt(const SpinConstrain<TK>& sc,
  */
 template <typename TK>
 bool check_gradient_decay(const SpinConstrain<TK>& sc,
-                          std::vector<ModuleBase::Vector3<double>> new_spin,
-                          std::vector<ModuleBase::Vector3<double>> spin,
-                          std::vector<ModuleBase::Vector3<double>> delta_lambda,
-                          std::vector<ModuleBase::Vector3<double>> dnu_last_step,
+                          const std::vector<ModuleBase::Vector3<double>>& new_spin,
+                          const std::vector<ModuleBase::Vector3<double>>& spin,
+                          const std::vector<ModuleBase::Vector3<double>>& delta_lambda,
+                          const std::vector<ModuleBase::Vector3<double>>& dnu_last_step,
                           bool print,
                           std::ostream& ofs_running)
 {
@@ -251,12 +250,6 @@ bool check_gradient_decay(const SpinConstrain<TK>& sc,
     std::vector<ModuleBase::Vector3<double>> spin_change(nat, 0.0);
     std::vector<ModuleBase::Vector3<double>> nu_change(nat, 1.0);
 
-    // Full gradient matrix: dM[ia][ic]/dlambda[ja][jc]
-    std::vector<std::vector<std::vector<std::vector<double>>>> spin_nu_gradient(
-        nat,
-        std::vector<std::vector<std::vector<double>>>(
-            3,
-            std::vector<std::vector<double>>(nat, std::vector<double>(3, 0.0))));
     // Diagonal gradient: dM[ia][ic]/dlambda[ia][ic] (self-susceptibility)
     std::vector<ModuleBase::Vector3<double>> spin_nu_gradient_diag(nat, 0.0);
     std::vector<std::pair<int, int>> max_gradient_index(ntype, std::make_pair(0, 0));
@@ -270,43 +263,37 @@ bool check_gradient_decay(const SpinConstrain<TK>& sc,
     where_fill_scalar_2d(constrain, 0, zero, spin_change);
     where_fill_scalar_2d(constrain, 0, one, nu_change);
 
-    // Calculate full gradient matrix
-    for (int ia = 0; ia < nat; ia++)
-    {
-        for (int ic = 0; ic < 3; ic++)
-        {
-            for (int ja = 0; ja < nat; ja++)
-            {
-                for (int jc = 0; jc < 3; jc++)
-                {
-                    if (std::abs(nu_change[ja][jc]) < 1e-30) {
-                        printf("[GRAD-DECAY] WARNING: nu_change[%d][%d] too small! delta_lambda=(%.6e,%.6e,%.6e) dnu_last=(%.6e,%.6e,%.6e)\n",
-                               ja, jc, delta_lambda[ja].x, delta_lambda[ja].y, delta_lambda[ja].z,
-                               dnu_last_step[ja].x, dnu_last_step[ja].y, dnu_last_step[ja].z);
-                        fflush(stdout);
-                        nu_change[ja][jc] = 1e-30;
-                    }
-                    spin_nu_gradient[ia][ic][ja][jc] = spin_change[ia][ic] / nu_change[ja][jc];
-                }
-            }
-        }
-    }
-
     const auto& atom_counts = sc.get_atomCounts();
     const auto& decay_grad = sc.get_decay_grad();
     const int nspin = sc.get_nspin();
 
     // Extract diagonal gradient and find max per atom type
+    int iat_offset = 0;
     for (const auto& sc_elem: atom_counts)
     {
         int it = sc_elem.first;
         int nat_it = sc_elem.second;
         max_gradient[it] = 0.0;
-        for (int ia = 0; ia < nat_it; ia++)
+        for (int ia_local = 0; ia_local < nat_it; ia_local++)
         {
+            const int ia = iat_offset + ia_local;
             for (int ic = 0; ic < 3; ic++)
             {
-                spin_nu_gradient_diag[ia][ic] = spin_nu_gradient[ia][ic][ia][ic];
+                if (std::abs(nu_change[ia][ic]) < 1e-30)
+                {
+                    printf("[GRAD-DECAY] WARNING: nu_change[%d][%d] too small! delta_lambda=(%.6e,%.6e,%.6e) dnu_last=(%.6e,%.6e,%.6e)\n",
+                           ia,
+                           ic,
+                           delta_lambda[ia].x,
+                           delta_lambda[ia].y,
+                           delta_lambda[ia].z,
+                           dnu_last_step[ia].x,
+                           dnu_last_step[ia].y,
+                           dnu_last_step[ia].z);
+                    fflush(stdout);
+                    nu_change[ia][ic] = 1e-30;
+                }
+                spin_nu_gradient_diag[ia][ic] = spin_change[ia][ic] / nu_change[ia][ic];
                 if (std::abs(spin_nu_gradient_diag[ia][ic]) > std::abs(max_gradient[it]))
                 {
                     max_gradient[it] = spin_nu_gradient_diag[ia][ic];
@@ -315,6 +302,7 @@ bool check_gradient_decay(const SpinConstrain<TK>& sc,
                 }
             }
         }
+        iat_offset += nat_it;
     }
 
     if (print)
@@ -473,10 +461,10 @@ template double cal_alpha_opt<std::complex<double>>(const SpinConstrain<std::com
                                                     std::vector<ModuleBase::Vector3<double>>,
                                                     const double);
 template bool check_gradient_decay<std::complex<double>>(const SpinConstrain<std::complex<double>>&,
-                                                          std::vector<ModuleBase::Vector3<double>>,
-                                                          std::vector<ModuleBase::Vector3<double>>,
-                                                          std::vector<ModuleBase::Vector3<double>>,
-                                                          std::vector<ModuleBase::Vector3<double>>,
+                                                          const std::vector<ModuleBase::Vector3<double>>&,
+                                                          const std::vector<ModuleBase::Vector3<double>>&,
+                                                          const std::vector<ModuleBase::Vector3<double>>&,
+                                                          const std::vector<ModuleBase::Vector3<double>>&,
                                                           bool, std::ostream&);
 
 // print_Mi / print_Mag_Force are generic (no per-TK stub needed): the

--- a/source/source_lcao/module_deltaspin/lambda_loop_helper.h
+++ b/source/source_lcao/module_deltaspin/lambda_loop_helper.h
@@ -112,8 +112,8 @@ double cal_alpha_opt(const SpinConstrain<TK>& sc,
  * @par Algorithm
  * 1. Compute spin_change = new_spin - spin
  * 2. Compute nu_change     = delta_lambda - dnu_last_step
- * 3. Build full gradient matrix dM[ia][ic]/dlambda[ja][jc]
- * 4. Extract diagonal; pick max abs per atom type
+ * 3. Compute only the diagonal response dM[ia][ic]/dlambda[ia][ic]
+ * 4. Pick the maximum absolute diagonal response per atom type
  * 5. Return true if max(|diag|) < decay_grad[itype] for any type
  *
  * @param sc             SpinConstrain instance
@@ -127,10 +127,10 @@ double cal_alpha_opt(const SpinConstrain<TK>& sc,
  */
 template <typename TK>
 bool check_gradient_decay(const SpinConstrain<TK>& sc,
-                          std::vector<ModuleBase::Vector3<double>> new_spin,
-                          std::vector<ModuleBase::Vector3<double>> spin,
-                          std::vector<ModuleBase::Vector3<double>> delta_lambda,
-                          std::vector<ModuleBase::Vector3<double>> dnu_last_step,
+                          const std::vector<ModuleBase::Vector3<double>>& new_spin,
+                          const std::vector<ModuleBase::Vector3<double>>& spin,
+                          const std::vector<ModuleBase::Vector3<double>>& delta_lambda,
+                          const std::vector<ModuleBase::Vector3<double>>& dnu_last_step,
                           bool print,
                           std::ostream& ofs_running);
 

--- a/source/source_lcao/module_deltaspin/template_helpers.cpp
+++ b/source/source_lcao/module_deltaspin/template_helpers.cpp
@@ -94,10 +94,10 @@ void spinconstrain::print_header<double>(const spinconstrain::SpinConstrain<doub
 /// @brief check_gradient_decay stub (TK=double): always return false (no early termination)
 template <>
 bool spinconstrain::check_gradient_decay<double>(const spinconstrain::SpinConstrain<double>& sc,
-                                                 std::vector<ModuleBase::Vector3<double>> new_spin,
-                                                 std::vector<ModuleBase::Vector3<double>> old_spin,
-                                                 std::vector<ModuleBase::Vector3<double>> new_delta_lambda,
-                                                 std::vector<ModuleBase::Vector3<double>> old_delta_lambda,
+                                                 const std::vector<ModuleBase::Vector3<double>>& new_spin,
+                                                 const std::vector<ModuleBase::Vector3<double>>& old_spin,
+                                                 const std::vector<ModuleBase::Vector3<double>>& new_delta_lambda,
+                                                 const std::vector<ModuleBase::Vector3<double>>& old_delta_lambda,
                                                  bool print,
                                                  std::ostream& ofs_running)
 {

--- a/source/source_lcao/module_deltaspin/test/CMakeLists.txt
+++ b/source/source_lcao/module_deltaspin/test/CMakeLists.txt
@@ -47,4 +47,17 @@ AddTest(
   SOURCES deltaspin_core_test.cpp
 )
 
+AddTest(
+  TARGET test_lambda_loop_helper
+  LIBS base device parameter symmetry
+  SOURCES test_lambda_loop_helper.cpp
+    ../spin_constrain.cpp
+    ../deltaspin_state.cpp
+    ../lambda_loop_helper.cpp
+    ../basic_funcs.cpp
+    ../../../source_cell/klist.cpp ../../../source_cell/klist_io.cpp
+    ../../../source_cell/parallel_kpoints.cpp
+    ../../../source_cell/reciprocal_grid.cpp
+)
+
 endif()

--- a/source/source_lcao/module_deltaspin/test/test_lambda_loop_helper.cpp
+++ b/source/source_lcao/module_deltaspin/test/test_lambda_loop_helper.cpp
@@ -1,0 +1,28 @@
+#include "source_lcao/module_deltaspin/lambda_loop_helper.h"
+#include "source_lcao/module_deltaspin/spin_constrain.h"
+
+#include "gtest/gtest.h"
+
+namespace spinconstrain
+{
+
+TEST(LambdaLoopHelper, GradientDecayUsesAtomsOfEachType)
+{
+    SpinConstrain<std::complex<double>>& sc = SpinConstrain<std::complex<double>>::getScInstance();
+    const std::map<int, int> atom_counts = {{0, 1}, {1, 2}};
+    const std::vector<ModuleBase::Vector3<double>> spin(3, {0.0, 0.0, 0.0});
+    const std::vector<ModuleBase::Vector3<double>> new_spin
+        = {{0.0, 0.0, 10.0}, {0.0, 0.0, 0.1}, {0.0, 0.0, 0.2}};
+    const std::vector<ModuleBase::Vector3<double>> old_lambda(3, {0.0, 0.0, 0.0});
+    const std::vector<ModuleBase::Vector3<double>> new_lambda(3, {0.0, 0.0, 1.0});
+    const std::vector<ModuleBase::Vector3<int>> constrain(3, {0, 0, 1});
+    const std::vector<double> decay_grad = {0.0, 0.9};
+
+    sc.set_atomCounts(atom_counts);
+    sc.set_constrain(constrain.data(), 3);
+    sc.set_decay_grad(decay_grad.data(), 2);
+
+    EXPECT_TRUE(check_gradient_decay(sc, new_spin, spin, new_lambda, old_lambda, false, std::cout));
+}
+
+} // namespace spinconstrain


### PR DESCRIPTION
## Summary

- compute only the diagonal moment/lambda response used by the DeltaSpin gradient-decay criterion, reducing temporary storage from quadratic to linear in atom count
- fix the per-species atom offset so gradient decay checks the atoms belonging to each element
- pass response vectors by const reference
- remove duplicate occupation and band-energy updates after `HSolverLCAO::solve`, which already performs both operations

These changes are independent of material, cell size, magnetic configuration, and calculation parameters. No user-facing interface or input semantics change, so no documentation update is required.

## Tests

- full `abacus_basic_para` LCAO/MPI/OpenMP/ELPA/LibXC build
- `MODULE_LCAO_deltaspin_basic_func_test`
- `MODULE_LCAO_deltaspin_spin_constrain_test`
- `MODULE_LCAO_deltaspin_template_helpers`
- `deltaspin_pw_test`
- `deltaspin_core_test`
- `test_lambda_loop_helper` (new multi-species regression)
- `agent_governance_check.py --base upstream/develop --head HEAD` (only documentation-review warning; addressed above)