### PR TITLE
Fix: add missing <string> include in simple_pexsi.h (Intel classic build)

### DIFF
--- a/source/source_hsolver/module_pexsi/simple_pexsi.h
+++ b/source/source_hsolver/module_pexsi/simple_pexsi.h
@@ -2,6 +2,7 @@
 #define SIMPLE_PEXSI_H
 
 #include <mpi.h>
+#include <string>
 // a simple interface for calling pexsi with 2D block cyclic distributed matrix
 namespace pexsi
 {


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have linked an issue or explained why this PR does not need one.
- [x] I have added adequate unit tests and/or case tests, or explained why not.
- [x] I have listed the exact verification commands run and their results.
- [x] I have described user-visible behavior changes, including INPUT parameter changes.
- [x] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [x] I have requested any needed governance exception below.

### Linked Issue
None — trivial header self-containment fix for an Intel classic (icpc) build failure; a dedicated issue would add no information beyond this description.

### Unit Tests and/or Case Tests for my changes
- Commands run:
  - Self-containment check, post-fix: `mpicxx -std=gnu++14 -fsyntax-only` on a TU containing only `#include "source_hsolver/module_pexsi/simple_pexsi.h"` — passes.
  - Same check on the pre-fix header: fails with `simple_pexsi.h:20:28: error: 'string' in namespace 'std' does not name a type` — confirming the header was not self-contained and only compiled via transitive `<string>` includes.
  - Intel classic `icpc` 2021.6/2022.1 build of `pexsi_solver.cpp` (which previously emitted `simple_pexsi.h(20): error: namespace "std" has no member "string"`): verified on the Intel classic machine.
- Result summary: all pass.
- Checks not run, with reason: no unit test applicable to an `#include` addition; no runtime behavior change.

### What's changed?
- `source_hsolver/module_pexsi/simple_pexsi.h`: add `#include <string>`. The header declares `simplePEXSI(..., const std::string PexsiOptionFile, ...)` but only included `<mpi.h>`; `std::string` relied on transitive includes. GCC/icpx happen to pull in `<string>` through other headers; Intel classic (icpc) does not, so compiling `pexsi_solver.cpp` fails with `namespace "std" has no member "string"`. Including `<string>` explicitly follows the self-contained-header principle and is safe on every compiler.

### Governance Notes
- INPUT/docs changes: none; no user-visible behavior change.
- Core module impact: HSolver/PEXSI header only; no runtime behavior change.
- Exceptions requested: none.
