### PR TITLE
Fix GPU validation Slurm account and stale PW test paths

### DIFF
--- a/.ci/slurm/build.sbatch.in
+++ b/.ci/slurm/build.sbatch.in
@@ -2,6 +2,7 @@
 #SBATCH --job-name=@JOB_NAME@
 #SBATCH --partition=@PARTITION@
 #SBATCH --qos=@QOS@
+#SBATCH --account=abacus-group
 #SBATCH --nodes=@NODES@
 #SBATCH --ntasks=@TASKS@
 #SBATCH --ntasks-per-node=@TASKS_PER_NODE@

--- a/.ci/slurm/case.sbatch.in
+++ b/.ci/slurm/case.sbatch.in
@@ -2,6 +2,7 @@
 #SBATCH --job-name=@JOB_NAME@
 #SBATCH --partition=@PARTITION@
 #SBATCH --qos=@QOS@
+#SBATCH --account=abacus-group
 #SBATCH --nodes=@NODES@
 #SBATCH --ntasks=@TASKS@
 #SBATCH --ntasks-per-node=@TASKS_PER_NODE@

--- a/.ci/slurm/config.ini
+++ b/.ci/slurm/config.ini
@@ -752,3 +752,9 @@ suite = 07_OFDFT
 name = 31_OF_KE_WT_GPU
 resource = pw_gpu1
 runner = autotest
+
+[case.124]
+suite = 01_PW
+name = 090_PW_out_pchg_wfc_spinor
+resource = pw_gpu1
+runner = autotest_gpu

--- a/.ci/slurm/config.ini
+++ b/.ci/slurm/config.ini
@@ -701,37 +701,37 @@ runner = autotest_gpu
 
 [case.115]
 suite = 01_PW
-name = 090_PW_VWR
+name = 091_PW_VWR
 resource = pw_gpu1
 runner = autotest_gpu
 
 [case.116]
 suite = 01_PW
-name = 091_PW_CR_VDW3
+name = 092_PW_CR_VDW3
 resource = pw_gpu1
 runner = autotest_gpu
 
 [case.117]
 suite = 01_PW
-name = 094_PW_NPT
+name = 095_PW_NPT
 resource = pw_gpu1
 runner = autotest_gpu
 
 [case.118]
 suite = 01_PW
-name = 098_PW_15_SO_avg
+name = 099_PW_15_SO_avg
 resource = pw_gpu1
 runner = autotest_gpu
 
 [case.119]
 suite = 01_PW
-name = 101_PW_MD_1O
+name = 102_PW_MD_1O
 resource = pw_gpu1
 runner = autotest_gpu
 
 [case.120]
 suite = 01_PW
-name = 102_PW_MD_2O
+name = 103_PW_MD_2O
 resource = pw_gpu1
 runner = autotest_gpu
 

--- a/.ci/slurm/slurm.py
+++ b/.ci/slurm/slurm.py
@@ -31,7 +31,7 @@ class Slurm:
         return result.stdout
 
     def submit(self, script: Path, array_count: Optional[int] = None) -> str:
-        output = self._run(("sbatch", "--parsable", str(script))).strip()
+        output = self._run(("sbatch", "--account=abacus-group", "--parsable", str(script))).strip()
         match = re.fullmatch(r"([0-9]+)(?:;[A-Za-z0-9_.-]+)?", output)
         if not match:
             raise SlurmError("invalid sbatch output: {!r}".format(output))

--- a/.ci/slurm/test_runner.py
+++ b/.ci/slurm/test_runner.py
@@ -42,7 +42,7 @@ def valid_result():
 class ConfigTests(unittest.TestCase):
     def test_current_matrix_is_loaded_from_ini(self):
         config = runner.load_config()
-        self.assertEqual(len(config.cases), 123)
+        self.assertEqual(len(config.cases), 124)
         self.assertEqual(list(config.resources), ["gpu1", "gpu2", "gpu4", "gpu4x2", "pw_gpu1"])
         self.assertEqual(config.resources["gpu4"].label, "4 GPUs")
         self.assertEqual(config.resources["gpu4x2"].label, "2 nodes / 8 GPUs")
@@ -60,7 +60,7 @@ class ConfigTests(unittest.TestCase):
             },
         )
         pw_cases = [case for case in config.cases if case.suite == "01_PW"]
-        self.assertEqual(len(pw_cases), 73)
+        self.assertEqual(len(pw_cases), 74)
         self.assertTrue(all(case.resource == "pw_gpu1" for case in pw_cases))
         self.assertTrue(all(case.runner == "autotest_gpu" for case in pw_cases))
         ofdft_cases = [case for case in config.cases if case.suite == "07_OFDFT"]
@@ -815,7 +815,7 @@ class ResultTests(unittest.TestCase):
             runner._print_result(result, root, "/remote/archives/manual/1-1.tar.gz")
             text = output.getvalue()
         self.assertIn("GPU validation: PASS", text)
-        self.assertIn("123 passed, 0 failed, 0 infrastructure", text)
+        self.assertIn("124 passed, 0 failed, 0 infrastructure", text)
         self.assertIn("Compile                  PASS", text)
         self.assertIn("tests/01_PW              PASS", text)
         self.assertRegex(text, r"tests/15_rtTDDFT_GPU\s+PASS")


### PR DESCRIPTION
GPU validation could fail before execution because Slurm submissions did not specify the abacus-group account, and six 01_PW entries in the GPU matrix referenced directories renamed in commit 74d75b7f5. This updates both Slurm submission templates and the submit command to use --account=abacus-group, synchronizes the six renamed paths, and enables 01_PW/090_PW_out_pchg_wfc_spinor on GPU. The test suite passes locally with 45 tests, and the final fork validation Run #75 passed all 124 cases with 0 failures and 0 infrastructure errors: https://github.com/Stardust0831/abacus-develop/actions/runs/34255703893