### PR TITLE
refactor: simplify MDCell initialization

### DIFF
--- a/source/source_cell/mdcell.cpp
+++ b/source/source_cell/mdcell.cpp
@@ -82,73 +82,40 @@ void MDCell::sync_backing_unitcell_owned_atoms_()
     }
 }
 
+void MDCell::initialize_from_unitcell(UnitCell& ucell,
+                                      double skin,
+                                      const ModuleBase::CommunicationDomain& comm_domain)
+{
+    backing_unitcell_ = &ucell;
+    nat_ = ucell.nat;
+    lat0_ = ucell.lat0;
+    omega_ = ucell.omega;
+    latvec_ = ucell.latvec;
+    gt_ = ucell.GT;
+    type_labels_.resize(static_cast<std::size_t>(ucell.ntype));
+    type_masses_.resize(static_cast<std::size_t>(ucell.ntype));
+    type_atom_counts_.resize(static_cast<std::size_t>(ucell.ntype));
+    for (int it = 0; it < ucell.ntype; ++it)
+    {
+        type_labels_[static_cast<std::size_t>(it)] = ucell.atoms[it].label;
+        type_masses_[static_cast<std::size_t>(it)] = ucell.atoms[it].mass;
+        type_atom_counts_[static_cast<std::size_t>(it)] = ucell.atoms[it].na;
+    }
+    cutoff_ = 0.0;
+    skin_ = skin;
+    neighbor_search_.reset();
+    neighbor_layout_valid_ = false;
+    owned_atoms_.clear();
+    ghost_atoms_.clear();
+
 #ifdef __MPI
-void MDCell::initialize_from_ucell_(UnitCell& ucell, MPI_Comm comm, double cutoff, double skin)
-{
-    backing_unitcell_ = &ucell;
-    nat_ = ucell.nat;
-    lat0_ = ucell.lat0;
-    omega_ = ucell.omega;
-    latvec_ = ucell.latvec;
-    gt_ = ucell.GT;
-    type_labels_.resize(static_cast<std::size_t>(ucell.ntype));
-    type_masses_.resize(static_cast<std::size_t>(ucell.ntype));
-    type_atom_counts_.resize(static_cast<std::size_t>(ucell.ntype));
-    for (int it = 0; it < ucell.ntype; ++it)
-    {
-        type_labels_[static_cast<std::size_t>(it)] = ucell.atoms[it].label;
-        type_masses_[static_cast<std::size_t>(it)] = ucell.atoms[it].mass;
-        type_atom_counts_[static_cast<std::size_t>(it)] = ucell.atoms[it].na;
-    }
-    comm_ = comm;
-    cutoff_ = cutoff;
-    skin_ = skin;
-
-    owned_atoms_.clear();
-    ghost_atoms_.clear();
+    comm_ = comm_domain.communicator();
     MPI_Comm_rank(comm_, &rank_);
     MPI_Comm_size(comm_, &size_);
-
-    decomp_.init(comm_, latvec_, lat0_, cutoff_, skin_);
+    decomp_.init(comm_, latvec_, lat0_, 0.0, 0.0);
     decomp_.split_owned_atoms_from_ucell(ucell, owned_atoms_);
-    clear_forces_(owned_atoms_);
-    exchange_ghost_atoms();
-}
-
-void MDCell::initialize_from_owned_atoms_(MPI_Comm comm, double cutoff, double skin)
-{
-    comm_ = comm;
-    cutoff_ = cutoff;
-    skin_ = skin;
-    MPI_Comm_rank(comm_, &rank_);
-    MPI_Comm_size(comm_, &size_);
-    decomp_.init(comm_, latvec_, lat0_, cutoff_, skin_);
-    clear_forces_(owned_atoms_);
-    exchange_ghost_atoms();
-}
 #else
-void MDCell::initialize_from_ucell_(UnitCell& ucell, double cutoff, double skin)
-{
-    backing_unitcell_ = &ucell;
-    nat_ = ucell.nat;
-    lat0_ = ucell.lat0;
-    omega_ = ucell.omega;
-    latvec_ = ucell.latvec;
-    gt_ = ucell.GT;
-    type_labels_.resize(static_cast<std::size_t>(ucell.ntype));
-    type_masses_.resize(static_cast<std::size_t>(ucell.ntype));
-    type_atom_counts_.resize(static_cast<std::size_t>(ucell.ntype));
-    for (int it = 0; it < ucell.ntype; ++it)
-    {
-        type_labels_[static_cast<std::size_t>(it)] = ucell.atoms[it].label;
-        type_masses_[static_cast<std::size_t>(it)] = ucell.atoms[it].mass;
-        type_atom_counts_[static_cast<std::size_t>(it)] = ucell.atoms[it].na;
-    }
-    cutoff_ = cutoff;
-    skin_ = skin;
-    owned_atoms_.clear();
-    ghost_atoms_.clear();
-
+    static_cast<void>(comm_domain);
     for (int it = 0; it < ucell.ntype; ++it)
     {
         for (int ia = 0; ia < ucell.atoms[it].na; ++ia)
@@ -164,30 +131,9 @@ void MDCell::initialize_from_ucell_(UnitCell& ucell, double cutoff, double skin)
                                              0));
         }
     }
-    exchange_ghost_atoms();
-}
+#endif
 
-void MDCell::initialize_from_owned_atoms_(double cutoff, double skin)
-{
-    cutoff_ = cutoff;
-    skin_ = skin;
     clear_forces_(owned_atoms_);
-    exchange_ghost_atoms();
-}
-#endif
-
-
-void MDCell::initialize_from_unitcell(UnitCell& ucell,
-                                      double cutoff,
-                                      double skin,
-                                      const ModuleBase::CommunicationDomain& comm_domain)
-{
-#ifdef __MPI
-    initialize_from_ucell_(ucell, comm_domain.communicator(), cutoff, skin);
-#else
-    static_cast<void>(comm_domain);
-    initialize_from_ucell_(ucell, cutoff, skin);
-#endif
 }
 
 void MDCell::initialize_from_owned_atoms(const ModuleBase::Matrix3& latvec,
@@ -199,7 +145,6 @@ void MDCell::initialize_from_owned_atoms(const ModuleBase::Matrix3& latvec,
                                          const std::vector<std::string>& type_labels,
                                          const std::vector<double>& type_masses,
                                          const std::vector<std::int64_t>& type_atom_counts,
-                                         double cutoff,
                                          double skin,
                                          const ModuleBase::CommunicationDomain& comm_domain)
 {
@@ -212,12 +157,42 @@ void MDCell::initialize_from_owned_atoms(const ModuleBase::Matrix3& latvec,
     type_labels_ = type_labels;
     type_masses_ = type_masses;
     type_atom_counts_ = type_atom_counts;
+    backing_unitcell_ = nullptr;
+    cutoff_ = 0.0;
+    skin_ = skin;
+    neighbor_search_.reset();
+    neighbor_layout_valid_ = false;
+    ghost_atoms_.clear();
 #ifdef __MPI
-    initialize_from_owned_atoms_(comm_domain.communicator(), cutoff, skin);
+    comm_ = comm_domain.communicator();
+    MPI_Comm_rank(comm_, &rank_);
+    MPI_Comm_size(comm_, &size_);
 #else
     static_cast<void>(comm_domain);
-    initialize_from_owned_atoms_(cutoff, skin);
 #endif
+    clear_forces_(owned_atoms_);
+}
+
+void MDCell::initialize_neighbors(double cutoff)
+{
+    if (cutoff <= 0.0)
+    {
+        throw std::runtime_error("MDCell neighbor cutoff must be positive.");
+    }
+
+    cutoff_ = cutoff;
+    neighbor_search_.reset();
+    neighbor_layout_valid_ = false;
+
+#ifdef __MPI
+    if (comm_ == MPI_COMM_NULL)
+    {
+        throw std::runtime_error("MDCell communication domain is not initialized.");
+    }
+    decomp_.init(comm_, latvec_, lat0_, cutoff_, skin_);
+#endif
+
+    migrate_owned_atoms();
 }
 
 #ifdef __MPI
@@ -341,6 +316,11 @@ void MDCell::migrate_owned_atoms()
 
 void MDCell::prepare_neighbors()
 {
+    if (cutoff_ <= 0.0)
+    {
+        throw std::runtime_error("MDCell neighbors must be initialized before use.");
+    }
+
     bool rebuild = !neighbor_layout_valid_ || neighbor_reference_frac_.size() != owned_atoms_.size();
     double local_max_displacement = 0.0;
     if (!rebuild)

--- a/source/source_cell/mdcell.h
+++ b/source/source_cell/mdcell.h
@@ -32,7 +32,6 @@ public:
     MDCell& operator=(MDCell&&);
 
     void initialize_from_unitcell(UnitCell& ucell,
-                                  double cutoff,
                                   double skin,
                                   const ModuleBase::CommunicationDomain& comm_domain);
     void initialize_from_owned_atoms(const ModuleBase::Matrix3& latvec,
@@ -44,9 +43,10 @@ public:
                                      const std::vector<std::string>& type_labels,
                                      const std::vector<double>& type_masses,
                                      const std::vector<std::int64_t>& type_atom_counts,
-                                     double cutoff,
                                      double skin,
                                      const ModuleBase::CommunicationDomain& comm_domain);
+
+    void initialize_neighbors(double cutoff);
 
 #ifdef __MPI
     int mpi_rank() const;
@@ -74,7 +74,7 @@ public:
     std::vector<LocalAtom>& mutable_owned_atoms();
     std::vector<LocalAtom>& mutable_ghost_atoms();
 
-    int nlocal() const { return static_cast<int>(owned_atoms_.size()); }
+    int nowned_atoms() const { return static_cast<int>(owned_atoms_.size()); }
     int nghost() const { return static_cast<int>(ghost_atoms_.size()); }
     double cutoff() const;
     bool has_backing_unitcell() const;
@@ -89,14 +89,6 @@ private:
     double get_omega() const override;
     const ModuleBase::Matrix3& get_latvec() const override;
     const ModuleBase::Matrix3& get_GT() const override;
-
-#ifdef __MPI
-    void initialize_from_ucell_(UnitCell& ucell, MPI_Comm comm, double cutoff, double skin);
-    void initialize_from_owned_atoms_(MPI_Comm comm, double cutoff, double skin);
-#else
-    void initialize_from_ucell_(UnitCell& ucell, double cutoff, double skin);
-    void initialize_from_owned_atoms_(double cutoff, double skin);
-#endif
 
     void sync_backing_unitcell_geometry_();
     void sync_backing_unitcell_owned_atoms_();

--- a/source/source_cell/mdcell_reader.cpp
+++ b/source/source_cell/mdcell_reader.cpp
@@ -187,15 +187,13 @@ std::vector<LocalAtom> read_owned_atoms(std::ifstream& ifs,
                                          const ModuleBase::Matrix3& primitive_latvec,
                                          const ModuleBase::Matrix3& primitive_gt,
                                          const std::vector<int>& cell_replica,
-                                         double cutoff,
-                                         double skin,
                                          std::int64_t& nat,
                                          const ModuleBase::CommunicationDomain& comm_domain)
 {
     int rank = 0;
 #ifdef __MPI
     DomainDecomposition decomposition;
-    decomposition.init(comm_domain.communicator(), metadata.latvec, metadata.lat0, cutoff, skin);
+    decomposition.init(comm_domain.communicator(), metadata.latvec, metadata.lat0, 0.0, 0.0);
     rank = comm_domain.rank();
 #endif
 
@@ -324,16 +322,10 @@ std::vector<LocalAtom> read_owned_atoms(std::ifstream& ifs,
 } // namespace
 
 MDCell MDCellReader::read_stru(const std::string& stru_file,
-                                          const std::vector<int>& cell_replica,
-                                          double cutoff,
-                                          double skin,
-                                          const ModuleBase::CommunicationDomain& comm_domain)
+                               const std::vector<int>& cell_replica,
+                               double skin,
+                               const ModuleBase::CommunicationDomain& comm_domain)
 {
-    if (cutoff <= 0.0)
-    {
-        throw std::runtime_error("MDCell requires a positive cutoff.");
-    }
-
     std::ifstream ifs(stru_file.c_str(), std::ios::in);
     if (!ifs)
     {
@@ -354,7 +346,7 @@ MDCell MDCellReader::read_stru(const std::string& stru_file,
     metadata.omega = std::abs(metadata.latvec.Det()) * metadata.lat0 * metadata.lat0 * metadata.lat0;
     std::int64_t nat = 0;
     const std::vector<LocalAtom> owned_atoms = read_owned_atoms(ifs, metadata, primitive_latvec, primitive_gt,
-                                                                  cell_replica, cutoff, skin, nat, comm_domain);
+                                                                  cell_replica, nat, comm_domain);
     MDCell mdcell;
     mdcell.initialize_from_owned_atoms(metadata.latvec,
                                        metadata.gt,
@@ -365,7 +357,6 @@ MDCell MDCellReader::read_stru(const std::string& stru_file,
                                        metadata.labels,
                                        metadata.masses,
                                        metadata.type_atom_counts,
-                                       cutoff,
                                        skin,
                                        comm_domain);
     mdcell.mutable_stru_meta() = metadata.stru_meta;

--- a/source/source_cell/mdcell_reader.h
+++ b/source/source_cell/mdcell_reader.h
@@ -15,7 +15,6 @@ class MDCellReader
 public:
     static MDCell read_stru(const std::string& stru_file,
                             const std::vector<int>& cell_replica,
-                            double cutoff,
                             double skin,
                             const ModuleBase::CommunicationDomain& comm_domain);
 };

--- a/source/source_cell/module_neighlist/bin_manager.cpp
+++ b/source/source_cell/module_neighlist/bin_manager.cpp
@@ -182,7 +182,7 @@ void BinManager::build_atom_neighbors(
     const std::vector<NeighborAtom>& binned_atoms
 )
 {
-    assert(atoms.size() == static_cast<size_t>(neighbor_list.get_nlocal()));
+    assert(atoms.size() == static_cast<size_t>(neighbor_list.get_ncentral_atoms()));
 
     double sradius2 = sradius_ * sradius_;
 
@@ -190,8 +190,8 @@ void BinManager::build_atom_neighbors(
 
     std::vector<int> neigh_tmp;
 
-    const int nlocal = neighbor_list.get_nlocal();
-    for (int i = 0; i < nlocal; i++)
+    const int ncentral_atoms = neighbor_list.get_ncentral_atoms();
+    for (int i = 0; i < ncentral_atoms; i++)
     {
         neigh_tmp.clear();
         const NeighborAtom& atom = atoms[i];

--- a/source/source_cell/module_neighlist/neighbor_list.h
+++ b/source/source_cell/module_neighlist/neighbor_list.h
@@ -12,12 +12,12 @@ public:
     NeighborList() = default;
     ~NeighborList() = default;
 
-    void initialize(std::size_t nlocal, std::size_t pgsize)
+    void initialize(std::size_t ncentral_atoms, std::size_t pgsize)
     {
-        nlocal_ = ModuleNeighList::checked_int_size(nlocal, "NeighborList local atom count");
+        ncentral_atoms_ = ModuleNeighList::checked_int_size(ncentral_atoms, "NeighborList central atom count");
         allocator_.initialize(ModuleNeighList::checked_int_size(pgsize, "NeighborList page size"));
-        numneigh_.assign(nlocal, 0);
-        firstneigh_.assign(nlocal, nullptr);
+        numneigh_.assign(ncentral_atoms, 0);
+        firstneigh_.assign(ncentral_atoms, nullptr);
     }
 
     void reset()
@@ -25,7 +25,7 @@ public:
         allocator_.reset();
     }
 
-    int get_nlocal() const { return nlocal_; }
+    int get_ncentral_atoms() const { return ncentral_atoms_; }
     int get_numneigh(int i) const { return numneigh_[i]; }
     int* get_firstneigh(int i) { return firstneigh_[i]; }
     const int* get_firstneigh(int i) const { return firstneigh_[i]; }
@@ -43,7 +43,7 @@ public:
     }
 
 private:
-    int nlocal_ = 0;
+    int ncentral_atoms_ = 0;
     std::vector<int> numneigh_;
     std::vector<int*> firstneigh_;
     PageAllocator allocator_;

--- a/source/source_cell/module_neighlist/neighbor_search.cpp
+++ b/source/source_cell/module_neighlist/neighbor_search.cpp
@@ -202,7 +202,7 @@ void NeighborSearch::filter_candidate_neighbors_(double cutoff, double lat0)
     const double cutoff2 = cutoff * cutoff;
     neighbor_list_.reset();
     std::vector<int> active;
-    for (int i = 0; i < candidate_neighbor_list_.get_nlocal(); ++i)
+    for (int i = 0; i < candidate_neighbor_list_.get_ncentral_atoms(); ++i)
     {
         active.clear();
         const NeighborAtom& center = all_atoms_[static_cast<std::size_t>(i)];

--- a/source/source_cell/module_neighlist/test/bin_manager_test.cpp
+++ b/source/source_cell/module_neighlist/test/bin_manager_test.cpp
@@ -82,7 +82,7 @@ TEST(BinManagerUnit, EmptyAtomsBuildNeighbors)
     nl.initialize(0, 16);
 
     bm.build_atom_neighbors(nl, atoms, atoms);
-    EXPECT_EQ(nl.get_nlocal(), 0);
+    EXPECT_EQ(nl.get_ncentral_atoms(), 0);
 }
 
 TEST(BinManagerUnit, BoundaryAndExactRadius)
@@ -166,7 +166,7 @@ TEST(BinManagerUnit, GhostAtomsAreCounted)
 
     bm.build_atom_neighbors(nl, inside, all_atoms);
 
-    EXPECT_EQ(nl.get_nlocal(), 1);
+    EXPECT_EQ(nl.get_ncentral_atoms(), 1);
     EXPECT_EQ(nl.get_numneigh(0), 1);
     bool found = false;
     if (nl.get_numneigh(0) > 0 && nl.get_firstneigh(0) != nullptr) {

--- a/source/source_cell/module_neighlist/test/mdcell_migrate_mpi_test.cpp
+++ b/source/source_cell/module_neighlist/test/mdcell_migrate_mpi_test.cpp
@@ -66,38 +66,38 @@ TEST(MdCellMigrateMpiTest, AtomCrossingDomainMigratesToNewOwner)
                   std::vector<std::string>(1, "X"),
                   std::vector<double>(1, 1.0),
                   std::vector<std::int64_t>(1, 2),
-                  0.1,
                   0.0,
                   ModuleBase::world_comm_domain());
+    mdcell.initialize_neighbors(0.1);
 
     ASSERT_EQ(mdcell.mpi_size(), size);
     if (size == 2)
     {
-        ASSERT_EQ(mdcell.nlocal(), 1);
+        ASSERT_EQ(mdcell.nowned_atoms(), 1);
         mdcell.mutable_owned_atoms()[0].vel.x = static_cast<double>(rank + 1);
         mdcell.mutable_owned_atoms()[0].force.y = static_cast<double>(rank + 3);
         mdcell.migrate_owned_atoms();
-        ASSERT_EQ(mdcell.nlocal(), 1);
+        ASSERT_EQ(mdcell.nowned_atoms(), 1);
         EXPECT_EQ(mdcell.owned_atoms()[0].owner_rank, rank);
         EXPECT_EQ(mdcell.owned_atoms()[0].vel.x, static_cast<double>(rank + 1));
         EXPECT_EQ(mdcell.owned_atoms()[0].force.y, static_cast<double>(rank + 3));
 
-        if (rank == 0 && mdcell.nlocal() == 1)
+        if (rank == 0 && mdcell.nowned_atoms() == 1)
         {
             mdcell.mutable_owned_atoms()[0].cart.x = 0.8;
         }
-        if (rank == 1 && mdcell.nlocal() == 1)
+        if (rank == 1 && mdcell.nowned_atoms() == 1)
         {
             mdcell.mutable_owned_atoms()[0].cart.x = 0.3;
         }
         mdcell.migrate_owned_atoms();
 
-        long long local_count = mdcell.nlocal();
+        long long local_count = mdcell.nowned_atoms();
         long long global_count = 0;
         MPI_Allreduce(&local_count, &global_count, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
         EXPECT_EQ(global_count, 2);
 
-        for (int i = 0; i < mdcell.nlocal(); ++i)
+        for (int i = 0; i < mdcell.nowned_atoms(); ++i)
         {
             EXPECT_EQ(mdcell.owned_atoms()[static_cast<std::size_t>(i)].owner_rank, rank);
         }
@@ -134,9 +134,9 @@ TEST(MdCellMigrateMpiTest, GhostForcesReturnToOwners)
                   std::vector<std::string>(1, "X"),
                   std::vector<double>(1, 1.0),
                   std::vector<std::int64_t>(1, 2),
-                  0.6,
                   0.0,
                   ModuleBase::world_comm_domain());
+    mdcell.initialize_neighbors(0.6);
 
     long long local_copies[2] = {0, 0};
     for (std::size_t iat = 0; iat < mdcell.ghost_atoms().size(); ++iat)
@@ -154,7 +154,7 @@ TEST(MdCellMigrateMpiTest, GhostForcesReturnToOwners)
     }
     mdcell.accumulate_ghost_forces();
 
-    ASSERT_EQ(mdcell.nlocal(), 1);
+    ASSERT_EQ(mdcell.nowned_atoms(), 1);
     const double expected = static_cast<double>(global_copies[rank] * (rank + 1));
     EXPECT_DOUBLE_EQ(mdcell.owned_atoms()[0].force.x, expected);
     EXPECT_DOUBLE_EQ(mdcell.owned_atoms()[0].force.y, 2.0 * expected);
@@ -190,16 +190,16 @@ TEST(MdCellMigrateMpiTest, SkinUpdatesFixedGhostLayoutBeforeRebuild)
                   std::vector<std::string>(1, "X"),
                   std::vector<double>(1, 1.0),
                   std::vector<std::int64_t>(1, 2),
-                  0.1,
                   0.2,
                   ModuleBase::world_comm_domain());
+    mdcell.initialize_neighbors(0.1);
 
     mdcell.prepare_neighbors();
     mdcell.mutable_owned_atoms()[0].frac.x += rank == 0 ? 0.05 : -0.05;
     mdcell.mutable_owned_atoms()[0].cart = mdcell.mutable_owned_atoms()[0].frac * latvec;
     mdcell.prepare_neighbors();
 
-    ASSERT_EQ(mdcell.nlocal(), 1);
+    ASSERT_EQ(mdcell.nowned_atoms(), 1);
     for (std::size_t i = 0; i < mdcell.ghost_atoms().size(); ++i)
     {
         const LocalAtom& ghost = mdcell.ghost_atoms()[i];

--- a/source/source_cell/module_neighlist/test/mdcell_reader_test.cpp
+++ b/source/source_cell/module_neighlist/test/mdcell_reader_test.cpp
@@ -81,7 +81,6 @@ TEST(MDCellReaderTest, ReadOwnedAtomsFromSTRUWithoutUnitCell)
 
     MDCell mdcell = MDCellReader::read_stru(stru_file,
                                              std::vector<int>{1, 1, 1},
-                                             1.0 * ModuleBase::ANGSTROM_AU,
                                              0.0,
                                              comm_domain);
 
@@ -223,7 +222,6 @@ TEST(MDCellReaderTest, RestartStruPreservesAtomRecordsAcrossRanks)
                   std::vector<double>{1.0, 1.0},
                   std::vector<std::int64_t>{2, 2},
                   0.0,
-                  0.0,
                   ModuleBase::world_comm_domain());
     StruMeta metadata;
     metadata.species.resize(2);
@@ -232,7 +230,6 @@ TEST(MDCellReaderTest, RestartStruPreservesAtomRecordsAcrossRanks)
 
     MDCell round_trip = MDCellReader::read_stru(output_file,
                                                  std::vector<int>{1, 1, 1},
-                                                 0.1,
                                                  0.0,
                                                  ModuleBase::world_comm_domain());
     double local_positions[4] = {0.0, 0.0, 0.0, 0.0};

--- a/source/source_cell/module_neighlist/test/neighbor_list_test.cpp
+++ b/source/source_cell/module_neighlist/test/neighbor_list_test.cpp
@@ -55,24 +55,24 @@ TEST(NeighborList_InitializeAndReset, Behavior)
 {
     NeighborList nl;
     nl.initialize(0, 16);
-    EXPECT_EQ(nl.get_nlocal(), 0);
+    EXPECT_EQ(nl.get_ncentral_atoms(), 0);
 
     nl.initialize(5, 8);
-    EXPECT_EQ(nl.get_nlocal(), 5);
+    EXPECT_EQ(nl.get_ncentral_atoms(), 5);
     for (int i = 0; i < 5; ++i) {
         EXPECT_EQ(nl.get_numneigh(i), 0);
         EXPECT_EQ(nl.get_firstneigh(i), nullptr);
     }
 
     nl.reset();
-    EXPECT_EQ(nl.get_nlocal(), 5);
+    EXPECT_EQ(nl.get_ncentral_atoms(), 5);
 }
 
 TEST(NeighborList_Getters, Accessors)
 {
     NeighborList nl;
     nl.initialize(3, 16);
-    EXPECT_EQ(nl.get_nlocal(), 3);
+    EXPECT_EQ(nl.get_ncentral_atoms(), 3);
     EXPECT_EQ(nl.get_numneigh(0), 0);
     EXPECT_EQ(nl.get_firstneigh(0), nullptr);
 }

--- a/source/source_cell/module_neighlist/test/neighbor_search_test.cpp
+++ b/source/source_cell/module_neighlist/test/neighbor_search_test.cpp
@@ -71,7 +71,7 @@ TEST(NeighborSearchTest, TwoAtomsNeighbor)
     ns.build_neighbors();
 
     const NeighborList& list = ns.get_neighbor_list();
-    ASSERT_EQ(list.get_nlocal(), 2);
+    ASSERT_EQ(list.get_ncentral_atoms(), 2);
     EXPECT_EQ(list.get_numneigh(0), 8);
     EXPECT_EQ(list.get_numneigh(1), 8);
 }
@@ -92,7 +92,7 @@ TEST(NeighborSearchTest, NoNeighbor)
     ns.build_neighbors();
 
     const NeighborList& list = ns.get_neighbor_list();
-    ASSERT_EQ(list.get_nlocal(), 2);
+    ASSERT_EQ(list.get_ncentral_atoms(), 2);
     EXPECT_EQ(list.get_numneigh(0), 0);
     EXPECT_EQ(list.get_numneigh(1), 0);
 }
@@ -112,7 +112,7 @@ TEST(NeighborSearchTest, SerialInitOwnsCentralAtomsAndBuildsImages)
     ns.init(ucell, 1.0);
 
     EXPECT_EQ(ns.get_inside_atoms().size(), 2U);
-    EXPECT_EQ(ns.get_neighbor_list().get_nlocal(), 2);
+    EXPECT_EQ(ns.get_neighbor_list().get_ncentral_atoms(), 2);
     EXPECT_EQ(ns.get_all_atoms().size(), 54U);
 
     const std::vector<NeighborAtom>& all_atoms = ns.get_all_atoms();

--- a/source/source_esolver/esolver.h
+++ b/source/source_esolver/esolver.h
@@ -46,17 +46,6 @@ class ESolver
     //! calcualte stress of given cell
     virtual void cal_stress(BaseCell& cell, ModuleBase::matrix& stress) = 0;
 
-    virtual bool supports_mdcell() const
-    {
-        return false;
-    }
-
-    virtual double mdcell_cutoff(const Input_para& inp) const
-    {
-        static_cast<void>(inp);
-        return 0.0;
-    }
-
     bool conv_esolver = true; // whether esolver is converged
 
     std::string classname;

--- a/source/source_esolver/esolver_dp.cpp
+++ b/source/source_esolver/esolver_dp.cpp
@@ -47,7 +47,10 @@ void ESolver_DP::before_all_runners(BaseCell& basecell, const Input_para& inp)
     {
         MDCell& mdcell = static_cast<MDCell&>(basecell);
 #ifdef __DPMD
+        mdcell.initialize_neighbors(dp.cutoff() * ModuleBase::ANGSTROM_AU);
         initialize_type_map_(mdcell.type_labels());
+#else
+        ModuleBase::WARNING_QUIT("ESolver_DP", "Please recompile with -D__DPMD");
 #endif
         return;
     }
@@ -80,9 +83,9 @@ void ESolver_DP::runner(BaseCell& basecell, const int istep)
         {
             mdcell.prepare_neighbors();
         }
-        const int nlocal = mdcell.nlocal();
+        const int nowned_atoms = mdcell.nowned_atoms();
         const int nghost = mdcell.nghost();
-        const int natom = nlocal + nghost;
+        const int natom = nowned_atoms + nghost;
         if (natom == 0)
         {
             ModuleBase::WARNING_QUIT("ESolver_DP", "MDCell contains no atoms.");
@@ -105,8 +108,8 @@ void ESolver_DP::runner(BaseCell& basecell, const int istep)
         std::vector<int> local_atype(static_cast<std::size_t>(natom), 0);
         for (int iat = 0; iat < natom; ++iat)
         {
-            const LocalAtom& atom = iat < nlocal ? owned_atoms[static_cast<std::size_t>(iat)]
-                                                  : ghost_atoms[static_cast<std::size_t>(iat - nlocal)];
+            const LocalAtom& atom = iat < nowned_atoms ? owned_atoms[static_cast<std::size_t>(iat)]
+                                                  : ghost_atoms[static_cast<std::size_t>(iat - nowned_atoms)];
             coord[3 * iat] = atom.cart.x * mdcell.lat0() * ModuleBase::BOHR_TO_A;
             coord[3 * iat + 1] = atom.cart.y * mdcell.lat0() * ModuleBase::BOHR_TO_A;
             coord[3 * iat + 2] = atom.cart.z * mdcell.lat0() * ModuleBase::BOHR_TO_A;
@@ -125,25 +128,25 @@ void ESolver_DP::runner(BaseCell& basecell, const int istep)
         }
 
         const NeighborList& neighbor_list = mdcell.neighbor_search().get_neighbor_list();
-        std::vector<int> ilist(static_cast<std::size_t>(nlocal), 0);
-        std::vector<int> numneigh(static_cast<std::size_t>(nlocal), 0);
-        std::vector<int*> firstneigh(static_cast<std::size_t>(nlocal), NULL);
-        for (int iat = 0; iat < nlocal; ++iat)
+        std::vector<int> ilist(static_cast<std::size_t>(nowned_atoms), 0);
+        std::vector<int> numneigh(static_cast<std::size_t>(nowned_atoms), 0);
+        std::vector<int*> firstneigh(static_cast<std::size_t>(nowned_atoms), NULL);
+        for (int iat = 0; iat < nowned_atoms; ++iat)
         {
             ilist[static_cast<std::size_t>(iat)] = iat;
             numneigh[static_cast<std::size_t>(iat)] = neighbor_list.get_numneigh(iat);
             firstneigh[static_cast<std::size_t>(iat)] = const_cast<int*>(neighbor_list.get_firstneigh(iat));
         }
 #ifdef __DPMDC
-        deepmd::hpp::InputNlist nlist(nlocal,
-                                      nlocal > 0 ? &ilist[0] : NULL,
-                                      nlocal > 0 ? &numneigh[0] : NULL,
-                                      nlocal > 0 ? &firstneigh[0] : NULL);
+        deepmd::hpp::InputNlist nlist(nowned_atoms,
+                                      nowned_atoms > 0 ? &ilist[0] : NULL,
+                                      nowned_atoms > 0 ? &numneigh[0] : NULL,
+                                      nowned_atoms > 0 ? &firstneigh[0] : NULL);
 #else
-        deepmd::InputNlist nlist(nlocal,
-                                 nlocal > 0 ? &ilist[0] : NULL,
-                                 nlocal > 0 ? &numneigh[0] : NULL,
-                                 nlocal > 0 ? &firstneigh[0] : NULL);
+        deepmd::InputNlist nlist(nowned_atoms,
+                                 nowned_atoms > 0 ? &ilist[0] : NULL,
+                                 nowned_atoms > 0 ? &numneigh[0] : NULL,
+                                 nowned_atoms > 0 ? &firstneigh[0] : NULL);
 #endif
         double local_energy = 0.0;
         std::vector<double> force, virial;
@@ -157,15 +160,15 @@ void ESolver_DP::runner(BaseCell& basecell, const int istep)
 
         std::vector<LocalAtom>& mutable_owned_atoms = mdcell.mutable_owned_atoms();
         std::vector<LocalAtom>& mutable_ghost_atoms = mdcell.mutable_ghost_atoms();
-        for (int iat = 0; iat < nlocal; ++iat)
+        for (int iat = 0; iat < nowned_atoms; ++iat)
         {
             mutable_owned_atoms[static_cast<std::size_t>(iat)].force.set(force[3 * iat], force[3 * iat + 1], force[3 * iat + 2]);
         }
         for (int iat = 0; iat < nghost; ++iat)
         {
-            mutable_ghost_atoms[static_cast<std::size_t>(iat)].force.set(force[3 * (nlocal + iat)],
-                                                                           force[3 * (nlocal + iat) + 1],
-                                                                           force[3 * (nlocal + iat) + 2]);
+            mutable_ghost_atoms[static_cast<std::size_t>(iat)].force.set(force[3 * (nowned_atoms + iat)],
+                                                                           force[3 * (nowned_atoms + iat) + 1],
+                                                                           force[3 * (nowned_atoms + iat) + 2]);
         }
         mdcell.accumulate_ghost_forces();
 
@@ -184,7 +187,7 @@ void ESolver_DP::runner(BaseCell& basecell, const int istep)
         const double fact_f = rescaling / (ModuleBase::Ry_to_eV * ModuleBase::ANGSTROM_AU);
         const double fact_v = rescaling / (mdcell.omega() * ModuleBase::Ry_to_eV);
         dp_potential = local_energy * fact_e;
-        for (int iat = 0; iat < nlocal; ++iat)
+        for (int iat = 0; iat < nowned_atoms; ++iat)
         {
             LocalAtom& atom = mutable_owned_atoms[static_cast<std::size_t>(iat)];
             atom.force *= fact_f;
@@ -266,29 +269,13 @@ double ESolver_DP::cal_energy()
     return dp_potential;
 }
 
-bool ESolver_DP::supports_mdcell() const
-{
-    return true;
-}
-
-double ESolver_DP::mdcell_cutoff(const Input_para& inp) const
-{
-    static_cast<void>(inp);
-#ifdef __DPMD
-    return dp.cutoff() * ModuleBase::ANGSTROM_AU;
-#else
-    ModuleBase::WARNING_QUIT("ESolver_DP::mdcell_cutoff", "Please recompile with -D__DPMD");
-    return 0.0;
-#endif
-}
-
 void ESolver_DP::cal_force(BaseCell& basecell, ModuleBase::matrix& force)
 {
     if (basecell.kind() == BaseCell::Kind::mdcell)
     {
         const MDCell& mdcell = static_cast<const MDCell&>(basecell);
-        force.create(mdcell.nlocal(), 3);
-        for (int iat = 0; iat < mdcell.nlocal(); ++iat)
+        force.create(mdcell.nowned_atoms(), 3);
+        for (int iat = 0; iat < mdcell.nowned_atoms(); ++iat)
         {
             const LocalAtom& atom = mdcell.owned_atoms()[static_cast<std::size_t>(iat)];
             force(iat, 0) = atom.force.x;

--- a/source/source_esolver/esolver_dp.h
+++ b/source/source_esolver/esolver_dp.h
@@ -68,9 +68,6 @@ class ESolver_DP : public ESolver
      */
     void cal_stress(BaseCell& basecell, ModuleBase::matrix& stress) override;
 
-    bool supports_mdcell() const override;
-    double mdcell_cutoff(const Input_para& inp) const override;
-
     /**
      * @brief Prints the final total energy of the DP model to the output file
      *

--- a/source/source_esolver/esolver_lj.cpp
+++ b/source/source_esolver/esolver_lj.cpp
@@ -18,16 +18,6 @@
 
 namespace ModuleESolver
 {
-double ESolver_LJ::mdcell_cutoff(const Input_para& inp) const
-{
-    double cutoff = 0.0;
-    for (std::size_t i = 0; i < inp.mdp.lj_rcut.size(); ++i)
-    {
-        cutoff = std::max(cutoff, inp.mdp.lj_rcut[i] * ModuleBase::ANGSTROM_AU);
-    }
-    return cutoff;
-}
-
 void ESolver_LJ::before_all_runners(BaseCell& cell, const Input_para& inp)
 {
     this->inp_ = &inp;
@@ -37,6 +27,12 @@ void ESolver_LJ::before_all_runners(BaseCell& cell, const Input_para& inp)
     if (cell.kind() == BaseCell::Kind::mdcell)
     {
         MDCell& mdcell = static_cast<MDCell&>(cell);
+        double cutoff = 0.0;
+        for (std::size_t i = 0; i < inp.mdp.lj_rcut.size(); ++i)
+        {
+            cutoff = std::max(cutoff, inp.mdp.lj_rcut[i] * ModuleBase::ANGSTROM_AU);
+        }
+        mdcell.initialize_neighbors(cutoff);
         rcut_search_radius(static_cast<int>(mdcell.type_labels().size()), inp.mdp.lj_rcut);
         set_c6_c12(static_cast<int>(mdcell.type_labels().size()), inp.mdp.lj_rule, inp.mdp.lj_epsilon, inp.mdp.lj_sigma);
         cal_en_shift(static_cast<int>(mdcell.type_labels().size()), inp.mdp.lj_eshift);
@@ -79,7 +75,7 @@ void ESolver_LJ::runner(BaseCell& cell, const int istep)
             atom_offsets[it + 1] = atom_offsets[it] + ucell.atoms[it].na;
         }
 
-        for (int local_i = 0; local_i < neighbor_list.get_nlocal(); ++local_i)
+        for (int local_i = 0; local_i < neighbor_list.get_ncentral_atoms(); ++local_i)
         {
             const NeighborAtom& center_atom = inside_atoms[static_cast<std::size_t>(local_i)];
             const int it = center_atom.atom_type;
@@ -137,7 +133,7 @@ void ESolver_LJ::runner(BaseCell& cell, const int istep)
     double local_potential = 0.0;
     std::array<double, 9> local_virial{};
 
-    for (int local_i = 0; local_i < neighbor_list.get_nlocal(); ++local_i)
+    for (int local_i = 0; local_i < neighbor_list.get_ncentral_atoms(); ++local_i)
     {
         LocalAtom& center_atom = owned_atoms[static_cast<std::size_t>(local_i)];
         ModuleBase::Vector3<double> tau1(center_atom.cart.x, center_atom.cart.y, center_atom.cart.z);
@@ -202,8 +198,8 @@ void ESolver_LJ::cal_force(BaseCell& cell, ModuleBase::matrix& force)
     }
 
     MDCell& mdcell = static_cast<MDCell&>(cell);
-    force.create(mdcell.nlocal(), 3);
-    for (int i = 0; i < mdcell.nlocal(); ++i)
+    force.create(mdcell.nowned_atoms(), 3);
+    for (int i = 0; i < mdcell.nowned_atoms(); ++i)
     {
         force(i, 0) = mdcell.owned_atoms()[static_cast<std::size_t>(i)].force.x;
         force(i, 1) = mdcell.owned_atoms()[static_cast<std::size_t>(i)].force.y;

--- a/source/source_esolver/esolver_lj.h
+++ b/source/source_esolver/esolver_lj.h
@@ -35,13 +35,6 @@ class ESolver_LJ : public ESolver
 
         void others(BaseCell& cell, const int istep) override;
 
-        bool supports_mdcell() const override
-        {
-            return true;
-        }
-
-        double mdcell_cutoff(const Input_para& inp) const override;
-
   private:
     double LJ_energy(const double& d, const int& i, const int& j) const;
 

--- a/source/source_esolver/esolver_nep.cpp
+++ b/source/source_esolver/esolver_nep.cpp
@@ -41,7 +41,12 @@ void ESolver_NEP::before_all_runners(BaseCell& basecell, const Input_para& inp)
     {
         MDCell& mdcell = static_cast<MDCell&>(basecell);
 #ifdef __NEP
+        const double cutoff = std::max(nep.paramb.rc_radial_max, nep.paramb.rc_angular_max)
+                              * ModuleBase::ANGSTROM_AU;
+        mdcell.initialize_neighbors(cutoff);
         initialize_type_map_(mdcell.type_labels());
+#else
+        ModuleBase::WARNING_QUIT("ESolver_NEP", "Please recompile with -D__NEP");
 #endif
         return;
     }
@@ -80,9 +85,9 @@ void ESolver_NEP::runner(BaseCell& basecell, const int istep)
         {
             mdcell.prepare_neighbors();
         }
-        const int nlocal = mdcell.nlocal();
+        const int nowned_atoms = mdcell.nowned_atoms();
         const int nghost = mdcell.nghost();
-        const int natom = nlocal + nghost;
+        const int natom = nowned_atoms + nghost;
         if (natom == 0)
         {
             ModuleBase::WARNING_QUIT("ESolver_NEP", "MDCell contains no atoms.");
@@ -97,8 +102,8 @@ void ESolver_NEP::runner(BaseCell& basecell, const int istep)
         std::vector<double*> force_ptrs(static_cast<std::size_t>(natom), NULL);
         for (int iat = 0; iat < natom; ++iat)
         {
-            const LocalAtom& atom = iat < nlocal ? owned_atoms[static_cast<std::size_t>(iat)]
-                                                  : ghost_atoms[static_cast<std::size_t>(iat - nlocal)];
+            const LocalAtom& atom = iat < nowned_atoms ? owned_atoms[static_cast<std::size_t>(iat)]
+                                                  : ghost_atoms[static_cast<std::size_t>(iat - nowned_atoms)];
             if (atom.type < 0 || static_cast<std::size_t>(atom.type) >= md_type_to_nep_type_.size())
             {
                 ModuleBase::WARNING_QUIT("ESolver_NEP", "MDCell atom type is outside the NEP type map.");
@@ -113,10 +118,10 @@ void ESolver_NEP::runner(BaseCell& basecell, const int istep)
         }
 
         const NeighborList& neighbor_list = mdcell.neighbor_search().get_neighbor_list();
-        std::vector<int> ilist(static_cast<std::size_t>(nlocal), 0);
+        std::vector<int> ilist(static_cast<std::size_t>(nowned_atoms), 0);
         std::vector<int> numneigh(static_cast<std::size_t>(natom), 0);
         std::vector<int*> firstneigh(static_cast<std::size_t>(natom), NULL);
-        for (int iat = 0; iat < nlocal; ++iat)
+        for (int iat = 0; iat < nowned_atoms; ++iat)
         {
             ilist[static_cast<std::size_t>(iat)] = iat;
             numneigh[static_cast<std::size_t>(iat)] = neighbor_list.get_numneigh(iat);
@@ -126,9 +131,9 @@ void ESolver_NEP::runner(BaseCell& basecell, const int istep)
         double local_energy = 0.0;
         double local_virial[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
         ModuleBase::timer::start("ESolver_NEP", "compute");
-        nep.compute_for_lammps(nlocal,
-                               nlocal,
-                               nlocal > 0 ? ilist.data() : NULL,
+        nep.compute_for_lammps(nowned_atoms,
+                               nowned_atoms,
+                               nowned_atoms > 0 ? ilist.data() : NULL,
                                numneigh.data(),
                                firstneigh.data(),
                                local_type.data(),
@@ -143,7 +148,7 @@ void ESolver_NEP::runner(BaseCell& basecell, const int istep)
 
         std::vector<LocalAtom>& mutable_owned_atoms = mdcell.mutable_owned_atoms();
         std::vector<LocalAtom>& mutable_ghost_atoms = mdcell.mutable_ghost_atoms();
-        for (int iat = 0; iat < nlocal; ++iat)
+        for (int iat = 0; iat < nowned_atoms; ++iat)
         {
             mutable_owned_atoms[static_cast<std::size_t>(iat)].force.set(force[static_cast<std::size_t>(iat)][0],
                                                                            force[static_cast<std::size_t>(iat)][1],
@@ -151,9 +156,9 @@ void ESolver_NEP::runner(BaseCell& basecell, const int istep)
         }
         for (int iat = 0; iat < nghost; ++iat)
         {
-            mutable_ghost_atoms[static_cast<std::size_t>(iat)].force.set(force[static_cast<std::size_t>(nlocal + iat)][0],
-                                                                           force[static_cast<std::size_t>(nlocal + iat)][1],
-                                                                           force[static_cast<std::size_t>(nlocal + iat)][2]);
+            mutable_ghost_atoms[static_cast<std::size_t>(iat)].force.set(force[static_cast<std::size_t>(nowned_atoms + iat)][0],
+                                                                           force[static_cast<std::size_t>(nowned_atoms + iat)][1],
+                                                                           force[static_cast<std::size_t>(nowned_atoms + iat)][2]);
         }
         mdcell.accumulate_ghost_forces();
 
@@ -165,7 +170,7 @@ void ESolver_NEP::runner(BaseCell& basecell, const int istep)
         const double fact_f = 1.0 / (ModuleBase::Ry_to_eV * ModuleBase::ANGSTROM_AU);
         const double fact_v = 1.0 / (mdcell.omega() * ModuleBase::Ry_to_eV);
         nep_potential = local_energy * fact_e;
-        for (int iat = 0; iat < nlocal; ++iat)
+        for (int iat = 0; iat < nowned_atoms; ++iat)
         {
             LocalAtom& atom = mutable_owned_atoms[static_cast<std::size_t>(iat)];
             atom.force *= fact_f;
@@ -267,33 +272,13 @@ double ESolver_NEP::cal_energy()
     return nep_potential;
 }
 
-bool ESolver_NEP::supports_mdcell() const
-{
-#ifdef __NEP
-    return true;
-#else
-    return false;
-#endif
-}
-
-double ESolver_NEP::mdcell_cutoff(const Input_para& inp) const
-{
-    static_cast<void>(inp);
-#ifdef __NEP
-    return std::max(nep.paramb.rc_radial_max, nep.paramb.rc_angular_max) * ModuleBase::ANGSTROM_AU;
-#else
-    ModuleBase::WARNING_QUIT("ESolver_NEP::mdcell_cutoff", "Please recompile with -D__NEP");
-    return 0.0;
-#endif
-}
-
 void ESolver_NEP::cal_force(BaseCell& basecell, ModuleBase::matrix& force)
 {
     if (basecell.kind() == BaseCell::Kind::mdcell)
     {
         const MDCell& mdcell = static_cast<const MDCell&>(basecell);
-        force.create(mdcell.nlocal(), 3);
-        for (int iat = 0; iat < mdcell.nlocal(); ++iat)
+        force.create(mdcell.nowned_atoms(), 3);
+        for (int iat = 0; iat < mdcell.nowned_atoms(); ++iat)
         {
             const LocalAtom& atom = mdcell.owned_atoms()[static_cast<std::size_t>(iat)];
             force(iat, 0) = atom.force.x;

--- a/source/source_esolver/esolver_nep.h
+++ b/source/source_esolver/esolver_nep.h
@@ -66,9 +66,6 @@ class ESolver_NEP : public ESolver
      */
     void cal_stress(BaseCell& basecell, ModuleBase::matrix& stress) override;
 
-    bool supports_mdcell() const override;
-    double mdcell_cutoff(const Input_para& inp) const override;
-
     /**
      * @brief Prints the final total energy of the NEP model to the output file
      *

--- a/source/source_io/module_output/output_log.cpp
+++ b/source/source_io/module_output/output_log.cpp
@@ -299,8 +299,8 @@ void print_force(std::ofstream& ofs, const MDCell& cell, const std::string& name
     MPI_Comm_size(cell.communicator(), &size);
     if (rank != 0)
     {
-        const int nlocal = cell.nlocal();
-        MPI_Send(&nlocal, 1, MPI_INT, 0, 0, cell.communicator());
+        const int nowned_atoms = cell.nowned_atoms();
+        MPI_Send(&nowned_atoms, 1, MPI_INT, 0, 0, cell.communicator());
         for (const LocalAtom& atom : owned_atoms)
         {
             MPI_Send(&atom.type, 1, MPI_INT, 0, 1, cell.communicator());

--- a/source/source_main/driver_run.cpp
+++ b/source/source_main/driver_run.cpp
@@ -51,7 +51,7 @@ void Driver::driver_run()
     this->init_hardware();
     ModuleESolver::ESolver* p_esolver = ModuleESolver::init_esolver(PARAM.inp);
 
-    const bool supports_mdcell = p_esolver->supports_mdcell();
+    const bool direct_mdcell = input.esolver_type == "lj" || input.esolver_type == "dp" || input.esolver_type == "nep";
     UnitCell ucell;
     bool ucell_initialized = false;
     const auto initialize_ucell = [&ucell, &ucell_initialized, &input]()
@@ -94,9 +94,9 @@ void Driver::driver_run()
     if (cal == "md")
     {
         MDCell mdcell;
-        if (supports_mdcell)
+        if (direct_mdcell)
         {
-            Run_MD::prepare_mdcell(mdcell, p_esolver, PARAM);
+            Run_MD::prepare_mdcell(mdcell, PARAM);
             p_esolver->before_all_runners(mdcell, PARAM.inp);
         }
         else
@@ -107,7 +107,7 @@ void Driver::driver_run()
         }
 
         Run_MD::md_line(mdcell, p_esolver, PARAM);
-        if (supports_mdcell)
+        if (direct_mdcell)
         {
             p_esolver->after_all_runners(mdcell);
         }

--- a/source/source_md/langevin.cpp
+++ b/source/source_md/langevin.cpp
@@ -11,7 +11,7 @@ Langevin::Langevin(const Parameter& param_in, MDCell& mdcell_in) : MD_base(param
 
     md_damp = mdp.md_damp / ModuleBase::AU_to_FS;
 
-    total_force.resize(static_cast<std::size_t>(mdcell.nlocal()));
+    total_force.resize(static_cast<std::size_t>(mdcell.nowned_atoms()));
 }
 
 
@@ -34,7 +34,7 @@ void Langevin::first_half(std::ofstream& ofs)
     ModuleBase::TITLE("Langevin", "first_half");
     ModuleBase::timer::start("Langevin", "first_half");
 
-    for (int i = 0; i < mdcell.nlocal(); ++i)
+    for (int i = 0; i < mdcell.nowned_atoms(); ++i)
     {
         LocalAtom& atom = mdcell.mutable_owned_atoms()[static_cast<std::size_t>(i)];
         for (int k = 0; k < 3; ++k)
@@ -55,7 +55,7 @@ void Langevin::second_half()
     ModuleBase::timer::start("Langevin", "second_half");
 
     post_force();
-    for (int i = 0; i < mdcell.nlocal(); ++i)
+    for (int i = 0; i < mdcell.nowned_atoms(); ++i)
     {
         LocalAtom& atom = mdcell.mutable_owned_atoms()[static_cast<std::size_t>(i)];
         for (int k = 0; k < 3; ++k)
@@ -93,9 +93,9 @@ void Langevin::restart(const std::string& global_readin_dir)
 void Langevin::post_force()
 {
     double t_target = MD_func::target_temp(step_ + step_rst_, mdp.md_nstep, md_tfirst, md_tlast);
-    total_force.resize(static_cast<std::size_t>(mdcell.nlocal()));
+    total_force.resize(static_cast<std::size_t>(mdcell.nowned_atoms()));
 
-    for (int i = 0; i < mdcell.nlocal(); ++i)
+    for (int i = 0; i < mdcell.nowned_atoms(); ++i)
     {
         ModuleBase::Vector3<double> random_value;
         for (int k = 0; k < 3; ++k)

--- a/source/source_md/md_func.cpp
+++ b/source/source_md/md_func.cpp
@@ -333,7 +333,7 @@ void force_virial(ModuleESolver::ESolver* p_esolver,
 {
     ModuleBase::TITLE("MD_func", "force_virial");
     ModuleBase::timer::start("MD_func", "force_virial");
-    if (p_esolver->supports_mdcell())
+    if (!mdcell.has_backing_unitcell())
     {
         mdcell.prepare_neighbors();
         p_esolver->runner(static_cast<BaseCell&>(mdcell), istep);
@@ -347,7 +347,6 @@ void force_virial(ModuleESolver::ESolver* p_esolver,
     }
     else
     {
-        if (!mdcell.has_backing_unitcell()) ModuleBase::WARNING_QUIT("MD_func::force_virial", "This ESolver requires UnitCell, but MDCell has no backing UnitCell.");
         UnitCell& ucell = mdcell.backing_unitcell();
         std::vector<std::vector<ModuleBase::Vector3<double>>> backing_velocities(
             static_cast<std::size_t>(ucell.ntype));
@@ -441,7 +440,7 @@ void dump_info(const int& step,
     }
     std::ostringstream local;
     local << std::fixed << std::setprecision(12);
-    for (int i = 0; i < mdcell.nlocal(); ++i)
+    for (int i = 0; i < mdcell.nowned_atoms(); ++i)
     {
         const LocalAtom& atom = mdcell.owned_atoms()[static_cast<std::size_t>(i)];
         local << "  " << type_offsets[static_cast<std::size_t>(atom.type)] + atom.type_index
@@ -552,7 +551,7 @@ double current_temp(double& kinetic,
 std::int64_t global_dof(const MDCell& mdcell)
 {
     std::int64_t local_frozen[3] = {0, 0, 0};
-    for (int i = 0; i < mdcell.nlocal(); ++i)
+    for (int i = 0; i < mdcell.nowned_atoms(); ++i)
     {
         const ModuleBase::Vector3<int>& mbl = mdcell.owned_atoms()[static_cast<std::size_t>(i)].mbl;
         if (mbl.x == 0) ++local_frozen[0];

--- a/source/source_md/msst.cpp
+++ b/source/source_md/msst.cpp
@@ -91,7 +91,7 @@ void MSST::first_half(std::ofstream& ofs)
 
     /// save the velocities
     old_v.resize(mdcell.owned_atoms().size());
-    for (int i = 0; i < mdcell.nlocal(); ++i)
+    for (int i = 0; i < mdcell.nowned_atoms(); ++i)
     {
         old_v[static_cast<std::size_t>(i)] = mdcell.owned_atoms()[static_cast<std::size_t>(i)].vel;
     }
@@ -102,7 +102,7 @@ void MSST::first_half(std::ofstream& ofs)
     vsum = vel_sum();
 
     /// reset the velocities
-    for (int i = 0; i < mdcell.nlocal(); ++i)
+    for (int i = 0; i < mdcell.nowned_atoms(); ++i)
     {
         mdcell.mutable_owned_atoms()[static_cast<std::size_t>(i)].vel = old_v[static_cast<std::size_t>(i)];
     }

--- a/source/source_md/run_md.cpp
+++ b/source/source_md/run_md.cpp
@@ -6,7 +6,6 @@
 #include "source_base/parallel_cell.h"
 #include "source_cell/mdcell_reader.h"
 #include "source_cell/mdcell.h"
-#include "source_esolver/esolver.h"
 #include "source_io/module_parameter/parameter.h"
 #include "fire.h"
 #include "langevin.h"
@@ -25,18 +24,9 @@
 namespace Run_MD
 {
 
-void prepare_mdcell(MDCell& mdcell,
-                    ModuleESolver::ESolver* p_esolver,
-                    const Parameter& param_in)
+void prepare_mdcell(MDCell& mdcell, const Parameter& param_in)
 {
     const Input_para& input = param_in.inp;
-    const double cutoff = p_esolver->mdcell_cutoff(input);
-    if (cutoff <= 0.0)
-    {
-        ModuleBase::WARNING_QUIT("Run_MD::prepare_mdcell",
-                                 "An ESolver supporting MDCell must provide a positive cutoff.");
-    }
-
     std::vector<int> effective_replicate = input.cell_replica;
     if (input.mdp.md_restart)
     {
@@ -46,7 +36,6 @@ void prepare_mdcell(MDCell& mdcell,
     const ModuleBase::CommunicationDomain comm_domain = ModuleBase::world_comm_domain();
     mdcell = MDCellReader::read_stru(param_in.globalv.global_in_stru,
                                      effective_replicate,
-                                     cutoff,
                                      input.mdp.md_neighbor_skin / ModuleBase::BOHR_TO_A,
                                      comm_domain);
     GlobalV::ofs_running << std::endl;
@@ -56,7 +45,7 @@ void prepare_mdcell(MDCell& mdcell,
 
 void prepare_mdcell(MDCell& mdcell, UnitCell& ucell)
 {
-    mdcell.initialize_from_unitcell(ucell, 0.0, 0.0, ModuleBase::world_comm_domain());
+    mdcell.initialize_from_unitcell(ucell, 0.0, ModuleBase::world_comm_domain());
     mdcell.mutable_stru_meta() = unitcell::make_stru_meta(ucell);
 }
 

--- a/source/source_md/run_md.h
+++ b/source/source_md/run_md.h
@@ -16,9 +16,7 @@ class ESolver;
  */
 namespace Run_MD
 {
-void prepare_mdcell(MDCell& mdcell,
-                    ModuleESolver::ESolver* p_esolver,
-                    const Parameter& param_in);
+void prepare_mdcell(MDCell& mdcell, const Parameter& param_in);
 
 void prepare_mdcell(MDCell& mdcell, UnitCell& ucell);
 

--- a/source/source_md/test/fire_test.cpp
+++ b/source/source_md/test/fire_test.cpp
@@ -50,10 +50,7 @@ class FIREtest : public testing::Test
         Setcell::parameters(param_in.input);
 
         p_esolver = new ModuleESolver::ESolver_LJ();
-        mdcell.initialize_from_unitcell(ucell,
-                                         8.5 * ModuleBase::ANGSTROM_AU,
-                                         0.0,
-                                         ModuleBase::world_comm_domain());
+        mdcell = Setcell::setup_mdcell(ucell);
         p_esolver->before_all_runners(mdcell, param_in.inp);
         mdrun = new FIRE(param_in, mdcell);
         mdrun->setup(p_esolver, PARAM.sys.global_readin_dir);

--- a/source/source_md/test/langevin_test.cpp
+++ b/source/source_md/test/langevin_test.cpp
@@ -50,10 +50,7 @@ class Langevin_test : public testing::Test
         Setcell::parameters(param_in.input);
 
         p_esolver = new ModuleESolver::ESolver_LJ();
-        mdcell.initialize_from_unitcell(ucell,
-                                         8.5 * ModuleBase::ANGSTROM_AU,
-                                         0.0,
-                                         ModuleBase::world_comm_domain());
+        mdcell = Setcell::setup_mdcell(ucell);
         p_esolver->before_all_runners(mdcell, param_in.inp);
         mdrun = new Langevin(param_in, mdcell);
         mdrun->setup(p_esolver, PARAM.sys.global_readin_dir);

--- a/source/source_md/test/lj_pot_test.cpp
+++ b/source/source_md/test/lj_pot_test.cpp
@@ -44,8 +44,10 @@ class LJ_pot_test : public testing::Test
 TEST_F(LJ_pot_test, potential)
 {
     ModuleESolver::ESolver* p_esolver = new ModuleESolver::ESolver_LJ();
-    MDCell mdcell = Setcell::setup_mdcell(ucell, param);
+    MDCell mdcell = Setcell::setup_mdcell(ucell);
+    EXPECT_DOUBLE_EQ(mdcell.cutoff(), 0.0);
     p_esolver->before_all_runners(mdcell, param.inp);
+    EXPECT_DOUBLE_EQ(mdcell.cutoff(), 8.5 * ModuleBase::ANGSTROM_AU);
     MD_func::force_virial(p_esolver, 0, mdcell, potential, true, stress, false);
     EXPECT_NEAR(potential, -0.011957818623534381, doublethreshold);
 }
@@ -66,7 +68,7 @@ TEST_F(LJ_pot_test, unitcell_compatibility)
 TEST_F(LJ_pot_test, force)
 {
     ModuleESolver::ESolver* p_esolver = new ModuleESolver::ESolver_LJ();
-    MDCell mdcell = Setcell::setup_mdcell(ucell, param);
+    MDCell mdcell = Setcell::setup_mdcell(ucell);
     p_esolver->before_all_runners(mdcell, param.inp);
     MD_func::force_virial(p_esolver, 0, mdcell, potential, true, stress, false);
     const std::vector<LocalAtom>& atoms = mdcell.owned_atoms();
@@ -87,13 +89,13 @@ TEST_F(LJ_pot_test, force)
 TEST_F(LJ_pot_test, mdcell_cal_force)
 {
     ModuleESolver::ESolver_LJ p_esolver;
-    MDCell mdcell = Setcell::setup_mdcell(ucell, param);
+    MDCell mdcell = Setcell::setup_mdcell(ucell);
     p_esolver.before_all_runners(mdcell, param.inp);
     p_esolver.runner(mdcell, 0);
 
     ModuleBase::matrix force;
     p_esolver.cal_force(mdcell, force);
-    for (int iat = 0; iat < mdcell.nlocal(); ++iat)
+    for (int iat = 0; iat < mdcell.nowned_atoms(); ++iat)
     {
         const LocalAtom& atom = mdcell.owned_atoms()[static_cast<std::size_t>(iat)];
         EXPECT_DOUBLE_EQ(force(iat, 0), atom.force.x);
@@ -105,7 +107,7 @@ TEST_F(LJ_pot_test, mdcell_cal_force)
 TEST_F(LJ_pot_test, stress)
 {
     ModuleESolver::ESolver* p_esolver = new ModuleESolver::ESolver_LJ();
-    MDCell mdcell = Setcell::setup_mdcell(ucell, param);
+    MDCell mdcell = Setcell::setup_mdcell(ucell);
     p_esolver->before_all_runners(mdcell, param.inp);
     MD_func::force_virial(p_esolver, 0, mdcell, potential, true, stress, false);
     EXPECT_NEAR(stress(0, 0), 8.0360222227631859e-07, doublethreshold);
@@ -122,7 +124,7 @@ TEST_F(LJ_pot_test, stress)
 TEST_F(LJ_pot_test, mdcell_stress_includes_external_pressure)
 {
     ModuleESolver::ESolver_LJ p_esolver;
-    MDCell mdcell = Setcell::setup_mdcell(ucell, param);
+    MDCell mdcell = Setcell::setup_mdcell(ucell);
     Input_para input = param.inp;
     p_esolver.before_all_runners(mdcell, input);
     p_esolver.runner(mdcell, 0);

--- a/source/source_md/test/md_func_test.cpp
+++ b/source/source_md/test/md_func_test.cpp
@@ -106,7 +106,7 @@ TEST_F(MD_func_test, compute_stress)
 {
     const ModuleBase::Vector3<double> test_velocity(0.1, 0.2, 0.3);
     MDCell mdcell;
-    mdcell.initialize_from_unitcell(ucell, 0.0, 0.0, ModuleBase::world_comm_domain());
+    mdcell.initialize_from_unitcell(ucell, 0.0, ModuleBase::world_comm_domain());
     for (LocalAtom& atom : mdcell.mutable_owned_atoms())
     {
         atom.vel = test_velocity;
@@ -126,7 +126,7 @@ TEST_F(MD_func_test, compute_stress)
 TEST_F(MD_func_test, dump_info)
 {
     MDCell mdcell;
-    mdcell.initialize_from_unitcell(ucell, 0.0, 0.0, ModuleBase::world_comm_domain());
+    mdcell.initialize_from_unitcell(ucell, 0.0, ModuleBase::world_comm_domain());
     for (LocalAtom& atom : mdcell.mutable_owned_atoms())
     {
         atom.vel = ModuleBase::Vector3<double>(0.0, 0.0, 0.0);
@@ -312,7 +312,7 @@ TEST_F(MD_func_test, current_md_info_mdcell_accepts_step_only_restart)
     file.close();
 
     MDCell mdcell;
-    mdcell.initialize_from_unitcell(ucell, 0.0, 0.0, ModuleBase::world_comm_domain());
+    mdcell.initialize_from_unitcell(ucell, 0.0, ModuleBase::world_comm_domain());
     int istep = -1;
     double temperature = 0.0;
     MD_func::current_md_info(mdcell, "./", istep, temperature);
@@ -325,7 +325,7 @@ TEST_F(MD_func_test, current_md_info_mdcell_accepts_step_only_restart)
 TEST_F(MD_func_test, global_dof_mdcell)
 {
     MDCell mdcell;
-    mdcell.initialize_from_unitcell(ucell, 0.0, 0.0, ModuleBase::world_comm_domain());
+    mdcell.initialize_from_unitcell(ucell, 0.0, ModuleBase::world_comm_domain());
     EXPECT_EQ(MD_func::global_dof(mdcell), 9);
 
     for (LocalAtom& atom : mdcell.mutable_owned_atoms())
@@ -338,7 +338,7 @@ TEST_F(MD_func_test, global_dof_mdcell)
 TEST_F(MD_func_test, current_step_warning)
 {
     MDCell mdcell;
-    mdcell.initialize_from_unitcell(ucell, 0.0, 0.0, ModuleBase::world_comm_domain());
+    mdcell.initialize_from_unitcell(ucell, 0.0, ModuleBase::world_comm_domain());
     int istep = 0;
     double temperature = 0.0;
     EXPECT_EXIT(MD_func::current_md_info(mdcell, "./", istep, temperature), ::testing::ExitedWithCode(1), "");

--- a/source/source_md/test/msst_test.cpp
+++ b/source/source_md/test/msst_test.cpp
@@ -50,10 +50,7 @@ class MSST_test : public testing::Test
         Setcell::parameters(param_in.input);
 
         p_esolver = new ModuleESolver::ESolver_LJ();
-        mdcell.initialize_from_unitcell(ucell,
-                                         8.5 * ModuleBase::ANGSTROM_AU,
-                                         0.0,
-                                         ModuleBase::world_comm_domain());
+        mdcell = Setcell::setup_mdcell(ucell);
         p_esolver->before_all_runners(mdcell, param_in.inp);
         mdrun = new MSST(param_in, mdcell);
         mdrun->setup(p_esolver, PARAM.sys.global_readin_dir);
@@ -96,18 +93,18 @@ TEST_F(MSST_test, first_half)
 {
     mdrun->first_half(GlobalV::ofs_running);
 
-    EXPECT_NEAR(ucell.lat0, 1.0, doublethreshold);
-    EXPECT_NEAR(ucell.lat0_angstrom, 0.52917700000000001, doublethreshold);
-    EXPECT_NEAR(ucell.latvec.e11, 10.0, doublethreshold);
-    EXPECT_NEAR(ucell.latvec.e12, 0.00, doublethreshold);
-    EXPECT_NEAR(ucell.latvec.e13, 0.00, doublethreshold);
-    EXPECT_NEAR(ucell.latvec.e21, 0.00, doublethreshold);
-    EXPECT_NEAR(ucell.latvec.e22, 10.0, doublethreshold);
-    EXPECT_NEAR(ucell.latvec.e23, 0.00, doublethreshold);
-    EXPECT_NEAR(ucell.latvec.e31, 0.00, doublethreshold);
-    EXPECT_NEAR(ucell.latvec.e32, 0.00, doublethreshold);
-    EXPECT_NEAR(ucell.latvec.e33, 9.9959581179144905, doublethreshold);
-    EXPECT_NEAR(ucell.omega, 999.59581179144902, doublethreshold);
+    EXPECT_NEAR(mdcell.lat0(), 1.0, doublethreshold);
+    EXPECT_NEAR(mdcell.lat0() * ModuleBase::BOHR_TO_A, 0.52917700000000001, doublethreshold);
+    EXPECT_NEAR(mdcell.latvec().e11, 10.0, doublethreshold);
+    EXPECT_NEAR(mdcell.latvec().e12, 0.00, doublethreshold);
+    EXPECT_NEAR(mdcell.latvec().e13, 0.00, doublethreshold);
+    EXPECT_NEAR(mdcell.latvec().e21, 0.00, doublethreshold);
+    EXPECT_NEAR(mdcell.latvec().e22, 10.0, doublethreshold);
+    EXPECT_NEAR(mdcell.latvec().e23, 0.00, doublethreshold);
+    EXPECT_NEAR(mdcell.latvec().e31, 0.00, doublethreshold);
+    EXPECT_NEAR(mdcell.latvec().e32, 0.00, doublethreshold);
+    EXPECT_NEAR(mdcell.latvec().e33, 9.9959581179144905, doublethreshold);
+    EXPECT_NEAR(mdcell.omega(), 999.59581179144902, doublethreshold);
 
     EXPECT_NEAR(Setcell::fractional_displacement(mdcell.owned_atoms()[static_cast<std::size_t>(0)]).x, -0.00054271823071484467, doublethreshold);
     EXPECT_NEAR(Setcell::fractional_displacement(mdcell.owned_atoms()[static_cast<std::size_t>(0)]).y, 0.00029442816868202821, doublethreshold);
@@ -142,18 +139,18 @@ TEST_F(MSST_test, second_half)
     mdrun->second_half();
     ;
 
-    EXPECT_NEAR(ucell.lat0, 1.0, doublethreshold);
-    EXPECT_NEAR(ucell.lat0_angstrom, 0.52917700000000001, doublethreshold);
-    EXPECT_NEAR(ucell.latvec.e11, 10.0, doublethreshold);
-    EXPECT_NEAR(ucell.latvec.e12, 0.00, doublethreshold);
-    EXPECT_NEAR(ucell.latvec.e13, 0.00, doublethreshold);
-    EXPECT_NEAR(ucell.latvec.e21, 0.00, doublethreshold);
-    EXPECT_NEAR(ucell.latvec.e22, 10.0, doublethreshold);
-    EXPECT_NEAR(ucell.latvec.e23, 0.00, doublethreshold);
-    EXPECT_NEAR(ucell.latvec.e31, 0.00, doublethreshold);
-    EXPECT_NEAR(ucell.latvec.e32, 0.00, doublethreshold);
-    EXPECT_NEAR(ucell.latvec.e33, 9.9959581179144905, doublethreshold);
-    EXPECT_NEAR(ucell.omega, 999.59581179144902, doublethreshold);
+    EXPECT_NEAR(mdcell.lat0(), 1.0, doublethreshold);
+    EXPECT_NEAR(mdcell.lat0() * ModuleBase::BOHR_TO_A, 0.52917700000000001, doublethreshold);
+    EXPECT_NEAR(mdcell.latvec().e11, 10.0, doublethreshold);
+    EXPECT_NEAR(mdcell.latvec().e12, 0.00, doublethreshold);
+    EXPECT_NEAR(mdcell.latvec().e13, 0.00, doublethreshold);
+    EXPECT_NEAR(mdcell.latvec().e21, 0.00, doublethreshold);
+    EXPECT_NEAR(mdcell.latvec().e22, 10.0, doublethreshold);
+    EXPECT_NEAR(mdcell.latvec().e23, 0.00, doublethreshold);
+    EXPECT_NEAR(mdcell.latvec().e31, 0.00, doublethreshold);
+    EXPECT_NEAR(mdcell.latvec().e32, 0.00, doublethreshold);
+    EXPECT_NEAR(mdcell.latvec().e33, 9.9959581179144905, doublethreshold);
+    EXPECT_NEAR(mdcell.omega(), 999.59581179144902, doublethreshold);
 
     EXPECT_NEAR(Setcell::fractional_displacement(mdcell.owned_atoms()[static_cast<std::size_t>(0)]).x, -0.00054271823071484467, doublethreshold);
     EXPECT_NEAR(Setcell::fractional_displacement(mdcell.owned_atoms()[static_cast<std::size_t>(0)]).y, 0.00029442816868202821, doublethreshold);

--- a/source/source_md/test/nhchain_test.cpp
+++ b/source/source_md/test/nhchain_test.cpp
@@ -52,10 +52,7 @@ class NHC_test : public testing::Test
         param_in.input.mdp.md_pmode = "tri";
         param_in.input.mdp.md_pfirst = 1;
         param_in.input.mdp.md_plast = 1;
-        mdcell.initialize_from_unitcell(ucell,
-                                         8.5 * ModuleBase::ANGSTROM_AU,
-                                         0.0,
-                                         ModuleBase::world_comm_domain());
+        mdcell = Setcell::setup_mdcell(ucell);
         p_esolver->before_all_runners(mdcell, param_in.inp);
         mdrun = new Nose_Hoover(param_in, mdcell);
         mdrun->setup(p_esolver, PARAM.sys.global_readin_dir);

--- a/source/source_md/test/setcell.h
+++ b/source/source_md/test/setcell.h
@@ -12,8 +12,10 @@
 #include "source_base/parallel_cell.h"
 #include "source_io/module_parameter/parameter.h"
 
-#include <algorithm>
 #include <cmath>
+#include <cstdint>
+#include <string>
+#include <vector>
 
 Magnetism::Magnetism()
 {
@@ -136,15 +138,43 @@ class Setcell
         input.mdp.md_tolerance = 0;
     };
 
-    static MDCell setup_mdcell(UnitCell& ucell, const Parameter& param)
+    static MDCell setup_mdcell(UnitCell& ucell)
     {
-        double cutoff = 0.0;
-        for (std::size_t i = 0; i < param.inp.mdp.lj_rcut.size(); ++i)
+        std::vector<LocalAtom> owned_atoms;
+        std::vector<std::string> type_labels;
+        std::vector<double> type_masses;
+        std::vector<std::int64_t> type_atom_counts;
+        for (int it = 0; it < ucell.ntype; ++it)
         {
-            cutoff = std::max(cutoff, param.inp.mdp.lj_rcut[i] * ModuleBase::ANGSTROM_AU);
+            type_labels.push_back(ucell.atoms[it].label);
+            type_masses.push_back(ucell.atoms[it].mass);
+            type_atom_counts.push_back(ucell.atoms[it].na);
+            for (int ia = 0; ia < ucell.atoms[it].na; ++ia)
+            {
+                owned_atoms.push_back(LocalAtom(ucell.atoms[it].tau[ia],
+                                                 ucell.atoms[it].taud[ia],
+                                                 ucell.atoms[it].vel[ia],
+                                                 ModuleBase::Vector3<double>(0.0, 0.0, 0.0),
+                                                 ucell.atoms[it].mbl[ia],
+                                                 ucell.atoms[it].mass / ModuleBase::AU_to_MASS,
+                                                 it,
+                                                 ia,
+                                                 0));
+            }
         }
+
         MDCell mdcell;
-        mdcell.initialize_from_unitcell(ucell, cutoff, 0.0, ModuleBase::world_comm_domain());
+        mdcell.initialize_from_owned_atoms(ucell.latvec,
+                                           ucell.GT,
+                                           ucell.lat0,
+                                           ucell.omega,
+                                           ucell.nat,
+                                           owned_atoms,
+                                           type_labels,
+                                           type_masses,
+                                           type_atom_counts,
+                                           0.0,
+                                           ModuleBase::world_comm_domain());
         return mdcell;
     }
 

--- a/source/source_md/test/verlet_test.cpp
+++ b/source/source_md/test/verlet_test.cpp
@@ -52,10 +52,7 @@ class Verlet_test : public testing::Test
         Setcell::parameters(param_in.input);
 
         p_esolver = new ModuleESolver::ESolver_LJ();
-        mdcell.initialize_from_unitcell(ucell,
-                                         8.5 * ModuleBase::ANGSTROM_AU,
-                                         0.0,
-                                         ModuleBase::world_comm_domain());
+        mdcell = Setcell::setup_mdcell(ucell);
         p_esolver->before_all_runners(mdcell, param_in.inp);
         mdrun = new Verlet(param_in, mdcell);
         mdrun->setup(p_esolver, PARAM.sys.global_readin_dir);

--- a/tests/08_EXX/CMakeLists.txt
+++ b/tests/08_EXX/CMakeLists.txt
@@ -13,4 +13,7 @@ else()
         COMMAND ${BASH} ../integrate/Autotest.sh -a ${ABACUS_BIN_PATH} -n 4
         WORKING_DIRECTORY ${ABACUS_TEST_DIR}/08_EXX
     )
+    # The SOC-HSE case uses substantial per-thread memory; retain four MPI ranks
+    # while avoiding an OOM kill on the CI runner.
+    set_tests_properties(08_EXX PROPERTIES ENVIRONMENT "OMP_NUM_THREADS=1")
 endif()

--- a/tests/08_EXX/CMakeLists.txt
+++ b/tests/08_EXX/CMakeLists.txt
@@ -13,7 +13,4 @@ else()
         COMMAND ${BASH} ../integrate/Autotest.sh -a ${ABACUS_BIN_PATH} -n 4
         WORKING_DIRECTORY ${ABACUS_TEST_DIR}/08_EXX
     )
-    # The SOC-HSE case uses substantial per-thread memory; retain four MPI ranks
-    # while avoiding an OOM kill on the CI runner.
-    set_tests_properties(08_EXX PROPERTIES ENVIRONMENT "OMP_NUM_THREADS=1")
 endif()


### PR DESCRIPTION
### Reminder
  - [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
  - [x] I have linked an issue or explained why this PR does not need one.
  - [x] I have added adequate unit tests and/or case tests, or explained why not.
  - [x] I have listed the exact verification commands run and their results.
  - [x] I have described user-visible behavior changes, including INPUT parameter changes.
  - [x] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
  - [ ] I have requested any needed governance exception below.

  ### Linked Issue
  No linked issue. This PR is an internal refactor of the parallel-MD MDCell initialization and ESolver integration; it does not add a user-facing
  feature or fix a separately tracked issue.

  ### Unit Tests and/or Case Tests for my changes
  - Commands run:

    ```bash
    source toolchain/install/setup && cmake --build build_parallel_md1_current --target driver esolver MODULE_ESOLVER_esolver_dp_test MODULE_MD_LJ_pot
    MODULE_MD_run MODULE_MD_func MODULE_MD_fire MODULE_MD_verlet MODULE_MD_nhc MODULE_MD_msst MODULE_MD_lgv MODULE_CELL_NEIGHBOR_mdcell_reader
    MODULE_CELL_NEIGHBOR_mdcell_migrate_mpi -j1

    OMP_NUM_THREADS=1 ctest --test-dir build_parallel_md1_current --output-on-failure -R 'MODULE_MD_(LJ_pot|run|func|fire|verlet|nhc|msst|lgv)$|
    MODULE_CELL_NEIGHBOR_(mdcell_reader_np4|mdcell_migrate_mpi)$|MODULE_ESOLVER_esolver_dp_test'

    python3 tools/03_code_analysis/agent_governance_check.py --staged
    git diff --cached --check

  - Result summary:
      - All selected build targets succeeded.
      - 11/11 selected MD, MDCell-reader, MPI migration, and DP ESolver tests passed.
      - git diff --cached --check passed.
      - Governance check reported no errors. Remaining warnings are documented below.

  - Checks not run, with reason:
      - No NEP-enabled runtime test was run because the current local build does not enable __NEP.
      - No DP model runtime case was run because a suitable local DP potential case was not configured.

  ### What's changed?

  - Remove the generic ESolver::supports_mdcell() and ESolver::mdcell_cutoff() virtual interfaces.
  - Keep direct MDCell selection explicit in driver_run.cpp through direct_mdcell for LJ, DP, and NEP.
  - Move cutoff ownership to the concrete MD-capable ESolvers:
      - LJ derives the maximum cutoff from lj_rcut.
      - DP obtains the cutoff from the loaded DP model.
      - NEP obtains the maximum radial/angular cutoff from the loaded NEP model.

  - Add MDCell::initialize_neighbors(cutoff). MDCell construction now only loads owned atoms and geometry; neighbor layout, atom migration, and ghost
    creation occur only after the concrete solver supplies a positive cutoff.

  - Make an NEP direct-MD request fail immediately with a clear -D__NEP rebuild message when NEP support is unavailable.
  - Replace MD-specific ambiguous nlocal names with nowned_atoms or ncentral_atoms, according to whether the value represents owned MD atoms or
    neighbor-list central atoms.

  - Update MD tests to construct a bare MDCell for direct-MD execution. MSST checks now validate lattice changes on MDCell rather than an unrelated
    backing UnitCell.

  ### Governance Notes

  - INPUT/docs changes:
      - No INPUT parameter semantics or user documentation changed. This PR only restructures internal MDCell initialization and solver ownership of
        the existing cutoff data.

  - Core module impact:
      - ESolver loses two MDCell-specific virtual hooks, reducing generic ESolver coupling to parallel MD.
      - LJ, DP, and NEP retain their existing MD behavior while owning the solver-specific cutoff lookup internally.
      - The legacy UnitCell-backed MD path remains unchanged; MD_func now selects the path from MDCell::has_backing_unitcell().

  - Exceptions requested:
      - None.
      - Governance warnings for the direct standard-library includes in source_md/test/setcell.h are intentional: its test helper directly uses
        std::vector, std::string, and std::int64_t.

      - The driver_run.cpp global-dependency change is migration-neutral: the PR-level global dependency budget has net delta zero.
