### PR TITLE
fix(vdw): exclude empty atoms from DFT-D2, DFT-D3 and DFT-D4

### DIFF
--- a/source/source_hamilt/module_vdw/test/vdw_test.cpp
+++ b/source/source_hamilt/module_vdw/test/vdw_test.cpp
@@ -144,6 +144,61 @@ void ClearUcell(UnitCell &ucell)
     delete[] ucell.atoms;
 }
 
+void construct_two_si_with_ghost(UnitCell& ucell)
+{
+    stru_ structure{std::vector<double>{0.5, 0.5, 0.0, 0.5, 0.0, 0.5, 0.0, 0.5, 0.5},
+                    std::vector<atomtype_>{atomtype_{"Si",
+                                                     std::vector<std::vector<double>>{{0., 0., 0.},
+                                                                                       {0.3, 0.25, 0.25}}},
+                                           atomtype_{"Si_empty",
+                                                     std::vector<std::vector<double>>{{0.1, 0.1, 0.1}}}}};
+    construct_ucell(structure, ucell);
+    ucell.atoms[0].ncpp.zv = 4.0;
+    ucell.atoms[1].flag_empty_element = true;
+    ucell.atoms[1].ncpp.psd = "Si";
+    ucell.atoms[1].ncpp.zv = 4.0;
+}
+
+void expect_empty_atoms_excluded(const vdw::VdwResult& reference,
+                                 const vdw::VdwResult& ghost,
+                                 int reference_nat)
+{
+    EXPECT_NEAR(ghost.energy, reference.energy, 1E-12);
+    EXPECT_EQ(ghost.has_force, reference.has_force);
+    EXPECT_EQ(ghost.has_stress, reference.has_stress);
+
+    if (reference.has_force && ghost.has_force)
+    {
+        EXPECT_EQ(ghost.force.size(), static_cast<std::size_t>(reference_nat + 1));
+        if (ghost.force.size() == static_cast<std::size_t>(reference_nat + 1)
+            && reference.force.size() == static_cast<std::size_t>(reference_nat))
+        {
+            for (int iat = 0; iat < reference_nat; ++iat)
+            {
+                EXPECT_NEAR(ghost.force[iat].x, reference.force[iat].x, 1E-12);
+                EXPECT_NEAR(ghost.force[iat].y, reference.force[iat].y, 1E-12);
+                EXPECT_NEAR(ghost.force[iat].z, reference.force[iat].z, 1E-12);
+            }
+            EXPECT_DOUBLE_EQ(ghost.force[reference_nat].x, 0.0);
+            EXPECT_DOUBLE_EQ(ghost.force[reference_nat].y, 0.0);
+            EXPECT_DOUBLE_EQ(ghost.force[reference_nat].z, 0.0);
+        }
+    }
+
+    if (reference.has_stress && ghost.has_stress)
+    {
+        EXPECT_NEAR(ghost.stress.e11, reference.stress.e11, 1E-12);
+        EXPECT_NEAR(ghost.stress.e12, reference.stress.e12, 1E-12);
+        EXPECT_NEAR(ghost.stress.e13, reference.stress.e13, 1E-12);
+        EXPECT_NEAR(ghost.stress.e21, reference.stress.e21, 1E-12);
+        EXPECT_NEAR(ghost.stress.e22, reference.stress.e22, 1E-12);
+        EXPECT_NEAR(ghost.stress.e23, reference.stress.e23, 1E-12);
+        EXPECT_NEAR(ghost.stress.e31, reference.stress.e31, 1E-12);
+        EXPECT_NEAR(ghost.stress.e32, reference.stress.e32, 1E-12);
+        EXPECT_NEAR(ghost.stress.e33, reference.stress.e33, 1E-12);
+    }
+}
+
 class vdwd2Test: public testing::Test
 {
     protected:
@@ -359,6 +414,20 @@ TEST_F(vdwd2Test, D2GetStress)
     EXPECT_NEAR(stress.e33, -0.00020491799872060734,1e-12);
 }
 
+TEST_F(vdwd2Test, EmptyAtomsAreExcluded)
+{
+    const vdw::VdwResult reference =
+        vdw::make_vdw(ucell, input)->evaluate(vdw::VdwRequest(true, true));
+
+    UnitCell ghost_ucell;
+    construct_two_si_with_ghost(ghost_ucell);
+    const vdw::VdwResult ghost =
+        vdw::make_vdw(ghost_ucell, input)->evaluate(vdw::VdwRequest(true, true));
+
+    expect_empty_atoms_excluded(reference, ghost, ucell.nat);
+    ClearUcell(ghost_ucell);
+}
+
 
 
 class vdwd3Test: public testing::Test
@@ -467,6 +536,21 @@ TEST_F(vdwd3Test, D30GetStress)
     EXPECT_NEAR(stress.e31, 0.0,1e-12);
     EXPECT_NEAR(stress.e32, -1.2732393110133044e-05,1e-12);
     EXPECT_NEAR(stress.e33, 4.5226077638555961e-05,1e-12);
+}
+
+TEST_F(vdwd3Test, EmptyAtomsAreExcluded)
+{
+    const vdw::VdwResult reference =
+        vdw::make_vdw(ucell, input)->evaluate(vdw::VdwRequest(true, true));
+
+    UnitCell ghost_ucell;
+    construct_two_si_with_ghost(ghost_ucell);
+
+    const vdw::VdwResult ghost =
+        vdw::make_vdw(ghost_ucell, input)->evaluate(vdw::VdwRequest(true, true));
+
+    expect_empty_atoms_excluded(reference, ghost, ucell.nat);
+    ClearUcell(ghost_ucell);
 }
 
 TEST_F(vdwd3Test, D3bjGetEnergy)
@@ -645,6 +729,32 @@ TEST_F(vdwd3abcTest, D3bjGetStress)
     EXPECT_NEAR(stress.e33, 3.4293409389506207e-05,1e-12);
 }
 
+TEST_F(vdwd3abcTest, EmptyAtomsAreExcludedWithThreeBodyTerm)
+{
+    const std::vector<std::string> methods{"d3_0", "d3_bj"};
+    for (const std::string& method : methods)
+    {
+        input.vdw_method = method;
+        const vdw::VdwResult reference =
+            vdw::make_vdw(ucell, input)->evaluate(vdw::VdwRequest(true, true));
+
+        UnitCell ghost_ucell;
+        stru_ structure{
+            std::vector<double>{0.75, 0.75, 0.0, 0.75, 0.0, 0.75, 0.0, 0.75, 0.75},
+            std::vector<atomtype_>{atomtype_{"Si", std::vector<std::vector<double>>{{0., 0., 0.}, {0.3, 0.25, 0.25}}},
+                                   atomtype_{"C", std::vector<std::vector<double>>{{0.5, 0.5, 0.5}}},
+                                   atomtype_{"C_empty", std::vector<std::vector<double>>{{0.2, 0.2, 0.2}}}}};
+        construct_ucell(structure, ghost_ucell);
+        ghost_ucell.atoms[2].flag_empty_element = true;
+        ghost_ucell.atoms[2].ncpp.psd = "C";
+
+        const vdw::VdwResult ghost =
+            vdw::make_vdw(ghost_ucell, input)->evaluate(vdw::VdwRequest(true, true));
+        expect_empty_atoms_excluded(reference, ghost, ucell.nat);
+        ClearUcell(ghost_ucell);
+    }
+}
+
 #ifdef __DFTD4
 
 class vdwd4Test: public testing::Test
@@ -742,6 +852,20 @@ TEST_F(vdwd4Test, D4GetStress)
     EXPECT_NEAR(stress.e33, 0.00016713814230248975, 1e-12);
 }
 
+TEST_F(vdwd4Test, EmptyAtomsAreExcluded)
+{
+    const vdw::VdwResult reference =
+        vdw::make_vdw(ucell, input)->evaluate(vdw::VdwRequest(true, true));
+
+    UnitCell ghost_ucell;
+    construct_two_si_with_ghost(ghost_ucell);
+    const vdw::VdwResult ghost =
+        vdw::make_vdw(ghost_ucell, input)->evaluate(vdw::VdwRequest(true, true));
+
+    expect_empty_atoms_excluded(reference, ghost, ucell.nat);
+    ClearUcell(ghost_ucell);
+}
+
 TEST_F(vdwd4Test, D4SGetEnergy)
 {
     input.vdw_d4_model = "d4s";
@@ -786,6 +910,21 @@ TEST_F(vdwd4Test, D4SGetStress)
     EXPECT_NEAR(stress.e31, 0.0, 1e-12);
     EXPECT_NEAR(stress.e32, -3.8521113344691535e-05, 1e-12);
     EXPECT_NEAR(stress.e33, 0.0001579183447576555, 1e-12);
+}
+
+TEST_F(vdwd4Test, EmptyAtomsAreExcludedForD4S)
+{
+    input.vdw_d4_model = "d4s";
+    const vdw::VdwResult reference =
+        vdw::make_vdw(ucell, input)->evaluate(vdw::VdwRequest(true, true));
+
+    UnitCell ghost_ucell;
+    construct_two_si_with_ghost(ghost_ucell);
+    const vdw::VdwResult ghost =
+        vdw::make_vdw(ghost_ucell, input)->evaluate(vdw::VdwRequest(true, true));
+
+    expect_empty_atoms_excluded(reference, ghost, ucell.nat);
+    ClearUcell(ghost_ucell);
 }
 
 #endif // __DFTD4

--- a/source/source_hamilt/module_vdw/vdwd2.h
+++ b/source/source_hamilt/module_vdw/vdwd2.h
@@ -38,8 +38,16 @@ class Vdwd2 : public Vdw
 
         for (int it1 = 0; it1 < ucell_.ntype; ++it1)
         {
+            if (ucell_.atoms[it1].flag_empty_element)
+            {
+                continue;
+            }
             for (int it2 = 0; it2 < ucell_.ntype; ++it2)
             {
+                if (ucell_.atoms[it2].flag_empty_element)
+                {
+                    continue;
+                }
                 const double C6_product
                     = sqrt(para_.C6().at(ucell_.atoms[it1].ncpp.psd) * para_.C6().at(ucell_.atoms[it2].ncpp.psd))
                       / pow(ucell_.lat0, 6);

--- a/source/source_hamilt/module_vdw/vdwd3.cpp
+++ b/source/source_hamilt/module_vdw/vdwd3.cpp
@@ -186,19 +186,30 @@ void Vdwd3::write_parameters(std::ofstream* plog) const
           << " smooth_width_3b=" << cutoffs_.width3 << std::endl;
 }
 
-d3::Structure Vdwd3::build_structure() const
+d3::Structure Vdwd3::build_structure(std::vector<int>& atom_indices) const
 {
     d3::Structure structure;
+    atom_indices.clear();
     structure.atomic_numbers.reserve(ucell_.nat);
     structure.positions.reserve(ucell_.nat);
+    atom_indices.reserve(ucell_.nat);
 
+    int iat = 0;
     for (int it = 0; it < ucell_.ntype; ++it)
     {
+        if (ucell_.atoms[it].flag_empty_element)
+        {
+            iat += ucell_.atoms[it].na;
+            continue;
+        }
+
         const int atomic_number = atomic_number_from_symbol(ucell_.atoms[it].ncpp.psd);
         for (int ia = 0; ia < ucell_.atoms[it].na; ++ia)
         {
             structure.atomic_numbers.push_back(atomic_number);
             structure.positions.push_back(to_d3_vector(ucell_.atoms[it].tau[ia] * ucell_.lat0));
+            atom_indices.push_back(iat);
+            ++iat;
         }
     }
 
@@ -217,7 +228,9 @@ void Vdwd3::evaluate_impl(const VdwRequest& request, VdwResult& result)
     d3::Result d3_result;
     std::string error;
     const bool derivatives = request.force || request.stress;
-    if (!d3::evaluate(build_structure(), parameters_, cutoffs_, derivatives, d3_result, error))
+    std::vector<int> atom_indices;
+    const d3::Structure structure = build_structure(atom_indices);
+    if (!d3::evaluate(structure, parameters_, cutoffs_, derivatives, d3_result, error))
     {
         ModuleBase::WARNING_QUIT("Vdwd3::evaluate", error);
     }
@@ -227,12 +240,13 @@ void Vdwd3::evaluate_impl(const VdwRequest& request, VdwResult& result)
 
     if (request.force)
     {
-        result.force.resize(ucell_.nat);
-        for (int iat = 0; iat < ucell_.nat; ++iat)
+        result.force.assign(ucell_.nat, ModuleBase::Vector3<double>(0.0, 0.0, 0.0));
+        for (std::size_t index = 0; index < atom_indices.size(); ++index)
         {
-            result.force[iat] = ModuleBase::Vector3<double>(-2.0 * d3_result.gradient[iat].x,
-                                                            -2.0 * d3_result.gradient[iat].y,
-                                                            -2.0 * d3_result.gradient[iat].z);
+            const int iat = atom_indices[index];
+            result.force[iat] = ModuleBase::Vector3<double>(-2.0 * d3_result.gradient[index].x,
+                                                            -2.0 * d3_result.gradient[index].y,
+                                                            -2.0 * d3_result.gradient[index].z);
         }
         result.has_force = true;
     }

--- a/source/source_hamilt/module_vdw/vdwd3.h
+++ b/source/source_hamilt/module_vdw/vdwd3.h
@@ -26,7 +26,7 @@ class Vdwd3 : public Vdw
     std::string canonical_method_;
 
     void evaluate_impl(const VdwRequest& request, VdwResult& result) override;
-    d3::Structure build_structure() const;
+    d3::Structure build_structure(std::vector<int>& atom_indices) const;
     void write_parameters(std::ofstream* plog) const;
 };
 

--- a/source/source_hamilt/module_vdw/vdwd4.cpp
+++ b/source/source_hamilt/module_vdw/vdwd4.cpp
@@ -104,6 +104,10 @@ Vdwd4::Vdwd4(const UnitCell& unit_in, const std::string& xc_name, const Input_pa
     double valence_charge = 0.0;
     for (int it = 0; it < ucell_.ntype; ++it)
     {
+        if (ucell_.atoms[it].flag_empty_element)
+        {
+            continue;
+        }
         valence_charge += ucell_.atoms[it].ncpp.zv * ucell_.atoms[it].na;
     }
     total_charge_ = valence_charge - input.nelec;
@@ -112,18 +116,28 @@ Vdwd4::Vdwd4(const UnitCell& unit_in, const std::string& xc_name, const Input_pa
 void Vdwd4::build_structure(std::vector<int>& numbers,
                             std::vector<double>& positions,
                             std::vector<double>& lattice,
-                            std::array<bool, 3>& periodic) const
+                            std::array<bool, 3>& periodic,
+                            std::vector<int>& atom_indices) const
 {
     numbers.clear();
     positions.clear();
     lattice.clear();
+    atom_indices.clear();
 
     numbers.reserve(ucell_.nat);
     positions.reserve(3 * ucell_.nat);
     lattice.reserve(9);
+    atom_indices.reserve(ucell_.nat);
 
+    int iat = 0;
     for (int it = 0; it < ucell_.ntype; ++it)
     {
+        if (ucell_.atoms[it].flag_empty_element)
+        {
+            iat += ucell_.atoms[it].na;
+            continue;
+        }
+
         const int atomic_number = atomic_number_from_symbol(ucell_.atoms[it].ncpp.psd);
 
         for (int ia = 0; ia < ucell_.atoms[it].na; ++ia)
@@ -134,6 +148,8 @@ void Vdwd4::build_structure(std::vector<int>& numbers,
             positions.push_back(position.x);
             positions.push_back(position.y);
             positions.push_back(position.z);
+            atom_indices.push_back(iat);
+            ++iat;
         }
     }
 
@@ -159,7 +175,8 @@ void Vdwd4::build_structure(std::vector<int>& numbers,
 
 void Vdwd4::compute(double& energy_ha,
                     std::vector<double>* gradient_ha_bohr,
-                    std::array<double, 9>* sigma_ha)
+                    std::array<double, 9>* sigma_ha,
+                    std::vector<int>& atom_indices)
 {
 #ifdef __DFTD4
     std::vector<int> numbers;
@@ -167,13 +184,13 @@ void Vdwd4::compute(double& energy_ha,
     std::vector<double> lattice;
     std::array<bool, 3> periodic;
 
-    build_structure(numbers, positions, lattice, periodic);
+    build_structure(numbers, positions, lattice, periodic, atom_indices);
 
     if (gradient_ha_bohr != nullptr
-        && gradient_ha_bohr->size() != static_cast<std::size_t>(3 * ucell_.nat))
+        && gradient_ha_bohr->size() < static_cast<std::size_t>(3 * numbers.size()))
     {
         ModuleBase::WARNING_QUIT("Vdwd4::compute",
-                                 "gradient_ha_bohr must have size 3 * nat when requested.");
+                                 "gradient_ha_bohr is too small for the filtered atom set.");
     }
 
     // These vectors own all arrays passed to DFT-D4. Their data() pointers
@@ -181,7 +198,7 @@ void Vdwd4::compute(double& energy_ha,
     dftd4_error error = dftd4_new_error();
 
     dftd4_structure mol = dftd4_new_structure(error,
-                                              ucell_.nat,
+                                              static_cast<int>(numbers.size()),
                                               numbers.data(),
                                               positions.data(),
                                               &total_charge_,
@@ -240,16 +257,18 @@ void Vdwd4::compute(double& energy_ha,
 }
 
 void Vdwd4::set_force_from_gradient(const std::vector<double>& gradient_ha_bohr,
-                                      VdwResult& result) const
+                                    const std::vector<int>& atom_indices,
+                                    VdwResult& result) const
 {
-    result.force.resize(ucell_.nat);
+    result.force.assign(ucell_.nat, ModuleBase::Vector3<double>(0.0, 0.0, 0.0));
 
-    for (int iat = 0; iat < ucell_.nat; ++iat)
+    for (std::size_t index = 0; index < atom_indices.size(); ++index)
     {
+        const int iat = atom_indices[index];
         // DFT-D4 returns dE/dR in Ha/Bohr; ABACUS forces are -dE/dR in Ry/Bohr.
-        result.force[iat].x = -2.0 * gradient_ha_bohr[3 * iat + 0];
-        result.force[iat].y = -2.0 * gradient_ha_bohr[3 * iat + 1];
-        result.force[iat].z = -2.0 * gradient_ha_bohr[3 * iat + 2];
+        result.force[iat].x = -2.0 * gradient_ha_bohr[3 * index + 0];
+        result.force[iat].y = -2.0 * gradient_ha_bohr[3 * index + 1];
+        result.force[iat].z = -2.0 * gradient_ha_bohr[3 * index + 2];
     }
 
     result.has_force = true;
@@ -279,6 +298,7 @@ void Vdwd4::evaluate_impl(const VdwRequest& request, VdwResult& result)
     ModuleBase::timer::start("Vdwd4", "evaluate");
 
     double energy_ha = 0.0;
+    std::vector<int> atom_indices;
     if (request.force || request.stress)
     {
         std::vector<double> gradient(3 * ucell_.nat, 0.0);
@@ -287,11 +307,11 @@ void Vdwd4::evaluate_impl(const VdwRequest& request, VdwResult& result)
 
         // The DFT-D4 C API evaluates energy, gradient and sigma together.
         // Keep all requested quantities from this single call.
-        compute(energy_ha, &gradient, &sigma);
+        compute(energy_ha, &gradient, &sigma, atom_indices);
 
         if (request.force)
         {
-            set_force_from_gradient(gradient, result);
+            set_force_from_gradient(gradient, atom_indices, result);
         }
         if (request.stress)
         {
@@ -300,7 +320,7 @@ void Vdwd4::evaluate_impl(const VdwRequest& request, VdwResult& result)
     }
     else
     {
-        compute(energy_ha, nullptr, nullptr);
+        compute(energy_ha, nullptr, nullptr, atom_indices);
     }
 
     // DFT-D4 returns Hartree; ABACUS vdW energies are stored in Ry.

--- a/source/source_hamilt/module_vdw/vdwd4.h
+++ b/source/source_hamilt/module_vdw/vdwd4.h
@@ -29,19 +29,23 @@ class Vdwd4 : public Vdw
 
     void evaluate_impl(const VdwRequest& request, VdwResult& result) override;
 
-    void set_force_from_gradient(const std::vector<double>& gradient_ha_bohr, VdwResult& result) const;
+    void set_force_from_gradient(const std::vector<double>& gradient_ha_bohr,
+                                const std::vector<int>& atom_indices,
+                                VdwResult& result) const;
     void set_stress_from_sigma(const std::array<double, 9>& sigma_ha, VdwResult& result) const;
 
     void build_structure(std::vector<int>& numbers,
                          std::vector<double>& positions,
                          std::vector<double>& lattice,
-                         std::array<bool, 3>& periodic) const;
+                         std::array<bool, 3>& periodic,
+                         std::vector<int>& atom_indices) const;
 
     // Optional output buffers are caller-owned and non-owning here.
     // Vdwd4 writes to them during compute() and never stores their pointers.
     void compute(double& energy_ha,
                  std::vector<double>* gradient_ha_bohr,
-                 std::array<double, 9>* sigma_ha);
+                 std::array<double, 9>* sigma_ha,
+                 std::vector<int>& atom_indices);
 };
 
 } // namespace vdw


### PR DESCRIPTION
  Empty atoms (`flag_empty_element=true`) provide additional basis functions for
  BSSE correction, but must not contribute to the dispersion correction. The
  current vdW implementation does not distinguish between real and empty atoms,
  which can introduce unphysical vdW contributions to the energy, forces and
  stress.

  This PR fixes empty atom handling in the DFT-D implementations:

  - Exclude empty atom types from the DFT-D2 pairwise dispersion-energy
    evaluation.
  - Exclude empty atoms from the structure passed to the DFT-D3 evaluator.
  - Exclude empty atoms from the structures passed to the DFT-D4 and DFT-D4S
    evaluators.
  - Remove dispersion-energy contributions involving empty atoms.
  - Remove the corresponding empty-atom contributions from the dispersion
    stress.
  - Set the dispersion-force contribution on empty atoms to zero. Other force
    contributions remain unaffected, so the total force on a empty atom may
    still be nonzero.

  The fix applies to DFT-D2, the DFT-D3 two-body and three-body terms, and both
  the DFT-D4 and DFT-D4S models.