### PR TITLE
Fix: Intel classic (icpc) build error "EKinetic is not a template"

### DIFF
--- a/source/source_lcao/module_operator_lcao/ekinetic.cpp
+++ b/source/source_lcao/module_operator_lcao/ekinetic.cpp
@@ -33,7 +33,7 @@ hamilt::EKinetic<hamilt::OperatorLCAO<TK, TR>>::EKinetic(
 
 // destructor
 template <typename TK, typename TR>
-hamilt::EKinetic<hamilt::OperatorLCAO<TK, TR>>::~EKinetic<hamilt::OperatorLCAO<TK, TR>>()
+hamilt::EKinetic<hamilt::OperatorLCAO<TK, TR>>::~EKinetic()
 {
     if (this->allocated)
     {

--- a/source/source_lcao/module_operator_lcao/ekinetic.h
+++ b/source/source_lcao/module_operator_lcao/ekinetic.h
@@ -12,9 +12,6 @@
 namespace hamilt
 {
 
-#ifndef __EKINETICTEMPLATE
-#define __EKINETICTEMPLATE
-
 /// The EKinetic class template inherits from class T
 /// it is used to calculate the electronic kinetic
 /// Template parameters:
@@ -24,8 +21,6 @@ template <class T>
 class EKinetic : public T
 {
 };
-
-#endif
 
 /// EKinetic class template specialization for OperatorLCAO<TK> base class
 /// It is used to calculate the electronic kinetic matrix in real space and fold it to k-space

--- a/source/source_pw/module_pwdft/op_pw_ekin.h
+++ b/source/source_pw/module_pwdft/op_pw_ekin.h
@@ -8,15 +8,7 @@
 
 namespace hamilt {
 
-// Not needed anymore
-#ifndef __EKINETICTEMPLATE
-#define __EKINETICTEMPLATE
-
 template<class T> class Ekinetic : public T {};
-// template<typename R, typename Device = base_device::DEVICE_CPU>
-// class Ekinetic : public OperatorPW<T, Device> {};
-
-#endif
 
 // template<typename R, typename Device = base_device::DEVICE_CPU>
 // class Ekinetic : public OperatorPW<T, Device>


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have linked an issue or explained why this PR does not need one.
- [x] I have added adequate unit tests and/or case tests, or explained why not.
- [x] I have listed the exact verification commands run and their results.
- [x] I have described user-visible behavior changes, including INPUT parameter changes.
- [x] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [x] I have requested any needed governance exception below.

### Linked Issue
Fix #7927

### Unit Tests and/or Case Tests for my changes
- Commands run:
  - `icpc` 2022.1 (Intel classic, Rocky Linux 8.8, LCAO+LIBRI+PEXSI+MLALGO enabled): direct compilation of `source/source_lcao/module_operator_lcao/ekinetic.cpp` — previously failing with `error: EKinetic is not a template`, now compiles.
  - `g++ -std=gnu++14 -fsyntax-only source/source_lcao/module_operator_lcao/ekinetic.cpp` with the standard ABACUS define set (`__EXX`, `__LCAO`, `__MPI`, ...), GCC 11.4.0.
  - `g++ -std=gnu++14 -fsyntax-only source/source_pw/module_pwdft/op_pw_ekin.cpp` (same flags).
  - Forced dual-include TUs (`op_pw_ekin.h` + `ekinetic.h`, both include orders) with `g++ -std=gnu++11 -fsyntax-only`: previously failing on GCC with `'EKinetic'/'Ekinetic' is not a class template`; now clean in both orders.
- Result summary: all pass.
- Checks not run, with reason: no new unit test added — this is a compile-compatibility fix with zero runtime behavior change; no Intel classic CI exists, and the affected TUs are covered by the existing GCC/icpx CI builds.

### What's changed?
- `source_lcao/module_operator_lcao/ekinetic.cpp`: the out-of-line destructor of the partial specialization `EKinetic<OperatorLCAO<TK,TR>>` is named plainly again (`~EKinetic()`), reverting the template-argument form `~EKinetic<hamilt::OperatorLCAO<TK, TR>>()` introduced by bbd23ca03 (#7879), which icpc's EDG frontend cannot resolve ("EKinetic is not a template"; the injected-class-name of the partial specialization is found as a type and cannot take a template argument list in this context). GCC/Clang(icpx) accept both forms, so GCC CI never caught it.
- `source_lcao/module_operator_lcao/ekinetic.h`, `source_pw/module_pwdft/op_pw_ekin.h`: removed the inner `#ifndef __EKINETICTEMPLATE` guard blocks. Both headers shared that one macro, so any TU including both headers (in either order) skipped the second primary template and failed — on any compiler, GCC included (currently unreachable in our build graph, but a latent hazard). The outer include guards already prevent double inclusion, and the change also drops the reserved double-underscore identifier.

### Governance Notes
- INPUT/docs changes: none; no user-visible behavior change.
- Core module impact: Operator layer only (LCAO kinetic operator definition + PW kinetic operator header). No runtime behavior change.
- Exceptions requested: none.
