### PR TITLE
module_dftu: pass nspin and onsite_radius explicitly, removing the two test access hacks it caused

### DIFF
--- a/source/source_lcao/force_stress_lcao.cpp
+++ b/source/source_lcao/force_stress_lcao.cpp
@@ -468,7 +468,9 @@ void Force_Stress_LCAO<T>::getForceStress(UnitCell& ucell,
                                                                    &gd,
                                                                    two_center_bundle.overlap_orb_onsite.get(),
                                                                    orb.cutoffs(),
-                                                                   &dftu);
+                                                                   &dftu,
+                                                                   PARAM.inp.nspin,
+                                                                   PARAM.inp.onsite_radius);
 
             tmpu.cal_force_stress(isforce, isstress, force_u, stress_u);
         }

--- a/source/source_lcao/hamilt_lcao.cpp
+++ b/source/source_lcao/hamilt_lcao.cpp
@@ -241,7 +241,9 @@ HamiltLCAO<TK, TR>::HamiltLCAO(const UnitCell& ucell,
                                                       &grid_d,
                                                       two_center_bundle.overlap_orb_onsite.get(),
                                                       orb.cutoffs(),
-                                                      p_dftu);
+                                                      p_dftu,
+                                                      PARAM.inp.nspin,
+                                                      PARAM.inp.onsite_radius);
             }
             this->getOperator()->add(plus_u);
         }
@@ -399,7 +401,9 @@ HamiltLCAO<TK, TR>::HamiltLCAO(const UnitCell& ucell,
                                                       &grid_d,
                                                       two_center_bundle.overlap_orb_onsite.get(),
                                                       orb.cutoffs(),
-                                                      p_dftu);
+                                                      p_dftu,
+                                                      PARAM.inp.nspin,
+                                                      PARAM.inp.onsite_radius);
             }
             this->getOperator()->add(plus_u);
         }

--- a/source/source_lcao/module_dftu/dftu_nao_op.cpp
+++ b/source/source_lcao/module_dftu/dftu_nao_op.cpp
@@ -4,7 +4,6 @@
 #include "source_base/tool_title.h"
 #include "source_cell/module_neighbor/sltk_grid_driver.h"
 #include "source_lcao/module_operator_lcao/operator_lcao.h"
-#include "source_io/module_parameter/parameter.h"
 #include "source_base/parallel_reduce.h"
 
 // Include the free function implementations for force/stress in real space
@@ -18,7 +17,9 @@ hamilt::DFTU<hamilt::OperatorLCAO<TK, TR>>::DFTU(HS_Matrix_K<TK>* hsk_in,
                                                  const Grid_Driver* GridD_in,
                                                  const TwoCenterIntegrator* intor,
                                                  const std::vector<double>& orb_cutoff,
-                                                 Plus_U* p_dftu)
+                                                 Plus_U* p_dftu,
+                                                 const int nspin_in,
+                                                 const double onsite_radius)
     : hamilt::OperatorLCAO<TK, TR>(hsk_in, kvec_d_in, hR_in), intor_(intor), orb_cutoff_(orb_cutoff)
 {
     this->cal_type = calculation_type::lcao_dftu;
@@ -28,9 +29,9 @@ hamilt::DFTU<hamilt::OperatorLCAO<TK, TR>>::DFTU(HS_Matrix_K<TK>* hsk_in,
     assert(this->ucell != nullptr);
 #endif
     // initialize HR to allocate sparse Nonlocal matrix memory
-    this->initialize_HR(GridD_in);
+    this->initialize_HR(GridD_in, onsite_radius);
     // set nspin
-    this->nspin = PARAM.inp.nspin;
+    this->nspin = nspin_in;
 }
 
 // destructor
@@ -41,7 +42,7 @@ hamilt::DFTU<hamilt::OperatorLCAO<TK, TR>>::~DFTU()
 
 // initialize_HR()
 template <typename TK, typename TR>
-void hamilt::DFTU<hamilt::OperatorLCAO<TK, TR>>::initialize_HR(const Grid_Driver* GridD)
+void hamilt::DFTU<hamilt::OperatorLCAO<TK, TR>>::initialize_HR(const Grid_Driver* GridD, const double onsite_radius)
 {
     ModuleBase::TITLE("DFTU", "initialize_HR");
     ModuleBase::timer::start("DFTU", "initialize_HR");
@@ -75,7 +76,7 @@ void hamilt::DFTU<hamilt::OperatorLCAO<TK, TR>>::initialize_HR(const Grid_Driver
             // When equal, the theoretical value of matrix element is zero,
             // but the calculated value is not zero due to the numerical error, which would lead to result changes.
             if (this->ucell->cal_dtau(iat0, iat1, R_index1).norm() * this->ucell->lat0
-                < orb_cutoff_[T1] + PARAM.inp.onsite_radius)
+                < orb_cutoff_[T1] + onsite_radius)
             {
                 is_adj[ad1] = true;
             }

--- a/source/source_lcao/module_dftu/dftu_nao_op.h
+++ b/source/source_lcao/module_dftu/dftu_nao_op.h
@@ -45,7 +45,9 @@ class DFTU<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
                                const Grid_Driver* gridD_in,
                                const TwoCenterIntegrator* intor,
                                const std::vector<double>& orb_cutoff,
-                               Plus_U* p_dftu);
+                               Plus_U* p_dftu,
+                               const int nspin_in,
+                               const double onsite_radius);
     ~DFTU<OperatorLCAO<TK, TR>>();
 
     /**
@@ -93,7 +95,7 @@ class DFTU<OperatorLCAO<TK, TR>> : public OperatorLCAO<TK, TR>
      * the size of HR will not change in DFTU,
      * because I don't want to expand HR larger than Nonlocal operator caused by DFTU
      */
-    void initialize_HR(const Grid_Driver* gridD_in);
+    void initialize_HR(const Grid_Driver* gridD_in, const double onsite_radius);
 
     /**
      * @brief calculate the <phi|alpha^I> overlap values and save them in this->nlm_tot

--- a/source/source_lcao/module_dftu/test/dftu_lcao_test.cpp
+++ b/source/source_lcao/module_dftu/test/dftu_lcao_test.cpp
@@ -2,9 +2,6 @@
 #include <chrono>
 
 // mock of DFTU
-#define private public
-#include "source_io/module_parameter/parameter.h"
-#undef private
 #include "../dftu_nao_op.h"
 #include "source_lcao/module_dftu/dftu_nao.h"
 
@@ -99,8 +96,6 @@ class DFTUTest : public ::testing::Test
         }
         dftu.u_current = {U_test};
         dftu.orbital_corr = {orbital_c_test};
-
-        PARAM.input.onsite_radius = 1.0;
     }
 
     void TearDown() override
@@ -147,13 +142,14 @@ class DFTUTest : public ::testing::Test
     int my_rank = 0;
     double U_test = 1.0;
     int orbital_c_test = 2;
+    double onsite_radius_test = 1.0;
 };
 
 // using TEST_F to test DFTU
 TEST_F(DFTUTest, constructHRd2d)
 {
     // test for nspin=1
-    PARAM.input.nspin = 1;
+    const int nspin = 1;
     std::vector<ModuleBase::Vector3<double>> kvec_d_in(1, ModuleBase::Vector3<double>(0.0, 0.0, 0.0));
     hamilt::HS_Matrix_K<double> hsk(paraV, true);
     hsk.set_zero_hk();
@@ -167,7 +163,7 @@ TEST_F(DFTUTest, constructHRd2d)
     }
     std::chrono::high_resolution_clock::time_point start_time = std::chrono::high_resolution_clock::now();
     hamilt::DFTU<hamilt::OperatorLCAO<double, double>>
-        op(&hsk, kvec_d_in, HR, ucell, &gd, &intor_, {1.0}, &dftu);
+        op(&hsk, kvec_d_in, HR, ucell, &gd, &intor_, {1.0}, &dftu, nspin, onsite_radius_test);
     std::chrono::high_resolution_clock::time_point end_time = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> elapsed_time
         = std::chrono::duration_cast<std::chrono::duration<double>>(end_time - start_time);
@@ -219,7 +215,7 @@ TEST_F(DFTUTest, constructHRd2d)
 TEST_F(DFTUTest, constructHRd2cd)
 {
     // test for nspin=2
-    PARAM.input.nspin = 2;
+    const int nspin = 2;
     std::vector<ModuleBase::Vector3<double>> kvec_d_in(2, ModuleBase::Vector3<double>(0.0, 0.0, 0.0));
     hamilt::HS_Matrix_K<std::complex<double>> hsk(paraV, true);
     hsk.set_zero_hk();
@@ -232,7 +228,7 @@ TEST_F(DFTUTest, constructHRd2cd)
         HR->get_wrapper()[i] = 0.0;
     }
     hamilt::DFTU<hamilt::OperatorLCAO<std::complex<double>, double>>
-        op(&hsk, kvec_d_in, HR, ucell, &gd, &intor_, {1.0}, &dftu);
+        op(&hsk, kvec_d_in, HR, ucell, &gd, &intor_, {1.0}, &dftu, nspin, onsite_radius_test);
     op.contributeHR();
     // check the occupations of dftu for spin-up
     for (int iat = 0; iat < test_size; iat++)

--- a/source/source_lcao/module_dftu/test/dftu_pw_test.cpp
+++ b/source/source_lcao/module_dftu/test/dftu_pw_test.cpp
@@ -1,9 +1,6 @@
 #include "gtest/gtest.h"
 #include <complex>
 #include <vector>
-#define private public
-#include "source_io/module_parameter/parameter.h"
-#undef private
 #include "source_base/matrix.h"
 #include "source_pw/module_pwdft/dftu_base_tools.h"
 
@@ -40,15 +37,14 @@ TEST_F(DftuPwTest, EnergyWeightsAllNspin)
     struct Case { int nspin; double expected_weight; double expected_diag; };
     Case cases[] = {{1, 1.0, 0.5}, {2, 0.5, 0.5}, {4, 0.25, 1.0}};
     for (const auto& c : cases) {
-        PARAM.input.nspin = c.nspin;
         double weight_eu = 1;
-        switch (PARAM.inp.nspin) {
+        switch (c.nspin) {
             case 1: weight_eu = 1.0; break;
             case 2: weight_eu = 0.5; break;
             case 4: weight_eu = 0.25; break;
             default: break;
         }
-        const double diag_coeff = PARAM.inp.nspin == 4 ? 1.0 : 0.5;
+        const double diag_coeff = c.nspin == 4 ? 1.0 : 0.5;
         EXPECT_DOUBLE_EQ(weight_eu, c.expected_weight);
         EXPECT_DOUBLE_EQ(diag_coeff, c.expected_diag);
     }


### PR DESCRIPTION
Follows the method established by #7921, applied to the one module outside
`source_io` where it actually removes the macro.

## Why these two files

`#define private public` has two independent root causes, and only one of them
is about `PARAM`:

- **(a)** the code under test reads global `PARAM` itself, so the test can only
  drive it by writing `PARAM.input` / `PARAM.sys`, which are private;
- **(b)** the test reaches into private members of the class under test.

Passing INPUT values explicitly fixes (a) and nothing else. I classified all 69
files that carry the macro by *which header the macro region actually covers*:
**11 are pure-(a)**, 22 are (a)+(b) where the macro survives either way, and 36
are pure-(b). Outside `source_io`, `module_dftu` holds the only two pure-(a)
files in the tree — so this is the complete (a)-driven macro removal available
outside that module.

## What changes

`dftu_nao_op.cpp` read two INPUT values out of the global singleton:
`PARAM.inp.nspin` in the constructor and `PARAM.inp.onsite_radius` inside
`initialize_HR()`. That is why `dftu_lcao_test.cpp` had to write `PARAM.input`,
and why it carried the macro.

Both now arrive as arguments. `initialize_HR()` is private and called only from
the constructor, so it simply takes `onsite_radius`; no new member was added for
it. `dftu_nao_op.cpp` now has zero `PARAM` references and no longer includes
`parameter.h`.

All five call sites are updated explicitly — **no default arguments were added**:

- `hamilt_lcao.cpp`, gamma-only and multi-k branches;
- `force_stress_lcao.cpp`, the `tmpu` force/stress instance;
- the two cases in `dftu_lcao_test.cpp`, which pass values they already set locally.

Those first three are the composition roots for LCAO operators — the same role
`relax_nsync.cpp` plays in #7921. The global reads concentrate there and the leaf
operator stays clean.

`dftu_pw_test.cpp` needed no production change at all. It was parking its loop
variable in the singleton and reading it straight back — writing the *private*
half and reading the *public* one:

```cpp
PARAM.input.nspin = c.nspin;
switch (PARAM.inp.nspin) { ... }
const double diag_coeff = PARAM.inp.nspin == 4 ? 1.0 : 0.5;
```

Nothing else reads it: the test's only production dependency,
`source_pw/module_pwdft/dftu_base_tools.cpp`, contains zero `PARAM` references.
`c.nspin` was already in scope.

## Why both files are in one PR

The governance budget counts `PARAM`/`GlobalV`/`GlobalC` occurrences PR-wide and
blocks on `added - removed > 0`. Unlike #7921 — where `relax_nsync.cpp` already
held an injected `Input_para*` and the refactor was net −64 — both production
call sites here sit inside `PARAM`-dense functions with no local `nspin` in
scope, so moving the read *out* of the leaf costs budget at the call sites:

| | Δ |
| --- | --- |
| `dftu_nao_op.cpp` — the 2 reads removed | −2 |
| `dftu_lcao_test.cpp` — 3 `PARAM.input` writes removed | −3 |
| `dftu_pw_test.cpp` — 3 `PARAM` lines removed | −3 |
| 3 production call sites — `nspin` + `onsite_radius` added | +6 |
| **net_delta** | **−2** |

Measured: `added=6, removed=8, net_delta=-2`. Split into two PRs, the second one
is +1 and CI blocks it. The `dftu_pw_test` cleanup is what pays for the refactor.

This is worth stating as a general point for the programme: **(a)-type refactors
are budget-positive by construction** — one read point becomes N call sites — so
they need either an existing injection point or a paired cleanup in the same PR.

## Test expectations are unchanged

No expected value was relaxed and no `result.ref` was regenerated.

Both `dftu_lcao_test` cases already set `nspin` explicitly (1 and 2) and
`onsite_radius` in `SetUp` (1.0), so nothing was relying on the `Input_para`
defaults — the regression that cost #7921 five suites when a new struct's
defaults did not mirror `input_parameter.h`. I checked every case before
touching them. The fixture member `onsite_radius_test = 1.0` carries the value
`SetUp` used to write into `PARAM`.

## Result

| | before | after |
| --- | --- | --- |
| files with the macro | 69 | 67 |
| occurrences | 97 | 95 |
| `PARAM`/`GlobalV` refs in `module_dftu` production code | 9 | 7 |

The 7 remaining are `ks_solver` in `dftu_nao_fs_k.cpp` / `dftu_nao_occ.cpp` and
`nspin` in `dftu_nao_energy.cpp`. None is in either test's `depend_files`, so
touching them buys no macro and only costs budget.

Nothing here adds an `#undef private` or `#undef protected`, and no file whose
macro survives is touched — #7921's scope rule: remove the macro, or leave the
file alone.

## Verification

Linux, `cmake -B build -G Ninja -DBUILD_TESTING=ON -DENABLE_LCAO=ON -DENABLE_MPI=ON -DENABLE_OPENMP=ON`:

- build: **3318/3318 targets, 0 errors**. Dropping the `parameter.h` include from
  `dftu_nao_op.cpp` exposed no transitive dependency.
- `ctest -R dftu`: **5/5 pass**, including both changed tests.
- full unit suite: **29 of 338 fail — the failure set is byte-identical to the
  base commit** (`402aa8dab`) built and run in a parallel worktree in the same
  environment. Both `comm` directions are empty: no new failures, no tests newly
  passing. The 29 are pre-existing and environment-related (`mpirun`-based
  `*_para`/`*_parallel` wrappers, plus `cubic_spline`, `math_sphbes`, `dav`,
  `bpcg`, `PSI_init`, ...).
- `agent_governance_check.py --base origin/develop --head HEAD`: **0 errors**,
  exit 0. The access-hack ratchet reports nothing at all (2 removed, 0 added).
- Verified via compiled objects that all five changed files were actually built,
  rather than skipped by the local feature configuration.

Governance warnings and why: the 6 "Global dependency budget" hits are the
`PARAM.inp.nspin` / `PARAM.inp.onsite_radius` arguments added at the three call
sites, explained above; net delta is −2. The "Documentation sync review" warning
applies because no INPUT parameter behaviour changed — this is an internal
signature change only, so `docs/parameters.yaml` and
`docs/advanced/input_files/input-main.md` need no update.

## What is deliberately not here

Reason-(b) files need a per-class decision in a production header — a public
`const` observer, an explicit `friend`, or turning a `void` method that writes a
private flag into one that returns it. That is the next tranche and is
independent of `PARAM`.

Reason-(a) elsewhere outside `source_io` no longer removes any macro: the six
`source_md` tests are driven entirely by five `PARAM` writes in `setcell.h` and
their integrators are already `PARAM`-free, but all six macros are (b);
`source_estate`'s remaining (a) is `nspin`/`nbands`/`nlocal`, which is the
de-globalization programme rather than one PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
