### PR TITLE
Fix: Intel classic (icpc) build error — ambiguous Conv_Coulomb_Pot_K::cal_orbs_ccp overloads

### DIFF
--- a/source/source_lcao/module_ri/conv_coulomb_pot_k.h
+++ b/source/source_lcao/module_ri/conv_coulomb_pot_k.h
@@ -3,14 +3,22 @@
 
 #include "source_hamilt/module_xc/coulomb_config.h"
 
+#include <type_traits>
+
 namespace Conv_Coulomb_Pot_K
 {
-	template<typename T> extern T cal_orbs_ccp(
+	// Constrains the scalar cal_orbs_ccp/cal_orbs_ccp_spencer overloads below:
+	// icpc cannot order them against the recursive std::vector overloads and
+	// reports an ambiguity, so the scalar overload is disabled for vectors.
+	template<typename T> struct is_std_vector : std::false_type {};
+	template<typename T, typename Alloc> struct is_std_vector<std::vector<T, Alloc>> : std::true_type {};
+
+	template<typename T> extern typename std::enable_if<!is_std_vector<T>::value, T>::type cal_orbs_ccp(
 		const T &orbs,
 		const CoulombParam &coulomb_param,
 		const double rmesh_times);
 
-	template<typename T> extern T cal_orbs_ccp_spencer(
+	template<typename T> extern typename std::enable_if<!is_std_vector<T>::value, T>::type cal_orbs_ccp_spencer(
 		const T &orbs,
 		const CoulombParam &coulomb_param,
 		const double rmesh_times);


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have linked an issue or explained why this PR does not need one.
- [x] I have added adequate unit tests and/or case tests, or explained why not.
- [x] I have listed the exact verification commands run and their results.
- [x] I have described user-visible behavior changes, including INPUT parameter changes.
- [x] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [x] I have requested any needed governance exception below.

### Linked Issue
Fix #7928

### Unit Tests and/or Case Tests for my changes
- Commands run:
  - Intel classic `icpc` 2021.6/2022.1 build of the previously failing call sites (`exx_lri.hpp:77`, `ewald_vq.hpp:59`, instantiated from `module_rdmft/rdmft.cpp`) — verified by the patch author; see commit message.
  - `g++ -std=gnu++14 -fsyntax-only source/source_lcao/module_ri/conv_coulomb_pot_k.cpp` with the standard ABACUS define set (`__EXX`, `__LCAO`, `__MPI`, ...), GCC 11.4.0.
  - `g++ -std=gnu++14 -fsyntax-only source/source_lcao/module_rdmft/rdmft.cpp` (same flags) — the translation unit icpc failed on; passes, confirming no regression for GCC.
  - Repo-wide grep for `is_std_vector`: no name collisions.
- Result summary: all pass.
- Checks not run, with reason: no new unit test — compile-compatibility fix with zero runtime behavior change; no Intel classic CI exists, and the affected TUs are covered by GCC/icpx CI.

### What's changed?
- `source_lcao/module_ri/conv_coulomb_pot_k.h`: the scalar overloads of `Conv_Coulomb_Pot_K::cal_orbs_ccp` / `cal_orbs_ccp_spencer` are now constrained with `std::enable_if<!is_std_vector<T>::value>`, so for `std::vector` arguments only the recursive vector overload participates in overload resolution. icpc's EDG frontend cannot order the two function templates by partial ordering and reported "more than one instance of overloaded function matches the argument list"; with the scalar candidate SFINAE'd out there is exactly one viable overload. GCC/icpx behavior is unchanged (they already picked the vector overload via partial ordering).

Note: `get_rmesh_proportion` in the same header keeps the old primary-template + `.cpp`-only explicit specialization pattern, but it has no call sites and is never instantiated, so it does not trigger the issue; it can be cleaned up in a follow-up if desired.

### Governance Notes
- INPUT/docs changes: none; no user-visible behavior change.
- Core module impact: `module_ri` only (Coulomb-potential convolution helpers used by EXX/RDMFT); no runtime behavior change.
- Exceptions requested: none.
