### PR TITLE
Fix: dispatch device memory wrappers by exact source/destination device pair

### DIFF
--- a/source/source_base/module_device/memory_op.cpp
+++ b/source/source_base/module_device/memory_op.cpp
@@ -1,6 +1,7 @@
 #include "memory_op.h"
 
 #include "source_base/memory_recorder.h"
+#include "source_base/tool_quit.h"
 #include "source_base/tool_threading.h"
 #ifdef __DSP
 #include "source_base/kernels/dsp/dsp_connector.h"
@@ -549,34 +550,51 @@ void set_memory(FPTYPE* arr, const int var, const size_t size, base_device::Abac
 
 template <typename FPTYPE>
 void synchronize_memory(FPTYPE* arr_out, const FPTYPE* arr_in, const size_t size, base_device::AbacusDevice_t device_type_out, base_device::AbacusDevice_t device_type_in){
-    if (device_type_out == base_device::AbacusDevice_t::CpuDevice || device_type_in == base_device::AbacusDevice_t::CpuDevice){
+    // The four source/destination combinations are mutually exclusive, so each
+    // branch must test BOTH devices. Using `||` here made the first branch match
+    // whenever either side was the CPU, which routed host<->device transfers to
+    // the host-to-host specialization.
+    if (device_type_out == base_device::AbacusDevice_t::CpuDevice && device_type_in == base_device::AbacusDevice_t::CpuDevice){
         synchronize_memory_op<FPTYPE, DEVICE_CPU, DEVICE_CPU>()(arr_out, arr_in, size);
     }
-    else if (device_type_out == base_device::AbacusDevice_t::CpuDevice || device_type_in == base_device::AbacusDevice_t::GpuDevice){
+#if __CUDA || __UT_USE_CUDA || __ROCM || __UT_USE_ROCM
+    else if (device_type_out == base_device::AbacusDevice_t::CpuDevice && device_type_in == base_device::AbacusDevice_t::GpuDevice){
         synchronize_memory_op<FPTYPE, DEVICE_CPU, DEVICE_GPU>()(arr_out, arr_in, size);
     }
-    else if (device_type_out == base_device::AbacusDevice_t::GpuDevice || device_type_in == base_device::AbacusDevice_t::CpuDevice){
+    else if (device_type_out == base_device::AbacusDevice_t::GpuDevice && device_type_in == base_device::AbacusDevice_t::CpuDevice){
         synchronize_memory_op<FPTYPE, DEVICE_GPU, DEVICE_CPU>()(arr_out, arr_in, size);
     }
-    else if (device_type_out == base_device::AbacusDevice_t::GpuDevice || device_type_in == base_device::AbacusDevice_t::GpuDevice){
+    else if (device_type_out == base_device::AbacusDevice_t::GpuDevice && device_type_in == base_device::AbacusDevice_t::GpuDevice){
         synchronize_memory_op<FPTYPE, DEVICE_GPU, DEVICE_GPU>()(arr_out, arr_in, size);
+    }
+#endif
+    else {
+        ModuleBase::WARNING_QUIT("base_device::memory::synchronize_memory",
+                                 "unsupported source/destination device combination");
     }
 }
 
 template <typename FPTYPE_out, typename FPTYPE_in>
 void cast_memory(FPTYPE_out* arr_out, const FPTYPE_in* arr_in, const size_t size, base_device::AbacusDevice_t device_type_out, base_device::AbacusDevice_t device_type_in)
 {
-    if (device_type_out == base_device::AbacusDevice_t::CpuDevice || device_type_in == base_device::AbacusDevice_t::CpuDevice){
+    // See synchronize_memory() above: dispatch on the exact (out, in) device pair.
+    if (device_type_out == base_device::AbacusDevice_t::CpuDevice && device_type_in == base_device::AbacusDevice_t::CpuDevice){
         cast_memory_op<FPTYPE_out, FPTYPE_in, DEVICE_CPU, DEVICE_CPU>()(arr_out, arr_in, size);
     }
-    else if (device_type_out == base_device::AbacusDevice_t::CpuDevice || device_type_in == base_device::AbacusDevice_t::GpuDevice){
+#if __CUDA || __UT_USE_CUDA || __ROCM || __UT_USE_ROCM
+    else if (device_type_out == base_device::AbacusDevice_t::CpuDevice && device_type_in == base_device::AbacusDevice_t::GpuDevice){
         cast_memory_op<FPTYPE_out, FPTYPE_in, DEVICE_CPU, DEVICE_GPU>()(arr_out, arr_in, size);
     }
-    else if (device_type_out == base_device::AbacusDevice_t::GpuDevice || device_type_in == base_device::AbacusDevice_t::CpuDevice){
+    else if (device_type_out == base_device::AbacusDevice_t::GpuDevice && device_type_in == base_device::AbacusDevice_t::CpuDevice){
         cast_memory_op<FPTYPE_out, FPTYPE_in, DEVICE_GPU, DEVICE_CPU>()(arr_out, arr_in, size);
     }
-    else if (device_type_out == base_device::AbacusDevice_t::GpuDevice || device_type_in == base_device::AbacusDevice_t::GpuDevice){
+    else if (device_type_out == base_device::AbacusDevice_t::GpuDevice && device_type_in == base_device::AbacusDevice_t::GpuDevice){
         cast_memory_op<FPTYPE_out, FPTYPE_in, DEVICE_GPU, DEVICE_GPU>()(arr_out, arr_in, size);
+    }
+#endif
+    else {
+        ModuleBase::WARNING_QUIT("base_device::memory::cast_memory",
+                                 "unsupported source/destination device combination");
     }
 }
 
@@ -590,6 +608,25 @@ void delete_memory(FPTYPE* arr, base_device::AbacusDevice_t device_type)
         delete_memory_op<FPTYPE, DEVICE_GPU>()(arr);
     }
 }
+
+// Explicit instantiations of the runtime-dispatch wrappers, so that the
+// declarations in memory_op.h can actually be linked from another translation
+// unit (and covered by unit tests). cast_memory is instantiated only for the
+// type pairs that cast_memory_op provides for all four device combinations.
+template void synchronize_memory<int>(int*, const int*, const size_t, base_device::AbacusDevice_t, base_device::AbacusDevice_t);
+template void synchronize_memory<float>(float*, const float*, const size_t, base_device::AbacusDevice_t, base_device::AbacusDevice_t);
+template void synchronize_memory<double>(double*, const double*, const size_t, base_device::AbacusDevice_t, base_device::AbacusDevice_t);
+template void synchronize_memory<std::complex<float>>(std::complex<float>*, const std::complex<float>*, const size_t, base_device::AbacusDevice_t, base_device::AbacusDevice_t);
+template void synchronize_memory<std::complex<double>>(std::complex<double>*, const std::complex<double>*, const size_t, base_device::AbacusDevice_t, base_device::AbacusDevice_t);
+
+template void cast_memory<float, float>(float*, const float*, const size_t, base_device::AbacusDevice_t, base_device::AbacusDevice_t);
+template void cast_memory<double, double>(double*, const double*, const size_t, base_device::AbacusDevice_t, base_device::AbacusDevice_t);
+template void cast_memory<float, double>(float*, const double*, const size_t, base_device::AbacusDevice_t, base_device::AbacusDevice_t);
+template void cast_memory<double, float>(double*, const float*, const size_t, base_device::AbacusDevice_t, base_device::AbacusDevice_t);
+template void cast_memory<std::complex<float>, std::complex<float>>(std::complex<float>*, const std::complex<float>*, const size_t, base_device::AbacusDevice_t, base_device::AbacusDevice_t);
+template void cast_memory<std::complex<double>, std::complex<double>>(std::complex<double>*, const std::complex<double>*, const size_t, base_device::AbacusDevice_t, base_device::AbacusDevice_t);
+template void cast_memory<std::complex<float>, std::complex<double>>(std::complex<float>*, const std::complex<double>*, const size_t, base_device::AbacusDevice_t, base_device::AbacusDevice_t);
+template void cast_memory<std::complex<double>, std::complex<float>>(std::complex<double>*, const std::complex<float>*, const size_t, base_device::AbacusDevice_t, base_device::AbacusDevice_t);
 
 } // namespace memory
 } // namespace base_device

--- a/source/source_base/module_device/test/memory_test.cpp
+++ b/source/source_base/module_device/test/memory_test.cpp
@@ -170,6 +170,59 @@ TEST_F(TestModulePsiMemory, delete_memory_op_complex_double_cpu)
     delete_memory_complex_double_cpu_op()(hz_xx);
 }
 
+// ---------------------------------------------------------------------------
+// Runtime-dispatch wrappers (issue #7553).
+//
+// synchronize_memory()/cast_memory() pick a compile-time specialization from a
+// pair of runtime AbacusDevice_t values. The branches used to be joined with
+// `||`, so the first one matched whenever EITHER side was the CPU and every
+// host<->device transfer was served by the host-to-host specialization. The
+// checks below pin the exact-pair dispatch for all combinations available in
+// the current build.
+// ---------------------------------------------------------------------------
+
+TEST_F(TestModulePsiMemory, synchronize_memory_dispatch_cpu_to_cpu)
+{
+    std::vector<double> h_xx(xx.size(), 0);
+    base_device::memory::synchronize_memory(h_xx.data(),
+                                            xx.data(),
+                                            xx.size(),
+                                            base_device::AbacusDevice_t::CpuDevice,
+                                            base_device::AbacusDevice_t::CpuDevice);
+    for (int ii = 0; ii < xx.size(); ii++)
+    {
+        EXPECT_EQ(h_xx[ii], xx[ii]);
+    }
+}
+
+TEST_F(TestModulePsiMemory, synchronize_memory_dispatch_complex_cpu_to_cpu)
+{
+    std::vector<std::complex<double>> hz_xx(z_xx.size(), std::complex<double>(0, 0));
+    base_device::memory::synchronize_memory(hz_xx.data(),
+                                            z_xx.data(),
+                                            z_xx.size(),
+                                            base_device::AbacusDevice_t::CpuDevice,
+                                            base_device::AbacusDevice_t::CpuDevice);
+    for (int ii = 0; ii < z_xx.size(); ii++)
+    {
+        EXPECT_EQ(hz_xx[ii], z_xx[ii]);
+    }
+}
+
+TEST_F(TestModulePsiMemory, cast_memory_dispatch_cpu_to_cpu)
+{
+    std::vector<float> h_xx(xx.size(), 0);
+    base_device::memory::cast_memory(h_xx.data(),
+                                     xx.data(),
+                                     xx.size(),
+                                     base_device::AbacusDevice_t::CpuDevice,
+                                     base_device::AbacusDevice_t::CpuDevice);
+    for (int ii = 0; ii < xx.size(); ii++)
+    {
+        EXPECT_FLOAT_EQ(h_xx[ii], static_cast<float>(xx[ii]));
+    }
+}
+
 #if __UT_USE_CUDA || __UT_USE_ROCM
 TEST_F(TestModulePsiMemory, set_memory_op_double_gpu)
 {
@@ -345,6 +398,92 @@ TEST_F(TestModulePsiMemory, delete_memory_op_complex_double_gpu)
 {
     thrust::device_ptr<std::complex<double>> dz_xx = thrust::device_malloc<std::complex<double>>(z_xx.size());
     delete_memory_complex_double_gpu_op()(thrust::raw_pointer_cast(dz_xx));
+}
+
+
+// Exact-pair dispatch across the host/device boundary (issue #7553). Before the
+// fix these three cases all reached synchronize_memory_op<..., CPU, CPU>, i.e. a
+// plain host memcpy on a device pointer.
+TEST_F(TestModulePsiMemory, synchronize_memory_dispatch_cpu_to_gpu)
+{
+    thrust::device_ptr<double> d_xx = thrust::device_malloc<double>(xx.size());
+    std::vector<double> hv_xx(xx.size(), 0);
+    thrust::copy(hv_xx.begin(), hv_xx.end(), d_xx);
+    base_device::memory::synchronize_memory(thrust::raw_pointer_cast(d_xx),
+                                            xx.data(),
+                                            xx.size(),
+                                            base_device::AbacusDevice_t::GpuDevice,
+                                            base_device::AbacusDevice_t::CpuDevice);
+
+    thrust::host_vector<double> h_xx(xx.size());
+    thrust::copy(d_xx, d_xx + xx.size(), h_xx.begin());
+    for (int ii = 0; ii < xx.size(); ii++)
+    {
+        EXPECT_EQ(h_xx[ii], xx[ii]);
+    }
+    thrust::device_free(d_xx);
+}
+
+TEST_F(TestModulePsiMemory, synchronize_memory_dispatch_gpu_to_cpu)
+{
+    thrust::device_ptr<double> d_xx = thrust::device_malloc<double>(xx.size());
+    thrust::copy(xx.begin(), xx.end(), d_xx);
+    thrust::host_vector<double> h_xx(xx.size());
+    base_device::memory::synchronize_memory(thrust::raw_pointer_cast(h_xx.data()),
+                                            thrust::raw_pointer_cast(d_xx),
+                                            xx.size(),
+                                            base_device::AbacusDevice_t::CpuDevice,
+                                            base_device::AbacusDevice_t::GpuDevice);
+
+    for (int ii = 0; ii < xx.size(); ii++)
+    {
+        EXPECT_EQ(h_xx[ii], xx[ii]);
+    }
+    thrust::device_free(d_xx);
+}
+
+TEST_F(TestModulePsiMemory, synchronize_memory_dispatch_gpu_to_gpu)
+{
+    thrust::device_ptr<double> d1_xx = thrust::device_malloc<double>(xx.size());
+    thrust::device_ptr<double> d2_xx = thrust::device_malloc<double>(xx.size());
+    thrust::copy(xx.begin(), xx.end(), d1_xx);
+    base_device::memory::synchronize_memory(thrust::raw_pointer_cast(d2_xx),
+                                            thrust::raw_pointer_cast(d1_xx),
+                                            xx.size(),
+                                            base_device::AbacusDevice_t::GpuDevice,
+                                            base_device::AbacusDevice_t::GpuDevice);
+
+    thrust::host_vector<double> h_xx(xx.size());
+    thrust::copy(d2_xx, d2_xx + xx.size(), h_xx.begin());
+    for (int ii = 0; ii < xx.size(); ii++)
+    {
+        EXPECT_EQ(h_xx[ii], xx[ii]);
+    }
+    thrust::device_free(d1_xx);
+    thrust::device_free(d2_xx);
+}
+
+TEST_F(TestModulePsiMemory, cast_memory_dispatch_cpu_to_gpu_and_back)
+{
+    thrust::device_ptr<float> d_xx = thrust::device_malloc<float>(xx.size());
+    base_device::memory::cast_memory(thrust::raw_pointer_cast(d_xx),
+                                     xx.data(),
+                                     xx.size(),
+                                     base_device::AbacusDevice_t::GpuDevice,
+                                     base_device::AbacusDevice_t::CpuDevice);
+
+    std::vector<double> h_xx(xx.size(), 0);
+    base_device::memory::cast_memory(h_xx.data(),
+                                     thrust::raw_pointer_cast(d_xx),
+                                     xx.size(),
+                                     base_device::AbacusDevice_t::CpuDevice,
+                                     base_device::AbacusDevice_t::GpuDevice);
+
+    for (int ii = 0; ii < xx.size(); ii++)
+    {
+        EXPECT_FLOAT_EQ(static_cast<float>(h_xx[ii]), static_cast<float>(xx[ii]));
+    }
+    thrust::device_free(d_xx);
 }
 
 #endif // __UT_USE_CUDA || __UT_USE_ROCM


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have linked an issue or explained why this PR does not need one.
- [x] I have added adequate unit tests and/or case tests, or explained why not.
- [x] I have listed the exact verification commands run and their results.
- [x] I have described user-visible behavior changes, including INPUT parameter changes.
- [x] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [x] I have requested any needed governance exception below.

### Linked Issue
Fix #7553

### Unit Tests and/or Case Tests for my changes
- Commands run (Linux, GCC, OpenMPI, `cmake -B build -G Ninja -DBUILD_TESTING=ON -DENABLE_LCAO=ON -DENABLE_MPI=ON -DENABLE_OPENMP=ON`):
  - `cmake --build build -j15 -- -k 0` — full build, 3318/3318 targets, 0 errors.
  - `ctest --test-dir build -R MODULE_BASE_DEVICE -V` — passed, including the three new CPU dispatch tests.
  - `ctest --test-dir build -R 'MODULE_PW_pw_test$|MODULE_ESTATE_elecstate_pw|MODULE_BASE_DEVICE'` — 3/3 passed. These two targets compile `memory_op.cpp` directly in a reduced configuration, so they confirm the new `tool_quit.h` dependency and the explicit instantiations link there as well.
- Checks not run, with reason: the four-pair GPU tests are guarded by `__UT_USE_CUDA`/`__UT_USE_ROCM` and were not executed — no GPU on the machine used. They are the ones that exercise the actual host/device mis-dispatch and need a GPU validation run.

### What's changed?

`synchronize_memory()` and `cast_memory()` pick a compile-time specialization from a pair of runtime `AbacusDevice_t` values, but joined their branch conditions with `||`:

```cpp
if (device_type_out == CpuDevice || device_type_in == CpuDevice) {
    synchronize_memory_op<FPTYPE, DEVICE_CPU, DEVICE_CPU>()(arr_out, arr_in, size);
}
else if (device_type_out == CpuDevice || device_type_in == GpuDevice) { ... }
```

The first branch matches whenever *either* side is the CPU, so `(GPU, CPU)` and `(CPU, GPU)` both reach the CPU-to-CPU specialization — a plain host `memcpy`/cast on a device pointer. `(GPU, GPU)` matches the second branch for the same reason. The four combinations are mutually exclusive, so each branch has to test both devices with `&&`. That is the fix.

Two things fall out of it:

- The GPU branches are now inside `#if __CUDA || __UT_USE_CUDA || __ROCM || __UT_USE_ROCM`, matching the guard on the `*_op` GPU specializations in `memory_op.h`. Without it these wrappers cannot be instantiated at all in a CPU-only build, because `synchronize_memory_op<T, DEVICE_CPU, DEVICE_GPU>` then resolves to the primary template, whose `operator()` has no definition.
- An unsupported device combination (e.g. `DspDevice`, `UnKnown`) now hits `WARNING_QUIT` instead of falling out of the `if`/`else` chain and silently leaving the destination buffer untouched.

**Severity, stated plainly: the defect is currently latent.** Both wrappers are declared in `memory_op.h` but were defined in the `.cpp` with no explicit instantiation, so they cannot be linked from another translation unit, and `grep` finds no call site anywhere in `source/`. Nothing miscopies today. What this PR fixes is a trap: the first caller to use the documented API would have got a silent host `memcpy` on a device pointer, with no diagnostic.

So the PR also makes the declared API real — explicit instantiations for `synchronize_memory` (`int`, `float`, `double`, `std::complex<float>`, `std::complex<double>`) and for `cast_memory` (only the eight type pairs that `cast_memory_op` provides for *all four* device combinations, so the instantiation list is identical in CPU-only and GPU builds) — and adds unit tests in `source_base/module_device/test/memory_test.cpp` that pin the dispatch: CPU-to-CPU in every configuration, and all four pairs under `__UT_USE_CUDA`/`__UT_USE_ROCM`.

Not changed, and worth a separate look: `resize_memory()`, `set_memory()` and `delete_memory()` dispatch on a single device, so they have no `||` defect, but they too fall through silently on an unrecognised `AbacusDevice_t`. I left them alone to keep this diff scoped to the issue.

### Governance Notes
- INPUT/docs changes: none. Internal device-dispatch fix; no INPUT parameter, no output format, no user-visible behaviour change, so `docs/parameters.yaml` and `input-main.md` are untouched.
- Core module impact: none of ESolver / HSolver / ElecState / Hamilt / Operator / Psi are touched. The change is confined to `source_base/module_device`. `memory_op.cpp` gains an `#include "source_base/tool_quit.h"`, which is not a new module-level dependency — `device.cpp` in the same directory already uses `ModuleBase::WARNING_QUIT`.
- No new `GlobalV` / `GlobalC` / `PARAM` references; no new default arguments; no new source files.
- Exceptions requested: none. The governance check reports only the standard "no docs change" warning, addressed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
