### PR TITLE
Fix LCAO Hermitian matrix handling and EXX little-group density restoration

### DIFF
--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -3384,7 +3384,7 @@
 - **Availability**: *[`symmetry`](#symmetry)==1 and ([`dft_functional`](#dft_functional) in [hse, hf, pbe0, scan0] or ([`basis_type`](#basis_type)==lcao and [`rpa`](#rpa)==true))*
 - **Description**: - False: only rotate k-space density matrix D(k) from irreducible k-points to accelerate diagonalization
   - True: rotate both D(k) and Hexx(R) to accelerate both diagonalization and EXX calculation
-  - For multi-k calculations, D(k) is averaged over the unitary little group of each irreducible k point before star expansion, for either setting.
+  For multi-k calculations, D(k) is averaged over the unitary little group of each irreducible k point before star expansion, for either setting.
 - **Default**: True
 
 ### out_ri_cv

--- a/docs/advanced/input_files/input-main.md
+++ b/docs/advanced/input_files/input-main.md
@@ -3384,6 +3384,7 @@
 - **Availability**: *[`symmetry`](#symmetry)==1 and ([`dft_functional`](#dft_functional) in [hse, hf, pbe0, scan0] or ([`basis_type`](#basis_type)==lcao and [`rpa`](#rpa)==true))*
 - **Description**: - False: only rotate k-space density matrix D(k) from irreducible k-points to accelerate diagonalization
   - True: rotate both D(k) and Hexx(R) to accelerate both diagonalization and EXX calculation
+  - For multi-k calculations, D(k) is averaged over the unitary little group of each irreducible k point before star expansion, for either setting.
 - **Default**: True
 
 ### out_ri_cv

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -4647,6 +4647,7 @@ parameters:
     description: |
       * False: only rotate k-space density matrix D(k) from irreducible k-points to accelerate diagonalization
       * True: rotate both D(k) and Hexx(R) to accelerate both diagonalization and EXX calculation
+      For multi-k calculations, D(k) is averaged over the unitary little group of each irreducible k point before star expansion, for either setting.
     default_value: "True"
     unit: ""
     availability: "symmetry==1 and (dft_functional in [hse, hf, pbe0, scan0] or (basis_type==lcao and rpa==true))"

--- a/source/source_hsolver/diago_elpa_native.cpp
+++ b/source/source_hsolver/diago_elpa_native.cpp
@@ -3,6 +3,7 @@
 #include "source_base/global_function.h"
 #include "source_base/module_external/blas_connector.h"
 #include "source_base/module_external/blacs_connector.h"
+#include "source_base/module_external/scalapack_connector.h"
 #include "source_base/timer.h"
 #include "source_base/tool_quit.h"
 #include "source_hsolver/module_genelpa/elpa_new.h"
@@ -71,6 +72,79 @@ void DiagoElpaNative<T>::diag_pool(hamilt::MatrixBlock<T>& h_mat,
     std::vector<Real> eigen(this->nlocal, 0.0);
     std::vector<T> eigenvectors(narows * nacols);
 
+    // The complex LCAO matrices follow the LAPACK UPLO='U' convention: only
+    // their upper triangles are guaranteed to contain the Hermitian matrix.
+    // ELPA's native generalized solver consumes both triangles, so complete
+    // private Hermitian copies before the solve.
+    std::vector<T> h_work;
+    std::vector<T> s_work;
+    T* h_elpa = h_mat.p;
+    T* s_elpa = s_mat.p;
+    int decomposed_state = this->DecomposedState;
+    if (!std::is_same<T, double>::value)
+    {
+        h_work.resize(narows * nacols);
+        s_work.resize(narows * nacols);
+        const int one = 1;
+        ScalapackConnector::tranc(nFull,
+                                  nFull,
+                                  T(1.0),
+                                  h_mat.p,
+                                  one,
+                                  one,
+                                  h_mat.desc,
+                                  T(0.0),
+                                  h_work.data(),
+                                  one,
+                                  one,
+                                  h_mat.desc);
+        ScalapackConnector::tranc(nFull,
+                                  nFull,
+                                  T(1.0),
+                                  s_mat.p,
+                                  one,
+                                  one,
+                                  s_mat.desc,
+                                  T(0.0),
+                                  s_work.data(),
+                                  one,
+                                  one,
+                                  s_mat.desc);
+        const auto local_to_global = [](const int local_index,
+                                        const int block_size,
+                                        const int process_coordinate,
+                                        const int source_coordinate,
+                                        const int process_count) {
+            if (source_coordinate < 0)
+            {
+                return local_index;
+            }
+            const int process_offset
+                = (process_coordinate - source_coordinate + process_count) % process_count;
+            return ((local_index / block_size) * process_count + process_offset) * block_size
+                   + local_index % block_size;
+        };
+        for (int local_col = 0; local_col < nacols; ++local_col)
+        {
+            const int global_col
+                = local_to_global(local_col, h_mat.desc[5], mypcol, h_mat.desc[7], npcols);
+            for (int local_row = 0; local_row < narows; ++local_row)
+            {
+                const int global_row
+                    = local_to_global(local_row, h_mat.desc[4], myprow, h_mat.desc[6], nprows);
+                if (global_row <= global_col)
+                {
+                    const int local_index = local_row + local_col * narows;
+                    h_work[local_index] = h_mat.p[local_index];
+                    s_work[local_index] = s_mat.p[local_index];
+                }
+            }
+        }
+        h_elpa = h_work.data();
+        s_elpa = s_work.data();
+        decomposed_state = 0;
+    }
+
     if (elpa_init(20210430) != ELPA_OK)
     {
         fprintf(stderr, "Error: ELPA API version not supported");
@@ -114,11 +188,11 @@ void DiagoElpaNative<T>::diag_pool(hamilt::MatrixBlock<T>& h_mat,
 #endif
 
     elpa_generalized_eigenvectors(handle,
-                                  h_mat.p,
-                                  s_mat.p,
+                                  h_elpa,
+                                  s_elpa,
                                   eigen.data(),
                                   eigenvectors.data(),
-                                  this->DecomposedState,
+                                  decomposed_state,
                                   &success);
     elpa_deallocate(handle, &success);
     elpa_uninit(&success);

--- a/source/source_hsolver/kernels/cuda/diag_cusolver.cu
+++ b/source/source_hsolver/kernels/cuda/diag_cusolver.cu
@@ -9,7 +9,8 @@ Diag_Cusolver_gvd::Diag_Cusolver_gvd(){
 
     itype = CUSOLVER_EIG_TYPE_1; // A*x = (lambda)*B*x
     jobz = CUSOLVER_EIG_MODE_VECTOR; // compute eigenvalues and eigenvectors.
-    uplo = CUBLAS_FILL_MODE_LOWER;
+    // LCAO supplies the authoritative upper triangle of the Hermitian H/S matrices.
+    uplo = CUBLAS_FILL_MODE_UPPER;
 
     d_A = NULL;
     d_B = NULL;

--- a/source/source_hsolver/module_genelpa/elpa_new_complex.cpp
+++ b/source/source_hsolver/module_genelpa/elpa_new_complex.cpp
@@ -79,7 +79,10 @@ int ELPA_Solver::generalized_eigenvector(std::complex<double>* A, std::complex<d
             t=-1;
             timer(myid, "A*U^-1", "2.1a", t);
         }
-        ScalapackConnector::gemm('C', 'N', nFull, nFull, nFull, 1.0, A, B, 0.0, zwork.data(), desc);
+        // LCAO provides the authoritative upper triangle of the Hermitian
+        // Hamiltonian. PZHEMM observes that contract, while PZGEMM would read
+        // an uninitialized/stale lower triangle through A^H.
+        ScalapackConnector::hemm('L', 'U', nFull, 1.0, A, B, 0.0, zwork.data(), desc);
         if(loglevel>1)
         {
             timer(myid, "A*U^-1", "2.1a", t);
@@ -105,7 +108,7 @@ int ELPA_Solver::generalized_eigenvector(std::complex<double>* A, std::complex<d
             t=-1;
             timer(myid, "B*A^T", "2.1b", t);
         }
-        ScalapackConnector::gemm('N', 'C', nFull, nFull, nFull, 1.0, B, A, 0.0, zwork.data(), desc);
+        ScalapackConnector::hemm('R', 'U', nFull, 1.0, A, B, 0.0, zwork.data(), desc);
         if(loglevel>1)
         {
             timer(myid, "B*A^T", "2.1b", t);

--- a/source/source_hsolver/module_genelpa/elpa_new_complex.cpp
+++ b/source/source_hsolver/module_genelpa/elpa_new_complex.cpp
@@ -108,7 +108,10 @@ int ELPA_Solver::generalized_eigenvector(std::complex<double>* A, std::complex<d
             t=-1;
             timer(myid, "B*A^T", "2.1b", t);
         }
-        ScalapackConnector::hemm('R', 'U', nFull, 1.0, A, B, 0.0, zwork.data(), desc);
+        // A now stores the general product H * U^-1, so its conjugate
+        // transpose must be formed with GEMM rather than treating A as
+        // Hermitian a second time.
+        ScalapackConnector::gemm('N', 'C', nFull, nFull, nFull, 1.0, B, A, 0.0, zwork.data(), desc);
         if(loglevel>1)
         {
             timer(myid, "B*A^T", "2.1b", t);

--- a/source/source_hsolver/test/CMakeLists.txt
+++ b/source/source_hsolver/test/CMakeLists.txt
@@ -93,7 +93,7 @@ if (ENABLE_MPI)
     AddTest(
       TARGET MODULE_HSOLVER_LCAO
       LIBS parameter  ELPA::ELPA base genelpa psi device
-      SOURCES diago_lcao_test.cpp ../diago_elpa.cpp ../diago_scalapack.cpp ../diago_lapack.cpp
+      SOURCES diago_lcao_test.cpp ../diago_elpa.cpp ../diago_elpa_native.cpp ../diago_scalapack.cpp ../diago_lapack.cpp
     )
     else()
       AddTest(

--- a/source/source_hsolver/test/diago_elpa_utils.h
+++ b/source/source_hsolver/test/diago_elpa_utils.h
@@ -167,7 +167,7 @@ void lapack_diago(double *hmatrix, double *smatrix, double *e, int &nFull)
     const char jobz = 'V'; // 'N':only calc eigenvalue, 'V': eigenvalues and eigenvectors
     const char uplo = 'U'; // Upper triangles
     int lwork = (nFull + 2) * nFull, info = 0;
-    double *ev = new double[nFull * nFull];
+    double *ev = new double[lwork];
 
     double *a = new double[nFull * nFull];
     double *b = new double[nFull * nFull];
@@ -196,7 +196,7 @@ void lapack_diago(std::complex<double> *hmatrix, std::complex<double> *smatrix, 
     const char uplo = 'U'; // Upper triangles
     int lwork = (nFull + 1) * nFull, info = 0;
     double *rwork = new double[3 * nFull - 2];
-    std::complex<double> *ev = new std::complex<double>[nFull * nFull];
+    std::complex<double> *ev = new std::complex<double>[lwork];
 
     std::complex<double> *a = new std::complex<double>[nFull * nFull];
     std::complex<double> *b = new std::complex<double>[nFull * nFull];

--- a/source/source_hsolver/test/diago_lcao_cusolver_test.cpp
+++ b/source/source_hsolver/test/diago_lcao_cusolver_test.cpp
@@ -138,6 +138,21 @@ class DiagoPrepare
         return ok;
     }
 
+    void poison_lower_triangle()
+    {
+        // The distributed solver buffers are column-major. Keep the original
+        // row-major fixtures intact for the independent LAPACK reference.
+        for (int col = 0; col < nlocal; ++col)
+        {
+            for (int row = col + 1; row < nlocal; ++row)
+            {
+                const int index = row + col * nlocal;
+                this->h_local[index] = T(123.0 + row + col);
+                this->s_local[index] = T(0.0);
+            }
+        }
+    }
+
     void print_hs()
     {
         if (!PRINT_HS)
@@ -207,6 +222,10 @@ class DiagoPrepare
     {
         this->pb2d();
         this->distribute_data();
+        if (ks_solver == "cusolver")
+        {
+            this->poison_lower_triangle();
+        }
         this->print_hs();
         this->set_env();
 

--- a/source/source_hsolver/test/diago_lcao_test.cpp
+++ b/source/source_hsolver/test/diago_lcao_test.cpp
@@ -430,6 +430,31 @@ TEST_P(DiagoElpaNativeUpperTest, PreservesInputsAndIgnoresLowerTriangle)
 }
 
 INSTANTIATE_TEST_SUITE_P(BlockSizes, DiagoElpaNativeUpperTest, ::testing::Values(1, 2, 3));
+
+TEST(DiagoElpaComplexTest, UsesAuthoritativeUpperTriangle)
+{
+    std::stringstream out_info;
+    DiagoPrepare<std::complex<double>> dp(0, 0, 1, 0, "genelpa", "H-KPoints-Si2.dat", "S-KPoints-Si2.dat");
+    ASSERT_TRUE(dp.produce_HS());
+
+    if (dp.myrank == 0)
+    {
+        dp.diago_lapack();
+        for (int row = 1; row < dp.nlocal; ++row)
+        {
+            for (int col = 0; col < row; ++col)
+            {
+                dp.h[row * dp.nlocal + col] = std::complex<double>(17.0 + row + col, -13.0);
+            }
+        }
+    }
+
+    dp.diago();
+    if (dp.myrank == 0)
+    {
+        EXPECT_TRUE(dp.compare_eigen(out_info)) << out_info.str();
+    }
+}
 #endif
 
 int main(int argc, char** argv)

--- a/source/source_hsolver/test/diago_lcao_test.cpp
+++ b/source/source_hsolver/test/diago_lcao_test.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 #ifdef __ELPA
 #include "source_hsolver/diago_elpa.h"
+#include "source_hsolver/diago_elpa_native.h"
 #endif
 #include "source_base/module_external/scalapack_connector.h"
 
@@ -138,6 +139,44 @@ class DiagoPrepare
 
         return ok;
     }
+
+#ifdef __ELPA
+    void diago_native_with_poisoned_lower()
+    {
+        this->pb2d();
+        this->distribute_data();
+        int nprows;
+        int npcols;
+        int myprow;
+        int mypcol;
+        Cblacs_gridinfo(icontxt, &nprows, &npcols, &myprow, &mypcol);
+        for (int col = 0; col < hmtest.ncol; ++col)
+        {
+            const int global_col = (col / nb2d * npcols + mypcol) * nb2d + col % nb2d;
+            for (int row = 0; row < hmtest.nrow; ++row)
+            {
+                const int global_row = (row / nb2d * nprows + myprow) * nb2d + row % nb2d;
+                if (global_row > global_col)
+                {
+                    const int index = row + col * hmtest.nrow;
+                    h_local[index] = T(123.0 + global_row + global_col);
+                    s_local[index] = T(0.0);
+                }
+            }
+        }
+        hmtest.h_local = h_local;
+        hmtest.s_local = s_local;
+        hsolver::DiagoElpaNative<T> solver(nlocal, nbands, false);
+        solver.diag(&hmtest, psi, e_solver.data());
+        EXPECT_EQ(hmtest.h_local, h_local);
+        EXPECT_EQ(hmtest.s_local, s_local);
+        // A second solve must not reuse an in-place decomposition of the
+        // private overlap copy or alter the caller's matrix storage.
+        solver.diag(&hmtest, psi, e_solver.data());
+        EXPECT_EQ(hmtest.h_local, h_local);
+        EXPECT_EQ(hmtest.s_local, s_local);
+    }
+#endif
 
     void print_hs()
     {
@@ -370,6 +409,28 @@ INSTANTIATE_TEST_SUITE_P(
         // DiagoPrepare<std::complex<double>>(0, 0, 32, 0, "genelpa", "H-KPoints-Si64.dat", "S-KPoints-Si64.dat"),
         DiagoPrepare<std::complex<double>>(0, 0, 1, 0, "scalapack_gvx", "H-KPoints-Si2.dat", "S-KPoints-Si2.dat"),
         DiagoPrepare<std::complex<double>>(0, 0, 32, 0, "scalapack_gvx", "H-KPoints-Si64.dat", "S-KPoints-Si64.dat")));
+
+#ifdef __ELPA
+class DiagoElpaNativeUpperTest : public ::testing::TestWithParam<int>
+{
+};
+
+TEST_P(DiagoElpaNativeUpperTest, PreservesInputsAndIgnoresLowerTriangle)
+{
+    DiagoPrepare<std::complex<double>> dp(0, 0, GetParam(), 0, "genelpa",
+                                          "H-KPoints-Si2.dat", "S-KPoints-Si2.dat");
+    ASSERT_TRUE(dp.produce_HS());
+    dp.diago_native_with_poisoned_lower();
+    if (dp.myrank == 0)
+    {
+        dp.diago_lapack();
+        std::stringstream out_info;
+        EXPECT_TRUE(dp.compare_eigen(out_info)) << out_info.str();
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(BlockSizes, DiagoElpaNativeUpperTest, ::testing::Values(1, 2, 3));
+#endif
 
 int main(int argc, char** argv)
 {

--- a/source/source_io/module_parameter/read_inp_exx_dftu.cpp
+++ b/source/source_io/module_parameter/read_inp_exx_dftu.cpp
@@ -525,7 +525,8 @@ void ReadInput::item_exx()
         item.category = "Exact Exchange (LCAO)";
         item.type = "Boolean";
         item.description = R"(* False: only rotate k-space density matrix D(k) from irreducible k-points to accelerate diagonalization
-* True: rotate both D(k) and Hexx(R) to accelerate both diagonalization and EXX calculation)";
+* True: rotate both D(k) and Hexx(R) to accelerate both diagonalization and EXX calculation
+For multi-k calculations, D(k) is averaged over the unitary little group of each irreducible k point before star expansion, for either setting.)";
         item.default_value = "True";
         item.unit = "";
         item.set_availability("symmetry==1 and (dft_functional in [hse, hf, pbe0, scan0] or (basis_type==lcao and rpa==true))");

--- a/source/source_lcao/module_ri/module_exx_symmetry/symm_rotation.cpp
+++ b/source/source_lcao/module_ri/module_exx_symmetry/symm_rotation.cpp
@@ -52,28 +52,37 @@ namespace ModuleSymmetry
         }
         this->spin_U_ = spin_U;  // keep for restore_HR_nspin4 (real-space EXX H(R) spin mixing)
 
-        // 2. calculate the rotation matrix in AO-representation for each ibz_kpoint and symmetry operation: M(k, isym)
-        auto restrict_kpt = [](const TCdouble& kvec, const double& symm_prec) -> TCdouble
-            {// in (-0.5, 0.5]
-                TCdouble kvec_res;
-                kvec_res.x = fmod(kvec.x + 100.5 - 0.5 * symm_prec, 1) - 0.5 + 0.5 * symm_prec;
-                kvec_res.y = fmod(kvec.y + 100.5 - 0.5 * symm_prec, 1) - 0.5 + 0.5 * symm_prec;
-                kvec_res.z = fmod(kvec.z + 100.5 - 0.5 * symm_prec, 1) - 0.5 + 0.5 * symm_prec;
-                if (std::abs(kvec_res.x) < symm_prec) { kvec_res.x = 0.0; }
-                if (std::abs(kvec_res.y) < symm_prec) { kvec_res.y = 0.0; }
-                if (std::abs(kvec_res.z) < symm_prec) { kvec_res.z = 0.0; }
-                return kvec_res;
-            };
-        int nks_ibz = kv.kstars.size(); // kv.nks = 2 * kv.nks_ibz when nspin=2
-        this->Ms_.resize(nks_ibz);
-        for (int ik_ibz = 0;ik_ibz < nks_ibz;++ik_ibz)
+        // A k-star contains only one operation per distinct k point. The other
+        // operations fixing k (modulo a reciprocal lattice vector) must still
+        // be averaged: a finite-grid SCF density need not respect this little group.
+        const int nks_ibz = kv.kstars.size();
+        this->Ms_.assign(nks_ibz, {});
+        this->little_groups_.assign(nks_ibz, {});
+        for (int ik_ibz = 0; ik_ibz < nks_ibz; ++ik_ibz)
         {
-            // const TCdouble& kvec_d_ibz = restrict_kpt((*kstars[ik_ibz].begin()).second * ucell.symm.kgmatrix[(*kstars[ik_ibz].begin()).first], ucell.symm.epsilon);
-            for (auto& isym_kvd : kv.kstars[ik_ibz]) {
-                if (isym_kvd.first < nop_tot) {
-                    this->Ms_[ik_ibz][isym_kvd.first] = this->contruct_2d_rot_mat_ao(ucell.symm, ucell.atoms, ucell.st, kv.kvec_d[ik_ibz], isym_kvd.first, pv, spin_U[isym_kvd.first]);
-}
-}
+            std::set<int> needed;
+            for (const auto& member : kv.kstars[ik_ibz])
+            {
+                const int op = (!this->magnetic_nspin4_ && member.first >= nsym_)
+                                   ? member.first - nsym_ : member.first;
+                needed.insert(op);
+            }
+            for (int op = 0; op < nsym_; ++op)
+            {
+                const auto delta = kv.kvec_d[ik_ibz] * ucell.symm.kgmatrix[op] - kv.kvec_d[ik_ibz];
+                if (std::abs(delta.x - std::round(delta.x)) < this->eps_
+                    && std::abs(delta.y - std::round(delta.y)) < this->eps_
+                    && std::abs(delta.z - std::round(delta.z)) < this->eps_)
+                {
+                    this->little_groups_[ik_ibz].push_back(op);
+                    needed.insert(op);
+                }
+            }
+            for (const int op : needed)
+            {
+                this->Ms_[ik_ibz][op] = this->contruct_2d_rot_mat_ao(
+                    ucell.symm, ucell.atoms, ucell.st, kv.kvec_d[ik_ibz], op, pv, spin_U[op]);
+            }
         }
         // output Ms of isym=1
         // std::ofstream ofs("Ms_kibz7_sym7.dat");
@@ -109,18 +118,37 @@ namespace ModuleSymmetry
         {
             for (int ik_ibz = 0;ik_ibz < nk;++ik_ibz) 
             {
+                // P_k D = |G_k|^{-1} sum_g M_g^T D M_g^*. This preserves
+                // Hermiticity and makes restoration independent of the chosen
+                // star representative; rotating just one arbitrary D does not.
+                const auto& little_group = this->little_groups_.at(ik_ibz);
+                assert(!little_group.empty());
+                std::vector<std::complex<double>> projected = dm_k_ibz[ik_ibz + is * nk];
+                if (little_group.size() > 1)
+                {
+                    std::fill(projected.begin(), projected.end(), 0.0);
+                    for (const int op : little_group)
+                    {
+                        const auto rotated = this->rot_matrix_ao(
+                            dm_k_ibz[ik_ibz + is * nk], ik_ibz, little_group.size(), op, pv);
+                        for (size_t i = 0; i < projected.size(); ++i)
+                        {
+                            projected[i] += rotated[i];
+                        }
+                    }
+                }
                 for (auto& isym_kvd : kv.kstars[ik_ibz]) 
                 {
                     if (isym_kvd.first == 0)
                     {
                         double factor = 1.0 / static_cast<double>(kv.kstars[ik_ibz].size());
                         std::vector<std::complex<double>> dm_scaled(pv.get_local_size());
-                        for (int i = 0;i < pv.get_local_size();++i) { dm_scaled[i] = factor * dm_k_ibz[ik_ibz + is * nk][i]; }
+                        for (int i = 0;i < pv.get_local_size();++i) { dm_scaled[i] = factor * projected[i]; }
                         dm_k_full.push_back(dm_scaled);
                     }
                     else if (isym_kvd.first < nsym_)
                     { //space group operations
-                        dm_k_full.push_back(this->rot_matrix_ao(dm_k_ibz[ik_ibz + is * nk], ik_ibz, kv.kstars[ik_ibz].size(), isym_kvd.first, pv));
+                        dm_k_full.push_back(this->rot_matrix_ao(projected, ik_ibz, kv.kstars[ik_ibz].size(), isym_kvd.first, pv));
                     }
                     else
                     {    // antiunitary elements: Theta * (spatial operation)
@@ -140,12 +168,12 @@ namespace ModuleSymmetry
                             // m=0: gray group: the space-group part of anti-unitary elements are the same of the unitary elements, isym_M < nsym_
                             // m!=0: Shubnikov group: using different space-group part of anti-unitary elements stored in gmatrix_anti with isym_M >= nsym_
                             dm_k_full.push_back(this->trs_spin_rotate(
-                                this->rot_matrix_ao(dm_k_ibz[ik_ibz + is * nk], ik_ibz, kv.kstars[ik_ibz].size(), isym_M, pv, false),
+                                this->rot_matrix_ao(projected, ik_ibz, kv.kstars[ik_ibz].size(), isym_M, pv, false),
                                 sigma_y, pv, 1.0));
                         }
                         else
                         {
-                            dm_k_full.push_back(this->rot_matrix_ao(dm_k_ibz[ik_ibz + is * nk], ik_ibz, kv.kstars[ik_ibz].size(), isym_M, pv, true));
+                            dm_k_full.push_back(this->rot_matrix_ao(projected, ik_ibz, kv.kstars[ik_ibz].size(), isym_M, pv, true));
                         }
                     }
                 }
@@ -492,7 +520,7 @@ namespace ModuleSymmetry
         const char notrans = 'N';
         std::complex<double> alpha(1.0, 0.0);
         const std::complex<double> beta(0.0, 0.0);
-        const int nbasis = PARAM.globalv.nlocal;
+        const int nbasis = pv.get_global_row_size();
         const int i1 = 1;
         if (TRS_conj)
         {

--- a/source/source_lcao/module_ri/module_exx_symmetry/symm_rotation.h
+++ b/source/source_lcao/module_ri/module_exx_symmetry/symm_rotation.h
@@ -74,6 +74,17 @@ namespace ModuleSymmetry
         std::vector<std::complex<double>> trs_spin_rotate(const std::vector<std::complex<double>>& X,
             const std::vector<std::complex<double>>& sigma_y, const Parallel_2D& pv, const double scale) const;
 
+        /// Inject synthetic AO rotations for density-restoration regression tests.
+        void set_density_rotations_for_testing(
+            const std::vector<std::map<int, std::vector<std::complex<double>>>>& rotations,
+            const std::vector<std::vector<int>>& little_groups,
+            const int nrot)
+        {
+            this->Ms_ = rotations;
+            this->little_groups_ = little_groups;
+            this->nsym_ = nrot;
+        }
+
         /// calculate Wigner D matrix
         double wigner_d(const double beta, const int l, const int m1, const int m2) const;
         std::complex<double> wigner_D(const TCdouble& euler_angle, const int l, const int m1, const int m2, const bool inv) const;
@@ -208,6 +219,10 @@ namespace ModuleSymmetry
         /// The unitary matrix associate D(Rk) with D(k) for each ibz-kpoint Rk and each symmetry operation.
         /// size: [nks_ibz][nsym][nbasis*nbasis], only need to calculate once.
         std::vector<std::map<int, std::vector<std::complex<double>>>> Ms_;
+
+        /// Unitary operations fixing each IBZ k point modulo reciprocal lattice vectors.
+        /// Geometry data built with Ms_ in cal_Ms, not an SCF workflow switch.
+        std::vector<std::vector<int>> little_groups_;
 
         /// (nspin=4) the SU(2) spin-1/2 rotation U(isym) for each symmetry operation, size [nsym].
         /// The spinor AO rotation is T(isym) (x) U(isym); restore_HR_nspin4 uses it to mix the 4 spin

--- a/source/source_lcao/module_ri/module_exx_symmetry/test/CMakeLists.txt
+++ b/source/source_lcao/module_ri/module_exx_symmetry/test/CMakeLists.txt
@@ -4,7 +4,7 @@ abacus_disable_feature_definitions(__ROCM)
 AddTest(
   TARGET MODULE_RI_EXX_SYMMETRY_rotation
   LIBS base device symmetry neighbor parameter
-  SOURCES symm_rotation_test.cpp ../symm_rotation.cpp ../symm_rot_out.cpp ../irreducible_sector.cpp ../irred_sec_bvk.cpp
+  SOURCES symm_rotation_test.cpp test_symm_rotation.cpp ../symm_rotation.cpp ../symm_rot_out.cpp ../irreducible_sector.cpp ../irred_sec_bvk.cpp
   ../../../../source_basis/module_ao/parallel_orbitals.cpp
 
 )

--- a/source/source_lcao/module_ri/module_exx_symmetry/test/test_symm_rotation.cpp
+++ b/source/source_lcao/module_ri/module_exx_symmetry/test/test_symm_rotation.cpp
@@ -1,0 +1,161 @@
+#include "../symm_rotation.h"
+#include "source_io/module_parameter/parameter.h"
+#include "gtest/gtest.h"
+
+class TestParameters
+{
+  public:
+    TestParameters(Parameter& parameters, const int nspin)
+        : parameters_(parameters), original_nspin_(parameters.inp.nspin)
+    {
+        parameters_.input.nspin = nspin;
+    }
+    ~TestParameters() { parameters_.input.nspin = original_nspin_; }
+
+  private:
+    Parameter& parameters_;
+    const int original_nspin_;
+};
+
+// K-point generation is outside this test: use explicit stars, but provide
+// the virtual symbols needed by the existing lightweight rotation test target.
+void ModuleCell::ReciprocalGrid::renew(const int&)
+{
+    ADD_FAILURE() << "Unexpected k-point generation";
+}
+void K_Vectors::renew(const int&)
+{
+    ADD_FAILURE() << "Unexpected k-point generation";
+}
+void K_Vectors::reduce_by_symmetry(const UnitCell&, const ModuleSymmetry::Symmetry&,
+                                  bool, std::string&, bool&, const int, std::ofstream&)
+{
+    ADD_FAILURE() << "Unexpected k-point reduction";
+}
+
+namespace
+{
+using Complex = std::complex<double>;
+
+// Independent dense product in the stored (transposed density) convention.
+std::vector<Complex> rotate_reference(const std::vector<Complex>& density,
+                                      const std::vector<Complex>& rotation,
+                                      const int n)
+{
+    std::vector<Complex> result(n * n, 0.0);
+    for (int i = 0; i < n; ++i)
+    {
+        for (int j = 0; j < n; ++j)
+        {
+            for (int a = 0; a < n; ++a)
+            {
+                for (int b = 0; b < n; ++b)
+                {
+                    result[i + j * n] += rotation[a + i * n] * density[a + b * n]
+                                         * std::conj(rotation[b + j * n]);
+                }
+            }
+        }
+    }
+    return result;
+}
+
+void check_little_group_restoration(const int nspin)
+{
+    const TestParameters parameters(PARAM, nspin);
+    const int channels = nspin == 2 ? 2 : 1;
+    const int n = 4;
+    Parallel_2D pv;
+    pv.init(n, n, 1, MPI_COMM_WORLD);
+    ModuleSymmetry::Symmetry_rotation rotation;
+    std::vector<Complex> identity(n * n, 0.0);
+    std::vector<Complex> little(n * n, 0.0);
+    std::vector<Complex> representative(n * n, 0.0);
+    std::vector<Complex> alternate(n * n, 0.0);
+    const int sign[n] = {1, 1, -1, -1};
+    for (int i = 0; i < n; ++i)
+    {
+        identity[i + i * n] = 1.0;
+        little[i + i * n] = sign[i];
+        const int row = (i + 1) % n;
+        representative[row + i * n] = std::polar(1.0, 0.3 * i);
+        alternate[row + i * n] = double(sign[row]) * representative[row + i * n];
+    }
+    auto local = [&pv, n](const std::vector<Complex>& dense) {
+        std::vector<Complex> result(pv.get_local_size());
+        for (int i = 0; i < n; ++i)
+        {
+            for (int j = 0; j < n; ++j)
+            {
+                if (pv.in_this_processor(i, j))
+                {
+                    result[pv.global2local_row(i) + pv.global2local_col(j) * pv.get_row_size()]
+                        = dense[i + j * n];
+                }
+            }
+        }
+        return result;
+    };
+    rotation.set_density_rotations_for_testing(
+        {{{0, local(identity)}, {1, local(little)}, {2, local(representative)}, {3, local(alternate)}}},
+        {{0, 1}}, 4);
+    K_Vectors kv;
+    kv.set_nkstot(channels);
+    kv.set_nkstot_nospin(2);
+    kv.kstars = {{{0, {0.25, 0.0, 0.0}}, {2, {0.0, 0.25, 0.0}}}};
+    std::vector<std::vector<Complex>> inputs;
+    std::vector<std::vector<Complex>> expected;
+    for (int spin = 0; spin < channels; ++spin)
+    {
+        std::vector<Complex> density(n * n);
+        std::vector<Complex> projected(n * n);
+        for (int i = 0; i < n; ++i)
+        {
+            for (int j = 0; j < n; ++j)
+            {
+                const Complex value((spin + 1) * (2.0 + i + j), 0.2 * (i - j));
+                density[i + j * n] = value;
+                // For this C2 little group, averaging removes exactly the odd blocks.
+                projected[i + j * n] = sign[i] == sign[j] ? 0.5 * value : Complex(0.0);
+            }
+        }
+        inputs.push_back(local(density));
+        expected.push_back(local(projected));
+        expected.push_back(local(rotate_reference(projected, representative, n)));
+    }
+    const auto restored = rotation.restore_dm(kv, inputs, pv);
+    ASSERT_EQ(restored.size(), expected.size());
+    for (size_t k = 0; k < expected.size(); ++k)
+    {
+        for (size_t i = 0; i < expected[k].size(); ++i)
+        {
+            EXPECT_NEAR(std::abs(restored[k][i] - expected[k][i]), 0.0, 1e-12);
+        }
+    }
+    // A different representative of the same star must give the same density.
+    kv.kstars = {{{0, {0.25, 0.0, 0.0}}, {3, {0.0, 0.25, 0.0}}}};
+    const auto changed_representative = rotation.restore_dm(kv, inputs, pv);
+    for (size_t k = 0; k < expected.size(); ++k)
+    {
+        for (size_t i = 0; i < expected[k].size(); ++i)
+        {
+            EXPECT_NEAR(std::abs(changed_representative[k][i] - restored[k][i]), 0.0, 1e-12);
+        }
+    }
+}
+} // namespace
+
+TEST(SymmetryDensityRestoration, LittleGroupAndStarWeight)
+{
+    check_little_group_restoration(1);
+}
+
+TEST(SymmetryDensityRestoration, IndependentSpinChannels)
+{
+    check_little_group_restoration(2);
+}
+
+TEST(SymmetryDensityRestoration, SpinorDensity)
+{
+    check_little_group_restoration(4);
+}

--- a/tests/08_EXX/08_KP_HSE_symm/README
+++ b/tests/08_EXX/08_KP_HSE_symm/README
@@ -1,1 +1,30 @@
-HSE calculation on Si, multiple k-points, cal force and stress, exx real number, symmetry=1
+HSE calculation on Si, multiple k-points, force and stress, real EXX, symmetry=1.
+
+The density at each irreducible k point must be averaged over its unitary
+little group before expanding its star. A star stores one representative per
+unique k point; it does not contain all operations fixing that point. On this
+coarse finite grid, omitting that average leaves the EXX density outside the
+space-group-invariant subspace, so rotating irreducible H(R) blocks can produce
+a non-Hermitian Hamiltonian.
+
+In ABACUS's transposed density storage, the average is
+  P_k(D) = sum_{g in G_k} M_g^T D M_g^* / |G_k|,
+where g k = k modulo a reciprocal lattice vector. P_k is a group projector:
+it preserves Hermiticity and removes dependence on the chosen unitary star
+representative. The existing star-size factor is applied only after averaging.
+The unit tests in module_exx_symmetry/test/test_symm_rotation.cpp exercise this
+contract with complex matrices and separate spin channels.
+
+The reference energy and stress were regenerated after this correction, with
+unchanged INPUT and thresholds. On the same case, corrected ScaLAPACK runs with
+1 and 4 MPI ranks and one-stage ELPA runs with 1 and 4 ranks agree within 1e-9 eV;
+all report totalstressref=2143.792554 and totalforceref=0.000000. Disabling only
+exx_symmetry_realspace (full EXX contraction with the same projected density)
+also agrees within 2e-10 eV. The maximum ||H-H^dagger||_F over 57 solves drops
+from 6.7e-3 to 1.3e-15. This is a fixed-input regression reference, not a claim of
+cutoff or outer-loop convergence. The historical timing reference is retained.
+
+Verification used GCC, OpenMPI 5.0.10, ELPA 2026.02.001, LibXC 7.0.0 and the
+repository-pinned LibRI. The two-stage ELPA backend in that environment failed
+before the first EXX update, so its result is not included in the agreement
+claim; no solver-stage change is part of this fix.

--- a/tests/08_EXX/08_KP_HSE_symm/result.ref
+++ b/tests/08_EXX/08_KP_HSE_symm/result.ref
@@ -1,7 +1,7 @@
-etotref -189.4277005988057567
-etotperatomref -94.7138502994
+etotref -189.4406826023468398
+etotperatomref -94.7203413012
 totalforceref 0.000000
-totalstressref 2155.899405
+totalstressref 2143.792554
 pointgroupref D_3d
 spacegroupref O_h
 nksibzref 3


### PR DESCRIPTION
### Reminder

- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have linked an issue or explained why this PR does not need one.
- [x] I have added adequate unit tests and/or case tests, or explained why not.
- [x] I have listed the exact verification commands run and their results.
- [x] I have described user-visible behavior changes, including INPUT parameter changes.
- [x] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [x] I have requested any needed governance exception below.

### Linked Issue

Related to #7914. This PR corrects authoritative-upper-triangle handling in the separate native ELPA and cuSolver implementations, and fixes an EXX little-group density-restoration issue exposed by enforcing that matrix contract. No separate issue is required.

The `genelpa` transform and fallback corrections from #7914 are now included through upstream develop, with TaoXia's original attribution preserved. They are no longer a pending dependency.

### Unit Tests and/or Case Tests for my changes

**Commands run**

For the fresh six-way experiment, each diagnostic variant was rebuilt from commit `75ee7493a`, then run in a separate case directory:

```sh
export OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
export UCX_TLS=^xpmem

cmake --build "$BUILD_DIR" -j8 --target abacus_std_para
"$BUILD_DIR/abacus_std_para" --version

# VARIANT_BINARY identifies the corresponding rebuilt diagnostic executable.
timeout 180 mpirun -np 1 "$VARIANT_BINARY"
```

The experiment crosses two controlled factors:

- little-group averaging: off / on;
- solver path: old PZGEMM transform control / corrected PZHEMM / ScaLAPACK.

The old-transform control changes only the Cholesky-branch `hemm('L','U',A,B)` operation back to `gemm('C','N',A,B)` on the same current baseline. It does not revert the whole repository. All recorded ELPA decomposition states were `1`; the fallback branch was not exercised in this experiment.

Both ELPA controls use the same diagnostic one-stage setting to avoid the previously observed installed two-stage library failure. This setting is not part of the production changes in the PR.

**Result summary**

All six calculations completed successfully on 2026-09-14.

| Solver path | Without little-group averaging: E (eV) | With little-group averaging: E (eV) |
|---|---:|---:|
| Old PZGEMM transform control | -189.4161946676993 | -189.4406826021399 |
| Corrected PZHEMM | -189.4135167215100 | -189.4406826018135 |
| ScaLAPACK | -189.4135167204379 | -189.4406826023468 |

Without averaging, the maximum solver-dependent energy difference is **2.678 meV**, while corrected PZHEMM and ScaLAPACK agree within `1.073e-9 eV`.

**After little-group averaging, all three paths agree within `5.33305e-10 eV`, including the old PZGEMM control.** They also give the same force absolute sum (`0.000000 eV/Å`) and stress absolute sum (`2143.792554 kbar`) at the output precision.

Matrix diagnostics were collected at the common solver entry point: **57 solves per case, 342 complete H/S and eigenpair records in total**.

| Solver path | Without averaging: max ‖H−H†‖F | With averaging: max ‖H−H†‖F | With averaging: max full-H normalized residual |
|---|---:|---:|---:|
| Old PZGEMM control | 6.728525e-3 | 1.193271e-15 | 3.143836e-16 |
| Corrected PZHEMM | 6.692699e-3 | 1.223335e-15 | 2.603592e-16 |
| ScaLAPACK | 6.692699e-3 | 1.197093e-15 | 2.724060e-16 |

The raw matrix norms use ABACUS's internal matrix units. The normalized residual is

```math
r = \frac{\| H C - S_{U} C E \|_{F}}
{\| H \|_{F} \| C \|_{F} + \| S_{U} C E \|_{F}}.
```

Here, $E$ is the diagonal matrix of computed eigenvalues, $H$ is the original full Hamiltonian, and $S_{U}$ is reconstructed from the authoritative upper triangle of $S$.

Independent NumPy Cholesky/eigvalsh calculations give eigenvalue disagreements no larger than `4.885e-15` in internal energy units after averaging.

Without averaging, corrected PZHEMM and ScaLAPACK solve the upper-triangle-completed Hermitian problem with residuals below `3.020e-16`, but their residuals against the original full H are approximately `3.511e-4`. After averaging, both the upper-triangle contract and the full-matrix eigenproblem are satisfied at roundoff.

Matched conditions and provenance:

- Source baseline: commit `75ee7493a`.
- Hardware: Intel Xeon CPU Max 9470C CPU.
- All runs: one MPI rank, one OpenMP thread, one OpenBLAS thread.
- GNU toolchain, OpenMPI 5.0.10, ELPA 2026.02.001-2603, LibXC 7.0.0, CMake 3.31.6; executable reports ABACUS `v3.11.0-beta9`.
- Input: `tests/08_EXX/08_KP_HSE_symm`, preserving its SCF/EXX thresholds and three EXX outer updates.
- SHA256 verification covered 2664 source/CMake files before building. Variant patches, source hashes, binary hashes, logs, and matrix records were retained.
- All six cases exited 0 and produced `#SCF IS CONVERGED#`, final energy, and normal termination records.
- The original source was subsequently restored, hash-verified, and rebuilt.

The retained focused regression coverage includes:

- Poisoned-lower-triangle tests against an independent LAPACK reference: previous native ELPA 3/3 failed, corrected implementation 3/3 passed; previous real/complex cuSolver 2/2 failed, corrected implementation 2/2 passed.
- Caller-owned native ELPA H/S buffers remain unchanged across two consecutive solves.
- Two complex ELPA upper-triangle/fallback tests, three native ELPA block-size tests, and three K-point solver tests passed in the earlier merged-source validation.
- Twelve EXX symmetry tests passed, including little-group/star-weight restoration, representative independence, separate spin channels, and spinor-density fixtures.

**Checks not run, with reason**

- GPU tests were not rerun in this CPU six-way experiment; the earlier cuSolver positive/negative-control results are retained.
- The complete solver CTest and four-rank complex ELPA runs previously encountered failures inside the installed two-stage ELPA library. They are not counted as passing verification.
- Full-repository testing was not run; verification targets the changed solver contract and EXX restoration behavior.

### What's changed?

This PR fixes two related correctness issues: Hermitian matrix input handling in native ELPA/cuSolver, and missing unitary little-group averaging before EXX k-star restoration.

**1. Respect the authoritative upper triangles of H and S**

For the generalized Hermitian eigenproblem,

```math
HC=SC\varepsilon,\qquad
S=U^\dagger U,\qquad
\widetilde H=U^{-\dagger}HU^{-1}.
```

LCAO supplies authoritative upper triangles of H/S. A solver must not depend on stale or unspecified lower-triangle entries.

The changes:

- Reconstruct private Hermitian H/S copies from the upper triangles before complex native ELPA solves.
- Preserve caller-owned buffers and avoid reusing a decomposition of temporary overlap storage.
- Select the upper triangle for real and complex cuSolver.
- Retain upstream's `genelpa` Hermitian-transform and fallback corrections.
- Correct the LAPACK regression workspace allocation to match its advertised size.

**2. Average the IBZ density over its little group before star expansion**

A k-star stores one representative operation for each distinct k point. It does not contain every operation fixing the irreducible k point modulo a reciprocal lattice vector.

Define the unitary little group as

```math
G_{k}=\{g\mid gk=k+\mathbf G,\quad
\mathbf G\text{ is a reciprocal lattice vector}\}.
```

The density must first be projected onto the invariant subspace:

```math
\mathcal{P}_{k}[D]
=\frac{1}{|G_{k}|}\sum_{g\in G_{k}}\mathcal{U}_{g}[D].
```

In ABACUS's transposed density storage convention,

```math
\mathcal{U}_{g}[D]=M_{g}^{T} D M_{g}^{*},\qquad
\mathcal{P}_{k}[D]
=\frac{1}{|G_{k}|}\sum_{g\in G_{k}}M_{g}^{T} D M_{g}^{*},
```

where $M_{g}$ is the AO rotation matrix in the code's convention.

This group average preserves Hermiticity, is idempotent, and makes the density invariant under little-group operations. Operations reaching the same star member differ by a little-group operation, so averaging removes dependence on the selected representative.

The implementation collects the required unitary little-group operations and AO rotations, averages the IBZ density, and then performs the existing star expansion. The existing star-size weight is applied separately after averaging. Identity-only little groups bypass the additional averaging work.

A single valid rotation preserves Hermiticity. The missing average instead leaves the density inconsistent with the symmetry relations assumed by reduced EXX contractions, which can produce a non-Hermitian Hamiltonian.

The six-way experiment demonstrates the consequence directly: **little-group averaging removes the solver-dependent energy split and restores the full Hamiltonian's Hermiticity and eigenproblem residuals to roundoff.** Matching the historical reference energy alone would not establish correctness.

The HSE reference and explanatory README are updated using independently checked results. The original case inputs and tolerances are retained.

### Governance Notes

- **INPUT/docs changes:** no new parameter names or defaults. The existing EXX symmetry description is synchronized between its C++ registration, `docs/parameters.yaml`, and `docs/advanced/input_files/input-main.md`. The HSE reference and README document the corrected behavior.
- **Core module impact:** native ELPA input preparation, cuSolver triangle selection, EXX AO-rotation preparation and density restoration, and their regression helpers. The average covers unitary little-group operations; existing antiunitary restoration handling is retained. No new full magnetic-group projection algorithm or `gga_grad` functionality is introduced.
- **Attribution:** TaoXia's upstream `genelpa` corrections retain their original attribution. The native ELPA/cuSolver corrections, regression-helper changes, and EXX little-group restoration fix are included in this PR.
- **Exceptions requested:** none. Local governance checks report no blockers. The additional PARAM reference in the EXX test fixture is balanced by a removed production reference, giving net zero global-reference growth.
