### PR TITLE
source_cell: replace #define private public with named friend grants in four tests

### DIFF
--- a/source/source_cell/magnetism.h
+++ b/source/source_cell/magnetism.h
@@ -5,11 +5,16 @@
 #include "source_base/vector3.h"
 #include <vector>
 
+class MagnetismTest;
+
 /**
  * @brief Class for magnetism calculations.
  */
 class Magnetism
 {
+    /// @brief the unit test drives the private judge_parallel() helper directly
+    friend class MagnetismTest;
+
 public:
     /// @brief Constructor
     Magnetism();

--- a/source/source_cell/read_pp.h
+++ b/source/source_cell/read_pp.h
@@ -11,6 +11,10 @@
 #include "source_base/matrix.h"
 #include "source_base/realarray.h"
 
+class AtomPseudoTest;
+class NCPPTest;
+class ReadPPTest;
+
 /**
  * @brief Pseudopot_upf class for reading pseudopotential files.
  *
@@ -19,6 +23,12 @@
  */
 class Pseudopot_upf
 {
+    /// @brief the unit tests drive the private format readers and the
+    /// complete_default_* helpers directly; see source_cell/test/
+    friend class AtomPseudoTest;
+    friend class NCPPTest;
+    friend class ReadPPTest;
+
 public:
     /// PP_INFO
     /// PP_HEADER

--- a/source/source_cell/test/atom_pseudo_test.cpp
+++ b/source/source_cell/test/atom_pseudo_test.cpp
@@ -22,16 +22,22 @@
  *     - bcast upf201 pp info to other processes
  */
 
-#define private public
 #include "source_cell/read_pp.h"
 #include "source_cell/pseudo.h"
 #include "source_cell/atom_pseudo.h"
-#undef private
 class AtomPseudoTest : public testing::Test
 {
 protected:
     std::unique_ptr<Pseudopot_upf> upf{new Pseudopot_upf};
     std::unique_ptr<Atom_pseudo> atom_pseudo{new Atom_pseudo};
+
+    // Pseudopot_upf declares this fixture a friend, but a TEST_F body lives in
+    // a class derived from it, and friendship is not inherited -- so the call
+    // into the private format reader has to happen here.
+    int read_pseudo_upf201(std::ifstream& ifs, Atom_pseudo& pp) const
+    {
+        return upf->read_pseudo_upf201(ifs, pp);
+    }
 };
 
 TEST_F(AtomPseudoTest, SetDSo)
@@ -43,7 +49,7 @@ TEST_F(AtomPseudoTest, SetDSo)
     std::ifstream ifs;
     ifs.open("./support/C.upf");
     const double pseudo_rcut = 15.0;
-    upf->read_pseudo_upf201(ifs, *atom_pseudo);
+    read_pseudo_upf201(ifs, *atom_pseudo);
     upf->complete_default(*atom_pseudo, pseudo_rcut);
     ifs.close();
     EXPECT_EQ(atom_pseudo->nh,14);
@@ -75,7 +81,7 @@ TEST_F(AtomPseudoTest, BcastAtomPseudo)
         std::ifstream ifs;
         ifs.open("./support/C.upf");
         const double pseudo_rcut = 15.0;
-        upf->read_pseudo_upf201(ifs, *atom_pseudo);
+        read_pseudo_upf201(ifs, *atom_pseudo);
         upf->complete_default(*atom_pseudo, pseudo_rcut);
         ifs.close();
     }

--- a/source/source_cell/test/magnetism_test.cpp
+++ b/source/source_cell/test/magnetism_test.cpp
@@ -17,9 +17,7 @@
  *      - and non-collinear case with nspin = 4
 */
 
-#define private public
 #include "source_cell/magnetism.h"
-#undef private
 
 
 class MagnetismTest : public ::testing::Test
@@ -34,6 +32,14 @@ class MagnetismTest : public ::testing::Test
     {
         delete magnetism;
     }
+
+    // Magnetism declares this fixture a friend, but a TEST_F body lives in a
+    // class derived from it, and friendship is not inherited -- so the call
+    // into the private helper has to happen here.
+    bool judge_parallel(const double a[3], const ModuleBase::Vector3<double>& b) const
+    {
+        return magnetism->judge_parallel(a, b);
+    }
 };
 
 TEST_F(MagnetismTest, Magnetism)
@@ -47,9 +53,9 @@ TEST_F(MagnetismTest, JudgeParallel)
 {
     double a[3] = {1.0, 0.0, 0.0};
     ModuleBase::Vector3<double> b(1.0, 0.0, 0.0);
-    EXPECT_TRUE(magnetism->judge_parallel(a, b));
+    EXPECT_TRUE(judge_parallel(a, b));
     b = ModuleBase::Vector3<double>(0.0, 1.0, 0.0);
-    EXPECT_FALSE(magnetism->judge_parallel(a, b));
+    EXPECT_FALSE(judge_parallel(a, b));
 }
 
 TEST_F(MagnetismTest, ComputeMagnetizationS2)

--- a/source/source_cell/test/pseudo_nc_test.cpp
+++ b/source/source_cell/test/pseudo_nc_test.cpp
@@ -21,15 +21,29 @@
  *   - print_pseudo
  */
 
-#define private public
 #include "source_cell/read_pp.h"
 #include "source_cell/atom_pseudo.h"
-#undef private
 class NCPPTest : public testing::Test
 {
 protected:
     std::unique_ptr<Pseudopot_upf> upf{new Pseudopot_upf};
     std::unique_ptr<Atom_pseudo> ncpp{new Atom_pseudo};
+
+    // Pseudopot_upf declares this fixture a friend, but a TEST_F body lives in
+    // a class derived from it, and friendship is not inherited -- so the calls
+    // into the private reader and the complete_default_* helpers happen here.
+    int read_pseudo_upf201(std::ifstream& ifs, Atom_pseudo& pp) const
+    {
+        return upf->read_pseudo_upf201(ifs, pp);
+    }
+    void complete_default_h(Atom_pseudo& pp) const
+    {
+        upf->complete_default_h(pp);
+    }
+    void complete_default_atom(Atom_pseudo& pp, const double pseudo_rcut) const
+    {
+        upf->complete_default_atom(pp, pseudo_rcut);
+    }
 };
 
 TEST_F(NCPPTest, SetPseudoH)
@@ -37,9 +51,9 @@ TEST_F(NCPPTest, SetPseudoH)
     std::ifstream ifs;
     //set
     ifs.open("./support/C.upf");
-    upf->read_pseudo_upf201(ifs, *ncpp);
+    read_pseudo_upf201(ifs, *ncpp);
     //set_pseudo_h
-    upf->complete_default_h(*ncpp);
+    complete_default_h(*ncpp);
 
     if(!ncpp->has_so)
     {
@@ -62,10 +76,10 @@ TEST_F(NCPPTest, SetPseudoAtom)
     //set
     ifs.open("./support/C.upf");
     const double pseudo_rcut = 15.0;
-    upf->read_pseudo_upf201(ifs, *ncpp);
+    read_pseudo_upf201(ifs, *ncpp);
     //set_pseudo_atom
-    upf->complete_default_h(*ncpp);
-    upf->complete_default_atom(*ncpp, pseudo_rcut);
+    complete_default_h(*ncpp);
+    complete_default_atom(*ncpp, pseudo_rcut);
     EXPECT_EQ(ncpp->rcut,pseudo_rcut);
 
     if(!ncpp->nlcc)
@@ -86,12 +100,12 @@ TEST_F(NCPPTest, SetPseudoNC)
     ifs.open("./support/C.upf");
     const double pseudo_rcut = 15.0;
     // set pseudo nbeta = 0
-    upf->read_pseudo_upf201(ifs, *ncpp);
+    read_pseudo_upf201(ifs, *ncpp);
     ncpp->nbeta = 0;
     upf->complete_default(*ncpp, pseudo_rcut);
     EXPECT_EQ(ncpp->nh,0);
     // set pseudo nbeta > 0
-    upf->read_pseudo_upf201(ifs, *ncpp);
+    read_pseudo_upf201(ifs, *ncpp);
     upf->complete_default(*ncpp, pseudo_rcut);
     EXPECT_EQ(ncpp->nh,14);
     EXPECT_EQ(ncpp->kkbeta,132);
@@ -105,7 +119,7 @@ TEST_F(NCPPTest, PrintNC)
     //set
     ifs.open("./support/C.upf");
     const double pseudo_rcut = 15.0;
-    upf->read_pseudo_upf201(ifs, *ncpp);
+    read_pseudo_upf201(ifs, *ncpp);
     upf->complete_default(*ncpp, pseudo_rcut);
     ifs.close();
     //print

--- a/source/source_cell/test/read_pp_test.cpp
+++ b/source/source_cell/test/read_pp_test.cpp
@@ -59,23 +59,63 @@
  *     - average_p: modulate the soc effect in pseudopotential
  */
 
-#define private public
 #include "source_cell/read_pp.h"
 #include "source_cell/atom_pseudo.h"
-#undef private
 class ReadPPTest : public testing::Test
 {
 protected:
     std::string output;
     std::unique_ptr<Pseudopot_upf> read_pp{new Pseudopot_upf};
     std::unique_ptr<Atom_pseudo> upf{new Atom_pseudo};
+
+    // Pseudopot_upf declares this fixture a friend, but a TEST_F body lives in
+    // a class derived from it, and friendship is not inherited -- so every call
+    // into a private format reader or helper is routed through these wrappers.
+    int read_pseudo_upf(std::ifstream& ifs, Atom_pseudo& pp) const
+    {
+        return read_pp->read_pseudo_upf(ifs, pp);
+    }
+    int read_pseudo_upf201(std::ifstream& ifs, Atom_pseudo& pp) const
+    {
+        return read_pp->read_pseudo_upf201(ifs, pp);
+    }
+    int read_pseudo_vwr(std::ifstream& ifs, Atom_pseudo& pp) const
+    {
+        return read_pp->read_pseudo_vwr(ifs, pp);
+    }
+    int read_pseudo_blps(std::ifstream& ifs, Atom_pseudo& pp) const
+    {
+        return read_pp->read_pseudo_blps(ifs, pp);
+    }
+    int set_pseudo_type(const std::string& fn, std::string& type) const
+    {
+        return read_pp->set_pseudo_type(fn, type);
+    }
+    void setqfnew(const int& nqf,
+                  const int& mesh,
+                  const int& l,
+                  const int& n,
+                  const double* qfcoef,
+                  const double* r,
+                  double* rho) const
+    {
+        read_pp->setqfnew(nqf, mesh, l, n, qfcoef, r, rho);
+    }
+    std::string& trim(std::string& in_str) const
+    {
+        return read_pp->trim(in_str);
+    }
+    std::string trimend(std::string& in_str) const
+    {
+        return read_pp->trimend(in_str);
+    }
 };
 
 TEST_F(ReadPPTest, ReadUPF100_Coulomb)
 {
     std::ifstream ifs;
     ifs.open("./support/Te.pbe-coulomb.UPF");
-    read_pp->read_pseudo_upf(ifs, *upf);
+    read_pseudo_upf(ifs, *upf);
     EXPECT_TRUE(upf->vloc_at.empty());
     EXPECT_EQ(read_pp->coulomb_potential, true);
     EXPECT_EQ(upf->tvanp, false);
@@ -89,7 +129,7 @@ TEST_F(ReadPPTest, ReadUPF100)
 {
     std::ifstream ifs;
     ifs.open("./support/Te.pbe-rrkj.UPF");
-    read_pp->read_pseudo_upf(ifs, *upf);
+    read_pseudo_upf(ifs, *upf);
     EXPECT_FALSE(upf->has_so); // no soc info
     EXPECT_EQ(upf->nv,0); // number of version
     EXPECT_EQ(upf->psd,"Te"); // element label
@@ -170,7 +210,7 @@ TEST_F(ReadPPTest, ReadUPF100USPP)
 {
     std::ifstream ifs;
     ifs.open("./support/fe_pbe_v1.5.uspp.F.UPF");
-    read_pp->read_pseudo_upf(ifs, *upf);
+    read_pseudo_upf(ifs, *upf);
     EXPECT_FALSE(upf->has_so);                                        // has soc info
     EXPECT_FALSE(read_pp->q_with_l);                                      // q_with_l
     EXPECT_EQ(upf->nv, 0);                                            // number of version
@@ -286,7 +326,7 @@ TEST_F(ReadPPTest, ReadUPF201_Coulomb)
 {
     std::ifstream ifs;
     ifs.open("./support/Al.pbe-coulomb.UPF");
-    read_pp->read_pseudo_upf201(ifs, *upf);
+    read_pseudo_upf201(ifs, *upf);
     EXPECT_TRUE(upf->vloc_at.empty());
     EXPECT_EQ(read_pp->coulomb_potential, true);
     EXPECT_EQ(upf->nbeta, 0);
@@ -299,7 +339,7 @@ TEST_F(ReadPPTest, ReadUPF201)
 {
     std::ifstream ifs;
     ifs.open("./support/Cu_ONCV_PBE-1.0.upf");
-    read_pp->read_pseudo_upf201(ifs, *upf);
+    read_pseudo_upf201(ifs, *upf);
     EXPECT_EQ(upf->psd,"Cu");
     EXPECT_EQ(upf->pp_type,"NC");
     EXPECT_FALSE(upf->has_so);
@@ -352,7 +392,7 @@ TEST_F(ReadPPTest, ReadUSPPUPF201)
 {
     std::ifstream ifs;
     ifs.open("./support/Al.pbe-sp-van.UPF");
-    read_pp->read_pseudo_upf201(ifs, *upf);
+    read_pseudo_upf201(ifs, *upf);
     EXPECT_EQ(upf->psd, "Al");
     EXPECT_EQ(upf->pp_type, "US");
     EXPECT_EQ(read_pp->relativistic, "no");
@@ -430,9 +470,9 @@ TEST_F(ReadPPTest, HeaderErr2011)
     std::ifstream ifs;
     // 1st
     ifs.open("./support/HeaderError1");
-    //read_pp->read_pseudo_upf201(ifs, *upf);
+    //read_pseudo_upf201(ifs, *upf);
     testing::internal::CaptureStdout();
-    EXPECT_EXIT(read_pp->read_pseudo_upf201(ifs, *upf),
+    EXPECT_EXIT(read_pseudo_upf201(ifs, *upf),
             ::testing::ExitedWithCode(1),"");
     output = testing::internal::GetCapturedStdout();
     EXPECT_THAT(output, testing::HasSubstr("Found no PP_HEADER"));
@@ -444,9 +484,9 @@ TEST_F(ReadPPTest, HeaderErr2012)
     std::ifstream ifs;
     // 2nd
     ifs.open("./support/HeaderError2");
-    //read_pp->read_pseudo_upf201(ifs, *upf);
+    //read_pseudo_upf201(ifs, *upf);
     testing::internal::CaptureStdout();
-    EXPECT_EXIT(read_pp->read_pseudo_upf201(ifs, *upf),
+    EXPECT_EXIT(read_pseudo_upf201(ifs, *upf),
             ::testing::ExitedWithCode(1),"");
     output = testing::internal::GetCapturedStdout();
     EXPECT_THAT(output, testing::HasSubstr("SEMI-LOCAL PSEUDOPOTENTIAL IS NOT SUPPORTED"));
@@ -458,9 +498,9 @@ TEST_F(ReadPPTest, HeaderErr2013)
     std::ifstream ifs;
     // 3rd
     ifs.open("./support/HeaderError3");
-    //read_pp->read_pseudo_upf201(ifs, *upf);
+    //read_pseudo_upf201(ifs, *upf);
     testing::internal::CaptureStdout();
-    EXPECT_EXIT(read_pp->read_pseudo_upf201(ifs, *upf),
+    EXPECT_EXIT(read_pseudo_upf201(ifs, *upf),
             ::testing::ExitedWithCode(1),"");
     output = testing::internal::GetCapturedStdout();
     EXPECT_THAT(output, testing::HasSubstr("PAW POTENTIAL IS NOT SUPPORTED"));
@@ -474,7 +514,7 @@ TEST_F(ReadPPTest, HeaderErr2015)
     GlobalV::ofs_warning.open("warning.log");
     ifs.open("./support/HeaderError5");
     upf->mesh = 1; // avoid assert(pp.mesh > 0) in line 406 of read_pp_upf201.cpp
-    read_pp->read_pseudo_upf201(ifs, *upf);
+    read_pseudo_upf201(ifs, *upf);
     GlobalV::ofs_warning.close();
     ifs.close();
     ifs.open("warning.log");
@@ -491,7 +531,7 @@ TEST_F(ReadPPTest, ReadUPF201FR)
     std::ifstream ifs;
     // this is a dojo full-relativisitic pp
     ifs.open("./support/C.upf");
-    read_pp->read_pseudo_upf201(ifs, *upf);
+    read_pseudo_upf201(ifs, *upf);
     EXPECT_EQ(upf->psd,"C");
     EXPECT_TRUE(upf->has_so);
     EXPECT_TRUE(upf->nlcc);
@@ -544,7 +584,7 @@ TEST_F(ReadPPTest, ReadUPF201MESH2)
     std::ifstream ifs;
     // this pp file has gipaw, thus a different header
     ifs.open("./support/Fe.pbe-sp-mt_gipaw.UPF");
-    read_pp->read_pseudo_upf201(ifs, *upf);
+    read_pseudo_upf201(ifs, *upf);
     EXPECT_EQ(upf->psd,"Fe");
     ifs.close();
 }
@@ -554,7 +594,7 @@ TEST_F(ReadPPTest, VWR)
     std::ifstream ifs;
     // this pp file is a vwr type of pp
     ifs.open("./support/vwr.Si");
-    read_pp->read_pseudo_vwr(ifs, *upf);
+    read_pseudo_vwr(ifs, *upf);
     EXPECT_EQ(upf->xc_func,"PZ");
     EXPECT_EQ(upf->pp_type,"NC");
     EXPECT_FALSE(upf->tvanp);
@@ -589,7 +629,7 @@ TEST_F(ReadPPTest, BLPS)
     std::ifstream ifs;
     // this pp file is a vwr type of pp
     ifs.open("./support/si.lda.lps");
-    read_pp->read_pseudo_blps(ifs, *upf);
+    read_pseudo_blps(ifs, *upf);
     EXPECT_FALSE(upf->nlcc);
     EXPECT_FALSE(upf->tvanp);
     EXPECT_FALSE(upf->has_so);
@@ -612,20 +652,20 @@ TEST_F(ReadPPTest, SetPseudoType)
 {
     std::string pp_address = "./support/Cu_ONCV_PBE-1.0.upf";
     std::string type = "auto";
-    read_pp->set_pseudo_type(pp_address,type);
+    set_pseudo_type(pp_address,type);
     EXPECT_EQ(type,"upf201");
     pp_address = "./support/Te.pbe-rrkj.UPF";
-    read_pp->set_pseudo_type(pp_address,type);
+    set_pseudo_type(pp_address,type);
     EXPECT_EQ(type,"upf");
 }
 
 TEST_F(ReadPPTest, Trim)
 {
     std::string tmp_string = "   aaa   \t  bbb\t  ";
-    output = read_pp->trim(tmp_string);
+    output = trim(tmp_string);
     EXPECT_EQ(output,"aaabbb");
     tmp_string = "   \taaa\tbbb\t   ";
-    output = read_pp->trimend(tmp_string);
+    output = trimend(tmp_string);
     EXPECT_EQ(output,"aaa\tbbb");
 }
 
@@ -655,7 +695,7 @@ TEST_F(ReadPPTest, SetUpfQ)
 {
     std::ifstream ifs;
     ifs.open("./support/Al.pbe-sp-van.UPF");
-    read_pp->read_pseudo_upf201(ifs, *upf);
+    read_pseudo_upf201(ifs, *upf);
     read_pp->set_upf_q(*upf);
     EXPECT_DOUBLE_EQ(upf->qfuncl(0, 0, 0), 0.0);
     EXPECT_DOUBLE_EQ(upf->qfuncl(0, 0, 100), 7.8994151918886213e-06);
@@ -691,7 +731,7 @@ TEST_F(ReadPPTest, SetQfNew)
     }
 
     // Call the function under test
-    read_pp->setqfnew(nqf, mesh, l, n, qfcoef, r, rho);
+    setqfnew(nqf, mesh, l, n, qfcoef, r, rho);
 
     // Validate the output
     for (int ir = 0; ir < mesh; ++ir)
@@ -761,7 +801,7 @@ TEST_F(ReadPPTest, AverageErrReturns)
     // LSPINORB = 0
     std::ifstream ifs;
     ifs.open("./support/Si.rel-pbe-rrkj.UPF");
-    read_pp->read_pseudo_upf(ifs, *upf);
+    read_pseudo_upf(ifs, *upf);
     EXPECT_TRUE(upf->has_so); // has soc info
     const bool lspinorb_0 = false;
     ierr = read_pp->average_p(lambda, *upf, lspinorb_0);
@@ -779,7 +819,7 @@ TEST_F(ReadPPTest, AverageLSPINORB0)
     std::ifstream ifs;
     // this is a dojo full-relativisitic pp
     ifs.open("./support/C.upf");
-    read_pp->read_pseudo_upf201(ifs, *upf);
+    read_pseudo_upf201(ifs, *upf);
     EXPECT_TRUE(upf->has_so); // has soc info
     int ierr;
     double lambda = 1.0;
@@ -796,7 +836,7 @@ TEST_F(ReadPPTest, AverageLSPINORB1)
     std::ifstream ifs;
     // this is a dojo full-relativisitic pp
     ifs.open("./support/C.upf");
-    read_pp->read_pseudo_upf201(ifs, *upf);
+    read_pseudo_upf201(ifs, *upf);
     EXPECT_TRUE(upf->has_so); // has soc info
     int ierr;
     double lambda = 1.1;


### PR DESCRIPTION
Second tranche of the `#define private public` cleanup, after #7940. That PR
removed the macros whose cause was the *code under test reading global `PARAM`*;
this one removes the macros whose cause is the *test calling a private method*,
which needs a different fix and touches no global state at all.

## Which files, and why these four

Classifying every macro region in the tree by what it actually covers gives two
root causes — **(a)** the production code reads global `PARAM` itself, so the
test can only drive it by writing the private `PARAM.input`/`PARAM.sys`; and
**(b)** the test reaches into the class under test. (b) subdivides further, and
the cheapest sub-case is the one handled here:

> the test calls a **private method** — no private data member is involved.

For these four files that is the *only* cause. None of them touches `PARAM`, so
there is no global-dependency work mixed in and no governance budget to balance
(unlike #7940, where the call-site cost had to be paid for by a paired cleanup).

- `magnetism_test.cpp` — `Magnetism::judge_parallel`, 2 call sites.
- `atom_pseudo_test.cpp` — `Pseudopot_upf::read_pseudo_upf201`, 2 call sites.
- `pseudo_nc_test.cpp` — `read_pseudo_upf201`, `complete_default_h`,
  `complete_default_atom`, 8 call sites.
- `read_pp_test.cpp` — `read_pseudo_upf`, `read_pseudo_upf201`,
  `read_pseudo_vwr`, `read_pseudo_blps`, `set_pseudo_type`, `setqfnew`, `trim`,
  `trimend`, 26 call sites.

In every case the private method is the thing the test exists to exercise — the
file headers say so (`read_pp_test.cpp` lists `read_pseudo_upf`,
`set_pseudo_type`, `trim`/`trimend` under "Tested Functions", and
`magnetism_test.cpp` lists `Magnetism::judge_parallel()`).

## The fix

An explicit `friend class <fixture>;` on the class under test, which is what
AGENTS.md rule 10 names and what this codebase already does in
`source_pw/module_pwdft/dftu_base.h` (`friend class DFTUTest;`) and
`source_io/module_parameter/parameter.h` (`friend class TestParameters;`). The
whole production-side change is 15 lines:

```cpp
class MagnetismTest;

class Magnetism
{
    /// @brief the unit test drives the private judge_parallel() helper directly
    friend class MagnetismTest;

public:
```

plus the same for `Pseudopot_upf` with its three fixtures. **No method changed
visibility, no signature changed, no member was added.**

This is a real narrowing rather than a cosmetic one. `#define private public`
reinterprets access control for the entire translation unit — including every
standard library header the TU pulls in, which is undefined behaviour that
surfaces at link or run time rather than as a compile error — and leaves that TU
disagreeing with the rest of the build about the layout and accessibility of
every class it sees. A `friend` declaration grants one named class access to one
other class, is visible in the header where the class is defined, and is
reviewable.

Friendship is not inherited and a `TEST_F` body lives in a class *derived* from
the fixture, so each fixture gains thin forwarding wrappers and the `TEST_F`
bodies call those. `dftu_lcao_test.cpp` already documents and uses exactly this
arrangement. Every wrapper forwards its arguments unmodified and returns what the
private method returns.

## What is deliberately unchanged

Public members and public methods the tests already used are untouched and still
accessed directly: `Pseudopot_upf::complete_default`, `init_pseudo_reader`,
`average_p`, `set_upf_q`, `set_empty_element`, `print_pseudo_upf` and its public
data (`kbeta`, `qfunc`, `qfcoef`, `lloc`, `nqf`, ...), and Magnetism's
`tot_mag` / `abs_mag` / `start_mag` / `compute_mag`. Only the calls that actually
needed the macro were rerouted.

`Magnetism::judge_parallel` could alternatively have been made a public static —
it is a pure predicate that touches no member. That was not done: it would
enlarge the public API permanently to serve a test, where `friend` does not.

No `#undef private` is introduced anywhere, and no file whose macro this PR does
not remove is touched — the scope rule from #7921.

## Result

| | before | after |
| --- | --- | --- |
| files with the macro (tree-wide) | 67 | 63 |
| occurrences | 95 | 91 |
| macro occurrences in these four files | 4 | 0 |

## Verification

Linux, `cmake -B build -G Ninja -DBUILD_TESTING=ON -DENABLE_LCAO=ON -DENABLE_MPI=ON -DENABLE_OPENMP=ON`:

- build: **0 errors** (branch and base both `BUILD_EXIT=0`).
- the affected tests: `MODULE_CELL_read_pp`, `MODULE_CELL_pseudo_nc`,
  `MODULE_CELL_atom_pseudo`, `MODULE_CELL_bcast_atom_pseudo_test`,
  `MODULE_CELL_magnetism` — **all pass**, with every assertion and expected value
  unchanged.
- full unit suite: **29 of 339 fail — the failure set is identical to the base
  commit** (`d3722debd`) built and run in a parallel worktree in the same
  environment; both `comm` directions are empty. The 29 are pre-existing and
  environment-related (`mpirun`-based `*_para`/`*_parallel` wrappers, plus
  `cubic_spline`, `math_sphbes`, `dav`, `bpcg`, `PSI_init`, ...).
- `agent_governance_check.py`: **0 errors**, exit 0. The access-hack ratchet
  reports nothing (4 removed, 0 added), and the global-dependency budget is
  untouched because no `PARAM`/`GlobalV`/`GlobalC` reference is added or removed.
- verified via compiled objects that all four changed test files were actually
  built, rather than skipped by the local feature configuration.

The one governance warning is "Documentation sync review": no INPUT parameter and
no user-visible behaviour changed — this is a test-visibility change only — so
`docs/parameters.yaml` and `docs/advanced/input_files/input-main.md` need no
update.

## What is not here

The remaining 63 files split by the same taxonomy. The next cheapest group is
tests that read a private member for which a **public getter already exists** and
is simply not being used — those need no production change at all. A related but
distinct case has to be handled with care: where the assertion is
`EXPECT_EQ(obj.get_x(), obj.x)`, substituting the getter makes it a tautology, so
the assertion has to be re-anchored to the known input value instead (which also
makes the test stronger). Beyond that lie tests that read private state with no
getter (a public `const` observer) and tests that *write* private state to build
a fixture (a setter or a different construction path) — the latter is the
expensive tail and includes `klist_test.cpp`, `charge_mixing_test.cpp` and
`read_input_item_test.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
