### PR TITLE
Refactor hsolver: DiagoIterAssist takes H|psi>/S|psi> functors

### DIFF
--- a/source/source_hsolver/diago_iter_assist.cpp
+++ b/source/source_hsolver/diago_iter_assist.cpp
@@ -20,7 +20,8 @@ namespace hsolver
 //----------------------------------------------------------------------
 template <typename T, typename Device>
 void DiagoIterAssist<T, Device>::diag_subspace(
-    const hamilt::Hamilt<T, Device>* const pHamilt, // hamiltonian operator carrier
+    const HPsiFunc& hpsi_func,                      // applies H to a block of vectors
+    const SPsiFunc& spsi_func,                      // applies S to a block of vectors
     const psi::Psi<T, Device>& psi,                 // [in] wavefunction
     psi::Psi<T, Device>& evc,                       // [out] wavefunction, eigenvectors
     Real* en,                                       // [out] eigenvalues
@@ -83,9 +84,7 @@ void DiagoIterAssist<T, Device>::diag_subspace(
 
         T *hpsi = temp;
         // do hPsi for all bands
-        psi::Range all_bands_range(1, psi.get_current_k(), 0, nstart - 1);
-        hpsi_info hpsi_in(&psi, all_bands_range, hpsi);
-        pHamilt->ops->hPsi(hpsi_in);
+        hpsi_func(psi.get_pointer(), hpsi, dmax, psi.get_current_nbas(), nstart);
 
         ModuleBase::gemm_op<T, Device>()('C',
                                          'N',
@@ -105,7 +104,7 @@ void DiagoIterAssist<T, Device>::diag_subspace(
             // Only calculate S_sub if not orthogonal
             T *spsi = temp;
             // do sPsi for all bands
-            pHamilt->sPsi(psi.get_pointer(), spsi, dmax, dmin, nstart);
+            spsi_func(psi.get_pointer(), spsi, dmax, dmin, nstart);
 
             ModuleBase::gemm_op<T, Device>()('C',
                                             'N',
@@ -176,7 +175,8 @@ void DiagoIterAssist<T, Device>::diag_subspace(
 
 template <typename T, typename Device>
 void DiagoIterAssist<T, Device>::diag_subspace_init(
-    hamilt::Hamilt<T, Device>* pHamilt,
+    const HPsiFunc& hpsi_func,
+    const SPsiFunc& spsi_func,
     const T* psi,
     int psi_nr,
     int psi_nc,
@@ -200,8 +200,8 @@ void DiagoIterAssist<T, Device>::diag_subspace_init(
     const int dmax = evc.get_nbasis();
     const int dmin = evc.get_current_ngk();
 
-    // skip the diagonalization if the operators are not allocated
-    if (pHamilt->ops == nullptr)
+    // skip the diagonalization if the caller has no operators allocated
+    if (!hpsi_func)
     {
         ModuleBase::WARNING(
             "DiagoIterAssist::diag_subspace_init",
@@ -247,11 +247,9 @@ void DiagoIterAssist<T, Device>::diag_subspace_init(
         {
             // psi_temp is one band psi, psi is all bands psi, the range always is 1 for the only band in psi_temp
             syncmem_complex_op()(ppsi, psi + i * psi_nc, psi_nc);
-            psi::Range band_by_band_range(true, 0, 0, 0);
-            hpsi_info hpsi_in(&psi_temp, band_by_band_range, hpsi);
 
             // H|Psi> to get hpsi for target band
-            pHamilt->ops->hPsi(hpsi_in);
+            hpsi_func(ppsi, hpsi, psi_temp.get_nbasis(), psi_temp.get_current_nbas(), 1);
 
             // calculate the related elements in hcc <Psi|H|Psi>
             ModuleBase::gemv_op<T, Device>()('C', psi_nc, nstart, &one, psi, psi_nc, hpsi, 1, &zero, hcc + i * nstart, 1);
@@ -262,7 +260,7 @@ void DiagoIterAssist<T, Device>::diag_subspace_init(
         for (int i = 0; i < nstart; i++)
         {
             syncmem_complex_op()(ppsi, psi + i * psi_nc, psi_nc);
-            pHamilt->sPsi(ppsi, spsi, dmin, dmin, 1);
+            spsi_func(ppsi, spsi, dmin, dmin, 1);
 
             ModuleBase::gemv_op<T, Device>()('C',
                                              psi_nc,
@@ -295,15 +293,13 @@ void DiagoIterAssist<T, Device>::diag_subspace_init(
 
         T* hpsi = temp;
         // do hPsi for all bands
-        psi::Range all_bands_range(true, 0, 0, nstart - 1);
-        hpsi_info hpsi_in(&psi_temp, all_bands_range, hpsi);
-        pHamilt->ops->hPsi(hpsi_in);
+        hpsi_func(ppsi, hpsi, psi_temp.get_nbasis(), psi_temp.get_current_nbas(), nstart);
 
         ModuleBase::gemm_op<T, Device>()('C', 'N', nstart, nstart, dmin, &one, ppsi, dmax, hpsi, dmax, &zero, hcc, nstart);
 
         T* spsi = temp;
         // do sPsi for all bands
-        pHamilt->sPsi(ppsi, spsi, psi_temp.get_nbasis(), psi_temp.get_nbasis(), psi_temp.get_nbands());
+        spsi_func(ppsi, spsi, psi_temp.get_nbasis(), psi_temp.get_nbasis(), psi_temp.get_nbands());
 
         ModuleBase::gemm_op<T, Device>()('C', 'N', nstart, nstart, dmin, &one, ppsi, dmax, spsi, dmax, &zero, scc, nstart);
         delmem_complex_op()(temp);
@@ -488,8 +484,9 @@ void DiagoIterAssist<T, Device>::diag_hegvd(const int nstart,
 
 template <typename T, typename Device>
 void DiagoIterAssist<T, Device>::cal_hs_subspace(
-    const hamilt::Hamilt<T, Device>* pHamilt, // hamiltonian operator carrier
-    const psi::Psi<T, Device>& psi,           // [in] wavefunction
+    const HPsiFunc& hpsi_func,      // applies H to a block of vectors
+    const SPsiFunc& spsi_func,      // applies S to a block of vectors
+    const psi::Psi<T, Device>& psi, // [in] wavefunction
     T* hcc,
     T* scc,
     const diag_comm_info& diag_comm)
@@ -511,9 +508,7 @@ void DiagoIterAssist<T, Device>::cal_hs_subspace(
 
         T* hpsi = temp;
         // do hPsi for all bands
-        psi::Range all_bands_range(1, psi.get_current_k(), 0, nstart - 1);
-        hpsi_info hpsi_in(&psi, all_bands_range, hpsi);
-        pHamilt->ops->hPsi(hpsi_in);
+        hpsi_func(psi.get_pointer(), hpsi, dmax, psi.get_current_nbas(), nstart);
 
         ModuleBase::gemm_op<T, Device>()('C',
                                          'N',
@@ -531,7 +526,7 @@ void DiagoIterAssist<T, Device>::cal_hs_subspace(
 
         T* spsi = temp;
         // do sPsi for all bands
-        pHamilt->sPsi(psi.get_pointer(), spsi, dmax, dmin, nstart);
+        spsi_func(psi.get_pointer(), spsi, dmax, dmin, nstart);
 
         ModuleBase::gemm_op<T, Device>()('C',
                                          'N',

--- a/source/source_hsolver/diago_iter_assist.h
+++ b/source/source_hsolver/diago_iter_assist.h
@@ -3,7 +3,6 @@
 
 #include "source_base/complexmatrix.h"
 #include "source_base/macros.h"
-#include "source_hamilt/hamilt.h"
 #include "source_psi/psi.h"
 
 #include <functional>
@@ -21,6 +20,18 @@ class DiagoIterAssist
     using Real = typename GetTypeReal<T>::type;
 
   public:
+    /// Apply H to a block of `nvec` vectors laid out with leading dimension
+    /// `ld_psi`. `current_nbasis` is the number of plane waves *without* npol;
+    /// it is passed explicitly rather than captured because the callers below
+    /// drive several different wavefunction layouts through the same functor.
+    using HPsiFunc = std::function<
+        void(T* psi_in, T* hpsi_out, const int ld_psi, const int current_nbasis, const int nvec)>;
+
+    /// Apply S to a block of `nbands` vectors. The parameter list mirrors
+    /// hamilt::Hamilt::sPsi exactly, so a caller's functor is a plain forwarder.
+    using SPsiFunc = std::function<
+        void(const T* psi_in, T* spsi_out, const int nrow, const int npw, const int nbands)>;
+
     static Real PW_DIAG_THR;
     static int PW_DIAG_NMAX;
 
@@ -40,14 +51,16 @@ class DiagoIterAssist
      *
      * @tparam T      Data type for computation (e.g., float, double).
      * @tparam Device Device type for computation (e.g., CPU, GPU).
-     * @param pHamilt Pointer to the Hamiltonian object.
+     * @param hpsi_func Applies H to a block of vectors.
+     * @param spsi_func Applies S to a block of vectors.
      * @param psi     Input wavefunction defining the subspace.
      * @param evc     Output container for computed eigenvectors.
      * @param en      Output array for computed eigenvalues.
      * @param n_band  Number of bands (eigenvalues/eigenvectors) to compute. Default is 0 (all).
      * @param is_S_orthogonal If true, assumes the input wavefunction is already orthogonalized.
      */
-    static void diag_subspace(const hamilt::Hamilt<T, Device>* const pHamilt,
+    static void diag_subspace(const HPsiFunc& hpsi_func,
+                              const SPsiFunc& spsi_func,
                               const psi::Psi<T, Device>& psi,
                               psi::Psi<T, Device>& evc,
                               Real* en,
@@ -56,7 +69,9 @@ class DiagoIterAssist
                               const bool is_S_orthogonal = false);
 
     /// @brief use LAPACK to diagonalize the Hamiltonian matrix
-    /// @param pHamilt interface to hamiltonian
+    /// @param hpsi_func applies H to a block of vectors; pass an empty functor
+    /// when the Hamiltonian has no operators allocated yet (see the note below)
+    /// @param spsi_func applies S to a block of vectors
     /// @param psi wavefunction to diagonalize
     /// @param psi_nr number of rows (nbands)
     /// @param psi_nc number of columns (nbasis)
@@ -65,10 +80,12 @@ class DiagoIterAssist
     /// @param basis_type "lcao", "lcao_in_pw" or "pw"; together with calculation it selects
     /// how the rotation matrix is applied to psi
     /// @param calculation "scf", "nscf", "md", "relax", ...
-    /// @note exception handle: if there is no operator initialized in Hamilt, will directly copy value from psi to evc,
-    /// and return all - zero eigenenergies.
+    /// @note exception handle: if hpsi_func is empty, meaning the caller has no
+    /// operators initialized in its Hamiltonian, will directly copy value from
+    /// psi to evc, and return all - zero eigenenergies.
     static void diag_subspace_init(
-        hamilt::Hamilt<T, Device>* pHamilt,
+        const HPsiFunc& hpsi_func,
+        const SPsiFunc& spsi_func,
         const T* psi,
         int psi_nr,
         int psi_nc,
@@ -96,12 +113,14 @@ class DiagoIterAssist
                             T *vcc);
 
     /// @brief calculate Hamiltonian and overlap matrix in subspace spanned by nstart states psi
-    /// @param pHamilt : hamiltonian operator carrier
+    /// @param hpsi_func : applies H to a block of vectors
+    /// @param spsi_func : applies S to a block of vectors
     /// @param psi : wavefunction
     /// @param hcc : Hamiltonian matrix
     /// @param scc : overlap matrix
-    static void cal_hs_subspace(const hamilt::Hamilt<T, Device>* pHamilt, // hamiltonian operator carrier
-                                const psi::Psi<T, Device>& psi,           // [in] wavefunction
+    static void cal_hs_subspace(const HPsiFunc& hpsi_func,
+                                const SPsiFunc& spsi_func,
+                                const psi::Psi<T, Device>& psi, // [in] wavefunction
                                 T* hcc,
                                 T* scc,
                                 const diag_comm_info& diag_comm);
@@ -131,8 +150,6 @@ class DiagoIterAssist
 
   private:
     constexpr static const Device* ctx = {};
-
-    using hpsi_info = typename hamilt::Operator<T, Device>::hpsi_info;
 
     using setmem_var_op = base_device::memory::set_memory_op<Real, Device>;
     using resmem_var_op = base_device::memory::resize_memory_op<Real, Device>;

--- a/source/source_hsolver/hsolver_lcaopw.cpp
+++ b/source/source_hsolver/hsolver_lcaopw.cpp
@@ -69,8 +69,26 @@ void HSolverLIP<T>::solve(hamilt::Hamilt<T>* pHamilt, // ESolver_KS_PW::p_hamilt
             }
         };
 #endif
+        /// An empty hpsi functor tells diag_subspace_init that the Hamiltonian
+        /// has no operators allocated yet, which used to be the ops == nullptr check.
+        typename hsolver::DiagoIterAssist<T>::HPsiFunc hpsi_func;
+        if (pHamilt->ops != nullptr)
+        {
+            hpsi_func = [pHamilt](T* psi_in, T* hpsi_out, const int ld_psi, const int current_nbasis, const int nvec) {
+                auto psi_wrapper = psi::Psi<T>(psi_in, 1, nvec, ld_psi, current_nbasis);
+                psi::Range bands_range(true, 0, 0, nvec - 1);
+                using hpsi_info = typename hamilt::Operator<T>::hpsi_info;
+                hpsi_info info(&psi_wrapper, bands_range, hpsi_out);
+                pHamilt->ops->hPsi(info);
+            };
+        }
+        auto spsi_func = [pHamilt](const T* psi_in, T* spsi_out, const int nrow, const int npw, const int nbands) {
+            pHamilt->sPsi(psi_in, spsi_out, nrow, npw, nbands);
+        };
+
         /// solve eigenvector and eigenvalue for H(k)
-        hsolver::DiagoIterAssist<T>::diag_subspace_init(pHamilt,                 // interface to hamilt
+        hsolver::DiagoIterAssist<T>::diag_subspace_init(hpsi_func,
+                                                        spsi_func,
                                                         transform.get_pointer(), // transform matrix between lcao and pw
                                                         transform.get_nbands(),
                                                         transform.get_nbasis(),

--- a/source/source_hsolver/hsolver_lcaopw.cpp
+++ b/source/source_hsolver/hsolver_lcaopw.cpp
@@ -75,16 +75,17 @@ void HSolverLIP<T>::solve(hamilt::Hamilt<T>* pHamilt, // ESolver_KS_PW::p_hamilt
         if (pHamilt->ops != nullptr)
         {
             hpsi_func = [pHamilt](T* psi_in, T* hpsi_out, const int ld_psi, const int current_nbasis, const int nvec) {
-                auto psi_wrapper = psi::Psi<T>(psi_in, 1, nvec, ld_psi, current_nbasis);
+                psi::Psi<T> psi_wrapper(psi_in, 1, nvec, ld_psi, current_nbasis);
                 psi::Range bands_range(true, 0, 0, nvec - 1);
                 using hpsi_info = typename hamilt::Operator<T>::hpsi_info;
                 hpsi_info info(&psi_wrapper, bands_range, hpsi_out);
                 pHamilt->ops->hPsi(info);
             };
         }
-        auto spsi_func = [pHamilt](const T* psi_in, T* spsi_out, const int nrow, const int npw, const int nbands) {
-            pHamilt->sPsi(psi_in, spsi_out, nrow, npw, nbands);
-        };
+        typename hsolver::DiagoIterAssist<T>::SPsiFunc spsi_func
+            = [pHamilt](const T* psi_in, T* spsi_out, const int nrow, const int npw, const int nbands) {
+                  pHamilt->sPsi(psi_in, spsi_out, nrow, npw, nbands);
+              };
 
         /// solve eigenvector and eigenvalue for H(k)
         hsolver::DiagoIterAssist<T>::diag_subspace_init(hpsi_func,

--- a/source/source_hsolver/hsolver_pw.cpp
+++ b/source/source_hsolver/hsolver_pw.cpp
@@ -285,33 +285,34 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm,
         // DiagoIterAssist drives more than one wavefunction layout through the
         // same functor, so it hands the dimensions over on every call instead of
         // relying on a captured set.
-        auto sub_hpsi_func
+        typename DiagoIterAssist<T, Device>::HPsiFunc sub_hpsi_func
             = [hm](T* psi_in, T* hpsi_out, const int ld_psi, const int current_nbasis, const int nvec) {
-                  auto psi_wrapper = psi::Psi<T, Device>(psi_in, 1, nvec, ld_psi, current_nbasis);
+                  psi::Psi<T, Device> psi_wrapper(psi_in, 1, nvec, ld_psi, current_nbasis);
                   psi::Range bands_range(true, 0, 0, nvec - 1);
                   using hpsi_info = typename hamilt::Operator<T, Device>::hpsi_info;
                   hpsi_info info(&psi_wrapper, bands_range, hpsi_out);
                   hm->ops->hPsi(info);
               };
-        auto sub_spsi_func
+        typename DiagoIterAssist<T, Device>::SPsiFunc sub_spsi_func
             = [hm](const T* psi_in, T* spsi_out, const int nrow, const int npw, const int nbands) {
                   hm->sPsi(psi_in, spsi_out, nrow, npw, nbands);
               };
-        auto subspace_func = [cur_nbasis, &comm_info, sub_hpsi_func, sub_spsi_func](T* psi_in,
-                                                                                    T* psi_out,
-                                                                                    const int ld_psi,
-                                                                                    const int nband,
-                                                                                    const bool S_orth) {
-            auto psi_in_wrapper = psi::Psi<T, Device>(psi_in, 1, nband, ld_psi, cur_nbasis);
-            auto psi_out_wrapper = psi::Psi<T, Device>(psi_out, 1, nband, ld_psi, cur_nbasis);
-            std::vector<Real> eigen(nband, 0.0);
-            DiagoIterAssist<T, Device>::diag_subspace(sub_hpsi_func,
-                                                      sub_spsi_func,
-                                                      psi_in_wrapper,
-                                                      psi_out_wrapper,
-                                                      eigen.data(),
-                                                      comm_info);
-        };
+        typename DiagoCG<T, Device>::SubspaceFunc subspace_func
+            = [cur_nbasis, &comm_info, sub_hpsi_func, sub_spsi_func](T* psi_in,
+                                                                     T* psi_out,
+                                                                     const int ld_psi,
+                                                                     const int nband,
+                                                                     const bool S_orth) {
+                  psi::Psi<T, Device> psi_in_wrapper(psi_in, 1, nband, ld_psi, cur_nbasis);
+                  psi::Psi<T, Device> psi_out_wrapper(psi_out, 1, nband, ld_psi, cur_nbasis);
+                  std::vector<Real> eigen(nband, 0.0);
+                  DiagoIterAssist<T, Device>::diag_subspace(sub_hpsi_func,
+                                                            sub_spsi_func,
+                                                            psi_in_wrapper,
+                                                            psi_out_wrapper,
+                                                            eigen.data(),
+                                                            comm_info);
+              };
         DiagoCG<T, Device> cg(this->basis_type,
                               this->calculation_type,
                               this->need_subspace,

--- a/source/source_hsolver/hsolver_pw.cpp
+++ b/source/source_hsolver/hsolver_pw.cpp
@@ -282,13 +282,36 @@ void HSolverPW<T, Device>::hamiltSolvePsiK(hamilt::Hamilt<T, Device>* hm,
         // wrap the subspace_func into a lambda function
         // if S_orth is true, then assume psi is S-orthogonal, solve standard eigenproblem
         // otherwise, solve generalized eigenproblem
-        auto subspace_func =
-            [hm, cur_nbasis, &comm_info](T* psi_in, T* psi_out, const int ld_psi, const int nband, const bool S_orth) {
-                auto psi_in_wrapper = psi::Psi<T, Device>(psi_in, 1, nband, ld_psi, cur_nbasis);
-                auto psi_out_wrapper = psi::Psi<T, Device>(psi_out, 1, nband, ld_psi, cur_nbasis);
-                std::vector<Real> eigen(nband, 0.0);
-                DiagoIterAssist<T, Device>::diag_subspace(hm, psi_in_wrapper, psi_out_wrapper, eigen.data(), comm_info);
-            };
+        // DiagoIterAssist drives more than one wavefunction layout through the
+        // same functor, so it hands the dimensions over on every call instead of
+        // relying on a captured set.
+        auto sub_hpsi_func
+            = [hm](T* psi_in, T* hpsi_out, const int ld_psi, const int current_nbasis, const int nvec) {
+                  auto psi_wrapper = psi::Psi<T, Device>(psi_in, 1, nvec, ld_psi, current_nbasis);
+                  psi::Range bands_range(true, 0, 0, nvec - 1);
+                  using hpsi_info = typename hamilt::Operator<T, Device>::hpsi_info;
+                  hpsi_info info(&psi_wrapper, bands_range, hpsi_out);
+                  hm->ops->hPsi(info);
+              };
+        auto sub_spsi_func
+            = [hm](const T* psi_in, T* spsi_out, const int nrow, const int npw, const int nbands) {
+                  hm->sPsi(psi_in, spsi_out, nrow, npw, nbands);
+              };
+        auto subspace_func = [cur_nbasis, &comm_info, sub_hpsi_func, sub_spsi_func](T* psi_in,
+                                                                                    T* psi_out,
+                                                                                    const int ld_psi,
+                                                                                    const int nband,
+                                                                                    const bool S_orth) {
+            auto psi_in_wrapper = psi::Psi<T, Device>(psi_in, 1, nband, ld_psi, cur_nbasis);
+            auto psi_out_wrapper = psi::Psi<T, Device>(psi_out, 1, nband, ld_psi, cur_nbasis);
+            std::vector<Real> eigen(nband, 0.0);
+            DiagoIterAssist<T, Device>::diag_subspace(sub_hpsi_func,
+                                                      sub_spsi_func,
+                                                      psi_in_wrapper,
+                                                      psi_out_wrapper,
+                                                      eigen.data(),
+                                                      comm_info);
+        };
         DiagoCG<T, Device> cg(this->basis_type,
                               this->calculation_type,
                               this->need_subspace,

--- a/source/source_hsolver/test/diago_cg_float_test.cpp
+++ b/source/source_hsolver/test/diago_cg_float_test.cpp
@@ -152,7 +152,18 @@ class DiagoCGPrepare
             auto psi_in_wrapper = psi::Psi<std::complex<float>>(psi_in, 1, nband, ld_psi, true);
             auto psi_out_wrapper = psi::Psi<std::complex<float>>(psi_out, 1, nband, ld_psi, true);
             std::vector<float> eigen(nband, 0.0f);
-            hsolver::DiagoIterAssist<std::complex<float>>::diag_subspace(ha,
+            auto sub_hpsi = [ha](std::complex<float>* p, std::complex<float>* hp, const int ld, const int cur_nbas, const int nvec) {
+                auto w = psi::Psi<std::complex<float>>(p, 1, nvec, ld, cur_nbas);
+                psi::Range r(true, 0, 0, nvec - 1);
+                using hpsi_info = typename hamilt::Operator<std::complex<float>>::hpsi_info;
+                hpsi_info info(&w, r, hp);
+                ha->ops->hPsi(info);
+            };
+            auto sub_spsi = [ha](const std::complex<float>* p, std::complex<float>* sp, const int nrow, const int npw, const int nb) {
+                ha->sPsi(p, sp, nrow, npw, nb);
+            };
+            hsolver::DiagoIterAssist<std::complex<float>>::diag_subspace(sub_hpsi,
+                                                                         sub_spsi,
                                                                          psi_in_wrapper,
                                                                          psi_out_wrapper,
                                                                          eigen.data(),

--- a/source/source_hsolver/test/diago_cg_float_test.cpp
+++ b/source/source_hsolver/test/diago_cg_float_test.cpp
@@ -152,14 +152,14 @@ class DiagoCGPrepare
             auto psi_in_wrapper = psi::Psi<std::complex<float>>(psi_in, 1, nband, ld_psi, true);
             auto psi_out_wrapper = psi::Psi<std::complex<float>>(psi_out, 1, nband, ld_psi, true);
             std::vector<float> eigen(nband, 0.0f);
-            auto sub_hpsi = [ha](std::complex<float>* p, std::complex<float>* hp, const int ld, const int cur_nbas, const int nvec) {
-                auto w = psi::Psi<std::complex<float>>(p, 1, nvec, ld, cur_nbas);
+            hsolver::DiagoIterAssist<std::complex<float>>::HPsiFunc sub_hpsi = [ha](std::complex<float>* p, std::complex<float>* hp, const int ld, const int cur_nbas, const int nvec) {
+                psi::Psi<std::complex<float>> w(p, 1, nvec, ld, cur_nbas);
                 psi::Range r(true, 0, 0, nvec - 1);
                 using hpsi_info = typename hamilt::Operator<std::complex<float>>::hpsi_info;
                 hpsi_info info(&w, r, hp);
                 ha->ops->hPsi(info);
             };
-            auto sub_spsi = [ha](const std::complex<float>* p, std::complex<float>* sp, const int nrow, const int npw, const int nb) {
+            hsolver::DiagoIterAssist<std::complex<float>>::SPsiFunc sub_spsi = [ha](const std::complex<float>* p, std::complex<float>* sp, const int nrow, const int npw, const int nb) {
                 ha->sPsi(p, sp, nrow, npw, nb);
             };
             hsolver::DiagoIterAssist<std::complex<float>>::diag_subspace(sub_hpsi,

--- a/source/source_hsolver/test/diago_cg_real_test.cpp
+++ b/source/source_hsolver/test/diago_cg_real_test.cpp
@@ -155,7 +155,18 @@ public:
                   auto psi_in_wrapper = psi::Psi<double>(psi_in, 1, nband, ld_psi, true);
                   auto psi_out_wrapper = psi::Psi<double>(psi_out, 1, nband, ld_psi, true);
                   std::vector<double> eigen(nband, 0.0);
-                  hsolver::DiagoIterAssist<double>::diag_subspace(ha,
+                  auto sub_hpsi = [ha](double* p, double* hp, const int ld, const int cur_nbas, const int nvec) {
+                      auto w = psi::Psi<double>(p, 1, nvec, ld, cur_nbas);
+                      psi::Range r(true, 0, 0, nvec - 1);
+                      using hpsi_info = typename hamilt::Operator<double>::hpsi_info;
+                      hpsi_info info(&w, r, hp);
+                      ha->ops->hPsi(info);
+                  };
+                  auto sub_spsi = [ha](const double* p, double* sp, const int nrow, const int npw, const int nb) {
+                      ha->sPsi(p, sp, nrow, npw, nb);
+                  };
+                  hsolver::DiagoIterAssist<double>::diag_subspace(sub_hpsi,
+                                                                  sub_spsi,
                                                                   psi_in_wrapper,
                                                                   psi_out_wrapper,
                                                                   eigen.data(),

--- a/source/source_hsolver/test/diago_cg_real_test.cpp
+++ b/source/source_hsolver/test/diago_cg_real_test.cpp
@@ -155,14 +155,14 @@ public:
                   auto psi_in_wrapper = psi::Psi<double>(psi_in, 1, nband, ld_psi, true);
                   auto psi_out_wrapper = psi::Psi<double>(psi_out, 1, nband, ld_psi, true);
                   std::vector<double> eigen(nband, 0.0);
-                  auto sub_hpsi = [ha](double* p, double* hp, const int ld, const int cur_nbas, const int nvec) {
-                      auto w = psi::Psi<double>(p, 1, nvec, ld, cur_nbas);
+                  hsolver::DiagoIterAssist<double>::HPsiFunc sub_hpsi = [ha](double* p, double* hp, const int ld, const int cur_nbas, const int nvec) {
+                      psi::Psi<double> w(p, 1, nvec, ld, cur_nbas);
                       psi::Range r(true, 0, 0, nvec - 1);
                       using hpsi_info = typename hamilt::Operator<double>::hpsi_info;
                       hpsi_info info(&w, r, hp);
                       ha->ops->hPsi(info);
                   };
-                  auto sub_spsi = [ha](const double* p, double* sp, const int nrow, const int npw, const int nb) {
+                  hsolver::DiagoIterAssist<double>::SPsiFunc sub_spsi = [ha](const double* p, double* sp, const int nrow, const int npw, const int nb) {
                       ha->sPsi(p, sp, nrow, npw, nb);
                   };
                   hsolver::DiagoIterAssist<double>::diag_subspace(sub_hpsi,

--- a/source/source_hsolver/test/diago_cg_test.cpp
+++ b/source/source_hsolver/test/diago_cg_test.cpp
@@ -147,14 +147,14 @@ class DiagoCGPrepare
             auto psi_in_wrapper = psi::Psi<std::complex<double>>(psi_in, 1, nband, ld_psi, true);
             auto psi_out_wrapper = psi::Psi<std::complex<double>>(psi_out, 1, nband, ld_psi, true);
             std::vector<double> eigen(nband, 0.0);
-            auto sub_hpsi = [ha](std::complex<double>* p, std::complex<double>* hp, const int ld, const int cur_nbas, const int nvec) {
-                auto w = psi::Psi<std::complex<double>>(p, 1, nvec, ld, cur_nbas);
+            hsolver::DiagoIterAssist<std::complex<double>>::HPsiFunc sub_hpsi = [ha](std::complex<double>* p, std::complex<double>* hp, const int ld, const int cur_nbas, const int nvec) {
+                psi::Psi<std::complex<double>> w(p, 1, nvec, ld, cur_nbas);
                 psi::Range r(true, 0, 0, nvec - 1);
                 using hpsi_info = typename hamilt::Operator<std::complex<double>>::hpsi_info;
                 hpsi_info info(&w, r, hp);
                 ha->ops->hPsi(info);
             };
-            auto sub_spsi = [ha](const std::complex<double>* p, std::complex<double>* sp, const int nrow, const int npw, const int nb) {
+            hsolver::DiagoIterAssist<std::complex<double>>::SPsiFunc sub_spsi = [ha](const std::complex<double>* p, std::complex<double>* sp, const int nrow, const int npw, const int nb) {
                 ha->sPsi(p, sp, nrow, npw, nb);
             };
             hsolver::DiagoIterAssist<std::complex<double>>::diag_subspace(sub_hpsi,

--- a/source/source_hsolver/test/diago_cg_test.cpp
+++ b/source/source_hsolver/test/diago_cg_test.cpp
@@ -147,7 +147,18 @@ class DiagoCGPrepare
             auto psi_in_wrapper = psi::Psi<std::complex<double>>(psi_in, 1, nband, ld_psi, true);
             auto psi_out_wrapper = psi::Psi<std::complex<double>>(psi_out, 1, nband, ld_psi, true);
             std::vector<double> eigen(nband, 0.0);
-            hsolver::DiagoIterAssist<std::complex<double>>::diag_subspace(ha,
+            auto sub_hpsi = [ha](std::complex<double>* p, std::complex<double>* hp, const int ld, const int cur_nbas, const int nvec) {
+                auto w = psi::Psi<std::complex<double>>(p, 1, nvec, ld, cur_nbas);
+                psi::Range r(true, 0, 0, nvec - 1);
+                using hpsi_info = typename hamilt::Operator<std::complex<double>>::hpsi_info;
+                hpsi_info info(&w, r, hp);
+                ha->ops->hPsi(info);
+            };
+            auto sub_spsi = [ha](const std::complex<double>* p, std::complex<double>* sp, const int nrow, const int npw, const int nb) {
+                ha->sPsi(p, sp, nrow, npw, nb);
+            };
+            hsolver::DiagoIterAssist<std::complex<double>>::diag_subspace(sub_hpsi,
+                                                                          sub_spsi,
                                                                           psi_in_wrapper,
                                                                           psi_out_wrapper,
                                                                           eigen.data(),

--- a/source/source_lcao/module_deltaspin/cal_mw_from_lambda.cpp
+++ b/source/source_lcao/module_deltaspin/cal_mw_from_lambda.cpp
@@ -184,24 +184,26 @@ void spinconstrain::SpinConstrain<std::complex<double>>::cal_mw_from_lambda(
                     {
                         /// Compute H(k) and extract subspace matrices for this k-point
                         hamilt_t->updateHk(ik);
-                        auto hpsi_func = [hamilt_t](std::complex<double>* psi_in,
-                                                    std::complex<double>* hpsi_out,
-                                                    const int ld_psi,
-                                                    const int current_nbasis,
-                                                    const int nvec) {
-                            auto psi_wrapper = psi::Psi<std::complex<double>, base_device::DEVICE_CPU>(psi_in, 1, nvec, ld_psi, current_nbasis);
-                            psi::Range bands_range(true, 0, 0, nvec - 1);
-                            using hpsi_info = typename hamilt::Operator<std::complex<double>, base_device::DEVICE_CPU>::hpsi_info;
-                            hpsi_info info(&psi_wrapper, bands_range, hpsi_out);
-                            hamilt_t->ops->hPsi(info);
-                        };
-                        auto spsi_func = [hamilt_t](const std::complex<double>* psi_in,
-                                                    std::complex<double>* spsi_out,
-                                                    const int nrow,
-                                                    const int npw,
-                                                    const int nbands) {
-                            hamilt_t->sPsi(psi_in, spsi_out, nrow, npw, nbands);
-                        };
+                        hsolver::DiagoIterAssist<std::complex<double>>::HPsiFunc hpsi_func
+                            = [hamilt_t](std::complex<double>* psi_in,
+                                         std::complex<double>* hpsi_out,
+                                         const int ld_psi,
+                                         const int current_nbasis,
+                                         const int nvec) {
+                                  psi::Psi<std::complex<double>, base_device::DEVICE_CPU> psi_wrapper(psi_in, 1, nvec, ld_psi, current_nbasis);
+                                  psi::Range bands_range(true, 0, 0, nvec - 1);
+                                  using hpsi_info = typename hamilt::Operator<std::complex<double>, base_device::DEVICE_CPU>::hpsi_info;
+                                  hpsi_info info(&psi_wrapper, bands_range, hpsi_out);
+                                  hamilt_t->ops->hPsi(info);
+                              };
+                        hsolver::DiagoIterAssist<std::complex<double>>::SPsiFunc spsi_func
+                            = [hamilt_t](const std::complex<double>* psi_in,
+                                         std::complex<double>* spsi_out,
+                                         const int nrow,
+                                         const int npw,
+                                         const int nbands) {
+                                  hamilt_t->sPsi(psi_in, spsi_out, nrow, npw, nbands);
+                              };
                         hsolver::DiagoIterAssist<std::complex<double>>::cal_hs_subspace(hpsi_func,
                                                                                         spsi_func,
                                                                                         psi_t[0],
@@ -264,24 +266,26 @@ void spinconstrain::SpinConstrain<std::complex<double>>::cal_mw_from_lambda(
                     if(initial_hs)
                     {
                         hamilt_t->updateHk(ik);
-                        auto hpsi_func = [hamilt_t](std::complex<double>* psi_in,
-                                                    std::complex<double>* hpsi_out,
-                                                    const int ld_psi,
-                                                    const int current_nbasis,
-                                                    const int nvec) {
-                            auto psi_wrapper = psi::Psi<std::complex<double>, base_device::DEVICE_GPU>(psi_in, 1, nvec, ld_psi, current_nbasis);
-                            psi::Range bands_range(true, 0, 0, nvec - 1);
-                            using hpsi_info = typename hamilt::Operator<std::complex<double>, base_device::DEVICE_GPU>::hpsi_info;
-                            hpsi_info info(&psi_wrapper, bands_range, hpsi_out);
-                            hamilt_t->ops->hPsi(info);
-                        };
-                        auto spsi_func = [hamilt_t](const std::complex<double>* psi_in,
-                                                    std::complex<double>* spsi_out,
-                                                    const int nrow,
-                                                    const int npw,
-                                                    const int nbands) {
-                            hamilt_t->sPsi(psi_in, spsi_out, nrow, npw, nbands);
-                        };
+                        hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_GPU>::HPsiFunc hpsi_func
+                            = [hamilt_t](std::complex<double>* psi_in,
+                                         std::complex<double>* hpsi_out,
+                                         const int ld_psi,
+                                         const int current_nbasis,
+                                         const int nvec) {
+                                  psi::Psi<std::complex<double>, base_device::DEVICE_GPU> psi_wrapper(psi_in, 1, nvec, ld_psi, current_nbasis);
+                                  psi::Range bands_range(true, 0, 0, nvec - 1);
+                                  using hpsi_info = typename hamilt::Operator<std::complex<double>, base_device::DEVICE_GPU>::hpsi_info;
+                                  hpsi_info info(&psi_wrapper, bands_range, hpsi_out);
+                                  hamilt_t->ops->hPsi(info);
+                              };
+                        hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_GPU>::SPsiFunc spsi_func
+                            = [hamilt_t](const std::complex<double>* psi_in,
+                                         std::complex<double>* spsi_out,
+                                         const int nrow,
+                                         const int npw,
+                                         const int nbands) {
+                                  hamilt_t->sPsi(psi_in, spsi_out, nrow, npw, nbands);
+                              };
                         hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_GPU>::cal_hs_subspace(
                             hpsi_func,
                             spsi_func,

--- a/source/source_lcao/module_deltaspin/cal_mw_from_lambda.cpp
+++ b/source/source_lcao/module_deltaspin/cal_mw_from_lambda.cpp
@@ -7,6 +7,7 @@
 #include "source_base/tool_title.h"
 #include "source_estate/elecstate_tools.h"
 #include "source_hsolver/diag_comm_info.h"
+#include "source_hamilt/hamilt.h"
 #include "source_hsolver/diago_iter_assist.h"
 #include "source_hsolver/hsolver_lcao.h"
 #include "source_io/module_parameter/parameter.h"
@@ -183,7 +184,26 @@ void spinconstrain::SpinConstrain<std::complex<double>>::cal_mw_from_lambda(
                     {
                         /// Compute H(k) and extract subspace matrices for this k-point
                         hamilt_t->updateHk(ik);
-                        hsolver::DiagoIterAssist<std::complex<double>>::cal_hs_subspace(hamilt_t,
+                        auto hpsi_func = [hamilt_t](std::complex<double>* psi_in,
+                                                    std::complex<double>* hpsi_out,
+                                                    const int ld_psi,
+                                                    const int current_nbasis,
+                                                    const int nvec) {
+                            auto psi_wrapper = psi::Psi<std::complex<double>, base_device::DEVICE_CPU>(psi_in, 1, nvec, ld_psi, current_nbasis);
+                            psi::Range bands_range(true, 0, 0, nvec - 1);
+                            using hpsi_info = typename hamilt::Operator<std::complex<double>, base_device::DEVICE_CPU>::hpsi_info;
+                            hpsi_info info(&psi_wrapper, bands_range, hpsi_out);
+                            hamilt_t->ops->hPsi(info);
+                        };
+                        auto spsi_func = [hamilt_t](const std::complex<double>* psi_in,
+                                                    std::complex<double>* spsi_out,
+                                                    const int nrow,
+                                                    const int npw,
+                                                    const int nbands) {
+                            hamilt_t->sPsi(psi_in, spsi_out, nrow, npw, nbands);
+                        };
+                        hsolver::DiagoIterAssist<std::complex<double>>::cal_hs_subspace(hpsi_func,
+                                                                                        spsi_func,
                                                                                         psi_t[0],
                                                                                         h_k,
                                                                                         s_k,
@@ -244,8 +264,27 @@ void spinconstrain::SpinConstrain<std::complex<double>>::cal_mw_from_lambda(
                     if(initial_hs)
                     {
                         hamilt_t->updateHk(ik);
+                        auto hpsi_func = [hamilt_t](std::complex<double>* psi_in,
+                                                    std::complex<double>* hpsi_out,
+                                                    const int ld_psi,
+                                                    const int current_nbasis,
+                                                    const int nvec) {
+                            auto psi_wrapper = psi::Psi<std::complex<double>, base_device::DEVICE_GPU>(psi_in, 1, nvec, ld_psi, current_nbasis);
+                            psi::Range bands_range(true, 0, 0, nvec - 1);
+                            using hpsi_info = typename hamilt::Operator<std::complex<double>, base_device::DEVICE_GPU>::hpsi_info;
+                            hpsi_info info(&psi_wrapper, bands_range, hpsi_out);
+                            hamilt_t->ops->hPsi(info);
+                        };
+                        auto spsi_func = [hamilt_t](const std::complex<double>* psi_in,
+                                                    std::complex<double>* spsi_out,
+                                                    const int nrow,
+                                                    const int npw,
+                                                    const int nbands) {
+                            hamilt_t->sPsi(psi_in, spsi_out, nrow, npw, nbands);
+                        };
                         hsolver::DiagoIterAssist<std::complex<double>, base_device::DEVICE_GPU>::cal_hs_subspace(
-                            hamilt_t,
+                            hpsi_func,
+                            spsi_func,
                             psi_t[0],
                             h_k,
                             s_k,

--- a/source/source_psi/psi_prepare.cpp
+++ b/source/source_psi/psi_prepare.cpp
@@ -253,14 +253,14 @@ void PSIPrepare<T, Device>::initialize_psi(Psi<std::complex<double>>* psi,
                 if (p_hamilt->ops != nullptr)
                 {
                     hpsi_func = [p_hamilt](T* psi_in, T* hpsi_out, const int ld_psi, const int current_nbasis, const int nvec) {
-                        auto psi_wrapper = Psi<T, Device>(psi_in, 1, nvec, ld_psi, current_nbasis);
+                        Psi<T, Device> psi_wrapper(psi_in, 1, nvec, ld_psi, current_nbasis);
                         Range bands_range(true, 0, 0, nvec - 1);
                         using hpsi_info = typename hamilt::Operator<T, Device>::hpsi_info;
                         hpsi_info info(&psi_wrapper, bands_range, hpsi_out);
                         p_hamilt->ops->hPsi(info);
                     };
                 }
-                auto spsi_func
+                typename hsolver::DiagoIterAssist<T, Device>::SPsiFunc spsi_func
                     = [p_hamilt](const T* psi_in, T* spsi_out, const int nrow, const int npw, const int nbands) {
                           p_hamilt->sPsi(psi_in, spsi_out, nrow, npw, nbands);
                       };

--- a/source/source_psi/psi_prepare.cpp
+++ b/source/source_psi/psi_prepare.cpp
@@ -1,5 +1,7 @@
 #include "psi_prepare.h"
 
+#include "source_hamilt/hamilt.h"
+
 #include "source_base/macros.h"
 #include "source_base/memory_recorder.h"
 #include "source_base/parallel_device.h"
@@ -245,11 +247,29 @@ void PSIPrepare<T, Device>::initialize_psi(Psi<std::complex<double>>* psi,
             if (this->ks_solver == "cg")
             {
                 std::vector<typename GetTypeReal<T>::type> etatom(nbands_start, 0.0);
+                /// An empty hpsi functor tells diag_subspace_init that the Hamiltonian
+                /// has no operators allocated yet, which used to be the ops == nullptr check.
+                typename hsolver::DiagoIterAssist<T, Device>::HPsiFunc hpsi_func;
+                if (p_hamilt->ops != nullptr)
+                {
+                    hpsi_func = [p_hamilt](T* psi_in, T* hpsi_out, const int ld_psi, const int current_nbasis, const int nvec) {
+                        auto psi_wrapper = Psi<T, Device>(psi_in, 1, nvec, ld_psi, current_nbasis);
+                        Range bands_range(true, 0, 0, nvec - 1);
+                        using hpsi_info = typename hamilt::Operator<T, Device>::hpsi_info;
+                        hpsi_info info(&psi_wrapper, bands_range, hpsi_out);
+                        p_hamilt->ops->hPsi(info);
+                    };
+                }
+                auto spsi_func
+                    = [p_hamilt](const T* psi_in, T* spsi_out, const int nrow, const int npw, const int nbands) {
+                          p_hamilt->sPsi(psi_in, spsi_out, nrow, npw, nbands);
+                      };
                 if (not_equal)
                 {
                     // for diagH_subspace_init, psi_device->get_pointer() and kspw_psi->get_pointer() should be
                     // different
-                    hsolver::DiagoIterAssist<T, Device>::diag_subspace_init(p_hamilt,
+                    hsolver::DiagoIterAssist<T, Device>::diag_subspace_init(hpsi_func,
+                                                                            spsi_func,
                                                                             psi_device->get_pointer(),
                                                                             nbands_start,
                                                                             nbasis,
@@ -262,7 +282,8 @@ void PSIPrepare<T, Device>::initialize_psi(Psi<std::complex<double>>* psi,
                 else
                 {
                     // for diagH_subspace, psi_device->get_pointer() and kspw_psi->get_pointer() can be the same
-                    hsolver::DiagoIterAssist<T, Device>::diag_subspace(p_hamilt,
+                    hsolver::DiagoIterAssist<T, Device>::diag_subspace(hpsi_func,
+                                                                       spsi_func,
                                                                        *psi_device,
                                                                        *kspw_psi,
                                                                        etatom.data(),


### PR DESCRIPTION
### Reminder
- [x] I have read `AGENTS.md` and `docs/developers_guide/agent_governance.md`.
- [x] I have linked an issue or explained why this PR does not need one.
- [x] I have added adequate unit tests and/or case tests, or explained why not.
- [x] I have listed the exact verification commands run and their results.
- [x] I have described user-visible behavior changes, including INPUT parameter changes.
- [x] I have explained core-module impact for ESolver, HSolver, ElecState, Hamilt, Operator, Psi, or other `source/` changes.
- [x] I have requested any needed governance exception below.

### Linked Issue

No issue. Third step of making `source_hsolver` a self-contained numerical
module, after #7920 and #7948. Behaviour-neutral.

There is a standing request for exactly this change in the tree:
`source_lcao/module_lr/hsolver_lrtd.hpp:122` reads

> `diagH_subspace` needs refactor: replace `Hamilt*` with `hpsi_func` — or I
> cannot use `is_subspace=true` as my `HamiltLR` does not inherit `Hamilt`.

This PR does the `Hamilt*` → `hpsi_func` part. Actually enabling the LR path is
left to whoever owns that module, since `HamiltLR` needs functors of its own.

### Unit Tests and/or Case Tests for my changes

**Commands run** (Linux, gcc, cmake 3.31 + ninja, 15 cores). Base commit
`9cbcc0b55` and this branch were built and tested in the **same build tree**.
`ENABLE_ELPA=ON` is needed for full coverage of the module.

```
cmake -B build -G Ninja -DBUILD_TESTING=ON -DENABLE_LCAO=ON -DENABLE_MPI=ON \
      -DENABLE_OPENMP=ON -DENABLE_ELPA=ON
cmake --build build -j15 -- -k 0
OMP_NUM_THREADS=1 ctest --test-dir build -E '^(0[1-9]|1[0-9])_'
python tools/03_code_analysis/agent_governance_check.py --staged
```

**Result summary**

| check | base `9cbcc0b55` | this branch |
|---|---|---|
| full build, ELPA on | 3328/3328, 0 errors | 3328/3328, 0 errors |
| unit tests | 91% passed, 29 failed of 339 | 91% passed, 29 failed of 339 |
| governance check | — | 0 blockers |

Failing sets are **identical test-for-test** (`diff` of the sorted lists is
empty); they are this sandbox's pre-existing failures.

**The unit suite does not actually exercise these three functions**, so that
result on its own is weak evidence. The CG unit tests pass
`DiagoIterAssist<T>::need_subspace` (which is `false`) into `DiagoCG`, so their
`subspace_func` — the one that calls `diag_subspace` — is never invoked. I
therefore drove each of the three converted entry points through integration
cases instead, and checked the total energy against the committed `result.ref`:

| case | reaches | nspin | branch etot (eV) | `result.ref` | Δ |
|---|---|---|---|---|---|
| `01_PW/022_PW_CG` | `diag_subspace` ×14 | 1 | -198.2238296277164 | -198.2238296207179 | 7e-9 |
| `01_PW/036_PW_AF` | `diag_subspace` ×60 | 2 | -5866.197297502092 | -5866.197297502891 | 8e-10 |
| `10_others/01_NP_KP_sp` | `diag_subspace_init` ×64 | 1 | -723.7838346685444 | -723.78383467 | 2e-9 |
| `01_PW/scf_deltaspin4` | `cal_hs_subspace` | **4** | -6369.1982731684611 | -6369.198273168575 | 1e-10 |
| `17_DS_DFTU/14_PW_DS_S4_XYZ` | `cal_hs_subspace` | **4** | -6369.198950976948 | -6369.19895097706 | 1e-10 |

Every case reproduces its reference to the precision the reference is stored at.
The call counts are read out of each run's own timing table, so the first three
rows are direct evidence that the converted code ran. `cal_hs_subspace` has no
timer of its own, but it is what fills the `h_k`/`s_k` subspace matrices that
`diag_responce` (×148 and ×156 in those two runs) then diagonalizes — a broken
substitution there could not land within 1e-10 of the reference.

The last two rows matter most: they are `nspin 4`, i.e. `npol == 2`, which is
the case the CPU branch's standing comment warns about and the one the unit
tests never reach.

**Checks not run, with reason**

- GPU (`base_device::DEVICE_GPU`) branches of `diag_subspace_init` and of
  `cal_mw_from_lambda.cpp`: no GPU runtime on the machine available to me. They
  are compiled by CI's CUDA job, and the substitution there is the same
  forwarding shim as the CPU branches, with the dimensions passed through
  unchanged (which is the reason the functors take them explicitly).
- `01_PW/BUG_SCF_DSPIN` would have been an `nspin 4` + `cg` case, but it exits
  non-zero on the base commit as well — it is a known-broken case, as its name
  says.

### What's changed?

`DiagoIterAssist` was the last *algorithm* class in `source_hsolver` still
holding a `hamilt::Hamilt<T, Device>*`. It used it for exactly two things,
`pHamilt->ops->hPsi(...)` and `pHamilt->sPsi(...)`, so its three
Hamiltonian-taking entry points — `diag_subspace`, `diag_subspace_init` and
`cal_hs_subspace` — now take two functors instead:

```cpp
using HPsiFunc = std::function<
    void(T* psi_in, T* hpsi_out, const int ld_psi, const int current_nbasis, const int nvec)>;
using SPsiFunc = std::function<
    void(const T* psi_in, T* spsi_out, const int nrow, const int npw, const int nbands)>;
```

`DiagoCG`, `DiagoDavid`, `DiagoDavSubspace` and `DiagoBPCG` have taken closures
for a while, and `HSolverPW::hamiltSolvePsiK` already builds them; this brings
the last one into line.

**Why these functors carry their dimensions instead of capturing them.** The
existing 4-argument `HPsiFunc` in `DiagoCG` and friends works because those
solvers drive one fixed wavefunction layout, so the caller can capture a single
`cur_nbasis`. `DiagoIterAssist` drives three:

| | psi handed to `hPsi` | `sPsi(nrow, npw, …)` |
|---|---|---|
| `diag_subspace`, `cal_hs_subspace` | the caller's own `psi` | `(dmax, dmin, nstart)` |
| `diag_subspace_init`, GPU branch | 1-band staging buffer | `(dmin, dmin, 1)` |
| `diag_subspace_init`, CPU branch | `nstart`-band staging buffer | `(psi_nc, psi_nc, nstart)` |

`sPsi`'s `npw` genuinely differs between the two branches of one function, so a
captured constant cannot reproduce it, and the CPU branch carries a standing
comment that `current_nbasis` must be npw **without** npol or `Nonlocal::act`'s
gemm K stops matching `vkb`'s row count. Passing the dimensions through keeps
every caller's functor a plain forwarder and makes the substitution checkable by
reading it, which matters because the SOC and GPU paths are not covered by the
unit tests available to me.

**Why the substitution is equivalent.** Where the old code handed
`Operator::hPsi` a `psi::Psi` plus a `Range`, the functor rebuilds a one-k
wrapper over the same pointer. That is the same thing because:

- `psi.get_pointer()` returns `psi_current`, which `fix_k` sets to
  `psi + ik * nbands * nbasis` — exactly the pointer
  `to_range(Range(1, current_k, 0, nstart-1))` computes;
- `Psi::get_npol()` reads `PARAM.inp.nspin` globally rather than a per-object
  member, so the wrapper reports the same `npol` (and hence the same
  `nbands * npol` inside `Operator::hPsi`) as the original object;
- `get_nbasis()` and `get_current_nbas()` are passed through explicitly, per the
  table above.

**The `ops == nullptr` early exit** in `diag_subspace_init` becomes an
empty-functor check. The two callers that can reach it (`psi_prepare.cpp`,
`hsolver_lcaopw.cpp`) build the functor only when `ops` is allocated and
otherwise leave it default-constructed, so the warning and the
copy-psi-to-evc fallback fire under exactly the same condition as before.

One honest caveat about that: `psi_prepare.cpp` builds a single functor and
uses it for both `diag_subspace_init` and `diag_subspace`, and `diag_subspace`
has never had a null-`ops` guard. So in the (unsupported, already-broken) state
where `ops` is null and that branch is taken, the failure changes shape — it
used to dereference a null pointer, and now throws `std::bad_function_call`.
Neither is a working state; I did not want to invent a new guard here.

| | before #7920 | #7948 | this PR |
|---|---|---|---|
| `source_hsolver` files including `source_hamilt` | 16 | 6 | **5** |
| `#include "source_hamilt/..."` lines there | 17 | 6 | **5** |

The five that remain are `hsolver_lcao.h`, `hsolver_lcaopw.{h,cpp}` and
`hsolver_pw.{h,cpp}` — the `HSolver*` façades, which legitimately own a
`Hamilt*` because they run the k-loop. Moving those out of `source_hsolver`
into the physics modules they belong to is the next and last step, not this one.

**Not in this PR:** `DiagoIterAssist`'s five mutable statics (`PW_DIAG_THR`,
`PW_DIAG_NMAX`, `avg_iter`, `need_subspace`, `SCF_ITER`). They are worth
removing — they are the AGENTS.md rule 2 pattern — but they create no
`source_hamilt` dependency, and only one algorithm actually reads one of them
(`diago_bpcg.cpp:302` reads `SCF_ITER`); the rest is parameter plumbing between
`setup_diago_params_*` and the `HSolverPW` constructor, which already has
matching instance members. That is a separate, self-contained change and mixing
it in here would double the diff and the risk.

### Governance Notes

- **INPUT/docs changes:** none. No `Input_Item`, no user-visible behavior, no
  output format is touched.
- **Core module impact:** HSolver, and Hamilt as seen from HSolver. No
  `hamilt::` class is modified — `DiagoIterAssist` simply stops asking for one.
  `Psi` and `Operator` are untouched. Callers in `source_psi` and
  `source_lcao/module_deltaspin` gain a forwarding functor each; the values that
  reach `Operator::hPsi` and `Hamilt::sPsi` are unchanged.
- **Exceptions requested:** none.
- **No default arguments** were added to keep old call sites compiling; all six
  call sites are updated in this PR (AGENTS.md rule 5). The two pre-existing
  defaults on `diag_subspace` (`n_band = 0`, `is_S_orthogonal = false`) are
  kept as they were.
- The forwarding functors are written out at each of the six call sites rather
  than behind a shared helper. A helper would have to live in `source_hamilt`
  to avoid re-introducing the dependency this PR removes; that seemed like the
  wrong thing to add here, and the natural moment to reconsider is after the
  façades move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
