### PR TITLE
source_basis/module_ao: use the getters that already exist instead of #define private public

### DIFF
--- a/source/source_basis/module_ao/test/orb_nonlocal_test.cpp
+++ b/source/source_basis/module_ao/test/orb_nonlocal_test.cpp
@@ -1,9 +1,7 @@
 #include "gtest/gtest.h"
 #include "source_base/global_variable.h"
 
-#define private public
 #include "source_basis/module_ao/orb_nonlocal.h"
-#undef private
 
 #ifdef __MPI
 #include <mpi.h>
@@ -54,12 +52,28 @@ void NumericalNonlocalTest::SetUp() {
 	type_ps_ = "NC";
 	nproj_ = 4;
 
-	nnl.resize(nproj_);
-	nnl[0].rcut = 1.0;
-	nnl[1].rcut = 3.0;
-	nnl[2].rcut = 4.0;
-	nnl[3].rcut = 2.0;
+	// set_type_info takes rcut_max to be the largest rcut among the projectors.
+	// Numerical_Nonlocal_Lm derives its rcut from the last point of the radial
+	// mesh it is given, so build each projector through the public
+	// set_NL_proj() instead of assigning the private member directly.
+	const double rcut[4] = {1.0, 3.0, 4.0, 2.0};
 	rcut_max_ = 4.0;
+
+	// set_NL_proj asserts that both meshes are odd and longer than one point;
+	// the beta values are irrelevant here, only rcut is read back.
+	const int nr = 3;
+	const int nk = 3;
+	const double dk = 0.01;
+	const double dr_uniform = 0.01;
+	const double beta_r[nr] = {0.0, 0.0, 0.0};
+
+	nnl.resize(nproj_);
+	for (int i = 0; i < nproj_; ++i) {
+		const double r_radial[nr] = {0.0, 0.5 * rcut[i], rcut[i]};
+		const double rab[nr] = {0.5 * rcut[i], 0.5 * rcut[i], 0.5 * rcut[i]};
+		nnl[i].set_NL_proj(elem_label_, ielem_, 0, nr, rab, r_radial, beta_r,
+				nk, dk, dr_uniform);
+	}
 }
 
 
@@ -72,11 +86,11 @@ TEST_F(NumericalNonlocalTest, SetTypeInfo) {
 
 	nn.set_type_info(ielem_, elem_label_, type_ps_, lmax_, nproj_, &nnl[0]);
 
-	EXPECT_EQ(nn.label, elem_label_);
-	EXPECT_EQ(nn.type, ielem_);
-	EXPECT_EQ(nn.lmax, lmax_);
-	EXPECT_DOUBLE_EQ(nn.rcut_max, rcut_max_);
-	EXPECT_EQ(nn.nproj, nproj_);
+	EXPECT_EQ(nn.getLabel(), elem_label_);
+	EXPECT_EQ(nn.getType(), ielem_);
+	EXPECT_EQ(nn.getLmax(), lmax_);
+	EXPECT_DOUBLE_EQ(nn.get_rcut_max(), rcut_max_);
+	EXPECT_EQ(nn.get_nproj(), nproj_);
 }
 
 
@@ -84,10 +98,13 @@ TEST_F(NumericalNonlocalTest, Getters) {
 
 	nn.set_type_info(ielem_, elem_label_, type_ps_, lmax_, nproj_, &nnl[0]);
 
-	EXPECT_EQ(nn.getLmax(), nn.lmax);
-	EXPECT_EQ(nn.getType(), nn.type);
-	EXPECT_EQ(nn.getLabel(), nn.label);
-	EXPECT_EQ(nn.getType_ps(), nn.type_ps);
+	// Anchored to the values set_type_info was given, not to the members the
+	// getters return -- comparing a getter against its own member can only ever
+	// catch a getter wired to the wrong field, and cannot fail otherwise.
+	EXPECT_EQ(nn.getLmax(), lmax_);
+	EXPECT_EQ(nn.getType(), ielem_);
+	EXPECT_EQ(nn.getLabel(), elem_label_);
+	EXPECT_EQ(nn.getType_ps(), type_ps_);
 	EXPECT_EQ(nn.get_rcut_max(), rcut_max_);
 }
 

--- a/source/source_basis/module_ao/test/orb_read_test.cpp
+++ b/source/source_basis/module_ao/test/orb_read_test.cpp
@@ -4,9 +4,7 @@
 #include "source_basis/module_ao/orb_atomic.h"
 #include "source_basis/module_ao/orb_atomic_lm.h"
 
-#define private public
 #include "source_basis/module_ao/orb_read.h"
-#undef private
 
 #ifdef __MPI
 #include <mpi.h>
@@ -178,7 +176,7 @@ TEST_F(LcaoOrbitalsTest, ReadOrbitals) {
         EXPECT_EQ(ao0.PhiLN(L,N).getL(), L);
         EXPECT_EQ(ao0.PhiLN(L,N).getChi(), N);
         EXPECT_EQ(ao0.PhiLN(L,N).getNr(), 801);
-        EXPECT_EQ(ao0.PhiLN(L,N).getNk(), lcao_.kmesh);
+        EXPECT_EQ(ao0.PhiLN(L,N).getNk(), lcao_.get_kmesh());
         EXPECT_EQ(ao0.PhiLN(L,N).getDk(), lcao_.dk);
         EXPECT_EQ(ao0.PhiLN(L,N).getDruniform(), lcao_.dr_uniform);
 
@@ -226,7 +224,7 @@ TEST_F(LcaoOrbitalsTest, ReadOrbitals) {
         EXPECT_EQ(ao1.PhiLN(L,N).getL(), L);
         EXPECT_EQ(ao1.PhiLN(L,N).getChi(), N);
         EXPECT_EQ(ao1.PhiLN(L,N).getNr(), 701);
-        EXPECT_EQ(ao1.PhiLN(L,N).getNk(), lcao_.kmesh);
+        EXPECT_EQ(ao1.PhiLN(L,N).getNk(), lcao_.get_kmesh());
         EXPECT_EQ(ao1.PhiLN(L,N).getDk(), lcao_.dk);
         EXPECT_EQ(ao1.PhiLN(L,N).getDruniform(), lcao_.dr_uniform);
 
@@ -287,7 +285,7 @@ TEST_F(LcaoOrbitalsTest, ReadOrbitals) {
         EXPECT_EQ(aod.PhiLN(L,N).getL(), L);
         EXPECT_EQ(aod.PhiLN(L,N).getChi(), N);
         EXPECT_EQ(aod.PhiLN(L,N).getNr(), 201);
-        EXPECT_EQ(aod.PhiLN(L,N).getNk(), lcao_.kmesh);
+        EXPECT_EQ(aod.PhiLN(L,N).getNk(), lcao_.get_kmesh());
         EXPECT_EQ(aod.PhiLN(L,N).getDk(), lcao_.dk);
         EXPECT_EQ(aod.PhiLN(L,N).getDruniform(), lcao_.dr_uniform);
 
@@ -307,18 +305,28 @@ TEST_F(LcaoOrbitalsTest, Getters) {
 
     this->lcao_read();
 
-    EXPECT_EQ(lcao_.get_ecutwfc(), lcao_.ecutwfc);
-    EXPECT_EQ(lcao_.get_kmesh(), lcao_.kmesh);
-    EXPECT_EQ(lcao_.get_dk(), lcao_.dk);
-    EXPECT_EQ(lcao_.get_dR(), lcao_.dR);
-    EXPECT_EQ(lcao_.get_Rmax(), lcao_.Rmax);
-    EXPECT_EQ(lcao_.get_lmax(), lcao_.lmax);
-    EXPECT_EQ(lcao_.get_lmax_d(), lcao_.lmax_d);
-    EXPECT_EQ(lcao_.get_nchimax(), lcao_.nchimax);
-    EXPECT_EQ(lcao_.get_nchimax_d(), lcao_.nchimax_d);
-    EXPECT_EQ(lcao_.get_ntype(), lcao_.ntype);
+    EXPECT_EQ(lcao_.get_ecutwfc(), ecutwfc_);
+    EXPECT_EQ(lcao_.get_dk(), dk_);
+    EXPECT_EQ(lcao_.get_dR(), dR_);
+    EXPECT_EQ(lcao_.get_Rmax(), Rmax_);
+    EXPECT_EQ(lcao_.get_ntype(), ntype_);
+    EXPECT_EQ(lcao_.get_lmax(), lmax_);
     EXPECT_EQ(lcao_.get_dr_uniform(), lcao_.dr_uniform);
-    EXPECT_EQ(lcao_.get_rcutmax_Phi(), lcao_.rcutmax_Phi);
+
+    // The remaining four are derived by Read_Orbitals rather than passed in, so
+    // they are anchored to the values this fixture's inputs and orbital files
+    // imply -- not to the members the getters return, which cannot fail.
+    //
+    // kmesh: ecutwfc >= 20, so Read_Orbitals takes int(sqrt(ecutwfc)/dk) + 4,
+    //        i.e. int(sqrt(123)/0.01) + 4 = 1109 + 4.
+    EXPECT_EQ(lcao_.get_kmesh(), 1113);
+    // nchimax: most orbitals of one l over both elements -- H is 2s1p and O is
+    //          2s2p1d, so 2 either way. lmax_d/nchimax_d come from jle.orb.
+    EXPECT_EQ(lcao_.get_nchimax(), 2);
+    EXPECT_EQ(lcao_.get_lmax_d(), 2);
+    EXPECT_EQ(lcao_.get_nchimax_d(), 2);
+    // rcutmax_Phi: largest cutoff over the elements -- H is 8 au, O is 7 au.
+    EXPECT_DOUBLE_EQ(lcao_.get_rcutmax_Phi(), 8.0);
 }
 
 


### PR DESCRIPTION
Third tranche of the `#define private public` cleanup, after #7940 (tests
driving global `PARAM`) and #7949 (tests calling private methods). This one
covers the case where the member the test reaches for **already has a public
getter** — so the macro comes off with no production change at all.

## Three cases, and the middle one is a trap

`orb_nonlocal_test.cpp` and `orb_read_test.cpp` reach into `Numerical_Nonlocal`
and `LCAO_Orbitals`. Neither file touches `PARAM`; nothing is added to a
production header. **The entire diff is in the two test files.**

**1. The member is used as a plain value** — read it through its getter.
`lcao_.kmesh` becomes `lcao_.get_kmesh()` (4 sites); the five `SetTypeInfo`
assertions become `nn.getLabel()`, `getType()`, `getLmax()`, `get_rcut_max()`,
`get_nproj()`. Those already compared against the fixture's inputs, so they stay
real checks.

**2. The assertion *is* `EXPECT_EQ(obj.get_x(), obj.x)`.** Substituting the
getter here would produce `EXPECT_EQ(get_x(), get_x())` — an assertion that
cannot fail. Mechanically removing the macro this way would leave the test
green and empty, which is worse than the macro. These are re-anchored to the
value the object was actually given.

`orb_nonlocal_test` already had one line in the right form
(`EXPECT_EQ(nn.get_rcut_max(), rcut_max_)`); the other four now match it.

In `LCAO_Orbitals::Getters`, seven of the twelve assertions covered private
members. `ntype` and `lmax` are passed straight into `Read_Orbitals`, so they
anchor to `ntype_` / `lmax_`. The remaining four are *derived*, and the
production formula is deliberately **not** restated in the test — a test that
recomputes the thing it is checking passes even when the formula is wrong. They
are asserted as the concrete values this fixture implies, each with its
provenance in a comment:

| | value | where it comes from |
| --- | --- | --- |
| `kmesh` | 1113 | `int(sqrt(ecutwfc)/dk) + 4` = `int(sqrt(123)/0.01) + 4` |
| `nchimax` | 2 | H is 2s1p, O is 2s2p1d |
| `lmax_d`, `nchimax_d` | 2 | from `jle.orb` |
| `rcutmax_Phi` | 8 au | H is 8 au, O is 7 au |

Each was measured against the built test, and `kmesh` additionally cross-checked
by hand against `Read_Orbitals` so the assertion records the correct value rather
than merely the observed one.

**3. The test *wrote* a private member to build a fixture** —
`nnl[i].rcut = 1.0` in `NumericalNonlocalTest::SetUp`.
`Numerical_Nonlocal_Lm` derives `rcut` from the last point of its radial mesh
(`rcut = r_radial_in[nr-1]`), so each projector is now built through the public
`set_NL_proj()` with a minimal three-point mesh whose endpoint is the wanted
rcut. This removes the write *and* exercises `set_NL_proj`, which no assertion in
this file reached before.

`ecutwfc`, `dk`, `dR`, `Rmax` and `dr_uniform` are public members of
`LCAO_Orbitals` and never needed the macro. The four that have a corresponding
fixture input are anchored to it for consistency; `dr_uniform` is left as it was.

## Result

Macro occurrences in these two files: **2 -> 0**. No `#undef private` is added,
and no file whose macro survives is touched.

## Verification

Linux, `cmake -B build -G Ninja -DBUILD_TESTING=ON -DENABLE_LCAO=ON -DENABLE_MPI=ON -DENABLE_OPENMP=ON`,
followed by `cmake --install build` — which matters here: the `module_ao` tests
get their orbital data from `install(DIRECTORY lcao_H2O ...)`, so without the
install step `ORB_read_test` fails and `ORB_atomic_lm_test` /
`ORB_nonlocal_lm_test` segfault on missing input, both before and after this
change.

- build: **0 errors** (branch and base both `BUILD_EXIT=0`).
- `MODULE_AO_ORB_nonlocal_test`, `MODULE_AO_ORB_read_test`,
  `MODULE_AO_ORB_atomic_lm_test`, `MODULE_AO_ORB_nonlocal_lm_test`: **all pass**.
- full unit suite: **2 of 339 fail — the failure set is identical to the base
  commit** (`9cbcc0b55`) built, installed and run in a parallel worktree in the
  same environment; both `comm` directions are empty. The two are
  `MODULE_HSOLVER_diago_hs_parallel` and `MODULE_HSOLVER_LCAO`, both
  `mpirun`-based and pre-existing.
- `agent_governance_check.py`: **0 errors**. The access-hack ratchet reports
  nothing (2 removed, 0 added) and no `PARAM`/`GlobalV`/`GlobalC` reference is
  added or removed, so the global-dependency budget is untouched.

No INPUT parameter and no user-visible behaviour changed, so
`docs/parameters.yaml` and `docs/advanced/input_files/input-main.md` need no
update.

## What is not here

The other two `module_ao` tests, `orb_atomic_lm_test.cpp` (887 lines) and
`orb_nonlocal_lm_test.cpp` (755 lines), hold the bulk of this category — roughly
190 further sites where a member with an existing getter is read directly. They
are left for a separate PR because they cannot be finished the same way: each
also calls private *methods* (`cal_kradial`, `cal_rradial_sbpool`, `plot`,
`freemem`, `renew`, `get_kradial`) and `orb_atomic_lm_test` reads `psir`, which
has no getter. Those need a `friend` grant in a production header — the #7949
pattern — which is a different review question from "use the accessor that
already exists", and mixing the two would obscure both.

Their getter-vs-member block has the same shape as the one fixed here but over
arrays (`get_psi()` vs `psi`), where there is no scalar input to re-anchor to;
that block is better routed through the fixture once the `friend` is in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
